### PR TITLE
feat(stream): P3 — StreamProcessor (LlmEvent → RenderEvent)

### DIFF
--- a/src/lyra/core/stream_processor.py
+++ b/src/lyra/core/stream_processor.py
@@ -68,6 +68,9 @@ class StreamProcessor:
         # --- pending text ---
         self._pending_text: str = ""
 
+        # --- reuse guard ---
+        self._consumed: bool = False
+
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
@@ -90,6 +93,7 @@ class StreamProcessor:
             ``ToolSummaryRenderEvent`` mid-turn (throttled) and at turn end
             (unconditional), followed by ``TextRenderEvent`` at turn end.
         """
+        self._mark_consumed()
         _result_received = False
         async for event in events:
             if isinstance(event, TextLlmEvent):
@@ -98,24 +102,33 @@ class StreamProcessor:
             elif isinstance(event, ToolUseLlmEvent):
                 self._accumulate(event)
                 if self._should_emit() and self._has_any_tool_events():
-                    yield self._snapshot()
+                    yield self._emit_snapshot()
 
             elif isinstance(event, ResultLlmEvent):
                 _result_received = True
                 if self._has_any_tool_events():
-                    yield self._snapshot(is_complete=True)
+                    yield self._emit_snapshot(is_complete=True)
                 yield TextRenderEvent(text=self._pending_text, is_final=True)
 
         # Stream ended without ResultLlmEvent (truncation or upstream error)
         if not _result_received:
             if self._has_any_tool_events():
-                yield self._snapshot(is_complete=True)
+                yield self._emit_snapshot(is_complete=True)
             if self._pending_text:
                 yield TextRenderEvent(text=self._pending_text, is_final=False)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _mark_consumed(self) -> None:
+        """Guard against reuse — raise if process() was already called."""
+        if self._consumed:
+            raise RuntimeError(
+                "StreamProcessor.process() called more than once. "
+                "Create a new instance per turn."
+            )
+        self._consumed = True
 
     def _accumulate_web(
         self, event: ToolUseLlmEvent, *, show_key: str, input_key: str
@@ -180,8 +193,8 @@ class StreamProcessor:
         elapsed = time.monotonic() - self._last_tool_emit
         return elapsed >= self._config.throttle_ms / 1000
 
-    def _snapshot(self, *, is_complete: bool = False) -> ToolSummaryRenderEvent:
-        """Build a ``ToolSummaryRenderEvent`` from a safe copy of all accumulators.
+    def _emit_snapshot(self, *, is_complete: bool = False) -> ToolSummaryRenderEvent:
+        """Emit a ``ToolSummaryRenderEvent`` from a safe copy of all accumulators.
 
         Side-effect: updates ``_last_tool_emit`` to ``time.monotonic()``.
         """

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -208,6 +208,8 @@ class TestStreamProcessor:
         ]
         assert len(final_summaries) == 1
         assert len(final_summaries[0].files) == 2
+        assert "a.py" in final_summaries[0].files
+        assert "b.py" in final_summaries[0].files
 
     # ------------------------------------------------------------------
     # T14 — Three files at group_threshold (SC-5)
@@ -233,6 +235,9 @@ class TestStreamProcessor:
         ]
         assert len(final_summaries) == 1
         assert len(final_summaries[0].files) == 3
+        assert "a.py" in final_summaries[0].files
+        assert "b.py" in final_summaries[0].files
+        assert "c.py" in final_summaries[0].files
 
     # ------------------------------------------------------------------
     # T15 — 80 edits over 5 files (SC-4, SC-5)


### PR DESCRIPTION
## Summary
- Implement channel-agnostic `StreamProcessor` (core/stream_processor.py) — the domain layer that aggregates `AsyncIterator[LlmEvent]` into `AsyncIterator[RenderEvent]` with config-driven thresholds, throttling, and per-tool visibility rules
- 16 unit tests covering all accumulation paths, threshold boundaries, throttle behaviour, and hexagonal boundary; zero network calls

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #385: arch(stream): P3 — StreamProcessor (LlmEvent → RenderEvent) | Open |
| Analysis | Embedded in parent #371 + `artifacts/analyses/371-arch-stream-processor-render-event-analysis.mdx` | Present |
| Spec | [371-arch-stream-processor-render-event-spec.mdx](artifacts/specs/371-arch-stream-processor-render-event-spec.mdx) — Slice S3 | Present |
| Implementation | 1 commit on `feat/385-arch-stream-p3-stream-processor` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (16 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/core/test_stream_processor.py -v` — all 16 pass
- [ ] Edit threshold boundary: 3 edits same file → names mode; 4 edits → count mode (edits=[], count=4)
- [ ] Group threshold: 2 files → individual display; 3 files → `len(files)==3` in event
- [ ] Throttle: `throttle_ms=9_999_999` → only final snapshot emits; `throttle_ms=0` → every tool emits
- [ ] Text-only turn: only `TextRenderEvent(is_final=True)` emitted, no `ToolSummaryRenderEvent`
- [ ] Hexagonal boundary: `grep -r "import aiogram\|import discord\|import anthropic" src/lyra/core/stream_processor.py` → 0 matches

## Notes
- **WebFetch normalisation:** `"WebFetch".lower()` → `"webfetch"` (no underscore). Accumulator matches both `"web_fetch"` and `"webfetch"` forms. P4 adapter should normalise tool names consistently.
- P3 is fully parallel with P2 — `StreamProcessor` only depends on the `LlmEvent`/`RenderEvent` types (P1 ✅), not on `LlmProvider.stream()` (P2).
- `ToolDisplayConfig.defaults()` used when no config injected; bootstrap wiring deferred to P5 (already merged).

Closes #385

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`