### PR TITLE
fix(security): use hmac.compare_digest for webhook secret (#212)

### DIFF
--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 import re
@@ -151,7 +152,7 @@ def _make_verifier(secret: str):
 
     async def verify(request: Request) -> None:
         incoming = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
-        if not secret or incoming != secret:
+        if not secret or not hmac.compare_digest(incoming, secret):
             raise HTTPException(status_code=401, detail="Unauthorized")
 
     return verify


### PR DESCRIPTION
## Summary
- Replace timing-vulnerable `!=` with constant-time `hmac.compare_digest()` in Telegram webhook secret validation
- Prevents timing oracle attacks on the webhook endpoint
- Closes #212

## Test plan
- [x] All 41 existing telegram adapter tests pass
- [ ] Verify webhook auth still rejects invalid secrets
- [ ] Verify webhook auth accepts valid secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)