### PR TITLE
docs(paradigm): formalize CLI/Library Python-first paradigm

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,42 @@
 # Lyra — Architecture & Decisions
 
 > Living document. Updated as decisions are made.
-> Last updated: 2026-03-12 (Phase 1b completions: per-channel queues #126, fastembed #82, scope_id #125, LLM circuit breaker #104)
+> Last updated: 2026-03-12 (Phase 1b completions: per-channel queues #126, fastembed #82, scope_id #125, LLM circuit breaker #104; Python-first paradigm #165)
+
+---
+
+## Python-first Paradigm
+
+> Adopted 2026-03-08. All new Roxabi projects follow this model.
+
+**No more monolithic servers.** Every project ships as:
+
+1. **A Python library** — importable package with a clean public API (`__init__.py` with `__all__`). Other projects depend on it directly via `uv` path/git dependency.
+2. **A CLI entrypoint** — thin shell over the library (`cli.py`), installed via `[project.scripts]`. The CLI adds zero logic; it parses args and calls library functions.
+
+### What "library" means per project
+
+| Project | Package | Public API surface | CLI entrypoint |
+|---------|---------|-------------------|---------------|
+| `voiceCLI` | `voicecli` | `generate`, `generate_async`, `clone`, `clone_async`, `transcribe`, `transcribe_async`, `list_engines`, `list_voices` | `voicecli` |
+| `imageCLI` | `imagecli` | `generate`, `get_engine`, `list_engines`, `preflight_check`, `load_config`, `parse_prompt_file` | `imagecli` |
+| `lyra` | `lyra` | Hub, Agent, Pool, Message, ChannelAdapter (internal SDK — not public) | daemon via supervisord |
+| `2ndBrain` | `knowledge` | Vault read/write/search (internal SDK) | `knowledge_bot` daemon |
+
+### Rules
+
+- **Library first**: implement in library, expose in CLI. Never implement logic in `cli.py`.
+- **No side effects on import**: engines/models load lazily. `import voicecli` is instant.
+- **`__all__` is the contract**: anything not in `__all__` is private. Other projects depend only on `__all__` exports.
+- **Python everywhere**: backends, CLIs, agents — all Python. Frontend (React, Vue) stays TypeScript when required by the target platform.
+- **`uv` for all**: `uv sync` installs; `uv tool install .` for global CLI install; cross-project deps via `uv add --editable path/to/lib`.
+
+### Why
+
+- Lyra can call `from voicecli import generate_async` — no subprocess, no HTTP server.
+- imageCLI, voiceCLI become Lyra skills with zero glue code.
+- Uniform patterns across projects reduce context-switching overhead.
+- Library callers get type-checked, IDE-navigable APIs. Shell callers get the same logic via CLI.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Lyra — Prioritized Roadmap
 
 > Living document. Updated as decisions are made.
-> Last updated: 2026-03-11
+> Last updated: 2026-03-12
 
 ---
 
@@ -159,6 +159,24 @@
 | #18 | YouTube automation pipeline | P3 |
 | #19 | Meta-skills + atomic SLM | P3 |
 | #20 | Polymarket agent | P3 |
+
+---
+
+## Paradigm enforcement
+
+> Python-first, CLI/Library paradigm adopted 2026-03-08. Formalized in #165.
+
+When onboarding a new project or reviewing an existing one, verify:
+
+- [ ] Package has `__init__.py` with `__all__` (library contract)
+- [ ] `cli.py` contains zero business logic (thin shell only)
+- [ ] Models/engines load lazily (no side effects on import)
+- [ ] Cross-project dependencies declared as `uv add --editable path/to/lib`
+- [ ] No HTTP server used as an inter-project integration layer
+
+Projects needing a library API review (tracked separately): `roxabi_boilerplate` (NestJS backend → FastAPI migration?), `ryvo` (same), `roxabi_site` (Vue/TS frontend — frontend stays TS).
+
+See `docs/ARCHITECTURE.md` → **Python-first Paradigm** for the full definition.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add **Python-first Paradigm** section to `ARCHITECTURE.md` — defines CLI/Library-first model, per-project public API surfaces, rules, and rationale
- Add **paradigm enforcement checklist** to `ROADMAP.md` with per-project migration notes and a pointer to ARCHITECTURE.md

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #165: docs(paradigm): formalize CLI/Library Python-first paradigm across all projects | Open |
| Implementation | 1 commit on `feat/165-docs-paradigm-python-first` | Complete |
| Verification | Lint ✅ Typecheck ✅ | Passed |

## Test Plan
- [ ] `ARCHITECTURE.md` — Python-first Paradigm section renders correctly; table of per-project APIs is accurate
- [ ] `ROADMAP.md` — enforcement checklist is present and links to ARCHITECTURE.md section
- [ ] voiceCLI README (separate commit on `voiceCLI/staging`) — Library API section shows correct `__all__` exports
- [ ] imageCLI README (separate commit on `imageCLI/staging`) — Library API section shows correct `__all__` exports

> Note: voiceCLI and imageCLI README updates were committed directly to their respective `staging` branches (separate repos).

Closes #165

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`