### PR TITLE
fix(adapters): user-scoped scope_id for shared spaces

### DIFF
--- a/src/lyra/adapters/discord_audio.py
+++ b/src/lyra/adapters/discord_audio.py
@@ -13,6 +13,7 @@ from lyra.core.message import (
     Platform,
     RoutingContext,
 )
+from lyra.core.scope import user_scoped
 
 if TYPE_CHECKING:
     from lyra.adapters.discord import DiscordAdapter
@@ -69,6 +70,10 @@ def normalize_audio(
     is_thread = isinstance(raw.channel, discord.Thread)
     scope_id = f"thread:{raw.channel.id}" if is_thread else f"channel:{raw.channel.id}"
     user_id = f"dc:user:{raw.author.id}"
+    # User-scope guild channels for audio too (#356).
+    is_guild_channel = raw.guild is not None and not is_thread
+    if is_guild_channel:
+        scope_id = user_scoped(scope_id, user_id)
     timestamp = raw.created_at
     platform_meta = {
         "guild_id": raw.guild.id if raw.guild else None,

--- a/src/lyra/adapters/discord_normalize.py
+++ b/src/lyra/adapters/discord_normalize.py
@@ -58,6 +58,15 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
         else f"channel:{resolved_channel_id}"
     )
 
+    # User-scope guild channels so each user gets their own pool (#356).
+    # Threads and DMs are left as-is (single-user or thread-session-resume).
+    user_id = f"dc:user:{raw.author.id}"
+    is_guild_channel = raw.guild is not None and not resolved_thread_id
+    if is_guild_channel:
+        from lyra.core.scope import user_scoped
+
+        scope_id = user_scoped(scope_id, user_id)
+
     # Detect channel type
     channel_type: str = "text"
     if is_thread:
@@ -68,7 +77,6 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
         channel_type = "voice"
 
     timestamp = raw.created_at
-    user_id = f"dc:user:{raw.author.id}"
 
     log.debug(
         "Normalizing discord message id=%s from user_id=%s",

--- a/src/lyra/adapters/discord_normalize.py
+++ b/src/lyra/adapters/discord_normalize.py
@@ -14,6 +14,7 @@ from lyra.core.message import (
     Platform,
     RoutingContext,
 )
+from lyra.core.scope import user_scoped
 from lyra.core.trust import TrustLevel
 
 if TYPE_CHECKING:
@@ -63,8 +64,6 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
     user_id = f"dc:user:{raw.author.id}"
     is_guild_channel = raw.guild is not None and not resolved_thread_id
     if is_guild_channel:
-        from lyra.core.scope import user_scoped
-
         scope_id = user_scoped(scope_id, user_id)
 
     # Detect channel type

--- a/src/lyra/adapters/telegram_inbound.py
+++ b/src/lyra/adapters/telegram_inbound.py
@@ -117,7 +117,10 @@ async def handle_voice_message(adapter: TelegramAdapter, msg: Any) -> None:
     chat_id: int = msg.chat.id
     message_id: int | None = msg.message_id
     user_id = f"tg:user:{msg.from_user.id}"
-    scope_id = _make_scope_id(chat_id, msg.message_thread_id)
+    is_group = msg.chat.type != "private"
+    scope_id = _make_scope_id(
+        chat_id, msg.message_thread_id, user_id=user_id, is_group=is_group
+    )
     log.info(
         "audio_received",
         extra={

--- a/src/lyra/adapters/telegram_inbound.py
+++ b/src/lyra/adapters/telegram_inbound.py
@@ -118,6 +118,8 @@ async def handle_voice_message(adapter: TelegramAdapter, msg: Any) -> None:
     message_id: int | None = msg.message_id
     user_id = f"tg:user:{msg.from_user.id}"
     is_group = msg.chat.type != "private"
+    # scope_id is computed here for early logging; normalize_audio() recomputes
+    # it independently with the same arguments (both call _make_scope_id).
     scope_id = _make_scope_id(
         chat_id, msg.message_thread_id, user_id=user_id, is_group=is_group
     )

--- a/src/lyra/adapters/telegram_normalize.py
+++ b/src/lyra/adapters/telegram_normalize.py
@@ -13,6 +13,7 @@ from lyra.core.message import (
     Platform,
     RoutingContext,
 )
+from lyra.core.scope import user_scoped
 from lyra.core.trust import TrustLevel
 
 if TYPE_CHECKING:
@@ -91,8 +92,6 @@ def _make_scope_id(
     In shared spaces (groups, supergroups) the scope includes the user
     identity so that each user gets their own pool (#356).
     """
-    from lyra.core.scope import user_scoped
-
     if topic_id is not None:
         base = f"chat:{chat_id}:topic:{topic_id}"
     else:

--- a/src/lyra/adapters/telegram_normalize.py
+++ b/src/lyra/adapters/telegram_normalize.py
@@ -79,11 +79,25 @@ def _extract_attachments(msg: Any) -> list[Attachment]:
     return result
 
 
-def _make_scope_id(chat_id: int, topic_id: int | None) -> str:
-    """Build the canonical scope_id for a Telegram chat/topic."""
+def _make_scope_id(
+    chat_id: int,
+    topic_id: int | None,
+    *,
+    user_id: str,
+    is_group: bool,
+) -> str:
+    """Build the canonical scope_id for a Telegram chat/topic.
+
+    In shared spaces (groups, supergroups) the scope includes the user
+    identity so that each user gets their own pool (#356).
+    """
+    from lyra.core.scope import user_scoped
+
     if topic_id is not None:
-        return f"chat:{chat_id}:topic:{topic_id}"
-    return f"chat:{chat_id}"
+        base = f"chat:{chat_id}:topic:{topic_id}"
+    else:
+        base = f"chat:{chat_id}"
+    return user_scoped(base, user_id) if is_group else base
 
 
 def _build_routing(  # noqa: PLR0913 — groups related metadata fields
@@ -143,7 +157,10 @@ def normalize(
 
     chat_id: int = raw.chat.id
     topic_id: int | None = raw.message_thread_id
-    scope_id = _make_scope_id(chat_id, topic_id)
+    user_id = f"tg:user:{raw.from_user.id}"
+    scope_id = _make_scope_id(
+        chat_id, topic_id, user_id=user_id, is_group=is_group
+    )
 
     text = raw.text or getattr(raw, "caption", None) or ""
     # Strip @mention prefix so content reaches the agent clean (align with Discord)
@@ -153,8 +170,6 @@ def normalize(
     timestamp = raw.date
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=timezone.utc)
-
-    user_id = f"tg:user:{raw.from_user.id}"
 
     log.debug(
         "Normalizing message from user_id=%s in chat_id=%s",
@@ -212,7 +227,11 @@ def normalize_audio(
         )
     chat_id: int = raw.chat.id
     topic_id: int | None = getattr(raw, "message_thread_id", None)
-    scope_id = _make_scope_id(chat_id, topic_id)
+    is_group = raw.chat.type != "private"
+    user_id = f"tg:user:{raw.from_user.id}"
+    scope_id = _make_scope_id(
+        chat_id, topic_id, user_id=user_id, is_group=is_group
+    )
     voice = raw.voice or raw.audio or getattr(raw, "video_note", None)
     duration_ms: int | None = None
     if voice is not None:
@@ -223,9 +242,7 @@ def normalize_audio(
     timestamp = raw.date
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=timezone.utc)
-    user_id = f"tg:user:{raw.from_user.id}"
     message_id = getattr(raw, "message_id", None)
-    is_group = raw.chat.type != "private"
     platform_meta, routing = _build_routing(
         adapter, chat_id, topic_id, message_id, scope_id, is_group
     )

--- a/src/lyra/core/hub/message_pipeline.py
+++ b/src/lyra/core/hub/message_pipeline.py
@@ -302,12 +302,7 @@ class MessagePipeline:
                 pool_id, str(msg.reply_to_id)
             )
             if session_id is not None:
-                if msg.platform_meta.get("is_group"):
-                    log.info(
-                        "reply-to-resume: group chat"
-                        " — skipping resume (cross-user risk)",
-                    )
-                elif not pool.is_idle:
+                if not pool.is_idle:
                     log.info(
                         "reply-to-resume: pool %r busy — skipping resume of session %r",
                         pool_id,
@@ -347,11 +342,9 @@ class MessagePipeline:
                 thread_session_id,
             )
 
-        # Path 3: last-active-session — skip group chats (cross-user risk).
-        # Always SKIPPED for group chats regardless of path2_attempted: the resume
-        # was a deliberate safety skip, not a failure, so no notification is warranted.
-        if msg.platform_meta.get("is_group"):
-            return ResumeStatus.SKIPPED
+        # Path 3: last-active-session.
+        # Group-chat is_group guards removed (#356) — scope_id is now user-scoped
+        # in shared spaces, so each user has their own pool by construction.
         if pool.is_idle and self._hub._turn_store is not None:
             last_sid = await self._hub._turn_store.get_last_session(pool_id)
             if last_sid is None:

--- a/src/lyra/core/scope.py
+++ b/src/lyra/core/scope.py
@@ -18,6 +18,9 @@ def user_scoped(scope_id: str, user_id: str) -> str:
     Call this from an adapter's ``normalize()`` when the message originates
     from a shared space (Telegram group, Discord guild channel, etc.).
 
+    **Not idempotent** — calling twice produces a corrupted scope_id.
+    Callers must ensure this is called exactly once per shared-space message.
+
     >>> user_scoped("chat:42", "tg:user:1")
     'chat:42:user:tg:user:1'
     """

--- a/src/lyra/core/scope.py
+++ b/src/lyra/core/scope.py
@@ -1,0 +1,24 @@
+"""Scope helpers — shared utilities for scope_id computation.
+
+Adapters compute ``scope_id`` deterministically from platform-specific
+routing data.  For shared spaces (groups, guild channels) the scope must
+include the user identity so that each user gets their own pool.
+
+The helper lives in ``core/`` because it is imported by multiple adapters;
+it produces a value that flows *into* core (via ``RoutingKey``), not out of
+it — ``RoutingKey.to_pool_id()`` treats ``scope_id`` as an opaque string.
+"""
+
+from __future__ import annotations
+
+
+def user_scoped(scope_id: str, user_id: str) -> str:
+    """Append user identity to a scope_id for shared-space isolation.
+
+    Call this from an adapter's ``normalize()`` when the message originates
+    from a shared space (Telegram group, Discord guild channel, etc.).
+
+    >>> user_scoped("chat:42", "tg:user:1")
+    'chat:42:user:tg:user:1'
+    """
+    return f"{scope_id}:user:{user_id}"

--- a/tests/adapters/test_discord_audio.py
+++ b/tests/adapters/test_discord_audio.py
@@ -70,7 +70,7 @@ def test_normalize_audio_attachment_fields() -> None:
     )
     assert isinstance(result, InboundAudio)
     assert result.id.startswith("discord:dc:user:42:")
-    assert result.scope_id == "channel:333"
+    assert result.scope_id == "channel:333:user:dc:user:42"
     assert result.mime_type == "audio/ogg"
     assert result.duration_ms is None
     assert result.file_id is None
@@ -90,7 +90,7 @@ def test_normalize_audio_channel_scope_id() -> None:
     result = adapter.normalize_audio(
         msg, b"x", "audio/ogg", trust_level=TrustLevel.TRUSTED
     )
-    assert result.scope_id == "channel:333"
+    assert result.scope_id == "channel:333:user:dc:user:42"
 
 
 def test_normalize_audio_thread_scope_id() -> None:

--- a/tests/adapters/test_discord_normalize.py
+++ b/tests/adapters/test_discord_normalize.py
@@ -41,7 +41,7 @@ def test_normalize_builds_correct_discord_context() -> None:
 
     assert isinstance(msg, InboundMessage)
     assert msg.platform == "discord"
-    assert msg.scope_id == "channel:333"
+    assert msg.scope_id == "channel:333:user:dc:user:42"
     assert msg.platform_meta["guild_id"] == 111
     assert msg.platform_meta["channel_id"] == 333
     assert msg.platform_meta["message_id"] == 555
@@ -328,3 +328,123 @@ def test_discord_token_not_in_logs(
         assert secret_token not in record.getMessage(), (
             f"Token found in log at {record.levelname}: {record.getMessage()!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# #356 — user-scoped scope_id in shared spaces
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_guild_channel_user_scoped_scope_id() -> None:
+    """Guild text channel → scope_id includes user_id suffix."""
+    from lyra.adapters.discord import DiscordAdapter
+    from lyra.core.message import InboundMessage
+
+    hub = MagicMock()
+    adapter = DiscordAdapter(
+        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+    discord_msg = SimpleNamespace(
+        guild=SimpleNamespace(id=111),
+        channel=SimpleNamespace(id=333, send=AsyncMock()),
+        author=SimpleNamespace(id=42, name="Alice", display_name="Alice", bot=False),
+        content="hello",
+        created_at=datetime.now(timezone.utc),
+        id=555,
+        mentions=[],
+    )
+
+    msg = adapter.normalize(discord_msg)
+
+    assert isinstance(msg, InboundMessage)
+    assert msg.scope_id == "channel:333:user:dc:user:42"
+    assert msg.user_id == "dc:user:42"
+
+
+def test_normalize_dm_scope_id_unchanged() -> None:
+    """Discord DM (guild=None) → scope_id has no user suffix (regression)."""
+    from lyra.adapters.discord import DiscordAdapter
+
+    hub = MagicMock()
+    adapter = DiscordAdapter(
+        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+    discord_msg = SimpleNamespace(
+        guild=None,
+        channel=SimpleNamespace(id=777, send=AsyncMock()),
+        author=SimpleNamespace(id=42, name="Alice", display_name="Alice", bot=False),
+        content="hello",
+        created_at=datetime.now(timezone.utc),
+        id=555,
+        mentions=[],
+    )
+
+    msg = adapter.normalize(discord_msg)
+
+    assert msg.scope_id == "channel:777"
+
+
+def test_normalize_thread_scope_id_unchanged() -> None:
+    """Discord thread → scope_id uses thread: prefix, no user suffix (regression)."""
+    from lyra.adapters.discord import DiscordAdapter
+
+    hub = MagicMock()
+    adapter = DiscordAdapter(
+        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+    discord_msg = SimpleNamespace(
+        guild=SimpleNamespace(id=111),
+        channel=discord.Thread.__new__(discord.Thread),
+        author=SimpleNamespace(id=42, name="Alice", display_name="Alice", bot=False),
+        content="hello",
+        created_at=datetime.now(timezone.utc),
+        id=555,
+        mentions=[],
+    )
+    # Simulate thread channel with id
+    discord_msg.channel.id = 888
+
+    msg = adapter.normalize(discord_msg, thread_id=888)
+
+    assert msg.scope_id == "thread:888"
+
+
+def test_two_users_same_guild_channel_get_distinct_pool_ids() -> None:
+    """Two users in the same guild channel → distinct scope_ids → distinct pool_ids."""
+    from lyra.adapters.discord import DiscordAdapter
+    from lyra.core.hub.hub_protocol import RoutingKey
+    from lyra.core.message import Platform
+
+    hub = MagicMock()
+    adapter = DiscordAdapter(
+        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+    def _make_guild_msg(user_id: int, user_name: str) -> object:
+        return SimpleNamespace(
+            guild=SimpleNamespace(id=111),
+            channel=SimpleNamespace(id=333, send=AsyncMock()),
+            author=SimpleNamespace(
+                id=user_id, name=user_name, display_name=user_name, bot=False
+            ),
+            content="hello",
+            created_at=datetime.now(timezone.utc),
+            id=555,
+            mentions=[],
+        )
+
+    msg_alice = adapter.normalize(_make_guild_msg(1, "Alice"))
+    msg_bob = adapter.normalize(_make_guild_msg(2, "Bob"))
+
+    assert msg_alice.scope_id != msg_bob.scope_id
+
+    key_alice = RoutingKey(Platform.DISCORD, "main", msg_alice.scope_id)
+    key_bob = RoutingKey(Platform.DISCORD, "main", msg_bob.scope_id)
+    assert key_alice.to_pool_id() != key_bob.to_pool_id()

--- a/tests/adapters/test_telegram_normalize_fields.py
+++ b/tests/adapters/test_telegram_normalize_fields.py
@@ -343,6 +343,31 @@ def test_normalize_group_chat_user_scoped_scope_id() -> None:
     assert msg.user_id == "tg:user:42"
 
 
+def test_normalize_group_chat_no_mention_still_user_scoped() -> None:
+    """Group chat without @mention → scope_id still includes user_id suffix."""
+    from lyra.adapters.telegram import TelegramAdapter
+
+    hub = MagicMock()
+    adapter = TelegramAdapter(
+        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+    )
+
+    aiogram_msg = SimpleNamespace(
+        chat=SimpleNamespace(id=456, type="group"),
+        from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+        text="hello everyone",
+        date=datetime.now(timezone.utc),
+        message_thread_id=None,
+        message_id=99,
+        entities=None,
+    )
+
+    msg = adapter.normalize(aiogram_msg)
+
+    assert msg.scope_id == "chat:456:user:tg:user:42"
+    assert msg.is_mention is False
+
+
 def test_normalize_forum_topic_user_scoped_scope_id() -> None:
     """Forum topic in supergroup → scope_id includes topic AND user_id suffix."""
     from lyra.adapters.telegram import TelegramAdapter

--- a/tests/adapters/test_telegram_normalize_fields.py
+++ b/tests/adapters/test_telegram_normalize_fields.py
@@ -231,7 +231,7 @@ def test_normalize_captures_topic_and_message_id_for_forum() -> None:
     assert msg.platform_meta["topic_id"] == 99
     assert msg.platform_meta["message_id"] == 777
     assert msg.platform_meta["is_group"] is True
-    assert msg.scope_id == "chat:456:topic:99"
+    assert msg.scope_id == "chat:456:topic:99:user:tg:user:42"
 
 
 def test_normalize_empty_text() -> None:
@@ -309,3 +309,119 @@ def test_normalize_reply_to_id_none_when_no_reply() -> None:
     msg = adapter.normalize(aiogram_msg)
 
     assert msg.reply_to_id is None
+
+
+# ---------------------------------------------------------------------------
+# #356 — user-scoped scope_id in shared spaces
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_group_chat_user_scoped_scope_id() -> None:
+    """Group chat → scope_id includes user_id suffix."""
+    from lyra.adapters.telegram import TelegramAdapter
+
+    hub = MagicMock()
+    adapter = TelegramAdapter(
+        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+    )
+    adapter._bot_username = "lyra_bot"
+
+    entity = SimpleNamespace(type="mention", offset=0, length=9)
+    aiogram_msg = SimpleNamespace(
+        chat=SimpleNamespace(id=456, type="group"),
+        from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+        text="@lyra_bot hello",
+        date=datetime.now(timezone.utc),
+        message_thread_id=None,
+        message_id=99,
+        entities=[entity],
+    )
+
+    msg = adapter.normalize(aiogram_msg)
+
+    assert msg.scope_id == "chat:456:user:tg:user:42"
+    assert msg.user_id == "tg:user:42"
+
+
+def test_normalize_forum_topic_user_scoped_scope_id() -> None:
+    """Forum topic in supergroup → scope_id includes topic AND user_id suffix."""
+    from lyra.adapters.telegram import TelegramAdapter
+
+    hub = MagicMock()
+    adapter = TelegramAdapter(
+        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+    )
+    adapter._bot_username = "lyra_bot"
+
+    entity = SimpleNamespace(type="mention", offset=0, length=9)
+    aiogram_msg = SimpleNamespace(
+        chat=SimpleNamespace(id=456, type="supergroup"),
+        from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+        text="@lyra_bot hello",
+        date=datetime.now(timezone.utc),
+        message_thread_id=7,
+        message_id=99,
+        entities=[entity],
+    )
+
+    msg = adapter.normalize(aiogram_msg)
+
+    assert msg.scope_id == "chat:456:topic:7:user:tg:user:42"
+
+
+def test_normalize_private_chat_scope_id_unchanged() -> None:
+    """Private chat → scope_id has no user suffix (regression)."""
+    from lyra.adapters.telegram import TelegramAdapter
+
+    hub = MagicMock()
+    adapter = TelegramAdapter(
+        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+    )
+
+    aiogram_msg = SimpleNamespace(
+        chat=SimpleNamespace(id=123, type="private"),
+        from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+        text="hello",
+        date=datetime.now(timezone.utc),
+        message_thread_id=None,
+        message_id=99,
+        entities=None,
+    )
+
+    msg = adapter.normalize(aiogram_msg)
+
+    assert msg.scope_id == "chat:123"
+
+
+def test_two_users_same_group_get_distinct_pool_ids() -> None:
+    """Two users in the same group → distinct scope_ids → distinct pool_ids."""
+    from lyra.adapters.telegram import TelegramAdapter
+    from lyra.core.hub.hub_protocol import RoutingKey
+    from lyra.core.message import Platform
+
+    hub = MagicMock()
+    adapter = TelegramAdapter(
+        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+    )
+    adapter._bot_username = "lyra_bot"
+
+    def _make_group_msg(user_id: int, user_name: str) -> object:
+        entity = SimpleNamespace(type="mention", offset=0, length=9)
+        return SimpleNamespace(
+            chat=SimpleNamespace(id=456, type="group"),
+            from_user=SimpleNamespace(id=user_id, full_name=user_name, is_bot=False),
+            text="@lyra_bot hi",
+            date=datetime.now(timezone.utc),
+            message_thread_id=None,
+            message_id=99,
+            entities=[entity],
+        )
+
+    msg_alice = adapter.normalize(_make_group_msg(1, "Alice"))
+    msg_bob = adapter.normalize(_make_group_msg(2, "Bob"))
+
+    assert msg_alice.scope_id != msg_bob.scope_id
+
+    key_alice = RoutingKey(Platform.TELEGRAM, "main", msg_alice.scope_id)
+    key_bob = RoutingKey(Platform.TELEGRAM, "main", msg_bob.scope_id)
+    assert key_alice.to_pool_id() != key_bob.to_pool_id()

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -258,7 +258,7 @@ def test_normalize_audio_private_chat_scope_id() -> None:
 
 
 def test_normalize_audio_topic_chat_scope_id() -> None:
-    """Topic chat → scope_id='chat:<id>:topic:<topic_id>'."""
+    """Topic chat → scope_id includes topic AND user suffix (#356)."""
     from lyra.core.trust import TrustLevel
 
     adapter, _ = _make_adapter()
@@ -266,7 +266,7 @@ def test_normalize_audio_topic_chat_scope_id() -> None:
     result = adapter.normalize_audio(
         msg, b"x", "audio/ogg", trust_level=TrustLevel.TRUSTED
     )
-    assert result.scope_id == "chat:42:topic:7"
+    assert result.scope_id == "chat:42:topic:7:user:tg:user:7"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -257,16 +257,28 @@ def test_normalize_audio_private_chat_scope_id() -> None:
     assert result.scope_id == "chat:42"
 
 
+def test_normalize_audio_group_chat_user_scoped_scope_id() -> None:
+    """Group chat (no topic) → scope_id includes user suffix (#356)."""
+    from lyra.core.trust import TrustLevel
+
+    adapter, _ = _make_adapter()
+    msg = _make_voice_msg(chat_id=42, chat_type="group")
+    result = adapter.normalize_audio(
+        msg, b"x", "audio/ogg", trust_level=TrustLevel.TRUSTED
+    )
+    assert result.scope_id == "chat:42:user:tg:user:7"
+
+
 def test_normalize_audio_topic_chat_scope_id() -> None:
     """Topic chat → scope_id includes topic AND user suffix (#356)."""
     from lyra.core.trust import TrustLevel
 
     adapter, _ = _make_adapter()
-    msg = _make_voice_msg(chat_id=42, topic_id=7, chat_type="supergroup")
+    msg = _make_voice_msg(chat_id=42, topic_id=7, user_id=99, chat_type="supergroup")
     result = adapter.normalize_audio(
         msg, b"x", "audio/ogg", trust_level=TrustLevel.TRUSTED
     )
-    assert result.scope_id == "chat:42:topic:7:user:tg:user:7"
+    assert result.scope_id == "chat:42:topic:7:user:tg:user:99"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_message_pipeline_context.py
+++ b/tests/core/test_message_pipeline_context.py
@@ -464,7 +464,8 @@ class TestResolveContextResumeStatus:
         hub._turn_store = _FakeTurnStore()  # type: ignore[attr-defined]
 
         _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
-        msg = dataclasses.replace(_base, platform_meta={**_base.platform_meta, "is_group": True})
+        _meta = {**_base.platform_meta, "is_group": True}
+        msg = dataclasses.replace(_base, platform_meta=_meta)
         pipeline = MessagePipeline(hub)
 
         status = await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]

--- a/tests/core/test_message_pipeline_context.py
+++ b/tests/core/test_message_pipeline_context.py
@@ -426,6 +426,8 @@ class TestResolveContextResumeStatus:
         pool._session_resume_fn = _rejected_resume  # type: ignore[attr-defined]
 
         _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
+        # is_group in platform_meta no longer affects the pipeline path since #356
+        # — included here only to document that it is now inert.
         _meta = {
             **_base.platform_meta,
             "thread_session_id": "tss-dead",
@@ -437,6 +439,38 @@ class TestResolveContextResumeStatus:
         status = await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]
 
         assert status == ResumeStatus.FRESH
+
+    async def test_path3_last_active_works_with_user_scoped_pool(self) -> None:
+        """Path 3: last-active-session works with user-scoped pool_id (#356)."""
+        pool_id = "telegram:main:chat:42:user:tg:user:alice"
+        hub = _make_hub()
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+
+        resumed: list[str] = []
+
+        async def _fake_resume(sid: str) -> bool:
+            resumed.append(sid)
+            return True
+
+        pool._session_resume_fn = _fake_resume  # type: ignore[attr-defined]
+
+        class _FakeTurnStore:
+            async def get_last_session(self, pid: str) -> str | None:
+                return "sess-alice-last" if pid == pool_id else None
+
+            async def close(self) -> None:
+                pass
+
+        hub._turn_store = _FakeTurnStore()  # type: ignore[attr-defined]
+
+        _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
+        msg = dataclasses.replace(_base, platform_meta={**_base.platform_meta, "is_group": True})
+        pipeline = MessagePipeline(hub)
+
+        status = await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]
+
+        assert status == ResumeStatus.RESUMED
+        assert resumed == ["sess-alice-last"]
 
 
 # -------------------------------------------------------------------

--- a/tests/core/test_message_pipeline_context.py
+++ b/tests/core/test_message_pipeline_context.py
@@ -134,10 +134,10 @@ class TestReplyToResumePipeline:
 
         assert resumed == []
 
-    async def test_no_resume_in_group_chat(self) -> None:
-        """Group chat guard prevents resume (cross-user risk)."""
-        pool_id = "telegram:main:chat:42"
-        mi = _StubMessageIndex({(pool_id, "tg-msg-55"): "sess-group"})
+    async def test_reply_to_resume_works_in_group_with_user_scoped_pool(self) -> None:
+        """Reply-to-resume works in groups now that pool_id is user-scoped (#356)."""
+        pool_id = "telegram:main:chat:42:user:tg:user:alice"
+        mi = _StubMessageIndex({(pool_id, "tg-msg-55"): "sess-alice"})
         hub = _make_hub()
         hub._message_index = mi  # type: ignore[assignment]
 
@@ -145,12 +145,13 @@ class TestReplyToResumePipeline:
 
         resumed: list[str] = []
 
-        async def _fake_resume(sid: str) -> None:
+        async def _fake_resume(sid: str) -> bool:
             resumed.append(sid)
+            return True
 
         pool._session_resume_fn = _fake_resume  # type: ignore[attr-defined]
 
-        _base = make_inbound_message(scope_id="chat:42")
+        _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
         msg = dataclasses.replace(
             _base,
             reply_to_id="tg-msg-55",
@@ -158,10 +159,11 @@ class TestReplyToResumePipeline:
         )
         pipeline = MessagePipeline(hub)
 
-        await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]
+        status = await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]
 
         assert mi.resolve_calls == [(pool_id, "tg-msg-55")]
-        assert resumed == []
+        assert resumed == ["sess-alice"]
+        assert status == ResumeStatus.RESUMED
 
     async def test_no_resume_when_message_index_none(self) -> None:
         """When hub._message_index is None, Path 1 is skipped entirely."""
@@ -407,14 +409,14 @@ class TestResolveContextResumeStatus:
 
         assert status == ResumeStatus.SKIPPED
 
-    async def test_path2_rejected_group_chat_returns_skipped(self) -> None:
-        """Path 2 rejected in a group chat → SKIPPED (silent, no notification).
+    async def test_path2_rejected_group_chat_returns_fresh(self) -> None:
+        """Path 2 rejected in a group chat → FRESH (no is_group guard since #356).
 
-        Group-chat resume is a deliberate safety skip regardless of whether
-        path 2 was attempted — broadcasting session-state into a shared channel
-        would leak per-user context to all participants.
+        With user-scoped pool_ids, group chats no longer need is_group guards.
+        Path 2 rejection falls through to Path 3, and without a TurnStore
+        this returns FRESH (user should be notified of fresh start).
         """
-        pool_id = "telegram:main:chat:42"
+        pool_id = "telegram:main:chat:42:user:tg:user:alice"
         hub = _make_hub()
         pool = hub.get_or_create_pool(pool_id, "lyra")
 
@@ -423,7 +425,7 @@ class TestResolveContextResumeStatus:
 
         pool._session_resume_fn = _rejected_resume  # type: ignore[attr-defined]
 
-        _base = make_inbound_message(scope_id="chat:42")
+        _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
         _meta = {
             **_base.platform_meta,
             "thread_session_id": "tss-dead",
@@ -434,7 +436,7 @@ class TestResolveContextResumeStatus:
 
         status = await pipeline._resolve_context(msg, pool, pool_id)  # type: ignore[attr-defined]
 
-        assert status == ResumeStatus.SKIPPED
+        assert status == ResumeStatus.FRESH
 
 
 # -------------------------------------------------------------------

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -95,7 +95,7 @@ class TestTelegramNormalizeRouting:
 
         msg = adapter.normalize(raw)
         assert msg.routing is not None
-        assert msg.routing.scope_id == "chat:123:topic:456"
+        assert msg.routing.scope_id == "chat:123:topic:456:user:tg:user:42"
         assert msg.routing.thread_id == "456"
 
     def test_routing_platform_meta_is_copy(self) -> None:
@@ -164,7 +164,7 @@ class TestDiscordNormalizeRouting:
         assert msg.routing is not None
         assert msg.routing.platform == "discord"
         assert msg.routing.bot_id == "main"
-        assert msg.routing.scope_id == "channel:789"
+        assert msg.routing.scope_id == "channel:789:user:dc:user:42"
         assert msg.routing.thread_id is None
         assert msg.routing.reply_to_message_id == "999"
 

--- a/tests/core/test_scope.py
+++ b/tests/core/test_scope.py
@@ -1,0 +1,26 @@
+"""Tests for lyra.core.scope — user_scoped() helper (#356)."""
+
+from __future__ import annotations
+
+from lyra.core.scope import user_scoped
+
+
+def test_user_scoped_appends_user_id() -> None:
+    """Basic case: chat scope + Telegram user."""
+    assert user_scoped("chat:42", "tg:user:1") == "chat:42:user:tg:user:1"
+
+
+def test_user_scoped_with_topic() -> None:
+    """Forum topic scope gets user suffix after topic."""
+    assert (
+        user_scoped("chat:42:topic:7", "tg:user:1")
+        == "chat:42:topic:7:user:tg:user:1"
+    )
+
+
+def test_user_scoped_discord_channel() -> None:
+    """Discord channel scope + Discord user."""
+    assert (
+        user_scoped("channel:333", "dc:user:42")
+        == "channel:333:user:dc:user:42"
+    )


### PR DESCRIPTION
## Summary
- Fix cross-user session leaking in Telegram groups and Discord guild channels by making `scope_id` user-scoped at the adapter layer
- Each user in a shared space now gets their own pool by construction, eliminating the need for defensive `is_group` guards in the resume pipeline
- Add `core/scope.py` with `user_scoped()` helper shared by both adapters

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #356: fix: session resumption in Telegram groups — scope_id must be per-user | Open |
| Spec | [356-user-scoped-session-resume-spec.mdx](artifacts/specs/356-user-scoped-session-resume-spec.mdx) | Present |
| Plan | [356-user-scoped-session-resume-plan.mdx](artifacts/plans/356-user-scoped-session-resume-plan.mdx) | Present |
| Implementation | 1 commit on `feat/356-user-scoped-scope-id` | Complete |
| Verification | Tests ✅ (2047 passed, 0 failed) | Passed |

## Changes

| File | Change |
|------|--------|
| `src/lyra/core/scope.py` | New `user_scoped()` helper |
| `src/lyra/adapters/telegram_normalize.py` | `_make_scope_id()` now user-scopes groups |
| `src/lyra/adapters/telegram_inbound.py` | Updated call site for voice messages |
| `src/lyra/adapters/discord_normalize.py` | `normalize()` now user-scopes guild channels |
| `src/lyra/core/hub/message_pipeline.py` | Removed `is_group` session guards (Path 1, 3) |

## Test Plan
- [ ] Telegram group: two users get distinct `pool_id` values
- [ ] Telegram DM: `scope_id` unchanged (`chat:{id}`)
- [ ] Telegram forum topic: `scope_id` includes topic AND user suffix
- [ ] Discord guild channel: two users get distinct `pool_id` values
- [ ] Discord DM: `scope_id` unchanged (`channel:{id}`)
- [ ] Discord thread: `scope_id` unchanged (`thread:{id}`)
- [ ] Reply-to-resume (Path 1) works in groups with user-scoped pool
- [ ] Last-active-session (Path 3) works in groups with user-scoped pool
- [ ] `is_group` admission gate in `telegram_inbound.py:72` still works (not removed)
- [ ] Full regression suite passes (2047 tests)

Closes #356

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`