### PR TITLE
feat(hub): add watchdog for long-running asyncio tasks (#195)

### DIFF
--- a/src/lyra/bootstrap/multibot_lifecycle.py
+++ b/src/lyra/bootstrap/multibot_lifecycle.py
@@ -48,7 +48,7 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
         _loop.add_signal_handler(signal.SIGINT, stop.set)
         _loop.add_signal_handler(signal.SIGTERM, stop.set)
 
-    from lyra.bootstrap.utils import _log_task_failure
+    from lyra.bootstrap.utils import watchdog
 
     tasks = [
         asyncio.create_task(hub.run(), name="hub"),
@@ -65,7 +65,6 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
         _audit_task = asyncio.create_task(
             _audit_consumer.run(), name="audit-consumer"
         )
-        _audit_task.add_done_callback(_log_task_failure)
         tasks.append(_audit_task)
     for tg_adapter in tg_adapters:
         tasks.append(
@@ -79,7 +78,6 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
             dc_adapter.start(dc_token),
             name=f"discord:{dc_bot_cfg.bot_id}",
         )
-        _dc_task.add_done_callback(_log_task_failure)
         tasks.append(_dc_task)
 
     tg_active = [f"telegram:{a._bot_id}" for a in tg_adapters]
@@ -91,7 +89,7 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
         health_port,
     )
 
-    await stop.wait()
+    await watchdog(tasks, stop)
 
     log.info("Shutdown signal received \u2014 stopping\u2026")
     for task in tasks:

--- a/src/lyra/bootstrap/utils.py
+++ b/src/lyra/bootstrap/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Sequence
 
 log = logging.getLogger(__name__)
 
@@ -23,3 +24,64 @@ def _log_task_failure(task: asyncio.Task[object]) -> None:
             exc,
             exc_info=exc,
         )
+
+
+async def watchdog(
+    tasks: Sequence[asyncio.Task[object]],
+    stop: asyncio.Event,
+) -> None:
+    """Monitor long-running tasks; trigger graceful shutdown if any exits unexpectedly.
+
+    Replaces a bare ``stop.wait()`` so that a silently-dying task no longer
+    leaves the process running in a degraded state.
+    """
+    if not tasks:
+        log.warning("watchdog: no tasks to monitor — waiting for stop signal.")
+        await stop.wait()
+        return
+
+    pending: set[asyncio.Task[object]] = set(tasks)
+    stop_task: asyncio.Task[object] = asyncio.create_task(
+        stop.wait(), name="watchdog-stop-sentinel"
+    )
+    pending.add(stop_task)
+
+    try:
+        while len(pending) > 1:  # more than just the stop sentinel
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+
+            if stop_task in done:
+                # Normal shutdown (SIGINT / SIGTERM) — let caller tear down.
+                return
+
+            for task in done:
+                name = task.get_name()
+                if task.cancelled():
+                    log.warning("Task '%s' was cancelled unexpectedly.", name)
+                else:
+                    exc = task.exception()
+                    if exc is not None:
+                        log.error(
+                            "Task '%s' crashed — triggering shutdown: %s",
+                            name,
+                            exc,
+                            exc_info=exc,
+                        )
+                    else:
+                        log.error(
+                            "Task '%s' exited unexpectedly — triggering shutdown.",
+                            name,
+                        )
+
+            log.info("Watchdog: requesting graceful shutdown.")
+            stop.set()
+            return
+    finally:
+        if not stop_task.done():
+            stop_task.cancel()
+            try:
+                await stop_task
+            except asyncio.CancelledError:
+                pass

--- a/tests/bootstrap/test_watchdog.py
+++ b/tests/bootstrap/test_watchdog.py
@@ -1,0 +1,228 @@
+"""Tests for bootstrap.utils.watchdog (#195)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lyra.bootstrap.utils import watchdog
+
+
+@pytest.fixture()
+def stop() -> asyncio.Event:
+    return asyncio.Event()
+
+
+# ---------------------------------------------------------------------------
+# Normal shutdown via stop event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_returns_on_stop_event(stop: asyncio.Event) -> None:
+    """Watchdog should return cleanly when stop is set externally (SIGINT/SIGTERM)."""
+
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    async def _set_stop_soon() -> None:
+        await asyncio.sleep(0)  # yield once so watchdog enters the loop
+        stop.set()
+
+    task = asyncio.create_task(_hang_forever(), name="forever")
+    trigger = asyncio.create_task(_set_stop_soon())
+    try:
+        await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
+        await trigger
+
+        # Watchdog should not cancel monitored tasks — that's the caller's job.
+        assert not task.done()
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Task crashes → shutdown triggered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_triggers_shutdown_on_task_crash(stop: asyncio.Event) -> None:
+    """If a monitored task raises, watchdog should set the stop event."""
+
+    async def _crash() -> None:
+        raise RuntimeError("boom")
+
+    task = asyncio.create_task(_crash(), name="crasher")
+    await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
+
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Task exits cleanly but unexpectedly → shutdown triggered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_triggers_shutdown_on_clean_exit(stop: asyncio.Event) -> None:
+    """A task that returns without error is still unexpected — watchdog shuts down."""
+
+    async def _exit_early() -> None:
+        return
+
+    task = asyncio.create_task(_exit_early(), name="early-exit")
+    await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
+
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Task cancelled unexpectedly → shutdown triggered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_triggers_shutdown_on_unexpected_cancel(
+    stop: asyncio.Event,
+) -> None:
+    """A task cancelled without stop being set is still unexpected."""
+
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    async def _cancel_soon(t: asyncio.Task[None]) -> None:
+        await asyncio.sleep(0)  # yield once so watchdog enters the loop
+        t.cancel()
+
+    task = asyncio.create_task(_hang_forever(), name="to-cancel")
+    asyncio.create_task(_cancel_soon(task))
+    await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
+
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Multiple tasks — first crash triggers shutdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_first_crash_among_many(stop: asyncio.Event) -> None:
+    """With multiple tasks, the first to crash triggers shutdown."""
+
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    async def _crash_soon() -> None:
+        await asyncio.sleep(0)  # yield once so watchdog enters the loop
+        raise RuntimeError("first down")
+
+    healthy = asyncio.create_task(_hang_forever(), name="healthy")
+    crasher = asyncio.create_task(_crash_soon(), name="crasher")
+    try:
+        await asyncio.wait_for(watchdog([healthy, crasher], stop), timeout=2.0)
+    finally:
+        healthy.cancel()
+        try:
+            await healthy
+        except asyncio.CancelledError:
+            pass
+
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Stop sentinel task is cleaned up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_cleans_up_sentinel_on_crash(stop: asyncio.Event) -> None:
+    """The internal stop-sentinel task should not leak after watchdog returns."""
+
+    async def _crash() -> None:
+        raise RuntimeError("boom")
+
+    task = asyncio.create_task(_crash(), name="crasher")
+    await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
+
+    # Give the event loop a tick to process cancellations.
+    await asyncio.sleep(0)
+
+    # No lingering tasks named watchdog-stop-sentinel.
+    for t in asyncio.all_tasks():
+        assert t.get_name() != "watchdog-stop-sentinel"
+
+
+# ---------------------------------------------------------------------------
+# Empty task list — falls back to stop.wait()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_empty_task_list_waits_for_stop(stop: asyncio.Event) -> None:
+    """With no tasks, watchdog should wait for the stop event instead of returning."""
+
+    async def _set_stop_soon() -> None:
+        await asyncio.sleep(0)
+        stop.set()
+
+    asyncio.create_task(_set_stop_soon())
+    await asyncio.wait_for(watchdog([], stop), timeout=2.0)
+
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Stop already set before watchdog starts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_stop_already_set(stop: asyncio.Event) -> None:
+    """If stop is pre-set, watchdog should return immediately without error."""
+
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    stop.set()
+    task = asyncio.create_task(_hang_forever(), name="forever")
+    try:
+        await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Watchdog returned without triggering any additional side effects.
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Simultaneous task completions in same done batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_simultaneous_crashes(stop: asyncio.Event) -> None:
+    """Two tasks that crash immediately may land in the same done batch."""
+
+    async def _crash_a() -> None:
+        raise RuntimeError("crash-a")
+
+    async def _crash_b() -> None:
+        raise RuntimeError("crash-b")
+
+    task_a = asyncio.create_task(_crash_a(), name="crash-a")
+    task_b = asyncio.create_task(_crash_b(), name="crash-b")
+    await asyncio.wait_for(watchdog([task_a, task_b], stop), timeout=2.0)
+
+    assert stop.is_set()


### PR DESCRIPTION
## Summary
- Add a `watchdog()` coroutine that monitors all long-running asyncio tasks via `asyncio.wait(FIRST_COMPLETED)` and triggers graceful shutdown if any exits unexpectedly (crash, clean exit, or rogue cancel)
- Replace bare `stop.wait()` in `run_lifecycle()` — previously a silently-dying task would leave the process running in a degraded state

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #195: chore(hub): add watchdog/restart for long-running asyncio tasks | Open |
| Implementation | 1 commit on `feat/195-asyncio-watchdog` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (6 new) | Passed |

## Test Plan
- [x] Task crash triggers graceful shutdown
- [x] Clean but unexpected task exit triggers shutdown
- [x] Unexpected task cancel triggers shutdown
- [x] First crash among multiple tasks triggers shutdown
- [x] Normal stop signal (SIGINT/SIGTERM) still works
- [x] Internal sentinel task is cleaned up after watchdog returns

Closes #195

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`