### PR TITLE
fix(hub): add TTL eviction for Hub.pools to prevent memory leak (#205)

### DIFF
--- a/src/lyra/core/hub.py
+++ b/src/lyra/core/hub.py
@@ -113,7 +113,7 @@ class Hub:
     # Per-user sliding window: drop messages beyond this rate.
     RATE_LIMIT = 20  # max messages per user per window
     RATE_WINDOW = 60  # window size in seconds
-    POOL_TTL = 3600  # evict idle pools after 1 hour (seconds)
+    POOL_TTL: float = 3600.0  # evict idle pools after 1 hour (seconds)
 
     def __init__(  # noqa: PLR0913 — DI constructor, each arg is a required dependency
         self,
@@ -141,6 +141,7 @@ class Hub:
         self._rate_limit = rate_limit
         self._rate_window = rate_window
         self._pool_ttl = pool_ttl
+        self._last_eviction_check: float = 0.0
         # Sliding window: maps (platform.value, bot_id, user_id) → deque of timestamps.
         # Rate limiting is per-user (not per-scope) to prevent rate-limit bypass
         # by switching chats. Entries are removed when the deque empties.
@@ -264,11 +265,21 @@ class Hub:
         self._evict_stale_pools()
         if pool_id not in self.pools:
             self.pools[pool_id] = Pool(pool_id=pool_id, agent_name=agent_name, hub=self)
-        return self.pools[pool_id]
+        pool = self.pools[pool_id]
+        pool._touch()
+        return pool
 
     def _evict_stale_pools(self) -> None:
-        """Remove idle pools whose last activity exceeds the TTL."""
+        """Remove idle pools whose last activity exceeds the TTL.
+
+        Throttled: skips the scan if less than TTL/10 has elapsed since the
+        last check, turning the common case (nothing to evict) into a single
+        float comparison.
+        """
         now = time.monotonic()
+        if (now - self._last_eviction_check) < self._pool_ttl / 10:
+            return
+        self._last_eviction_check = now
         stale = [
             pid
             for pid, pool in self.pools.items()
@@ -277,7 +288,8 @@ class Hub:
         for pid in stale:
             del self.pools[pid]
         if stale:
-            log.info("evicted %d stale pool(s): %s", len(stale), stale)
+            log.info("evicted %d stale pool(s)", len(stale))
+            log.debug("evicted pool IDs: %s", stale)
 
     # ------------------------------------------------------------------
     # Rate limiting

--- a/src/lyra/core/pool.py
+++ b/src/lyra/core/pool.py
@@ -43,11 +43,20 @@ class Pool:
         self._turn_timeout = turn_timeout
         self._inbox: asyncio.Queue[InboundMessage] = asyncio.Queue()
         self._current_task: asyncio.Task | None = None
-        self.last_active: float = time.monotonic()
+        self._last_active: float = time.monotonic()
+
+    @property
+    def last_active(self) -> float:
+        """Monotonic timestamp of last activity (read-only for external callers)."""
+        return self._last_active
+
+    def _touch(self) -> None:
+        """Refresh last_active to now."""
+        self._last_active = time.monotonic()
 
     def submit(self, msg: InboundMessage) -> None:
         """Enqueue msg; start processing task if not running."""
-        self.last_active = time.monotonic()
+        self._touch()
         self._inbox.put_nowait(msg)
         if self._current_task is None or self._current_task.done():
             self._current_task = asyncio.create_task(

--- a/tests/core/test_hub.py
+++ b/tests/core/test_hub.py
@@ -1378,13 +1378,17 @@ async def test_dispatch_response_accepts_legacy_response() -> None:
 class TestPoolTTLEviction:
     """Hub._evict_stale_pools removes idle pools exceeding the TTL."""
 
+    @staticmethod
+    def _force_eviction_eligible(hub: Hub) -> None:
+        """Reset throttle so the next get_or_create_pool triggers eviction."""
+        hub._last_eviction_check = 0.0
+
     def test_stale_idle_pool_evicted(self) -> None:
         """An idle pool past TTL is removed on next get_or_create_pool call."""
         hub = Hub(pool_ttl=60)
         pool = hub.get_or_create_pool("p1", "agent")
-        # Simulate staleness: set last_active far in the past
-        pool.last_active -= 120
-        # Access triggers eviction
+        pool._last_active -= 120
+        self._force_eviction_eligible(hub)
         hub.get_or_create_pool("p2", "agent")
         assert "p1" not in hub.pools
         assert "p2" in hub.pools
@@ -1393,10 +1397,10 @@ class TestPoolTTLEviction:
         """A pool with a running task is never evicted, even past TTL."""
         hub = Hub(pool_ttl=60)
         pool = hub.get_or_create_pool("p1", "agent")
-        pool.last_active -= 120
-        # Simulate active task
+        pool._last_active -= 120
         pool._current_task = MagicMock()
         pool._current_task.done.return_value = False
+        self._force_eviction_eligible(hub)
         hub.get_or_create_pool("p2", "agent")
         assert "p1" in hub.pools  # not evicted — still active
 
@@ -1404,24 +1408,23 @@ class TestPoolTTLEviction:
         """A recently active idle pool is kept."""
         hub = Hub(pool_ttl=60)
         hub.get_or_create_pool("p1", "agent")
-        # Immediately create another — p1 is fresh
+        self._force_eviction_eligible(hub)
         hub.get_or_create_pool("p2", "agent")
         assert "p1" in hub.pools
 
     def test_pool_ttl_default(self) -> None:
-        """Default POOL_TTL is 3600 seconds."""
-        assert Hub.POOL_TTL == 3600
+        """Default POOL_TTL is 3600s and passes through to _pool_ttl."""
         hub = Hub()
-        assert hub._pool_ttl == 3600
+        assert hub._pool_ttl == 3600.0
 
     def test_done_task_pool_evicted(self) -> None:
         """A pool whose task finished (done()=True) is evicted when stale."""
         hub = Hub(pool_ttl=60)
         pool = hub.get_or_create_pool("p1", "agent")
-        pool.last_active -= 120
-        # Simulate a finished task (done but not yet None)
+        pool._last_active -= 120
         pool._current_task = MagicMock()
         pool._current_task.done.return_value = True
+        self._force_eviction_eligible(hub)
         hub.get_or_create_pool("p2", "agent")
         assert "p1" not in hub.pools  # evicted — task is done
 
@@ -1431,14 +1434,23 @@ class TestPoolTTLEviction:
         p1 = hub.get_or_create_pool("p1", "agent")
         hub.get_or_create_pool("p2", "agent")
         p3 = hub.get_or_create_pool("p3", "agent")
-        # Make p1 and p3 stale, keep p2 fresh
-        p1.last_active -= 120
-        p3.last_active -= 120
+        p1._last_active -= 120
+        p3._last_active -= 120
+        self._force_eviction_eligible(hub)
         hub.get_or_create_pool("p4", "agent")
         assert "p1" not in hub.pools
         assert "p3" not in hub.pools
         assert "p2" in hub.pools
         assert "p4" in hub.pools
+
+    def test_eviction_throttled(self) -> None:
+        """Eviction scan is throttled — skipped if less than TTL/10 elapsed."""
+        hub = Hub(pool_ttl=60)
+        pool = hub.get_or_create_pool("p1", "agent")
+        pool._last_active -= 120
+        # Don't reset throttle — second call is within TTL/10
+        hub.get_or_create_pool("p2", "agent")
+        assert "p1" in hub.pools  # not evicted — throttled
 
     async def test_submit_refreshes_last_active(self) -> None:
         """Pool.submit() updates last_active timestamp."""
@@ -1446,7 +1458,7 @@ class TestPoolTTLEviction:
 
         hub = Hub(pool_ttl=60)
         pool = hub.get_or_create_pool("p1", "agent")
-        pool.last_active -= 50  # nearly stale
+        pool._last_active -= 50  # nearly stale
         t0 = time.monotonic()
         msg = make_inbound_message()
         pool.submit(msg)


### PR DESCRIPTION
## Summary
- Add TTL-based eviction for `Hub.pools` to prevent unbounded memory growth
- Idle pools older than `POOL_TTL` (default 1h) are lazily evicted on each `get_or_create_pool()` call
- Active pools (with running tasks) are never evicted

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #205: fix(hub): add TTL eviction for Hub.pools to prevent memory leak | Open |
| Implementation | 1 commit on `feat/205-hub-pool-ttl-eviction` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5 new) | Passed |

## Test Plan
- [x] Stale idle pool is evicted after TTL
- [x] Active pool (running task) is not evicted even past TTL
- [x] Fresh pool is not evicted
- [x] Default TTL is 3600s
- [x] `Pool.submit()` refreshes `last_active` timestamp

Closes #205

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`