### PR TITLE
fix(types): replace cast(ChannelAdapter) with typed test doubles

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+from collections.abc import AsyncIterator
 from dataclasses import dataclass as _dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,12 +25,16 @@ from lyra.core.message import (
     Attachment,
     InboundAudio,
     InboundMessage,
+    OutboundAttachment,
+    OutboundAudio,
+    OutboundAudioChunk,
     OutboundMessage,
     Platform,
     Response,
     RoutingContext,
 )
 from lyra.core.pool import Pool
+from lyra.core.render_events import RenderEvent
 from lyra.core.stores.agent_store import AgentRow, AgentStore
 from lyra.core.stores.auth_store import AuthStore
 from lyra.core.stores.pairing import PairingConfig, PairingManager
@@ -77,14 +82,14 @@ def make_plugin(
 
 
 class MockAdapter:
-    """Minimal ChannelAdapter for testing."""
+    """Typed ChannelAdapter test double — implements the full protocol."""
 
-    def normalize(self, raw: object) -> InboundMessage:
+    def normalize(self, raw: Any) -> InboundMessage:
         raise NotImplementedError
 
     def normalize_audio(
         self,
-        raw: object,
+        raw: Any,
         audio_bytes: bytes,
         mime_type: str,
         *,
@@ -100,25 +105,29 @@ class MockAdapter:
     async def send_streaming(
         self,
         original_msg: InboundMessage,
-        events: object,
-        outbound: object = None,
+        events: AsyncIterator[RenderEvent],
+        outbound: OutboundMessage | None = None,
     ) -> None:
         pass
 
-    async def render_audio(self, msg: object, inbound: InboundMessage) -> None:
+    async def render_audio(
+        self, msg: OutboundAudio, inbound: InboundMessage
+    ) -> None:
         pass
 
     async def render_audio_stream(
-        self, chunks: object, inbound: InboundMessage
+        self, chunks: AsyncIterator[OutboundAudioChunk], inbound: InboundMessage
     ) -> None:
         pass
 
     async def render_voice_stream(
-        self, chunks: object, inbound: InboundMessage
+        self, chunks: AsyncIterator[OutboundAudioChunk], inbound: InboundMessage
     ) -> None:
         pass
 
-    async def render_attachment(self, msg: object, inbound: InboundMessage) -> None:
+    async def render_attachment(
+        self, msg: OutboundAttachment, inbound: InboundMessage
+    ) -> None:
         pass
 
 
@@ -624,8 +633,8 @@ def make_msg(text: str = "hello") -> InboundMessage:
 # ---------------------------------------------------------------------------
 
 
-class _MockAdapter:
-    """Minimal adapter that records sent messages."""
+class _MockAdapter(MockAdapter):
+    """Adapter that records sent messages — extends MockAdapter."""
 
     def __init__(self) -> None:
         self.sent: list[OutboundMessage] = []
@@ -636,28 +645,6 @@ class _MockAdapter:
         outbound: OutboundMessage,
     ) -> None:
         self.sent.append(outbound)
-
-    async def send_streaming(
-        self,
-        original_msg: InboundMessage,
-        events: object,
-        outbound: object = None,
-    ) -> None:
-        pass
-
-    async def render_audio(
-        self,
-        msg: object,
-        inbound: InboundMessage,
-    ) -> None:
-        pass
-
-    async def render_attachment(
-        self,
-        msg: object,
-        inbound: InboundMessage,
-    ) -> None:
-        pass
 
 
 class _NullAgent(AgentBase):
@@ -686,10 +673,8 @@ def _make_hub(**kwargs: Any) -> Hub:
     )
     hub.register_agent(agent)
 
-    from lyra.core.hub.hub_protocol import ChannelAdapter
-
     adapter = _MockAdapter()
-    hub.register_adapter(Platform.TELEGRAM, "main", cast(ChannelAdapter, adapter))
+    hub.register_adapter(Platform.TELEGRAM, "main", adapter)
     hub.register_binding(
         Platform.TELEGRAM,
         "main",

--- a/tests/core/test_hub_streaming.py
+++ b/tests/core/test_hub_streaming.py
@@ -140,6 +140,7 @@ class TestDispatchStreaming:
 
         await hub.dispatch_streaming(msg, gen())
 
+        assert all(isinstance(e, TextRenderEvent) for e in streamed)
         assert streamed == [
             TextRenderEvent(text="Hello", is_final=False),
             TextRenderEvent(text=" world", is_final=True),
@@ -225,6 +226,7 @@ class TestDispatchStreaming:
             ) -> None:
                 sent.append(outbound)
 
+        # LegacyAdapter intentionally lacks send_streaming — tests voice fallback path
         hub.register_adapter(
             Platform.TELEGRAM,
             "main",

--- a/tests/core/test_hub_streaming.py
+++ b/tests/core/test_hub_streaming.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from lyra.core import Agent, AgentBase, Hub, Pool
@@ -17,7 +17,7 @@ from lyra.core.message import (
 )
 from lyra.core.render_events import RenderEvent, TextRenderEvent
 from lyra.tts import TTSService
-from tests.core.conftest import make_inbound_message
+from tests.core.conftest import MockAdapter, make_inbound_message
 
 
 def _mock_tts_on(hub: Hub) -> AsyncMock:
@@ -37,27 +37,18 @@ class TestDispatchStreaming:
         hub = Hub()
         received: list[str] = []
 
-        class StreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class StreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
+                events: AsyncIterator[RenderEvent],
                 outbound: OutboundMessage | None = None,
             ) -> None:
                 async for event in events:
                     if isinstance(event, TextRenderEvent):
                         received.append(event.text)
 
-        hub.register_adapter(
-            Platform.TELEGRAM,
-            "main",
-            cast(ChannelAdapter, StreamAdapter()),
-        )
+        hub.register_adapter(Platform.TELEGRAM, "main", StreamAdapter())
         msg = make_inbound_message(platform="telegram", bot_id="main")
 
         async def gen() -> AsyncIterator[TextRenderEvent]:
@@ -71,26 +62,17 @@ class TestDispatchStreaming:
         """dispatch_streaming sets _last_processed_at on successful stream."""
         hub = Hub()
 
-        class StreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class StreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
+                events: AsyncIterator[RenderEvent],
                 outbound: OutboundMessage | None = None,
             ) -> None:
                 async for _ in events:
                     pass
 
-        hub.register_adapter(
-            Platform.TELEGRAM,
-            "main",
-            cast(ChannelAdapter, StreamAdapter()),
-        )
+        hub.register_adapter(Platform.TELEGRAM, "main", StreamAdapter())
         assert hub._last_processed_at is None
         msg = make_inbound_message(platform="telegram", bot_id="main")
 
@@ -137,28 +119,19 @@ class TestDispatchStreaming:
             "synthesize_and_dispatch_audio",
             _mock_synth,
         )
-        streamed: list[TextRenderEvent] = []
+        streamed: list[RenderEvent] = []
 
-        class StreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class StreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
-                outbound: object = None,
+                events: AsyncIterator[RenderEvent],
+                outbound: OutboundMessage | None = None,
             ) -> None:
                 async for chunk in events:
                     streamed.append(chunk)
 
-        hub.register_adapter(
-            Platform.TELEGRAM,
-            "main",
-            cast(ChannelAdapter, StreamAdapter()),
-        )
+        hub.register_adapter(Platform.TELEGRAM, "main", StreamAdapter())
         msg = make_inbound_message(platform="telegram", bot_id="main", modality="voice")
 
         async def gen() -> AsyncIterator[TextRenderEvent]:
@@ -188,26 +161,17 @@ class TestDispatchStreaming:
             _mock_synth,
         )
 
-        class StreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class StreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
-                outbound: object = None,
+                events: AsyncIterator[RenderEvent],
+                outbound: OutboundMessage | None = None,
             ) -> None:
                 async for _ in events:
                     pass
 
-        hub.register_adapter(
-            Platform.TELEGRAM,
-            "main",
-            cast(ChannelAdapter, StreamAdapter()),
-        )
+        hub.register_adapter(Platform.TELEGRAM, "main", StreamAdapter())
         msg = make_inbound_message(platform="telegram", bot_id="main", modality="voice")
 
         async def gen() -> AsyncIterator[TextRenderEvent]:
@@ -224,27 +188,18 @@ class TestDispatchStreaming:
         hub = Hub()
         streamed: list[str] = []
 
-        class StreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class StreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
-                outbound: object = None,
+                events: AsyncIterator[RenderEvent],
+                outbound: OutboundMessage | None = None,
             ) -> None:
                 async for chunk in events:
                     if isinstance(chunk, TextRenderEvent):
                         streamed.append(chunk.text)
 
-        hub.register_adapter(
-            Platform.TELEGRAM,
-            "main",
-            cast(ChannelAdapter, StreamAdapter()),
-        )
+        hub.register_adapter(Platform.TELEGRAM, "main", StreamAdapter())
         msg = make_inbound_message(platform="telegram", bot_id="main", modality="voice")
 
         async def gen() -> AsyncIterator[TextRenderEvent]:
@@ -305,25 +260,20 @@ class TestDispatchStreaming:
         )
         streamed: list[str] = []
 
-        class StreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class StreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
-                outbound: object = None,
+                events: AsyncIterator[RenderEvent],
+                outbound: OutboundMessage | None = None,
             ) -> None:
                 async for chunk in events:
                     if isinstance(chunk, TextRenderEvent):
                         streamed.append(chunk.text)
 
         adapter = StreamAdapter()
-        hub.register_adapter(Platform.TELEGRAM, "main", cast(ChannelAdapter, adapter))
-        dispatcher = OutboundDispatcher("telegram", cast(ChannelAdapter, adapter))
+        hub.register_adapter(Platform.TELEGRAM, "main", adapter)
+        dispatcher = OutboundDispatcher("telegram", adapter)
         hub.register_outbound_dispatcher(Platform.TELEGRAM, "main", dispatcher)
         await dispatcher.start()
 
@@ -374,16 +324,11 @@ class TestHubRunStreaming:
 
                 return _stream()
 
-        class CapturingStreamAdapter:
-            async def send(
-                self, original_msg: InboundMessage, outbound: OutboundMessage
-            ) -> None:
-                pass
-
+        class CapturingStreamAdapter(MockAdapter):
             async def send_streaming(
                 self,
                 original_msg: InboundMessage,
-                events: AsyncIterator[Any],
+                events: AsyncIterator[RenderEvent],
                 outbound: OutboundMessage | None = None,
             ) -> None:
                 async for chunk in events:
@@ -392,11 +337,7 @@ class TestHubRunStreaming:
 
         config = Agent(name="streamer", system_prompt="", memory_namespace="lyra")
         hub.register_agent(StreamingAgent(config))
-        hub.register_adapter(
-            Platform.TELEGRAM,
-            "main",
-            cast(ChannelAdapter, CapturingStreamAdapter()),
-        )
+        hub.register_adapter(Platform.TELEGRAM, "main", CapturingStreamAdapter())
         hub.register_binding(
             Platform.TELEGRAM, "main", "chat:42", "streamer", "telegram:main:chat:42"
         )

--- a/tests/core/test_message_pipeline_guards.py
+++ b/tests/core/test_message_pipeline_guards.py
@@ -4,13 +4,11 @@ gate removal assertions (#208, #245)."""
 from __future__ import annotations
 
 import asyncio
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from lyra.core.agent import Agent
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.hub import Hub
-from lyra.core.hub.hub_protocol import ChannelAdapter
 from lyra.core.hub.message_pipeline import Action, MessagePipeline
 from lyra.core.message import InboundMessage, Platform, Response
 from lyra.core.pool import Pool
@@ -53,7 +51,7 @@ class TestPipelineGuardStages:
         hub.register_adapter(
             Platform.TELEGRAM,
             "main",
-            cast(ChannelAdapter, _MockAdapter()),
+            _MockAdapter(),
         )
         pipeline = MessagePipeline(hub)
         msg = make_inbound_message()
@@ -65,7 +63,7 @@ class TestPipelineGuardStages:
         hub.register_adapter(
             Platform.TELEGRAM,
             "main",
-            cast(ChannelAdapter, _MockAdapter()),
+            _MockAdapter(),
         )
         # Binding references non-existent agent
         hub.register_binding(

--- a/tests/integration/test_message_pipeline.py
+++ b/tests/integration/test_message_pipeline.py
@@ -22,11 +22,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
-from lyra.core.hub.hub_protocol import ChannelAdapter
 from lyra.core.hub.message_pipeline import Action, MessagePipeline
 from lyra.core.message import Platform
 from tests.core.conftest import (
@@ -151,7 +150,7 @@ class TestMessagePipelineTraces:
 
         hub = Hub()
         adapter = _MockAdapter()
-        hub.register_adapter(Platform.TELEGRAM, "main", cast(ChannelAdapter, adapter))
+        hub.register_adapter(Platform.TELEGRAM, "main", adapter)
         # Intentionally no binding registered
 
         pipeline = MessagePipeline(hub, trace_hook=_make_trace_hook(steps))
@@ -176,7 +175,7 @@ class TestMessagePipelineTraces:
 
         hub = Hub()
         adapter = _MockAdapter()
-        hub.register_adapter(Platform.TELEGRAM, "main", cast(ChannelAdapter, adapter))
+        hub.register_adapter(Platform.TELEGRAM, "main", adapter)
         hub.register_binding(
             Platform.TELEGRAM, "main", "*", "ghost_agent", "telegram:main:*"
         )


### PR DESCRIPTION
## Summary
- **MockAdapter** in `tests/core/conftest.py` now fully implements the `ChannelAdapter` protocol with correct type annotations (was using `object` params and missing `render_audio_stream`)
- **_MockAdapter** and all inline test adapters (`StreamAdapter`, `CapturingStreamAdapter`) subclass `MockAdapter`, eliminating boilerplate and 13 `cast(ChannelAdapter, ...)` calls
- Remaining 2 casts are intentional — `LegacyAdapter` tests verify the fallback when `send_streaming` is missing

Closes #434

## Test plan
- [x] `ruff check` — clean
- [x] `pyright` — 0 errors on changed files
- [x] `pytest` — 1599/1599 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)