### PR TITLE
feat(telegram): add message_id to TelegramContext for session-message mapping

### DIFF
--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -226,7 +226,11 @@ class TelegramAdapter:
     async def send_streaming(
         self, original_msg: Message, chunks: AsyncIterator[str]
     ) -> None:
-        """Stream response with edit-in-place, debounced at ~500ms."""
+        """Stream response with edit-in-place, debounced at ~500ms.
+
+        TODO: store placeholder.message_id in response.metadata["reply_message_id"]
+        once send_streaming() receives a Response argument (#67).
+        """
         if not isinstance(original_msg.platform_context, TelegramContext):
             log.error(
                 "send_streaming() called with non-TelegramContext for msg_id=%s",

--- a/src/lyra/core/message.py
+++ b/src/lyra/core/message.py
@@ -63,6 +63,14 @@ def extract_text(msg: "Message") -> str:
 
 @dataclass(frozen=True)
 class TelegramContext:
+    """Platform context for Telegram messages.
+
+    Unlike DiscordContext where message_id is always present, Telegram
+    service messages (e.g. user joined, pinned message) have no message_id,
+    so the field is optional. All ordinary bot-interaction messages will
+    have a non-None message_id.
+    """
+
     chat_id: int
     topic_id: int | None = None
     is_group: bool = False

--- a/tests/adapters/test_telegram.py
+++ b/tests/adapters/test_telegram.py
@@ -333,9 +333,9 @@ def test_normalize_captures_message_id() -> None:
     from lyra.adapters.telegram import TelegramAdapter
     from lyra.core.message import TelegramContext
 
+    # Arrange
     hub = MagicMock()
     adapter = TelegramAdapter(bot_id="main", token="test-token-secret", hub=hub)
-
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
         from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
@@ -346,34 +346,75 @@ def test_normalize_captures_message_id() -> None:
         entities=None,
     )
 
+    # Act
     msg = adapter._normalize(aiogram_msg)
 
+    # Assert
     assert isinstance(msg.platform_context, TelegramContext)
     assert msg.platform_context.message_id == 777
 
 
 def test_normalize_message_id_none_when_absent() -> None:
-    """_normalize() sets TelegramContext.message_id=None when message_id absent."""
+    """_normalize() sets TelegramContext.message_id=None when message_id absent.
+
+    Note: real aiogram Message objects always have message_id (required Bot API field).
+    This test exercises the getattr defensive fallback used by SimpleNamespace stubs.
+    """
     from lyra.adapters.telegram import TelegramAdapter
     from lyra.core.message import TelegramContext
 
+    # Arrange
     hub = MagicMock()
     adapter = TelegramAdapter(bot_id="main", token="test-token-secret", hub=hub)
-
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
         from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
         text="hello",
         date=datetime.now(timezone.utc),
         message_thread_id=None,
-        # no message_id attribute
+        # no message_id attribute — exercises getattr(..., None) defensive path
         entities=None,
     )
 
+    # Act
     msg = adapter._normalize(aiogram_msg)
 
+    # Assert
     assert isinstance(msg.platform_context, TelegramContext)
     assert msg.platform_context.message_id is None
+
+
+# ---------------------------------------------------------------------------
+# T11c — _normalize() captures both topic_id and message_id for group/forum
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_captures_topic_and_message_id_for_forum() -> None:
+    """Forum supergroup: both topic_id and message_id captured simultaneously."""
+    from lyra.adapters.telegram import TelegramAdapter
+    from lyra.core.message import TelegramContext
+
+    # Arrange
+    hub = MagicMock()
+    adapter = TelegramAdapter(bot_id="main", token="test-token-secret", hub=hub)
+    aiogram_msg = SimpleNamespace(
+        chat=SimpleNamespace(id=456, type="supergroup"),
+        from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+        text="hello forum",
+        date=datetime.now(timezone.utc),
+        message_thread_id=99,
+        message_id=777,
+        entities=None,
+    )
+
+    # Act
+    msg = adapter._normalize(aiogram_msg)
+
+    # Assert
+    assert isinstance(msg.platform_context, TelegramContext)
+    assert msg.platform_context.topic_id == 99
+    assert msg.platform_context.message_id == 777
+    assert msg.platform_context.is_group is True
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +435,7 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
         TextContent,
     )
 
+    # Arrange
     hub = MagicMock()
     bot = AsyncMock()
     sent_msg = SimpleNamespace(message_id=888)
@@ -417,6 +459,9 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
     )
     response = Response(content="reply")
 
+    # Act
     await adapter.send(original_msg, response)
 
+    # Assert
+    bot.send_message.assert_awaited_once_with(chat_id=123, text="reply")
     assert response.metadata["reply_message_id"] == 888


### PR DESCRIPTION
## Summary
- Add `message_id: int | None` to `TelegramContext` so Lyra can track which Telegram message corresponds to each hub turn
- Capture `msg.message_id` in `TelegramAdapter._normalize()` on every inbound message
- Store bot reply `message_id` in `response.metadata["reply_message_id"]` after `send()`, enabling future reply-to-resume and cross-session editing

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #102: feat: add message_id to TelegramContext for session-message mapping | Open |
| Implementation | 1 commit on `feat/102-telegram-context-message-id` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new, 172 total) | Passed |

## Test Plan
- [ ] `TelegramContext.message_id` is populated for every incoming message (T11)
- [ ] Falls back to `None` when `message_id` absent from aiogram payload (T11b)
- [ ] Bot reply `message_id` stored in `response.metadata["reply_message_id"]` (T12)
- [ ] All existing adapter tests pass (T2–T10)
- [ ] Pool history entries automatically include `message_id` via `TelegramContext`

Closes #102

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`