### PR TITLE
fix(hub): replace blocking os.write/os.close in _audio_loop with async I/O (#203)

### DIFF
--- a/src/lyra/core/hub.py
+++ b/src/lyra/core/hub.py
@@ -491,8 +491,11 @@ class Hub:
         fd, path = tempfile.mkstemp(suffix=suffix)
         try:
             os.write(fd, data)
-        finally:
+        except BaseException:
             os.close(fd)
+            Path(path).unlink(missing_ok=True)
+            raise
+        os.close(fd)
         return path
 
     async def _dispatch_audio_reply(


### PR DESCRIPTION
## Summary
- Move blocking `tempfile.mkstemp()` + `os.write()` + `os.close()` out of the event loop in `_audio_loop`
- Extract a `_write_temp_audio()` static helper called via `asyncio.to_thread()` so file I/O never blocks the async loop during audio transcription

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #203: fix(hub): replace blocking os.write/os.close in _audio_loop with async I/O | Open |
| Implementation | 1 commit on `feat/203-async-audio-io` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (785 passed) | Passed |

## Test Plan
- [ ] Send a voice message to Lyra and verify transcription still works
- [ ] Confirm no blocking I/O warnings in async debug mode

Closes #203

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`