### PR TITLE
feat(discord): store reply_message_id in response metadata (#116)

### DIFF
--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -227,6 +227,9 @@ class DiscordAdapter(discord.Client):
                 sent = await messageable.send(content)
             # Store for session persistence (#67) and reply-to-resume (#83).
             response.metadata["reply_message_id"] = sent.id
+            log.debug(
+                "stored reply_message_id=%s for msg_id=%s", sent.id, original_msg.id
+            )
             if self._circuit_registry is not None:
                 cb = self._circuit_registry.get("discord")
                 if cb is not None:

--- a/tests/adapters/test_discord.py
+++ b/tests/adapters/test_discord.py
@@ -633,6 +633,7 @@ async def test_send_stores_reply_message_id_channel_send() -> None:
         TextContent,
     )
 
+    # Arrange
     hub = MagicMock()
     adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
 
@@ -656,8 +657,10 @@ async def test_send_stores_reply_message_id_channel_send() -> None:
     )
     response = Response(content="hi")
 
+    # Act
     await adapter.send(hub_msg, response)
 
+    # Assert
     mock_channel.send.assert_awaited_once_with("hi")
     assert response.metadata["reply_message_id"] == 888
 
@@ -680,10 +683,11 @@ async def test_send_stores_reply_message_id_msg_reply() -> None:
         TextContent,
     )
 
+    # Arrange
     hub = MagicMock()
     adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
 
-    sent_msg = SimpleNamespace(id=999)
+    sent_msg = SimpleNamespace(id=7777)
     mock_message = AsyncMock()
     mock_message.reply = AsyncMock(return_value=sent_msg)
     mock_channel = AsyncMock()
@@ -705,8 +709,58 @@ async def test_send_stores_reply_message_id_msg_reply() -> None:
     )
     response = Response(content="hi")
 
+    # Act
     await adapter.send(hub_msg, response)
 
+    # Assert
     mock_channel.fetch_message.assert_awaited_once_with(555)
     mock_message.reply.assert_awaited_once_with("hi")
-    assert response.metadata["reply_message_id"] == 999
+    assert response.metadata["reply_message_id"] == 7777
+
+
+# ---------------------------------------------------------------------------
+# T16 — send() does NOT set reply_message_id when send fails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_no_reply_message_id_on_failure() -> None:
+    """send() must NOT set reply_message_id in metadata when the send call throws."""
+    from lyra.adapters.discord import DiscordAdapter
+    from lyra.core.message import (
+        DiscordContext,
+        Message,
+        MessageType,
+        Platform,
+        Response,
+        TextContent,
+    )
+
+    # Arrange
+    hub = MagicMock()
+    adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+
+    mock_channel = AsyncMock()
+    mock_channel.send = AsyncMock(side_effect=Exception("network error"))
+    adapter.get_channel = MagicMock(return_value=mock_channel)
+
+    hub_msg = Message(
+        id="msg-1",
+        platform=Platform.DISCORD,
+        bot_id="main",
+        user_id="dc:user:42",
+        user_name="Alice",
+        is_mention=False,
+        is_from_bot=False,
+        content=TextContent(text="hello"),
+        type=MessageType.TEXT,
+        timestamp=datetime.now(timezone.utc),
+        platform_context=DiscordContext(guild_id=111, channel_id=333, message_id=555),
+    )
+    response = Response(content="hi")
+
+    # Act
+    await adapter.send(hub_msg, response)
+
+    # Assert
+    assert "reply_message_id" not in response.metadata


### PR DESCRIPTION
## Summary

- Store bot's sent message ID in `response.metadata["reply_message_id"]` after `send()`, mirroring Telegram's pattern from #102
- Covers both `channel.send()` (non-mention) and `msg.reply()` (mention) paths
- `send_streaming()` gets a TODO for when it receives a `Response` argument (#67)
- Adds T14/T15 tests covering both send paths

Closes #116

## Test plan

- [x] T14: `send()` via `channel.send()` stores `reply_message_id` in metadata
- [x] T15: `send()` via `msg.reply()` stores `reply_message_id` in metadata
- [x] All 19 existing Discord adapter tests still pass
- [x] Lint, typecheck, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)