### PR TITLE
feat(core): trust re-resolution — move Authenticator.resolve() to Hub side

### DIFF
--- a/artifacts/specs/445-distributed-lyra-nats-spec.mdx
+++ b/artifacts/specs/445-distributed-lyra-nats-spec.mdx
@@ -186,11 +186,13 @@ NATS was baked unconditionally into `provision.sh` as part of A2. This must be c
 5. `task_done()` → no-op for core NATS (ack semantics with JetStream in Slice D)
 6. Serialization strips non-JSON-serializable values from `platform_meta` (specifically: `_session_update_fn` callable)
 
-#### C3: Trust re-resolution on Hub side
+#### C3: Trust re-resolution on Hub side ✅ (#456)
 
-1. `Authenticator.resolve()` moves from adapter-side to Hub-side
-2. Adapter sends raw `user_id` + `platform` over NATS; Hub resolves trust level post-deserialization
-3. Required because adapter can no longer access the auth store in a separate process
+1. `Authenticator.resolve()` moved from adapter-side to Hub-side (`Hub.register_authenticator()`, `Hub._resolve_message_trust()`)
+2. Adapter sends messages with `trust_level=PUBLIC` (raw); Hub overwrites with authoritative trust before pipeline
+3. `TrustGuardMiddleware` added to Hub pipeline — drops BLOCKED users (replaces adapter-side GuardChain)
+4. Bootstrap wires authenticators onto Hub (`hub.register_authenticator(platform, bot_id, auth)`) instead of adapters
+5. Out-of-band gates (Discord slash commands) use `hub.resolve_identity()` — auth store never accessed directly by adapters
 
 #### C4: Extract Hub into standalone process
 

--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -91,6 +91,15 @@ class DiscordAdapter(discord.Client):
         super().__init__(intents=intents)
         self.tree = discord.app_commands.CommandTree(self)
         _register_voice_app_commands(self.tree, self)
+        if auth is not _DENY_ALL:
+            import warnings
+
+            warnings.warn(
+                "DiscordAdapter(auth=...) is deprecated after C3 — "
+                "use hub.register_authenticator() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._hub = hub
         self._bot_id = bot_id
         self._circuit_registry = circuit_registry

--- a/src/lyra/adapters/discord_inbound.py
+++ b/src/lyra/adapters/discord_inbound.py
@@ -19,6 +19,7 @@ from lyra.adapters.discord_threads import (
     retrieve_thread_session,
 )
 from lyra.core.message import InboundMessage, Platform
+from lyra.core.trust import TrustLevel
 
 if TYPE_CHECKING:
     from lyra.adapters.discord import DiscordAdapter
@@ -36,19 +37,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
     if message.author.bot:
         return
 
-    # Auth gate — runs before normalize() and before audio handling.
-    _raw_uid = str(message.author.id)
-    roles = (
-        [str(r.id) for r in message.author.roles]
-        if hasattr(message.author, "roles")
-        else []
-    )
-    identity = adapter._auth.resolve(_raw_uid, roles=roles)
-    if adapter._guard_chain.run(identity):
-        log.info("auth_reject user=%s channel=discord", f"dc:user:{message.author.id}")
-        return
-    trust = identity.trust_level
-
+    # C3: adapters send raw identity fields; Hub resolves trust in run().
     # Audio attachment detection
     audio_attachment = next(
         (
@@ -59,12 +48,12 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
         None,
     )
     if audio_attachment is not None:
-        await _handle_audio(adapter, message, audio_attachment, trust)
+        await _handle_audio(adapter, message, audio_attachment, TrustLevel.PUBLIC)
         return  # audio messages handled separately; skip text path
 
     # Voice command dispatch — guild-only; runs before mention/DM filter.
     if message.guild is not None:
-        if await adapter._handle_voice_command(message, trust):
+        if await adapter._handle_voice_command(message, TrustLevel.PUBLIC):
             return
 
     # Pre-detect mention (needed for auto-thread decision)
@@ -204,8 +193,8 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
             message,
             thread_id=resolved_thread_id,
             channel_id=resolved_channel_id,
-            trust_level=trust,
-            is_admin=identity.is_admin,
+            trust_level=TrustLevel.PUBLIC,
+            is_admin=False,
         )
     except Exception:
         log.exception("Failed to normalize discord message id=%s", message.id)

--- a/src/lyra/adapters/discord_normalize.py
+++ b/src/lyra/adapters/discord_normalize.py
@@ -84,6 +84,7 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
     )
 
     _display_name = getattr(raw.author, "display_name", None)
+    roles = tuple(str(r.id) for r in getattr(raw.author, "roles", []) or [])
     attachments = extract_attachments(getattr(raw, "attachments", None) or [])
     _reference = getattr(raw, "reference", None)
     reply_to_id: str | None = (
@@ -122,6 +123,7 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
         trust="user",
         trust_level=trust_level,
         is_admin=is_admin,
+        roles=roles,
         platform_meta=platform_meta,
         routing=routing,
         reply_to_id=reply_to_id,

--- a/src/lyra/adapters/discord_voice_commands.py
+++ b/src/lyra/adapters/discord_voice_commands.py
@@ -141,10 +141,13 @@ async def handle_voice_command(
 
 
 def _resolve_slash_trust(adapter: "DiscordAdapter", user_id: str) -> TrustLevel:
-    """Resolve trust level for a slash command interaction user."""
-    identity = adapter._auth.resolve(user_id)
-    rejection = adapter._guard_chain.run(identity)
-    if rejection is not None:
+    """Resolve trust level for a slash command interaction user.
+
+    Slash commands are out-of-band Discord interactions that don't flow through
+    the inbound message bus. Trust is delegated to the Hub authenticator (C3).
+    """
+    identity = adapter._hub.resolve_identity(user_id, "discord", adapter._bot_id)
+    if identity.trust_level == TrustLevel.BLOCKED:
         return TrustLevel.BLOCKED
     return identity.trust_level
 

--- a/src/lyra/adapters/discord_voice_commands.py
+++ b/src/lyra/adapters/discord_voice_commands.py
@@ -91,7 +91,8 @@ async def handle_join_command(
         if args.strip().lower().split()[:1] == ["stay"]
         else VoiceMode.TRANSIENT
     )
-    if mode == VoiceMode.PERSISTENT and trust < TrustLevel.TRUSTED:
+    _elevated = {TrustLevel.TRUSTED, TrustLevel.OWNER}
+    if mode == VoiceMode.PERSISTENT and trust not in _elevated:
         await reply_safe(
             message,
             "Persistent mode requires elevated permissions.",
@@ -127,7 +128,7 @@ async def handle_voice_command(
     guild = message.guild
     guild_id = str(guild.id)
     if cmd.name == "leave":
-        if trust < TrustLevel.TRUSTED:
+        if trust not in {TrustLevel.TRUSTED, TrustLevel.OWNER}:
             await reply_safe(
                 message,
                 "You don't have permission to use this command.",
@@ -189,7 +190,8 @@ async def _handle_join_slash(
         )
         return
     voice_mode = VoiceMode.PERSISTENT if mode == "stay" else VoiceMode.TRANSIENT
-    if voice_mode == VoiceMode.PERSISTENT and trust < TrustLevel.TRUSTED:
+    _elevated = {TrustLevel.TRUSTED, TrustLevel.OWNER}
+    if voice_mode == VoiceMode.PERSISTENT and trust not in _elevated:
         voice_mode = VoiceMode.TRANSIENT
     try:
         await adapter._vsm.join(guild, channel, voice_mode)
@@ -239,7 +241,7 @@ def register_voice_app_commands(
             )
             return
         trust = _resolve_slash_trust(adapter, str(interaction.user.id))
-        if trust < TrustLevel.TRUSTED:
+        if trust not in {TrustLevel.TRUSTED, TrustLevel.OWNER}:
             await interaction.response.send_message(
                 "You don't have permission to use this command.",
                 ephemeral=True,

--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -103,6 +103,15 @@ class TelegramAdapter:
         msg_manager: MessageManager | None = None,
         auth: Authenticator = _DENY_ALL,
     ) -> None:
+        if auth is not _DENY_ALL:
+            import warnings
+
+            warnings.warn(
+                "TelegramAdapter(auth=...) is deprecated after C3 — "
+                "use hub.register_authenticator() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._bot_id = bot_id
         self._token = token
         self._webhook_secret = webhook_secret

--- a/src/lyra/adapters/telegram_inbound.py
+++ b/src/lyra/adapters/telegram_inbound.py
@@ -11,6 +11,7 @@ from lyra.adapters.telegram_audio import _download_audio
 from lyra.adapters.telegram_formatting import _make_send_kwargs
 from lyra.adapters.telegram_normalize import _make_scope_id, normalize_audio
 from lyra.core.message import InboundMessage, Platform
+from lyra.core.trust import TrustLevel
 
 if TYPE_CHECKING:
     from lyra.adapters.telegram import TelegramAdapter
@@ -57,14 +58,9 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
     if not msg.from_user or getattr(msg.from_user, "is_bot", False):
         return
 
-    user_id = str(msg.from_user.id)
-    identity = adapter._auth.resolve(user_id)
-    if adapter._guard_chain.run(identity):
-        log.info("auth_reject user=%s channel=telegram", user_id)
-        return
-
+    # C3: adapters send raw identity fields; Hub resolves trust in run().
     hub_msg = adapter.normalize(
-        msg, trust_level=identity.trust_level, is_admin=identity.is_admin
+        msg, trust_level=TrustLevel.PUBLIC, is_admin=False
     )
 
     # In group chats, only respond when directly mentioned.
@@ -101,12 +97,7 @@ async def handle_voice_message(adapter: TelegramAdapter, msg: Any) -> None:
     if not msg.from_user or getattr(msg.from_user, "is_bot", False):
         return
 
-    uid = str(msg.from_user.id)
-    identity = adapter._auth.resolve(uid)
-    if adapter._guard_chain.run(identity):
-        log.info("auth_reject user=%s channel=telegram", uid)
-        return
-
+    # C3: adapters send raw identity fields; Hub resolves trust in run().
     voice = msg.voice or msg.audio or getattr(msg, "video_note", None)
     if voice is None:
         return
@@ -166,12 +157,13 @@ async def handle_voice_message(adapter: TelegramAdapter, msg: Any) -> None:
         tmp_path.unlink(missing_ok=True)
 
     # is_admin not propagated to InboundAudio — InboundAudio.is_admin is deferred (see #315)  # noqa: E501
+    # C3: trust resolved by Hub; adapter passes PUBLIC as raw identity.
     hub_audio = normalize_audio(
         adapter,
         msg,
         audio_bytes=audio_bytes,
         mime_type="audio/ogg",
-        trust_level=identity.trust_level,
+        trust_level=TrustLevel.PUBLIC,
     )
 
     adapter._start_typing(chat_id)

--- a/src/lyra/adapters/telegram_inbound.py
+++ b/src/lyra/adapters/telegram_inbound.py
@@ -59,9 +59,7 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
         return
 
     # C3: adapters send raw identity fields; Hub resolves trust in run().
-    hub_msg = adapter.normalize(
-        msg, trust_level=TrustLevel.PUBLIC, is_admin=False
-    )
+    hub_msg = adapter.normalize(msg, trust_level=TrustLevel.PUBLIC, is_admin=False)
 
     # In group chats, only respond when directly mentioned.
     # In private chats, always respond.

--- a/src/lyra/bootstrap/multibot_lifecycle.py
+++ b/src/lyra/bootstrap/multibot_lifecycle.py
@@ -62,9 +62,7 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
 
         _audit_queue = hub._event_bus.subscribe()
         _audit_consumer = AuditConsumer(_audit_queue)
-        _audit_task = asyncio.create_task(
-            _audit_consumer.run(), name="audit-consumer"
-        )
+        _audit_task = asyncio.create_task(_audit_consumer.run(), name="audit-consumer")
         tasks.append(_audit_task)
     for tg_adapter in tg_adapters:
         tasks.append(

--- a/src/lyra/bootstrap/multibot_stores.py
+++ b/src/lyra/bootstrap/multibot_stores.py
@@ -36,8 +36,7 @@ _CONFIG_TABLES = (
 )
 
 _SENTINEL_DDL = (
-    "CREATE TABLE IF NOT EXISTS _migration_complete"
-    " (migrated_at TEXT NOT NULL)"
+    "CREATE TABLE IF NOT EXISTS _migration_complete (migrated_at TEXT NOT NULL)"
 )
 
 
@@ -101,8 +100,7 @@ def _atomic_table_copy(  # noqa: C901 — sequential migration steps
             if not _IDENT_RE.match(table):
                 raise ValueError(f"Invalid table name: {table!r}")
             row = src.execute(
-                "SELECT sql FROM sqlite_master"
-                " WHERE type='table' AND name=?",
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
                 (table,),
             ).fetchone()
             if row is None:
@@ -168,9 +166,7 @@ def _migrate_to_config_db(vault_dir: Path) -> None:
         tmp_prefix=".config_db_migrate_",
     )
     if n:
-        log.warning(
-            "auth.db split: migrated %d rows to config.db (tombstones kept)", n
-        )
+        log.warning("auth.db split: migrated %d rows to config.db (tombstones kept)", n)
 
 
 def _migrate_threads_to_discord_db(vault_dir: Path) -> None:

--- a/src/lyra/bootstrap/multibot_wiring.py
+++ b/src/lyra/bootstrap/multibot_wiring.py
@@ -68,9 +68,10 @@ async def wire_telegram_adapters(  # noqa: PLR0913 — wiring requires all deps
             webhook_secret=tg_webhook_secret or "",
             circuit_registry=circuit_registry,
             msg_manager=msg_manager,
-            auth=auth,
         )
         await adapter.resolve_identity()
+        # C3: Hub is the trust authority — register authenticator here, not on adapter.
+        hub.register_authenticator(Platform.TELEGRAM, bot_cfg.bot_id, auth)
         hub.register_adapter(Platform.TELEGRAM, bot_cfg.bot_id, adapter)
 
         tg_key = RoutingKey(Platform.TELEGRAM, bot_cfg.bot_id, "*")
@@ -177,11 +178,12 @@ async def wire_discord_adapters(  # noqa: PLR0913, C901 — wiring requires all 
             msg_manager=msg_manager,
             auto_thread=bot_cfg.auto_thread,
             thread_hot_hours=bot_cfg.thread_hot_hours,
-            auth=auth,
             thread_store=thread_store,
             watch_channels=watch_channels,
             vault_channels=vault_channels,
         )
+        # C3: Hub is the trust authority — register authenticator here, not on adapter.
+        hub.register_authenticator(Platform.DISCORD, bot_cfg.bot_id, auth)
         hub.register_adapter(Platform.DISCORD, bot_cfg.bot_id, adapter)
 
         dc_key = RoutingKey(Platform.DISCORD, bot_cfg.bot_id, "*")

--- a/src/lyra/bootstrap/multibot_wiring.py
+++ b/src/lyra/bootstrap/multibot_wiring.py
@@ -15,7 +15,7 @@ from lyra.config import (
     TelegramBotConfig,
     TelegramMultiConfig,
 )
-from lyra.core.auth import AuthMiddleware
+from lyra.core.authenticator import Authenticator
 from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.hub import Hub, OutboundDispatcher, RoutingKey
 from lyra.core.message import Platform
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 async def wire_telegram_adapters(  # noqa: PLR0913 — wiring requires all deps
     hub: Hub,
-    tg_bot_auths: list[tuple[TelegramBotConfig, AuthMiddleware]],
+    tg_bot_auths: list[tuple[TelegramBotConfig, Authenticator]],
     bot_agent_map: dict[tuple[str, str], str],
     cred_store: CredentialStore,
     circuit_registry: CircuitRegistry,
@@ -105,7 +105,7 @@ async def wire_telegram_adapters(  # noqa: PLR0913 — wiring requires all deps
 
 async def wire_discord_adapters(  # noqa: PLR0913, C901 — wiring requires all deps
     hub: Hub,
-    dc_bot_auths: list[tuple[DiscordBotConfig, AuthMiddleware]],
+    dc_bot_auths: list[tuple[DiscordBotConfig, Authenticator]],
     bot_agent_map: dict[tuple[str, str], str],
     cred_store: CredentialStore,
     circuit_registry: CircuitRegistry,
@@ -134,83 +134,85 @@ async def wire_discord_adapters(  # noqa: PLR0913, C901 — wiring requires all 
         await thread_store.connect()
 
     try:
-      for bot_cfg, auth in dc_bot_auths:
-        resolved_agent = bot_agent_map.get(("discord", bot_cfg.bot_id))
-        if resolved_agent is None:
-            log.warning(
-                "discord bot_id=%r not in bot_agent_map — skipping adapter",
-                bot_cfg.bot_id,
+        for bot_cfg, auth in dc_bot_auths:
+            resolved_agent = bot_agent_map.get(("discord", bot_cfg.bot_id))
+            if resolved_agent is None:
+                log.warning(
+                    "discord bot_id=%r not in bot_agent_map — skipping adapter",
+                    bot_cfg.bot_id,
+                )
+                continue
+
+            dc_creds = await cred_store.get_full("discord", bot_cfg.bot_id)
+            if dc_creds is None:
+                raise MissingCredentialsError("discord", bot_cfg.bot_id)
+            dc_token, _ = dc_creds
+
+            watch_channels: frozenset[int] = frozenset()
+            vault_channels: frozenset[int] = frozenset()
+            if agent_store is not None:
+                bot_settings = agent_store.get_bot_settings("discord", bot_cfg.bot_id)
+
+                def _parse_channel_ids(key: str) -> frozenset[int]:
+                    raw_ids = bot_settings.get(key, [])
+                    valid: list[int] = []
+                    for ch in raw_ids:
+                        try:
+                            valid.append(int(ch))
+                        except (ValueError, TypeError):
+                            log.warning(
+                                "%s: invalid channel id %r for bot %r — skipping",
+                                key,
+                                ch,
+                                bot_cfg.bot_id,
+                            )
+                    return frozenset(valid)
+
+                watch_channels = _parse_channel_ids("watch_channels")
+                vault_channels = _parse_channel_ids("vault_channels")
+
+            adapter = DiscordAdapter(
+                hub=hub,
+                bot_id=bot_cfg.bot_id,
+                circuit_registry=circuit_registry,
+                msg_manager=msg_manager,
+                auto_thread=bot_cfg.auto_thread,
+                thread_hot_hours=bot_cfg.thread_hot_hours,
+                thread_store=thread_store,
+                watch_channels=watch_channels,
+                vault_channels=vault_channels,
             )
-            continue
+            # C3: Hub is the trust authority — register here, not on adapter.
+            hub.register_authenticator(Platform.DISCORD, bot_cfg.bot_id, auth)
+            hub.register_adapter(Platform.DISCORD, bot_cfg.bot_id, adapter)
 
-        dc_creds = await cred_store.get_full("discord", bot_cfg.bot_id)
-        if dc_creds is None:
-            raise MissingCredentialsError("discord", bot_cfg.bot_id)
-        dc_token, _ = dc_creds
+            dc_key = RoutingKey(Platform.DISCORD, bot_cfg.bot_id, "*")
+            hub.register_binding(
+                Platform.DISCORD,
+                bot_cfg.bot_id,
+                "*",
+                resolved_agent,
+                dc_key.to_pool_id(),
+            )
 
-        watch_channels: frozenset[int] = frozenset()
-        vault_channels: frozenset[int] = frozenset()
-        if agent_store is not None:
-            bot_settings = agent_store.get_bot_settings("discord", bot_cfg.bot_id)
+            dispatcher = OutboundDispatcher(
+                platform_name="discord",
+                adapter=adapter,
+                circuit=circuit_registry.get("discord"),
+                circuit_registry=circuit_registry,
+                bot_id=bot_cfg.bot_id,
+            )
+            hub.register_outbound_dispatcher(
+                Platform.DISCORD, bot_cfg.bot_id, dispatcher
+            )
 
-            def _parse_channel_ids(key: str) -> frozenset[int]:
-                raw_ids = bot_settings.get(key, [])
-                valid: list[int] = []
-                for ch in raw_ids:
-                    try:
-                        valid.append(int(ch))
-                    except (ValueError, TypeError):
-                        log.warning(
-                            "%s: invalid channel id %r for bot %r — skipping",
-                            key,
-                            ch,
-                            bot_cfg.bot_id,
-                        )
-                return frozenset(valid)
-
-            watch_channels = _parse_channel_ids("watch_channels")
-            vault_channels = _parse_channel_ids("vault_channels")
-
-        adapter = DiscordAdapter(
-            hub=hub,
-            bot_id=bot_cfg.bot_id,
-            circuit_registry=circuit_registry,
-            msg_manager=msg_manager,
-            auto_thread=bot_cfg.auto_thread,
-            thread_hot_hours=bot_cfg.thread_hot_hours,
-            thread_store=thread_store,
-            watch_channels=watch_channels,
-            vault_channels=vault_channels,
-        )
-        # C3: Hub is the trust authority — register authenticator here, not on adapter.
-        hub.register_authenticator(Platform.DISCORD, bot_cfg.bot_id, auth)
-        hub.register_adapter(Platform.DISCORD, bot_cfg.bot_id, adapter)
-
-        dc_key = RoutingKey(Platform.DISCORD, bot_cfg.bot_id, "*")
-        hub.register_binding(
-            Platform.DISCORD,
-            bot_cfg.bot_id,
-            "*",
-            resolved_agent,
-            dc_key.to_pool_id(),
-        )
-
-        dispatcher = OutboundDispatcher(
-            platform_name="discord",
-            adapter=adapter,
-            circuit=circuit_registry.get("discord"),
-            circuit_registry=circuit_registry,
-            bot_id=bot_cfg.bot_id,
-        )
-        hub.register_outbound_dispatcher(Platform.DISCORD, bot_cfg.bot_id, dispatcher)
-
-        adapters.append((adapter, bot_cfg, dc_token))
-        dispatchers.append(dispatcher)
-        log.info(
-            "Registered Discord bot bot_id=%r agent=%r",
-            bot_cfg.bot_id,
-            resolved_agent,
-        )
+            adapters.append((adapter, bot_cfg, dc_token))
+            dispatchers.append(dispatcher)
+            log.info(
+                "Registered Discord bot bot_id=%r agent=%r",
+                bot_cfg.bot_id,
+                resolved_agent,
+            )
     except Exception:
         # Close the shared ThreadStore on wiring failure (#417 fix)
         if thread_store is not None:
@@ -227,16 +229,16 @@ def _build_bot_auths(
     auth_store: AuthStore,
     admin_user_ids: frozenset[str] = frozenset(),
 ) -> tuple[
-    list[tuple[TelegramBotConfig, AuthMiddleware]],
-    list[tuple[DiscordBotConfig, AuthMiddleware]],
+    list[tuple[TelegramBotConfig, Authenticator]],
+    list[tuple[DiscordBotConfig, Authenticator]],
 ]:
     """Build (bot_cfg, auth) pairs for each platform, skipping bots without auth."""
-    tg_bot_auths: list[tuple[TelegramBotConfig, AuthMiddleware]] = []
-    dc_bot_auths: list[tuple[DiscordBotConfig, AuthMiddleware]] = []
+    tg_bot_auths: list[tuple[TelegramBotConfig, Authenticator]] = []
+    dc_bot_auths: list[tuple[DiscordBotConfig, Authenticator]] = []
 
     try:
         for bot_cfg in tg_multi_cfg.bots:
-            auth = AuthMiddleware.from_bot_config(
+            auth = Authenticator.from_bot_config(
                 raw_config,
                 "telegram",
                 bot_cfg.bot_id,
@@ -252,7 +254,7 @@ def _build_bot_auths(
             tg_bot_auths.append((bot_cfg, auth))
 
         for bot_cfg in dc_multi_cfg.bots:
-            auth = AuthMiddleware.from_bot_config(
+            auth = Authenticator.from_bot_config(
                 raw_config,
                 "discord",
                 bot_cfg.bot_id,

--- a/src/lyra/cli.py
+++ b/src/lyra/cli.py
@@ -30,6 +30,7 @@ from lyra.cli_setup import setup_app
 # Version
 # ---------------------------------------------------------------------------
 
+
 def _get_version() -> str:
     try:
         return importlib.metadata.version("lyra")

--- a/src/lyra/commands/svc/handlers.py
+++ b/src/lyra/commands/svc/handlers.py
@@ -59,9 +59,7 @@ def _validate(action: str, args: list[str]) -> tuple[str | None, Response | None
         )
     service = args[1].lower()
     if service not in _ALLOWED_SERVICES:
-        return None, Response(
-            content=f"Unknown service '{args[1]}'.\n{_SERVICES_LIST}"
-        )
+        return None, Response(content=f"Unknown service '{args[1]}'.\n{_SERVICES_LIST}")
     return service, None
 
 

--- a/src/lyra/core/agent_config.py
+++ b/src/lyra/core/agent_config.py
@@ -111,9 +111,7 @@ class SmartRoutingConfig(BaseModel):
 
     @field_validator("routing_table", mode="before")
     @classmethod
-    def _coerce_routing_table_keys(
-        cls, v: Any
-    ) -> dict[Complexity, str]:
+    def _coerce_routing_table_keys(cls, v: Any) -> dict[Complexity, str]:
         """Convert string keys to Complexity enum values when loading from JSON."""
         if not isinstance(v, dict):
             return v

--- a/src/lyra/core/audio_pipeline.py
+++ b/src/lyra/core/audio_pipeline.py
@@ -160,6 +160,8 @@ class AudioPipeline:
             return
         key = RoutingKey(platform_enum, audio.bot_id, audio.scope_id)
 
+        audio = self._hub._resolve_audio_trust(audio)
+
         if audio.trust_level == TrustLevel.BLOCKED:
             log.warning("audio %s has trust_level=BLOCKED — dropped", audio.id)
             return

--- a/src/lyra/core/cli_pool_worker.py
+++ b/src/lyra/core/cli_pool_worker.py
@@ -139,11 +139,7 @@ class CliPoolWorkerMixin:
     async def _spawn(
         self, pool_id: str, model_config: ModelConfig, system_prompt: str = ""
     ) -> _ProcessEntry | None:
-        spawn_cwd = (
-            self._cwd_overrides.get(pool_id)
-            or model_config.cwd
-            or _LYRA_ROOT
-        )
+        spawn_cwd = self._cwd_overrides.get(pool_id) or model_config.cwd or _LYRA_ROOT
         resume_session_id = self._resume_session_ids.pop(pool_id, None)
         cmd, prompt_file = self._build_cmd(
             model_config,
@@ -279,9 +275,7 @@ class CliPoolWorkerMixin:
                     await self._kill(pool_id)
                     # Fire-and-forget notification for idle evictions
                     if self._on_reap and reason == "idle":
-                        _t = asyncio.create_task(
-                            self._on_reap(pool_id, reason)
-                        )
+                        _t = asyncio.create_task(self._on_reap(pool_id, reason))
                         _t.add_done_callback(
                             lambda t, pid=pool_id: (
                                 log.warning(

--- a/src/lyra/core/hub/event_bus.py
+++ b/src/lyra/core/hub/event_bus.py
@@ -62,7 +62,6 @@ class PipelineEventBus:
         if now - self._last_warn.get(qid, 0.0) >= _DROP_WARN_INTERVAL:
             self._last_warn[qid] = now
             log.warning(
-                "PipelineEventBus: subscriber queue full"
-                " — events dropped (maxsize=%d)",
+                "PipelineEventBus: subscriber queue full — events dropped (maxsize=%d)",
                 self._maxsize,
             )

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import time
 from typing import TYPE_CHECKING
 
 from ..agent import AgentBase
 from ..audio_pipeline import AudioPipeline
+from ..authenticator import Authenticator
 from ..bus import Bus
+from ..identity import Identity
 from ..inbound_bus import LocalBus
 from ..message import InboundAudio, InboundMessage, Platform
 from ..pool import Pool
+from ..trust import TrustLevel
 from .hub_outbound import HubOutboundMixin
 from .hub_protocol import (  # noqa: F401 — public re-export
     Binding,
@@ -124,6 +128,8 @@ class Hub(HubOutboundMixin):
         self._event_bus: PipelineEventBus | None = event_bus
         self._pool_manager = PoolManager(self)
         self._audio_pipeline = AudioPipeline(self)
+        # C3: per-(platform, bot_id) authenticator registry — Hub is the trust authority
+        self._authenticators: dict[tuple[Platform, str], Authenticator] = {}
 
     @property
     def pools(self) -> dict[str, Pool]:
@@ -179,6 +185,61 @@ class Hub(HubOutboundMixin):
         dispatcher: OutboundDispatcher,
     ) -> None:
         self.outbound_dispatchers[(platform, bot_id)] = dispatcher
+
+    def register_authenticator(
+        self, platform: Platform, bot_id: str, auth: Authenticator
+    ) -> None:
+        """Register the Authenticator for a (platform, bot_id) pair.
+
+        Called during bootstrap wiring. The Hub is the trust authority — adapters
+        send raw identity fields; trust is resolved here (C3).
+        """
+        self._authenticators[(platform, bot_id)] = auth
+
+    def resolve_identity(
+        self, user_id: str | None, platform: str, bot_id: str
+    ) -> Identity:
+        """Resolve identity for a user on a given (platform, bot_id).
+
+        Used by out-of-band adapter gates (e.g. Discord slash commands) that
+        don't flow through the inbound message bus. Returns PUBLIC identity
+        when no authenticator is registered for the pair.
+        """
+        try:
+            key = (Platform(platform), bot_id)
+        except ValueError:
+            return Identity(
+                user_id=user_id or "", trust_level=TrustLevel.PUBLIC, is_admin=False
+            )
+        auth = self._authenticators.get(key)
+        if auth is None:
+            return Identity(
+                user_id=user_id or "", trust_level=TrustLevel.PUBLIC, is_admin=False
+            )
+        return auth.resolve(user_id)
+
+    def _resolve_message_trust(self, msg: InboundMessage) -> InboundMessage:
+        """Re-resolve trust level on the Hub side (C3 — trust re-resolution).
+
+        Adapters send messages with trust_level=PUBLIC (raw). Hub overwrites with
+        the authoritative resolved identity before the pipeline sees the message.
+        No-op when no authenticator is registered for the (platform, bot_id) pair.
+        """
+        try:
+            key = (Platform(msg.platform), msg.bot_id)
+        except ValueError:
+            return msg
+        auth = self._authenticators.get(key)
+        if auth is None:
+            return msg
+        identity = auth.resolve(msg.user_id if msg.user_id else None)
+        trust_unchanged = identity.trust_level == msg.trust_level
+        admin_unchanged = identity.is_admin == msg.is_admin
+        if trust_unchanged and admin_unchanged:
+            return msg
+        return dataclasses.replace(
+            msg, trust_level=identity.trust_level, is_admin=identity.is_admin
+        )
 
     def register_binding(
         self,
@@ -287,6 +348,7 @@ class Hub(HubOutboundMixin):
             msg = await self.inbound_bus.get()
             try:
                 try:
+                    msg = self._resolve_message_trust(msg)
                     result = await pipeline.process(msg)
                 except Exception:
                     log.exception("pipeline.process() failed for msg id=%s", msg.id)

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -196,6 +196,12 @@ class Hub(HubOutboundMixin):
         """
         self._authenticators[(platform, bot_id)] = auth
 
+    def _get_authenticator(
+        self, platform: Platform, bot_id: str
+    ) -> "Authenticator | None":
+        """Return the registered Authenticator for (platform, bot_id), or None."""
+        return self._authenticators.get((platform, bot_id))
+
     def resolve_identity(
         self, user_id: str | None, platform: str, bot_id: str
     ) -> Identity:
@@ -206,12 +212,12 @@ class Hub(HubOutboundMixin):
         when no authenticator is registered for the pair.
         """
         try:
-            key = (Platform(platform), bot_id)
+            key_platform = Platform(platform)
         except ValueError:
             return Identity(
                 user_id=user_id or "", trust_level=TrustLevel.PUBLIC, is_admin=False
             )
-        auth = self._authenticators.get(key)
+        auth = self._get_authenticator(key_platform, bot_id)
         if auth is None:
             return Identity(
                 user_id=user_id or "", trust_level=TrustLevel.PUBLIC, is_admin=False
@@ -226,13 +232,15 @@ class Hub(HubOutboundMixin):
         No-op when no authenticator is registered for the (platform, bot_id) pair.
         """
         try:
-            key = (Platform(msg.platform), msg.bot_id)
+            key_platform = Platform(msg.platform)
         except ValueError:
             return msg
-        auth = self._authenticators.get(key)
+        auth = self._get_authenticator(key_platform, msg.bot_id)
         if auth is None:
             return msg
-        identity = auth.resolve(msg.user_id if msg.user_id else None)
+        uid = msg.user_id if msg.user_id else None
+        roles = list(getattr(msg, "roles", ()))
+        identity = auth.resolve(uid, roles=roles)
         trust_unchanged = identity.trust_level == msg.trust_level
         admin_unchanged = identity.is_admin == msg.is_admin
         if trust_unchanged and admin_unchanged:
@@ -240,6 +248,25 @@ class Hub(HubOutboundMixin):
         return dataclasses.replace(
             msg, trust_level=identity.trust_level, is_admin=identity.is_admin
         )
+
+    def _resolve_audio_trust(self, audio: "InboundAudio") -> "InboundAudio":
+        """Re-resolve trust level for InboundAudio (C3).
+
+        Mirrors _resolve_message_trust(). Called by AudioPipeline before the
+        BLOCKED check to ensure Hub-resolved trust.
+        """
+        try:
+            key_platform = Platform(audio.platform)
+        except ValueError:
+            return audio
+        auth = self._get_authenticator(key_platform, audio.bot_id)
+        if auth is None:
+            return audio
+        uid = audio.user_id if audio.user_id else None
+        identity = auth.resolve(uid)
+        if identity.trust_level == audio.trust_level:
+            return audio
+        return dataclasses.replace(audio, trust_level=identity.trust_level)
 
     def register_binding(
         self,
@@ -348,7 +375,6 @@ class Hub(HubOutboundMixin):
             msg = await self.inbound_bus.get()
             try:
                 try:
-                    msg = self._resolve_message_trust(msg)
                     result = await pipeline.process(msg)
                 except Exception:
                     log.exception("pipeline.process() failed for msg id=%s", msg.id)

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -237,6 +237,9 @@ class Hub(HubOutboundMixin):
             return msg
         auth = self._get_authenticator(key_platform, msg.bot_id)
         if auth is None:
+            log.debug(
+                "no authenticator for %s/%s — trust unchanged", key_platform, msg.bot_id
+            )
             return msg
         uid = msg.user_id if msg.user_id else None
         roles = list(getattr(msg, "roles", ()))
@@ -261,6 +264,11 @@ class Hub(HubOutboundMixin):
             return audio
         auth = self._get_authenticator(key_platform, audio.bot_id)
         if auth is None:
+            log.debug(
+                "no authenticator for %s/%s — trust unchanged",
+                key_platform,
+                audio.bot_id,
+            )
             return audio
         uid = audio.user_id if audio.user_id else None
         identity = auth.resolve(uid)

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -164,12 +164,13 @@ def build_default_pipeline(
     trace_hook: TraceHook | None = None,
     event_bus: PipelineEventBus | None = None,
 ) -> MiddlewarePipeline:
-    """Build the standard middleware pipeline with all 6 stages."""
+    """Build the standard middleware pipeline with all 8 stages."""
     from .middleware_stages import (
         CommandMiddleware,
         CreatePoolMiddleware,
         RateLimitMiddleware,
         ResolveBindingMiddleware,
+        ResolveTrustMiddleware,
         TraceMiddleware,
         TrustGuardMiddleware,
         ValidatePlatformMiddleware,
@@ -180,6 +181,7 @@ def build_default_pipeline(
         [
             TraceMiddleware(),
             ValidatePlatformMiddleware(),
+            ResolveTrustMiddleware(),
             TrustGuardMiddleware(),
             RateLimitMiddleware(),
             ResolveBindingMiddleware(),

--- a/src/lyra/core/hub/middleware.py
+++ b/src/lyra/core/hub/middleware.py
@@ -171,6 +171,7 @@ def build_default_pipeline(
         RateLimitMiddleware,
         ResolveBindingMiddleware,
         TraceMiddleware,
+        TrustGuardMiddleware,
         ValidatePlatformMiddleware,
     )
     from .middleware_submit import SubmitToPoolMiddleware
@@ -179,6 +180,7 @@ def build_default_pipeline(
         [
             TraceMiddleware(),
             ValidatePlatformMiddleware(),
+            TrustGuardMiddleware(),
             RateLimitMiddleware(),
             ResolveBindingMiddleware(),
             CreatePoolMiddleware(),

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -74,9 +74,7 @@ class ValidatePlatformMiddleware:
             )
             ctx.emit(
                 MessageDropped(
-                    msg_id=msg.id,
-                    stage=type(self).__name__,
-                    reason="unknown_platform",
+                    msg_id=msg.id, stage=type(self).__name__, reason="unknown_platform"
                 )
             )
             return _DROP
@@ -105,9 +103,7 @@ class TrustGuardMiddleware:
             )
             ctx.emit(
                 MessageDropped(
-                    msg_id=msg.id,
-                    stage=type(self).__name__,
-                    reason="trust_blocked",
+                    msg_id=msg.id, stage=type(self).__name__, reason="trust_blocked"
                 )
             )
             return _DROP
@@ -133,9 +129,7 @@ class RateLimitMiddleware:
             ctx.trace("inbound", "rate_limited", action=Action.DROP.value)
             ctx.emit(
                 MessageDropped(
-                    msg_id=msg.id,
-                    stage=type(self).__name__,
-                    reason="rate_limited",
+                    msg_id=msg.id, stage=type(self).__name__, reason="rate_limited"
                 )
             )
             return _DROP
@@ -158,15 +152,11 @@ class ResolveBindingMiddleware:
 
         binding = ctx.hub.resolve_binding(msg)
         if binding is None:
-            log.warning(
-                "unmatched routing key %s — message dropped", ctx.key
-            )
+            log.warning("unmatched routing key %s — message dropped", ctx.key)
             ctx.trace("pool", "no_binding", action=Action.DROP.value)
             ctx.emit(
                 MessageDropped(
-                    msg_id=msg.id,
-                    stage=type(self).__name__,
-                    reason="no_binding",
+                    msg_id=msg.id, stage=type(self).__name__, reason="no_binding"
                 )
             )
             return _DROP
@@ -187,9 +177,7 @@ class ResolveBindingMiddleware:
             )
             ctx.emit(
                 MessageDropped(
-                    msg_id=msg.id,
-                    stage=type(self).__name__,
-                    reason="no_agent",
+                    msg_id=msg.id, stage=type(self).__name__, reason="no_agent"
                 )
             )
             return _DROP
@@ -261,21 +249,15 @@ class CommandMiddleware:
         next: Next,
     ) -> PipelineResult:
         if ctx.pool is None:
-            raise RuntimeError(
-                "CreatePoolMiddleware must precede CommandMiddleware"
-            )
+            raise RuntimeError("CreatePoolMiddleware must precede CommandMiddleware")
         if ctx.key is None:
-            raise RuntimeError(
-                "RateLimitMiddleware must precede CommandMiddleware"
-            )
+            raise RuntimeError("RateLimitMiddleware must precede CommandMiddleware")
 
         router = ctx.router
         if router and router.is_command(msg):
             _cmd = msg.text.split()[0] if msg.text else ""
             ctx.trace("processor", "command_detected", command=_cmd)
-            return await self._dispatch_command(
-                msg, _cmd, router, ctx, next
-            )
+            return await self._dispatch_command(msg, _cmd, router, ctx, next)
 
         return await next(msg, ctx)
 
@@ -287,45 +269,25 @@ class CommandMiddleware:
         ctx: PipelineContext,
         next: Next,
     ) -> PipelineResult:
-        pool = ctx.pool  # guaranteed non-None by __call__ guard
-        key = ctx.key  # guaranteed non-None by __call__ guard
+        pool = ctx.pool
+        key = ctx.key
         try:
             response = await router.dispatch(msg, pool)
         except Exception as exc:
-            log.exception(
-                "command dispatch failed for %s: %s", key, exc
-            )
-            _content = (
-                ctx.hub._msg_manager.get("generic")
-                if ctx.hub._msg_manager
-                else GENERIC_ERROR_REPLY
-            )
-            response = Response(content=_content)
-            ctx.trace(
-                "outbound",
-                "command_error",
-                action=Action.COMMAND_HANDLED.value,
-            )
+            log.exception("command dispatch failed for %s: %s", key, exc)
+            mgr = ctx.hub._msg_manager
+            _content = mgr.get("generic") if mgr else GENERIC_ERROR_REPLY
+            ctx.trace("outbound", "command_error", action=Action.COMMAND_HANDLED.value)
             return PipelineResult(
-                action=Action.COMMAND_HANDLED, response=response
+                action=Action.COMMAND_HANDLED, response=Response(content=_content)
             )
 
         if response is None:
             ctx.trace("processor", "command_fallthrough")
             return await next(msg, ctx)
 
-        ctx.trace(
-            "outbound",
-            "command_handled",
-            action=Action.COMMAND_HANDLED.value,
-        )
+        ctx.trace("outbound", "command_handled", action=Action.COMMAND_HANDLED.value)
         ctx.emit(
-            CommandDispatched(
-                msg_id=msg.id,
-                stage=type(self).__name__,
-                command=cmd,
-            )
+            CommandDispatched(msg_id=msg.id, stage=type(self).__name__, command=cmd)
         )
-        return PipelineResult(
-            action=Action.COMMAND_HANDLED, response=response
-        )
+        return PipelineResult(action=Action.COMMAND_HANDLED, response=response)

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -66,12 +66,8 @@ class ValidatePlatformMiddleware:
                 msg.platform,
                 msg.id,
             )
-            ctx.trace(
-                "inbound",
-                "platform_invalid",
-                platform=msg.platform,
-                action=Action.DROP.value,
-            )
+            ctx.trace("inbound", "platform_invalid",
+                      platform=msg.platform, action=Action.DROP.value)
             ctx.emit(
                 MessageDropped(
                     msg_id=msg.id, stage=type(self).__name__, reason="unknown_platform"
@@ -81,13 +77,22 @@ class ValidatePlatformMiddleware:
         return await next(msg, ctx)
 
 
-class TrustGuardMiddleware:
-    """Stage 2: drop messages from BLOCKED users.
+class ResolveTrustMiddleware:
+    """Stage 2: resolve trust level from Hub authenticator (C3).
 
-    Replaces the adapter-side GuardChain (C3 — trust re-resolution). Trust is
-    resolved by Hub._resolve_message_trust() before the pipeline runs, so this
-    stage sees the authoritative trust level.
+    Overwrites adapter-supplied trust_level=PUBLIC with authoritative trust.
+    Must precede TrustGuardMiddleware.
     """
+
+    async def __call__(
+        self, msg: InboundMessage, ctx: PipelineContext, next: Next
+    ) -> PipelineResult:
+        msg = ctx.hub._resolve_message_trust(msg)
+        return await next(msg, ctx)
+
+
+class TrustGuardMiddleware:
+    """Stage 3: drop BLOCKED users (C3). Trust resolved by ResolveTrustMiddleware."""
 
     async def __call__(
         self,
@@ -111,7 +116,7 @@ class TrustGuardMiddleware:
 
 
 class RateLimitMiddleware:
-    """Stage 3: drop messages that exceed the per-user rate limit."""
+    """Stage 4: drop messages that exceed the per-user rate limit."""
 
     async def __call__(
         self,
@@ -137,7 +142,7 @@ class RateLimitMiddleware:
 
 
 class ResolveBindingMiddleware:
-    """Stage 3: resolve binding + look up agent. Sets ctx.binding, ctx.agent."""
+    """Stage 5: resolve binding + look up agent. Sets ctx.binding, ctx.agent."""
 
     async def __call__(
         self,
@@ -187,7 +192,7 @@ class ResolveBindingMiddleware:
 
 
 class CreatePoolMiddleware:
-    """Stage 4: get or create the pool. Sets ctx.pool, ctx.router."""
+    """Stage 6: get or create the pool. Sets ctx.pool, ctx.router."""
 
     async def __call__(
         self,
@@ -240,7 +245,7 @@ class CreatePoolMiddleware:
 
 
 class CommandMiddleware:
-    """Stage 5: detect and dispatch commands."""
+    """Stage 7: detect and dispatch commands."""
 
     async def __call__(
         self,

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -19,6 +19,7 @@ from ..message import (
     Response,
 )
 from ..trace import TraceContext
+from ..trust import TrustLevel
 from .message_pipeline import (
     _DROP,
     Action,
@@ -82,8 +83,39 @@ class ValidatePlatformMiddleware:
         return await next(msg, ctx)
 
 
+class TrustGuardMiddleware:
+    """Stage 2: drop messages from BLOCKED users.
+
+    Replaces the adapter-side GuardChain (C3 — trust re-resolution). Trust is
+    resolved by Hub._resolve_message_trust() before the pipeline runs, so this
+    stage sees the authoritative trust level.
+    """
+
+    async def __call__(
+        self,
+        msg: InboundMessage,
+        ctx: PipelineContext,
+        next: Next,
+    ) -> PipelineResult:
+        if msg.trust_level == TrustLevel.BLOCKED:
+            log.info(
+                "trust_blocked user=%s platform=%s — message dropped",
+                msg.user_id,
+                msg.platform,
+            )
+            ctx.emit(
+                MessageDropped(
+                    msg_id=msg.id,
+                    stage=type(self).__name__,
+                    reason="trust_blocked",
+                )
+            )
+            return _DROP
+        return await next(msg, ctx)
+
+
 class RateLimitMiddleware:
-    """Stage 2: drop messages that exceed the per-user rate limit."""
+    """Stage 3: drop messages that exceed the per-user rate limit."""
 
     async def __call__(
         self,

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -81,16 +81,11 @@ class SubmitToPoolMiddleware:
         pool = ctx.pool
         # Register session persistence callback once.
         _update_fn = msg.platform_meta.get("_session_update_fn")
-        if (
-            _update_fn is not None
-            and pool._observer._session_update_fn is None
-        ):
+        if _update_fn is not None and pool._observer._session_update_fn is None:
             pool._observer.register_session_update_fn(_update_fn)
 
         try:
-            status = await self._resolve_context(
-                msg, pool, pool.pool_id, ctx
-            )
+            status = await self._resolve_context(msg, pool, pool.pool_id, ctx)
         except Exception:
             log.warning(
                 "_resolve_context failed — continuing with active session",
@@ -144,18 +139,13 @@ class SubmitToPoolMiddleware:
 
         # Path 1: reply-to-resume via MessageIndex (#341).
         if msg.reply_to_id is not None and hub._message_index is None:
-            log.debug(
-                "reply-to-resume: no MessageIndex configured — skipping"
-            )
+            log.debug("reply-to-resume: no MessageIndex configured — skipping")
         if msg.reply_to_id is not None and hub._message_index is not None:
-            session_id = await hub._message_index.resolve(
-                pool_id, str(msg.reply_to_id)
-            )
+            session_id = await hub._message_index.resolve(pool_id, str(msg.reply_to_id))
             if session_id is not None:
                 if not pool.is_idle:
                     log.info(
-                        "reply-to-resume: pool %r busy"
-                        " — skipping resume of session %r",
+                        "reply-to-resume: pool %r busy — skipping resume of session %r",
                         pool_id,
                         session_id,
                     )
@@ -169,9 +159,7 @@ class SubmitToPoolMiddleware:
                     return ResumeStatus.RESUMED
 
         # Path 2: thread-session-resume.
-        thread_session_id: str | None = msg.platform_meta.get(
-            "thread_session_id"
-        )
+        thread_session_id: str | None = msg.platform_meta.get("thread_session_id")
         if thread_session_id is not None:
             if not pool.is_idle:
                 log.info(
@@ -212,8 +200,7 @@ class SubmitToPoolMiddleware:
                 )
                 if _alive:
                     log.debug(
-                        "last-session-resume: pool %r already on"
-                        " session %r",
+                        "last-session-resume: pool %r already on session %r",
                         pool_id,
                         last_sid,
                     )
@@ -233,9 +220,7 @@ class SubmitToPoolMiddleware:
                 await pool.resume_session(last_sid)
                 return ResumeStatus.RESUMED
 
-        return (
-            ResumeStatus.FRESH if path2_attempted else ResumeStatus.SKIPPED
-        )
+        return ResumeStatus.FRESH if path2_attempted else ResumeStatus.SKIPPED
 
     async def _notify_session_fallthrough(
         self, msg: InboundMessage, ctx: PipelineContext

--- a/src/lyra/core/message.py
+++ b/src/lyra/core/message.py
@@ -64,7 +64,8 @@ class InboundMessage:
     """Normalized inbound envelope produced by all channel adapters.
 
     platform_meta carries platform-specific routing data. See spec platform_meta table.
-    Security: trust is always 'user' from adapters — never set above adapter layer.
+    Security (C3): adapters set trust_level=PUBLIC; Hub overwrites via
+    _resolve_message_trust() (ResolveTrustMiddleware) before the pipeline runs.
     Bot-authored messages are filtered by adapters before normalize() is called.
     """
 
@@ -79,6 +80,7 @@ class InboundMessage:
     text_raw: str  # original text with platform markup
     trust_level: TrustLevel
     is_admin: bool = False
+    roles: tuple[str, ...] = ()
     attachments: list[Attachment] = field(default_factory=list)
     reply_to_id: str | None = None
     thread_id: str | None = None
@@ -104,7 +106,8 @@ class InboundAudio:
 
     Mirrors InboundMessage for audio: adapters produce this; hub/agents consume it.
     Adapters enqueue via InboundAudioBus; hub/agents consume from its staging queue.
-    Security: trust is always 'user' from adapters — never set above adapter layer.
+    Security (C3): adapters set trust_level=PUBLIC; Hub overwrites via
+    _resolve_audio_trust() (AudioPipeline) before the BLOCKED check.
     """
 
     id: str

--- a/src/lyra/integrations/base.py
+++ b/src/lyra/integrations/base.py
@@ -84,9 +84,7 @@ class ServiceControlFailed(Exception):
 class AudioConverter(Protocol):
     """Async audio converter: WAV → OGG/Opus."""
 
-    async def convert_wav_to_ogg(
-        self, wav_path: Path, ogg_path: Path
-    ) -> None: ...
+    async def convert_wav_to_ogg(self, wav_path: Path, ogg_path: Path) -> None: ...
 
 
 @runtime_checkable

--- a/src/lyra/monitoring/escalation.py
+++ b/src/lyra/monitoring/escalation.py
@@ -74,10 +74,14 @@ async def _escalate_via_cli(
 
     proc = await asyncio.create_subprocess_exec(
         "claude",
-        "-p", prompt,
-        "--model", config.diagnostic_model,
-        "--output-format", "text",
-        "--max-turns", "1",
+        "-p",
+        prompt,
+        "--model",
+        config.diagnostic_model,
+        "--output-format",
+        "text",
+        "--max-turns",
+        "1",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -253,7 +253,7 @@ class TestTrustGuardMiddleware:
 class TestHubTrustResolutionEdgeCases:
     """Edge cases for Hub._resolve_message_trust()."""
 
-    def _make_msg(self, **kwargs) -> "InboundMessage":
+    def _make_msg(self, **kwargs):
         from lyra.core.message import InboundMessage
 
         defaults = dict(
@@ -273,7 +273,7 @@ class TestHubTrustResolutionEdgeCases:
         return InboundMessage(**defaults)
 
     def test_empty_user_id_passed_as_none_to_auth_resolve(self) -> None:
-        """Empty string user_id is treated as None — auth.resolve() is called with None."""
+        """Empty string user_id → auth.resolve() is called with None."""
         from unittest.mock import MagicMock
 
         from lyra.core.authenticator import Authenticator
@@ -296,7 +296,7 @@ class TestHubTrustResolutionEdgeCases:
         hub._resolve_message_trust(msg)
 
         # Assert: auth.resolve was called with None (empty string is falsy → None)
-        # _resolve_message_trust passes roles=list(getattr(msg, "roles", ())) — empty list here.
+        # _resolve_message_trust passes roles=list(getattr(msg, "roles", ())).
         auth.resolve.assert_called_once_with(None, roles=[])
 
     def test_invalid_platform_returns_message_unchanged(self) -> None:
@@ -356,14 +356,16 @@ class TestHubResolveIdentity:
     """Hub.resolve_identity() edge cases."""
 
     def test_resolve_identity_invalid_platform_returns_public(self) -> None:
-        """Unknown platform string returns a PUBLIC identity (ValueError caught internally)."""
+        """Unknown platform returns PUBLIC (ValueError caught internally)."""
         from lyra.core.hub.hub import Hub
 
         # Arrange
         hub = Hub()
 
         # Act
-        result = hub.resolve_identity(user_id="u1", platform="badplatform", bot_id="main")
+        result = hub.resolve_identity(
+            user_id="u1", platform="badplatform", bot_id="main"
+        )
 
         # Assert
         assert result.trust_level == TrustLevel.PUBLIC

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -270,7 +270,7 @@ class TestHubTrustResolutionEdgeCases:
             is_admin=False,
         )
         defaults.update(kwargs)
-        return InboundMessage(**defaults)
+        return InboundMessage(**defaults)  # type: ignore[arg-type]
 
     def test_empty_user_id_passed_as_none_to_auth_resolve(self) -> None:
         """Empty string user_id → auth.resolve() is called with None."""

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -1,4 +1,9 @@
-"""Tests for DiscordAdapter auth gate (S5)."""
+"""Tests for Discord adapter inbound path and Hub-side auth gate (C3).
+
+After C3 (trust re-resolution #456), adapters forward all messages with
+trust_level=PUBLIC to the bus; the Hub resolves trust and TrustGuardMiddleware
+drops BLOCKED users. These tests verify the adapter-side half of that contract.
+"""
 
 from __future__ import annotations
 
@@ -17,12 +22,7 @@ from lyra.core.trust import TrustLevel
 
 
 def _make_discord_msg_ns(user_id: int = 42, roles: list | None = None) -> object:
-    """Build a minimal discord-like DM message SimpleNamespace.
-
-    Uses guild=None (DM) so messages pass the group-chat filter introduced
-    in 9f9072d. Tests that specifically need guild context should set guild
-    directly on the returned namespace.
-    """
+    """Build a minimal discord-like DM message SimpleNamespace."""
     author_kwargs: dict = {
         "id": user_id,
         "name": "Alice",
@@ -45,155 +45,25 @@ def _make_discord_msg_ns(user_id: int = 42, roles: list | None = None) -> object
 
 
 # ---------------------------------------------------------------------------
-# Slice S5: DiscordAdapter auth gate tests
+# C3: Adapter always forwards with PUBLIC trust — Hub resolves trust
 # ---------------------------------------------------------------------------
 
 
-class TestDiscordAuth:
-    """Auth gate tests for DiscordAdapter.on_message."""
+class TestDiscordAdapterInbound:
+    """C3 contract: adapter forwards all non-bot messages with raw PUBLIC trust."""
 
     @pytest.mark.asyncio
-    async def test_blocked_user_skips_normalize(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """BLOCKED user: on_message returns early without calling normalize()."""
-        import logging
-        from unittest.mock import patch
-
+    async def test_any_user_forwarded_with_public_trust(self) -> None:
+        """All users reach the bus with trust_level=PUBLIC (Hub resolves trust)."""
         from lyra.adapters.discord import DiscordAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.BLOCKED
-        auth.resolve.return_value = Identity(
-            user_id="dc:user:42",
-            trust_level=TrustLevel.BLOCKED,
-            is_admin=False,
-        )
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
         hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(
-            hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
-        )
+        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
-        with caplog.at_level(logging.INFO, logger="lyra.adapters.discord"):
-            with patch.object(adapter, "normalize") as mock_norm:
-                await adapter.on_message(_make_discord_msg_ns())
-
-        mock_norm.assert_not_called()
-        hub.inbound_bus.put.assert_not_called()
-        assert any("auth_reject" in r.message for r in caplog.records)
-
-    @pytest.mark.asyncio
-    async def test_role_match_returns_trust(self) -> None:
-        """User with a matching role: message produced with correct trust_level."""
-        from lyra.adapters.discord import DiscordAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.TRUSTED
-        auth.resolve.return_value = Identity(
-            user_id="dc:user:42",
-            trust_level=TrustLevel.TRUSTED,
-            is_admin=False,
-        )
-
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(
-            hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
-        )
-        adapter._bot_user = SimpleNamespace(id=999, bot=True)
-
-        msg_ns = _make_discord_msg_ns(roles=["123456"])
-        await adapter.on_message(msg_ns)
-
-        # Verify role snowflake IDs were passed to auth.resolve
-        call_kwargs = auth.resolve.call_args
-        assert call_kwargs is not None
-        passed_roles = call_kwargs.kwargs.get("roles") or (
-            call_kwargs.args[1] if len(call_kwargs.args) > 1 else []
-        )
-        assert "123456" in passed_roles
-
-    @pytest.mark.asyncio
-    async def test_dm_fallback_user_id_only(self) -> None:
-        """DM message (no roles attribute): auth.check called with roles=[]."""
-        from lyra.adapters.discord import DiscordAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.PUBLIC
-        auth.resolve.return_value = Identity(
-            user_id="dc:user:42",
-            trust_level=TrustLevel.PUBLIC,
-            is_admin=False,
-        )
-
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(
-            hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
-        )
-        adapter._bot_user = SimpleNamespace(id=999, bot=True)
-
-        # No roles attribute on author (DM scenario)
-        dm_msg = SimpleNamespace(
-            guild=None,
-            channel=SimpleNamespace(id=333, send=AsyncMock()),
-            author=SimpleNamespace(
-                id=42, name="Alice", display_name="Alice", bot=False
-            ),
-            content="hello",
-            created_at=datetime.now(timezone.utc),
-            id=555,
-            mentions=[],
-            reply=AsyncMock(),
-            attachments=[],
-        )
-
-        await adapter.on_message(dm_msg)
-
-        call_kwargs = auth.resolve.call_args
-        assert call_kwargs is not None
-        passed_roles = call_kwargs.kwargs.get("roles") or (
-            call_kwargs.args[1] if len(call_kwargs.args) > 1 else []
-        )
-        assert passed_roles == []
-
-    @pytest.mark.asyncio
-    async def test_public_user_message_forwarded(self) -> None:
-        """PUBLIC user: message reaches bus with trust_level=TrustLevel.PUBLIC."""
-        from lyra.adapters.discord import DiscordAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.PUBLIC
-        auth.resolve.return_value = Identity(
-            user_id="dc:user:42",
-            trust_level=TrustLevel.PUBLIC,
-            is_admin=False,
-        )
-
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(
-            hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
-        )
-        adapter._bot_user = SimpleNamespace(id=999, bot=True)
-
-        msg_ns = _make_discord_msg_ns()
-        await adapter.on_message(msg_ns)
+        await adapter.on_message(_make_discord_msg_ns())
 
         hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
@@ -201,59 +71,175 @@ class TestDiscordAuth:
         assert msg.is_admin is False
 
     @pytest.mark.asyncio
-    async def test_admin_user_has_is_admin_set(self) -> None:
-        """Admin user: message produced with is_admin=True."""
-        from lyra.adapters.discord import DiscordAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
+    async def test_bot_message_still_dropped_early(self) -> None:
+        """Bot-authored messages are filtered before reaching the bus."""
+        from unittest.mock import patch
 
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.resolve.return_value = Identity(
-            user_id="dc:user:42",
-            trust_level=TrustLevel.TRUSTED,
-            is_admin=True,
+        from lyra.adapters.discord import DiscordAdapter
+
+        hub = MagicMock()
+        hub.inbound_bus = MagicMock()
+        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+        adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+        bot_msg = SimpleNamespace(
+            guild=None,
+            channel=SimpleNamespace(id=333, send=AsyncMock()),
+            author=SimpleNamespace(id=99, name="Bot", display_name="Bot", bot=True),
+            content="I'm a bot",
+            created_at=datetime.now(timezone.utc),
+            id=556,
+            mentions=[],
+            reply=AsyncMock(),
+            attachments=[],
         )
+
+        with patch.object(adapter, "normalize") as mock_norm:
+            await adapter.on_message(bot_msg)
+
+        mock_norm.assert_not_called()
+        hub.inbound_bus.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_with_roles_forwarded_with_public_trust(self) -> None:
+        """User with roles is forwarded with PUBLIC trust (roles irrelevant at adapter)."""  # noqa: E501
+        from lyra.adapters.discord import DiscordAdapter
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
         hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(
-            hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
-        )
+        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
-        msg_ns = _make_discord_msg_ns()
+        msg_ns = _make_discord_msg_ns(roles=["123456"])
         await adapter.on_message(msg_ns)
 
         hub.inbound_bus.put.assert_awaited_once()
         _platform, msg = hub.inbound_bus.put.call_args[0]
-        assert msg.is_admin is True
+        assert msg.trust_level == TrustLevel.PUBLIC
 
-    @pytest.mark.asyncio
-    async def test_integration_blocked_user_rejected_by_real_guard(self) -> None:
-        """Integration: real Authenticator + real GuardChain rejects BLOCKED user."""
-        from unittest.mock import patch
 
-        from lyra.adapters.discord import DiscordAdapter
+# ---------------------------------------------------------------------------
+# C3: Hub-side trust resolution
+# ---------------------------------------------------------------------------
+
+
+class TestHubTrustResolution:
+    """Hub._resolve_message_trust() correctly overwrites adapter-supplied trust."""
+
+    def test_resolves_trust_from_authenticator(self) -> None:
+        """Hub re-resolves trust on dequeued message."""
         from lyra.core.authenticator import Authenticator
-        from lyra.core.guard import BlockedGuard, GuardChain
+        from lyra.core.hub.hub import Hub
+        from lyra.core.message import InboundMessage, Platform
 
         store = MagicMock()
-        store.check.return_value = TrustLevel.BLOCKED
-        auth = Authenticator(store=store, role_map={}, default=TrustLevel.BLOCKED)
-        guard_chain = GuardChain([BlockedGuard()])
+        store.check.return_value = TrustLevel.TRUSTED
+        auth = Authenticator(store=store, role_map={}, default=TrustLevel.PUBLIC)
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        adapter = DiscordAdapter(
-            hub=hub, bot_id="main", intents=discord.Intents.none(), auth=auth
+        hub = Hub()
+        hub.register_authenticator(Platform.TELEGRAM, "main", auth)
+
+        msg = InboundMessage(
+            id="test-1",
+            platform="telegram",
+            bot_id="main",
+            scope_id="tg:user:42",
+            user_id="tg:user:42",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            trust_level=TrustLevel.PUBLIC,  # adapter-supplied raw value
+            is_admin=False,
         )
-        adapter._bot_user = SimpleNamespace(id=999, bot=True)
-        # Inject real guard chain
-        adapter._guard_chain = guard_chain
 
-        with patch.object(adapter, "normalize") as mock_norm:
-            await adapter.on_message(_make_discord_msg_ns())
+        result = hub._resolve_message_trust(msg)
 
-        mock_norm.assert_not_called()
-        hub.inbound_bus.put.assert_not_called()
+        assert result.trust_level == TrustLevel.TRUSTED
+
+    def test_no_authenticator_returns_message_unchanged(self) -> None:
+        """Hub returns message unchanged when no authenticator registered."""
+        from lyra.core.hub.hub import Hub
+        from lyra.core.message import InboundMessage
+
+        hub = Hub()
+
+        msg = InboundMessage(
+            id="test-2",
+            platform="telegram",
+            bot_id="main",
+            scope_id="tg:user:42",
+            user_id="tg:user:42",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            trust_level=TrustLevel.PUBLIC,
+            is_admin=False,
+        )
+
+        result = hub._resolve_message_trust(msg)
+
+        assert result is msg  # unchanged — same object
+
+
+# ---------------------------------------------------------------------------
+# C3: TrustGuardMiddleware drops BLOCKED users
+# ---------------------------------------------------------------------------
+
+
+class TestTrustGuardMiddleware:
+    """TrustGuardMiddleware drops messages from BLOCKED users."""
+
+    @pytest.mark.asyncio
+    async def test_blocked_message_dropped(self) -> None:
+        """Message with BLOCKED trust level is dropped; next() not called."""
+        from unittest.mock import AsyncMock
+
+        from lyra.core.hub.message_pipeline import _DROP
+        from lyra.core.hub.middleware import PipelineContext
+        from lyra.core.hub.middleware_stages import TrustGuardMiddleware
+        from lyra.core.message import InboundMessage
+
+        mw = TrustGuardMiddleware()
+        next_fn = AsyncMock()
+        ctx = MagicMock(spec=PipelineContext)
+        ctx.emit = MagicMock()
+
+        msg = MagicMock(spec=InboundMessage)
+        msg.trust_level = TrustLevel.BLOCKED
+        msg.user_id = "tg:user:42"
+        msg.platform = "telegram"
+        msg.id = "test-id"
+
+        result = await mw(msg, ctx, next_fn)
+
+        assert result is _DROP
+        next_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_blocked_message_passes_through(self) -> None:
+        """Message with PUBLIC/TRUSTED trust level passes to next middleware."""
+        from unittest.mock import AsyncMock
+
+        from lyra.core.hub.middleware import PipelineContext
+        from lyra.core.hub.middleware_stages import TrustGuardMiddleware
+        from lyra.core.message import InboundMessage
+
+        mw = TrustGuardMiddleware()
+        sentinel = object()
+        next_fn = AsyncMock(return_value=sentinel)
+        ctx = MagicMock(spec=PipelineContext)
+        ctx.emit = MagicMock()
+
+        for trust in (TrustLevel.PUBLIC, TrustLevel.TRUSTED, TrustLevel.OWNER):
+            msg = MagicMock(spec=InboundMessage)
+            msg.trust_level = trust
+            msg.user_id = "tg:user:42"
+            msg.platform = "telegram"
+            msg.id = f"test-id-{trust}"
+
+            result = await mw(msg, ctx, next_fn)
+
+            assert result is sentinel, f"Expected pass-through for trust={trust}"

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -243,3 +243,127 @@ class TestTrustGuardMiddleware:
             result = await mw(msg, ctx, next_fn)
 
             assert result is sentinel, f"Expected pass-through for trust={trust}"
+
+
+# ---------------------------------------------------------------------------
+# Finding J: _resolve_message_trust() edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestHubTrustResolutionEdgeCases:
+    """Edge cases for Hub._resolve_message_trust()."""
+
+    def _make_msg(self, **kwargs) -> "InboundMessage":
+        from lyra.core.message import InboundMessage
+
+        defaults = dict(
+            id="test-edge",
+            platform="telegram",
+            bot_id="main",
+            scope_id="tg:user:42",
+            user_id="tg:user:42",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            trust_level=TrustLevel.PUBLIC,
+            is_admin=False,
+        )
+        defaults.update(kwargs)
+        return InboundMessage(**defaults)
+
+    def test_empty_user_id_passed_as_none_to_auth_resolve(self) -> None:
+        """Empty string user_id is treated as None — auth.resolve() is called with None."""
+        from unittest.mock import MagicMock
+
+        from lyra.core.authenticator import Authenticator
+        from lyra.core.hub.hub import Hub
+        from lyra.core.identity import Identity
+        from lyra.core.message import Platform
+
+        # Arrange
+        auth = MagicMock(spec=Authenticator)
+        auth.resolve.return_value = Identity(
+            user_id="", trust_level=TrustLevel.BLOCKED, is_admin=False
+        )
+
+        hub = Hub()
+        hub.register_authenticator(Platform.TELEGRAM, "main", auth)
+
+        msg = self._make_msg(user_id="")
+
+        # Act
+        hub._resolve_message_trust(msg)
+
+        # Assert: auth.resolve was called with None (empty string is falsy → None)
+        # _resolve_message_trust passes roles=list(getattr(msg, "roles", ())) — empty list here.
+        auth.resolve.assert_called_once_with(None, roles=[])
+
+    def test_invalid_platform_returns_message_unchanged(self) -> None:
+        """Invalid platform string causes early return — message object is unchanged."""
+        from lyra.core.authenticator import Authenticator
+        from lyra.core.hub.hub import Hub
+        from lyra.core.message import Platform
+
+        # Arrange
+        store = MagicMock()
+        store.check.return_value = TrustLevel.TRUSTED
+        auth = Authenticator(store=store, role_map={}, default=TrustLevel.PUBLIC)
+
+        hub = Hub()
+        hub.register_authenticator(Platform.TELEGRAM, "main", auth)
+
+        msg = self._make_msg(platform="badplatform")
+
+        # Act
+        result = hub._resolve_message_trust(msg)
+
+        # Assert: same object returned (ValueError path, no copy made)
+        assert result is msg
+
+    def test_auth_resolve_raises_propagates_to_caller(self) -> None:
+        """_resolve_message_trust propagates exceptions raised by auth.resolve().
+
+        Hub.run() wraps _resolve_message_trust in try/except and continues the loop.
+        Here we verify the raw propagation from _resolve_message_trust itself.
+        """
+        from unittest.mock import MagicMock
+
+        from lyra.core.authenticator import Authenticator
+        from lyra.core.hub.hub import Hub
+        from lyra.core.message import Platform
+
+        # Arrange
+        auth = MagicMock(spec=Authenticator)
+        auth.resolve.side_effect = RuntimeError("store unavailable")
+
+        hub = Hub()
+        hub.register_authenticator(Platform.TELEGRAM, "main", auth)
+
+        msg = self._make_msg()
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="store unavailable"):
+            hub._resolve_message_trust(msg)
+
+
+# ---------------------------------------------------------------------------
+# Finding K: resolve_identity() invalid platform
+# ---------------------------------------------------------------------------
+
+
+class TestHubResolveIdentity:
+    """Hub.resolve_identity() edge cases."""
+
+    def test_resolve_identity_invalid_platform_returns_public(self) -> None:
+        """Unknown platform string returns a PUBLIC identity (ValueError caught internally)."""
+        from lyra.core.hub.hub import Hub
+
+        # Arrange
+        hub = Hub()
+
+        # Act
+        result = hub.resolve_identity(user_id="u1", platform="badplatform", bot_id="main")
+
+        # Assert
+        assert result.trust_level == TrustLevel.PUBLIC

--- a/tests/adapters/test_telegram_auth.py
+++ b/tests/adapters/test_telegram_auth.py
@@ -1,19 +1,21 @@
-"""Tests for TelegramAdapter auth gate and HTTP auth/status endpoints.
+"""Tests for Telegram adapter inbound path and Hub-side auth gate (C3).
 
-Covers: TestTelegramAuth (S4 auth gate), T2 (missing secret → 401),
-T9 (missing env var → SystemExit), SC-14 (GET /status returns all circuits).
+After C3 (trust re-resolution #456), adapters forward all messages with
+trust_level=PUBLIC to the bus; the Hub resolves trust and TrustGuardMiddleware
+drops BLOCKED users. These tests verify the adapter-side half of that contract.
+
+Covers: T2 (missing secret → 401), T9 (missing env var → SystemExit),
+SC-14 (GET /status returns all circuits), C3 (adapter forwards with PUBLIC trust).
 """
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.adapters.telegram import _ALLOW_ALL
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.trust import TrustLevel
 
@@ -45,12 +47,10 @@ async def test_missing_secret_returns_401() -> None:
     """POST /webhooks/telegram/main without X-Telegram-Bot-Api-Secret-Token → 401."""
     import httpx
 
-    from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
+    from lyra.adapters.telegram import TelegramAdapter
 
     hub = MagicMock()
-    adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
-    )
+    adapter = TelegramAdapter(bot_id="main", token="test-token-secret", hub=hub)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=adapter.app)
@@ -71,7 +71,7 @@ def test_missing_token_raises_on_load(monkeypatch: pytest.MonkeyPatch) -> None:
     """load_config() raises SystemExit with 'TELEGRAM_TOKEN' when env var is absent."""
     monkeypatch.delenv("TELEGRAM_TOKEN", raising=False)
 
-    from lyra.config import load_config  # ImportError expected in RED
+    from lyra.config import load_config
 
     with pytest.raises(SystemExit, match="TELEGRAM_TOKEN"):
         load_config()
@@ -89,7 +89,6 @@ async def test_get_status_endpoint_returns_all_circuits() -> None:
 
     from lyra.adapters.telegram import TelegramAdapter
 
-    # Arrange — registry with all 4 circuits
     registry = CircuitRegistry()
     for name in ("anthropic", "telegram", "discord", "hub"):
         registry.register(
@@ -103,10 +102,8 @@ async def test_get_status_endpoint_returns_all_circuits() -> None:
         hub=hub,
         webhook_secret="secret",
         circuit_registry=registry,
-        auth=_ALLOW_ALL,
     )
 
-    # Act
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=adapter.app)
     ) as client:
@@ -115,7 +112,6 @@ async def test_get_status_endpoint_returns_all_circuits() -> None:
             headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
         )
 
-    # Assert
     assert response.status_code == 200
     data = response.json()
     assert "services" in data
@@ -126,147 +122,22 @@ async def test_get_status_endpoint_returns_all_circuits() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Slice S4: TelegramAdapter auth gate tests
+# C3: Adapter always forwards with PUBLIC trust — Hub resolves trust
 # ---------------------------------------------------------------------------
 
 
-class TestTelegramAuth:
-    """Auth gate tests for TelegramAdapter._on_message and _on_voice_message."""
+class TestTelegramAdapterInbound:
+    """C3 contract: adapter forwards all non-bot messages with raw PUBLIC trust."""
 
     @pytest.mark.asyncio
-    async def test_blocked_user_skips_normalize(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """BLOCKED user: _on_message returns early without calling normalize()."""
-        from unittest.mock import patch
-
+    async def test_any_user_forwarded_with_public_trust(self) -> None:
+        """All users reach the bus with trust_level=PUBLIC (Hub resolves trust)."""
         from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.BLOCKED
-        auth.resolve.return_value = Identity(
-            user_id="tg:user:42",
-            trust_level=TrustLevel.BLOCKED,
-            is_admin=False,
-        )
-
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
-
-        with caplog.at_level(logging.INFO, logger="lyra.adapters.telegram"):
-            with patch.object(adapter, "normalize") as mock_norm:
-                await adapter._on_message(_make_aiogram_msg())
-
-        mock_norm.assert_not_called()
-        hub.inbound_bus.put.assert_not_called()
-        assert any("auth_reject" in r.message for r in caplog.records)
-
-    @pytest.mark.asyncio
-    async def test_allowed_user_has_trust_level(self) -> None:
-        """TRUSTED user: message produced with correct trust_level."""
-        from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.TRUSTED
-        auth.resolve.return_value = Identity(
-            user_id="tg:user:42",
-            trust_level=TrustLevel.TRUSTED,
-            is_admin=False,
-        )
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
         hub.inbound_bus.put = AsyncMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
-        adapter.bot = AsyncMock()
-
-        await adapter._on_message(_make_aiogram_msg())
-
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform, msg = hub.inbound_bus.put.call_args[0]
-        assert msg.trust_level == TrustLevel.TRUSTED
-        assert msg.is_admin is False
-
-    @pytest.mark.asyncio
-    async def test_admin_user_has_is_admin_set(self) -> None:
-        """Admin user: message produced with is_admin=True."""
-        from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.resolve.return_value = Identity(
-            user_id="tg:user:42",
-            trust_level=TrustLevel.TRUSTED,
-            is_admin=True,
-        )
-
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
-        adapter.bot = AsyncMock()
-
-        await adapter._on_message(_make_aiogram_msg())
-
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform, msg = hub.inbound_bus.put.call_args[0]
-        assert msg.is_admin is True
-
-    @pytest.mark.asyncio
-    async def test_voice_blocked_skips_normalize(self) -> None:
-        """BLOCKED user on voice: _on_voice_message returns early without sending."""
-        from unittest.mock import patch
-
-        from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.BLOCKED
-        auth.resolve.return_value = Identity(
-            user_id="tg:user:42",
-            trust_level=TrustLevel.BLOCKED,
-            is_admin=False,
-        )
-
-        hub = MagicMock()
-        bot = AsyncMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
-        adapter.bot = bot
-
-        voice_msg = _make_aiogram_msg()
-        with patch.object(adapter, "normalize_audio") as mock_norm_audio:
-            await adapter._on_voice_message(voice_msg)
-
-        # bot.send_message should NOT have been called (blocked before handling)
-        bot.send_message.assert_not_called()
-        mock_norm_audio.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_public_user_message_forwarded(self) -> None:
-        """PUBLIC user: message reaches bus with trust_level=TrustLevel.PUBLIC."""
-        from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.auth import AuthMiddleware
-        from lyra.core.identity import Identity
-
-        auth = MagicMock(spec=AuthMiddleware)
-        auth.check.return_value = TrustLevel.PUBLIC
-        auth.resolve.return_value = Identity(
-            user_id="tg:user:42",
-            trust_level=TrustLevel.PUBLIC,
-            is_admin=False,
-        )
-
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
+        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
         adapter.bot = AsyncMock()
 
         await adapter._on_message(_make_aiogram_msg())
@@ -277,27 +148,73 @@ class TestTelegramAuth:
         assert msg.is_admin is False
 
     @pytest.mark.asyncio
-    async def test_integration_blocked_user_rejected_by_real_guard(self) -> None:
-        """Integration: real Authenticator + real GuardChain rejects BLOCKED user."""
+    async def test_bot_message_still_dropped_early(self) -> None:
+        """Bot-authored messages are filtered before reaching the bus."""
         from unittest.mock import patch
 
         from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.authenticator import Authenticator
-        from lyra.core.guard import BlockedGuard, GuardChain
-
-        store = MagicMock()
-        store.check.return_value = TrustLevel.BLOCKED
-        auth = Authenticator(store=store, role_map={}, default=TrustLevel.BLOCKED)
-        guard_chain = GuardChain([BlockedGuard()])
 
         hub = MagicMock()
         hub.inbound_bus = MagicMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=auth)
-        # Inject real guard chain
-        adapter._guard_chain = guard_chain
+        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+
+        bot_msg = SimpleNamespace(
+            chat=SimpleNamespace(id=123, type="private"),
+            from_user=SimpleNamespace(id=99, full_name="Bot", is_bot=True),
+            text="I'm a bot",
+            date=datetime.now(timezone.utc),
+            message_thread_id=None,
+            message_id=2,
+            entities=None,
+        )
 
         with patch.object(adapter, "normalize") as mock_norm:
-            await adapter._on_message(_make_aiogram_msg())
+            await adapter._on_message(bot_msg)
 
         mock_norm.assert_not_called()
         hub.inbound_bus.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_voice_message_forwarded_with_public_trust(self) -> None:
+        """Voice messages reach the bus with trust_level=PUBLIC."""
+        from unittest.mock import patch
+
+        from lyra.adapters.telegram import TelegramAdapter
+
+        hub = MagicMock()
+        hub.inbound_audio_bus = MagicMock()
+        hub.inbound_audio_bus.registered_platforms = MagicMock(return_value=[])
+        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+        adapter.bot = AsyncMock()
+
+        voice_msg = SimpleNamespace(
+            chat=SimpleNamespace(id=123, type="private"),
+            from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+            text=None,
+            date=datetime.now(timezone.utc),
+            message_thread_id=None,
+            message_id=3,
+            voice=SimpleNamespace(file_id="f123", duration=5),
+            audio=None,
+            video_note=None,
+            entities=None,
+        )
+
+        _fake_audio = MagicMock(read_bytes=lambda: b"audio", unlink=MagicMock())
+        _fake_dl = AsyncMock(return_value=(_fake_audio, 5.0))
+        with patch("lyra.adapters.telegram_inbound._download_audio", new=_fake_dl):
+            with patch(  # noqa: E501
+                "lyra.adapters.telegram_inbound.normalize_audio"
+            ) as mock_norm_audio:
+                mock_norm_audio.return_value = MagicMock()
+                _fake_push = AsyncMock()
+                with patch(
+                    "lyra.adapters.telegram_inbound.push_to_hub_guarded",
+                    new=_fake_push,
+                ):
+                    await adapter._on_voice_message(voice_msg)
+
+        # normalize_audio called with PUBLIC trust
+        mock_norm_audio.assert_called_once()
+        call_kwargs = mock_norm_audio.call_args
+        assert call_kwargs.kwargs.get("trust_level") == TrustLevel.PUBLIC

--- a/tests/bootstrap/test_multibot_wiring.py
+++ b/tests/bootstrap/test_multibot_wiring.py
@@ -1,0 +1,104 @@
+"""Tests for bootstrap wiring — hub.register_authenticator is called (Finding I)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lyra.config import TelegramBotConfig
+from lyra.core.authenticator import Authenticator
+from lyra.core.hub.hub import Hub
+from lyra.core.message import Platform
+from lyra.core.trust import TrustLevel
+
+
+# ---------------------------------------------------------------------------
+# Finding I: wire_telegram_adapters registers the authenticator on the hub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wire_telegram_adapters_registers_authenticator() -> None:
+    """wire_telegram_adapters() must call hub.register_authenticator(Platform.TELEGRAM, bot_id, auth)."""
+    from lyra.bootstrap.multibot_wiring import wire_telegram_adapters
+    from lyra.core.circuit_breaker import CircuitRegistry
+
+    # Arrange — real Hub so register_authenticator actually records the call
+    hub = Hub()
+
+    bot_cfg = TelegramBotConfig(bot_id="main")
+    auth = Authenticator(store=None, role_map={}, default=TrustLevel.PUBLIC)
+
+    # bot_agent_map maps ("telegram", bot_id) → agent_name
+    bot_agent_map: dict[tuple[str, str], str] = {("telegram", "main"): "lyra_default"}
+
+    # Mock CredentialStore: get_full returns (token, webhook_secret)
+    cred_store = MagicMock()
+    cred_store.get_full = AsyncMock(return_value=("fake-token", "fake-secret"))
+
+    circuit_registry = CircuitRegistry()
+
+    msg_manager = MagicMock()
+    msg_manager.get.return_value = None
+
+    # Patch TelegramAdapter so we don't make real HTTP calls.
+    # resolve_identity() is an async method that calls the Telegram API — mock it.
+    mock_adapter_instance = MagicMock()
+    mock_adapter_instance.resolve_identity = AsyncMock()
+
+    with patch(
+        "lyra.bootstrap.multibot_wiring.TelegramAdapter",
+        return_value=mock_adapter_instance,
+    ):
+        # Act
+        adapters, dispatchers = await wire_telegram_adapters(
+            hub=hub,
+            tg_bot_auths=[(bot_cfg, auth)],
+            bot_agent_map=bot_agent_map,
+            cred_store=cred_store,
+            circuit_registry=circuit_registry,
+            msg_manager=msg_manager,
+        )
+
+    # Assert — hub._authenticators should have the entry for (TELEGRAM, "main")
+    assert (Platform.TELEGRAM, "main") in hub._authenticators
+    registered_auth = hub._authenticators[(Platform.TELEGRAM, "main")]
+    assert registered_auth is auth
+
+    # Sanity: one adapter and one dispatcher were returned
+    assert len(adapters) == 1
+    assert len(dispatchers) == 1
+
+
+@pytest.mark.asyncio
+async def test_wire_telegram_adapters_skips_missing_agent_mapping() -> None:
+    """wire_telegram_adapters() skips bots not in bot_agent_map without raising."""
+    from lyra.bootstrap.multibot_wiring import wire_telegram_adapters
+    from lyra.core.circuit_breaker import CircuitRegistry
+
+    # Arrange
+    hub = Hub()
+    bot_cfg = TelegramBotConfig(bot_id="orphan_bot")
+    auth = Authenticator(store=None, role_map={}, default=TrustLevel.PUBLIC)
+
+    cred_store = MagicMock()
+    cred_store.get_full = AsyncMock(return_value=("token", None))
+
+    circuit_registry = CircuitRegistry()
+    msg_manager = MagicMock()
+
+    # Act — bot_agent_map is empty so "orphan_bot" has no agent
+    adapters, dispatchers = await wire_telegram_adapters(
+        hub=hub,
+        tg_bot_auths=[(bot_cfg, auth)],
+        bot_agent_map={},
+        cred_store=cred_store,
+        circuit_registry=circuit_registry,
+        msg_manager=msg_manager,
+    )
+
+    # Assert — nothing registered, nothing returned
+    assert adapters == []
+    assert dispatchers == []
+    assert (Platform.TELEGRAM, "orphan_bot") not in hub._authenticators

--- a/tests/bootstrap/test_multibot_wiring.py
+++ b/tests/bootstrap/test_multibot_wiring.py
@@ -10,8 +10,7 @@ from lyra.config import TelegramBotConfig
 from lyra.core.authenticator import Authenticator
 from lyra.core.hub.hub import Hub
 from lyra.core.message import Platform
-from lyra.core.trust import TrustLevel
-
+from lyra.core.trust import TrustLevel  # noqa: F401 — used in Authenticator(default=)
 
 # ---------------------------------------------------------------------------
 # Finding I: wire_telegram_adapters registers the authenticator on the hub
@@ -20,7 +19,7 @@ from lyra.core.trust import TrustLevel
 
 @pytest.mark.asyncio
 async def test_wire_telegram_adapters_registers_authenticator() -> None:
-    """wire_telegram_adapters() must call hub.register_authenticator(Platform.TELEGRAM, bot_id, auth)."""
+    """wire_telegram_adapters() must call hub.register_authenticator() with the auth."""
     from lyra.bootstrap.multibot_wiring import wire_telegram_adapters
     from lyra.core.circuit_breaker import CircuitRegistry
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,7 +245,7 @@ def patch_all(
     _mock_auth_cls.from_bot_config = MagicMock(
         side_effect=lambda *a, **kw: next(_bot_auth_results)
     )
-    monkeypatch.setattr(wiring_mod, "AuthMiddleware", _mock_auth_cls)
+    monkeypatch.setattr(wiring_mod, "Authenticator", _mock_auth_cls)
 
     _fake_auth_store = MagicMock()
     _fake_auth_store.connect = AsyncMock()


### PR DESCRIPTION
## Summary

- Move `Authenticator.resolve()` from adapter-side to Hub-side — Hub is now the trust authority (C3 of #445 Slice C)
- Add `TrustGuardMiddleware` to Hub pipeline (stage 2) replacing adapter-side `GuardChain` — BLOCKED users dropped at Hub, not adapter
- Adapters now send all messages with `trust_level=PUBLIC` (raw); Hub overwrites with authoritative identity before pipeline runs

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #456: feat(core): trust re-resolution — move Authenticator.resolve() to Hub side | Open |
| Spec | [445-distributed-lyra-nats-spec.mdx](artifacts/specs/445-distributed-lyra-nats-spec.mdx) § C3 | Present (C3 marked done) |
| Implementation | 1 commit on `feat/456-trust-re-resolution` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (13 new / rewritten) | Passed |

## What changed

**Hub (`hub.py`)**
- `_authenticators: dict[(Platform, bot_id), Authenticator]` registry
- `register_authenticator(platform, bot_id, auth)` — called from bootstrap
- `resolve_identity(user_id, platform, bot_id)` — for out-of-band gates (slash commands)
- `_resolve_message_trust(msg)` — re-resolves trust on dequeued message; called in `run()` before pipeline

**Pipeline (`middleware_stages.py`, `middleware.py`)**
- `TrustGuardMiddleware` added as stage 2 — drops `BLOCKED` messages with log + telemetry event

**Adapters**
- `telegram_inbound.py`, `discord_inbound.py`: removed `auth.resolve()` + `_guard_chain.run()` from inbound handlers; `normalize()` always called with `trust_level=TrustLevel.PUBLIC, is_admin=False`
- `discord_voice_commands.py`: `_resolve_slash_trust()` now uses `adapter._hub.resolve_identity()` — auth store never accessed directly by adapters

**Bootstrap**
- `multibot_wiring.py`: `hub.register_authenticator(platform, bot_id, auth)` instead of passing `auth=` to adapter constructors

## Test Plan
- [ ] Send message as a BLOCKED user — Hub drops it (TrustGuardMiddleware), no response
- [ ] Send message as a TRUSTED user — Hub resolves trust, message processed normally
- [ ] Discord `/join` slash command as TRUSTED user — joins voice channel
- [ ] Discord `/leave` slash command as BLOCKED user — rejected with permission error
- [ ] Restart Lyra and verify adapter logs show no auth_reject (moved to Hub)

Closes #456

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`