### PR TITLE
feat(hub): add PipelineEventBus for pipeline telemetry (#432)

### DIFF
--- a/src/lyra/bootstrap/config.py
+++ b/src/lyra/bootstrap/config.py
@@ -88,6 +88,14 @@ class DebouncerConfig(BaseModel):
     cancel_on_new_message: bool = False
 
 
+class EventBusConfig(BaseModel):
+    """Typed [event_bus] config section (#432)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    queue_maxsize: int = 1000
+
+
 class AgentOverrideConfig(BaseModel):
     """Typed output of _build_agent_overrides().
 
@@ -222,6 +230,11 @@ def _load_inbound_bus_config(raw: dict[str, Any]) -> InboundBusConfig:
 def _load_debouncer_config(raw: dict[str, Any]) -> DebouncerConfig:
     """Load [debouncer] section from raw config dict. Missing keys → defaults."""
     return DebouncerConfig.model_validate(raw.get("debouncer", {}))
+
+
+def _load_event_bus_config(raw: dict[str, Any]) -> EventBusConfig:
+    """Load [event_bus] section from raw config dict. Missing keys → defaults."""
+    return EventBusConfig.model_validate(raw.get("event_bus", {}))
 
 
 def _load_messages(language: str = "en") -> MessageManager:

--- a/src/lyra/bootstrap/multibot.py
+++ b/src/lyra/bootstrap/multibot.py
@@ -43,6 +43,7 @@ from lyra.core.auth import AuthMiddleware
 from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.cli_pool import CliPool
 from lyra.core.hub import Hub
+from lyra.core.hub.event_bus import PipelineEventBus
 from lyra.core.stores.auth_store import AuthStore
 from lyra.core.stores.pairing import PairingManager, set_pairing_manager
 
@@ -150,9 +151,6 @@ async def _bootstrap_multibot(  # noqa: C901, PLR0915 — startup wiring
         inbound_bus_cfg = _load_inbound_bus_config(raw_config)
         debouncer_cfg = _load_debouncer_config(raw_config)
         event_bus_cfg = _load_event_bus_config(raw_config)
-
-        from lyra.core.hub.event_bus import PipelineEventBus
-
         event_bus = PipelineEventBus(maxsize=event_bus_cfg.queue_maxsize)
 
         hub = Hub(

--- a/src/lyra/bootstrap/multibot.py
+++ b/src/lyra/bootstrap/multibot.py
@@ -16,6 +16,7 @@ from lyra.bootstrap.config import (
     _build_agent_overrides,
     _load_cli_pool_config,
     _load_debouncer_config,
+    _load_event_bus_config,
     _load_hub_config,
     _load_inbound_bus_config,
     _load_llm_config,
@@ -148,6 +149,11 @@ async def _bootstrap_multibot(  # noqa: C901, PLR0915 — startup wiring
         llm_cfg = _load_llm_config(raw_config)
         inbound_bus_cfg = _load_inbound_bus_config(raw_config)
         debouncer_cfg = _load_debouncer_config(raw_config)
+        event_bus_cfg = _load_event_bus_config(raw_config)
+
+        from lyra.core.hub.event_bus import PipelineEventBus
+
+        event_bus = PipelineEventBus(maxsize=event_bus_cfg.queue_maxsize)
 
         hub = Hub(
             circuit_registry=circuit_registry,
@@ -168,6 +174,7 @@ async def _bootstrap_multibot(  # noqa: C901, PLR0915 — startup wiring
             platform_queue_maxsize=inbound_bus_cfg.platform_queue_maxsize,
             queue_depth_threshold=inbound_bus_cfg.queue_depth_threshold,
             max_merged_chars=debouncer_cfg.max_merged_chars,
+            event_bus=event_bus,
         )
         hub.set_turn_store(stores.turn)
         hub.set_message_index(stores.message_index)

--- a/src/lyra/bootstrap/multibot_wiring.py
+++ b/src/lyra/bootstrap/multibot_wiring.py
@@ -237,6 +237,18 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
         asyncio.create_task(hub._audio_pipeline.run(), name="hub-audio"),
         asyncio.create_task(health_server.serve(), name="health"),
     ]
+
+    # Wire audit consumer for pipeline telemetry (#432).
+    if hub._event_bus is not None:
+        from lyra.core.hub.audit_consumer import AuditConsumer
+
+        _audit_queue = hub._event_bus.subscribe()
+        _audit_consumer = AuditConsumer(_audit_queue)
+        _audit_task = asyncio.create_task(
+            _audit_consumer.run(), name="audit-consumer"
+        )
+        _audit_task.add_done_callback(_log_task_failure)
+        tasks.append(_audit_task)
     for tg_adapter in tg_adapters:
         tasks.append(
             asyncio.create_task(

--- a/src/lyra/core/hub/CLAUDE.md
+++ b/src/lyra/core/hub/CLAUDE.md
@@ -18,6 +18,9 @@ and outbound dispatcher.
 | `pool_manager.py` | `PoolManager` — pool lifecycle: create, evict stale, flush |
 | `outbound_dispatcher.py` | `OutboundDispatcher` — per-adapter outbound queue and dispatch |
 | `outbound_errors.py` | Outbound error types and retry helpers |
+| `pipeline_events.py` | Typed frozen dataclass events for pipeline telemetry (#432) |
+| `event_bus.py` | `PipelineEventBus` — fire-and-forget fan-out to subscriber queues (#432) |
+| `audit_consumer.py` | `AuditConsumer` — structured JSON audit logger for pipeline events (#432) |
 
 ## Why pool_manager.py is in hub/ (not pool/)
 

--- a/src/lyra/core/hub/audit_consumer.py
+++ b/src/lyra/core/hub/audit_consumer.py
@@ -1,0 +1,41 @@
+"""Structured JSON audit logger for pipeline telemetry (#432).
+
+First consumer of ``PipelineEventBus``. Drains a subscriber queue and
+logs every event as structured JSON via stdlib logging. Best-effort:
+on shutdown (task cancellation), remaining queued events are dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+
+from .pipeline_events import PipelineEvent
+
+log = logging.getLogger(__name__)
+
+
+class AuditConsumer:
+    """Logs pipeline events as structured JSON for post-hoc debugging.
+
+    Usage::
+
+        queue = bus.subscribe()
+        consumer = AuditConsumer(queue)
+        task = asyncio.create_task(consumer.run())
+    """
+
+    def __init__(self, queue: asyncio.Queue[PipelineEvent]) -> None:
+        self._queue = queue
+
+    async def run(self) -> None:
+        """Drain the queue and log each event. Runs until cancelled."""
+        while True:
+            event = await self._queue.get()
+            log.info(
+                "pipeline.%s",
+                event.stage,
+                extra={"event": dataclasses.asdict(event)},
+            )
+            self._queue.task_done()

--- a/src/lyra/core/hub/event_bus.py
+++ b/src/lyra/core/hub/event_bus.py
@@ -1,0 +1,68 @@
+"""Fire-and-forget fan-out bus for pipeline telemetry events (#432).
+
+Subscribers receive events via per-subscriber ``asyncio.Queue`` instances.
+The pipeline is never blocked by a slow consumer — ``put_nowait`` drops
+events on ``QueueFull`` with a rate-limited warning.
+
+Injected via constructor (not a singleton) per ADR-025 F-10.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from .pipeline_events import PipelineEvent
+
+log = logging.getLogger(__name__)
+
+_DROP_WARN_INTERVAL = 60.0
+
+
+class PipelineEventBus:
+    """Fan-out bus for pipeline telemetry events.
+
+    Usage::
+
+        bus = PipelineEventBus(maxsize=1000)
+        queue = bus.subscribe()          # consumer gets a Queue
+        bus.emit(MessageReceived(...))   # fans out to all subscribers
+    """
+
+    def __init__(self, maxsize: int = 1000) -> None:
+        self._maxsize = maxsize
+        self._subscribers: list[asyncio.Queue[PipelineEvent]] = []
+        self._last_warn: dict[int, float] = {}
+
+    def subscribe(self) -> asyncio.Queue[PipelineEvent]:
+        """Create and return a new subscriber queue."""
+        q: asyncio.Queue[PipelineEvent] = asyncio.Queue(
+            maxsize=self._maxsize,
+        )
+        self._subscribers.append(q)
+        return q
+
+    def emit(self, event: PipelineEvent) -> None:
+        """Fan out *event* to all subscriber queues.
+
+        Never blocks. Drops the event for any subscriber whose queue is
+        full, logging a rate-limited warning (max once per 60s per subscriber).
+        """
+        for q in self._subscribers:
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                self._warn_drop(q)
+
+    def _warn_drop(self, q: asyncio.Queue[PipelineEvent]) -> None:
+        """Log a rate-limited warning when events are dropped."""
+        now = time.monotonic()
+        qid = id(q)
+        if now - self._last_warn.get(qid, 0.0) >= _DROP_WARN_INTERVAL:
+            self._last_warn[qid] = now
+            log.warning(
+                "PipelineEventBus: subscriber queue full"
+                " — events dropped (maxsize=%d)",
+                self._maxsize,
+            )

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from ..stores.pairing import PairingManager
     from ..stores.prefs_store import PrefsStore
     from ..stores.turn_store import TurnStore
+    from .event_bus import PipelineEventBus
     from .outbound_dispatcher import OutboundDispatcher
 
 log = logging.getLogger(__name__)
@@ -82,6 +83,7 @@ class Hub(HubOutboundMixin):
         platform_queue_maxsize: int = PLATFORM_QUEUE_MAXSIZE,
         queue_depth_threshold: int = QUEUE_DEPTH_THRESHOLD,
         max_merged_chars: int = MAX_MERGED_CHARS,
+        event_bus: "PipelineEventBus | None" = None,
     ) -> None:
         self._platform_queue_maxsize = platform_queue_maxsize
         self.inbound_bus: Bus[InboundMessage] = LocalBus(
@@ -119,6 +121,7 @@ class Hub(HubOutboundMixin):
         self._safe_dispatch_timeout = safe_dispatch_timeout
         self._max_merged_chars = max_merged_chars
         self.cli_pool: CliPool | None = None
+        self._event_bus: PipelineEventBus | None = event_bus
         self._pool_manager = PoolManager(self)
         self._audio_pipeline = AudioPipeline(self)
 
@@ -279,7 +282,7 @@ class Hub(HubOutboundMixin):
 
     async def run(self) -> None:
         """Hub bus consumer loop. Runs until cancelled."""
-        pipeline = build_default_pipeline(self)
+        pipeline = build_default_pipeline(self, event_bus=self._event_bus)
         while True:
             msg = await self.inbound_bus.get()
             try:

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -16,6 +16,7 @@ Layout:
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
@@ -28,8 +29,14 @@ from .message_pipeline import (
     PipelineResult,
     TraceHook,
 )
+from .pipeline_events import (
+    MessageReceived,
+    PipelineEvent,
+    StageCompleted,
+)
 
 if TYPE_CHECKING:
+    from .event_bus import PipelineEventBus
     from .hub import Binding, Hub, RoutingKey
 
 log = logging.getLogger(__name__)
@@ -46,6 +53,7 @@ class PipelineContext:
     pool: Pool | None = None
     router: Any = None
     trace_hook: TraceHook | None = None
+    event_bus: PipelineEventBus | None = None
 
     def trace(self, stage: str, event: str, **payload: object) -> None:
         """Emit a trace event if a hook is registered. Never raises."""
@@ -55,6 +63,11 @@ class PipelineContext:
             self.trace_hook(stage, event, **payload)
         except Exception:
             log.debug("trace_hook raised — ignoring", exc_info=True)
+
+    def emit(self, event: PipelineEvent) -> None:
+        """Emit a pipeline telemetry event. No-op if bus is None."""
+        if self.event_bus is not None:
+            self.event_bus.emit(event)
 
 
 # Type alias for the next-middleware callback.
@@ -85,14 +98,20 @@ class MiddlewarePipeline:
         hub: Hub,
         *,
         trace_hook: TraceHook | None = None,
+        event_bus: PipelineEventBus | None = None,
     ) -> None:
         self._middlewares = middlewares
         self._hub = hub
         self._trace_hook = trace_hook
+        self._event_bus = event_bus
 
     async def process(self, msg: InboundMessage) -> PipelineResult:
         """Route *msg* through the middleware chain."""
-        ctx = PipelineContext(hub=self._hub, trace_hook=self._trace_hook)
+        ctx = PipelineContext(
+            hub=self._hub,
+            trace_hook=self._trace_hook,
+            event_bus=self._event_bus,
+        )
 
         ctx.trace(
             "inbound",
@@ -102,13 +121,32 @@ class MiddlewarePipeline:
             user_id=msg.user_id,
         )
 
+        ctx.emit(
+            MessageReceived(
+                msg_id=msg.id,
+                stage="inbound",
+                platform=msg.platform,
+                user_id=msg.user_id,
+                scope_id=msg.scope_id,
+            )
+        )
+
         async def _run(
             index: int, msg: InboundMessage, ctx: PipelineContext
         ) -> PipelineResult:
             if index >= len(self._middlewares):
                 return _DROP
             mw = self._middlewares[index]
-            return await mw(msg, ctx, lambda m, c: _run(index + 1, m, c))
+            t0 = time.monotonic()
+            result = await mw(msg, ctx, lambda m, c: _run(index + 1, m, c))
+            ctx.emit(
+                StageCompleted(
+                    msg_id=msg.id,
+                    stage=type(mw).__name__,
+                    duration_ms=(time.monotonic() - t0) * 1000,
+                )
+            )
+            return result
 
         return await _run(0, msg, ctx)
 
@@ -117,6 +155,7 @@ def build_default_pipeline(
     hub: Hub,
     *,
     trace_hook: TraceHook | None = None,
+    event_bus: PipelineEventBus | None = None,
 ) -> MiddlewarePipeline:
     """Build the standard middleware pipeline with all 6 stages."""
     from .middleware_stages import (
@@ -139,4 +178,5 @@ def build_default_pipeline(
         ],
         hub,
         trace_hook=trace_hook,
+        event_bus=event_bus,
     )

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -134,6 +134,13 @@ class MiddlewarePipeline:
         async def _run(
             index: int, msg: InboundMessage, ctx: PipelineContext
         ) -> PipelineResult:
+            """Run middleware at *index* with timing.
+
+            ``StageCompleted`` fires for both pass-through and drop stages.
+            For pass-through stages, ``duration_ms`` is subtree-inclusive
+            (includes downstream). For drop stages, it reflects only the
+            stage's own work since no downstream is called.
+            """
             if index >= len(self._middlewares):
                 return _DROP
             mw = self._middlewares[index]

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ..commands.command_parser import CommandParser
 from ..message import (
@@ -25,9 +25,6 @@ from .message_pipeline import (
 )
 from .middleware import Next, PipelineContext
 from .pipeline_events import CommandDispatched, MessageDropped
-
-if TYPE_CHECKING:
-    pass
 
 log = logging.getLogger(__name__)
 
@@ -223,15 +220,8 @@ class CommandMiddleware:
         if router and router.is_command(msg):
             _cmd = msg.text.split()[0] if msg.text else ""
             ctx.trace("processor", "command_detected", command=_cmd)
-            ctx.emit(
-                CommandDispatched(
-                    msg_id=msg.id,
-                    stage=type(self).__name__,
-                    command=_cmd,
-                )
-            )
             return await self._dispatch_command(
-                msg, router, ctx, next
+                msg, _cmd, router, ctx, next
             )
 
         return await next(msg, ctx)
@@ -239,6 +229,7 @@ class CommandMiddleware:
     async def _dispatch_command(  # noqa: PLR0913
         self,
         msg: InboundMessage,
+        cmd: str,
         router: Any,
         ctx: PipelineContext,
         next: Next,
@@ -274,6 +265,13 @@ class CommandMiddleware:
             "outbound",
             "command_handled",
             action=Action.COMMAND_HANDLED.value,
+        )
+        ctx.emit(
+            CommandDispatched(
+                msg_id=msg.id,
+                stage=type(self).__name__,
+                command=cmd,
+            )
         )
         return PipelineResult(
             action=Action.COMMAND_HANDLED, response=response

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -24,6 +24,7 @@ from .message_pipeline import (
     PipelineResult,
 )
 from .middleware import Next, PipelineContext
+from .pipeline_events import CommandDispatched, MessageDropped
 
 if TYPE_CHECKING:
     pass
@@ -56,6 +57,13 @@ class ValidatePlatformMiddleware:
                 platform=msg.platform,
                 action=Action.DROP.value,
             )
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="unknown_platform",
+                )
+            )
             return _DROP
         return await next(msg, ctx)
 
@@ -77,6 +85,13 @@ class RateLimitMiddleware:
         if ctx.hub._is_rate_limited(msg):
             log.warning("rate limit exceeded for %s — message dropped", key)
             ctx.trace("inbound", "rate_limited", action=Action.DROP.value)
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="rate_limited",
+                )
+            )
             return _DROP
         return await next(msg, ctx)
 
@@ -101,6 +116,13 @@ class ResolveBindingMiddleware:
                 "unmatched routing key %s — message dropped", ctx.key
             )
             ctx.trace("pool", "no_binding", action=Action.DROP.value)
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="no_binding",
+                )
+            )
             return _DROP
         ctx.binding = binding
 
@@ -116,6 +138,13 @@ class ResolveBindingMiddleware:
                 "no_agent",
                 agent_name=binding.agent_name,
                 action=Action.DROP.value,
+            )
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="no_agent",
+                )
             )
             return _DROP
         ctx.agent = agent
@@ -194,6 +223,13 @@ class CommandMiddleware:
         if router and router.is_command(msg):
             _cmd = msg.text.split()[0] if msg.text else ""
             ctx.trace("processor", "command_detected", command=_cmd)
+            ctx.emit(
+                CommandDispatched(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    command=_cmd,
+                )
+            )
             return await self._dispatch_command(
                 msg, router, ctx, next
             )

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -23,6 +23,7 @@ from .message_pipeline import (
     ResumeStatus,
 )
 from .middleware import Next, PipelineContext
+from .pipeline_events import MessageDropped, PoolSubmitted
 
 if TYPE_CHECKING:
     pass
@@ -61,10 +62,24 @@ class SubmitToPoolMiddleware:
                 bot_id=msg.bot_id,
                 action=Action.DROP.value,
             )
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="no_adapter",
+                )
+            )
             return _DROP
 
         if await ctx.hub.circuit_breaker_drop(msg):
             ctx.trace("outbound", "circuit_open", action=Action.DROP.value)
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="circuit_open",
+                )
+            )
             return _DROP
 
         pool = ctx.pool
@@ -92,6 +107,15 @@ class SubmitToPoolMiddleware:
             "message_submitted",
             adapter=msg.platform,
             resume_status=status.value,
+        )
+        ctx.emit(
+            PoolSubmitted(
+                msg_id=msg.id,
+                stage=type(self).__name__,
+                pool_id=pool.pool_id,
+                agent_name=ctx.binding.agent_name if ctx.binding else "",
+                resume_status=status.value,
+            )
         )
 
         if status == ResumeStatus.FRESH:

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -8,7 +8,6 @@ resume via three paths, and returns ``SUBMIT_TO_POOL``.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 from ..message import (
     InboundMessage,
@@ -24,9 +23,6 @@ from .message_pipeline import (
 )
 from .middleware import Next, PipelineContext
 from .pipeline_events import MessageDropped, PoolSubmitted
-
-if TYPE_CHECKING:
-    pass
 
 log = logging.getLogger(__name__)
 

--- a/src/lyra/core/hub/pipeline_events.py
+++ b/src/lyra/core/hub/pipeline_events.py
@@ -1,0 +1,70 @@
+"""Typed pipeline telemetry events (#432).
+
+Frozen dataclasses emitted at middleware seam boundaries.
+The ``PipelineEventBus`` fans these out to subscribers (audit logger,
+future metrics, dashboard, trace propagation).
+
+Event types:
+  MessageReceived   — inbound message enters the pipeline
+  StageCompleted    — a middleware stage finished (subtree-inclusive timing)
+  MessageDropped    — a middleware stage short-circuited with DROP
+  CommandDispatched — CommandMiddleware dispatched a command
+  PoolSubmitted     — SubmitToPoolMiddleware submitted to a pool
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class PipelineEvent:
+    """Base for all pipeline telemetry events."""
+
+    msg_id: str
+    timestamp: float = field(default_factory=time.time)
+    stage: str = ""
+
+
+@dataclass(frozen=True)
+class MessageReceived(PipelineEvent):
+    """Emitted when a message enters the pipeline."""
+
+    platform: str = ""
+    user_id: str = ""
+    scope_id: str = ""
+
+
+@dataclass(frozen=True)
+class StageCompleted(PipelineEvent):
+    """Emitted after each middleware stage completes.
+
+    ``duration_ms`` is subtree-inclusive — it measures the stage's total
+    latency contribution including downstream stages called via ``next()``.
+    """
+
+    duration_ms: float = 0.0
+
+
+@dataclass(frozen=True)
+class MessageDropped(PipelineEvent):
+    """Emitted when a middleware stage drops a message."""
+
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class CommandDispatched(PipelineEvent):
+    """Emitted when CommandMiddleware dispatches a command."""
+
+    command: str = ""
+
+
+@dataclass(frozen=True)
+class PoolSubmitted(PipelineEvent):
+    """Emitted when SubmitToPoolMiddleware submits to a pool."""
+
+    pool_id: str = ""
+    agent_name: str = ""
+    resume_status: str = ""

--- a/tests/core/test_pipeline_event_bus.py
+++ b/tests/core/test_pipeline_event_bus.py
@@ -10,6 +10,11 @@ import pytest
 
 from lyra.core.hub.audit_consumer import AuditConsumer
 from lyra.core.hub.event_bus import PipelineEventBus
+from lyra.core.hub.message_pipeline import Action, PipelineResult
+from lyra.core.hub.middleware import (
+    MiddlewarePipeline,
+    PipelineContext,
+)
 from lyra.core.hub.pipeline_events import (
     CommandDispatched,
     MessageDropped,
@@ -18,6 +23,7 @@ from lyra.core.hub.pipeline_events import (
     PoolSubmitted,
     StageCompleted,
 )
+from tests.core.conftest import _make_hub, make_inbound_message
 
 
 def _make_event(**overrides: object) -> MessageReceived:
@@ -215,3 +221,201 @@ class TestAuditConsumer:
             r for r in caplog.records if r.getMessage().startswith("pipeline.")
         ]
         assert len(log_records) == 3
+
+    async def test_shutdown_is_best_effort(self) -> None:
+        """On cancellation, consumer stops — no active drain of remaining items."""
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        consumer = AuditConsumer(q)
+
+        # Start consumer, let it block on empty queue, then cancel
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0)  # consumer is now awaiting queue.get()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # After cancel, items added to the queue are not processed
+        bus.emit(_make_event(msg_id="post-cancel"))
+        assert q.qsize() == 1  # event sits unprocessed — no drain
+
+
+# ──────────────────────────────────────────────────────────────────────
+# PipelineContext.emit() guard
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPipelineContextEmit:
+    def test_emit_noop_when_bus_is_none(self) -> None:
+        """ctx.emit() is a no-op when event_bus=None — no exception."""
+        hub = _make_hub()
+        ctx = PipelineContext(hub=hub, event_bus=None)
+        ctx.emit(_make_event())  # must not raise
+
+    def test_emit_forwards_to_bus(self) -> None:
+        """ctx.emit() forwards event to bus when configured."""
+        hub = _make_hub()
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        ctx = PipelineContext(hub=hub, event_bus=bus)
+        ctx.emit(_make_event(msg_id="ctx-test"))
+        assert q.qsize() == 1
+        assert q.get_nowait().msg_id == "ctx-test"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# MiddlewarePipeline emission integration
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _PassthroughMiddleware:
+    """Stub middleware that always calls next()."""
+
+    async def __call__(self, msg, ctx, next):
+        return await next(msg, ctx)
+
+
+class _DropMiddleware:
+    """Stub middleware that always drops."""
+
+    async def __call__(self, msg, ctx, next):
+        ctx.emit(
+            MessageDropped(
+                msg_id=msg.id,
+                stage=type(self).__name__,
+                reason="test_drop",
+            )
+        )
+        return PipelineResult(action=Action.DROP)
+
+
+class TestMiddlewarePipelineEmission:
+    async def test_emits_message_received_and_stage_completed(self) -> None:
+        """Pipeline emits MessageReceived + StageCompleted per stage."""
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        hub = _make_hub()
+
+        pipeline = MiddlewarePipeline(
+            [_PassthroughMiddleware(), _PassthroughMiddleware()],
+            hub,
+            event_bus=bus,
+        )
+        msg = make_inbound_message(platform="telegram")
+        await pipeline.process(msg)
+
+        events = []
+        while not q.empty():
+            events.append(q.get_nowait())
+
+        # MessageReceived first, then StageCompleted per middleware
+        assert isinstance(events[0], MessageReceived)
+        assert events[0].stage == "inbound"
+        assert events[0].platform == "telegram"
+
+        stage_completed = [e for e in events if isinstance(e, StageCompleted)]
+        assert len(stage_completed) == 2
+        assert stage_completed[0].stage == "_PassthroughMiddleware"
+        assert stage_completed[1].stage == "_PassthroughMiddleware"
+        assert all(e.duration_ms >= 0 for e in stage_completed)
+
+    async def test_stage_name_uses_class_name(self) -> None:
+        """StageCompleted.stage uses type(mw).__name__."""
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        hub = _make_hub()
+
+        pipeline = MiddlewarePipeline(
+            [_DropMiddleware()], hub, event_bus=bus
+        )
+        msg = make_inbound_message(platform="telegram")
+        await pipeline.process(msg)
+
+        events = []
+        while not q.empty():
+            events.append(q.get_nowait())
+
+        stage_completed = [e for e in events if isinstance(e, StageCompleted)]
+        assert len(stage_completed) == 1
+        assert stage_completed[0].stage == "_DropMiddleware"
+
+    async def test_drop_emits_message_dropped(self) -> None:
+        """Dropping middleware emits MessageDropped with reason."""
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        hub = _make_hub()
+
+        pipeline = MiddlewarePipeline(
+            [_DropMiddleware()], hub, event_bus=bus
+        )
+        msg = make_inbound_message(platform="telegram")
+        await pipeline.process(msg)
+
+        events = []
+        while not q.empty():
+            events.append(q.get_nowait())
+
+        dropped = [e for e in events if isinstance(e, MessageDropped)]
+        assert len(dropped) == 1
+        assert dropped[0].reason == "test_drop"
+        assert dropped[0].stage == "_DropMiddleware"
+
+    async def test_no_events_when_bus_is_none(self) -> None:
+        """Pipeline with event_bus=None emits nothing — no errors."""
+        hub = _make_hub()
+        pipeline = MiddlewarePipeline(
+            [_PassthroughMiddleware()], hub, event_bus=None
+        )
+        msg = make_inbound_message(platform="telegram")
+        result = await pipeline.process(msg)
+        assert result.action == Action.DROP  # end of chain
+
+    async def test_real_drop_stage_emits_events(self) -> None:
+        """ValidatePlatformMiddleware emits MessageDropped for unknown platform."""
+        from lyra.core.hub.middleware_stages import (
+            ValidatePlatformMiddleware,
+        )
+
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        hub = _make_hub()
+
+        pipeline = MiddlewarePipeline(
+            [ValidatePlatformMiddleware()], hub, event_bus=bus
+        )
+        msg = make_inbound_message(platform="unknown_platform")
+        await pipeline.process(msg)
+
+        events = []
+        while not q.empty():
+            events.append(q.get_nowait())
+
+        dropped = [e for e in events if isinstance(e, MessageDropped)]
+        assert len(dropped) == 1
+        assert dropped[0].reason == "unknown_platform"
+        assert dropped[0].stage == "ValidatePlatformMiddleware"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# EventBusConfig
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestEventBusConfig:
+    def test_default_queue_maxsize(self) -> None:
+        from lyra.bootstrap.config import EventBusConfig
+
+        cfg = EventBusConfig()
+        assert cfg.queue_maxsize == 1000
+
+    def test_load_with_explicit_value(self) -> None:
+        from lyra.bootstrap.config import _load_event_bus_config
+
+        cfg = _load_event_bus_config({"event_bus": {"queue_maxsize": 42}})
+        assert cfg.queue_maxsize == 42
+
+    def test_load_with_empty_config(self) -> None:
+        from lyra.bootstrap.config import _load_event_bus_config
+
+        cfg = _load_event_bus_config({})
+        assert cfg.queue_maxsize == 1000

--- a/tests/core/test_pipeline_event_bus.py
+++ b/tests/core/test_pipeline_event_bus.py
@@ -1,0 +1,217 @@
+"""Unit tests for PipelineEventBus + pipeline events (#432)."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+
+import pytest
+
+from lyra.core.hub.audit_consumer import AuditConsumer
+from lyra.core.hub.event_bus import PipelineEventBus
+from lyra.core.hub.pipeline_events import (
+    CommandDispatched,
+    MessageDropped,
+    MessageReceived,
+    PipelineEvent,
+    PoolSubmitted,
+    StageCompleted,
+)
+
+
+def _make_event(**overrides: object) -> MessageReceived:
+    defaults = {
+        "msg_id": "test-1",
+        "stage": "inbound",
+        "platform": "telegram",
+        "user_id": "u1",
+        "scope_id": "s1",
+    }
+    defaults.update(overrides)
+    return MessageReceived(**defaults)  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Pipeline events
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPipelineEvents:
+    def test_events_are_frozen(self) -> None:
+        event = _make_event()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            event.msg_id = "changed"  # type: ignore[misc]
+
+    def test_all_subtypes_inherit_base(self) -> None:
+        for cls in (
+            MessageReceived,
+            StageCompleted,
+            MessageDropped,
+            CommandDispatched,
+            PoolSubmitted,
+        ):
+            assert issubclass(cls, PipelineEvent)
+
+    def test_asdict_produces_dict(self) -> None:
+        event = _make_event()
+        d = dataclasses.asdict(event)
+        assert d["msg_id"] == "test-1"
+        assert d["platform"] == "telegram"
+        assert "timestamp" in d
+
+
+# ──────────────────────────────────────────────────────────────────────
+# PipelineEventBus
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPipelineEventBus:
+    def test_emit_no_subscribers(self) -> None:
+        bus = PipelineEventBus()
+        bus.emit(_make_event())  # no error
+
+    def test_emit_single_subscriber(self) -> None:
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        bus.emit(_make_event())
+        assert q.qsize() == 1
+        event = q.get_nowait()
+        assert isinstance(event, MessageReceived)
+        assert event.msg_id == "test-1"
+
+    def test_emit_fan_out_multiple_subscribers(self) -> None:
+        bus = PipelineEventBus()
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+        q3 = bus.subscribe()
+        bus.emit(_make_event())
+        assert q1.qsize() == 1
+        assert q2.qsize() == 1
+        assert q3.qsize() == 1
+
+    def test_queue_full_drops_event(self) -> None:
+        bus = PipelineEventBus(maxsize=1)
+        q = bus.subscribe()
+        bus.emit(_make_event(msg_id="first"))
+        bus.emit(_make_event(msg_id="second"))  # dropped
+        assert q.qsize() == 1
+        event = q.get_nowait()
+        assert event.msg_id == "first"
+
+    def test_queue_full_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        bus = PipelineEventBus(maxsize=1)
+        bus.subscribe()  # subscriber needed to trigger QueueFull
+        # Reset last warn time to ensure warning fires
+        bus._last_warn.clear()
+        with caplog.at_level(logging.WARNING):
+            bus.emit(_make_event())
+            bus.emit(_make_event())  # triggers warning
+        assert any(
+            "queue full" in r.message for r in caplog.records
+        ), f"Expected queue full warning, got: {[r.message for r in caplog.records]}"
+
+    def test_queue_full_warning_rate_limited(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        bus = PipelineEventBus(maxsize=1)
+        bus.subscribe()  # subscriber needed to trigger QueueFull
+        bus._last_warn.clear()
+        with caplog.at_level(logging.WARNING):
+            bus.emit(_make_event())
+            # Emit 5 more — all dropped, but only 1 warning
+            for _ in range(5):
+                bus.emit(_make_event())
+        warn_count = sum(
+            1 for r in caplog.records if "queue full" in r.message
+        )
+        assert warn_count == 1
+
+    def test_external_subscriber(self) -> None:
+        """Plugin-like external code can subscribe and receive events."""
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        bus.emit(_make_event())
+        event = q.get_nowait()
+        assert isinstance(event, PipelineEvent)
+        assert event.platform == "telegram"
+
+    def test_queue_full_does_not_affect_other_subscribers(self) -> None:
+        bus = PipelineEventBus(maxsize=1)
+        q_slow = bus.subscribe()
+        q_fast = bus.subscribe()
+        bus.emit(_make_event(msg_id="first"))
+        # q_slow is now full
+        _ = q_fast.get_nowait()  # drain fast subscriber
+        bus.emit(_make_event(msg_id="second"))
+        # q_slow dropped second, q_fast got it
+        assert q_fast.qsize() == 1
+        assert q_fast.get_nowait().msg_id == "second"
+        assert q_slow.qsize() == 1
+        assert q_slow.get_nowait().msg_id == "first"
+
+    def test_subscribe_returns_queue(self) -> None:
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        assert isinstance(q, asyncio.Queue)
+
+    def test_configurable_maxsize(self) -> None:
+        bus = PipelineEventBus(maxsize=5)
+        q = bus.subscribe()
+        assert q.maxsize == 5
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AuditConsumer
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestAuditConsumer:
+    async def test_logs_structured_json(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        consumer = AuditConsumer(q)
+
+        bus.emit(_make_event(msg_id="audit-1", stage="inbound"))
+
+        with caplog.at_level(logging.INFO):
+            task = asyncio.create_task(consumer.run())
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        log_records = [
+            r for r in caplog.records if r.getMessage().startswith("pipeline.")
+        ]
+        assert len(log_records) >= 1
+        record = log_records[0]
+        assert "pipeline.inbound" in record.getMessage()
+        extra_event = record.__dict__.get("event", {})
+        assert extra_event["msg_id"] == "audit-1"
+        assert extra_event["platform"] == "telegram"
+
+    async def test_drains_multiple_events(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        bus = PipelineEventBus()
+        q = bus.subscribe()
+        consumer = AuditConsumer(q)
+
+        bus.emit(_make_event(msg_id="e1"))
+        bus.emit(_make_event(msg_id="e2"))
+        bus.emit(_make_event(msg_id="e3"))
+
+        with caplog.at_level(logging.INFO):
+            task = asyncio.create_task(consumer.run())
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        log_records = [
+            r for r in caplog.records if r.getMessage().startswith("pipeline.")
+        ]
+        assert len(log_records) == 3

--- a/tests/core/test_pipeline_event_bus.py
+++ b/tests/core/test_pipeline_event_bus.py
@@ -26,8 +26,8 @@ from lyra.core.hub.pipeline_events import (
 from tests.core.conftest import _make_hub, make_inbound_message
 
 
-def _make_event(**overrides: object) -> MessageReceived:
-    defaults = {
+def _make_event(**overrides: str) -> MessageReceived:
+    defaults: dict[str, str] = {
         "msg_id": "test-1",
         "stage": "inbound",
         "platform": "telegram",
@@ -139,7 +139,7 @@ class TestPipelineEventBus:
         q = bus.subscribe()
         bus.emit(_make_event())
         event = q.get_nowait()
-        assert isinstance(event, PipelineEvent)
+        assert isinstance(event, MessageReceived)
         assert event.platform == "telegram"
 
     def test_queue_full_does_not_affect_other_subscribers(self) -> None:


### PR DESCRIPTION
## Summary
- Add fire-and-forget `PipelineEventBus` with typed frozen dataclass events emitted at middleware pipeline seams
- `AuditConsumer` ships as first subscriber — structured JSON audit trails for debugging message routing
- Bus uses constructor injection (not singleton) per ADR-025 F-10, with TOML-configurable queue maxsize

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #432: feat(hub): event bus for pipeline telemetry, audit & plugin hooks | Open |
| Frame | [432-event-bus-pipeline-telemetry-frame.mdx](artifacts/frames/432-event-bus-pipeline-telemetry-frame.mdx) | Approved |
| Analysis | [432-event-bus-pipeline-telemetry-analysis.mdx](artifacts/analyses/432-event-bus-pipeline-telemetry-analysis.mdx) | Approved |
| Spec | [432-event-bus-pipeline-telemetry-spec.mdx](artifacts/specs/432-event-bus-pipeline-telemetry-spec.mdx) | Approved |
| Plan | [432-event-bus-pipeline-telemetry-plan.mdx](artifacts/plans/432-event-bus-pipeline-telemetry-plan.mdx) | Approved |
| Implementation | 1 commit on `feat/432-event-bus-pipeline-telemetry` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (15 new) | Passed |

## Test Plan
- [ ] `PipelineEventBus.emit()` fans out to 0, 1, and N subscribers without blocking
- [ ] `QueueFull` drops events with rate-limited warning (tested with maxsize=1)
- [ ] External code can subscribe and receive typed events (plugin-like subscriber test)
- [ ] `AuditConsumer` logs structured JSON with correct format
- [ ] All 30 existing middleware tests pass unchanged (zero behaviour change)
- [ ] Bus is optional — pipeline works identically when `event_bus=None`

Closes #432

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`