### PR TITLE
refactor(hub): extract MessagePipeline into composable middleware chain

### DIFF
--- a/src/lyra/core/hub/__init__.py
+++ b/src/lyra/core/hub/__init__.py
@@ -17,6 +17,9 @@ from .middleware import (
     PipelineContext as PipelineContext,
 )
 from .middleware import (
+    PipelineMiddleware as PipelineMiddleware,
+)
+from .middleware import (
     build_default_pipeline as build_default_pipeline,
 )
 from .outbound_dispatcher import OutboundDispatcher as OutboundDispatcher
@@ -28,6 +31,7 @@ __all__ = [
     "MessagePipeline",
     "MiddlewarePipeline",
     "OutboundDispatcher",
+    "PipelineMiddleware",
     "PipelineContext",
     "PipelineResult",
     "RoutingKey",

--- a/src/lyra/core/hub/__init__.py
+++ b/src/lyra/core/hub/__init__.py
@@ -10,6 +10,15 @@ from .message_pipeline import (
 from .message_pipeline import (
     PipelineResult as PipelineResult,
 )
+from .middleware import (
+    MiddlewarePipeline as MiddlewarePipeline,
+)
+from .middleware import (
+    PipelineContext as PipelineContext,
+)
+from .middleware import (
+    build_default_pipeline as build_default_pipeline,
+)
 from .outbound_dispatcher import OutboundDispatcher as OutboundDispatcher
 
 __all__ = [
@@ -17,7 +26,10 @@ __all__ = [
     "ChannelAdapter",
     "Hub",
     "MessagePipeline",
+    "MiddlewarePipeline",
     "OutboundDispatcher",
+    "PipelineContext",
     "PipelineResult",
     "RoutingKey",
+    "build_default_pipeline",
 ]

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -22,6 +22,7 @@ from .message_pipeline import (  # noqa: F401 — public re-export (Action)
     MessagePipeline,
     PipelineResult,
 )
+from .middleware import MiddlewarePipeline, build_default_pipeline
 from .pool_manager import PoolManager
 
 if TYPE_CHECKING:
@@ -282,7 +283,7 @@ class Hub(HubOutboundMixin):
 
     async def run(self) -> None:
         """Hub bus consumer loop. Runs until cancelled."""
-        pipeline = MessagePipeline(self)
+        pipeline = build_default_pipeline(self)
         while True:
             msg = await self.inbound_bus.get()
             try:

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -17,9 +17,8 @@ from .hub_protocol import (  # noqa: F401 — public re-export
     RoutingKey,
 )
 from .hub_rate_limit import RateLimiter
-from .message_pipeline import (  # noqa: F401 — public re-export (Action)
+from .message_pipeline import (  # noqa: F401 — public re-export
     Action,
-    MessagePipeline,
     PipelineResult,
 )
 from .middleware import build_default_pipeline

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -22,7 +22,7 @@ from .message_pipeline import (  # noqa: F401 — public re-export (Action)
     MessagePipeline,
     PipelineResult,
 )
-from .middleware import MiddlewarePipeline, build_default_pipeline
+from .middleware import build_default_pipeline
 from .pool_manager import PoolManager
 
 if TYPE_CHECKING:

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -14,7 +14,7 @@ import dataclasses
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol
 
 from ..agent import AgentBase
 from ..commands.command_parser import CommandParser
@@ -26,6 +26,7 @@ from ..message import (
 )
 from ..pool import Pool
 from .message_pipeline import (
+    _DROP,
     _SESSION_FALLTHROUGH_MSG,
     Action,
     PipelineResult,
@@ -39,8 +40,6 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _command_parser = CommandParser()
-
-_DROP = PipelineResult(action=Action.DROP)
 
 
 @dataclass
@@ -69,7 +68,6 @@ class PipelineContext:
 Next = Callable[[InboundMessage, PipelineContext], Awaitable[PipelineResult]]
 
 
-@runtime_checkable
 class PipelineMiddleware(Protocol):
     """One stage of the inbound message pipeline.
 
@@ -184,7 +182,10 @@ class ResolveBindingMiddleware:
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
-        assert ctx.key is not None
+        if ctx.key is None:
+            raise RuntimeError(
+                "RateLimitMiddleware must precede ResolveBindingMiddleware"
+            )
 
         binding = ctx.hub.resolve_binding(msg)
         if binding is None:
@@ -221,8 +222,15 @@ class CreatePoolMiddleware:
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
-        assert ctx.binding is not None
-        assert ctx.agent is not None
+        if ctx.binding is None:
+            raise RuntimeError(
+                "ResolveBindingMiddleware must precede CreatePoolMiddleware"
+            )
+        if ctx.agent is None:
+            raise RuntimeError(
+                "ResolveBindingMiddleware must set ctx.agent"
+                " before CreatePoolMiddleware"
+            )
 
         pool = ctx.hub.get_or_create_pool(
             ctx.binding.pool_id,
@@ -237,6 +245,11 @@ class CreatePoolMiddleware:
         )
 
         ctx.router = getattr(ctx.agent, "command_router", None)
+
+        # Wire provider callbacks once at pool creation.
+        _agent = ctx.hub.agent_registry.get(pool.agent_name)
+        if _agent is not None and hasattr(_agent, "configure_pool"):
+            _agent.configure_pool(pool)
 
         # Parse command context and rewrite bare URLs (#99).
         cmd_ctx = _command_parser.parse(msg.text)
@@ -258,8 +271,14 @@ class CommandMiddleware:
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
-        assert ctx.pool is not None
-        assert ctx.key is not None
+        if ctx.pool is None:
+            raise RuntimeError(
+                "CreatePoolMiddleware must precede CommandMiddleware"
+            )
+        if ctx.key is None:
+            raise RuntimeError(
+                "RateLimitMiddleware must precede CommandMiddleware"
+            )
 
         router = ctx.router
         if router and router.is_command(msg):
@@ -278,13 +297,8 @@ class CommandMiddleware:
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
-        assert ctx.pool is not None
-        assert ctx.key is not None
-        pool = ctx.pool
-        key = ctx.key
-        _agent = ctx.hub.agent_registry.get(pool.agent_name)
-        if _agent is not None and hasattr(_agent, "configure_pool"):
-            _agent.configure_pool(pool)
+        pool = ctx.pool  # guaranteed non-None by __call__ guard
+        key = ctx.key  # guaranteed non-None by __call__ guard
         try:
             response = await router.dispatch(msg, pool)
         except Exception as exc:
@@ -319,8 +333,14 @@ class SubmitToPoolMiddleware:
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
-        assert ctx.pool is not None
-        assert ctx.key is not None
+        if ctx.pool is None:
+            raise RuntimeError(
+                "CreatePoolMiddleware must precede SubmitToPoolMiddleware"
+            )
+        if ctx.key is None:
+            raise RuntimeError(
+                "RateLimitMiddleware must precede SubmitToPoolMiddleware"
+            )
 
         if (ctx.key.platform, msg.bot_id) not in ctx.hub.adapter_registry:
             log.error(
@@ -346,11 +366,6 @@ class SubmitToPoolMiddleware:
         _update_fn = msg.platform_meta.get("_session_update_fn")
         if _update_fn is not None and pool._observer._session_update_fn is None:
             pool._observer.register_session_update_fn(_update_fn)
-
-        # Wire provider callbacks before _resolve_context.
-        _agent = ctx.hub.agent_registry.get(pool.agent_name)
-        if _agent is not None and hasattr(_agent, "configure_pool"):
-            _agent.configure_pool(pool)
 
         try:
             status = await self._resolve_context(msg, pool, pool.pool_id, ctx)
@@ -384,6 +399,14 @@ class SubmitToPoolMiddleware:
 
         Three paths (priority order): (1) reply-to-resume, (2) thread-session-resume,
         (3) last-active-session from TurnStore.
+
+        Returns:
+            RESUMED  — a session was successfully resumed via any path.
+            FRESH    — Path 2 was attempted but rejected (session pruned /
+                       invalid / expired); Claude will start fresh. The caller
+                       should notify the user.
+            SKIPPED  — no resume was attempted (pool busy, group chat, first
+                       use, no TurnStore, …). Silent and expected.
         """
         hub = ctx.hub
         path2_attempted = False

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from ..agent import AgentBase
@@ -26,11 +26,11 @@ from ..message import (
 )
 from ..pool import Pool
 from .message_pipeline import (
+    _SESSION_FALLTHROUGH_MSG,
     Action,
     PipelineResult,
     ResumeStatus,
     TraceHook,
-    _SESSION_FALLTHROUGH_MSG,
 )
 
 if TYPE_CHECKING:
@@ -265,19 +265,23 @@ class CommandMiddleware:
         if router and router.is_command(msg):
             _cmd = msg.text.split()[0] if msg.text else ""
             ctx.trace("processor", "command_detected", command=_cmd)
-            return await self._dispatch_command(msg, router, ctx.pool, ctx.key, ctx, next)
+            return await self._dispatch_command(
+                msg, router, ctx, next
+            )
 
         return await next(msg, ctx)
 
-    async def _dispatch_command(
+    async def _dispatch_command(  # noqa: PLR0913
         self,
         msg: InboundMessage,
         router: Any,
-        pool: Pool,
-        key: RoutingKey,
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
+        assert ctx.pool is not None
+        assert ctx.key is not None
+        pool = ctx.pool
+        key = ctx.key
         _agent = ctx.hub.agent_registry.get(pool.agent_name)
         if _agent is not None and hasattr(_agent, "configure_pool"):
             _agent.configure_pool(pool)

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -6,31 +6,26 @@ or delegates to the next middleware via ``await next(msg, ctx)``.
 
 The pipeline is strictly sequential — no concurrent fan-out, preserving FIFO
 ordering and session resume atomicity.
+
+Layout:
+  middleware.py         — protocol, context, runner, factory
+  middleware_stages.py  — stages 1–5 (guards + command dispatch)
+  middleware_submit.py  — stage 6 (pool submit + session resume)
 """
 
 from __future__ import annotations
 
-import dataclasses
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
 from ..agent import AgentBase
-from ..commands.command_parser import CommandParser
-from ..message import (
-    GENERIC_ERROR_REPLY,
-    InboundMessage,
-    Platform,
-    Response,
-)
+from ..message import InboundMessage
 from ..pool import Pool
 from .message_pipeline import (
     _DROP,
-    _SESSION_FALLTHROUGH_MSG,
-    Action,
     PipelineResult,
-    ResumeStatus,
     TraceHook,
 )
 
@@ -38,8 +33,6 @@ if TYPE_CHECKING:
     from .hub import Binding, Hub, RoutingKey
 
 log = logging.getLogger(__name__)
-
-_command_parser = CommandParser()
 
 
 @dataclass
@@ -64,7 +57,7 @@ class PipelineContext:
             log.debug("trace_hook raised — ignoring", exc_info=True)
 
 
-# Type alias for the next-middleware callback (defined after PipelineContext).
+# Type alias for the next-middleware callback.
 Next = Callable[[InboundMessage, PipelineContext], Awaitable[PipelineResult]]
 
 
@@ -120,418 +113,21 @@ class MiddlewarePipeline:
         return await _run(0, msg, ctx)
 
 
-# ──────────────────────────────────────────────────────────────────────
-# Concrete middlewares (1:1 mapping from MessagePipeline private methods)
-# ──────────────────────────────────────────────────────────────────────
-
-
-class ValidatePlatformMiddleware:
-    """Stage 1: reject messages from unknown platforms."""
-
-    async def __call__(
-        self,
-        msg: InboundMessage,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        try:
-            Platform(msg.platform)
-        except ValueError:
-            log.warning(
-                "unknown platform %r in msg id=%s — message dropped",
-                msg.platform,
-                msg.id,
-            )
-            ctx.trace(
-                "inbound",
-                "platform_invalid",
-                platform=msg.platform,
-                action=Action.DROP.value,
-            )
-            return _DROP
-        return await next(msg, ctx)
-
-
-class RateLimitMiddleware:
-    """Stage 2: drop messages that exceed the per-user rate limit."""
-
-    async def __call__(
-        self,
-        msg: InboundMessage,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        from .hub import RoutingKey  # noqa: PLC0415
-
-        key = RoutingKey(Platform(msg.platform), msg.bot_id, msg.scope_id)
-        ctx.key = key
-
-        if ctx.hub._is_rate_limited(msg):
-            log.warning("rate limit exceeded for %s — message dropped", key)
-            ctx.trace("inbound", "rate_limited", action=Action.DROP.value)
-            return _DROP
-        return await next(msg, ctx)
-
-
-class ResolveBindingMiddleware:
-    """Stage 3: resolve binding + look up agent. Sets ctx.binding, ctx.agent."""
-
-    async def __call__(
-        self,
-        msg: InboundMessage,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        if ctx.key is None:
-            raise RuntimeError(
-                "RateLimitMiddleware must precede ResolveBindingMiddleware"
-            )
-
-        binding = ctx.hub.resolve_binding(msg)
-        if binding is None:
-            log.warning("unmatched routing key %s — message dropped", ctx.key)
-            ctx.trace("pool", "no_binding", action=Action.DROP.value)
-            return _DROP
-        ctx.binding = binding
-
-        agent = ctx.hub.agent_registry.get(binding.agent_name)
-        if agent is None:
-            log.warning(
-                "no agent registered for %r (routing %s) — message dropped",
-                binding.agent_name,
-                ctx.key,
-            )
-            ctx.trace(
-                "pool",
-                "no_agent",
-                agent_name=binding.agent_name,
-                action=Action.DROP.value,
-            )
-            return _DROP
-        ctx.agent = agent
-
-        return await next(msg, ctx)
-
-
-class CreatePoolMiddleware:
-    """Stage 4: get or create the conversation pool. Sets ctx.pool, ctx.router."""
-
-    async def __call__(
-        self,
-        msg: InboundMessage,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        if ctx.binding is None:
-            raise RuntimeError(
-                "ResolveBindingMiddleware must precede CreatePoolMiddleware"
-            )
-        if ctx.agent is None:
-            raise RuntimeError(
-                "ResolveBindingMiddleware must set ctx.agent"
-                " before CreatePoolMiddleware"
-            )
-
-        pool = ctx.hub.get_or_create_pool(
-            ctx.binding.pool_id,
-            ctx.binding.agent_name,
-        )
-        ctx.pool = pool
-        ctx.trace(
-            "pool",
-            "agent_selected",
-            agent=ctx.binding.agent_name,
-            pool_id=ctx.binding.pool_id,
-        )
-
-        ctx.router = getattr(ctx.agent, "command_router", None)
-
-        # Wire provider callbacks once at pool creation.
-        _agent = ctx.hub.agent_registry.get(pool.agent_name)
-        if _agent is not None and hasattr(_agent, "configure_pool"):
-            _agent.configure_pool(pool)
-
-        # Parse command context and rewrite bare URLs (#99).
-        cmd_ctx = _command_parser.parse(msg.text)
-        if cmd_ctx is not None:
-            msg = dataclasses.replace(msg, command=cmd_ctx)
-
-        if ctx.router and hasattr(ctx.router, "prepare"):
-            msg = ctx.router.prepare(msg)
-
-        return await next(msg, ctx)
-
-
-class CommandMiddleware:
-    """Stage 5: detect and dispatch commands."""
-
-    async def __call__(
-        self,
-        msg: InboundMessage,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        if ctx.pool is None:
-            raise RuntimeError(
-                "CreatePoolMiddleware must precede CommandMiddleware"
-            )
-        if ctx.key is None:
-            raise RuntimeError(
-                "RateLimitMiddleware must precede CommandMiddleware"
-            )
-
-        router = ctx.router
-        if router and router.is_command(msg):
-            _cmd = msg.text.split()[0] if msg.text else ""
-            ctx.trace("processor", "command_detected", command=_cmd)
-            return await self._dispatch_command(
-                msg, router, ctx, next
-            )
-
-        return await next(msg, ctx)
-
-    async def _dispatch_command(  # noqa: PLR0913
-        self,
-        msg: InboundMessage,
-        router: Any,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        pool = ctx.pool  # guaranteed non-None by __call__ guard
-        key = ctx.key  # guaranteed non-None by __call__ guard
-        try:
-            response = await router.dispatch(msg, pool)
-        except Exception as exc:
-            log.exception("command dispatch failed for %s: %s", key, exc)
-            _content = (
-                ctx.hub._msg_manager.get("generic")
-                if ctx.hub._msg_manager
-                else GENERIC_ERROR_REPLY
-            )
-            response = Response(content=_content)
-            ctx.trace(
-                "outbound",
-                "command_error",
-                action=Action.COMMAND_HANDLED.value,
-            )
-            return PipelineResult(action=Action.COMMAND_HANDLED, response=response)
-
-        if response is None:  # !-prefixed command not found — fall through
-            ctx.trace("processor", "command_fallthrough")
-            return await next(msg, ctx)
-
-        ctx.trace("outbound", "command_handled", action=Action.COMMAND_HANDLED.value)
-        return PipelineResult(action=Action.COMMAND_HANDLED, response=response)
-
-
-class SubmitToPoolMiddleware:
-    """Stage 6 (terminal): validate adapter, check circuit breaker, submit."""
-
-    async def __call__(
-        self,
-        msg: InboundMessage,
-        ctx: PipelineContext,
-        next: Next,
-    ) -> PipelineResult:
-        if ctx.pool is None:
-            raise RuntimeError(
-                "CreatePoolMiddleware must precede SubmitToPoolMiddleware"
-            )
-        if ctx.key is None:
-            raise RuntimeError(
-                "RateLimitMiddleware must precede SubmitToPoolMiddleware"
-            )
-
-        if (ctx.key.platform, msg.bot_id) not in ctx.hub.adapter_registry:
-            log.error(
-                "no adapter registered for (%s, %s) — response dropped",
-                msg.platform,
-                msg.bot_id,
-            )
-            ctx.trace(
-                "outbound",
-                "no_adapter",
-                platform=msg.platform,
-                bot_id=msg.bot_id,
-                action=Action.DROP.value,
-            )
-            return _DROP
-
-        if await ctx.hub.circuit_breaker_drop(msg):
-            ctx.trace("outbound", "circuit_open", action=Action.DROP.value)
-            return _DROP
-
-        pool = ctx.pool
-        # Register session persistence callback once.
-        _update_fn = msg.platform_meta.get("_session_update_fn")
-        if _update_fn is not None and pool._observer._session_update_fn is None:
-            pool._observer.register_session_update_fn(_update_fn)
-
-        try:
-            status = await self._resolve_context(msg, pool, pool.pool_id, ctx)
-        except Exception:
-            log.warning(
-                "_resolve_context failed — continuing with active session",
-                exc_info=True,
-            )
-            status = ResumeStatus.SKIPPED
-
-        ctx.trace(
-            "outbound",
-            "message_submitted",
-            adapter=msg.platform,
-            resume_status=status.value,
-        )
-
-        if status == ResumeStatus.FRESH:
-            await self._notify_session_fallthrough(msg, ctx)
-
-        return PipelineResult(action=Action.SUBMIT_TO_POOL, pool=pool)
-
-    async def _resolve_context(  # noqa: C901
-        self,
-        msg: InboundMessage,
-        pool: Pool,
-        pool_id: str,
-        ctx: PipelineContext,
-    ) -> ResumeStatus:
-        """Attempt session resume before pool.submit().
-
-        Three paths (priority order): (1) reply-to-resume, (2) thread-session-resume,
-        (3) last-active-session from TurnStore.
-
-        Returns:
-            RESUMED  — a session was successfully resumed via any path.
-            FRESH    — Path 2 was attempted but rejected (session pruned /
-                       invalid / expired); Claude will start fresh. The caller
-                       should notify the user.
-            SKIPPED  — no resume was attempted (pool busy, group chat, first
-                       use, no TurnStore, …). Silent and expected.
-        """
-        hub = ctx.hub
-        path2_attempted = False
-
-        # Path 1: reply-to-resume via MessageIndex (#341).
-        if msg.reply_to_id is not None and hub._message_index is None:
-            log.debug("reply-to-resume: no MessageIndex configured — skipping")
-        if msg.reply_to_id is not None and hub._message_index is not None:
-            session_id = await hub._message_index.resolve(
-                pool_id, str(msg.reply_to_id)
-            )
-            if session_id is not None:
-                if not pool.is_idle:
-                    log.info(
-                        "reply-to-resume: pool %r busy — skipping resume of session %r",
-                        pool_id,
-                        session_id,
-                    )
-                else:
-                    log.info(
-                        "reply-to-resume: resuming session %r for pool %r",
-                        session_id,
-                        pool_id,
-                    )
-                    await pool.resume_session(session_id)
-                    return ResumeStatus.RESUMED
-
-        # Path 2: thread-session-resume.
-        thread_session_id: str | None = msg.platform_meta.get("thread_session_id")
-        if thread_session_id is not None:
-            if not pool.is_idle:
-                log.info(
-                    "thread-session-resume: pool %r busy — skipping %r",
-                    pool_id,
-                    thread_session_id,
-                )
-                return ResumeStatus.SKIPPED
-            log.info(
-                "thread-session-resume: resuming %r for pool %r",
-                thread_session_id,
-                pool_id,
-            )
-            path2_attempted = True
-            accepted = await pool.resume_session(thread_session_id)
-            if accepted:
-                return ResumeStatus.RESUMED
-            log.info(
-                "thread-session-resume: session %r not accepted"
-                " — falling through to Path 3",
-                thread_session_id,
-            )
-
-        # Path 3: last-active-session.
-        if pool.is_idle and hub._turn_store is not None:
-            last_sid = await hub._turn_store.get_last_session(pool_id)
-            if last_sid is None:
-                log.debug(
-                    "last-session-resume: no prior session for pool %r",
-                    pool_id,
-                )
-            elif last_sid == pool.session_id:
-                _agent = hub.agent_registry.get(pool.agent_name)
-                _alive = (
-                    _agent.is_backend_alive(pool.pool_id)
-                    if _agent is not None
-                    else True
-                )
-                if _alive:
-                    log.debug(
-                        "last-session-resume: pool %r already on session %r",
-                        pool_id,
-                        last_sid,
-                    )
-                    return ResumeStatus.SKIPPED
-                log.warning(
-                    "last-session-resume: pool %r session %r matches"
-                    " but backend is dead — skipping guard",
-                    pool_id,
-                    last_sid,
-                )
-            else:
-                log.info(
-                    "last-session-resume: resuming %r for pool %r",
-                    last_sid,
-                    pool_id,
-                )
-                await pool.resume_session(last_sid)
-                return ResumeStatus.RESUMED
-
-        return ResumeStatus.FRESH if path2_attempted else ResumeStatus.SKIPPED
-
-    async def _notify_session_fallthrough(
-        self, msg: InboundMessage, ctx: PipelineContext
-    ) -> None:
-        """Send a pre-response notice when Path 2 resume fails."""
-        from .outbound_errors import try_notify_user
-
-        try:
-            platform = Platform(msg.platform)
-        except ValueError:
-            return
-        adapter = ctx.hub.adapter_registry.get((platform, msg.bot_id))
-        if adapter is None:
-            return
-        circuit = (
-            ctx.hub.circuit_registry.get(msg.platform)
-            if ctx.hub.circuit_registry is not None
-            else None
-        )
-        await try_notify_user(
-            msg.platform, adapter, msg, _SESSION_FALLTHROUGH_MSG, circuit=circuit
-        )
-
-
-# ──────────────────────────────────────────────────────────────────────
-# Factory — default middleware stack
-# ──────────────────────────────────────────────────────────────────────
-
-
 def build_default_pipeline(
     hub: Hub,
     *,
     trace_hook: TraceHook | None = None,
 ) -> MiddlewarePipeline:
     """Build the standard middleware pipeline with all 6 stages."""
+    from .middleware_stages import (
+        CommandMiddleware,
+        CreatePoolMiddleware,
+        RateLimitMiddleware,
+        ResolveBindingMiddleware,
+        ValidatePlatformMiddleware,
+    )
+    from .middleware_submit import SubmitToPoolMiddleware
+
     return MiddlewarePipeline(
         [
             ValidatePlatformMiddleware(),

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -1,0 +1,519 @@
+"""Composable middleware pipeline for inbound message routing (#431).
+
+Replaces the monolithic ``MessagePipeline`` class with a chain of independent
+middleware objects. Each middleware either short-circuits with a ``PipelineResult``
+or delegates to the next middleware via ``await next(msg, ctx)``.
+
+The pipeline is strictly sequential — no concurrent fan-out, preserving FIFO
+ordering and session resume atomicity.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from ..agent import AgentBase
+from ..commands.command_parser import CommandParser
+from ..message import (
+    GENERIC_ERROR_REPLY,
+    InboundMessage,
+    Platform,
+    Response,
+)
+from ..pool import Pool
+from .message_pipeline import (
+    Action,
+    PipelineResult,
+    ResumeStatus,
+    TraceHook,
+    _SESSION_FALLTHROUGH_MSG,
+)
+
+if TYPE_CHECKING:
+    from .hub import Binding, Hub, RoutingKey
+
+log = logging.getLogger(__name__)
+
+_command_parser = CommandParser()
+
+_DROP = PipelineResult(action=Action.DROP)
+
+
+@dataclass
+class PipelineContext:
+    """Mutable routing context accumulated as middleware runs."""
+
+    hub: Hub
+    key: RoutingKey | None = None
+    binding: Binding | None = None
+    agent: AgentBase | None = None
+    pool: Pool | None = None
+    router: Any = None
+    trace_hook: TraceHook | None = None
+
+    def trace(self, stage: str, event: str, **payload: object) -> None:
+        """Emit a trace event if a hook is registered. Never raises."""
+        if self.trace_hook is None:
+            return
+        try:
+            self.trace_hook(stage, event, **payload)
+        except Exception:
+            log.debug("trace_hook raised — ignoring", exc_info=True)
+
+
+# Type alias for the next-middleware callback (defined after PipelineContext).
+Next = Callable[[InboundMessage, PipelineContext], Awaitable[PipelineResult]]
+
+
+@runtime_checkable
+class PipelineMiddleware(Protocol):
+    """One stage of the inbound message pipeline.
+
+    Return a ``PipelineResult`` to short-circuit (DROP / COMMAND_HANDLED),
+    or call ``await next(msg, ctx)`` to pass to the next middleware.
+    """
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult: ...
+
+
+class MiddlewarePipeline:
+    """Runs a list of middleware sequentially. Replaces MessagePipeline."""
+
+    def __init__(
+        self,
+        middlewares: list[PipelineMiddleware],
+        hub: Hub,
+        *,
+        trace_hook: TraceHook | None = None,
+    ) -> None:
+        self._middlewares = middlewares
+        self._hub = hub
+        self._trace_hook = trace_hook
+
+    async def process(self, msg: InboundMessage) -> PipelineResult:
+        """Route *msg* through the middleware chain."""
+        ctx = PipelineContext(hub=self._hub, trace_hook=self._trace_hook)
+
+        ctx.trace(
+            "inbound",
+            "message_received",
+            msg_id=msg.id,
+            platform=msg.platform,
+            user_id=msg.user_id,
+        )
+
+        async def _run(
+            index: int, msg: InboundMessage, ctx: PipelineContext
+        ) -> PipelineResult:
+            if index >= len(self._middlewares):
+                return _DROP
+            mw = self._middlewares[index]
+            return await mw(msg, ctx, lambda m, c: _run(index + 1, m, c))
+
+        return await _run(0, msg, ctx)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Concrete middlewares (1:1 mapping from MessagePipeline private methods)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class ValidatePlatformMiddleware:
+    """Stage 1: reject messages from unknown platforms."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        try:
+            Platform(msg.platform)
+        except ValueError:
+            log.warning(
+                "unknown platform %r in msg id=%s — message dropped",
+                msg.platform,
+                msg.id,
+            )
+            ctx.trace(
+                "inbound",
+                "platform_invalid",
+                platform=msg.platform,
+                action=Action.DROP.value,
+            )
+            return _DROP
+        return await next(msg, ctx)
+
+
+class RateLimitMiddleware:
+    """Stage 2: drop messages that exceed the per-user rate limit."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        from .hub import RoutingKey  # noqa: PLC0415
+
+        key = RoutingKey(Platform(msg.platform), msg.bot_id, msg.scope_id)
+        ctx.key = key
+
+        if ctx.hub._is_rate_limited(msg):
+            log.warning("rate limit exceeded for %s — message dropped", key)
+            ctx.trace("inbound", "rate_limited", action=Action.DROP.value)
+            return _DROP
+        return await next(msg, ctx)
+
+
+class ResolveBindingMiddleware:
+    """Stage 3: resolve binding + look up agent. Sets ctx.binding, ctx.agent."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        assert ctx.key is not None
+
+        binding = ctx.hub.resolve_binding(msg)
+        if binding is None:
+            log.warning("unmatched routing key %s — message dropped", ctx.key)
+            ctx.trace("pool", "no_binding", action=Action.DROP.value)
+            return _DROP
+        ctx.binding = binding
+
+        agent = ctx.hub.agent_registry.get(binding.agent_name)
+        if agent is None:
+            log.warning(
+                "no agent registered for %r (routing %s) — message dropped",
+                binding.agent_name,
+                ctx.key,
+            )
+            ctx.trace(
+                "pool",
+                "no_agent",
+                agent_name=binding.agent_name,
+                action=Action.DROP.value,
+            )
+            return _DROP
+        ctx.agent = agent
+
+        return await next(msg, ctx)
+
+
+class CreatePoolMiddleware:
+    """Stage 4: get or create the conversation pool. Sets ctx.pool, ctx.router."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        assert ctx.binding is not None
+        assert ctx.agent is not None
+
+        pool = ctx.hub.get_or_create_pool(
+            ctx.binding.pool_id,
+            ctx.binding.agent_name,
+        )
+        ctx.pool = pool
+        ctx.trace(
+            "pool",
+            "agent_selected",
+            agent=ctx.binding.agent_name,
+            pool_id=ctx.binding.pool_id,
+        )
+
+        ctx.router = getattr(ctx.agent, "command_router", None)
+
+        # Parse command context and rewrite bare URLs (#99).
+        cmd_ctx = _command_parser.parse(msg.text)
+        if cmd_ctx is not None:
+            msg = dataclasses.replace(msg, command=cmd_ctx)
+
+        if ctx.router and hasattr(ctx.router, "prepare"):
+            msg = ctx.router.prepare(msg)
+
+        return await next(msg, ctx)
+
+
+class CommandMiddleware:
+    """Stage 5: detect and dispatch commands."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        assert ctx.pool is not None
+        assert ctx.key is not None
+
+        router = ctx.router
+        if router and router.is_command(msg):
+            _cmd = msg.text.split()[0] if msg.text else ""
+            ctx.trace("processor", "command_detected", command=_cmd)
+            return await self._dispatch_command(msg, router, ctx.pool, ctx.key, ctx, next)
+
+        return await next(msg, ctx)
+
+    async def _dispatch_command(
+        self,
+        msg: InboundMessage,
+        router: Any,
+        pool: Pool,
+        key: RoutingKey,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        _agent = ctx.hub.agent_registry.get(pool.agent_name)
+        if _agent is not None and hasattr(_agent, "configure_pool"):
+            _agent.configure_pool(pool)
+        try:
+            response = await router.dispatch(msg, pool)
+        except Exception as exc:
+            log.exception("command dispatch failed for %s: %s", key, exc)
+            _content = (
+                ctx.hub._msg_manager.get("generic")
+                if ctx.hub._msg_manager
+                else GENERIC_ERROR_REPLY
+            )
+            response = Response(content=_content)
+            ctx.trace(
+                "outbound",
+                "command_error",
+                action=Action.COMMAND_HANDLED.value,
+            )
+            return PipelineResult(action=Action.COMMAND_HANDLED, response=response)
+
+        if response is None:  # !-prefixed command not found — fall through
+            ctx.trace("processor", "command_fallthrough")
+            return await next(msg, ctx)
+
+        ctx.trace("outbound", "command_handled", action=Action.COMMAND_HANDLED.value)
+        return PipelineResult(action=Action.COMMAND_HANDLED, response=response)
+
+
+class SubmitToPoolMiddleware:
+    """Stage 6 (terminal): validate adapter, check circuit breaker, submit."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        assert ctx.pool is not None
+        assert ctx.key is not None
+
+        if (ctx.key.platform, msg.bot_id) not in ctx.hub.adapter_registry:
+            log.error(
+                "no adapter registered for (%s, %s) — response dropped",
+                msg.platform,
+                msg.bot_id,
+            )
+            ctx.trace(
+                "outbound",
+                "no_adapter",
+                platform=msg.platform,
+                bot_id=msg.bot_id,
+                action=Action.DROP.value,
+            )
+            return _DROP
+
+        if await ctx.hub.circuit_breaker_drop(msg):
+            ctx.trace("outbound", "circuit_open", action=Action.DROP.value)
+            return _DROP
+
+        pool = ctx.pool
+        # Register session persistence callback once.
+        _update_fn = msg.platform_meta.get("_session_update_fn")
+        if _update_fn is not None and pool._observer._session_update_fn is None:
+            pool._observer.register_session_update_fn(_update_fn)
+
+        # Wire provider callbacks before _resolve_context.
+        _agent = ctx.hub.agent_registry.get(pool.agent_name)
+        if _agent is not None and hasattr(_agent, "configure_pool"):
+            _agent.configure_pool(pool)
+
+        try:
+            status = await self._resolve_context(msg, pool, pool.pool_id, ctx)
+        except Exception:
+            log.warning(
+                "_resolve_context failed — continuing with active session",
+                exc_info=True,
+            )
+            status = ResumeStatus.SKIPPED
+
+        ctx.trace(
+            "outbound",
+            "message_submitted",
+            adapter=msg.platform,
+            resume_status=status.value,
+        )
+
+        if status == ResumeStatus.FRESH:
+            await self._notify_session_fallthrough(msg, ctx)
+
+        return PipelineResult(action=Action.SUBMIT_TO_POOL, pool=pool)
+
+    async def _resolve_context(  # noqa: C901
+        self,
+        msg: InboundMessage,
+        pool: Pool,
+        pool_id: str,
+        ctx: PipelineContext,
+    ) -> ResumeStatus:
+        """Attempt session resume before pool.submit().
+
+        Three paths (priority order): (1) reply-to-resume, (2) thread-session-resume,
+        (3) last-active-session from TurnStore.
+        """
+        hub = ctx.hub
+        path2_attempted = False
+
+        # Path 1: reply-to-resume via MessageIndex (#341).
+        if msg.reply_to_id is not None and hub._message_index is None:
+            log.debug("reply-to-resume: no MessageIndex configured — skipping")
+        if msg.reply_to_id is not None and hub._message_index is not None:
+            session_id = await hub._message_index.resolve(
+                pool_id, str(msg.reply_to_id)
+            )
+            if session_id is not None:
+                if not pool.is_idle:
+                    log.info(
+                        "reply-to-resume: pool %r busy — skipping resume of session %r",
+                        pool_id,
+                        session_id,
+                    )
+                else:
+                    log.info(
+                        "reply-to-resume: resuming session %r for pool %r",
+                        session_id,
+                        pool_id,
+                    )
+                    await pool.resume_session(session_id)
+                    return ResumeStatus.RESUMED
+
+        # Path 2: thread-session-resume.
+        thread_session_id: str | None = msg.platform_meta.get("thread_session_id")
+        if thread_session_id is not None:
+            if not pool.is_idle:
+                log.info(
+                    "thread-session-resume: pool %r busy — skipping %r",
+                    pool_id,
+                    thread_session_id,
+                )
+                return ResumeStatus.SKIPPED
+            log.info(
+                "thread-session-resume: resuming %r for pool %r",
+                thread_session_id,
+                pool_id,
+            )
+            path2_attempted = True
+            accepted = await pool.resume_session(thread_session_id)
+            if accepted:
+                return ResumeStatus.RESUMED
+            log.info(
+                "thread-session-resume: session %r not accepted"
+                " — falling through to Path 3",
+                thread_session_id,
+            )
+
+        # Path 3: last-active-session.
+        if pool.is_idle and hub._turn_store is not None:
+            last_sid = await hub._turn_store.get_last_session(pool_id)
+            if last_sid is None:
+                log.debug(
+                    "last-session-resume: no prior session for pool %r",
+                    pool_id,
+                )
+            elif last_sid == pool.session_id:
+                _agent = hub.agent_registry.get(pool.agent_name)
+                _alive = (
+                    _agent.is_backend_alive(pool.pool_id)
+                    if _agent is not None
+                    else True
+                )
+                if _alive:
+                    log.debug(
+                        "last-session-resume: pool %r already on session %r",
+                        pool_id,
+                        last_sid,
+                    )
+                    return ResumeStatus.SKIPPED
+                log.warning(
+                    "last-session-resume: pool %r session %r matches"
+                    " but backend is dead — skipping guard",
+                    pool_id,
+                    last_sid,
+                )
+            else:
+                log.info(
+                    "last-session-resume: resuming %r for pool %r",
+                    last_sid,
+                    pool_id,
+                )
+                await pool.resume_session(last_sid)
+                return ResumeStatus.RESUMED
+
+        return ResumeStatus.FRESH if path2_attempted else ResumeStatus.SKIPPED
+
+    async def _notify_session_fallthrough(
+        self, msg: InboundMessage, ctx: PipelineContext
+    ) -> None:
+        """Send a pre-response notice when Path 2 resume fails."""
+        from .outbound_errors import try_notify_user
+
+        try:
+            platform = Platform(msg.platform)
+        except ValueError:
+            return
+        adapter = ctx.hub.adapter_registry.get((platform, msg.bot_id))
+        if adapter is None:
+            return
+        circuit = (
+            ctx.hub.circuit_registry.get(msg.platform)
+            if ctx.hub.circuit_registry is not None
+            else None
+        )
+        await try_notify_user(
+            msg.platform, adapter, msg, _SESSION_FALLTHROUGH_MSG, circuit=circuit
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Factory — default middleware stack
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_default_pipeline(
+    hub: Hub,
+    *,
+    trace_hook: TraceHook | None = None,
+) -> MiddlewarePipeline:
+    """Build the standard middleware pipeline with all 6 stages."""
+    return MiddlewarePipeline(
+        [
+            ValidatePlatformMiddleware(),
+            RateLimitMiddleware(),
+            ResolveBindingMiddleware(),
+            CreatePoolMiddleware(),
+            CommandMiddleware(),
+            SubmitToPoolMiddleware(),
+        ],
+        hub,
+        trace_hook=trace_hook,
+    )

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -1,0 +1,244 @@
+"""Concrete middleware stages for the inbound message pipeline (#431).
+
+Each class is one stage of the pipeline, independently testable with a
+mock ``next()`` callback. Stages 1–5 (guards + command dispatch) live here;
+stage 6 (pool submit + session resume) lives in ``middleware_submit.py``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ..commands.command_parser import CommandParser
+from ..message import (
+    GENERIC_ERROR_REPLY,
+    InboundMessage,
+    Platform,
+    Response,
+)
+from .message_pipeline import (
+    _DROP,
+    Action,
+    PipelineResult,
+)
+from .middleware import Next, PipelineContext
+
+if TYPE_CHECKING:
+    pass
+
+log = logging.getLogger(__name__)
+
+_command_parser = CommandParser()
+
+
+class ValidatePlatformMiddleware:
+    """Stage 1: reject messages from unknown platforms."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        try:
+            Platform(msg.platform)
+        except ValueError:
+            log.warning(
+                "unknown platform %r in msg id=%s — message dropped",
+                msg.platform,
+                msg.id,
+            )
+            ctx.trace(
+                "inbound",
+                "platform_invalid",
+                platform=msg.platform,
+                action=Action.DROP.value,
+            )
+            return _DROP
+        return await next(msg, ctx)
+
+
+class RateLimitMiddleware:
+    """Stage 2: drop messages that exceed the per-user rate limit."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        from .hub import RoutingKey  # noqa: PLC0415
+
+        key = RoutingKey(Platform(msg.platform), msg.bot_id, msg.scope_id)
+        ctx.key = key
+
+        if ctx.hub._is_rate_limited(msg):
+            log.warning("rate limit exceeded for %s — message dropped", key)
+            ctx.trace("inbound", "rate_limited", action=Action.DROP.value)
+            return _DROP
+        return await next(msg, ctx)
+
+
+class ResolveBindingMiddleware:
+    """Stage 3: resolve binding + look up agent. Sets ctx.binding, ctx.agent."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        if ctx.key is None:
+            raise RuntimeError(
+                "RateLimitMiddleware must precede ResolveBindingMiddleware"
+            )
+
+        binding = ctx.hub.resolve_binding(msg)
+        if binding is None:
+            log.warning(
+                "unmatched routing key %s — message dropped", ctx.key
+            )
+            ctx.trace("pool", "no_binding", action=Action.DROP.value)
+            return _DROP
+        ctx.binding = binding
+
+        agent = ctx.hub.agent_registry.get(binding.agent_name)
+        if agent is None:
+            log.warning(
+                "no agent registered for %r (routing %s) — message dropped",
+                binding.agent_name,
+                ctx.key,
+            )
+            ctx.trace(
+                "pool",
+                "no_agent",
+                agent_name=binding.agent_name,
+                action=Action.DROP.value,
+            )
+            return _DROP
+        ctx.agent = agent
+
+        return await next(msg, ctx)
+
+
+class CreatePoolMiddleware:
+    """Stage 4: get or create the pool. Sets ctx.pool, ctx.router."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        if ctx.binding is None:
+            raise RuntimeError(
+                "ResolveBindingMiddleware must precede CreatePoolMiddleware"
+            )
+        if ctx.agent is None:
+            raise RuntimeError(
+                "ResolveBindingMiddleware must set ctx.agent"
+                " before CreatePoolMiddleware"
+            )
+
+        pool = ctx.hub.get_or_create_pool(
+            ctx.binding.pool_id,
+            ctx.binding.agent_name,
+        )
+        ctx.pool = pool
+        ctx.trace(
+            "pool",
+            "agent_selected",
+            agent=ctx.binding.agent_name,
+            pool_id=ctx.binding.pool_id,
+        )
+
+        ctx.router = getattr(ctx.agent, "command_router", None)
+
+        # Wire provider callbacks once at pool creation.
+        _agent = ctx.hub.agent_registry.get(pool.agent_name)
+        if _agent is not None and hasattr(_agent, "configure_pool"):
+            _agent.configure_pool(pool)
+
+        # Parse command context and rewrite bare URLs (#99).
+        cmd_ctx = _command_parser.parse(msg.text)
+        if cmd_ctx is not None:
+            msg = dataclasses.replace(msg, command=cmd_ctx)
+
+        if ctx.router and hasattr(ctx.router, "prepare"):
+            msg = ctx.router.prepare(msg)
+
+        return await next(msg, ctx)
+
+
+class CommandMiddleware:
+    """Stage 5: detect and dispatch commands."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        if ctx.pool is None:
+            raise RuntimeError(
+                "CreatePoolMiddleware must precede CommandMiddleware"
+            )
+        if ctx.key is None:
+            raise RuntimeError(
+                "RateLimitMiddleware must precede CommandMiddleware"
+            )
+
+        router = ctx.router
+        if router and router.is_command(msg):
+            _cmd = msg.text.split()[0] if msg.text else ""
+            ctx.trace("processor", "command_detected", command=_cmd)
+            return await self._dispatch_command(
+                msg, router, ctx, next
+            )
+
+        return await next(msg, ctx)
+
+    async def _dispatch_command(  # noqa: PLR0913
+        self,
+        msg: InboundMessage,
+        router: Any,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        pool = ctx.pool  # guaranteed non-None by __call__ guard
+        key = ctx.key  # guaranteed non-None by __call__ guard
+        try:
+            response = await router.dispatch(msg, pool)
+        except Exception as exc:
+            log.exception(
+                "command dispatch failed for %s: %s", key, exc
+            )
+            _content = (
+                ctx.hub._msg_manager.get("generic")
+                if ctx.hub._msg_manager
+                else GENERIC_ERROR_REPLY
+            )
+            response = Response(content=_content)
+            ctx.trace(
+                "outbound",
+                "command_error",
+                action=Action.COMMAND_HANDLED.value,
+            )
+            return PipelineResult(
+                action=Action.COMMAND_HANDLED, response=response
+            )
+
+        if response is None:
+            ctx.trace("processor", "command_fallthrough")
+            return await next(msg, ctx)
+
+        ctx.trace(
+            "outbound",
+            "command_handled",
+            action=Action.COMMAND_HANDLED.value,
+        )
+        return PipelineResult(
+            action=Action.COMMAND_HANDLED, response=response
+        )

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -1,0 +1,244 @@
+"""Terminal middleware stage: pool submission + session resume (#431).
+
+``SubmitToPoolMiddleware`` is the final stage in the default pipeline.
+It validates the adapter, checks the circuit breaker, attempts session
+resume via three paths, and returns ``SUBMIT_TO_POOL``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..message import (
+    InboundMessage,
+    Platform,
+)
+from ..pool import Pool
+from .message_pipeline import (
+    _DROP,
+    _SESSION_FALLTHROUGH_MSG,
+    Action,
+    PipelineResult,
+    ResumeStatus,
+)
+from .middleware import Next, PipelineContext
+
+if TYPE_CHECKING:
+    pass
+
+log = logging.getLogger(__name__)
+
+
+class SubmitToPoolMiddleware:
+    """Stage 6 (terminal): validate adapter, circuit breaker, submit."""
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        if ctx.pool is None:
+            raise RuntimeError(
+                "CreatePoolMiddleware must precede SubmitToPoolMiddleware"
+            )
+        if ctx.key is None:
+            raise RuntimeError(
+                "RateLimitMiddleware must precede SubmitToPoolMiddleware"
+            )
+
+        if (ctx.key.platform, msg.bot_id) not in ctx.hub.adapter_registry:
+            log.error(
+                "no adapter registered for (%s, %s) — response dropped",
+                msg.platform,
+                msg.bot_id,
+            )
+            ctx.trace(
+                "outbound",
+                "no_adapter",
+                platform=msg.platform,
+                bot_id=msg.bot_id,
+                action=Action.DROP.value,
+            )
+            return _DROP
+
+        if await ctx.hub.circuit_breaker_drop(msg):
+            ctx.trace("outbound", "circuit_open", action=Action.DROP.value)
+            return _DROP
+
+        pool = ctx.pool
+        # Register session persistence callback once.
+        _update_fn = msg.platform_meta.get("_session_update_fn")
+        if (
+            _update_fn is not None
+            and pool._observer._session_update_fn is None
+        ):
+            pool._observer.register_session_update_fn(_update_fn)
+
+        try:
+            status = await self._resolve_context(
+                msg, pool, pool.pool_id, ctx
+            )
+        except Exception:
+            log.warning(
+                "_resolve_context failed — continuing with active session",
+                exc_info=True,
+            )
+            status = ResumeStatus.SKIPPED
+
+        ctx.trace(
+            "outbound",
+            "message_submitted",
+            adapter=msg.platform,
+            resume_status=status.value,
+        )
+
+        if status == ResumeStatus.FRESH:
+            await self._notify_session_fallthrough(msg, ctx)
+
+        return PipelineResult(action=Action.SUBMIT_TO_POOL, pool=pool)
+
+    async def _resolve_context(  # noqa: C901
+        self,
+        msg: InboundMessage,
+        pool: Pool,
+        pool_id: str,
+        ctx: PipelineContext,
+    ) -> ResumeStatus:
+        """Attempt session resume before pool.submit().
+
+        Three paths (priority order): (1) reply-to-resume,
+        (2) thread-session-resume, (3) last-active-session from TurnStore.
+
+        Returns:
+            RESUMED  — a session was successfully resumed via any path.
+            FRESH    — Path 2 was attempted but rejected (session pruned /
+                       invalid / expired); Claude will start fresh. The
+                       caller should notify the user.
+            SKIPPED  — no resume was attempted (pool busy, group chat,
+                       first use, no TurnStore, …). Silent and expected.
+        """
+        hub = ctx.hub
+        path2_attempted = False
+
+        # Path 1: reply-to-resume via MessageIndex (#341).
+        if msg.reply_to_id is not None and hub._message_index is None:
+            log.debug(
+                "reply-to-resume: no MessageIndex configured — skipping"
+            )
+        if msg.reply_to_id is not None and hub._message_index is not None:
+            session_id = await hub._message_index.resolve(
+                pool_id, str(msg.reply_to_id)
+            )
+            if session_id is not None:
+                if not pool.is_idle:
+                    log.info(
+                        "reply-to-resume: pool %r busy"
+                        " — skipping resume of session %r",
+                        pool_id,
+                        session_id,
+                    )
+                else:
+                    log.info(
+                        "reply-to-resume: resuming session %r for pool %r",
+                        session_id,
+                        pool_id,
+                    )
+                    await pool.resume_session(session_id)
+                    return ResumeStatus.RESUMED
+
+        # Path 2: thread-session-resume.
+        thread_session_id: str | None = msg.platform_meta.get(
+            "thread_session_id"
+        )
+        if thread_session_id is not None:
+            if not pool.is_idle:
+                log.info(
+                    "thread-session-resume: pool %r busy — skipping %r",
+                    pool_id,
+                    thread_session_id,
+                )
+                return ResumeStatus.SKIPPED
+            log.info(
+                "thread-session-resume: resuming %r for pool %r",
+                thread_session_id,
+                pool_id,
+            )
+            path2_attempted = True
+            accepted = await pool.resume_session(thread_session_id)
+            if accepted:
+                return ResumeStatus.RESUMED
+            log.info(
+                "thread-session-resume: session %r not accepted"
+                " — falling through to Path 3",
+                thread_session_id,
+            )
+
+        # Path 3: last-active-session.
+        if pool.is_idle and hub._turn_store is not None:
+            last_sid = await hub._turn_store.get_last_session(pool_id)
+            if last_sid is None:
+                log.debug(
+                    "last-session-resume: no prior session for pool %r",
+                    pool_id,
+                )
+            elif last_sid == pool.session_id:
+                _agent = hub.agent_registry.get(pool.agent_name)
+                _alive = (
+                    _agent.is_backend_alive(pool.pool_id)
+                    if _agent is not None
+                    else True
+                )
+                if _alive:
+                    log.debug(
+                        "last-session-resume: pool %r already on"
+                        " session %r",
+                        pool_id,
+                        last_sid,
+                    )
+                    return ResumeStatus.SKIPPED
+                log.warning(
+                    "last-session-resume: pool %r session %r matches"
+                    " but backend is dead — skipping guard",
+                    pool_id,
+                    last_sid,
+                )
+            else:
+                log.info(
+                    "last-session-resume: resuming %r for pool %r",
+                    last_sid,
+                    pool_id,
+                )
+                await pool.resume_session(last_sid)
+                return ResumeStatus.RESUMED
+
+        return (
+            ResumeStatus.FRESH if path2_attempted else ResumeStatus.SKIPPED
+        )
+
+    async def _notify_session_fallthrough(
+        self, msg: InboundMessage, ctx: PipelineContext
+    ) -> None:
+        """Send a pre-response notice when Path 2 resume fails."""
+        from .outbound_errors import try_notify_user
+
+        try:
+            platform = Platform(msg.platform)
+        except ValueError:
+            return
+        adapter = ctx.hub.adapter_registry.get((platform, msg.bot_id))
+        if adapter is None:
+            return
+        circuit = (
+            ctx.hub.circuit_registry.get(msg.platform)
+            if ctx.hub.circuit_registry is not None
+            else None
+        )
+        await try_notify_user(
+            msg.platform,
+            adapter,
+            msg,
+            _SESSION_FALLTHROUGH_MSG,
+            circuit=circuit,
+        )

--- a/tests/core/test_hub_tts_dispatch.py
+++ b/tests/core/test_hub_tts_dispatch.py
@@ -14,7 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lyra.core.hub import Hub
-from lyra.core.hub.message_pipeline import Action, MessagePipeline, PipelineResult
+from lyra.core.hub.message_pipeline import Action, PipelineResult
+from lyra.core.hub.middleware import MiddlewarePipeline
 from lyra.core.message import InboundMessage, OutboundAudio, Response
 from tests.core.conftest import make_inbound_message
 
@@ -57,7 +58,7 @@ class TestHubRunAudioDispatch:
         hub.dispatch_response = AsyncMock()
 
         mock = AsyncMock(return_value=pipeline_result)
-        with patch.object(MessagePipeline, "process", new=mock):
+        with patch.object(MiddlewarePipeline, "process", new=mock):
             await _run_hub_one_msg(hub, msg)
 
         hub.dispatch_audio.assert_awaited_once_with(msg, audio)
@@ -74,7 +75,7 @@ class TestHubRunAudioDispatch:
         hub.dispatch_response = AsyncMock()
 
         mock = AsyncMock(return_value=pipeline_result)
-        with patch.object(MessagePipeline, "process", new=mock):
+        with patch.object(MiddlewarePipeline, "process", new=mock):
             await _run_hub_one_msg(hub, msg)
 
         hub.dispatch_response.assert_awaited_once_with(msg, response)
@@ -92,7 +93,7 @@ class TestHubRunAudioDispatch:
         hub.dispatch_response = AsyncMock()
 
         mock = AsyncMock(return_value=pipeline_result)
-        with patch.object(MessagePipeline, "process", new=mock):
+        with patch.object(MiddlewarePipeline, "process", new=mock):
             await _run_hub_one_msg(hub, msg)
 
         hub.dispatch_response.assert_awaited_once_with(msg, response)
@@ -109,7 +110,7 @@ class TestHubRunAudioDispatch:
         hub.dispatch_response = AsyncMock()
 
         mock = AsyncMock(return_value=pipeline_result)
-        with patch.object(MessagePipeline, "process", new=mock):
+        with patch.object(MiddlewarePipeline, "process", new=mock):
             await _run_hub_one_msg(hub, msg)
 
         hub.dispatch_response.assert_not_awaited()
@@ -131,7 +132,7 @@ class TestHubRunAudioDispatch:
         hub.dispatch_response = AsyncMock()
 
         mock = AsyncMock(return_value=pipeline_result)
-        with patch.object(MessagePipeline, "process", new=mock):
+        with patch.object(MiddlewarePipeline, "process", new=mock):
             await _run_hub_one_msg(hub, msg)
 
         hub.dispatch_response.assert_awaited_once_with(msg, response)

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -11,16 +11,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from lyra.core.hub.message_pipeline import Action, PipelineResult, ResumeStatus
 from lyra.core.hub.middleware import (
-    CommandMiddleware,
-    CreatePoolMiddleware,
     MiddlewarePipeline,
     PipelineContext,
-    RateLimitMiddleware,
-    ResolveBindingMiddleware,
-    SubmitToPoolMiddleware,
-    ValidatePlatformMiddleware,
     build_default_pipeline,
 )
+from lyra.core.hub.middleware_stages import (
+    CommandMiddleware,
+    CreatePoolMiddleware,
+    RateLimitMiddleware,
+    ResolveBindingMiddleware,
+    ValidatePlatformMiddleware,
+)
+from lyra.core.hub.middleware_submit import SubmitToPoolMiddleware
 from lyra.core.message import Platform, Response
 from tests.core.conftest import _make_hub, make_inbound_message
 

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -6,9 +6,10 @@ no Hub required for most tests.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import dataclasses
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from lyra.core.hub.message_pipeline import Action, PipelineResult
+from lyra.core.hub.message_pipeline import Action, PipelineResult, ResumeStatus
 from lyra.core.hub.middleware import (
     CommandMiddleware,
     CreatePoolMiddleware,
@@ -91,6 +92,8 @@ class TestValidatePlatform:
 
 class TestRateLimit:
     async def test_not_limited_calls_next(self) -> None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+
         mw = RateLimitMiddleware()
         ctx = _make_ctx()
         next_fn = _make_next()
@@ -100,7 +103,7 @@ class TestRateLimit:
 
         next_fn.assert_awaited_once()
         assert result == _PASS
-        assert ctx.key is not None
+        assert ctx.key == RoutingKey(Platform.TELEGRAM, "main", "chat:42")
 
     async def test_rate_limited_drops(self) -> None:
         mw = RateLimitMiddleware()
@@ -399,3 +402,262 @@ class TestBuildDefaultPipeline:
         result = await pipeline.process(msg)
 
         assert result.action == Action.DROP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fix #3: CommandMiddleware error path
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCommandErrorPath:
+    async def test_dispatch_raises_returns_error_response(self) -> None:
+        """Command dispatch exception → COMMAND_HANDLED with generic error."""
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        router = MagicMock()
+        router.is_command.return_value = True
+        router.dispatch = AsyncMock(side_effect=RuntimeError("boom"))
+
+        mw = CommandMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+            router=router,
+        )
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.COMMAND_HANDLED
+        assert result.response is not None
+        assert "boom" not in (result.response.content or "")
+
+    async def test_dispatch_raises_emits_command_error_trace(self) -> None:
+        """Command dispatch exception fires command_error trace event."""
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        events: list[dict] = []
+
+        def hook(stage, event, **kw):
+            events.append({"stage": stage, "event": event, **kw})
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        router = MagicMock()
+        router.is_command.return_value = True
+        router.dispatch = AsyncMock(side_effect=RuntimeError("boom"))
+
+        mw = CommandMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+            router=router,
+            trace_hook=hook,
+        )
+        msg = make_inbound_message()
+
+        await mw(msg, ctx, _make_next())
+
+        assert any(e["event"] == "command_error" for e in events)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fix #4: SubmitToPoolMiddleware circuit-breaker drop
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCircuitBreakerDrop:
+    async def test_circuit_breaker_open_drops(self) -> None:
+        """Open circuit breaker in SubmitToPoolMiddleware → DROP."""
+        from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        registry = CircuitRegistry()
+        cb = CircuitBreaker(
+            name="anthropic", failure_threshold=1, recovery_timeout=60
+        )
+        registry.register(cb)
+        cb.record_failure()
+
+        hub = _make_hub(circuit_registry=registry)
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+        )
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.DROP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fix #5: _resolve_context resume paths (via SubmitToPoolMiddleware)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestResolveContextMiddleware:
+    async def test_no_thread_session_returns_skipped(self) -> None:
+        """No thread_session_id and no TurnStore → SKIPPED."""
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        ctx = PipelineContext(hub=hub)
+        mw = SubmitToPoolMiddleware()
+        msg = make_inbound_message()
+
+        status = await mw._resolve_context(msg, pool, pool.pool_id, ctx)
+
+        assert status == ResumeStatus.SKIPPED
+
+    async def test_thread_session_accepted_returns_resumed(self) -> None:
+        """thread_session_id + accepted → RESUMED."""
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+
+        async def _fake_resume(sid: str) -> bool:
+            return True
+
+        pool._session_resume_fn = _fake_resume  # type: ignore[attr-defined]
+
+        ctx = PipelineContext(hub=hub)
+        mw = SubmitToPoolMiddleware()
+        _base = make_inbound_message(scope_id="chat:42")
+        _meta = {**_base.platform_meta, "thread_session_id": "tss-1"}
+        msg = dataclasses.replace(_base, platform_meta=_meta)
+
+        status = await mw._resolve_context(msg, pool, pool.pool_id, ctx)
+
+        assert status == ResumeStatus.RESUMED
+
+    async def test_thread_session_rejected_returns_fresh(self) -> None:
+        """thread_session_id rejected, no TurnStore → FRESH."""
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+
+        async def _fake_resume(sid: str) -> bool:
+            return False
+
+        pool._session_resume_fn = _fake_resume  # type: ignore[attr-defined]
+
+        ctx = PipelineContext(hub=hub)
+        mw = SubmitToPoolMiddleware()
+        _base = make_inbound_message(scope_id="chat:42")
+        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
+        msg = dataclasses.replace(_base, platform_meta=_meta)
+
+        status = await mw._resolve_context(msg, pool, pool.pool_id, ctx)
+
+        assert status == ResumeStatus.FRESH
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fix #6: PipelineContext.trace exception swallowing
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestTraceExceptionSwallowing:
+    async def test_raising_trace_hook_does_not_propagate(self) -> None:
+        """A raising trace_hook must not propagate exceptions."""
+
+        def bad_hook(stage, event, **kw):
+            raise RuntimeError("trace bug")
+
+        ctx = _make_ctx(trace_hook=bad_hook)
+
+        # Must not raise
+        ctx.trace("stage", "event", key="value")
+
+    async def test_raising_trace_in_pipeline_does_not_abort(self) -> None:
+        """A raising trace_hook must not abort pipeline processing."""
+
+        def bad_hook(stage, event, **kw):
+            raise RuntimeError("trace bug")
+
+        hub = _make_hub()
+        pipeline = build_default_pipeline(hub, trace_hook=bad_hook)
+        msg = make_inbound_message()
+
+        result = await pipeline.process(msg)
+
+        assert result.action == Action.SUBMIT_TO_POOL
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fix #7: empty/exhausted pipeline → DROP
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestEmptyPipeline:
+    async def test_empty_pipeline_drops(self) -> None:
+        """A pipeline with no middlewares returns DROP."""
+        hub = _make_hub()
+        pipeline = MiddlewarePipeline([], hub)
+        msg = make_inbound_message()
+
+        result = await pipeline.process(msg)
+
+        assert result.action == Action.DROP
+
+    async def test_next_past_last_middleware_drops(self) -> None:
+        """Calling next past the last middleware returns DROP."""
+
+        class PassThrough:
+            async def __call__(self, msg, ctx, next):
+                return await next(msg, ctx)
+
+        hub = _make_hub()
+        pipeline = MiddlewarePipeline([PassThrough()], hub)
+        msg = make_inbound_message()
+
+        result = await pipeline.process(msg)
+
+        assert result.action == Action.DROP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fix #8: _notify_session_fallthrough on FRESH
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestNotifySessionFallthroughMiddleware:
+    async def test_notify_called_when_fresh(self) -> None:
+        """FRESH status triggers try_notify_user."""
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+
+        async def _rejected_resume(sid: str) -> bool:
+            return False
+
+        pool._session_resume_fn = _rejected_resume  # type: ignore[attr-defined]
+
+        _base = make_inbound_message(scope_id="chat:42")
+        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
+        msg = dataclasses.replace(_base, platform_meta=_meta)
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+        )
+
+        notify_calls: list[tuple] = []
+
+        async def _fake_notify(platform, _a, _o, text, **_kw):
+            notify_calls.append((platform, text))
+
+        _patch = "lyra.core.hub.outbound_errors.try_notify_user"
+        with patch(_patch, side_effect=_fake_notify):
+            result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.SUBMIT_TO_POOL
+        assert len(notify_calls) == 1
+        assert "starting fresh" in notify_calls[0][1]

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -8,9 +8,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
-from lyra.core.agent import Agent
 from lyra.core.hub.message_pipeline import Action, PipelineResult
 from lyra.core.hub.middleware import (
     CommandMiddleware,
@@ -24,8 +21,7 @@ from lyra.core.hub.middleware import (
     build_default_pipeline,
 )
 from lyra.core.message import Platform, Response
-from tests.core.conftest import _make_hub, _NullAgent, make_inbound_message
-
+from tests.core.conftest import _make_hub, make_inbound_message
 
 _DROP = PipelineResult(action=Action.DROP)
 _PASS = PipelineResult(action=Action.SUBMIT_TO_POOL)
@@ -136,7 +132,7 @@ class TestResolveBinding:
         next_fn = _make_next()
         msg = make_inbound_message()
 
-        result = await mw(msg, ctx, next_fn)
+        await mw(msg, ctx, next_fn)
 
         next_fn.assert_awaited_once()
         assert ctx.binding is not None
@@ -193,7 +189,7 @@ class TestCreatePool:
         next_fn = _make_next()
         msg = make_inbound_message()
 
-        result = await mw(msg, ctx, next_fn)
+        await mw(msg, ctx, next_fn)
 
         next_fn.assert_awaited_once()
         assert ctx.pool is not None
@@ -220,7 +216,7 @@ class TestCommand:
         next_fn = _make_next()
         msg = make_inbound_message()
 
-        result = await mw(msg, ctx, next_fn)
+        await mw(msg, ctx, next_fn)
 
         next_fn.assert_awaited_once()
 
@@ -269,7 +265,7 @@ class TestCommand:
         next_fn = _make_next()
         msg = make_inbound_message()
 
-        result = await mw(msg, ctx, next_fn)
+        await mw(msg, ctx, next_fn)
 
         next_fn.assert_awaited_once()
 

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -1,0 +1,405 @@
+"""Unit tests for middleware pipeline (#431).
+
+Each middleware is tested independently with a mock ``next()`` callback —
+no Hub required for most tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lyra.core.agent import Agent
+from lyra.core.hub.message_pipeline import Action, PipelineResult
+from lyra.core.hub.middleware import (
+    CommandMiddleware,
+    CreatePoolMiddleware,
+    MiddlewarePipeline,
+    PipelineContext,
+    RateLimitMiddleware,
+    ResolveBindingMiddleware,
+    SubmitToPoolMiddleware,
+    ValidatePlatformMiddleware,
+    build_default_pipeline,
+)
+from lyra.core.message import Platform, Response
+from tests.core.conftest import _make_hub, _NullAgent, make_inbound_message
+
+
+_DROP = PipelineResult(action=Action.DROP)
+_PASS = PipelineResult(action=Action.SUBMIT_TO_POOL)
+
+
+def _make_next(result: PipelineResult = _PASS) -> AsyncMock:
+    """Build a mock ``next`` callback returning *result*."""
+    return AsyncMock(return_value=result)
+
+
+def _make_ctx(**overrides) -> PipelineContext:
+    """Build a PipelineContext with a real hub and optional overrides."""
+    hub = _make_hub()
+    ctx = PipelineContext(hub=hub)
+    for k, v in overrides.items():
+        setattr(ctx, k, v)
+    return ctx
+
+
+# ──────────────────────────────────────────────────────────────────────
+# ValidatePlatformMiddleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestValidatePlatform:
+    async def test_valid_platform_calls_next(self) -> None:
+        mw = ValidatePlatformMiddleware()
+        ctx = _make_ctx()
+        next_fn = _make_next()
+        msg = make_inbound_message(platform="telegram")
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_awaited_once()
+        assert result == _PASS
+
+    async def test_unknown_platform_drops(self) -> None:
+        mw = ValidatePlatformMiddleware()
+        ctx = _make_ctx()
+        next_fn = _make_next()
+        msg = make_inbound_message(platform="unknown_plat")
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_not_awaited()
+        assert result.action == Action.DROP
+
+    async def test_traces_platform_invalid(self) -> None:
+        events: list[dict] = []
+
+        def hook(stage, event, **kw):
+            events.append({"stage": stage, "event": event, **kw})
+
+        mw = ValidatePlatformMiddleware()
+        ctx = _make_ctx(trace_hook=hook)
+        msg = make_inbound_message(platform="bad_plat")
+
+        await mw(msg, ctx, _make_next())
+
+        assert any(e["event"] == "platform_invalid" for e in events)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RateLimitMiddleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestRateLimit:
+    async def test_not_limited_calls_next(self) -> None:
+        mw = RateLimitMiddleware()
+        ctx = _make_ctx()
+        next_fn = _make_next()
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_awaited_once()
+        assert result == _PASS
+        assert ctx.key is not None
+
+    async def test_rate_limited_drops(self) -> None:
+        mw = RateLimitMiddleware()
+        hub = _make_hub(rate_limit=1, rate_window=60)
+        ctx = PipelineContext(hub=hub)
+        msg = make_inbound_message()
+
+        # First call passes
+        await mw(msg, ctx, _make_next())
+        # Second call drops
+        ctx2 = PipelineContext(hub=hub)
+        result = await mw(msg, ctx2, _make_next())
+
+        assert result.action == Action.DROP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# ResolveBindingMiddleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestResolveBinding:
+    async def test_binding_found_calls_next(self) -> None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        mw = ResolveBindingMiddleware()
+        ctx = _make_ctx()
+        ctx.key = RoutingKey(Platform.TELEGRAM, "main", "chat:42")
+        next_fn = _make_next()
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_awaited_once()
+        assert ctx.binding is not None
+        assert ctx.agent is not None
+
+    async def test_no_binding_drops(self) -> None:
+        from lyra.core.hub import Hub
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = Hub()
+        # No binding registered
+        mw = ResolveBindingMiddleware()
+        ctx = PipelineContext(hub=hub)
+        ctx.key = RoutingKey(Platform.TELEGRAM, "main", "chat:42")
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.DROP
+
+    async def test_no_agent_drops(self) -> None:
+        from lyra.core.hub import Hub
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = Hub()
+        from tests.core.conftest import _MockAdapter
+
+        hub.register_adapter(Platform.TELEGRAM, "main", _MockAdapter())  # type: ignore[arg-type]
+        hub.register_binding(Platform.TELEGRAM, "main", "*", "ghost", "telegram:main:*")
+        mw = ResolveBindingMiddleware()
+        ctx = PipelineContext(hub=hub)
+        ctx.key = RoutingKey(Platform.TELEGRAM, "main", "chat:42")
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.DROP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CreatePoolMiddleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCreatePool:
+    async def test_creates_pool_and_router(self) -> None:
+        from lyra.core.hub.hub_protocol import Binding
+
+        hub = _make_hub()
+        agent = hub.agent_registry["lyra"]
+        binding = Binding(agent_name="lyra", pool_id="telegram:main:chat:42")
+        mw = CreatePoolMiddleware()
+        ctx = PipelineContext(hub=hub, binding=binding, agent=agent)
+        next_fn = _make_next()
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_awaited_once()
+        assert ctx.pool is not None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CommandMiddleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCommand:
+    async def test_non_command_calls_next(self) -> None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        mw = CommandMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+            router=None,
+        )
+        next_fn = _make_next()
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_awaited_once()
+
+    async def test_command_dispatched(self) -> None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        router = MagicMock()
+        router.is_command.return_value = True
+        router.dispatch = AsyncMock(return_value=Response(content="ok"))
+
+        mw = CommandMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+            router=router,
+        )
+        next_fn = _make_next()
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, next_fn)
+
+        assert result.action == Action.COMMAND_HANDLED
+        assert result.response is not None
+        assert result.response.content == "ok"
+        next_fn.assert_not_awaited()
+
+    async def test_command_fallthrough_calls_next(self) -> None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        router = MagicMock()
+        router.is_command.return_value = True
+        router.dispatch = AsyncMock(return_value=None)  # not found
+
+        mw = CommandMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+            router=router,
+        )
+        next_fn = _make_next()
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, next_fn)
+
+        next_fn.assert_awaited_once()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SubmitToPoolMiddleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSubmitToPool:
+    async def test_submits_to_pool(self) -> None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = _make_hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+        )
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.SUBMIT_TO_POOL
+        assert result.pool is pool
+
+    async def test_no_adapter_drops(self) -> None:
+        from lyra.core.hub import Hub
+        from lyra.core.hub.hub_protocol import RoutingKey
+
+        hub = Hub()
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(
+            hub=hub,
+            pool=pool,
+            key=RoutingKey(Platform.TELEGRAM, "main", "chat:42"),
+        )
+        msg = make_inbound_message()
+
+        result = await mw(msg, ctx, _make_next())
+
+        assert result.action == Action.DROP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# MiddlewarePipeline (end-to-end chain)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestMiddlewarePipelineChain:
+    async def test_chain_order_preserved(self) -> None:
+        """Middlewares execute in registration order."""
+        order: list[str] = []
+
+        class MW:
+            def __init__(self, name: str):
+                self._name = name
+
+            async def __call__(self, msg, ctx, next):
+                order.append(self._name)
+                return await next(msg, ctx)
+
+        class Terminal:
+            async def __call__(self, msg, ctx, next):
+                order.append("terminal")
+                return _PASS
+
+        hub = _make_hub()
+        pipeline = MiddlewarePipeline([MW("a"), MW("b"), Terminal()], hub)
+        msg = make_inbound_message()
+
+        result = await pipeline.process(msg)
+
+        assert order == ["a", "b", "terminal"]
+        assert result == _PASS
+
+    async def test_short_circuit_stops_chain(self) -> None:
+        """A middleware returning DROP stops the chain."""
+
+        class Blocker:
+            async def __call__(self, msg, ctx, next):
+                return _DROP
+
+        class Unreachable:
+            async def __call__(self, msg, ctx, next):
+                raise AssertionError("should not be reached")
+
+        hub = _make_hub()
+        pipeline = MiddlewarePipeline([Blocker(), Unreachable()], hub)
+        msg = make_inbound_message()
+
+        result = await pipeline.process(msg)
+
+        assert result.action == Action.DROP
+
+    async def test_trace_hook_receives_message_received(self) -> None:
+        events: list[dict] = []
+
+        def hook(stage, event, **kw):
+            events.append({"stage": stage, "event": event, **kw})
+
+        hub = _make_hub()
+        pipeline = build_default_pipeline(hub, trace_hook=hook)
+        msg = make_inbound_message()
+
+        await pipeline.process(msg)
+
+        assert any(e["event"] == "message_received" for e in events)
+
+
+class TestBuildDefaultPipeline:
+    async def test_happy_path(self) -> None:
+        """Full default pipeline routes a valid message to SUBMIT_TO_POOL."""
+        hub = _make_hub()
+        pipeline = build_default_pipeline(hub)
+        msg = make_inbound_message()
+
+        result = await pipeline.process(msg)
+
+        assert result.action == Action.SUBMIT_TO_POOL
+        assert result.pool is not None
+
+    async def test_unknown_platform_drops(self) -> None:
+        hub = _make_hub()
+        pipeline = build_default_pipeline(hub)
+        msg = make_inbound_message(platform="unknown")
+
+        result = await pipeline.process(msg)
+
+        assert result.action == Action.DROP


### PR DESCRIPTION
## Summary
- Extract the monolithic `MessagePipeline` class into 6 composable middleware objects (`ValidatePlatform`, `RateLimit`, `ResolveBinding`, `CreatePool`, `Command`, `SubmitToPool`), each independently testable with a mock `next()` — no Hub required
- `Hub.run()` now uses `build_default_pipeline()` via `MiddlewarePipeline`; old `MessagePipeline` preserved for type import backward compatibility

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #431: extract MessagePipeline stages into composable middleware chain | Open |
| Implementation | 1 commit on `feat/431-middleware-pipeline` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (19 new) | 1635 passed, 0 failures |

## Test Plan
- [x] All 43 existing pipeline tests pass unchanged (`test_message_pipeline_guards`, `test_message_pipeline_context`, `test_message_pipeline` integration)
- [x] 13 TTS dispatch tests updated to patch `MiddlewarePipeline` instead of `MessagePipeline`
- [x] 19 new middleware unit tests: each middleware tested in isolation with mock `next()`
- [x] Full test suite: 1635 passed, 20 skipped, 0 failures
- [ ] Verify trace events emitted at same stages as before
- [ ] Verify plugin middleware insertion works (future PR)

Closes #431

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`