### PR TITLE
feat(adapters): !join / !leave voice commands — Discord command handling

### DIFF
--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -285,6 +285,11 @@ class DiscordAdapter(discord.Client):
 
     async def _handle_leave_command(self, message: Any, guild_id: str) -> None:
         """Execute !leave: disconnect if active, reply with outcome."""
+        log.info(
+            "voice_cmd cmd=leave user=%s guild=%s",
+            getattr(message.author, "id", "?"),
+            guild_id,
+        )
         if self._vsm.get(guild_id) is None:
             await self._reply_safe(
                 message, "I'm not in a voice channel.", label="not-in-channel"
@@ -294,7 +299,11 @@ class DiscordAdapter(discord.Client):
             await self._reply_safe(message, "Left the voice channel.", label="leave")
 
     async def _handle_join_command(
-        self, message: Any, guild: Any, args: str
+        self,
+        message: Any,
+        guild: Any,
+        args: str,
+        trust: TrustLevel = TrustLevel.TRUSTED,
     ) -> None:
         """Execute !join / !join stay: connect to user's voice channel."""
         voice_state = getattr(message.author, "voice", None)
@@ -308,6 +317,13 @@ class DiscordAdapter(discord.Client):
             if args.strip().lower().split()[:1] == ["stay"]
             else VoiceMode.TRANSIENT
         )
+        if mode == VoiceMode.PERSISTENT and trust < TrustLevel.TRUSTED:
+            await self._reply_safe(
+                message,
+                "Persistent mode requires elevated permissions.",
+                label="persistent-denied",
+            )
+            mode = VoiceMode.TRANSIENT
         try:
             await self._vsm.join(guild, voice_state.channel, mode)
         except VoiceAlreadyActiveError:
@@ -320,7 +336,9 @@ class DiscordAdapter(discord.Client):
                 message, "Voice is not available right now.", label="voice-unavailable"
             )
 
-    async def _handle_voice_command(self, message: Any) -> bool:
+    async def _handle_voice_command(
+        self, message: Any, trust: TrustLevel = TrustLevel.TRUSTED
+    ) -> bool:
         """Detect and handle !join / !join stay / !leave voice commands.
 
         Returns True if a voice command was handled (caller should return early).
@@ -334,9 +352,16 @@ class DiscordAdapter(discord.Client):
         guild = message.guild
         guild_id = str(guild.id)
         if cmd.name == "leave":
+            if trust < TrustLevel.TRUSTED:
+                await self._reply_safe(
+                    message,
+                    "You don't have permission to use this command.",
+                    label="leave-denied",
+                )
+                return True
             await self._handle_leave_command(message, guild_id)
         else:
-            await self._handle_join_command(message, guild, cmd.args)
+            await self._handle_join_command(message, guild, cmd.args, trust=trust)
         return True
 
     def normalize_audio(
@@ -589,7 +614,7 @@ class DiscordAdapter(discord.Client):
         # work from any text channel without requiring a bot mention.
         # Guild guard: voice channels are guild-only; skip in DMs.
         if message.guild is not None:
-            if await self._handle_voice_command(message):
+            if await self._handle_voice_command(message, trust):
                 return
 
         # Pre-detect mention (needed for auto-thread decision)

--- a/tests/adapters/test_discord_voice.py
+++ b/tests/adapters/test_discord_voice.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import lyra.adapters.discord_voice as dv_module
-from lyra.adapters.discord import DiscordAdapter
+from lyra.adapters.discord import _ALLOW_ALL, DiscordAdapter
 from lyra.adapters.discord_voice import (
     PCMQueueSource,
     VoiceAlreadyActiveError,
@@ -19,6 +19,7 @@ from lyra.adapters.discord_voice import (
     VoiceSessionManager,
     _check_voice_deps,
 )
+from lyra.core.auth import TrustLevel
 from lyra.core.message import InboundMessage, OutboundAudioChunk
 
 _FRAME = 3840
@@ -648,7 +649,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("!join", author_voice_channel=voice_ch)
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -665,7 +666,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("/join", author_voice_channel=voice_ch)
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -682,7 +683,42 @@ class TestHandleVoiceCommand:
         msg = _make_message("!join stay", author_voice_channel=voice_ch)
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
+
+        # Assert
+        assert result is True
+        join_mock.assert_awaited_once_with(msg.guild, voice_ch, VoiceMode.PERSISTENT)
+
+    @pytest.mark.asyncio
+    async def test_join_stay_case_insensitive_is_persistent(self) -> None:
+        # Arrange — "!join STAY" (uppercase) must map to PERSISTENT
+        hub = MagicMock()
+        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        join_mock = AsyncMock()
+        adapter._vsm.join = join_mock
+        voice_ch = MagicMock()
+        msg = _make_message("!join STAY", author_voice_channel=voice_ch)
+
+        # Act
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
+
+        # Assert
+        assert result is True
+        join_mock.assert_awaited_once_with(msg.guild, voice_ch, VoiceMode.PERSISTENT)
+
+    @pytest.mark.asyncio
+    async def test_join_stay_with_extra_args_is_persistent(self) -> None:
+        # Arrange — "!join stay please" should still be PERSISTENT
+        # (prefix match on first token)
+        hub = MagicMock()
+        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        join_mock = AsyncMock()
+        adapter._vsm.join = join_mock
+        voice_ch = MagicMock()
+        msg = _make_message("!join stay please", author_voice_channel=voice_ch)
+
+        # Act
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -699,7 +735,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("!leave")
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -717,7 +753,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("!leave")
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -736,7 +772,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("hello world")
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is False
@@ -753,7 +789,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("!join", author_voice_channel=None)
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -771,7 +807,7 @@ class TestHandleVoiceCommand:
         msg.author.voice = None  # no voice attribute at all
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -789,7 +825,7 @@ class TestHandleVoiceCommand:
         msg = _make_message("!join", author_voice_channel=voice_ch)
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -810,7 +846,7 @@ class TestHandleVoiceCommand:
 
         # Act
         with caplog.at_level(logging.WARNING):
-            result = await adapter._handle_voice_command(msg)
+            result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -830,7 +866,7 @@ class TestHandleVoiceCommand:
 
         # Act
         with caplog.at_level(logging.ERROR):
-            result = await adapter._handle_voice_command(msg)
+            result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is True
@@ -847,7 +883,37 @@ class TestHandleVoiceCommand:
         msg = _make_message("!help")
 
         # Act
-        result = await adapter._handle_voice_command(msg)
+        result = await adapter._handle_voice_command(msg, TrustLevel.TRUSTED)
 
         # Assert
         assert result is False
+
+
+class TestOnMessageVoiceCommandWiring:
+    @pytest.mark.asyncio
+    async def test_voice_command_in_guild_skips_hub_push(self) -> None:
+        # Arrange — !join in a guild text channel should NOT reach hub.inbound_bus
+        hub = MagicMock()
+        hub.inbound_bus = MagicMock()
+        hub.inbound_bus.put_nowait = MagicMock()
+        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter._auth = _ALLOW_ALL  # permit the message
+        # Mock _handle_voice_command to return True (simulates voice command handled)
+        adapter._handle_voice_command = AsyncMock(return_value=True)
+
+        # Build a minimal guild message mock
+        message = MagicMock()
+        message.author.bot = False
+        message.author.id = 42
+        message.author.roles = []
+        message.guild = MagicMock()
+        message.attachments = []
+        message.content = "!join"
+        # not a Thread, not ForumChannel, not VoiceChannel
+        message.channel = MagicMock(spec=[])
+
+        # Act
+        await adapter.on_message(message)
+
+        # Assert — hub inbound bus was NOT called
+        hub.inbound_bus.put_nowait.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `_handle_voice_command()` to `DiscordAdapter`: detects `!join`, `!join stay`, `!leave` via `CommandParser` and delegates to `VoiceSessionManager`
- Wire voice command dispatch into `on_message()` before the mention/DM filter so commands work from any guild text channel without a bot mention

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #257: feat(adapters): !join / !leave voice commands | Open |
| Implementation | 1 commit on `feat/257-join-leave-voice-commands` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (9 new) | Passed |

## Test Plan
- [ ] `!join` in a text channel with user in a voice channel → Lyra joins in TRANSIENT mode
- [ ] `!join stay` → Lyra joins in PERSISTENT mode (stays after stream ends)
- [ ] `!leave` → Lyra disconnects and clears session
- [ ] `!join` when already connected → reply "Already in a voice channel."
- [ ] `!join` when user not in a voice channel → reply "Join a voice channel first."
- [ ] Non-voice commands (e.g. `!help`, regular text) → pass through to normal dispatch unaffected
- [ ] Voice commands in DMs → skipped (guild guard)

Closes #257

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`