### PR TITLE
chore(deps): bump github actions (checkout v6, setup-node v6, setup-uv v7, semantic-pr v6)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Enable auto-merge (squash)
         run: gh pr merge "$PR_NUMBER" --auto --squash
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Update all reviewed PRs targeting this branch
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,8 +15,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: npm ci

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         with:
           types: |
             feat


### PR DESCRIPTION
## Summary

Consolidates 4 Dependabot PRs into one:

- `actions/checkout` v4 → v6 (auto-merge.yml, ci.yml, deploy-preview.yml)
- `actions/setup-node` v4 → v6 (deploy-preview.yml)
- `astral-sh/setup-uv` v5 → v7 (ci.yml)
- `amannn/action-semantic-pull-request` v5 → v6 (pr-title.yml)

Closes #37, closes #38, closes #39, closes #40

## Test plan

- [ ] CI passes on this PR
- [ ] All 4 Dependabot PRs closed by the closing keywords above

🤖 Generated with [Claude Code](https://claude.com/claude-code)