### PR TITLE
refactor(message): update demo + docs to use InboundMessage (#176)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -5,24 +5,15 @@ from datetime import datetime, timezone
 
 from lyra.core.agent import Agent, AgentBase
 from lyra.core.hub import Hub
-from lyra.core.message import (
-    Message,
-    MessageType,
-    Platform,
-    Response,
-    TelegramContext,
-    TextContent,
-)
+from lyra.core.message import InboundMessage, Platform, Response
 from lyra.core.pool import Pool
 
 
 class EchoAgent(AgentBase):
     """Echoes back whatever the user sends."""
 
-    async def process(self, msg: Message, pool: Pool) -> Response:
-        content = msg.content
-        text = content.text if isinstance(content, TextContent) else str(content)
-        return Response(content=f"Echo: {text}")
+    async def process(self, msg: InboundMessage, pool: Pool) -> Response:
+        return Response(content=f"Echo: {msg.text}")
 
 
 class FakeAdapter:
@@ -31,7 +22,7 @@ class FakeAdapter:
     def __init__(self) -> None:
         self.responses: list[Response] = []
 
-    async def send(self, original_msg: Message, response: Response) -> None:
+    async def send(self, original_msg: InboundMessage, response: Response) -> None:
         self.responses.append(response)
         print(f"  <- {response.content}")
 
@@ -52,15 +43,18 @@ async def main() -> None:
 
     # Simulate messages
     for text in ["Hello Lyra!", "How does routing work?", "Goodbye"]:
-        msg = Message.from_adapter(
-            platform=Platform.TELEGRAM,
+        msg = InboundMessage(
+            id=f"demo-{text[:5]}",
+            platform="telegram",
             bot_id="main",
+            scope_id="chat:123",
             user_id="tg:user:42",
             user_name="Mickael",
-            content=TextContent(text=text),
-            type=MessageType.TEXT,
+            is_mention=True,
+            text=text,
+            text_raw=text,
             timestamp=datetime.now(timezone.utc),
-            platform_context=TelegramContext(chat_id=123),
+            platform_meta={"chat_id": 123},
         )
         print(f"  -> {text}")
         await hub.bus.put(msg)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,20 +138,24 @@ Discord  ──▶ dc_inbound Queue ──┘         (bounded 100)        │
 
 **Unified message format:**
 ```python
-@dataclass
-class Message:
+@dataclass(frozen=True)
+class InboundMessage:
     id: str
-    platform: Platform          # Platform.TELEGRAM | Platform.DISCORD
+    platform: str               # "telegram" | "discord" | ...
     bot_id: str                 # "main" (one bot per platform)
+    scope_id: str               # canonical routing scope (computed by adapter)
     user_id: str                # canonical sender ID (rate-limiting, pairing)
-    platform_context: ...       # TelegramContext | DiscordContext (scope routing)
-    content: MessageContent     # TextContent | ImageContent | AudioContent
-    type: MessageType
+    user_name: str
+    is_mention: bool
+    text: str                   # normalized plain text (markup stripped)
+    text_raw: str               # original text with platform markup
+    attachments: list[Attachment]
+    reply_to_id: str | None
+    thread_id: str | None
     timestamp: datetime
-    metadata: dict
-
-    def extract_scope_id(self) -> str:
-        """Return conversation scope: chat:NNN, thread:NNN, channel:NNN, …"""
+    locale: str | None
+    trust: Literal["user", "system"]
+    platform_meta: dict         # platform-specific routing data (chat_id, guild_id, …)
 ```
 
 ### Bindings (routing table)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -324,23 +324,15 @@ from datetime import datetime, timezone
 
 from lyra.core.agent import Agent, AgentBase
 from lyra.core.hub import Hub
-from lyra.core.message import (
-    Message,
-    MessageType,
-    Platform,
-    Response,
-    TelegramContext,
-    TextContent,
-)
+from lyra.core.message import InboundMessage, Platform, Response
 from lyra.core.pool import Pool
 
 
 class EchoAgent(AgentBase):
     """Echoes back whatever the user sends."""
 
-    async def process(self, msg: Message, pool: Pool) -> Response:
-        text = msg.content.text if isinstance(msg.content, TextContent) else str(msg.content)
-        return Response(content=f"Echo: {text}")
+    async def process(self, msg: InboundMessage, pool: Pool) -> Response:
+        return Response(content=f"Echo: {msg.text}")
 
 
 class FakeAdapter:
@@ -349,7 +341,7 @@ class FakeAdapter:
     def __init__(self) -> None:
         self.responses: list[Response] = []
 
-    async def send(self, original_msg: Message, response: Response) -> None:
+    async def send(self, original_msg: InboundMessage, response: Response) -> None:
         self.responses.append(response)
         print(f"  <- {response.content}")
 
@@ -370,15 +362,18 @@ async def main() -> None:
 
     # Simulate messages
     for text in ["Hello Lyra!", "How does routing work?", "Goodbye"]:
-        msg = Message.from_adapter(
-            platform=Platform.TELEGRAM,
+        msg = InboundMessage(
+            id=f"demo-{text[:5]}",
+            platform="telegram",
             bot_id="main",
+            scope_id="chat:123",
             user_id="tg:user:42",
             user_name="Mickael",
-            content=TextContent(text=text),
-            type=MessageType.TEXT,
+            is_mention=True,
+            text=text,
+            text_raw=text,
             timestamp=datetime.now(timezone.utc),
-            platform_context=TelegramContext(chat_id=123),
+            platform_meta={"chat_id": 123},
         )
         print(f"  -> {text}")
         await hub.bus.put(msg)


### PR DESCRIPTION
## Summary
- Update `demo.py` to use `InboundMessage` instead of removed legacy `Message`/`TelegramContext`/`TextContent` types
- Update `docs/ARCHITECTURE.md` §Unified message format to reflect `InboundMessage` as the sole inbound type
- Update `docs/GETTING-STARTED.md` demo code to match

Closes #176

## Test plan
- [x] `uv run pytest` — 599 passed
- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)