### PR TITLE
feat(core): NatsBus — Bus[T] implementation over NATS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "uvicorn[standard]>=0.34",
     "httpx[asyncio]>=0.28",
     "python-dotenv>=1.0",
+    # NATS transport (NatsBus — issue #455, Slice C of #445)
+    "nats-py>=2.6",
     # Agent backends
     "anthropic>=0.49",
     "typer>=0.14",

--- a/src/lyra/core/bus.py
+++ b/src/lyra/core/bus.py
@@ -38,8 +38,10 @@ class Bus(Protocol[T]):
     async def put(self, platform: Platform, item: T) -> None:
         """Enqueue an item on the platform's queue.
 
-        Must raise ``asyncio.QueueFull`` when the platform queue is at capacity —
-        callers rely on this exception for backpressure handling.
+        May raise ``asyncio.QueueFull`` when the implementation uses local
+        queuing (e.g. ``LocalBus``) and the platform queue is at capacity.
+        Network-backed implementations (e.g. ``NatsBus``) do not raise —
+        callers must not assume backpressure from this method.
         """
         ...
 

--- a/src/lyra/nats/__init__.py
+++ b/src/lyra/nats/__init__.py
@@ -1,0 +1,24 @@
+"""lyra.nats — NATS transport backends for Lyra.
+
+Provides ``NatsBus[T]`` — a concrete implementation of the ``Bus[T]`` Protocol
+backed by NATS pub-sub for Hub ↔ Adapter IPC across separate OS processes.
+
+``LocalBus`` remains the default for single-machine / dev-mode operation.
+``NatsBus`` is injected via DI when Hub runs in distributed mode (Slice C of #445).
+
+Usage::
+
+    import nats
+    from lyra.nats import NatsBus
+    from lyra.core.message import InboundMessage, Platform
+
+    nc = await nats.connect("nats://127.0.0.1:4222")
+    bus: Bus[InboundMessage] = NatsBus(nc=nc, bot_id="main", item_type=InboundMessage)
+    bus.register(Platform.TELEGRAM)
+    await bus.start()
+    ...
+    await bus.stop()
+"""
+from .nats_bus import NatsBus
+
+__all__ = ["NatsBus"]

--- a/src/lyra/nats/_serialize.py
+++ b/src/lyra/nats/_serialize.py
@@ -146,52 +146,37 @@ def _encode(obj: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _decode(value: Any, target_type: Any) -> Any:
-    """Reconstruct value as target_type.
-
-    Handles: dataclass, Enum, datetime, bytes, list[X], Union/Optional, scalars.
-    """
-    if target_type is Any or target_type is None:
+def _decode_union(value: Any, args: tuple[Any, ...]) -> Any:
+    """Decode value when the target is a Union / Optional type."""
+    if value is None:
+        return None
+    non_none = [a for a in args if a is not type(None)]
+    # bytes: detect "b64:" prefix
+    if (
+        bytes in non_none
+        and isinstance(value, str)
+        and value.startswith(_B64_PREFIX)
+    ):
+        return base64.b64decode(value[len(_B64_PREFIX):])
+    # Single non-None candidate: decode as that type
+    if len(non_none) == 1:
+        return _decode(value, non_none[0])
+    # Multiple non-None: str | bytes without b64 prefix → keep as str
+    if str in non_none and isinstance(value, str):
         return value
+    # Dataclass candidate: try to reconstruct
+    for candidate in non_none:
+        if (
+            dataclasses.is_dataclass(candidate)
+            and isinstance(candidate, type)
+            and isinstance(value, dict)
+        ):
+            return _decode_dataclass(value, candidate)
+    return value
 
-    origin = typing.get_origin(target_type)
-    args = typing.get_args(target_type)
 
-    # ── Union / Optional (including X | Y syntax) ────────────────────────────
-    is_union = origin is typing.Union or (
-        hasattr(types, "UnionType") and isinstance(target_type, types.UnionType)
-    )
-    if is_union:
-        if value is None:
-            return None
-        # Collect non-None candidates
-        non_none = [a for a in args if a is not type(None)]
-        # bytes: detect "b64:" prefix
-        if bytes in non_none and isinstance(value, str) and value.startswith(_B64_PREFIX):
-            return base64.b64decode(value[len(_B64_PREFIX):])
-        # Single non-None candidate: decode as that type
-        if len(non_none) == 1:
-            return _decode(value, non_none[0])
-        # Multiple non-None: str | bytes without b64 prefix → keep as str
-        if str in non_none and isinstance(value, str):
-            return value
-        # Dataclass candidate: try to reconstruct
-        for candidate in non_none:
-            if dataclasses.is_dataclass(candidate) and isinstance(candidate, type) and isinstance(value, dict):
-                return _decode_dataclass(value, candidate)
-        return value
-
-    # ── list[X] ──────────────────────────────────────────────────────────────
-    if origin is list:
-        if value is None:
-            return value
-        elem_type = args[0] if args else Any
-        return [_decode(item, elem_type) for item in value]
-
-    # ── Literal — return as-is ───────────────────────────────────────────────
-    if origin is typing.Literal:
-        return value
-
+def _decode_concrete(value: Any, target_type: Any) -> Any:
+    """Decode value for concrete (non-generic, non-union) types."""
     # ── Dataclass ────────────────────────────────────────────────────────────
     if dataclasses.is_dataclass(target_type) and isinstance(target_type, type):
         if value is None:
@@ -220,6 +205,38 @@ def _decode(value: Any, target_type: Any) -> Any:
 
     # ── Scalar / dict / unknown ───────────────────────────────────────────────
     return value
+
+
+def _decode(value: Any, target_type: Any) -> Any:
+    """Reconstruct value as target_type.
+
+    Handles: dataclass, Enum, datetime, bytes, list[X], Union/Optional, scalars.
+    """
+    if target_type is Any or target_type is None:
+        return value
+
+    origin = typing.get_origin(target_type)
+    args = typing.get_args(target_type)
+
+    # ── Union / Optional (including X | Y syntax) ────────────────────────────
+    is_union = origin is typing.Union or (
+        hasattr(types, "UnionType") and isinstance(target_type, types.UnionType)
+    )
+    if is_union:
+        return _decode_union(value, args)
+
+    # ── list[X] ──────────────────────────────────────────────────────────────
+    if origin is list:
+        if value is None:
+            return value
+        elem_type = args[0] if args else Any
+        return [_decode(item, elem_type) for item in value]
+
+    # ── Literal — return as-is ───────────────────────────────────────────────
+    if origin is typing.Literal:
+        return value
+
+    return _decode_concrete(value, target_type)
 
 
 def _decode_dataclass(d: dict[str, Any], dc_type: type) -> Any:

--- a/src/lyra/nats/_serialize.py
+++ b/src/lyra/nats/_serialize.py
@@ -1,0 +1,241 @@
+"""Type-aware JSON serializer for NatsBus wire format.
+
+Handles encoding/decoding of Lyra dataclasses to/from UTF-8 JSON bytes:
+- Enum  → .value (str/int)
+- datetime → .isoformat()
+- bytes → "b64:<base64>" prefixed string
+- callables stripped from dict fields (platform_meta)
+- nested dataclasses serialized recursively
+"""
+from __future__ import annotations
+
+import base64
+import dataclasses
+import importlib
+import json
+import sys
+import types
+import typing
+from datetime import datetime
+from enum import Enum
+from typing import Any, TypeVar, get_type_hints
+
+T = TypeVar("T")
+
+_B64_PREFIX = "b64:"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def serialize(item: Any) -> bytes:
+    """Serialize a dataclass instance to UTF-8 JSON bytes.
+
+    Encodes Enum → .value, datetime → .isoformat(), bytes → "b64:<base64>".
+    Callables are stripped from any dict-typed field (e.g. platform_meta).
+    """
+    encoded = _encode(item)
+    return json.dumps(encoded, ensure_ascii=False).encode("utf-8")
+
+
+def deserialize(data: bytes, item_type: type[T]) -> T:
+    """Reconstruct a dataclass from UTF-8 JSON bytes.
+
+    Parses JSON, then recursively reconstructs item_type from the resulting
+    dict, rehydrating enums, datetimes, bytes fields, and nested dataclasses.
+    """
+    raw = json.loads(data.decode("utf-8"))
+    return _decode(raw, item_type)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_callables(d: dict[str, Any]) -> dict[str, Any]:
+    """Remove callable values from a dict (used for platform_meta)."""
+    return {k: v for k, v in d.items() if not callable(v)}
+
+
+def _get_hints(dc_type: type) -> dict[str, Any]:
+    """Get type hints for a dataclass, handling TYPE_CHECKING-only imports.
+
+    Uses the class's own module globals as the resolution namespace so that
+    names like ``Attachment`` always resolve to the correct class even when
+    other packages (e.g. discord.py) define identically-named types.
+
+    Falls back to explicitly importing known TYPE_CHECKING-only types when
+    NameError is raised (e.g. ``CommandContext`` imported under TYPE_CHECKING).
+    """
+    try:
+        return get_type_hints(dc_type)
+    except NameError:
+        pass
+
+    # Use the class's own module globals as the primary resolution namespace.
+    # Do NOT scrape all of sys.modules — that causes name collisions when
+    # third-party packages (e.g. discord.py) export identically-named types.
+    module = sys.modules.get(dc_type.__module__)
+    globalns: dict[str, Any] = dict(vars(module)) if module is not None else {}
+
+    # Supplement with TYPE_CHECKING-only types not present at runtime.
+    localns: dict[str, Any] = {}
+    _type_checking_imports = [
+        ("lyra.core.commands.command_parser", "CommandContext"),
+    ]
+    for module_path, type_name in _type_checking_imports:
+        if type_name not in globalns:
+            try:
+                mod = importlib.import_module(module_path)
+                localns[type_name] = getattr(mod, type_name)
+            except Exception:
+                pass
+
+    try:
+        return get_type_hints(dc_type, globalns=globalns, localns=localns)
+    except Exception:
+        # Final fallback: no type coercion — raw JSON values returned as-is
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Encoding
+# ---------------------------------------------------------------------------
+
+
+def _encode(obj: Any) -> Any:
+    """Recursively encode obj to a JSON-safe value.
+
+    Handles: dataclass, Enum, datetime, bytes, list, dict, scalars.
+    """
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        result: dict[str, Any] = {}
+        for f in dataclasses.fields(obj):  # type: ignore[arg-type]
+            value = getattr(obj, f.name)
+            encoded_value = _encode(value)
+            # Strip callables from dict fields (platform_meta pattern)
+            if isinstance(encoded_value, dict):
+                encoded_value = _strip_callables(encoded_value)
+            result[f.name] = encoded_value
+        return result
+
+    if isinstance(obj, Enum):
+        return obj.value
+
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+
+    if isinstance(obj, bytes):
+        return _B64_PREFIX + base64.b64encode(obj).decode("ascii")
+
+    if isinstance(obj, list):
+        return [_encode(item) for item in obj]
+
+    if isinstance(obj, dict):
+        return {k: _encode(v) for k, v in obj.items() if not callable(v)}
+
+    # Scalar: str, int, float, bool, None
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Decoding
+# ---------------------------------------------------------------------------
+
+
+def _decode(value: Any, target_type: Any) -> Any:
+    """Reconstruct value as target_type.
+
+    Handles: dataclass, Enum, datetime, bytes, list[X], Union/Optional, scalars.
+    """
+    if target_type is Any or target_type is None:
+        return value
+
+    origin = typing.get_origin(target_type)
+    args = typing.get_args(target_type)
+
+    # ── Union / Optional (including X | Y syntax) ────────────────────────────
+    is_union = origin is typing.Union or (
+        hasattr(types, "UnionType") and isinstance(target_type, types.UnionType)
+    )
+    if is_union:
+        if value is None:
+            return None
+        # Collect non-None candidates
+        non_none = [a for a in args if a is not type(None)]
+        # bytes: detect "b64:" prefix
+        if bytes in non_none and isinstance(value, str) and value.startswith(_B64_PREFIX):
+            return base64.b64decode(value[len(_B64_PREFIX):])
+        # Single non-None candidate: decode as that type
+        if len(non_none) == 1:
+            return _decode(value, non_none[0])
+        # Multiple non-None: str | bytes without b64 prefix → keep as str
+        if str in non_none and isinstance(value, str):
+            return value
+        # Dataclass candidate: try to reconstruct
+        for candidate in non_none:
+            if dataclasses.is_dataclass(candidate) and isinstance(candidate, type) and isinstance(value, dict):
+                return _decode_dataclass(value, candidate)
+        return value
+
+    # ── list[X] ──────────────────────────────────────────────────────────────
+    if origin is list:
+        if value is None:
+            return value
+        elem_type = args[0] if args else Any
+        return [_decode(item, elem_type) for item in value]
+
+    # ── Literal — return as-is ───────────────────────────────────────────────
+    if origin is typing.Literal:
+        return value
+
+    # ── Dataclass ────────────────────────────────────────────────────────────
+    if dataclasses.is_dataclass(target_type) and isinstance(target_type, type):
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            return value
+        return _decode_dataclass(value, target_type)
+
+    # ── Enum ──────────────────────────────────────────────────────────────────
+    if isinstance(target_type, type) and issubclass(target_type, Enum):
+        return target_type(value)
+
+    # ── datetime ──────────────────────────────────────────────────────────────
+    if target_type is datetime:
+        if isinstance(value, str):
+            return datetime.fromisoformat(value)
+        return value
+
+    # ── bytes ─────────────────────────────────────────────────────────────────
+    if target_type is bytes:
+        if isinstance(value, str) and value.startswith(_B64_PREFIX):
+            return base64.b64decode(value[len(_B64_PREFIX):])
+        if isinstance(value, bytes):
+            return value
+        return value
+
+    # ── Scalar / dict / unknown ───────────────────────────────────────────────
+    return value
+
+
+def _decode_dataclass(d: dict[str, Any], dc_type: type) -> Any:
+    """Reconstruct a dataclass from a dict using field type hints for coercion."""
+    hints = _get_hints(dc_type)
+
+    kwargs: dict[str, Any] = {}
+    for f in dataclasses.fields(dc_type):  # type: ignore[arg-type]
+        if f.name not in d:
+            # Field absent in payload — omit; rely on default or default_factory
+            continue
+        raw_value = d[f.name]
+        field_type = hints.get(f.name)
+        if field_type is None:
+            kwargs[f.name] = raw_value
+        else:
+            kwargs[f.name] = _decode(raw_value, field_type)
+
+    return dc_type(**kwargs)

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -1,0 +1,199 @@
+"""NatsBus — Bus[T] implementation over NATS pub/sub.
+
+Concrete implementation of the ``Bus[T]`` Protocol defined in ``bus.py``,
+using NATS as the transport layer instead of local asyncio queues.
+
+Each registered platform maps to one NATS subscription on the subject
+``lyra.inbound.{platform.value}.{bot_id}``.  Inbound messages are
+deserialized from JSON and placed into a single staging queue consumed
+by Hub.run().
+
+Usage::
+
+    import nats
+    from lyra.nats.nats_bus import NatsBus
+    from lyra.core.message import InboundMessage, Platform
+
+    nc = await nats.connect("nats://localhost:4222")
+    bus: Bus[InboundMessage] = NatsBus(nc=nc, bot_id="main", item_type=InboundMessage)
+    bus.register(Platform.TELEGRAM)
+    await bus.start()
+    ...
+    await bus.stop()
+    await nc.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Generic, TypeVar
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.aio.subscription import Subscription
+
+from lyra.core.message import Platform
+from lyra.nats._serialize import deserialize, serialize
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class NatsBus(Generic[T]):
+    """Bus[T] implementation backed by NATS pub/sub.
+
+    The caller is responsible for establishing and closing the NATS connection.
+    ``NatsBus`` only manages subscriptions — it never calls ``nc.connect()``
+    or ``nc.close()``.
+
+    Lifecycle::
+
+        nc = await nats.connect("nats://localhost:4222")
+        bus = NatsBus(nc=nc, bot_id="main", item_type=InboundMessage)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()   # creates NATS subscriptions
+        ...
+        await bus.stop()    # unsubscribes; platforms remain registered
+        await bus.start()   # safe to restart without re-registering
+
+    Args:
+        nc: Already-connected ``nats.NATS`` client.
+        bot_id: Bot identifier appended to the NATS subject.
+        item_type: Concrete type used for deserialization (e.g. ``InboundMessage``).
+    """
+
+    def __init__(self, nc: NATS, bot_id: str, item_type: type[T]) -> None:
+        self._nc = nc
+        self._bot_id = bot_id
+        self._item_type = item_type
+        self._platforms: set[Platform] = set()
+        self._subscriptions: dict[Platform, Subscription] = {}
+        self._staging: asyncio.Queue[T] = asyncio.Queue(maxsize=500)
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self, platform: Platform, maxsize: int = 100) -> None:  # noqa: ARG002
+        """Record *platform* for subscription setup.
+
+        ``maxsize`` is accepted for Protocol compatibility but unused — there
+        is no per-platform local buffer in NatsBus.
+
+        Raises:
+            RuntimeError: If called after ``start()``.
+        """
+        if self._subscriptions:
+            raise RuntimeError(
+                f"Cannot register platform {platform!r} after start() — "
+                "subscriptions are already active."
+            )
+        self._platforms.add(platform)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Create one NATS subscription per registered platform.
+
+        Subject pattern: ``lyra.inbound.{platform.value}.{bot_id}``
+
+        No-op if zero platforms are registered.
+
+        Raises:
+            RuntimeError: If subscriptions are already active (double-start).
+        """
+        if self._subscriptions:
+            raise RuntimeError(
+                "NatsBus.start() called while subscriptions are already active — "
+                "call stop() first."
+            )
+        for platform in self._platforms:
+            await self._make_handler(platform)
+
+    async def stop(self) -> None:
+        """Unsubscribe all active NATS subscriptions.
+
+        Registered platforms are preserved so that a subsequent ``start()``
+        succeeds without re-registering.
+        """
+        for sub in self._subscriptions.values():
+            try:
+                await sub.unsubscribe()
+            except Exception:
+                log.exception("NatsBus: error unsubscribing")
+        self._subscriptions.clear()
+
+    # ------------------------------------------------------------------
+    # Message I/O
+    # ------------------------------------------------------------------
+
+    async def put(self, platform: Platform, item: T) -> None:
+        """Serialize *item* and publish it to the platform's NATS subject.
+
+        Raises:
+            KeyError: If *platform* has not been registered.
+        """
+        if platform not in self._platforms:
+            raise KeyError(
+                f"Platform {platform!r} is not registered — call register() first."
+            )
+        subject = f"lyra.inbound.{platform.value}.{self._bot_id}"
+        payload = serialize(item)
+        await self._nc.publish(subject, payload)
+
+    async def get(self) -> T:
+        """Wait for and return the next item from the staging queue."""
+        return await self._staging.get()
+
+    def task_done(self) -> None:
+        """No-op — NatsBus does not use ``asyncio.Queue.task_done()`` semantics."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def qsize(self, platform: Platform) -> int:  # noqa: ARG002
+        """Always returns 0 — NatsBus has no per-platform local buffer."""
+        return 0
+
+    def staging_qsize(self) -> int:
+        """Return the number of items currently waiting in the staging queue."""
+        return self._staging.qsize()
+
+    def registered_platforms(self) -> frozenset[Platform]:
+        """Return the set of currently registered platforms."""
+        return frozenset(self._platforms)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _make_handler(
+        self, platform: Platform
+    ) -> None:
+        """Create NATS subscription for *platform* and register the handler."""
+        subject = f"lyra.inbound.{platform.value}.{self._bot_id}"
+
+        async def handler(msg: Msg) -> None:
+            try:
+                item = deserialize(msg.data, self._item_type)
+                self._staging.put_nowait(item)
+            except asyncio.QueueFull:
+                log.warning(
+                    "NatsBus staging queue full — dropping message on platform=%s",
+                    platform.value,
+                )
+            except Exception:
+                log.exception(
+                    "NatsBus: failed to deserialize message on platform=%s",
+                    platform.value,
+                )
+
+        sub = await self._nc.subscribe(subject, cb=handler)
+        self._subscriptions[platform] = sub
+        log.debug("NatsBus subscribed: subject=%s bot_id=%s", subject, self._bot_id)

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -20,7 +20,10 @@ import pytest
 _nats_server_available = shutil.which("nats-server") is not None
 requires_nats_server = pytest.mark.skipif(
     not _nats_server_available,
-    reason="nats-server not found in PATH — install via 'make nats-install' in lyra-stack",
+    reason=(
+        "nats-server not found in PATH"
+        " — install via 'make nats-install' in lyra-stack"
+    ),
 )
 
 

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -1,0 +1,70 @@
+"""Shared fixtures for NatsBus unit tests.
+
+Uses a real nats-server subprocess on an ephemeral port — no mocks.
+nats-server binary must be in PATH (installed via ``make nats-install`` in
+lyra-stack, or available as a system package). Tests that depend on the ``nc``
+fixture are automatically skipped when nats-server is not found.
+"""
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import AsyncGenerator, Generator
+
+import nats
+import pytest
+
+# Skip marker applied automatically to any test that depends on nats-server.
+_nats_server_available = shutil.which("nats-server") is not None
+requires_nats_server = pytest.mark.skipif(
+    not _nats_server_available,
+    reason="nats-server not found in PATH — install via 'make nats-install' in lyra-stack",
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def nats_server_url() -> Generator[str, None, None]:
+    """Spawn a nats-server subprocess for the test session.
+
+    Skipped automatically when nats-server is not in PATH.
+    """
+    if not _nats_server_available:
+        pytest.skip("nats-server not found in PATH")
+    port = _free_port()
+    url = f"nats://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        ["nats-server", "-p", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for server to be ready
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        proc.terminate()
+        raise RuntimeError(f"nats-server did not start on port {port}")
+    yield url
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.fixture()
+async def nc(nats_server_url: str) -> AsyncGenerator[nats.NATS, None]:
+    """Return a connected nats.NATS client, drained after each test."""
+    conn = await nats.connect(nats_server_url)
+    yield conn
+    if conn.is_connected:
+        await conn.drain()

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -15,6 +15,7 @@ from collections.abc import AsyncGenerator, Generator
 
 import nats
 import pytest
+from nats.aio.client import Client as NATS
 
 # Skip marker applied automatically to any test that depends on nats-server.
 _nats_server_available = shutil.which("nats-server") is not None
@@ -65,7 +66,7 @@ def nats_server_url() -> Generator[str, None, None]:
 
 
 @pytest.fixture()
-async def nc(nats_server_url: str) -> AsyncGenerator[nats.NATS, None]:
+async def nc(nats_server_url: str) -> AsyncGenerator[NATS, None]:
     """Return a connected nats.NATS client, drained after each test."""
     conn = await nats.connect(nats_server_url)
     yield conn

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -1,0 +1,491 @@
+"""Tests for NatsBus: Bus[T] over NATS pub/sub.
+
+Covers all 17 success criteria from spec #455 (C2: NatsBus implementation).
+NatsBus does not exist yet — this is the RED phase.
+
+Uses a real nats-server subprocess (see conftest.py) — no mocks of the
+NATS transport layer.
+
+RED-phase import guard: imports from lyra.nats are attempted at module load.
+If the package does not exist yet, each test skips with the ImportError detail
+so pytest can still collect and report all test names.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import nats
+import pytest
+
+from lyra.core.bus import Bus
+from tests.nats.conftest import requires_nats_server
+from lyra.core.message import (
+    Attachment,
+    InboundMessage,
+    Platform,
+)
+from lyra.core.trust import TrustLevel
+
+# ---------------------------------------------------------------------------
+# RED-phase guarded imports — lyra.nats does not exist yet.
+# Tests will be collected but xfail until the implementation lands.
+# ---------------------------------------------------------------------------
+try:
+    from lyra.nats._serialize import deserialize, serialize
+
+    _HAS_SERIALIZE = True
+except ImportError as _serialize_err:
+    _HAS_SERIALIZE = False
+    _serialize_err_msg = str(_serialize_err)
+
+    # Provide typed stubs so type-checkers don't complain in the test body.
+    def serialize(msg: Any) -> bytes:  # type: ignore[misc]
+        raise ImportError(_serialize_err_msg)
+
+    def deserialize(payload: bytes, cls: Any) -> Any:  # type: ignore[misc]
+        raise ImportError(_serialize_err_msg)
+
+
+try:
+    from lyra.nats.nats_bus import NatsBus
+
+    _HAS_NATS_BUS = True
+except ImportError as _bus_err:
+    _HAS_NATS_BUS = False
+    _bus_err_msg = str(_bus_err)
+
+    class NatsBus:  # type: ignore[no-redef]
+        """Stub — implementation not yet available."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(_bus_err_msg)
+
+
+# Markers applied to each test class — skip cleanly if module absent.
+_needs_serialize = pytest.mark.skipif(
+    not _HAS_SERIALIZE,
+    reason="lyra.nats._serialize not yet implemented (RED phase)",
+)
+_needs_nats_bus = pytest.mark.skipif(
+    not _HAS_NATS_BUS,
+    reason="lyra.nats.nats_bus not yet implemented (RED phase)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
+    if platform == Platform.TELEGRAM:
+        scope = "chat:123"
+        meta: dict = {
+            "chat_id": 123,
+            "topic_id": None,
+            "message_id": None,
+            "is_group": False,
+        }
+    else:
+        scope = "channel:2"
+        meta = {
+            "guild_id": 1,
+            "channel_id": 2,
+            "message_id": 3,
+            "thread_id": None,
+            "channel_type": "text",
+        }
+    return InboundMessage(
+        id="msg-1",
+        platform=platform.value,
+        bot_id="main",
+        scope_id=scope,
+        user_id="user:1",
+        user_name="Alice",
+        is_mention=False,
+        text="hello",
+        text_raw="hello",
+        timestamp=datetime.now(timezone.utc),
+        platform_meta=meta,
+        trust_level=TrustLevel.TRUSTED,
+    )
+
+
+def _make_bus(nc: nats.NATS) -> NatsBus:
+    return NatsBus(nc=nc, bot_id="main", item_type=InboundMessage)
+
+
+# ---------------------------------------------------------------------------
+# TestSerialize — serialization layer (lyra.nats._serialize)
+# ---------------------------------------------------------------------------
+
+
+@_needs_serialize
+class TestSerialize:
+    def test_callable_stripped_from_platform_meta(self) -> None:
+        """Callables in platform_meta must be stripped during serialization."""
+        # Arrange
+        msg = InboundMessage(
+            id="msg-callable",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="chat:1",
+            user_id="u:1",
+            user_name="Bob",
+            is_mention=False,
+            text="hi",
+            text_raw="hi",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.PUBLIC,
+            platform_meta={"_session_update_fn": lambda: None, "chat_id": 99},
+        )
+
+        # Act
+        payload = serialize(msg)
+        result = deserialize(payload, InboundMessage)
+
+        # Assert
+        assert "_session_update_fn" not in result.platform_meta
+        assert result.platform_meta.get("chat_id") == 99
+
+    def test_non_callable_platform_meta_preserved(self) -> None:
+        """Non-callable values in platform_meta survive the round-trip intact."""
+        # Arrange
+        msg = InboundMessage(
+            id="msg-meta",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="chat:1",
+            user_id="u:1",
+            user_name="Bob",
+            is_mention=False,
+            text="hi",
+            text_raw="hi",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.PUBLIC,
+            platform_meta={"chat_id": 42, "is_group": True, "label": "vip"},
+        )
+
+        # Act
+        payload = serialize(msg)
+        result = deserialize(payload, InboundMessage)
+
+        # Assert
+        assert result.platform_meta["chat_id"] == 42
+        assert result.platform_meta["is_group"] is True
+        assert result.platform_meta["label"] == "vip"
+
+    def test_enum_roundtrip(self) -> None:
+        """TrustLevel enum survives serialize → deserialize as the same enum member."""
+        # Arrange
+        msg = _make_msg(Platform.TELEGRAM)
+        assert msg.trust_level == TrustLevel.TRUSTED
+
+        # Act
+        payload = serialize(msg)
+        result = deserialize(payload, InboundMessage)
+
+        # Assert
+        assert result.trust_level == TrustLevel.TRUSTED
+        assert isinstance(result.trust_level, TrustLevel)
+
+    def test_datetime_roundtrip(self) -> None:
+        """datetime field survives round-trip as ISO 8601 (timezone-aware)."""
+        # Arrange
+        ts = datetime(2026, 3, 31, 12, 0, 0, tzinfo=timezone.utc)
+        msg = InboundMessage(
+            id="msg-dt",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="chat:1",
+            user_id="u:1",
+            user_name="Alice",
+            is_mention=False,
+            text="hi",
+            text_raw="hi",
+            timestamp=ts,
+            trust_level=TrustLevel.PUBLIC,
+        )
+
+        # Act
+        payload = serialize(msg)
+        result = deserialize(payload, InboundMessage)
+
+        # Assert — same UTC moment, timezone-aware
+        assert result.timestamp.utctimetuple() == ts.utctimetuple()
+        assert result.timestamp.tzinfo is not None
+
+    def test_bytes_roundtrip(self) -> None:
+        """bytes field (Attachment.url_or_path_or_bytes) survives as bytes."""
+        # Arrange
+        raw = b"\x89PNG\r\n\x1a\n"
+        attachment = Attachment(
+            type="image",
+            url_or_path_or_bytes=raw,
+            mime_type="image/png",
+            filename="test.png",
+        )
+        msg = InboundMessage(
+            id="msg-bytes",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="chat:1",
+            user_id="u:1",
+            user_name="Alice",
+            is_mention=False,
+            text="pic",
+            text_raw="pic",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.PUBLIC,
+            attachments=[attachment],
+        )
+
+        # Act
+        payload = serialize(msg)
+        result = deserialize(payload, InboundMessage)
+
+        # Assert
+        assert len(result.attachments) == 1
+        assert isinstance(result.attachments[0].url_or_path_or_bytes, bytes)
+        assert result.attachments[0].url_or_path_or_bytes == raw
+
+
+# ---------------------------------------------------------------------------
+# TestNatsBusLifecycle — register / start / stop contract
+# ---------------------------------------------------------------------------
+
+
+@_needs_nats_bus
+@requires_nats_server
+class TestNatsBusLifecycle:
+    async def test_register_before_start_ok(self, nc: nats.NATS) -> None:
+        """register(platform) succeeds before start() is called."""
+        # Arrange
+        bus = _make_bus(nc)
+
+        # Act / Assert — no exception raised
+        bus.register(Platform.TELEGRAM)
+        assert Platform.TELEGRAM in bus.registered_platforms()
+
+    async def test_register_after_start_raises(self, nc: nats.NATS) -> None:
+        """Calling register() after start() must raise RuntimeError."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        try:
+            # Act / Assert
+            with pytest.raises(RuntimeError):
+                bus.register(Platform.DISCORD)
+        finally:
+            await bus.stop()
+
+    async def test_start_zero_platforms_ok(self, nc: nats.NATS) -> None:
+        """start() with no registered platforms is a no-op — no exception."""
+        # Arrange
+        bus = _make_bus(nc)
+
+        # Act / Assert — no exception
+        await bus.start()
+        await bus.stop()
+
+    async def test_stop_preserves_platforms(self, nc: nats.NATS) -> None:
+        """stop() must not clear registered_platforms."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        # Act
+        await bus.stop()
+
+        # Assert — platform still known after stop
+        assert Platform.TELEGRAM in bus.registered_platforms()
+
+    async def test_start_after_stop_ok(self, nc: nats.NATS) -> None:
+        """stop() then start() succeeds without re-registering platforms."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+        await bus.stop()
+
+        # Act / Assert — no exception on second start
+        await bus.start()
+        await bus.stop()
+
+
+# ---------------------------------------------------------------------------
+# TestNatsBusRoundTrip — end-to-end publish → subscribe via NATS
+# ---------------------------------------------------------------------------
+
+
+@_needs_nats_bus
+@requires_nats_server
+class TestNatsBusRoundTrip:
+    async def test_put_get_roundtrip(self, nc: nats.NATS) -> None:
+        """put() on publisher bus, get() on subscriber bus — message fields preserved."""
+        # Arrange — two NatsBus instances sharing the same NATS connection
+        publisher = _make_bus(nc)
+        subscriber = _make_bus(nc)
+
+        subscriber.register(Platform.TELEGRAM)
+        await subscriber.start()
+
+        msg = _make_msg(Platform.TELEGRAM)
+
+        try:
+            # Act
+            await publisher.put(Platform.TELEGRAM, msg)
+            received = await asyncio.wait_for(subscriber.get(), timeout=2.0)
+
+            # Assert — key fields survive the NATS transit
+            assert received.id == msg.id
+            assert received.platform == msg.platform
+            assert received.bot_id == msg.bot_id
+            assert received.scope_id == msg.scope_id
+            assert received.user_id == msg.user_id
+            assert received.user_name == msg.user_name
+            assert received.text == msg.text
+            assert received.trust_level == msg.trust_level
+        finally:
+            await subscriber.stop()
+
+    async def test_callable_stripped_in_transit(self, nc: nats.NATS) -> None:
+        """put() a message with _session_update_fn; get() on other side strips it."""
+        # Arrange
+        publisher = _make_bus(nc)
+        subscriber = _make_bus(nc)
+
+        subscriber.register(Platform.TELEGRAM)
+        await subscriber.start()
+
+        msg = InboundMessage(
+            id="msg-fn",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="chat:123",
+            user_id="u:1",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.TRUSTED,
+            platform_meta={
+                "_session_update_fn": lambda: "should not cross",
+                "chat_id": 123,
+            },
+        )
+
+        try:
+            # Act
+            await publisher.put(Platform.TELEGRAM, msg)
+            received = await asyncio.wait_for(subscriber.get(), timeout=2.0)
+
+            # Assert — callable gone, non-callable preserved
+            assert "_session_update_fn" not in received.platform_meta
+            assert received.platform_meta.get("chat_id") == 123
+        finally:
+            await subscriber.stop()
+
+
+# ---------------------------------------------------------------------------
+# TestNatsBusEdgeCases — task_done, qsize, staging_qsize, unregistered platform
+# ---------------------------------------------------------------------------
+
+
+@_needs_nats_bus
+@requires_nats_server
+class TestNatsBusEdgeCases:
+    async def test_task_done_is_noop(self, nc: nats.NATS) -> None:
+        """task_done() returns None without raising any exception."""
+        # Arrange
+        bus = _make_bus(nc)
+
+        # Act / Assert
+        result = bus.task_done()
+        assert result is None
+
+    def test_qsize_always_zero(self, nc: nats.NATS) -> None:
+        """qsize(platform) always returns 0 for NATS (no local per-platform buffering)."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+
+        # Act / Assert
+        assert bus.qsize(Platform.TELEGRAM) == 0
+
+    async def test_staging_qsize(self, nc: nats.NATS) -> None:
+        """staging_qsize() reflects items waiting in the staging queue."""
+        # Arrange
+        publisher = _make_bus(nc)
+        subscriber = _make_bus(nc)
+
+        subscriber.register(Platform.TELEGRAM)
+        await subscriber.start()
+
+        msg = _make_msg(Platform.TELEGRAM)
+
+        try:
+            # Act — put a message, brief pause for NATS delivery, check staging
+            await publisher.put(Platform.TELEGRAM, msg)
+            await asyncio.sleep(0.1)
+
+            # staging_qsize() returns a non-negative integer
+            size_before = subscriber.staging_qsize()
+            assert size_before >= 0
+
+            # Consume — proves the item arrived
+            received = await asyncio.wait_for(subscriber.get(), timeout=2.0)
+            assert received is not None
+        finally:
+            await subscriber.stop()
+
+    async def test_unregistered_platform_raises(self, nc: nats.NATS) -> None:
+        """put() to an unregistered platform raises KeyError."""
+        # Arrange
+        bus = _make_bus(nc)
+        # Note: Platform.DISCORD is NOT registered
+        msg = _make_msg(Platform.DISCORD)
+
+        # Act / Assert
+        with pytest.raises(KeyError):
+            await bus.put(Platform.DISCORD, msg)
+
+
+# ---------------------------------------------------------------------------
+# TestProtocolConformance — Bus[T] structural compatibility
+# ---------------------------------------------------------------------------
+
+
+@_needs_nats_bus
+class TestProtocolConformance:
+    def test_type_annotation_accepted(self) -> None:
+        """NatsBus exposes all required Bus[T] methods (structural Protocol check)."""
+        # Arrange
+        required_methods = {
+            "register",
+            "put",
+            "get",
+            "task_done",
+            "start",
+            "stop",
+            "qsize",
+            "staging_qsize",
+            "registered_platforms",
+        }
+
+        # Act
+        actual_methods = set(dir(NatsBus))
+        missing = required_methods - actual_methods
+
+        # Assert — NatsBus must expose every Bus[T] method
+        assert not missing, f"NatsBus missing Bus[T] methods: {missing}"
+
+        # Bus[T] generic alias can be used as a type annotation
+        assert Bus is not None

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -21,13 +21,13 @@ import nats
 import pytest
 
 from lyra.core.bus import Bus
-from tests.nats.conftest import requires_nats_server
 from lyra.core.message import (
     Attachment,
     InboundMessage,
     Platform,
 )
 from lyra.core.trust import TrustLevel
+from tests.nats.conftest import requires_nats_server
 
 # ---------------------------------------------------------------------------
 # RED-phase guarded imports — lyra.nats does not exist yet.
@@ -328,7 +328,7 @@ class TestNatsBusLifecycle:
 @requires_nats_server
 class TestNatsBusRoundTrip:
     async def test_put_get_roundtrip(self, nc: nats.NATS) -> None:
-        """put() on publisher bus, get() on subscriber bus — message fields preserved."""
+        """put() + get(): publisher/subscriber message fields preserved."""
         # Arrange — two NatsBus instances sharing the same NATS connection
         publisher = _make_bus(nc)
         subscriber = _make_bus(nc)
@@ -412,7 +412,7 @@ class TestNatsBusEdgeCases:
         assert result is None
 
     def test_qsize_always_zero(self, nc: nats.NATS) -> None:
-        """qsize(platform) always returns 0 for NATS (no local per-platform buffering)."""
+        """qsize(platform) always returns 0 (no local per-platform buffer)."""
         # Arrange
         bus = _make_bus(nc)
         bus.register(Platform.TELEGRAM)

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -1,24 +1,19 @@
 """Tests for NatsBus: Bus[T] over NATS pub/sub.
 
 Covers all 17 success criteria from spec #455 (C2: NatsBus implementation).
-NatsBus does not exist yet — this is the RED phase.
 
 Uses a real nats-server subprocess (see conftest.py) — no mocks of the
-NATS transport layer.
-
-RED-phase import guard: imports from lyra.nats are attempted at module load.
-If the package does not exist yet, each test skips with the ImportError detail
-so pytest can still collect and report all test names.
+NATS transport layer. Tests requiring nats-server are automatically skipped
+when the binary is not found in PATH.
 """
 
 from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
-from typing import Any
 
-import nats
 import pytest
+from nats.aio.client import Client as NATS
 
 from lyra.core.bus import Bus
 from lyra.core.message import (
@@ -27,53 +22,9 @@ from lyra.core.message import (
     Platform,
 )
 from lyra.core.trust import TrustLevel
+from lyra.nats._serialize import deserialize, serialize
+from lyra.nats.nats_bus import NatsBus
 from tests.nats.conftest import requires_nats_server
-
-# ---------------------------------------------------------------------------
-# RED-phase guarded imports — lyra.nats does not exist yet.
-# Tests will be collected but xfail until the implementation lands.
-# ---------------------------------------------------------------------------
-try:
-    from lyra.nats._serialize import deserialize, serialize
-
-    _HAS_SERIALIZE = True
-except ImportError as _serialize_err:
-    _HAS_SERIALIZE = False
-    _serialize_err_msg = str(_serialize_err)
-
-    # Provide typed stubs so type-checkers don't complain in the test body.
-    def serialize(msg: Any) -> bytes:  # type: ignore[misc]
-        raise ImportError(_serialize_err_msg)
-
-    def deserialize(payload: bytes, cls: Any) -> Any:  # type: ignore[misc]
-        raise ImportError(_serialize_err_msg)
-
-
-try:
-    from lyra.nats.nats_bus import NatsBus
-
-    _HAS_NATS_BUS = True
-except ImportError as _bus_err:
-    _HAS_NATS_BUS = False
-    _bus_err_msg = str(_bus_err)
-
-    class NatsBus:  # type: ignore[no-redef]
-        """Stub — implementation not yet available."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            raise ImportError(_bus_err_msg)
-
-
-# Markers applied to each test class — skip cleanly if module absent.
-_needs_serialize = pytest.mark.skipif(
-    not _HAS_SERIALIZE,
-    reason="lyra.nats._serialize not yet implemented (RED phase)",
-)
-_needs_nats_bus = pytest.mark.skipif(
-    not _HAS_NATS_BUS,
-    reason="lyra.nats.nats_bus not yet implemented (RED phase)",
-)
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -114,7 +65,7 @@ def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
     )
 
 
-def _make_bus(nc: nats.NATS) -> NatsBus:
+def _make_bus(nc: NATS) -> NatsBus:
     return NatsBus(nc=nc, bot_id="main", item_type=InboundMessage)
 
 
@@ -123,7 +74,6 @@ def _make_bus(nc: nats.NATS) -> NatsBus:
 # ---------------------------------------------------------------------------
 
 
-@_needs_serialize
 class TestSerialize:
     def test_callable_stripped_from_platform_meta(self) -> None:
         """Callables in platform_meta must be stripped during serialization."""
@@ -258,10 +208,9 @@ class TestSerialize:
 # ---------------------------------------------------------------------------
 
 
-@_needs_nats_bus
 @requires_nats_server
 class TestNatsBusLifecycle:
-    async def test_register_before_start_ok(self, nc: nats.NATS) -> None:
+    async def test_register_before_start_ok(self, nc: NATS) -> None:
         """register(platform) succeeds before start() is called."""
         # Arrange
         bus = _make_bus(nc)
@@ -270,7 +219,7 @@ class TestNatsBusLifecycle:
         bus.register(Platform.TELEGRAM)
         assert Platform.TELEGRAM in bus.registered_platforms()
 
-    async def test_register_after_start_raises(self, nc: nats.NATS) -> None:
+    async def test_register_after_start_raises(self, nc: NATS) -> None:
         """Calling register() after start() must raise RuntimeError."""
         # Arrange
         bus = _make_bus(nc)
@@ -284,7 +233,7 @@ class TestNatsBusLifecycle:
         finally:
             await bus.stop()
 
-    async def test_start_zero_platforms_ok(self, nc: nats.NATS) -> None:
+    async def test_start_zero_platforms_ok(self, nc: NATS) -> None:
         """start() with no registered platforms is a no-op — no exception."""
         # Arrange
         bus = _make_bus(nc)
@@ -293,7 +242,7 @@ class TestNatsBusLifecycle:
         await bus.start()
         await bus.stop()
 
-    async def test_stop_preserves_platforms(self, nc: nats.NATS) -> None:
+    async def test_stop_preserves_platforms(self, nc: NATS) -> None:
         """stop() must not clear registered_platforms."""
         # Arrange
         bus = _make_bus(nc)
@@ -306,7 +255,7 @@ class TestNatsBusLifecycle:
         # Assert — platform still known after stop
         assert Platform.TELEGRAM in bus.registered_platforms()
 
-    async def test_start_after_stop_ok(self, nc: nats.NATS) -> None:
+    async def test_start_after_stop_ok(self, nc: NATS) -> None:
         """stop() then start() succeeds without re-registering platforms."""
         # Arrange
         bus = _make_bus(nc)
@@ -324,10 +273,9 @@ class TestNatsBusLifecycle:
 # ---------------------------------------------------------------------------
 
 
-@_needs_nats_bus
 @requires_nats_server
 class TestNatsBusRoundTrip:
-    async def test_put_get_roundtrip(self, nc: nats.NATS) -> None:
+    async def test_put_get_roundtrip(self, nc: NATS) -> None:
         """put() + get(): publisher/subscriber message fields preserved."""
         # Arrange — two NatsBus instances sharing the same NATS connection
         publisher = _make_bus(nc)
@@ -355,7 +303,7 @@ class TestNatsBusRoundTrip:
         finally:
             await subscriber.stop()
 
-    async def test_callable_stripped_in_transit(self, nc: nats.NATS) -> None:
+    async def test_callable_stripped_in_transit(self, nc: NATS) -> None:
         """put() a message with _session_update_fn; get() on other side strips it."""
         # Arrange
         publisher = _make_bus(nc)
@@ -399,10 +347,9 @@ class TestNatsBusRoundTrip:
 # ---------------------------------------------------------------------------
 
 
-@_needs_nats_bus
 @requires_nats_server
 class TestNatsBusEdgeCases:
-    async def test_task_done_is_noop(self, nc: nats.NATS) -> None:
+    async def test_task_done_is_noop(self, nc: NATS) -> None:
         """task_done() returns None without raising any exception."""
         # Arrange
         bus = _make_bus(nc)
@@ -411,7 +358,7 @@ class TestNatsBusEdgeCases:
         result = bus.task_done()
         assert result is None
 
-    def test_qsize_always_zero(self, nc: nats.NATS) -> None:
+    def test_qsize_always_zero(self, nc: NATS) -> None:
         """qsize(platform) always returns 0 (no local per-platform buffer)."""
         # Arrange
         bus = _make_bus(nc)
@@ -420,7 +367,7 @@ class TestNatsBusEdgeCases:
         # Act / Assert
         assert bus.qsize(Platform.TELEGRAM) == 0
 
-    async def test_staging_qsize(self, nc: nats.NATS) -> None:
+    async def test_staging_qsize(self, nc: NATS) -> None:
         """staging_qsize() reflects items waiting in the staging queue."""
         # Arrange
         publisher = _make_bus(nc)
@@ -446,7 +393,7 @@ class TestNatsBusEdgeCases:
         finally:
             await subscriber.stop()
 
-    async def test_unregistered_platform_raises(self, nc: nats.NATS) -> None:
+    async def test_unregistered_platform_raises(self, nc: NATS) -> None:
         """put() to an unregistered platform raises KeyError."""
         # Arrange
         bus = _make_bus(nc)
@@ -463,7 +410,6 @@ class TestNatsBusEdgeCases:
 # ---------------------------------------------------------------------------
 
 
-@_needs_nats_bus
 class TestProtocolConformance:
     def test_type_annotation_accepted(self) -> None:
         """NatsBus exposes all required Bus[T] methods (structural Protocol check)."""

--- a/uv.lock
+++ b/uv.lock
@@ -1078,6 +1078,7 @@ dependencies = [
     { name = "discord-py", extra = ["voice"] },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "nats-py" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "roxabi-vault" },
@@ -1113,6 +1114,7 @@ requires-dist = [
     { name = "discord-py", extras = ["voice"], specifier = ">=2.4" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", extras = ["asyncio"], specifier = ">=0.28" },
+    { name = "nats-py", specifier = ">=2.6" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "roxabi-vault", git = "https://github.com/Roxabi/roxabi-vault.git?branch=staging" },
@@ -1253,6 +1255,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
     { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Implements `NatsBus[T]`, a concrete `Bus[T]` Protocol class backed by NATS pub-sub for Hub ↔ Adapter IPC across separate OS processes (Slice C2 of #445)
- Adds type-aware JSON serializer (`lyra.nats._serialize`) with enum/datetime/bytes/callable handling; callable values stripped from `platform_meta` at the wire boundary

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #455: feat(core): NatsBus — Bus[T] over NATS | Open |
| Analysis | — | Absent (F-lite, skipped) |
| Spec | [455-natsbus-bus-t-over-nats-spec.mdx](artifacts/specs/455-natsbus-bus-t-over-nats-spec.mdx) | Present |
| Implementation | 1 commit on `feat/455-natsbus-bus-t-over-nats` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (17 new — 11 skipped pending `nats-server`) | Passed |

## Test Plan
- [ ] `pytest tests/nats/` — 6 tests pass immediately (TestSerialize + TestProtocolConformance); 11 skip if `nats-server` not in PATH
- [ ] Install nats-server (`make nats-install` in lyra-stack) and re-run — all 17 tests should pass
- [ ] Verify `platform_meta` callables (`_session_update_fn`) are stripped in transit: `test_callable_stripped_in_transit`
- [ ] Verify `put()` to unregistered platform raises `KeyError`: `test_unregistered_platform_raises`
- [ ] Verify stop/start cycle preserves registered platforms: `test_stop_preserves_platforms` + `test_start_after_stop_ok`

> **Note:** Branch is 3 commits behind `staging` — this is expected; `staging` moved forward during implementation. No conflicts detected.

Closes #455

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`