### PR TITLE
feat(agent): add AgentRefiner — patch + interactive refine CLI

### DIFF
--- a/src/lyra/cli_agent_crud.py
+++ b/src/lyra/cli_agent_crud.py
@@ -404,7 +404,7 @@ def refine(
     name: str = typer.Argument(..., help="Agent name to refine."),
 ) -> None:
     """Interactively refine an agent profile via LLM-guided session."""
-    from lyra.core.agent_refiner import AgentRefiner, TerminalIO
+    from lyra.core.agent_refiner import AgentRefiner, RefinementCancelled, TerminalIO
 
     async def _run() -> None:
         store = await _connect_store()
@@ -417,7 +417,7 @@ def refine(
             before_row = store.get(name)
             try:
                 patch = refiner.run_session(io)
-            except KeyboardInterrupt:
+            except RefinementCancelled:
                 typer.echo("\nRefinement session cancelled.")
                 raise typer.Exit(0)
             except RuntimeError as e:

--- a/src/lyra/core/agent_refiner.py
+++ b/src/lyra/core/agent_refiner.py
@@ -15,11 +15,21 @@ __all__ = [
     "AgentRefiner",
     "LlmProvider",
     "REFINABLE_FIELDS",
+    "RefinementCancelled",
     "RefinementContext",
     "RefinementPatch",
     "SdkLlmProvider",
     "TerminalIO",
 ]
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RefinementCancelled(Exception):
+    """Raised when the operator aborts an interactive refinement session."""
+
 
 # ---------------------------------------------------------------------------
 # Allow-list of patchable AgentRow fields
@@ -114,7 +124,12 @@ class LlmProvider(Protocol):
 class SdkLlmProvider:
     """Anthropic SDK-based LLM provider (sync)."""
 
-    def __init__(self, api_key: str, model: str = "claude-haiku-4-5-20251001") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        # Haiku: lowest latency/cost for interactive CLI session
+        model: str = "claude-haiku-4-5-20251001",
+    ) -> None:
         import anthropic
 
         self._client = anthropic.Anthropic(api_key=api_key)
@@ -222,7 +237,7 @@ class AgentRefiner:
                 turn -= 1  # don't count empty prompts against the limit
                 continue
             if user_input.lower() in ("quit", "exit", "abort"):
-                raise KeyboardInterrupt("Session aborted by user.")
+                raise RefinementCancelled("Session aborted by user.")
 
             waiting_for_confirmation = user_input.lower().strip(".!") in _CONFIRM_WORDS
 

--- a/tests/core/test_agent_refiner.py
+++ b/tests/core/test_agent_refiner.py
@@ -11,6 +11,7 @@ import pytest
 from lyra.core.agent_models import AgentRow
 from lyra.core.agent_refiner import (
     AgentRefiner,
+    RefinementCancelled,
     RefinementContext,
     RefinementPatch,
     TerminalIO,
@@ -127,7 +128,7 @@ class TestReadProfile:
 
         # Assert — RefinementContext is frozen
         assert isinstance(ctx, RefinementContext)
-        with pytest.raises((AttributeError, TypeError)):
+        with pytest.raises(AttributeError):
             ctx.agent_name = "new_name"  # type: ignore[misc]
 
 
@@ -214,6 +215,14 @@ class TestRefinementPatch:
 
 class TestPatchCommand:
     """lyra agent patch — CLI integration via typer CliRunner."""
+
+    @pytest.fixture()
+    def cli(self):
+        from typer.testing import CliRunner
+
+        from lyra.cli_agent import agent_app
+
+        return CliRunner(), agent_app
 
     def test_patch_command_success(self) -> None:
         # Arrange
@@ -311,6 +320,7 @@ class TestPatchInvalidJson:
 
         from lyra.cli_agent import agent_app
 
+        # Typer's CliRunner merges stderr into output by default — no mix_stderr needed
         runner = CliRunner()
 
         # Act
@@ -452,7 +462,7 @@ class TestRunSession:
         refiner = AgentRefiner("lyra_default", store, driver=mock_driver)
 
         # Act + Assert
-        with pytest.raises(KeyboardInterrupt):
+        with pytest.raises(RefinementCancelled):
             refiner.run_session(mock_io)
 
         # Assert driver was called only for the greeting, not again after abort
@@ -473,7 +483,7 @@ class TestRunSession:
         refiner = AgentRefiner("lyra_default", store, driver=mock_driver)
 
         # Act + Assert
-        with pytest.raises(KeyboardInterrupt):
+        with pytest.raises(RefinementCancelled):
             refiner.run_session(mock_io)
 
 
@@ -683,7 +693,7 @@ class TestRefineCommand:
             "lyra.cli_agent_crud._connect_store", side_effect=fake_connect
         ), mock_patch(
             "lyra.core.agent_refiner.AgentRefiner.run_session",
-            side_effect=KeyboardInterrupt(),
+            side_effect=RefinementCancelled(),
         ):
             result = runner.invoke(agent_app, ["refine", "lyra_default"])
 


### PR DESCRIPTION
## Summary

- Add `AgentRefiner` core (`RefinementContext`, `RefinementPatch`, `TerminalIO`, `SdkLlmProvider`) in `src/lyra/core/agent_refiner.py`
- Add `lyra agent patch <name> --json '{...}'` — non-interactive partial AgentRow update (used by bot passthrough and Claude Code skill)
- Add `lyra agent refine <name>` — LLM-guided interactive session: reads profile, proposes field changes, writes confirmed patch to DB
- Register "refine" passthrough in `lyra_default` and `aryl_default` DB rows so `/refine` is forwarded to Claude in-chat
- Create `~/projects/lyra-plugins/` marketplace with `refine-agent` SKILL.md; register as `lyra-marketplace` in `~/.claude/settings.json`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #352: feat: agent profile refiner — CLI + bot passthrough + Claude Code skill | Open |
| Analysis | — (F-lite: skipped) | Absent |
| Spec | [352-agent-profile-refiner-spec.mdx](artifacts/specs/352-agent-profile-refiner-spec.mdx) | Present |
| Plan | [352-agent-profile-refiner-plan.mdx](artifacts/plans/352-agent-profile-refiner-plan.mdx) | Present |
| Implementation | 1 commit on `feat/352-agent-profile-refiner` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (30 new) | Passed |

## Test Plan

- [ ] `lyra agent patch lyra_default --json '{"model": "claude-opus-4-6"}'` — applies and prints "Patched"
- [ ] `lyra agent patch lyra_default --json 'not-json'` — exits 1 with "invalid JSON"
- [ ] `lyra agent refine --help` — shows usage
- [ ] `sqlite3 ~/.lyra/auth.db "SELECT name, passthroughs_json FROM agents;"` — both agents include "refine"
- [ ] `lyra agent refine <name>` with `ANTHROPIC_API_KEY` set — starts interactive session
- [ ] `lyra agent refine unknown` — exits with clear error
- [ ] `~/projects/lyra-plugins/.claude-plugin/marketplace.json` — valid JSON, `lyra-marketplace` in `~/.claude/settings.json`

Closes #352

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`