### PR TITLE
fix(pool): kill backend + log warning on turn timeout

### DIFF
--- a/src/lyra/agents/simple_agent.py
+++ b/src/lyra/agents/simple_agent.py
@@ -86,6 +86,12 @@ class SimpleAgent(AgentBase):
         """Delegate to the LlmProvider's liveness check."""
         return self._provider.is_alive(pool_id)
 
+    async def reset_backend(self, pool_id: str) -> None:
+        """Kill the backend process so the next turn gets a fresh one."""
+        reset_fn = getattr(self._provider, "reset", None)
+        if reset_fn is not None:
+            await reset_fn(pool_id)
+
     def _build_router_kwargs(self) -> dict[str, object]:
         return {
             "runtime_config_holder": self._runtime_config_holder,

--- a/src/lyra/core/agent.py
+++ b/src/lyra/core/agent.py
@@ -667,6 +667,14 @@ class AgentBase(ABC):
         """
         return True
 
+    async def reset_backend(self, _pool_id: str) -> None:
+        """Kill and reset the backend process for this pool.
+
+        Called by the pool on turn timeout to discard a potentially stuck
+        process.  Subclasses backed by persistent processes should override
+        this; the default no-op is correct for SDK-backed agents.
+        """
+
     @abstractmethod
     async def process(
         self,

--- a/src/lyra/core/pool.py
+++ b/src/lyra/core/pool.py
@@ -256,11 +256,17 @@ class Pool:
                 self._process_one(msg, agent), timeout=self._turn_timeout
             )
         except asyncio.TimeoutError:
+            log.warning(
+                "pool %s: turn timeout after %.0fs — killing backend",
+                self.pool_id,
+                self._turn_timeout,
+            )
             if not agent.is_backend_alive(self.pool_id):
                 log.error(
                     "pool %s: backend process died — timeout caused by dead process",
                     self.pool_id,
                 )
+            await agent.reset_backend(self.pool_id)
             _reply = self._msg("timeout", "Your request timed out. Please try again.")
             await self._safe_dispatch(msg, Response(content=_reply))
         except asyncio.CancelledError:

--- a/tests/core/test_pool.py
+++ b/tests/core/test_pool.py
@@ -105,6 +105,9 @@ class SlowAgent:
     def is_backend_alive(self, pool_id: str) -> bool:
         return True
 
+    async def reset_backend(self, pool_id: str) -> None:
+        pass
+
     async def process(
         self,
         msg: InboundMessage,


### PR DESCRIPTION
## Summary

- On turn timeout, the CliPool process was left alive in a broken I/O state (stdin written, stdout unconsumed), causing any subsequent message to silently hang or fail
- Add `reset_backend()` to `AgentBase` (no-op) and `SimpleAgent` (→ `provider.reset(pool_id)`) — kills the corrupted process so the next turn spawns fresh
- Add `log.warning` in the `TimeoutError` handler so timeouts are visible in logs (previously invisible when the process was still alive)

Reproduces the 2026-03-14 incident: message at 01:34:30 got no response, pool silently broken for 20 min until idle reaper killed the process.

## Test plan
- [ ] `tests/core/test_pool.py` — all 19 pool tests pass
- [ ] `test_pool_timeout_sends_timeout_reply` specifically validates timeout reply is dispatched
- [ ] Added `reset_backend()` to `SlowAgent` test mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)