### PR TITLE
feat(core): amend Bus[T] Protocol — async put() (#447)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -60,7 +60,7 @@ async def main() -> None:
             trust_level=TrustLevel.TRUSTED,
         )
         print(f"  -> {text}")
-        hub.inbound_bus.put(Platform.TELEGRAM, msg)
+        await hub.inbound_bus.put(Platform.TELEGRAM, msg)
 
     # Let the hub process all messages
     while hub.inbound_bus.staging_qsize() > 0:

--- a/src/lyra/adapters/_shared.py
+++ b/src/lyra/adapters/_shared.py
@@ -94,7 +94,7 @@ async def push_to_hub_guarded(  # noqa: PLR0913 — each arg is a distinct guard
             return
 
     try:
-        inbound_bus.put(platform, msg)
+        await inbound_bus.put(platform, msg)
     except asyncio.QueueFull:
         if on_drop is not None:
             on_drop()

--- a/src/lyra/core/audio_pipeline.py
+++ b/src/lyra/core/audio_pipeline.py
@@ -252,7 +252,7 @@ class AudioPipeline:
             language=result.language,  # propagate Whisper-detected language
         )
         try:
-            self._hub.inbound_bus.put(platform_enum, msg)
+            await self._hub.inbound_bus.put(platform_enum, msg)
         except asyncio.QueueFull:
             log.warning("inbound bus full — transcribed audio %s dropped", audio.id)
             return

--- a/src/lyra/core/bus.py
+++ b/src/lyra/core/bus.py
@@ -36,7 +36,11 @@ class Bus(Protocol[T]):
         ...
 
     async def put(self, platform: Platform, item: T) -> None:
-        """Enqueue an item on the platform's queue."""
+        """Enqueue an item on the platform's queue.
+
+        Must raise ``asyncio.QueueFull`` when the platform queue is at capacity —
+        callers rely on this exception for backpressure handling.
+        """
         ...
 
     async def get(self) -> T:

--- a/src/lyra/core/bus.py
+++ b/src/lyra/core/bus.py
@@ -35,8 +35,8 @@ class Bus(Protocol[T]):
         """Register a bounded queue for the given platform."""
         ...
 
-    def put(self, platform: Platform, item: T) -> None:
-        """Enqueue an item on the platform's queue (synchronous, non-blocking)."""
+    async def put(self, platform: Platform, item: T) -> None:
+        """Enqueue an item on the platform's queue."""
         ...
 
     async def get(self) -> T:

--- a/src/lyra/core/inbound_bus.py
+++ b/src/lyra/core/inbound_bus.py
@@ -86,7 +86,7 @@ class LocalBus(Generic[T]):
             )
         self._queues[platform] = asyncio.Queue(maxsize=maxsize)
 
-    def put(self, platform: Platform, item: T) -> None:
+    async def put(self, platform: Platform, item: T) -> None:
         """Enqueue an item on the platform's queue.
 
         Raises asyncio.QueueFull if the platform queue is at capacity.

--- a/tests/adapters/test_discord_audio.py
+++ b/tests/adapters/test_discord_audio.py
@@ -116,7 +116,7 @@ async def test_on_message_enqueues_audio_on_audio_bus() -> None:
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
     hub.inbound_audio_bus = MagicMock()
-    hub.inbound_audio_bus.put = MagicMock()
+    hub.inbound_audio_bus.put = AsyncMock()
     adapter = DiscordAdapter(
         hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
     )

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -195,7 +195,7 @@ class TestDiscordAuth:
         msg_ns = _make_discord_msg_ns()
         await adapter.on_message(msg_ns)
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
         assert msg.trust_level == TrustLevel.PUBLIC
         assert msg.is_admin is False
@@ -225,7 +225,7 @@ class TestDiscordAuth:
         msg_ns = _make_discord_msg_ns()
         await adapter.on_message(msg_ns)
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
         assert msg.is_admin is True
 

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -74,7 +74,7 @@ class TestDiscordAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = DiscordAdapter(
             hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
         )
@@ -105,7 +105,7 @@ class TestDiscordAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = DiscordAdapter(
             hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
         )
@@ -139,7 +139,7 @@ class TestDiscordAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = DiscordAdapter(
             hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
         )
@@ -186,7 +186,7 @@ class TestDiscordAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = DiscordAdapter(
             hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
         )
@@ -216,7 +216,7 @@ class TestDiscordAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = DiscordAdapter(
             hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
         )

--- a/tests/adapters/test_discord_edge.py
+++ b/tests/adapters/test_discord_edge.py
@@ -73,7 +73,7 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock(side_effect=asyncio.QueueFull())
+    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     adapter = DiscordAdapter(
         hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
@@ -119,7 +119,7 @@ async def test_on_message_drops_silently_when_hub_circuit_open() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock()
+    hub.inbound_bus.put = AsyncMock()
 
     adapter = DiscordAdapter(
         hub=hub,
@@ -159,7 +159,7 @@ async def test_on_message_notifies_user_when_hub_circuit_open_dm() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock()
+    hub.inbound_bus.put = AsyncMock()
 
     adapter = DiscordAdapter(
         hub=hub,
@@ -273,7 +273,7 @@ async def test_discord_msg_manager_injection_backpressure_ack() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock(side_effect=asyncio.QueueFull())
+    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     adapter = DiscordAdapter(
         hub=hub,

--- a/tests/adapters/test_discord_outbound.py
+++ b/tests/adapters/test_discord_outbound.py
@@ -45,7 +45,7 @@ async def test_own_message_is_filtered() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock()
+    hub.inbound_bus.put = AsyncMock()
 
     adapter = DiscordAdapter(
         hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -69,7 +69,7 @@ class TestDiscordAutoThread:
         create_thread_mock.assert_awaited_once()
 
         # Assert — hub.inbound_bus.put was called and the InboundMessage has thread_id
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
         assert hub_msg.platform_meta["thread_id"] == 9999
         assert hub_msg.scope_id == "thread:9999"
@@ -198,7 +198,7 @@ class TestDiscordAutoThread:
         await adapter.on_message(discord_msg)
 
         # Assert — message still processed (bus.put called)
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_auto_thread_exception_recovers_partial_thread(self) -> None:
@@ -248,7 +248,7 @@ class TestDiscordAutoThread:
         await adapter.on_message(discord_msg)
 
         # Assert — message processed with recovered thread scope
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
         assert hub_msg.scope_id == "thread:8888"
         assert hub_msg.platform_meta["thread_id"] == 8888

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -29,7 +29,7 @@ class TestDiscordAutoThread:
         # Arrange
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -82,7 +82,7 @@ class TestDiscordAutoThread:
         # Arrange
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -126,7 +126,7 @@ class TestDiscordAutoThread:
         # Arrange
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -166,7 +166,7 @@ class TestDiscordAutoThread:
         # Arrange
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -208,7 +208,7 @@ class TestDiscordAutoThread:
         # Arrange
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,

--- a/tests/adapters/test_discord_typing.py
+++ b/tests/adapters/test_discord_typing.py
@@ -251,7 +251,7 @@ async def test_on_message_cancels_typing_when_message_dropped_queue_full() -> No
     adapter.get_channel = MagicMock(return_value=mock_channel)
 
     discord_msg = SimpleNamespace(
-        guild=SimpleNamespace(id=111),
+        guild=None,  # DM — ensures message reaches push_to_hub_guarded
         channel=SimpleNamespace(id=333, send=AsyncMock()),
         author=SimpleNamespace(id=42, name="Alice", display_name="Alice", bot=False),
         content="hello",

--- a/tests/adapters/test_discord_typing.py
+++ b/tests/adapters/test_discord_typing.py
@@ -194,7 +194,7 @@ async def test_on_message_does_not_cancel_typing_when_message_queued() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock()  # succeeds — no QueueFull
+    hub.inbound_bus.put = AsyncMock()  # succeeds — no QueueFull
 
     adapter = DiscordAdapter(
         hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
@@ -239,7 +239,7 @@ async def test_on_message_cancels_typing_when_message_dropped_queue_full() -> No
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock(side_effect=_asyncio.QueueFull())
+    hub.inbound_bus.put = AsyncMock(side_effect=_asyncio.QueueFull())
 
     adapter = DiscordAdapter(
         hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL

--- a/tests/adapters/test_discord_vault_channel.py
+++ b/tests/adapters/test_discord_vault_channel.py
@@ -54,7 +54,7 @@ class TestVaultChannels:
 
         await adapter.on_message(discord_msg)
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_vault_channel_text_rewritten_as_add_vault_command(self) -> None:
@@ -95,7 +95,7 @@ class TestVaultChannels:
 
         await adapter.on_message(discord_msg)
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
         assert hub_msg.text == "/add-vault remember this important thing"
 
@@ -141,7 +141,7 @@ class TestVaultChannels:
         await adapter.on_message(discord_msg)
 
         # Message is processed
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         # But no thread is created
         create_thread_mock.assert_not_awaited()
 

--- a/tests/adapters/test_discord_vault_channel.py
+++ b/tests/adapters/test_discord_vault_channel.py
@@ -22,7 +22,7 @@ class TestVaultChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -63,7 +63,7 @@ class TestVaultChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -106,7 +106,7 @@ class TestVaultChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -152,7 +152,7 @@ class TestVaultChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -187,7 +187,7 @@ class TestVaultChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,

--- a/tests/adapters/test_discord_voice_commands.py
+++ b/tests/adapters/test_discord_voice_commands.py
@@ -322,7 +322,7 @@ class TestOnMessageVoiceCommandWiring:
         # Arrange — !join in a guild text channel should NOT reach hub.inbound_bus
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put_nowait = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = DiscordAdapter(hub=hub, bot_id="main")
         adapter._auth = _ALLOW_ALL  # permit the message
         # Mock _handle_voice_command to return True (simulates voice command handled)
@@ -343,4 +343,4 @@ class TestOnMessageVoiceCommandWiring:
         await adapter.on_message(message)
 
         # Assert — hub inbound bus was NOT called
-        hub.inbound_bus.put_nowait.assert_not_called()
+        hub.inbound_bus.put.assert_not_called()

--- a/tests/adapters/test_discord_watch.py
+++ b/tests/adapters/test_discord_watch.py
@@ -22,7 +22,7 @@ class TestWatchChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -68,7 +68,7 @@ class TestWatchChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -117,7 +117,7 @@ class TestWatchChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -154,7 +154,7 @@ class TestWatchChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -201,7 +201,7 @@ class TestWatchChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,
@@ -242,7 +242,7 @@ class TestWatchChannels:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
             hub=hub,

--- a/tests/adapters/test_discord_watch.py
+++ b/tests/adapters/test_discord_watch.py
@@ -147,7 +147,6 @@ class TestWatchChannels:
         hub.inbound_bus.put.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.asyncio
     async def test_watch_channel_auto_thread_disabled(self) -> None:
         """Watch channel + auto_thread=False: message processed, no thread created."""
         from lyra.adapters.discord import DiscordAdapter

--- a/tests/adapters/test_discord_watch.py
+++ b/tests/adapters/test_discord_watch.py
@@ -59,7 +59,7 @@ class TestWatchChannels:
 
         await adapter.on_message(discord_msg)
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_watch_channel_creates_auto_thread(self) -> None:
@@ -106,7 +106,7 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         create_thread_mock.assert_awaited_once()
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
         assert hub_msg.platform_meta["thread_id"] == 8888
 
@@ -189,7 +189,7 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         # Message still processed even though auto_thread=False
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         # No thread created
         create_thread_mock.assert_not_awaited()
 
@@ -232,7 +232,7 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         # Processed via owned-thread path, not watch channel
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_watch_channel_create_thread_exception_fallback(self) -> None:
@@ -277,4 +277,4 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         # Message still processed despite create_thread failure
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()

--- a/tests/adapters/test_telegram_auth.py
+++ b/tests/adapters/test_telegram_auth.py
@@ -187,7 +187,7 @@ class TestTelegramAuth:
 
         await adapter._on_message(_make_aiogram_msg())
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
         assert msg.trust_level == TrustLevel.TRUSTED
         assert msg.is_admin is False
@@ -214,7 +214,7 @@ class TestTelegramAuth:
 
         await adapter._on_message(_make_aiogram_msg())
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
         assert msg.is_admin is True
 
@@ -271,7 +271,7 @@ class TestTelegramAuth:
 
         await adapter._on_message(_make_aiogram_msg())
 
-        hub.inbound_bus.put.assert_called_once()
+        hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
         assert msg.trust_level == TrustLevel.PUBLIC
         assert msg.is_admin is False

--- a/tests/adapters/test_telegram_auth.py
+++ b/tests/adapters/test_telegram_auth.py
@@ -181,7 +181,7 @@ class TestTelegramAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
         adapter.bot = AsyncMock()
 
@@ -208,7 +208,7 @@ class TestTelegramAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
         adapter.bot = AsyncMock()
 
@@ -265,7 +265,7 @@ class TestTelegramAuth:
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = MagicMock()
+        hub.inbound_bus.put = AsyncMock()
         adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
         adapter.bot = AsyncMock()
 

--- a/tests/adapters/test_telegram_on_message.py
+++ b/tests/adapters/test_telegram_on_message.py
@@ -55,7 +55,7 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock(side_effect=asyncio.QueueFull())
+    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     bot = AsyncMock()
     bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
@@ -95,7 +95,7 @@ async def test_telegram_msg_manager_injection_backpressure_ack() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock(side_effect=asyncio.QueueFull())
+    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     bot = AsyncMock()
     bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
@@ -169,7 +169,7 @@ async def test_on_message_drops_and_notifies_when_hub_circuit_open() -> None:
 
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = MagicMock()
+    hub.inbound_bus.put = AsyncMock()
 
     bot = AsyncMock()
     bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -45,7 +45,7 @@ def _make_adapter() -> tuple[TelegramAdapter, MagicMock]:
     hub = MagicMock()
     hub.inbound_bus = MagicMock()
     hub.inbound_audio_bus = MagicMock()
-    hub.inbound_audio_bus.put = MagicMock()
+    hub.inbound_audio_bus.put = AsyncMock()
     adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=_ALLOW_ALL)
     bot_mock = AsyncMock()
     bot_mock.send_chat_action = AsyncMock()

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -299,7 +299,7 @@ async def push_to_hub(hub: Hub, msg: InboundMessage) -> None:
         bus.register(platform)
     if isinstance(bus, LocalBus) and not bus._feeders:
         await bus.start()
-    bus.put(platform, msg)
+    await bus.put(platform, msg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_audio_pipeline_constraints.py
+++ b/tests/core/test_audio_pipeline_constraints.py
@@ -57,11 +57,11 @@ class TestAudioPipelineTrustLevel:
 
         # Blocked audio
         audio = make_audio(trust_level=TrustLevel.BLOCKED)
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         # Followed by a normal audio to prove the loop didn't stall
         normal = make_audio(audio_id="audio-2", trust_level=TrustLevel.TRUSTED)
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, normal)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, normal)
 
         await hub.inbound_bus.start()
         await hub.inbound_audio_bus.start()
@@ -104,11 +104,11 @@ class TestAudioPipelineRateLimit:
 
         # First audio consumes the rate allowance
         audio1 = make_audio(audio_id="audio-1")
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio1)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio1)
 
         # Second audio should be rate-limited
         audio2 = make_audio(audio_id="audio-2")
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio2)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio2)
 
         await hub.inbound_bus.start()
         await hub.inbound_audio_bus.start()
@@ -153,7 +153,7 @@ class TestAudioPipelineSlashInjection:
         object.__setattr__(hub, "dispatch_response", capture)
 
         audio = make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         await hub.inbound_audio_bus.start()
         task = asyncio.create_task(hub._audio_pipeline.run())
@@ -186,7 +186,7 @@ class TestAudioPipelineTranscriptCap:
         object.__setattr__(hub, "dispatch_response", lambda msg, resp: asyncio.sleep(0))
 
         audio = make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         await hub.inbound_bus.start()
         await hub.inbound_audio_bus.start()
@@ -229,11 +229,11 @@ class TestAudioPipelineBusFull:
 
         # Fill the per-platform queue (don't start bus — no feeder to drain)
         filler = make_inbound_message()
-        hub.inbound_bus.put(Platform.TELEGRAM, filler)
+        await hub.inbound_bus.put(Platform.TELEGRAM, filler)
 
         # Now send audio — it will be transcribed but put() raises QueueFull
         audio = make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         await hub.inbound_audio_bus.start()
         task = asyncio.create_task(hub._audio_pipeline.run())

--- a/tests/core/test_hub_audio_loop.py
+++ b/tests/core/test_hub_audio_loop.py
@@ -104,7 +104,7 @@ class TestAudioLoopTranscription:
     async def test_transcribed_audio_enqueued_as_inbound_message(self, hub_with_stt):
         hub, stt = hub_with_stt
         audio = _make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         # Stub dispatch_response so the echo reply doesn't raise KeyError
         object.__setattr__(hub, "dispatch_response", lambda msg, resp: asyncio.sleep(0))
@@ -139,7 +139,7 @@ class TestAudioLoopNoSTT:
     async def test_no_stt_dispatches_unsupported_reply(self, hub_no_stt):
         hub = hub_no_stt
         audio = _make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         dispatched: list[tuple[InboundMessage, Response]] = []
         done = asyncio.Event()
@@ -174,7 +174,7 @@ class TestAudioLoopSTTFailure:
         hub.inbound_audio_bus.register(Platform.TELEGRAM, maxsize=10)
 
         audio = _make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         dispatched: list[tuple[InboundMessage, Response]] = []
         done = asyncio.Event()
@@ -209,7 +209,7 @@ class TestAudioLoopNoise:
         hub.inbound_audio_bus.register(Platform.TELEGRAM, maxsize=10)
 
         audio = _make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         dispatched: list[tuple[InboundMessage, Response]] = []
         done = asyncio.Event()
@@ -304,7 +304,7 @@ class TestProcessAudioItemPropagatesLanguage:
         object.__setattr__(hub, "dispatch_response", lambda msg, resp: asyncio.sleep(0))
 
         audio = _make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         await hub.inbound_bus.start()
         await hub.inbound_audio_bus.start()
@@ -329,7 +329,7 @@ class TestAudioLoopTaskDone:
     async def test_task_done_called(self, hub_with_stt):
         hub, _ = hub_with_stt
         audio = _make_audio()
-        hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
+        await hub.inbound_audio_bus.put(Platform.TELEGRAM, audio)
 
         # Stub dispatch_response so the echo reply doesn't raise KeyError
         object.__setattr__(hub, "dispatch_response", lambda msg, resp: asyncio.sleep(0))

--- a/tests/core/test_inbound_audio_bus.py
+++ b/tests/core/test_inbound_audio_bus.py
@@ -51,23 +51,23 @@ class TestInboundAudioBusRegistration:
         bus = InboundAudioBus()
         assert bus.qsize(Platform.TELEGRAM) == 0
 
-    def test_put_increments_qsize(self) -> None:
+    async def test_put_increments_qsize(self) -> None:
         bus = InboundAudioBus()
         bus.register(Platform.TELEGRAM, maxsize=10)
-        bus.put(Platform.TELEGRAM, _make_audio())
+        await bus.put(Platform.TELEGRAM, _make_audio())
         assert bus.qsize(Platform.TELEGRAM) == 1
 
-    def test_put_raises_queue_full(self) -> None:
+    async def test_put_raises_queue_full(self) -> None:
         bus = InboundAudioBus()
         bus.register(Platform.TELEGRAM, maxsize=1)
-        bus.put(Platform.TELEGRAM, _make_audio())
+        await bus.put(Platform.TELEGRAM, _make_audio())
         with pytest.raises(asyncio.QueueFull):
-            bus.put(Platform.TELEGRAM, _make_audio())
+            await bus.put(Platform.TELEGRAM, _make_audio())
 
-    def test_put_unregistered_platform_raises(self) -> None:
+    async def test_put_unregistered_platform_raises(self) -> None:
         bus = InboundAudioBus()
         with pytest.raises(KeyError):
-            bus.put(Platform.TELEGRAM, _make_audio())
+            await bus.put(Platform.TELEGRAM, _make_audio())
 
     def test_registered_platforms(self) -> None:
         bus = InboundAudioBus()
@@ -85,7 +85,7 @@ class TestInboundAudioBusFeeder:
 
         try:
             audio = _make_audio()
-            bus.put(Platform.TELEGRAM, audio)
+            await bus.put(Platform.TELEGRAM, audio)
             received = await asyncio.wait_for(bus.get(), timeout=0.5)
             assert received is audio
         finally:
@@ -98,11 +98,11 @@ class TestInboundAudioBusFeeder:
         await bus.start()
 
         try:
-            bus.put(Platform.TELEGRAM, _make_audio(Platform.TELEGRAM))
+            await bus.put(Platform.TELEGRAM, _make_audio(Platform.TELEGRAM))
             with pytest.raises(asyncio.QueueFull):
-                bus.put(Platform.TELEGRAM, _make_audio(Platform.TELEGRAM))
+                await bus.put(Platform.TELEGRAM, _make_audio(Platform.TELEGRAM))
             # Discord unaffected
-            bus.put(Platform.DISCORD, _make_audio(Platform.DISCORD))
+            await bus.put(Platform.DISCORD, _make_audio(Platform.DISCORD))
         finally:
             await bus.stop()
 
@@ -120,7 +120,7 @@ class TestInboundAudioBusFeeder:
         await bus.start()
 
         try:
-            bus.put(Platform.TELEGRAM, _make_audio())
+            await bus.put(Platform.TELEGRAM, _make_audio())
             # Wait for feeder to forward (avoids sleep-based flake)
             await asyncio.wait_for(bus.get(), timeout=0.5)
             bus.task_done()
@@ -134,7 +134,7 @@ class TestInboundAudioBusFeeder:
         await bus.start()
 
         try:
-            bus.put(Platform.TELEGRAM, _make_audio())
+            await bus.put(Platform.TELEGRAM, _make_audio())
             await asyncio.wait_for(bus.get(), timeout=0.5)
             bus.task_done()  # should not raise
         finally:

--- a/tests/core/test_inbound_bus.py
+++ b/tests/core/test_inbound_bus.py
@@ -60,20 +60,20 @@ class TestInboundBusRegistration:
         bus = LocalBus()
         assert bus.qsize(Platform.TELEGRAM) == 0
 
-    def test_put_increments_qsize(self) -> None:
+    async def test_put_increments_qsize(self) -> None:
         bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=10)
         msg = _make_msg(Platform.TELEGRAM)
-        bus.put(Platform.TELEGRAM, msg)
+        await bus.put(Platform.TELEGRAM, msg)
         assert bus.qsize(Platform.TELEGRAM) == 1
 
-    def test_put_raises_queue_full(self) -> None:
+    async def test_put_raises_queue_full(self) -> None:
         bus = LocalBus()
         bus.register(Platform.TELEGRAM, maxsize=1)
         msg = _make_msg(Platform.TELEGRAM)
-        bus.put(Platform.TELEGRAM, msg)
+        await bus.put(Platform.TELEGRAM, msg)
         with pytest.raises(asyncio.QueueFull):
-            bus.put(Platform.TELEGRAM, msg)
+            await bus.put(Platform.TELEGRAM, msg)
 
 
 class TestInboundBusFeeder:
@@ -84,7 +84,7 @@ class TestInboundBusFeeder:
 
         try:
             msg = _make_msg(Platform.TELEGRAM)
-            bus.put(Platform.TELEGRAM, msg)
+            await bus.put(Platform.TELEGRAM, msg)
 
             # Wait for feeder to forward to staging
             received = await asyncio.wait_for(bus.get(), timeout=0.5)
@@ -103,12 +103,12 @@ class TestInboundBusFeeder:
             dc_msg = _make_msg(Platform.DISCORD)
 
             # Fill telegram queue
-            bus.put(Platform.TELEGRAM, tg_msg)
+            await bus.put(Platform.TELEGRAM, tg_msg)
             with pytest.raises(asyncio.QueueFull):
-                bus.put(Platform.TELEGRAM, tg_msg)
+                await bus.put(Platform.TELEGRAM, tg_msg)
 
             # Discord queue unaffected — put succeeds (not raises QueueFull)
-            bus.put(Platform.DISCORD, dc_msg)
+            await bus.put(Platform.DISCORD, dc_msg)
         finally:
             await bus.stop()
 

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -192,7 +192,7 @@ class TestHealthEndpoint:
             },
             trust_level=TrustLevel.TRUSTED,
         )
-        hub.inbound_bus.put(Platform.TELEGRAM, msg)
+        await hub.inbound_bus.put(Platform.TELEGRAM, msg)
 
         app = create_health_app(hub)
         transport = ASGITransport(app=app)

--- a/tests/test_monitoring_checks_orchestrator.py
+++ b/tests/test_monitoring_checks_orchestrator.py
@@ -40,7 +40,7 @@ class TestRunChecks:
             "lyra.monitoring.checks.subprocess.run",
             lambda *a, **kw: MagicMock(
                 returncode=0,
-                stdout="lyra                             RUNNING   pid 1234, uptime 1:00:00\n",
+                stdout="lyra                             RUNNING   pid 1234, uptime 1:00:00\n",  # noqa: E501
             ),
         )
 

--- a/tests/test_monitoring_checks_primitives.py
+++ b/tests/test_monitoring_checks_primitives.py
@@ -19,7 +19,7 @@ class TestCheckProcess:
             "lyra.monitoring.checks.subprocess.run",
             lambda *a, **kw: MagicMock(
                 returncode=0,
-                stdout="lyra_telegram                    RUNNING   pid 1234, uptime 1:00:00\n",
+                stdout="lyra_telegram                    RUNNING   pid 1234, uptime 1:00:00\n",  # noqa: E501
             ),
         )
         from lyra.monitoring.checks import check_process

--- a/tests/test_monitoring_escalation.py
+++ b/tests/test_monitoring_escalation.py
@@ -300,7 +300,7 @@ class TestRunFallbackChain:
             "lyra.monitoring.checks.subprocess.run",
             lambda *a, **kw: MagicMock(
                 returncode=0,
-                stdout="lyra_telegram                    RUNNING   pid 1234, uptime 1:00:00\n",
+                stdout="lyra_telegram                    RUNNING   pid 1234, uptime 1:00:00\n",  # noqa: E501
             ),
         )
 

--- a/tests/test_monitoring_escalation.py
+++ b/tests/test_monitoring_escalation.py
@@ -121,9 +121,18 @@ class TestEscalateToLLM:
         )
 
         with (
-            patch("lyra.monitoring.escalation.shutil.which", return_value="/usr/bin/claude"),
-            patch("lyra.monitoring.escalation.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("lyra.monitoring.escalation.asyncio.wait_for", return_value=mock_proc.communicate.return_value),
+            patch(
+                "lyra.monitoring.escalation.shutil.which",
+                return_value="/usr/bin/claude",
+            ),
+            patch(
+                "lyra.monitoring.escalation.asyncio.create_subprocess_exec",
+                return_value=mock_proc,
+            ),
+            patch(
+                "lyra.monitoring.escalation.asyncio.wait_for",
+                return_value=mock_proc.communicate.return_value,
+            ),
         ):
             result = await escalate_to_llm(failed_report, config)
 


### PR DESCRIPTION
## Summary
- Amend `Bus[T].put()` signature from sync to `async def put()` in `core/bus.py` Protocol — forward-compatibility with NATS (Slice A1 of #445)
- `LocalBus.put()` gains async wrapper; body unchanged (`put_nowait()` — zero behavioral regression)
- All callers (`_shared.py`, `audio_pipeline.py`) and all test mocks/call sites updated

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #447: feat(core): amend Bus[T] Protocol — async put() | Open |
| Implementation | 1 commit on `feat/447-async-bus-put` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (17 test files updated) | Passed |

## Test Plan
- [ ] `pytest` green (2209 passed, 20 skipped)
- [ ] `pyright` reports 0 errors on changed files
- [ ] `LocalBus` backpressure still raises `asyncio.QueueFull` on full queue
- [ ] `push_to_hub_guarded()` correctly awaits `bus.put()` — circuit open and QueueFull paths both work

Closes #447

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`