### PR TITLE
refactor(core): extract Bus[T] Protocol, rename InboundBus to LocalBus (#48)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -39,7 +39,8 @@ async def main() -> None:
     hub.register_adapter(Platform.TELEGRAM, "main", adapter)
     hub.register_binding(Platform.TELEGRAM, "main", "*", "echo", "telegram:main:*")
 
-    # Start hub consumer
+    # Start bus feeders + hub consumer
+    await hub.inbound_bus.start()
     hub_task = asyncio.create_task(hub.run())
 
     # Simulate messages
@@ -59,10 +60,10 @@ async def main() -> None:
             trust_level=TrustLevel.TRUSTED,
         )
         print(f"  -> {text}")
-        await hub.bus.put(msg)
+        hub.inbound_bus.put(Platform.TELEGRAM, msg)
 
     # Let the hub process all messages
-    await hub.bus.join()
+    await hub.inbound_bus._staging.join()  # type: ignore[union-attr]
 
     print(f"\nDone — {len(adapter.responses)} messages routed successfully.")
     hub_task.cancel()

--- a/demo.py
+++ b/demo.py
@@ -63,7 +63,8 @@ async def main() -> None:
         hub.inbound_bus.put(Platform.TELEGRAM, msg)
 
     # Let the hub process all messages
-    await hub.inbound_bus._staging.join()  # type: ignore[union-attr]
+    while hub.inbound_bus.staging_qsize() > 0:
+        await asyncio.sleep(0)
 
     print(f"\nDone — {len(adapter.responses)} messages routed successfully.")
     hub_task.cancel()

--- a/src/lyra/adapters/_shared.py
+++ b/src/lyra/adapters/_shared.py
@@ -33,7 +33,7 @@ from lyra.core.message import (
 )
 
 if TYPE_CHECKING:
-    from lyra.core.inbound_bus import InboundBus
+    from lyra.core.bus import Bus
     from lyra.core.messages import MessageManager
 
 __all__ = [
@@ -59,7 +59,7 @@ log = logging.getLogger(__name__)
 
 async def push_to_hub_guarded(  # noqa: PLR0913 — each arg is a distinct guard/callback dependency
     *,
-    inbound_bus: "InboundBus[Any]",
+    inbound_bus: "Bus[Any]",
     platform: Platform,
     msg: InboundMessage | InboundAudio,
     circuit_registry: CircuitRegistry | None,

--- a/src/lyra/core/CLAUDE.md
+++ b/src/lyra/core/CLAUDE.md
@@ -9,13 +9,13 @@ shared protocols. Everything else in the project depends on `core/`.
 ## Key architecture: hub-and-spoke
 
 ```
-Inbound (platform) → InboundBus → MessagePipeline → Pool → Agent → LlmProvider
+Inbound (platform) → Bus[T] (LocalBus) → MessagePipeline → Pool → Agent → LlmProvider
                                                         ↓
 Outbound (platform) ←──────────────── OutboundDispatcher ←──────────────────
 ```
 
 - `Hub` (`hub/hub.py`) is the singleton coordinator. It owns one `PoolManager`, one
-  `InboundBus`, one `OutboundDispatcher` per registered adapter, and the agent registry.
+  `LocalBus` (typed as `Bus[T]`), one `OutboundDispatcher` per registered adapter, and the agent registry.
 - `Pool` (`pool/pool.py`) is one-per-conversation-scope. It serialises turns, debounces
   rapid messages, and holds the SDK history deque. A Pool never knows which platform
   it came from — routing is done by `PoolManager` before the Pool is touched.

--- a/src/lyra/core/__init__.py
+++ b/src/lyra/core/__init__.py
@@ -8,6 +8,7 @@ from .hub import (
     PipelineResult,
     RoutingKey,
 )
+from .inbound_bus import LocalBus
 from .message import (
     Attachment,
     Button,
@@ -21,7 +22,6 @@ from .message import (
     Response,
     RoutingContext,
 )
-from .inbound_bus import LocalBus
 from .pool import Pool
 from .render_events import (
     FileEditSummary,

--- a/src/lyra/core/__init__.py
+++ b/src/lyra/core/__init__.py
@@ -1,4 +1,5 @@
 from .agent import Agent, AgentBase
+from .bus import Bus
 from .hub import (
     Action,
     ChannelAdapter,
@@ -20,6 +21,7 @@ from .message import (
     Response,
     RoutingContext,
 )
+from .inbound_bus import LocalBus
 from .pool import Pool
 from .render_events import (
     FileEditSummary,
@@ -34,6 +36,7 @@ __all__ = [
     "Agent",
     "AgentBase",
     "Attachment",
+    "Bus",
     "Button",
     "ChannelAdapter",
     "CodeBlock",
@@ -42,6 +45,7 @@ __all__ = [
     "Hub",
     "MessagePipeline",
     "InboundMessage",
+    "LocalBus",
     "MediaPart",
     "OutboundAttachment",
     "OutboundMessage",

--- a/src/lyra/core/bus.py
+++ b/src/lyra/core/bus.py
@@ -1,0 +1,68 @@
+"""Bus — generic inbound message transport protocol.
+
+Defines the ``Bus[T]`` Protocol that the Hub depends on for inbound message
+routing.  The concrete implementation is ``LocalBus`` in ``inbound_bus.py``
+(backed by ``asyncio.Queue``).  Future transports (e.g. NATS, issue #50)
+implement the same Protocol without touching Hub internals.
+
+Usage::
+
+    from lyra.core.bus import Bus
+    from lyra.core.inbound_bus import LocalBus
+    from lyra.core.message import InboundMessage
+
+    bus: Bus[InboundMessage] = LocalBus(name="inbound")
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+from .message import Platform
+
+T = TypeVar("T")
+
+
+class Bus(Protocol[T]):
+    """Generic inbound message transport.
+
+    Structural protocol — concrete classes satisfy it without inheriting.
+    Invariant in ``T`` (both covariant ``get() -> T`` and contravariant
+    ``put(item: T)`` positions).
+    """
+
+    def register(self, platform: Platform, maxsize: int = 100) -> None:
+        """Register a bounded queue for the given platform."""
+        ...
+
+    def put(self, platform: Platform, item: T) -> None:
+        """Enqueue an item on the platform's queue (synchronous, non-blocking)."""
+        ...
+
+    async def get(self) -> T:
+        """Wait for and return the next item from the staging queue."""
+        ...
+
+    def task_done(self) -> None:
+        """Notify that the current item was processed."""
+        ...
+
+    async def start(self) -> None:
+        """Start the bus (spawn feeder tasks, open connections, etc.)."""
+        ...
+
+    async def stop(self) -> None:
+        """Stop the bus and clean up resources."""
+        ...
+
+    def qsize(self, platform: Platform) -> int:
+        """Return the current number of items in the platform's queue."""
+        ...
+
+    def staging_qsize(self) -> int:
+        """Return the current number of items in the staging queue."""
+        ...
+
+    def registered_platforms(self) -> frozenset[Platform]:
+        """Return the set of platforms with a registered queue."""
+        ...

--- a/src/lyra/core/hub/CLAUDE.md
+++ b/src/lyra/core/hub/CLAUDE.md
@@ -10,7 +10,7 @@ and outbound dispatcher.
 
 | File | Responsibility |
 |------|---------------|
-| `hub.py` | `Hub` class — main entry point; owns InboundBus, adapters, PoolManager, OutboundDispatcher |
+| `hub.py` | `Hub` class — main entry point; owns Bus[T] (LocalBus), adapters, PoolManager, OutboundDispatcher |
 | `hub_outbound.py` | `HubOutboundMixin` — outbound dispatch helpers mixed into Hub |
 | `hub_protocol.py` | `ChannelAdapter` protocol, `RoutingKey` NamedTuple, `Binding` type |
 | `hub_rate_limit.py` | Per-adapter rate limiting logic |

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING
 
 from ..agent import AgentBase
 from ..audio_pipeline import AudioPipeline
-from ..inbound_bus import InboundBus
+from ..bus import Bus
+from ..inbound_bus import LocalBus
 from ..message import InboundAudio, InboundMessage, Platform
 from ..pool import Pool
 from .hub_outbound import HubOutboundMixin
@@ -43,7 +44,7 @@ log = logging.getLogger(__name__)
 
 
 class Hub(HubOutboundMixin):
-    """Central hub: InboundBus + OutboundDispatchers + adapter registry + pools."""
+    """Central hub: Bus + OutboundDispatchers + adapter registry + pools."""
 
     # Class-level defaults used directly in tests and when Hub() is constructed
     # without config.  Production values come from [hub] in config.toml via
@@ -83,12 +84,12 @@ class Hub(HubOutboundMixin):
         max_merged_chars: int = MAX_MERGED_CHARS,
     ) -> None:
         self._platform_queue_maxsize = platform_queue_maxsize
-        self.inbound_bus: InboundBus[InboundMessage] = InboundBus(
+        self.inbound_bus: Bus[InboundMessage] = LocalBus(
             name="inbound",
             staging_maxsize=staging_maxsize,
             queue_depth_threshold=queue_depth_threshold,
         )
-        self.inbound_audio_bus: InboundBus[InboundAudio] = InboundBus(
+        self.inbound_audio_bus: Bus[InboundAudio] = LocalBus(
             name="inbound-audio",
             staging_maxsize=staging_maxsize,
             queue_depth_threshold=queue_depth_threshold,
@@ -124,10 +125,6 @@ class Hub(HubOutboundMixin):
     @property
     def pools(self) -> dict[str, Pool]:
         return self._pool_manager.pools
-
-    @property
-    def bus(self) -> asyncio.Queue[InboundMessage]:
-        return self.inbound_bus._staging
 
     def register_agent(self, agent: AgentBase) -> None:
         """Register an agent implementation by name."""

--- a/src/lyra/core/inbound_audio_bus.py
+++ b/src/lyra/core/inbound_audio_bus.py
@@ -1,17 +1,17 @@
-"""InboundAudioBus — backwards-compatible alias for InboundBus[InboundAudio].
+"""InboundAudioBus — backwards-compatible alias for LocalBus[InboundAudio].
 
-The implementation is the generic ``InboundBus[T]`` in ``inbound_bus.py``.
+The implementation is the generic ``LocalBus[T]`` in ``inbound_bus.py``.
 This module exists so existing import sites can continue to use
 ``from .inbound_audio_bus import InboundAudioBus`` without change.
 """
 
 from __future__ import annotations
 
-from .inbound_bus import InboundBus
+from .inbound_bus import LocalBus
 from .message import InboundAudio
 
-# InboundAudioBus is InboundBus specialised for audio envelopes.
+# InboundAudioBus is LocalBus specialised for audio envelopes.
 # The name= parameter drives feeder task names and log messages.
-InboundAudioBus = InboundBus[InboundAudio]
+InboundAudioBus = LocalBus[InboundAudio]
 
 __all__ = ["InboundAudioBus"]

--- a/src/lyra/core/inbound_bus.py
+++ b/src/lyra/core/inbound_bus.py
@@ -1,5 +1,6 @@
-"""InboundBus — generic per-platform inbound queues with feeder tasks and staging queue.
+"""LocalBus — generic per-platform inbound queues with feeder tasks and staging queue.
 
+Concrete implementation of the ``Bus[T]`` Protocol defined in ``bus.py``.
 Each registered platform gets its own bounded asyncio.Queue. Independent feeder
 tasks drain per-platform queues into a single staging queue consumed by Hub.run().
 This isolates platform-level backpressure: a flood on one platform cannot starve
@@ -7,18 +8,19 @@ another platform's messages.
 
 Usage::
 
-    from lyra.core.inbound_bus import InboundBus
+    from lyra.core.bus import Bus
+    from lyra.core.inbound_bus import LocalBus
     from lyra.core.message import InboundMessage, InboundAudio, Platform
 
     # Text messages
-    bus: InboundBus[InboundMessage] = InboundBus(name="inbound")
+    bus: Bus[InboundMessage] = LocalBus(name="inbound")
     bus.register(Platform.TELEGRAM, maxsize=100)
     await bus.start()
     ...
     await bus.stop()
 
     # Audio envelopes — depth monitoring included
-    audio_bus: InboundBus[InboundAudio] = InboundBus(name="inbound-audio")
+    audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")
     audio_bus.register(Platform.TELEGRAM, maxsize=100)
     await audio_bus.start()
 """
@@ -36,12 +38,14 @@ log = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-class InboundBus(Generic[T]):
+class LocalBus(Generic[T]):
     """Generic per-platform inbound queues + staging queue consumed by Hub.run().
+
+    Concrete implementation of ``Bus[T]`` Protocol.
 
     Lifecycle::
 
-        bus: InboundBus[InboundMessage] = InboundBus(name="inbound")
+        bus: Bus[InboundMessage] = LocalBus(name="inbound")
         bus.register(Platform.TELEGRAM, maxsize=100)
         bus.register(Platform.DISCORD, maxsize=100)
         await bus.start()          # spawns feeder tasks
@@ -109,7 +113,7 @@ class InboundBus(Generic[T]):
         """
         if self._feeders:
             raise RuntimeError(
-                f"InboundBus({self._name!r}).start() called while feeders are "
+                f"LocalBus({self._name!r}).start() called while feeders are "
                 "already running — call stop() first."
             )
         for platform, queue in self._queues.items():
@@ -122,7 +126,7 @@ class InboundBus(Generic[T]):
     async def _feeder(self, platform: Platform, queue: asyncio.Queue[T]) -> None:
         """Drain platform queue into the staging queue indefinitely."""
         log.debug(
-            "InboundBus(%r) feeder started for platform=%s",
+            "LocalBus(%r) feeder started for platform=%s",
             self._name,
             platform.value,
         )

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -285,6 +285,23 @@ def make_inbound_message(  # noqa: PLR0913
     return InboundMessage(**kwargs)
 
 
+async def push_to_hub(hub: Hub, msg: InboundMessage) -> None:
+    """Inject *msg* into the hub's inbound bus for testing.
+
+    Registers the platform and starts the bus feeders if needed, then
+    enqueues via the ``Bus`` Protocol's ``put()`` method.
+    """
+    from lyra.core.inbound_bus import LocalBus
+
+    platform = Platform(msg.platform)
+    bus = hub.inbound_bus
+    if platform not in bus.registered_platforms():
+        bus.register(platform)
+    if isinstance(bus, LocalBus) and not bus._feeders:
+        await bus.start()
+    bus.put(platform, msg)
+
+
 # ---------------------------------------------------------------------------
 # StreamingIterator shared helpers (used by test_cli_streaming_parse +
 # test_cli_streaming_lifecycle)

--- a/tests/core/test_audio_pipeline_constraints.py
+++ b/tests/core/test_audio_pipeline_constraints.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 
 from lyra.core.hub import Hub
+from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import InboundMessage, Platform, Response
 from lyra.core.trust import TrustLevel
 from tests.core.conftest import FakeSTT, make_audio, make_inbound_message
@@ -67,8 +68,10 @@ class TestAudioPipelineTrustLevel:
         task = asyncio.create_task(hub._audio_pipeline.run())
         try:
             # The normal audio should produce the echo reply
+            # Cast to LocalBus for test access to private staging queue
+            staging = cast(LocalBus[InboundMessage], hub.inbound_bus)._staging
             msg: InboundMessage = await asyncio.wait_for(
-                hub.inbound_bus._staging.get(), timeout=2.0
+                staging.get(), timeout=2.0
             )
             assert msg.id == "audio-2"
             # No dispatch for the blocked audio — capture should only have the
@@ -112,7 +115,9 @@ class TestAudioPipelineRateLimit:
         task = asyncio.create_task(hub._audio_pipeline.run())
         try:
             # Wait for the first audio to be enqueued as text
-            await asyncio.wait_for(hub.inbound_bus._staging.get(), timeout=2.0)
+            # Cast to LocalBus for test access to private staging queue
+            staging = cast(LocalBus[InboundMessage], hub.inbound_bus)._staging
+            await asyncio.wait_for(staging.get(), timeout=2.0)
             # Give the loop time to process second audio and dispatch rate limit
             await asyncio.sleep(0.1)
             # The rate-limited reply should be dispatched
@@ -187,8 +192,10 @@ class TestAudioPipelineTranscriptCap:
         await hub.inbound_audio_bus.start()
         task = asyncio.create_task(hub._audio_pipeline.run())
         try:
+            # Cast to LocalBus for test access to private staging queue
+            staging = cast(LocalBus[InboundMessage], hub.inbound_bus)._staging
             msg: InboundMessage = await asyncio.wait_for(
-                hub.inbound_bus._staging.get(), timeout=2.0
+                staging.get(), timeout=2.0
             )
             assert len(msg.text) == 2000
         finally:

--- a/tests/core/test_command_router_detection.py
+++ b/tests/core/test_command_router_detection.py
@@ -34,7 +34,7 @@ from lyra.core.message import (
 from lyra.core.messages import MessageManager
 from lyra.core.pool import Pool
 
-from .conftest import make_echo_plugin_dir, make_message, make_router
+from .conftest import make_echo_plugin_dir, make_message, make_router, push_to_hub
 
 TOML_PATH = (
     Path(__file__).resolve().parent.parent.parent
@@ -261,7 +261,7 @@ class TestPassthroughNonCommandInHub:
         )
 
         plain_msg = make_message(content="hello, how are you?")
-        await hub.bus.put(plain_msg)
+        await push_to_hub(hub, plain_msg)
 
         try:
             await asyncio.wait_for(hub.run(), timeout=0.3)
@@ -311,7 +311,7 @@ class TestPassthroughNonCommandInHub:
         )
 
         command_msg = make_message(content="/help")
-        await hub.bus.put(command_msg)
+        await push_to_hub(hub, command_msg)
 
         try:
             await asyncio.wait_for(hub.run(), timeout=0.3)

--- a/tests/core/test_command_router_special.py
+++ b/tests/core/test_command_router_special.py
@@ -34,7 +34,7 @@ from lyra.core.message import (
 )
 from lyra.core.pool import Pool
 
-from .conftest import make_echo_plugin_dir, make_message, make_router
+from .conftest import make_echo_plugin_dir, make_message, make_router, push_to_hub
 
 # ---------------------------------------------------------------------------
 # Helpers local to this file
@@ -158,7 +158,7 @@ class TestBangPrefixFallthrough:
             Platform.TELEGRAM, "main", "chat:42", "lyra", "telegram:main:chat:42"
         )
 
-        await hub.bus.put(make_message(content="!unknown_xyz"))
+        await push_to_hub(hub, make_message(content="!unknown_xyz"))
 
         try:
             await asyncio.wait_for(hub.run(), timeout=0.3)

--- a/tests/core/test_hub_audio_loop.py
+++ b/tests/core/test_hub_audio_loop.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 
 from lyra.core.hub import Hub
+from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import InboundAudio, InboundMessage, Platform, Response
 from lyra.core.trust import TrustLevel
 
@@ -113,8 +114,10 @@ class TestAudioLoopTranscription:
         task = asyncio.create_task(hub._audio_pipeline.run())
         try:
             # Wait for the message to appear on the inbound bus staging queue
+            # Cast to LocalBus for test access to private staging queue
+            staging = cast(LocalBus[InboundMessage], hub.inbound_bus)._staging
             msg: InboundMessage = await asyncio.wait_for(
-                hub.inbound_bus._staging.get(), timeout=2.0
+                staging.get(), timeout=2.0
             )
             assert msg.id == "audio-1"
             assert msg.text == "Hello world"
@@ -307,8 +310,10 @@ class TestProcessAudioItemPropagatesLanguage:
         await hub.inbound_audio_bus.start()
         task = asyncio.create_task(hub._audio_pipeline.run())
         try:
+            # Cast to LocalBus for test access to private staging queue
+            staging = cast(LocalBus[InboundMessage], hub.inbound_bus)._staging
             msg: InboundMessage = await asyncio.wait_for(
-                hub.inbound_bus._staging.get(), timeout=2.0
+                staging.get(), timeout=2.0
             )
             assert msg.language == "fr"
         finally:
@@ -334,11 +339,14 @@ class TestAudioLoopTaskDone:
         task = asyncio.create_task(hub._audio_pipeline.run())
         try:
             # Wait for re-enqueued message
-            await asyncio.wait_for(hub.inbound_bus._staging.get(), timeout=2.0)
+            # Cast to LocalBus for test access to private staging queue
+            inbound_staging = cast(LocalBus[InboundMessage], hub.inbound_bus)._staging
+            await asyncio.wait_for(inbound_staging.get(), timeout=2.0)
             # Give the loop time to call task_done
             await asyncio.sleep(0.05)
             # join() should return immediately since task_done was called
-            await asyncio.wait_for(hub.inbound_audio_bus._staging.join(), timeout=1.0)
+            audio_staging = cast(LocalBus[InboundAudio], hub.inbound_audio_bus)._staging
+            await asyncio.wait_for(audio_staging.join(), timeout=1.0)
         finally:
             task.cancel()
             await hub.inbound_audio_bus.stop()

--- a/tests/core/test_hub_circuit_fast_fail.py
+++ b/tests/core/test_hub_circuit_fast_fail.py
@@ -19,7 +19,7 @@ from lyra.core.message import (
     OutboundMessage,
     Platform,
 )
-from tests.core.conftest import make_circuit_registry, make_inbound_message
+from tests.core.conftest import make_circuit_registry, make_inbound_message, push_to_hub
 
 # ---------------------------------------------------------------------------
 # SC-07 — Anthropic circuit OPEN: fast-fail reply, agent.process() skipped
@@ -77,7 +77,7 @@ async def test_anthropic_circuit_open_sends_fast_fail_and_skips_agent() -> None:
     hub.register_binding(Platform.TELEGRAM, "main", "*", "test", "telegram:main:*")
 
     # Act — put one message on bus and let hub process it
-    await hub.bus.put(make_inbound_message())
+    await push_to_hub(hub, make_inbound_message())
     hub_task = asyncio.create_task(hub.run())
     await asyncio.sleep(0.05)
     hub_task.cancel()
@@ -146,7 +146,7 @@ async def test_anthropic_circuit_open_includes_retry_after() -> None:
     hub.register_binding(Platform.TELEGRAM, "main", "*", "test", "telegram:main:*")
 
     # Act
-    await hub.bus.put(make_inbound_message())
+    await push_to_hub(hub, make_inbound_message())
     hub_task = asyncio.create_task(hub.run())
     await asyncio.sleep(0.05)
     hub_task.cancel()

--- a/tests/core/test_hub_circuit_streaming.py
+++ b/tests/core/test_hub_circuit_streaming.py
@@ -17,7 +17,7 @@ from lyra.core.message import (
     OutboundMessage,
     Platform,
 )
-from tests.core.conftest import make_circuit_registry, make_inbound_message
+from tests.core.conftest import make_circuit_registry, make_inbound_message, push_to_hub
 
 # ---------------------------------------------------------------------------
 # SC-10 — Clean streaming records hub circuit success
@@ -65,7 +65,7 @@ async def test_hub_records_success_on_clean_streaming() -> None:
     hub.register_binding(Platform.TELEGRAM, "main", "*", "test", "telegram:main:*")
 
     # Act
-    await hub.bus.put(make_inbound_message())
+    await push_to_hub(hub, make_inbound_message())
     hub_task = asyncio.create_task(hub.run())
     await asyncio.sleep(0.1)
     hub_task.cancel()
@@ -128,7 +128,7 @@ async def test_mid_stream_failure_records_anthropic_failure() -> None:
     hub.register_binding(Platform.TELEGRAM, "main", "*", "test", "telegram:main:*")
 
     # Act
-    await hub.bus.put(make_inbound_message())
+    await push_to_hub(hub, make_inbound_message())
     hub_task = asyncio.create_task(hub.run())
     await asyncio.sleep(0.1)
     hub_task.cancel()
@@ -191,7 +191,7 @@ async def test_hub_circuit_opens_after_threshold() -> None:
 
     # Act — enqueue 2 messages to trip the threshold
     for _ in range(2):
-        await hub.bus.put(make_inbound_message())
+        await push_to_hub(hub, make_inbound_message())
     hub_task = asyncio.create_task(hub.run())
     await asyncio.sleep(0.2)
     hub_task.cancel()
@@ -273,7 +273,7 @@ async def test_hub_msg_manager_injection_generic_on_agent_failure() -> None:
 
     # Act — put one message; hub processes it and sends an error reply
     msg = make_inbound_message(platform="telegram", bot_id="main", user_id="alice")
-    await hub.bus.put(msg)
+    await push_to_hub(hub, msg)
     hub_task = asyncio.create_task(hub.run())
     await asyncio.sleep(0.1)
     hub_task.cancel()

--- a/tests/core/test_hub_init.py
+++ b/tests/core/test_hub_init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,7 +14,9 @@ from lyra.core import (
     Hub,
     Pool,
 )
+from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import (
+    InboundMessage,
     Platform,
 )
 from tests.core.conftest import MockAdapter
@@ -103,7 +105,9 @@ class TestHubInit:
         hub.register_adapter(Platform.TELEGRAM, "main", MockAdapter())
         assert hub.inbound_bus.qsize(Platform.TELEGRAM) == 0
         # Per-platform queue has BUS_SIZE maxsize
-        assert hub.inbound_bus._queues[Platform.TELEGRAM].maxsize == Hub.BUS_SIZE
+        # Cast to LocalBus for test access to private _queues dict
+        queues = cast(LocalBus[InboundMessage], hub.inbound_bus)._queues
+        assert queues[Platform.TELEGRAM].maxsize == Hub.BUS_SIZE
 
     def test_empty_registries(self) -> None:
         hub = Hub()

--- a/tests/core/test_hub_init.py
+++ b/tests/core/test_hub_init.py
@@ -95,6 +95,8 @@ class TestHubInit:
         hub = Hub()
         assert Hub.BUS_SIZE == 100
         assert isinstance(hub.inbound_bus, LocalBus)
+        # hub.bus property was removed in #48 — no raw asyncio.Queue exposure
+        assert not hasattr(hub, "bus")
 
     def test_per_platform_queue_is_bounded_after_register_adapter(self) -> None:
         hub = Hub()

--- a/tests/core/test_hub_init.py
+++ b/tests/core/test_hub_init.py
@@ -90,13 +90,11 @@ class TestAgent:
 
 class TestHubInit:
     def test_inbound_bus_exists(self) -> None:
-        from lyra.core.inbound_bus import InboundBus
+        from lyra.core.inbound_bus import LocalBus
 
         hub = Hub()
         assert Hub.BUS_SIZE == 100
-        assert isinstance(hub.inbound_bus, InboundBus)
-        # hub.bus is a backward-compat alias for the staging queue (unbounded)
-        assert isinstance(hub.bus, asyncio.Queue)
+        assert isinstance(hub.inbound_bus, LocalBus)
 
     def test_per_platform_queue_is_bounded_after_register_adapter(self) -> None:
         hub = Hub()

--- a/tests/core/test_hub_routing.py
+++ b/tests/core/test_hub_routing.py
@@ -118,7 +118,8 @@ class TestUnmatchedRouting:
             except asyncio.TimeoutError:
                 pass  # expected — run() never returns on its own
         assert any("unmatched" in r.message.lower() for r in caplog.records)
-        assert hub.inbound_bus.staging_qsize() == 0  # message was consumed (dropped, not re-queued)
+        # message was consumed (dropped, not re-queued)
+        assert hub.inbound_bus.staging_qsize() == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_hub_routing.py
+++ b/tests/core/test_hub_routing.py
@@ -9,7 +9,7 @@ import pytest
 
 from lyra.core import Agent, AgentBase, Hub, Pool, Response
 from lyra.core.message import InboundMessage, Platform
-from tests.core.conftest import MockAdapter, make_inbound_message
+from tests.core.conftest import MockAdapter, make_inbound_message, push_to_hub
 
 # ---------------------------------------------------------------------------
 # T3 — Hub routing key (RoutingKey replaces BindingKey)
@@ -110,7 +110,7 @@ class TestUnmatchedRouting:
     ) -> None:
         hub = Hub()
         msg = make_inbound_message(platform="telegram", user_id="nobody")
-        await hub.bus.put(msg)
+        await push_to_hub(hub, msg)
         with caplog.at_level(logging.WARNING, logger="lyra.core.hub"):
             # run() loops forever — use a short timeout to exercise one iteration
             try:
@@ -118,7 +118,7 @@ class TestUnmatchedRouting:
             except asyncio.TimeoutError:
                 pass  # expected — run() never returns on its own
         assert any("unmatched" in r.message.lower() for r in caplog.records)
-        assert hub.bus.empty()  # message was consumed (dropped, not re-queued)
+        assert hub.inbound_bus.staging_qsize() == 0  # message was consumed (dropped, not re-queued)
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +163,7 @@ class TestAgentRegistryMiss:
             Platform.TELEGRAM, "main", "chat:42", "ghost", "telegram:main:chat:42"
         )
         msg = make_inbound_message(platform="telegram", bot_id="main", user_id="alice")
-        await hub.bus.put(msg)
+        await push_to_hub(hub, msg)
 
         with caplog.at_level(logging.WARNING, logger="lyra.core.hub"):
             try:
@@ -172,7 +172,7 @@ class TestAgentRegistryMiss:
                 pass  # expected — run() never returns on its own
 
         assert any("no agent registered" in r.message.lower() for r in caplog.records)
-        assert hub.bus.empty()
+        assert hub.inbound_bus.staging_qsize() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +201,7 @@ class TestMissingAdapterDrop:
         )
         # Deliberately do NOT register an adapter for (TELEGRAM, "main")
         msg = make_inbound_message(platform="telegram", bot_id="main", user_id="alice")
-        await hub.bus.put(msg)
+        await push_to_hub(hub, msg)
 
         with caplog.at_level(logging.ERROR, logger="lyra.core.hub"):
             try:
@@ -210,7 +210,7 @@ class TestMissingAdapterDrop:
                 pass  # expected — run() never returns on its own
 
         assert any("no adapter registered" in r.message.lower() for r in caplog.records)
-        assert hub.bus.empty()
+        assert hub.inbound_bus.staging_qsize() == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_hub_streaming.py
+++ b/tests/core/test_hub_streaming.py
@@ -17,7 +17,7 @@ from lyra.core.message import (
 )
 from lyra.core.render_events import RenderEvent, TextRenderEvent
 from lyra.tts import TTSService
-from tests.core.conftest import MockAdapter, make_inbound_message
+from tests.core.conftest import MockAdapter, make_inbound_message, push_to_hub
 
 
 def _mock_tts_on(hub: Hub) -> AsyncMock:
@@ -345,7 +345,7 @@ class TestHubRunStreaming:
         )
 
         msg = make_inbound_message(platform="telegram", bot_id="main", user_id="alice")
-        await hub.bus.put(msg)
+        await push_to_hub(hub, msg)
 
         try:
             await asyncio.wait_for(hub.run(), timeout=0.5)

--- a/tests/core/test_hub_tts_dispatch.py
+++ b/tests/core/test_hub_tts_dispatch.py
@@ -17,7 +17,7 @@ from lyra.core.hub import Hub
 from lyra.core.hub.message_pipeline import Action, PipelineResult
 from lyra.core.hub.middleware import MiddlewarePipeline
 from lyra.core.message import InboundMessage, OutboundAudio, Response
-from tests.core.conftest import make_inbound_message
+from tests.core.conftest import make_inbound_message, push_to_hub
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -31,7 +31,7 @@ def _make_pipeline_result(response: Response) -> PipelineResult:
 
 async def _run_hub_one_msg(hub: Hub, msg: InboundMessage) -> None:
     """Put *msg* on the bus and run Hub.run() until it processes one message."""
-    await hub.bus.put(msg)
+    await push_to_hub(hub, msg)
     try:
         await asyncio.wait_for(hub.run(), timeout=0.3)
     except asyncio.TimeoutError:

--- a/tests/core/test_inbound_bus.py
+++ b/tests/core/test_inbound_bus.py
@@ -1,4 +1,4 @@
-"""Tests for InboundBus: per-platform queues + feeder tasks + staging queue."""
+"""Tests for LocalBus: per-platform queues + feeder tasks + staging queue."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lyra.core.auth import TrustLevel
-from lyra.core.inbound_bus import InboundBus
+from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import (
     InboundMessage,
     Platform,
@@ -46,29 +46,29 @@ def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
 
 class TestInboundBusRegistration:
     def test_register_creates_queue(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=50)
         assert Platform.TELEGRAM in bus._queues
         assert bus._queues[Platform.TELEGRAM].maxsize == 50
 
     def test_qsize_zero_initially(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM)
         assert bus.qsize(Platform.TELEGRAM) == 0
 
     def test_qsize_unknown_platform_returns_zero(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         assert bus.qsize(Platform.TELEGRAM) == 0
 
     def test_put_increments_qsize(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=10)
         msg = _make_msg(Platform.TELEGRAM)
         bus.put(Platform.TELEGRAM, msg)
         assert bus.qsize(Platform.TELEGRAM) == 1
 
     def test_put_raises_queue_full(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=1)
         msg = _make_msg(Platform.TELEGRAM)
         bus.put(Platform.TELEGRAM, msg)
@@ -78,7 +78,7 @@ class TestInboundBusRegistration:
 
 class TestInboundBusFeeder:
     async def test_feeder_forwards_to_staging(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=10)
         await bus.start()
 
@@ -93,7 +93,7 @@ class TestInboundBusFeeder:
             await bus.stop()
 
     async def test_two_platforms_isolated(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=1)
         bus.register(Platform.DISCORD, maxsize=10)
         await bus.start()
@@ -113,7 +113,7 @@ class TestInboundBusFeeder:
             await bus.stop()
 
     async def test_stop_cancels_feeders(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=10)
         await bus.start()
         assert len(bus._feeders) == 1
@@ -122,7 +122,7 @@ class TestInboundBusFeeder:
         assert len(bus._feeders) == 0
 
     async def test_double_start_raises(self) -> None:
-        bus = InboundBus()
+        bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=10)
         await bus.start()
 

--- a/tests/core/test_message_pipeline_guards.py
+++ b/tests/core/test_message_pipeline_guards.py
@@ -17,6 +17,7 @@ from tests.core.conftest import (
     _MockAdapter,
     _NullAgent,
     make_inbound_message,
+    push_to_hub,
 )
 
 # -------------------------------------------------------------------
@@ -232,7 +233,7 @@ class TestPipelineIntegration:
         submitted: list[InboundMessage] = []
         object.__setattr__(pool, "submit", lambda m: submitted.append(m))
 
-        await hub.bus.put(msg)
+        await push_to_hub(hub, msg)
         try:
             await asyncio.wait_for(hub.run(), timeout=0.3)
         except asyncio.TimeoutError:

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -6,6 +6,7 @@ Classes: TestHealthUnauthenticated, TestHealthEndpoint, TestHubTimestamps.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 
@@ -20,6 +21,7 @@ from lyra.core.message import (
 )
 from lyra.core.trust import TrustLevel
 from tests.conftest import AUTH_HEADERS, HEALTH_SECRET
+from tests.core.conftest import push_to_hub
 
 # ---------------------------------------------------------------------------
 # T0 — /health unauthenticated returns minimal response (#207)
@@ -146,7 +148,8 @@ class TestHealthEndpoint:
             },
             trust_level=TrustLevel.TRUSTED,
         )
-        await hub.bus.put(msg)
+        await push_to_hub(hub, msg)
+        await asyncio.sleep(0)  # let feeder task move message to staging
 
         app = create_health_app(hub)
         transport = ASGITransport(app=app)


### PR DESCRIPTION
## Summary
- Extract `Bus[T]` Protocol in `core/bus.py` (9 methods, invariant in T) as the inbound message transport interface
- Rename `InboundBus` → `LocalBus` — Hub now types its bus attributes as `Bus[T]` instead of concrete class
- Remove leaky `Hub.bus` property that exposed raw `asyncio.Queue` and migrate all 21 test call sites to use `push_to_hub()` helper via the Bus Protocol

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #48: Bus abstraction — extract LocalBus/NatsBus interface | Open |
| Analysis | `48-bus-abstraction-analysis.mdx` | Present (on staging) |
| Spec | `48-bus-abstraction-spec.mdx` | Present (on staging) |
| Implementation | 1 commit on `feat/48-bus-abstraction` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2093 passed, 0 failed) | Passed |

## Test Plan
- [ ] `from lyra.core.bus import Bus` and `from lyra.core.inbound_bus import LocalBus` importable
- [ ] `LocalBus[T]` structurally satisfies `Bus[T]` — Pyright passes with 0 errors
- [ ] Hub types `inbound_bus` as `Bus[InboundMessage]` and `inbound_audio_bus` as `Bus[InboundAudio]`
- [ ] `Hub.bus` property no longer exists — no raw `asyncio.Queue` exposure
- [ ] All 2093 existing tests pass without behavioral modification
- [ ] No NATS dependency introduced — pure refactor

Closes #48

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`