### PR TITLE
feat(pipeline): notify user when session silently falls through to fresh start

### DIFF
--- a/src/lyra/core/message_pipeline.py
+++ b/src/lyra/core/message_pipeline.py
@@ -286,8 +286,10 @@ class MessagePipeline:
             )
 
         # Path 3: last-active-session — skip group chats (cross-user risk).
+        # Always SKIPPED for group chats regardless of path2_attempted: the resume
+        # was a deliberate safety skip, not a failure, so no notification is warranted.
         if msg.platform_meta.get("is_group"):
-            return ResumeStatus.FRESH if path2_attempted else ResumeStatus.SKIPPED
+            return ResumeStatus.SKIPPED
         if pool.is_idle and self._hub._turn_store is not None:
             last_sid = await self._hub._turn_store.get_last_session(pool_id)
             if last_sid is None:

--- a/tests/core/test_message_pipeline_context.py
+++ b/tests/core/test_message_pipeline_context.py
@@ -7,7 +7,7 @@ import asyncio
 import dataclasses
 from unittest.mock import patch
 
-from lyra.core.message_pipeline import MessagePipeline, ResumeStatus
+from lyra.core.message_pipeline import Action, MessagePipeline, ResumeStatus
 from tests.core.conftest import _make_hub, make_inbound_message
 
 # -------------------------------------------------------------------
@@ -407,6 +407,35 @@ class TestResolveContextResumeStatus:
 
         assert status == ResumeStatus.SKIPPED
 
+    async def test_path2_rejected_group_chat_returns_skipped(self) -> None:
+        """Path 2 rejected in a group chat → SKIPPED (silent, no notification).
+
+        Group-chat resume is a deliberate safety skip regardless of whether
+        path 2 was attempted — broadcasting session-state into a shared channel
+        would leak per-user context to all participants.
+        """
+        pool_id = "telegram:main:chat:42"
+        hub = _make_hub()
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+
+        async def _rejected_resume(sid: str) -> bool:
+            return False
+
+        pool._session_resume_fn = _rejected_resume  # type: ignore[attr-defined]
+
+        _base = make_inbound_message(scope_id="chat:42")
+        _meta = {
+            **_base.platform_meta,
+            "thread_session_id": "tss-dead",
+            "is_group": True,
+        }
+        msg = dataclasses.replace(_base, platform_meta=_meta)
+        pipeline = MessagePipeline(hub)
+
+        status = await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]
+
+        assert status == ResumeStatus.SKIPPED
+
 
 # -------------------------------------------------------------------
 # T7.2 — _submit_to_pool notification on FRESH (#380)
@@ -443,8 +472,9 @@ class TestNotifySessionFallthrough:
             from lyra.core.message import Platform
 
             key = RoutingKey(Platform("telegram"), "main", "chat:42")
-            await pipeline._submit_to_pool(msg, pool, key)  # type: ignore[attr-defined]
+            result = await pipeline._submit_to_pool(msg, pool, key)  # type: ignore[attr-defined]
 
+        assert result.action == Action.SUBMIT_TO_POOL
         assert len(notify_calls) == 1
         platform_called, text_called = notify_calls[0]
         assert platform_called == "telegram"
@@ -477,8 +507,9 @@ class TestNotifySessionFallthrough:
             from lyra.core.message import Platform
 
             key = RoutingKey(Platform("telegram"), "main", "chat:42")
-            await pipeline._submit_to_pool(msg, pool, key)  # type: ignore[attr-defined]
+            result = await pipeline._submit_to_pool(msg, pool, key)  # type: ignore[attr-defined]
 
+        assert result.action == Action.SUBMIT_TO_POOL
         assert notify_calls == []
 
     async def test_no_notify_when_skipped(self) -> None:
@@ -501,6 +532,7 @@ class TestNotifySessionFallthrough:
             from lyra.core.message import Platform
 
             key = RoutingKey(Platform("telegram"), "main", "chat:42")
-            await pipeline._submit_to_pool(msg, pool, key)  # type: ignore[attr-defined]
+            result = await pipeline._submit_to_pool(msg, pool, key)  # type: ignore[attr-defined]
 
+        assert result.action == Action.SUBMIT_TO_POOL
         assert notify_calls == []


### PR DESCRIPTION
## Summary
- `_resolve_context()` now returns a `ResumeStatus` enum (`RESUMED` / `FRESH` / `SKIPPED`) instead of `None`, exposing what actually happened to callers
- When Path 2 (thread-session-resume) is attempted but rejected (pruned / expired session), `_submit_to_pool` fires a pre-response warning via the existing `try_notify_user` helper *before* dispatching to Claude — user sees: _⚠️ Couldn't resume your previous session — starting fresh._
- Path 3 rescue still returns `RESUMED` (no notification). Pool-busy and no-prior-session cases return `SKIPPED` (silent, expected)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #380: feat(pipeline): notify user when session silently falls through to fresh start | Open |
| Implementation | 1 commit on `feat/380-notify-session-fallthrough` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (9 new, 1886 total) | Passed |

## Test Plan
- [ ] Send a message with a `thread_session_id` that maps to a pruned/expired session — bot replies with ⚠️ warning, then Claude's normal response
- [ ] Normal first-use message (no `thread_session_id`) — no warning, silent as before
- [ ] Reply-to-resume or last-active-session rescues the session — no warning, `RESUMED` returned
- [ ] Pool busy when `thread_session_id` present — no warning (`SKIPPED`), not treated as surprising

Closes #380

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`