### PR TITLE
feat(core): extract Hub into standalone lyra_hub process (#457)

### DIFF
--- a/artifacts/specs/472-unified-identity-layer-spec.mdx
+++ b/artifacts/specs/472-unified-identity-layer-spec.mdx
@@ -1,0 +1,282 @@
+---
+title: "Unified Identity Layer — one person, N platform identities"
+description: "Solution spec for Shape 3: prefixed keys + alias table, all-in-one delivery"
+issue: 472
+status: approved
+tier: F-full
+date: 2026-03-31
+promoted_from: "artifacts/analyses/472-unified-identity-layer-analysis.mdx"
+---
+
+## Context
+
+Promoted from [analysis](../analyses/472-unified-identity-layer-analysis.mdx) (Shape 3 — Prefixed Keys + Alias Table). Addresses two problems:
+
+- **P0 (production broken):** `seed_from_config()` stores bare IDs (`"7377831990"`) but Hub-side resolution receives prefixed IDs (`"tg:user:7377831990"`) after C3 (`96ac94b`). Cache miss → owner falls to default trust.
+- **P1 (identity gap):** No concept of "a person." Trust, prefs, and memory are siloed per platform identity.
+
+Delivery: all-in-one pass (single PR, 2-week cycle).
+
+## Goal
+
+Same person recognized as the same user across all platforms — one trust level, one set of prefs, one memory context.
+
+## Users
+
+- **Mickael** — sole operator, uses Telegram and Discord daily. Currently blocked from own bot on production.
+- **Future paired users** — anyone using Lyra on multiple platforms via `/join`.
+
+## Expected Behavior
+
+### Seed fix (P0)
+
+On startup, `seed_from_config()` reads `owner_users = [7377831990]` from `[[auth.telegram_bots]]`. It prefixes the ID based on the section: `"telegram"` → `"tg:user:7377831990"`, `"discord"` → `"dc:user:987654321"`. A one-time cleanup deletes stale bare-ID rows from the `grants` table (rows where `identity_key` lacks a `tg:user:` / `dc:user:` prefix).
+
+After seed, `Authenticator.resolve("tg:user:7377831990")` → `AuthStore.check("tg:user:7377831990")` → cache hit → `OWNER`. The C3 regression is fixed.
+
+### Identity linking (P1)
+
+Mickael sends `/link` from Telegram. Lyra generates a challenge code (6-char alphanumeric, 5-min TTL). Mickael sends `/link <code>` from Discord. Lyra matches the code, creates an alias linking both platform IDs to a primary identity (the ID that initiated the challenge). Both identities now resolve to the same trust level, prefs, and memory.
+
+### Trust cascade
+
+When resolving trust for any platform ID, the system:
+1. Looks up the alias cache → finds all linked IDs for this person
+2. Checks `AuthStore` for each linked ID
+3. If **any** linked ID has stored trust `BLOCKED` → returns `BLOCKED` (no escalation)
+4. Otherwise returns the highest trust level across all linked IDs (OWNER > TRUSTED > PUBLIC)
+
+Two separate BLOCKED guards:
+- **At resolution time:** If any linked ID is BLOCKED, the entire group resolves to BLOCKED. This prevents escalation through aliases even if one platform ID has a higher trust level.
+- **At link time:** `/link` is rejected if either identity is currently BLOCKED. This prevents creating aliases that would immediately trigger the resolution-time guard.
+
+### Admin cascade
+
+`is_admin` is true if **any** linked platform ID appears in `[admin].user_ids` or has stored trust `== OWNER`. This ensures admin status follows the person, not the platform.
+
+### Prefs sharing
+
+`PrefsStore.get_prefs(user_id)` resolves aliases first: queries all linked IDs, returns prefs from the first ID that has non-default values. `set_pref()` writes to the requesting platform ID (so each platform can still override independently if desired).
+
+### Memory sharing
+
+`MemoryManager.recall(user_id, ...)` resolves aliases:
+- **Sessions:** `json_extract(metadata,'$.user_id') IN (?, ?, ...)` covering all linked IDs
+- **Concepts:** queries `f"{namespace}:{alias_id}"` for each linked ID, merges results in Python
+- **Preferences (memory-level):** expands `user_id` filter to all linked IDs
+
+Memory writes continue to use `snap.user_id` (the platform ID that sent the message). This means new memories are written under the platform-specific ID, but reads aggregate across all linked IDs.
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class IdentityAliasStore {
+        <<SqliteStore>>
+        -_cache: dict~str, str~ «platform_id → primary_id»
+        -_reverse: dict~str, set~str~~ «primary_id → all linked IDs»
+        +connect() async
+        +close() async
+        +resolve_aliases(platform_id: str) set~str~ «sync, from cache»
+        +link(primary_id: str, secondary_id: str) async «write-through»
+        +unlink(platform_id: str) async «write-through»
+    }
+
+    class AuthStore {
+        <<existing>>
+        -_cache: dict~str, tuple~TrustLevel, datetime~~
+        +check(identity_key: str) TrustLevel «sync»
+        +seed_from_config(raw, section) async «CHANGED: adds platform prefix»
+    }
+
+    class Authenticator {
+        <<existing>>
+        -_alias_store: IdentityAliasStore | None «NEW field»
+        +resolve(user_id, roles, command) Identity «CHANGED: alias-aware»
+    }
+
+    class PrefsStore {
+        <<existing>>
+        -_alias_store: IdentityAliasStore | None «NEW field»
+        +get_prefs(user_id: str) async UserPrefs «CHANGED: alias-aware»
+    }
+
+    class MemoryManager {
+        <<existing>>
+        -_alias_store: IdentityAliasStore | None «NEW field»
+        +recall(user_id, namespace, ...) async str «CHANGED: alias-aware»
+    }
+
+    IdentityAliasStore --> AuthStore : used by Authenticator
+    IdentityAliasStore --> PrefsStore : used by get_prefs
+    IdentityAliasStore --> MemoryManager : used by recall
+```
+
+### Identity aliases table schema
+
+```sql
+CREATE TABLE IF NOT EXISTS identity_aliases (
+    platform_user_id TEXT PRIMARY KEY,   -- "dc:user:987654321"
+    primary_id       TEXT NOT NULL,      -- "tg:user:7377831990"
+    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+-- The primary_id itself is NOT in this table as a row.
+-- resolve_aliases() returns {platform_user_id} ∪ {primary_id} ∪ {all rows where primary_id matches}.
+```
+
+Flat N:1 structure. Each platform ID maps to exactly one primary. No transitive chains → no cycles by design.
+
+### Link challenge table schema
+
+```sql
+CREATE TABLE IF NOT EXISTS link_challenges (
+    code_hash    TEXT PRIMARY KEY,
+    initiator_id TEXT NOT NULL,       -- platform ID that started the challenge
+    platform     TEXT NOT NULL,       -- "telegram" | "discord"
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at   TEXT NOT NULL
+);
+```
+
+### Consumer map
+
+```mermaid
+flowchart TD
+    IA[IdentityAliasStore]
+
+    subgraph "Auth domain"
+        AUTH[Authenticator.resolve]
+        AS[AuthStore.check]
+        AUTH -->|"resolve_aliases(uid)"| IA
+        AUTH -->|"check(alias) for each"| AS
+    end
+
+    subgraph "Prefs domain"
+        PS[PrefsStore.get_prefs]
+        PS -->|"resolve_aliases(uid)"| IA
+    end
+
+    subgraph "Memory domain"
+        MM[MemoryManager.recall]
+        MM -->|"resolve_aliases(uid)"| IA
+    end
+
+    subgraph "Commands"
+        LINK["/link command"]
+        LINK -->|"link(primary, secondary)"| IA
+    end
+
+    subgraph "Bootstrap"
+        SEED[seed_from_config]
+        SEED -->|"prefixed IDs"| AS
+        SEED -.->|"future: auto-link owner across platforms"| IA
+    end
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|----------|----------------|------|--------|
+| `Authenticator.resolve()` | `resolve_aliases()` → all linked IDs | Every message (middleware stage 2) | This issue |
+| `PrefsStore.get_prefs()` | `resolve_aliases()` → all linked IDs | TTS synthesis, future `/setpref` | This issue |
+| `MemoryManager.recall()` | `resolve_aliases()` → all linked IDs | System prompt build (per-pool) | This issue |
+| `/link` command | `link()`, `unlink()` | User-initiated | This issue |
+| `seed_from_config()` | N/A (writes to AuthStore only) | Bootstrap | This issue (prefix fix) |
+| Memory upserts | `resolve_aliases()` → primary ID for writes | Session flush, extraction | Future (writes stay platform-scoped for now) |
+| Config auto-linking | `link()` for owner_users across platforms | Bootstrap | Future |
+
+## Breadboard
+
+### U1: Seed prefix fix
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| Bootstrap calls `seed_from_config(raw, "telegram")` | `AuthStore.seed_from_config()` | Reads `owner_users`, prefixes with `_PLATFORM_PREFIX[section]`, inserts into `grants` |
+| Cleanup bare-ID rows (idempotent) | `AuthStore._cleanup_bare_ids()` | `DELETE FROM grants WHERE identity_key NOT LIKE '%:%'` (no colon = bare ID). Runs on every `connect()` — no-op on fresh installs or after first cleanup. |
+| Cache warm after cleanup | `AuthStore._warm_cache()` | Reloads cache from DB |
+
+### U2: Identity alias store
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| Store opens DB, creates table, warms cache | `IdentityAliasStore.connect()` | Loads all `identity_aliases` rows into `_cache` and `_reverse` |
+| Sync alias lookup | `IdentityAliasStore.resolve_aliases(platform_id)` | **Algorithm:** 1) Check `_cache[platform_id]` → if hit, get `primary_id`, return `{primary_id} ∪ _reverse[primary_id]`. 2) Check `_reverse[platform_id]` → if hit, caller IS the primary, return `{platform_id} ∪ _reverse[platform_id]`. 3) Neither → return `{platform_id}` (no alias). |
+| Create link | `IdentityAliasStore.link(primary_id, secondary_id)` | INSERT into DB. Write-through: `_cache[secondary_id] = primary_id`, `_reverse[primary_id].add(secondary_id)` |
+| Remove link | `IdentityAliasStore.unlink(platform_id)` | DELETE from DB. Write-through: look up `primary_id = _cache[platform_id]`, delete `_cache[platform_id]`, remove `platform_id` from `_reverse[primary_id]` (if `_reverse[primary_id]` is now empty, delete the key) |
+
+### U3: Alias-aware trust resolution
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| Resolve trust for platform ID | `Authenticator.resolve(user_id)` | `aliases = alias_store.resolve_aliases(user_id)` (resolved once, reused for trust + admin). `levels = [store.check(a) for a in aliases]`. If any is BLOCKED → BLOCKED. Else `max(levels)`. |
+| Admin check across aliases | `Authenticator.resolve()` | Reuses same `aliases` set: `is_admin = any(a in _admin_user_ids or store.check(a) == OWNER for a in aliases)` |
+| BLOCKED any-linked guard | `Authenticator._resolve_trust()` | If `store.check(a) == BLOCKED` for **any** `a` in `aliases` → BLOCKED (no alias escalation) |
+
+### U4: `/link` command
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| User sends `/link` (no args) | `LinkCommand.initiate()` | Generate 6-char code, SHA-256 hash, store in `link_challenges` with 5-min TTL. Reply with code. |
+| User sends `/link <code>` from another platform | `LinkCommand.complete()` | Validate code, check both IDs are not BLOCKED, call `alias_store.link(initiator_id, completer_id)` |
+| Expired/invalid code | `LinkCommand.complete()` | Reply with error, no alias created. Delete expired row from `link_challenges` on check. |
+| User sends `/unlink` | `LinkCommand.unlink()` | Call `alias_store.unlink(user_id)`, reply with confirmation |
+| Stale challenge cleanup | `LinkCommand.initiate()` | Before inserting new challenge: `DELETE FROM link_challenges WHERE expires_at < datetime('now')` |
+
+### U5: Alias-aware prefs
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| Read prefs with alias fallback | `PrefsStore.get_prefs(user_id)` | `aliases = alias_store.resolve_aliases(user_id)` → single `SELECT ... WHERE user_id IN (?, ...)` query. Merge results: for each pref key, use first non-default value found. Returned `UserPrefs.user_id` = the requesting platform ID (not the alias that had the value). |
+| Write prefs | `PrefsStore.set_pref(user_id, key, value)` | Unchanged — writes to requesting platform ID |
+
+### U6: Alias-aware memory recall
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| Recall sessions | `MemoryManager.recall()` | `aliases = resolve_aliases(user_id)` → build `IN` clause with `", ".join("?" * len(aliases))` dynamic placeholders → `json_extract(metadata,'$.user_id') IN (?, ...)` |
+| Recall concepts | `MemoryManager.recall()` | For each alias: search `f"{namespace}:{alias}"` via `self._db.search()`, merge + deduplicate results in Python |
+| Recall preferences (memory-level) | `MemoryManager._fetch_preferences()` | Existing method fetches by namespace then filters in Python (`metadata.user_id == user_id`). Change to: `metadata.user_id in aliases` (no SQL change needed) |
+| Write sessions/concepts/prefs | `MemoryManagerUpserts` | Unchanged — writes use `snap.user_id` (platform ID) |
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|-------|-------------|------|
+| S1 | Seed prefix fix + cleanup | U1 | Owner sends message on Telegram → recognized as OWNER (not blocked) |
+| S2 | IdentityAliasStore | U2 | Unit test: `link("tg:user:1", "dc:user:2")` → `resolve_aliases("dc:user:2")` returns `{"tg:user:1", "dc:user:2"}` |
+| S3 | Alias-aware trust resolution | U3 | `tg:user:1` is OWNER → after linking, `dc:user:2` also resolves as OWNER. BLOCKED ID cannot `/link`. |
+| S4 | `/link` command | U4 | Initiate `/link` on Telegram → get code → `/link <code>` on Discord → alias created |
+| S5 | Alias-aware prefs | U5 | Set TTS language on Telegram → visible on Discord after linking |
+| S6 | Alias-aware memory recall | U6 | Conversation context from Telegram sessions visible when chatting on Discord |
+
+## Success Criteria
+
+- [ ] `seed_from_config()` prefixes IDs: `"telegram"` → `"tg:user:"`, `"discord"` → `"dc:user:"`
+- [ ] One-time cleanup deletes bare-ID rows from `grants` (rows without `:` in `identity_key`)
+- [ ] After seed + cleanup, `Authenticator.resolve("tg:user:<owner_id>")` returns `OWNER`
+- [ ] `IdentityAliasStore` follows async store pattern: `__init__` no I/O, `connect()` opens DB + warms cache, `close()` tears down
+- [ ] `resolve_aliases()` is synchronous (reads from in-memory cache, no I/O) — matches `AuthStore.check()` contract
+- [ ] `link()` and `unlink()` are async, write-through to both DB and cache
+- [ ] `identity_aliases` table is flat N:1 (one `primary_id` per `platform_user_id`) — no transitive chains
+- [ ] After `link("tg:user:1", "dc:user:2")`, `resolve_aliases("dc:user:2")` returns `{"tg:user:1", "dc:user:2"}`
+- [ ] After `link("tg:user:1", "dc:user:2")`, `resolve_aliases("tg:user:1")` returns `{"tg:user:1", "dc:user:2"}` (primary ID lookup via `_reverse`)
+- [ ] `Authenticator.resolve()` with alias store: resolves aliases once, reuses for both trust and admin checks
+- [ ] `Authenticator.resolve()`: takes max trust across all linked IDs (OWNER > TRUSTED > PUBLIC)
+- [ ] If **any** linked ID has stored trust `BLOCKED`, resolution returns `BLOCKED` regardless of other aliases' trust levels
+- [ ] `/link` is rejected if either identity is `BLOCKED`
+- [ ] `is_admin` is true if any linked ID is in `_admin_user_ids` or has stored `OWNER`
+- [ ] `resolve_aliases()` when called with the primary ID (no row in `_cache`): checks `_reverse`, returns `{primary_id} ∪ _reverse[primary_id]`
+- [ ] `/link` initiate: generates code (6-char, 5-min TTL), stores hash in `link_challenges`
+- [ ] `/link <code>` from another platform: validates code, creates alias, replies with confirmation
+- [ ] `/unlink` removes the alias for the requesting platform ID, updates both `_cache` and `_reverse`
+- [ ] Expired `link_challenges` rows cleaned up on each `/link` initiate
+- [ ] `PrefsStore.get_prefs()` with alias store: queries all linked IDs, returns first non-default
+- [ ] `PrefsStore.set_pref()` unchanged — writes to requesting platform ID
+- [ ] `MemoryManager.recall()` with alias store: session query covers all linked user_ids
+- [ ] `MemoryManager.recall()` with alias store: concept search covers all linked `{ns}:{user_id}` namespaces
+- [ ] `MemoryManager._fetch_preferences()` with alias store: filters across all linked user_ids
+- [ ] Memory writes (`upsert_session`, `upsert_concept`, `upsert_preference`) unchanged — use `snap.user_id`
+- [ ] All existing tests pass (no regressions)
+- [ ] New tests cover: seed prefix, bare-ID cleanup, alias CRUD, trust cascade, BLOCKED exception, admin cascade, prefs alias, memory alias, `/link` flow, `/unlink`

--- a/src/lyra/bootstrap/health.py
+++ b/src/lyra/bootstrap/health.py
@@ -78,6 +78,7 @@ def create_health_app(hub: Hub) -> FastAPI:
             "last_message_age_s": last_message_age_s,
             "uptime_s": round(uptime_s, 1),
             "circuits": circuits,
+            "adapters": len(hub.adapter_registry),
         }
 
         # Reaper fields only present when a CLI pool is configured

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -1,0 +1,453 @@
+"""Bootstrap standalone Hub — NATS-connected Hub without embedded adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+
+import nats
+
+from lyra.bootstrap.agent_factory import _resolve_agents, _resolve_bot_agent_map
+from lyra.bootstrap.config import (
+    MessageIndexConfig,
+    _build_agent_overrides,
+    _load_cli_pool_config,
+    _load_debouncer_config,
+    _load_event_bus_config,
+    _load_hub_config,
+    _load_inbound_bus_config,
+    _load_llm_config,
+    _load_messages,
+    _load_pairing_config,
+    _load_pool_config,
+    _load_raw_config,
+    _load_circuit_config,
+)
+from lyra.bootstrap.health import create_health_app
+from lyra.bootstrap.lifecycle_helpers import (
+    setup_signal_handlers,
+    teardown_buses,
+    teardown_dispatchers,
+)
+from lyra.bootstrap.multibot_stores import open_stores
+from lyra.bootstrap.multibot_wiring import _build_bot_auths
+from lyra.bootstrap.voice_overlay import init_stt, init_tts
+from lyra.config import (
+    DiscordMultiConfig,
+    TelegramMultiConfig,
+    load_multibot_config,
+)
+from lyra.core.agent import Agent
+from lyra.core.agent_loader import agent_row_to_config
+from lyra.core.circuit_breaker import CircuitRegistry
+from lyra.core.cli_pool import CliPool
+from lyra.core.hub import Hub
+from lyra.core.hub.event_bus import PipelineEventBus
+from lyra.core.hub.outbound_dispatcher import OutboundDispatcher
+from lyra.core.inbound_bus import LocalBus
+from lyra.core.message import InboundAudio, InboundMessage, Platform
+from lyra.core.stores.pairing import PairingManager, set_pairing_manager
+from lyra.nats.nats_bus import NatsBus
+from lyra.nats.nats_channel_proxy import NatsChannelProxy
+
+log = logging.getLogger(__name__)
+
+_LOCKFILE = Path.home() / ".lyra" / "hub.lock"
+
+
+def _release_lockfile() -> None:
+    """Remove the Hub lockfile if it exists."""
+    try:
+        _LOCKFILE.unlink(missing_ok=True)
+    except OSError as exc:
+        log.warning("Could not remove lockfile %s: %s", _LOCKFILE, exc)
+
+
+def _acquire_lockfile() -> None:
+    """Write current PID to the lockfile.
+
+    If the lockfile already exists and the recorded PID is still alive,
+    log an error and exit — another Hub process is running.
+    Registers an atexit handler to clean up the lockfile on normal exit.
+    """
+    if _LOCKFILE.exists():
+        try:
+            pid_str = _LOCKFILE.read_text().strip()
+            pid = int(pid_str)
+            try:
+                os.kill(pid, 0)  # signal 0 = existence check only
+                sys.exit(
+                    f"Hub is already running (PID {pid}). "
+                    f"Remove {_LOCKFILE} if the process is stale."
+                )
+            except ProcessLookupError:
+                # PID no longer alive — stale lockfile, safe to overwrite
+                log.warning("Stale lockfile found (PID %d not running) — overwriting", pid)
+            except PermissionError:
+                # PID exists but we can't signal it — treat as alive
+                sys.exit(
+                    f"Hub is already running (PID {pid}, permission denied). "
+                    f"Remove {_LOCKFILE} if the process is stale."
+                )
+        except (ValueError, OSError) as exc:
+            log.warning("Could not read lockfile %s (%s) — overwriting", _LOCKFILE, exc)
+
+    _LOCKFILE.parent.mkdir(parents=True, exist_ok=True)
+    _LOCKFILE.write_text(str(os.getpid()))
+    atexit.register(_release_lockfile)
+
+
+async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
+    raw_config: dict,
+    *,
+    _stop: asyncio.Event | None = None,
+) -> None:
+    """Wire standalone Hub connected to NATS and run until stop.
+
+    The Hub receives inbound messages via NATS subscriptions (NatsBus) and
+    dispatches outbound responses via NatsChannelProxy — no platform SDKs are
+    embedded in this process.
+
+    Requires:
+        NATS_URL: NATS server URL (e.g. ``nats://localhost:4222``).
+    """
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit(
+            "NATS_URL is required for standalone Hub mode. "
+            "Set NATS_URL=nats://localhost:4222 (or your NATS server address)."
+        )
+
+    _acquire_lockfile()
+
+    try:
+        nc = await nats.connect(nats_url)
+        log.info("Connected to NATS at %s", nats_url)
+    except Exception as exc:
+        sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
+
+    inbound_bus: NatsBus[InboundMessage] = NatsBus(
+        nc=nc, bot_id="hub", item_type=InboundMessage
+    )
+    # Audio is not routed over NATS in C4 — use a local bus as a no-op sink
+    inbound_audio_bus: LocalBus[InboundAudio] = LocalBus(name="inbound-audio")
+
+    vault_dir = Path(os.environ.get("LYRA_VAULT_DIR", str(Path.home() / ".lyra")))
+    vault_dir.mkdir(parents=True, exist_ok=True)
+
+    async with open_stores(vault_dir) as stores:
+        # Prune stale message_index entries
+        mi_cfg = MessageIndexConfig(**raw_config.get("message_index", {}))
+        pruned = await stores.message_index.cleanup_older_than(mi_cfg.retention_days)
+        if pruned:
+            log.info(
+                "message_index: pruned %d entries older than %d days",
+                pruned,
+                mi_cfg.retention_days,
+            )
+
+        # Seed per-bot owner/trusted users as permanent grants
+        auth_block: dict = raw_config.get("auth", {})
+        for entry in auth_block.get("telegram_bots", []):
+            synthetic = {"auth": {"telegram": entry}}
+            await stores.auth.seed_from_config(synthetic, "telegram")
+        for entry in auth_block.get("discord_bots", []):
+            synthetic = {"auth": {"discord": entry}}
+            await stores.auth.seed_from_config(synthetic, "discord")
+
+        circuit_registry, admin_user_ids = _load_circuit_config(raw_config)
+
+        try:
+            tg_multi_cfg, dc_multi_cfg = load_multibot_config(raw_config)
+        except ValueError as exc:
+            sys.exit(str(exc))
+
+        tg_bot_auths, dc_bot_auths = _build_bot_auths(
+            raw_config,
+            tg_multi_cfg,
+            dc_multi_cfg,
+            stores.auth,
+            admin_user_ids,
+        )
+        log.info("Authenticator: %d admin_user_id(s) configured", len(admin_user_ids))
+
+        if not tg_bot_auths and not dc_bot_auths:
+            sys.exit(
+                "No adapters configured — add at least one [[telegram.bots]] or"
+                " [[discord.bots]] entry with a matching [[auth.telegram_bots]] or"
+                " [[auth.discord_bots]] section to config.toml"
+            )
+
+        # Resolve (platform, bot_id) -> agent_name
+        bot_agent_map = await _resolve_bot_agent_map(
+            stores.agent, tg_multi_cfg.bots, dc_multi_cfg.bots
+        )
+        agent_names: set[str] = set(bot_agent_map.values())
+
+        # Load all agent configs from DB
+        agent_configs: dict[str, Agent] = {}
+        for n in sorted(agent_names):
+            row = stores.agent.get(n)
+            if row is not None:
+                overrides = _build_agent_overrides(raw_config, n)
+                agent_configs[n] = agent_row_to_config(
+                    row, instance_overrides=overrides.model_dump()
+                )
+            else:
+                log.error("Agent %r not found in DB — skipping", n)
+        if not agent_configs:
+            sys.exit(
+                "No agent configs could be loaded — run 'lyra agent init' to seed the"
+                " agents table"
+            )
+        first_agent_name = next(iter(sorted(agent_configs)))
+        first_agent_config = agent_configs[first_agent_name]
+
+        msg_manager = _load_messages(language=first_agent_config.i18n_language)
+
+        # Pairing manager
+        pairing_config = _load_pairing_config(raw_config)
+        if pairing_config.enabled and not admin_user_ids:
+            log.warning(
+                "Pairing enabled but [admin].user_ids is empty — "
+                "/invite and /unpair require is_admin=True "
+                "(granted to [admin].user_ids entries "
+                "or users configured as OWNER in [[auth.*_bots]])"
+            )
+        pm: PairingManager | None = None
+        if pairing_config.enabled:
+            pm = PairingManager(
+                config=pairing_config,
+                db_path=vault_dir / "pairing.db",
+                auth_store=stores.auth,
+            )
+            await pm.connect()
+            set_pairing_manager(pm)
+
+        # STT / TTS services (audio not over NATS in C4, but agent may still need them)
+        stt_service = init_stt(first_agent_config)
+        tts_service = init_tts(stt_service)
+
+        cli_pool_cfg = _load_cli_pool_config(raw_config)
+        hub_cfg = _load_hub_config(raw_config)
+        pool_cfg = _load_pool_config(raw_config)
+        llm_cfg = _load_llm_config(raw_config)
+        inbound_bus_cfg = _load_inbound_bus_config(raw_config)
+        debouncer_cfg = _load_debouncer_config(raw_config)
+        event_bus_cfg = _load_event_bus_config(raw_config)
+        event_bus = PipelineEventBus(maxsize=event_bus_cfg.queue_maxsize)
+
+        hub = Hub(
+            circuit_registry=circuit_registry,
+            msg_manager=msg_manager,
+            pairing_manager=pm,
+            stt=stt_service,
+            tts=tts_service,
+            debounce_ms=debouncer_cfg.default_debounce_ms,
+            cancel_on_new_message=debouncer_cfg.cancel_on_new_message,
+            prefs_store=stores.prefs,
+            turn_timeout=cli_pool_cfg.turn_timeout,
+            pool_ttl=hub_cfg.pool_ttl,
+            rate_limit=hub_cfg.rate_limit,
+            rate_window=hub_cfg.rate_window,
+            max_sdk_history=pool_cfg.max_sdk_history,
+            safe_dispatch_timeout=pool_cfg.safe_dispatch_timeout,
+            staging_maxsize=inbound_bus_cfg.staging_maxsize,
+            platform_queue_maxsize=inbound_bus_cfg.platform_queue_maxsize,
+            queue_depth_threshold=inbound_bus_cfg.queue_depth_threshold,
+            max_merged_chars=debouncer_cfg.max_merged_chars,
+            event_bus=event_bus,
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=inbound_audio_bus,
+        )
+        hub.set_turn_store(stores.turn)
+        hub.set_message_index(stores.message_index)
+
+        # Build cli_pool if any agent needs it
+        cli_pool: CliPool | None = None
+        for cfg in agent_configs.values():
+            if cfg.llm_config.backend == "claude-cli":
+                cli_pool = CliPool(
+                    idle_ttl=cli_pool_cfg.idle_ttl,
+                    default_timeout=cli_pool_cfg.default_timeout,
+                    reaper_interval=cli_pool_cfg.reaper_interval,
+                    kill_timeout=cli_pool_cfg.kill_timeout,
+                    read_buffer_bytes=cli_pool_cfg.read_buffer_bytes,
+                    stdin_drain_timeout=cli_pool_cfg.stdin_drain_timeout,
+                    max_idle_retries=cli_pool_cfg.max_idle_retries,
+                    intermediate_timeout=cli_pool_cfg.intermediate_timeout,
+                )
+                await cli_pool.start()
+                break
+        hub.cli_pool = cli_pool
+
+        # Create and register all agents
+        all_agents = _resolve_agents(
+            agent_configs,
+            cli_pool,
+            circuit_registry,
+            msg_manager,
+            stt_service,
+            tts_service,
+            agent_store=stores.agent,
+            llm_cfg=llm_cfg,
+        )
+        for ag in all_agents.values():
+            hub.register_agent(ag)
+
+        # Wire each (platform, bot_id) to a NatsChannelProxy + OutboundDispatcher
+        dispatchers: list[OutboundDispatcher] = []
+
+        for bot_cfg, auth in tg_bot_auths:
+            resolved_agent = bot_agent_map.get(("telegram", bot_cfg.bot_id))
+            if resolved_agent is None:
+                log.warning(
+                    "telegram bot_id=%r not in bot_agent_map — skipping",
+                    bot_cfg.bot_id,
+                )
+                continue
+
+            proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id=bot_cfg.bot_id)
+            hub.register_authenticator(Platform.TELEGRAM, bot_cfg.bot_id, auth)
+            hub.register_adapter(Platform.TELEGRAM, bot_cfg.bot_id, proxy)
+
+            from lyra.core.hub.hub_protocol import RoutingKey
+
+            tg_key = RoutingKey(Platform.TELEGRAM, bot_cfg.bot_id, "*")
+            hub.register_binding(
+                Platform.TELEGRAM,
+                bot_cfg.bot_id,
+                "*",
+                resolved_agent,
+                tg_key.to_pool_id(),
+            )
+
+            dispatcher = OutboundDispatcher(
+                platform_name="telegram",
+                adapter=proxy,
+                circuit=circuit_registry.get("telegram"),
+                circuit_registry=circuit_registry,
+                bot_id=bot_cfg.bot_id,
+            )
+            hub.register_outbound_dispatcher(Platform.TELEGRAM, bot_cfg.bot_id, dispatcher)
+            dispatchers.append(dispatcher)
+            log.info(
+                "Registered NATS proxy: telegram bot_id=%r agent=%r",
+                bot_cfg.bot_id,
+                resolved_agent,
+            )
+
+        for bot_cfg, auth in dc_bot_auths:
+            resolved_agent = bot_agent_map.get(("discord", bot_cfg.bot_id))
+            if resolved_agent is None:
+                log.warning(
+                    "discord bot_id=%r not in bot_agent_map — skipping",
+                    bot_cfg.bot_id,
+                )
+                continue
+
+            proxy = NatsChannelProxy(nc=nc, platform=Platform.DISCORD, bot_id=bot_cfg.bot_id)
+            hub.register_authenticator(Platform.DISCORD, bot_cfg.bot_id, auth)
+            hub.register_adapter(Platform.DISCORD, bot_cfg.bot_id, proxy)
+
+            from lyra.core.hub.hub_protocol import RoutingKey
+
+            dc_key = RoutingKey(Platform.DISCORD, bot_cfg.bot_id, "*")
+            hub.register_binding(
+                Platform.DISCORD,
+                bot_cfg.bot_id,
+                "*",
+                resolved_agent,
+                dc_key.to_pool_id(),
+            )
+
+            dispatcher = OutboundDispatcher(
+                platform_name="discord",
+                adapter=proxy,
+                circuit=circuit_registry.get("discord"),
+                circuit_registry=circuit_registry,
+                bot_id=bot_cfg.bot_id,
+            )
+            hub.register_outbound_dispatcher(Platform.DISCORD, bot_cfg.bot_id, dispatcher)
+            dispatchers.append(dispatcher)
+            log.info(
+                "Registered NATS proxy: discord bot_id=%r agent=%r",
+                bot_cfg.bot_id,
+                resolved_agent,
+            )
+
+        # Lifecycle: start buses, dispatchers, hub, health server
+        await hub.inbound_bus.start()
+        await hub.inbound_audio_bus.start()
+        for d in dispatchers:
+            await d.start()
+
+        import uvicorn
+
+        health_port = int(os.environ.get("LYRA_HEALTH_PORT", "8443"))
+        health_app = create_health_app(hub)
+        health_config = uvicorn.Config(
+            health_app, host="127.0.0.1", port=health_port, log_level="warning"
+        )
+        health_server = uvicorn.Server(health_config)
+
+        stop = _stop if _stop is not None else asyncio.Event()
+        if _stop is None:
+            setup_signal_handlers(stop)
+
+        from lyra.bootstrap.utils import watchdog
+
+        tasks = [
+            asyncio.create_task(hub.run(), name="hub"),
+            asyncio.create_task(hub._audio_pipeline.run(), name="hub-audio"),
+            asyncio.create_task(health_server.serve(), name="health"),
+        ]
+
+        if hub._event_bus is not None:
+            from lyra.core.hub.audit_consumer import AuditConsumer
+
+            _audit_queue = hub._event_bus.subscribe()
+            _audit_consumer = AuditConsumer(_audit_queue)
+            tasks.append(asyncio.create_task(_audit_consumer.run(), name="audit-consumer"))
+
+        active = (
+            [f"telegram:{c.bot_id}" for c, _ in tg_bot_auths]
+            + [f"discord:{c.bot_id}" for c, _ in dc_bot_auths]
+        )
+        log.info(
+            "Hub standalone started — NATS proxies: %s, health on :%d.",
+            ", ".join(active) if active else "none",
+            health_port,
+        )
+
+        await watchdog(tasks, stop)
+
+        log.info("Shutdown signal received — stopping...")
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await teardown_buses(hub.inbound_bus, hub.inbound_audio_bus)
+        await teardown_dispatchers(dispatchers)
+        if pm is not None:
+            await pm.close()
+        if cli_pool is not None:
+            await cli_pool.drain(timeout=60.0)
+            active_ids = cli_pool.get_active_pool_ids()
+            if active_ids:
+                await hub.notify_shutdown_inflight(active_ids)
+            await cli_pool.stop()
+
+    # Close NATS connection after stores context exits
+    try:
+        await nc.close()
+        log.info("NATS connection closed.")
+    except Exception as exc:
+        log.warning("Error closing NATS connection: %s", exc)
+
+    _release_lockfile()
+    log.info("Hub standalone stopped.")

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -6,7 +6,6 @@ import asyncio
 import atexit
 import logging
 import os
-import signal
 import sys
 from pathlib import Path
 
@@ -25,7 +24,6 @@ from lyra.bootstrap.config import (
     _load_messages,
     _load_pairing_config,
     _load_pool_config,
-    _load_raw_config,
     _load_circuit_config,
 )
 from lyra.bootstrap.health import create_health_app
@@ -37,14 +35,9 @@ from lyra.bootstrap.lifecycle_helpers import (
 from lyra.bootstrap.multibot_stores import open_stores
 from lyra.bootstrap.multibot_wiring import _build_bot_auths
 from lyra.bootstrap.voice_overlay import init_stt, init_tts
-from lyra.config import (
-    DiscordMultiConfig,
-    TelegramMultiConfig,
-    load_multibot_config,
-)
+from lyra.config import load_multibot_config
 from lyra.core.agent import Agent
 from lyra.core.agent_loader import agent_row_to_config
-from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.cli_pool import CliPool
 from lyra.core.hub import Hub
 from lyra.core.hub.event_bus import PipelineEventBus

--- a/src/lyra/bootstrap/lifecycle_helpers.py
+++ b/src/lyra/bootstrap/lifecycle_helpers.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
+from collections.abc import Sequence
+from typing import Any, Protocol
 
 log = logging.getLogger(__name__)
+
+
+class _Stoppable(Protocol):
+    async def stop(self) -> Any: ...
 
 
 def setup_signal_handlers(stop: asyncio.Event) -> None:
@@ -15,13 +21,13 @@ def setup_signal_handlers(stop: asyncio.Event) -> None:
     loop.add_signal_handler(signal.SIGTERM, stop.set)
 
 
-async def teardown_buses(*buses: object) -> None:
+async def teardown_buses(*buses: _Stoppable) -> None:
     """Stop all provided buses (Bus[T] instances)."""
     for bus in buses:
         await bus.stop()
 
 
-async def teardown_dispatchers(dispatchers: list) -> None:
+async def teardown_dispatchers(dispatchers: Sequence[_Stoppable]) -> None:
     """Stop all outbound dispatchers."""
     for d in dispatchers:
         await d.stop()

--- a/src/lyra/bootstrap/lifecycle_helpers.py
+++ b/src/lyra/bootstrap/lifecycle_helpers.py
@@ -1,0 +1,27 @@
+"""Shared lifecycle helpers for multibot and standalone Hub bootstrap."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+
+log = logging.getLogger(__name__)
+
+
+def setup_signal_handlers(stop: asyncio.Event) -> None:
+    """Register SIGINT/SIGTERM handlers on the running event loop."""
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGINT, stop.set)
+    loop.add_signal_handler(signal.SIGTERM, stop.set)
+
+
+async def teardown_buses(*buses: object) -> None:
+    """Stop all provided buses (Bus[T] instances)."""
+    for bus in buses:
+        await bus.stop()
+
+
+async def teardown_dispatchers(dispatchers: list) -> None:
+    """Stop all outbound dispatchers."""
+    for d in dispatchers:
+        await d.stop()

--- a/src/lyra/bootstrap/multibot_lifecycle.py
+++ b/src/lyra/bootstrap/multibot_lifecycle.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import signal
 
 import uvicorn
 
 from lyra.bootstrap.health import create_health_app
+from lyra.bootstrap.lifecycle_helpers import setup_signal_handlers, teardown_buses, teardown_dispatchers
 from lyra.core.cli_pool import CliPool
 from lyra.core.hub import Hub
 from lyra.core.stores.pairing import PairingManager
@@ -44,9 +44,7 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
 
     stop = _stop if _stop is not None else asyncio.Event()
     if _stop is None:
-        _loop = asyncio.get_running_loop()
-        _loop.add_signal_handler(signal.SIGINT, stop.set)
-        _loop.add_signal_handler(signal.SIGTERM, stop.set)
+        setup_signal_handlers(stop)
 
     from lyra.bootstrap.utils import watchdog
 
@@ -93,12 +91,8 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
     for task in tasks:
         task.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
-    await hub.inbound_bus.stop()
-    await hub.inbound_audio_bus.stop()
-    for d in tg_dispatchers:
-        await d.stop()
-    for d in dc_dispatchers:
-        await d.stop()
+    await teardown_buses(hub.inbound_bus, hub.inbound_audio_bus)
+    await teardown_dispatchers(tg_dispatchers + dc_dispatchers)
     for dc_adapter, _, _dc_tok in dc_adapters:
         await dc_adapter.close()
     if pm is not None:

--- a/src/lyra/cli.py
+++ b/src/lyra/cli.py
@@ -56,6 +56,29 @@ lyra_app.add_typer(config_app, name="config")
 lyra_app.add_typer(bot_app, name="bot")
 lyra_app.add_typer(setup_app, name="setup")
 
+hub_app = typer.Typer(name="hub", help="Run standalone Hub process (requires NATS).")
+lyra_app.add_typer(hub_app, name="hub")
+
+# ---------------------------------------------------------------------------
+# lyra hub
+# ---------------------------------------------------------------------------
+
+
+@hub_app.callback(invoke_without_command=True)
+def _hub_callback(ctx: typer.Context) -> None:
+    """Start the standalone Hub process connected to NATS."""
+    if ctx.invoked_subcommand is None:
+        _run_hub()
+
+
+def _run_hub() -> None:
+    from lyra.bootstrap.config import _load_raw_config
+    from lyra.bootstrap.hub_standalone import _bootstrap_hub_standalone
+
+    raw_config = _load_raw_config()
+    asyncio.run(_bootstrap_hub_standalone(raw_config))
+
+
 # ---------------------------------------------------------------------------
 # lyra (root)
 # ---------------------------------------------------------------------------

--- a/src/lyra/core/bus.py
+++ b/src/lyra/core/bus.py
@@ -31,8 +31,12 @@ class Bus(Protocol[T]):
     ``put(item: T)`` positions).
     """
 
-    def register(self, platform: Platform, maxsize: int = 100) -> None:
-        """Register a bounded queue for the given platform."""
+    def register(self, platform: Platform, maxsize: int = 100, bot_id: str | None = None) -> None:
+        """Register a bounded queue for the given platform.
+
+        bot_id is used by NatsBus to key subscriptions per (platform, bot_id).
+        LocalBus ignores it.
+        """
         ...
 
     async def put(self, platform: Platform, item: T) -> None:

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -88,14 +88,16 @@ class Hub(HubOutboundMixin):
         queue_depth_threshold: int = QUEUE_DEPTH_THRESHOLD,
         max_merged_chars: int = MAX_MERGED_CHARS,
         event_bus: "PipelineEventBus | None" = None,
+        inbound_bus: "Bus[InboundMessage] | None" = None,
+        inbound_audio_bus: "Bus[InboundAudio] | None" = None,
     ) -> None:
         self._platform_queue_maxsize = platform_queue_maxsize
-        self.inbound_bus: Bus[InboundMessage] = LocalBus(
+        self.inbound_bus: Bus[InboundMessage] = inbound_bus or LocalBus(
             name="inbound",
             staging_maxsize=staging_maxsize,
             queue_depth_threshold=queue_depth_threshold,
         )
-        self.inbound_audio_bus: Bus[InboundAudio] = LocalBus(
+        self.inbound_audio_bus: Bus[InboundAudio] = inbound_audio_bus or LocalBus(
             name="inbound-audio",
             staging_maxsize=staging_maxsize,
             queue_depth_threshold=queue_depth_threshold,
@@ -172,10 +174,10 @@ class Hub(HubOutboundMixin):
     ) -> None:
         self.adapter_registry[(platform, bot_id)] = adapter
         if platform not in self.inbound_bus.registered_platforms():
-            self.inbound_bus.register(platform, maxsize=self._platform_queue_maxsize)
+            self.inbound_bus.register(platform, maxsize=self._platform_queue_maxsize, bot_id=bot_id)
         if platform not in self.inbound_audio_bus.registered_platforms():
             self.inbound_audio_bus.register(
-                platform, maxsize=self._platform_queue_maxsize
+                platform, maxsize=self._platform_queue_maxsize, bot_id=bot_id
             )
 
     def register_outbound_dispatcher(

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -173,12 +173,10 @@ class Hub(HubOutboundMixin):
         adapter: ChannelAdapter,
     ) -> None:
         self.adapter_registry[(platform, bot_id)] = adapter
-        if platform not in self.inbound_bus.registered_platforms():
-            self.inbound_bus.register(platform, maxsize=self._platform_queue_maxsize, bot_id=bot_id)
-        if platform not in self.inbound_audio_bus.registered_platforms():
-            self.inbound_audio_bus.register(
-                platform, maxsize=self._platform_queue_maxsize, bot_id=bot_id
-            )
+        self.inbound_bus.register(platform, maxsize=self._platform_queue_maxsize, bot_id=bot_id)
+        self.inbound_audio_bus.register(
+            platform, maxsize=self._platform_queue_maxsize, bot_id=bot_id
+        )
 
     def register_outbound_dispatcher(
         self,

--- a/src/lyra/core/inbound_bus.py
+++ b/src/lyra/core/inbound_bus.py
@@ -72,12 +72,14 @@ class LocalBus(Generic[T]):
         self._threshold = queue_depth_threshold
         self._depth_exceeded = False
 
-    def register(self, platform: Platform, maxsize: int = 100) -> None:
+    def register(self, platform: Platform, maxsize: int = 100, bot_id: str | None = None) -> None:  # noqa: ARG002
         """Register a bounded queue for the given platform.
 
         Must be called before start(). Raises RuntimeError if called after
         start() — the new queue would have no feeder task and messages would
         silently never reach staging.
+
+        bot_id is accepted for protocol compatibility but ignored by LocalBus.
         """
         if self._feeders:
             raise RuntimeError(

--- a/src/lyra/core/inbound_bus.py
+++ b/src/lyra/core/inbound_bus.py
@@ -86,6 +86,8 @@ class LocalBus(Generic[T]):
                 f"Cannot register platform {platform!r} after start() — "
                 "feeders are already running."
             )
+        if platform in self._queues:
+            return  # Already registered — idempotent for multi-bot
         self._queues[platform] = asyncio.Queue(maxsize=maxsize)
 
     async def put(self, platform: Platform, item: T) -> None:

--- a/src/lyra/nats/__init__.py
+++ b/src/lyra/nats/__init__.py
@@ -20,5 +20,6 @@ Usage::
     await bus.stop()
 """
 from .nats_bus import NatsBus
+from .nats_channel_proxy import NatsChannelProxy
 
-__all__ = ["NatsBus"]
+__all__ = ["NatsBus", "NatsChannelProxy"]

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -3,8 +3,8 @@
 Concrete implementation of the ``Bus[T]`` Protocol defined in ``bus.py``,
 using NATS as the transport layer instead of local asyncio queues.
 
-Each registered platform maps to one NATS subscription on the subject
-``lyra.inbound.{platform.value}.{bot_id}``.  Inbound messages are
+Each registered (platform, bot_id) pair maps to one NATS subscription on the
+subject ``lyra.inbound.{platform.value}.{bot_id}``.  Inbound messages are
 deserialized from JSON and placed into a single staging queue consumed
 by Hub.run().
 
@@ -21,6 +21,12 @@ Usage::
     ...
     await bus.stop()
     await nc.close()
+
+Multi-bot usage::
+
+    bus.register(Platform.TELEGRAM, bot_id="bot-a")
+    bus.register(Platform.TELEGRAM, bot_id="bot-b")
+    await bus.start()  # two subscriptions: one per (platform, bot_id) pair
 """
 
 from __future__ import annotations
@@ -55,12 +61,13 @@ class NatsBus(Generic[T]):
         bus.register(Platform.TELEGRAM)
         await bus.start()   # creates NATS subscriptions
         ...
-        await bus.stop()    # unsubscribes; platforms remain registered
+        await bus.stop()    # unsubscribes; registrations remain intact
         await bus.start()   # safe to restart without re-registering
 
     Args:
         nc: Already-connected ``nats.NATS`` client.
-        bot_id: Bot identifier appended to the NATS subject.
+        bot_id: Default bot identifier used when ``register()`` is called
+            without an explicit ``bot_id``.
         item_type: Concrete type used for deserialization (e.g. ``InboundMessage``).
     """
 
@@ -68,19 +75,22 @@ class NatsBus(Generic[T]):
         self._nc = nc
         self._bot_id = bot_id
         self._item_type = item_type
-        self._platforms: set[Platform] = set()
-        self._subscriptions: dict[Platform, Subscription] = {}
+        self._registrations: set[tuple[Platform, str]] = set()
+        self._subscriptions: dict[tuple[Platform, str], Subscription] = {}
         self._staging: asyncio.Queue[T] = asyncio.Queue(maxsize=500)
 
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
 
-    def register(self, platform: Platform, maxsize: int = 100) -> None:  # noqa: ARG002
-        """Record *platform* for subscription setup.
+    def register(self, platform: Platform, maxsize: int = 100, bot_id: str | None = None) -> None:  # noqa: ARG002
+        """Record *(platform, bot_id)* for subscription setup.
 
         ``maxsize`` is accepted for Protocol compatibility but unused — there
         is no per-platform local buffer in NatsBus.
+
+        When ``bot_id`` is omitted or ``None``, the constructor's ``bot_id``
+        is used, preserving backward compatibility.
 
         Raises:
             RuntimeError: If called after ``start()``.
@@ -90,18 +100,19 @@ class NatsBus(Generic[T]):
                 f"Cannot register platform {platform!r} after start() — "
                 "subscriptions are already active."
             )
-        self._platforms.add(platform)
+        resolved_bid = bot_id or self._bot_id
+        self._registrations.add((platform, resolved_bid))
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
-        """Create one NATS subscription per registered platform.
+        """Create one NATS subscription per registered (platform, bot_id) pair.
 
         Subject pattern: ``lyra.inbound.{platform.value}.{bot_id}``
 
-        No-op if zero platforms are registered.
+        No-op if zero registrations exist.
 
         Raises:
             RuntimeError: If subscriptions are already active (double-start).
@@ -111,14 +122,14 @@ class NatsBus(Generic[T]):
                 "NatsBus.start() called while subscriptions are already active — "
                 "call stop() first."
             )
-        for platform in self._platforms:
-            await self._make_handler(platform)
+        for platform, bid in self._registrations:
+            await self._make_handler(platform, bid)
 
     async def stop(self) -> None:
         """Unsubscribe all active NATS subscriptions.
 
-        Registered platforms are preserved so that a subsequent ``start()``
-        succeeds without re-registering.
+        Registered (platform, bot_id) pairs are preserved so that a subsequent
+        ``start()`` succeeds without re-registering.
         """
         for sub in self._subscriptions.values():
             try:
@@ -134,14 +145,18 @@ class NatsBus(Generic[T]):
     async def put(self, platform: Platform, item: T) -> None:
         """Serialize *item* and publish it to the platform's NATS subject.
 
+        Uses the first matching registration's bot_id for the subject.
+
         Raises:
             KeyError: If *platform* has not been registered.
         """
-        if platform not in self._platforms:
+        registered_platforms = frozenset(p for p, _ in self._registrations)
+        if platform not in registered_platforms:
             raise KeyError(
                 f"Platform {platform!r} is not registered — call register() first."
             )
-        subject = f"lyra.inbound.{platform.value}.{self._bot_id}"
+        bid = next((b for p, b in self._registrations if p == platform), self._bot_id)
+        subject = f"lyra.inbound.{platform.value}.{bid}"
         payload = serialize(item)
         await self._nc.publish(subject, payload)
 
@@ -167,17 +182,15 @@ class NatsBus(Generic[T]):
 
     def registered_platforms(self) -> frozenset[Platform]:
         """Return the set of currently registered platforms."""
-        return frozenset(self._platforms)
+        return frozenset(p for p, _ in self._registrations)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _make_handler(
-        self, platform: Platform
-    ) -> None:
-        """Create NATS subscription for *platform* and register the handler."""
-        subject = f"lyra.inbound.{platform.value}.{self._bot_id}"
+    async def _make_handler(self, platform: Platform, bot_id: str) -> None:
+        """Create NATS subscription for *(platform, bot_id)* and register the handler."""
+        subject = f"lyra.inbound.{platform.value}.{bot_id}"
 
         async def handler(msg: Msg) -> None:
             try:
@@ -185,15 +198,17 @@ class NatsBus(Generic[T]):
                 self._staging.put_nowait(item)
             except asyncio.QueueFull:
                 log.warning(
-                    "NatsBus staging queue full — dropping message on platform=%s",
+                    "NatsBus staging queue full — dropping message on platform=%s bot_id=%s",
                     platform.value,
+                    bot_id,
                 )
             except Exception:
                 log.exception(
-                    "NatsBus: failed to deserialize message on platform=%s",
+                    "NatsBus: failed to deserialize message on platform=%s bot_id=%s",
                     platform.value,
+                    bot_id,
                 )
 
         sub = await self._nc.subscribe(subject, cb=handler)
-        self._subscriptions[platform] = sub
-        log.debug("NatsBus subscribed: subject=%s bot_id=%s", subject, self._bot_id)
+        self._subscriptions[(platform, bot_id)] = sub
+        log.debug("NatsBus subscribed: subject=%s bot_id=%s", subject, bot_id)

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import Generic, TypeVar
 
 from nats.aio.client import Client as NATS
@@ -101,6 +102,13 @@ class NatsBus(Generic[T]):
                 "subscriptions are already active."
             )
         resolved_bid = bot_id or self._bot_id
+        if not re.fullmatch(r'[A-Za-z0-9_-]+', resolved_bid):
+            raise ValueError(
+                f"Invalid bot_id for NATS subject: {resolved_bid!r} — "
+                "must match [A-Za-z0-9_-]+"
+            )
+        if (platform, resolved_bid) in self._registrations:
+            return  # Already registered — idempotent
         self._registrations.add((platform, resolved_bid))
 
     # ------------------------------------------------------------------

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -27,6 +28,13 @@ from lyra.nats._serialize import serialize
 
 log = logging.getLogger(__name__)
 
+_NATS_UNSAFE = re.compile(r'[.*> ]')
+
+
+def _safe_subject_token(value: str) -> str:
+    """Sanitize a value for use as a NATS subject token."""
+    return _NATS_UNSAFE.sub('_', value)
+
 
 class NatsChannelProxy:
     """ChannelAdapter that publishes outbound messages to NATS subjects.
@@ -39,6 +47,11 @@ class NatsChannelProxy:
 
     def __init__(self, nc: NATS, platform: Platform, bot_id: str) -> None:
         """Store nc, platform, bot_id. No I/O."""
+        if not re.fullmatch(r'[A-Za-z0-9_-]+', bot_id):
+            raise ValueError(
+                f"Invalid bot_id for NATS subject: {bot_id!r} — "
+                "must match [A-Za-z0-9_-]+"
+            )
         self._nc = nc
         self._platform = platform
         self._bot_id = bot_id
@@ -87,7 +100,7 @@ class NatsChannelProxy:
     ) -> None:
         """Publish streaming render events to NATS as chunked messages."""
         subject = (
-            f"lyra.outbound.stream.{self._platform.value}.{self._bot_id}.{original_msg.id}"
+            f"lyra.outbound.stream.{self._platform.value}.{self._bot_id}.{_safe_subject_token(original_msg.id)}"
         )
         seq = 0
         try:

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -1,0 +1,174 @@
+"""NatsChannelProxy — ChannelAdapter implementation over NATS.
+
+Publishes outbound messages to NATS subjects instead of calling platform SDKs.
+Used by the standalone Hub process to dispatch responses to remote adapters.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from nats.aio.client import Client as NATS
+
+from lyra.core.message import (
+    InboundAudio,
+    InboundMessage,
+    OutboundAttachment,
+    OutboundAudio,
+    OutboundAudioChunk,
+    OutboundMessage,
+    Platform,
+)
+from lyra.core.render_events import RenderEvent, TextRenderEvent
+from lyra.core.trust import TrustLevel
+from lyra.nats._serialize import serialize
+
+log = logging.getLogger(__name__)
+
+
+class NatsChannelProxy:
+    """ChannelAdapter that publishes outbound messages to NATS subjects.
+
+    Implements the ChannelAdapter Protocol from hub_protocol.py.
+    Inbound normalization is not supported — raises NotImplementedError.
+    Audio-over-NATS (C5) is not yet implemented — audio methods log a warning
+    and drain iterators without publishing.
+    """
+
+    def __init__(self, nc: NATS, platform: Platform, bot_id: str) -> None:
+        """Store nc, platform, bot_id. No I/O."""
+        self._nc = nc
+        self._platform = platform
+        self._bot_id = bot_id
+
+    # ------------------------------------------------------------------
+    # Inbound normalization — not supported by this proxy
+    # ------------------------------------------------------------------
+
+    def normalize(self, raw: Any) -> InboundMessage:
+        raise NotImplementedError(
+            "NatsChannelProxy does not normalize inbound messages"
+        )
+
+    def normalize_audio(
+        self,
+        raw: Any,
+        audio_bytes: bytes,
+        mime_type: str,
+        *,
+        trust_level: TrustLevel,
+    ) -> InboundAudio:
+        raise NotImplementedError("NatsChannelProxy does not normalize inbound audio")
+
+    # ------------------------------------------------------------------
+    # Outbound dispatch
+    # ------------------------------------------------------------------
+
+    async def send(
+        self, original_msg: InboundMessage, outbound: OutboundMessage
+    ) -> None:
+        """Publish an outbound text message to NATS."""
+        subject = f"lyra.outbound.{self._platform.value}.{self._bot_id}"
+        envelope = {
+            "type": "outbound",
+            "msg_id": original_msg.id,
+            "outbound": json.loads(serialize(outbound).decode("utf-8")),
+        }
+        payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+        await self._nc.publish(subject, payload)
+
+    async def send_streaming(
+        self,
+        original_msg: InboundMessage,
+        events: AsyncIterator[RenderEvent],
+        outbound: OutboundMessage | None = None,
+    ) -> None:
+        """Publish streaming render events to NATS as chunked messages."""
+        subject = (
+            f"lyra.outbound.stream.{self._platform.value}.{self._bot_id}.{original_msg.id}"
+        )
+        seq = 0
+        try:
+            async for event in events:
+                event_type = (
+                    "text" if isinstance(event, TextRenderEvent) else "tool_summary"
+                )
+                chunk = {
+                    "type": "stream_chunk",
+                    "msg_id": original_msg.id,
+                    "seq": seq,
+                    "event_type": event_type,
+                    "payload": json.loads(serialize(event).decode("utf-8")),
+                    "done": (
+                        getattr(event, "is_final", False)
+                        or getattr(event, "is_complete", False)
+                    ),
+                }
+                await self._nc.publish(
+                    subject,
+                    json.dumps(chunk, ensure_ascii=False).encode("utf-8"),
+                )
+                seq += 1
+        except Exception:
+            log.exception(
+                "NatsChannelProxy: NATS publish failed during streaming,"
+                " draining iterator"
+            )
+            async for _ in events:
+                pass
+
+    # ------------------------------------------------------------------
+    # Audio — not yet implemented (C5)
+    # ------------------------------------------------------------------
+
+    async def render_audio(self, msg: OutboundAudio, inbound: InboundMessage) -> None:
+        """Audio-over-NATS not implemented (C5) — drops audio silently."""
+        log.warning(
+            "audio-over-NATS not implemented (C5) — dropping audio for msg %s",
+            inbound.id,
+        )
+
+    async def render_audio_stream(
+        self,
+        chunks: AsyncIterator[OutboundAudioChunk],
+        inbound: InboundMessage,
+    ) -> None:
+        """Audio streaming not implemented (C5) — drains iterator."""
+        log.warning(
+            "audio-over-NATS not implemented (C5) — dropping audio stream for msg %s",
+            inbound.id,
+        )
+        async for _ in chunks:
+            pass
+
+    async def render_voice_stream(
+        self,
+        chunks: AsyncIterator[OutboundAudioChunk],
+        inbound: InboundMessage,
+    ) -> None:
+        """Voice streaming not implemented (C5) — drains iterator."""
+        log.warning(
+            "audio-over-NATS not implemented (C5) — dropping voice stream for msg %s",
+            inbound.id,
+        )
+        async for _ in chunks:
+            pass
+
+    # ------------------------------------------------------------------
+    # Attachment dispatch
+    # ------------------------------------------------------------------
+
+    async def render_attachment(
+        self, msg: OutboundAttachment, inbound: InboundMessage
+    ) -> None:
+        """Publish an outbound attachment to NATS."""
+        subject = f"lyra.outbound.{self._platform.value}.{self._bot_id}"
+        envelope = {
+            "type": "attachment",
+            "msg_id": inbound.id,
+            "attachment": json.loads(serialize(msg).decode("utf-8")),
+        }
+        payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+        await self._nc.publish(subject, payload)

--- a/tests/bootstrap/test_lifecycle_helpers.py
+++ b/tests/bootstrap/test_lifecycle_helpers.py
@@ -1,0 +1,100 @@
+"""Tests for shared lifecycle helpers."""
+from __future__ import annotations
+
+import asyncio
+import signal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lyra.bootstrap.lifecycle_helpers import (
+    setup_signal_handlers,
+    teardown_buses,
+    teardown_dispatchers,
+)
+
+
+def test_setup_signal_handlers_registers_sigint_and_sigterm() -> None:
+    """setup_signal_handlers registers handlers for both SIGINT and SIGTERM."""
+    mock_loop = MagicMock()
+    stop = asyncio.Event()
+
+    with patch("lyra.bootstrap.lifecycle_helpers.asyncio.get_running_loop", return_value=mock_loop):
+        setup_signal_handlers(stop)
+
+    calls = mock_loop.add_signal_handler.call_args_list
+    signals_registered = {c.args[0] for c in calls}
+    assert signal.SIGINT in signals_registered
+    assert signal.SIGTERM in signals_registered
+
+
+def test_setup_signal_handlers_uses_stop_event() -> None:
+    """setup_signal_handlers wires the stop event's set method as the callback."""
+    mock_loop = MagicMock()
+    stop = asyncio.Event()
+
+    with patch("lyra.bootstrap.lifecycle_helpers.asyncio.get_running_loop", return_value=mock_loop):
+        setup_signal_handlers(stop)
+
+    for call in mock_loop.add_signal_handler.call_args_list:
+        callback = call.args[1]
+        assert callback == stop.set
+
+
+@pytest.mark.asyncio
+async def test_teardown_buses_calls_stop_on_each_bus() -> None:
+    """teardown_buses calls .stop() on every bus passed in."""
+    bus_a = AsyncMock()
+    bus_b = AsyncMock()
+
+    await teardown_buses(bus_a, bus_b)
+
+    bus_a.stop.assert_awaited_once()
+    bus_b.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_teardown_buses_no_buses_is_a_noop() -> None:
+    """teardown_buses with no arguments completes without error."""
+    await teardown_buses()
+
+
+@pytest.mark.asyncio
+async def test_teardown_dispatchers_calls_stop_on_each_dispatcher() -> None:
+    """teardown_dispatchers calls .stop() on every dispatcher passed in."""
+    d1 = AsyncMock()
+    d2 = AsyncMock()
+    d3 = AsyncMock()
+
+    await teardown_dispatchers([d1, d2, d3])
+
+    d1.stop.assert_awaited_once()
+    d2.stop.assert_awaited_once()
+    d3.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_teardown_dispatchers_empty_list_is_a_noop() -> None:
+    """teardown_dispatchers with an empty list completes without error."""
+    await teardown_dispatchers([])
+
+
+@pytest.mark.asyncio
+async def test_teardown_dispatchers_stop_order_matches_input() -> None:
+    """teardown_dispatchers stops dispatchers in the order they are provided."""
+    call_order: list[str] = []
+
+    async def stop_d1() -> None:
+        call_order.append("d1")
+
+    async def stop_d2() -> None:
+        call_order.append("d2")
+
+    d1 = MagicMock()
+    d1.stop = stop_d1
+    d2 = MagicMock()
+    d2.stop = stop_d2
+
+    await teardown_dispatchers([d1, d2])
+
+    assert call_order == ["d1", "d2"]

--- a/tests/core/test_bus_injection.py
+++ b/tests/core/test_bus_injection.py
@@ -1,0 +1,146 @@
+"""Tests for Hub bus injection and bot_id propagation to Bus.register()."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from lyra.core.bus import Bus
+from lyra.core.hub import Hub
+from lyra.core.inbound_bus import LocalBus
+from lyra.core.message import InboundAudio, InboundMessage, Platform
+from tests.core.conftest import MockAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_bus() -> MagicMock:
+    """Return a MagicMock that satisfies the Bus[T] Protocol."""
+    bus = MagicMock(spec=Bus)
+    bus.registered_platforms.return_value = frozenset()
+    return bus
+
+
+# ---------------------------------------------------------------------------
+# Default construction — LocalBus created internally
+# ---------------------------------------------------------------------------
+
+
+class TestHubDefaultBus:
+    def test_default_inbound_bus_is_local_bus(self) -> None:
+        hub = Hub()
+        assert isinstance(hub.inbound_bus, LocalBus)
+
+    def test_default_inbound_audio_bus_is_local_bus(self) -> None:
+        hub = Hub()
+        assert isinstance(hub.inbound_audio_bus, LocalBus)
+
+    def test_two_default_buses_are_distinct_instances(self) -> None:
+        hub = Hub()
+        assert hub.inbound_bus is not hub.inbound_audio_bus
+
+    def test_no_bus_args_backward_compat(self) -> None:
+        """Hub() with no bus args must work identically to before the change."""
+        hub = Hub()
+        hub.register_adapter(Platform.TELEGRAM, "main", MockAdapter())
+        assert Platform.TELEGRAM in hub.inbound_bus.registered_platforms()
+        assert Platform.TELEGRAM in hub.inbound_audio_bus.registered_platforms()
+
+
+# ---------------------------------------------------------------------------
+# Injected bus — Hub uses the provided instance
+# ---------------------------------------------------------------------------
+
+
+class TestHubInjectedBus:
+    def test_injected_inbound_bus_is_used(self) -> None:
+        mock_bus: Any = _make_mock_bus()
+        hub = Hub(inbound_bus=mock_bus)
+        assert hub.inbound_bus is mock_bus
+
+    def test_injected_inbound_audio_bus_is_used(self) -> None:
+        mock_audio_bus: Any = _make_mock_bus()
+        hub = Hub(inbound_audio_bus=mock_audio_bus)
+        assert hub.inbound_audio_bus is mock_audio_bus
+
+    def test_injected_bus_not_overwritten_by_local_bus(self) -> None:
+        mock_bus: Any = _make_mock_bus()
+        hub = Hub(inbound_bus=mock_bus)
+        # Must remain the injected instance — not replaced by a LocalBus
+        assert not isinstance(hub.inbound_bus, LocalBus)
+
+    def test_both_buses_injected_independently(self) -> None:
+        mock_bus: Any = _make_mock_bus()
+        mock_audio_bus: Any = _make_mock_bus()
+        hub = Hub(inbound_bus=mock_bus, inbound_audio_bus=mock_audio_bus)
+        assert hub.inbound_bus is mock_bus
+        assert hub.inbound_audio_bus is mock_audio_bus
+
+
+# ---------------------------------------------------------------------------
+# register_adapter passes bot_id to bus.register()
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAdapterBotId:
+    def test_register_passes_bot_id_to_inbound_bus(self) -> None:
+        mock_bus: Any = _make_mock_bus()
+        hub = Hub(inbound_bus=mock_bus)
+        hub.register_adapter(Platform.TELEGRAM, "mybot", MockAdapter())
+        mock_bus.register.assert_called_once_with(
+            Platform.TELEGRAM,
+            maxsize=Hub.PLATFORM_QUEUE_MAXSIZE,
+            bot_id="mybot",
+        )
+
+    def test_register_passes_bot_id_to_inbound_audio_bus(self) -> None:
+        mock_audio_bus: Any = _make_mock_bus()
+        hub = Hub(inbound_audio_bus=mock_audio_bus)
+        hub.register_adapter(Platform.TELEGRAM, "audiobot", MockAdapter())
+        mock_audio_bus.register.assert_called_once_with(
+            Platform.TELEGRAM,
+            maxsize=Hub.PLATFORM_QUEUE_MAXSIZE,
+            bot_id="audiobot",
+        )
+
+    def test_register_skipped_if_platform_already_registered(self) -> None:
+        mock_bus: Any = _make_mock_bus()
+        # Simulate platform already registered so the guard short-circuits.
+        mock_bus.registered_platforms.return_value = frozenset({Platform.TELEGRAM})
+        hub = Hub(inbound_bus=mock_bus)
+        hub.register_adapter(Platform.TELEGRAM, "bot1", MockAdapter())
+        mock_bus.register.assert_not_called()
+
+    def test_second_bot_same_platform_does_not_re_register(self) -> None:
+        """Only the first register_adapter call per platform triggers bus.register()."""
+        hub = Hub()
+        hub.register_adapter(Platform.TELEGRAM, "bot1", MockAdapter())
+        # Registering a second bot on the same platform must NOT call register()
+        # again (the guard checks registered_platforms).
+        platforms_before = set(hub.inbound_bus.registered_platforms())
+        hub.register_adapter(Platform.TELEGRAM, "bot2", MockAdapter())
+        platforms_after = set(hub.inbound_bus.registered_platforms())
+        assert platforms_before == platforms_after
+
+
+# ---------------------------------------------------------------------------
+# LocalBus.register accepts and ignores bot_id
+# ---------------------------------------------------------------------------
+
+
+class TestLocalBusRegisterBotId:
+    def test_local_bus_accepts_bot_id_kwarg(self) -> None:
+        bus: LocalBus[InboundMessage] = LocalBus(name="test")
+        # Must not raise when bot_id is supplied.
+        bus.register(Platform.TELEGRAM, maxsize=50, bot_id="anybot")
+        assert Platform.TELEGRAM in bus.registered_platforms()
+
+    def test_local_bus_bot_id_none_works(self) -> None:
+        bus: LocalBus[InboundMessage] = LocalBus(name="test")
+        bus.register(Platform.DISCORD, bot_id=None)
+        assert Platform.DISCORD in bus.registered_platforms()

--- a/tests/core/test_bus_injection.py
+++ b/tests/core/test_bus_injection.py
@@ -108,24 +108,30 @@ class TestRegisterAdapterBotId:
             bot_id="audiobot",
         )
 
-    def test_register_skipped_if_platform_already_registered(self) -> None:
+    def test_register_always_called_bus_handles_idempotency(self) -> None:
         mock_bus: Any = _make_mock_bus()
-        # Simulate platform already registered so the guard short-circuits.
-        mock_bus.registered_platforms.return_value = frozenset({Platform.TELEGRAM})
+        hub = Hub(inbound_bus=mock_bus)
+        # Hub always calls register(); Bus is responsible for idempotency.
+        hub.register_adapter(Platform.TELEGRAM, "bot1", MockAdapter())
+        mock_bus.register.assert_called_once_with(
+            Platform.TELEGRAM,
+            maxsize=Hub.PLATFORM_QUEUE_MAXSIZE,
+            bot_id="bot1",
+        )
+
+    def test_second_bot_same_platform_calls_register_twice(self) -> None:
+        """Hub always calls bus.register() — Bus handles idempotency internally."""
+        mock_bus: Any = _make_mock_bus()
         hub = Hub(inbound_bus=mock_bus)
         hub.register_adapter(Platform.TELEGRAM, "bot1", MockAdapter())
-        mock_bus.register.assert_not_called()
-
-    def test_second_bot_same_platform_does_not_re_register(self) -> None:
-        """Only the first register_adapter call per platform triggers bus.register()."""
-        hub = Hub()
-        hub.register_adapter(Platform.TELEGRAM, "bot1", MockAdapter())
-        # Registering a second bot on the same platform must NOT call register()
-        # again (the guard checks registered_platforms).
-        platforms_before = set(hub.inbound_bus.registered_platforms())
         hub.register_adapter(Platform.TELEGRAM, "bot2", MockAdapter())
-        platforms_after = set(hub.inbound_bus.registered_platforms())
-        assert platforms_before == platforms_after
+        assert mock_bus.register.call_count == 2
+        mock_bus.register.assert_any_call(
+            Platform.TELEGRAM, maxsize=Hub.PLATFORM_QUEUE_MAXSIZE, bot_id="bot1"
+        )
+        mock_bus.register.assert_any_call(
+            Platform.TELEGRAM, maxsize=Hub.PLATFORM_QUEUE_MAXSIZE, bot_id="bot2"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nats/test_hub_standalone.py
+++ b/tests/nats/test_hub_standalone.py
@@ -1,0 +1,207 @@
+"""Integration tests for hub_standalone bootstrap helpers.
+
+Covers:
+- NATS_URL guard (SystemExit when env var missing)
+- Lockfile lifecycle (acquire / release / stale PID / live PID block)
+- Health endpoint basic response (no NATS required)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import lyra.bootstrap.hub_standalone as _hub_standalone_mod
+from lyra.bootstrap.hub_standalone import _acquire_lockfile, _release_lockfile
+
+
+# ---------------------------------------------------------------------------
+# test_nats_url_guard_missing
+# ---------------------------------------------------------------------------
+
+
+class TestNatsUrlGuard:
+    async def test_nats_url_guard_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """_bootstrap_hub_standalone exits with SystemExit when NATS_URL is not set."""
+        # Arrange
+        monkeypatch.delenv("NATS_URL", raising=False)
+        raw_config = _test_config()
+
+        # Act / Assert — must exit before touching NATS
+        from lyra.bootstrap.hub_standalone import _bootstrap_hub_standalone
+
+        with pytest.raises(SystemExit) as exc_info:
+            await _bootstrap_hub_standalone(raw_config)
+
+        assert exc_info.value.code is not None
+        assert "NATS_URL" in str(exc_info.value.code)
+
+
+# ---------------------------------------------------------------------------
+# test_lockfile_created_and_cleaned
+# ---------------------------------------------------------------------------
+
+
+class TestLockfileLifecycle:
+    def test_lockfile_created_and_cleaned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_acquire_lockfile writes PID; _release_lockfile removes the file."""
+        # Arrange — redirect _LOCKFILE to a temp path
+        lockfile = tmp_path / "hub.lock"
+        monkeypatch.setattr(_hub_standalone_mod, "_LOCKFILE", lockfile)
+
+        # Act — acquire
+        _acquire_lockfile()
+
+        # Assert — file exists with correct PID
+        assert lockfile.exists(), "Lockfile should be created by _acquire_lockfile()"
+        assert lockfile.read_text().strip() == str(os.getpid())
+
+        # Act — release
+        _release_lockfile()
+
+        # Assert — file is gone
+        assert not lockfile.exists(), "Lockfile should be removed by _release_lockfile()"
+
+    def test_lockfile_blocks_second_instance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_acquire_lockfile exits when the lockfile holds a live PID."""
+        # Arrange — write our own PID (we are alive)
+        lockfile = tmp_path / "hub.lock"
+        lockfile.write_text(str(os.getpid()))
+        monkeypatch.setattr(_hub_standalone_mod, "_LOCKFILE", lockfile)
+
+        # Act / Assert — should sys.exit because PID is alive
+        with pytest.raises(SystemExit) as exc_info:
+            _acquire_lockfile()
+
+        assert exc_info.value.code is not None
+        # Message should mention the PID and lockfile path
+        message = str(exc_info.value.code)
+        assert str(os.getpid()) in message or "already running" in message
+
+    def test_lockfile_overwrites_stale_pid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_acquire_lockfile overwrites a lockfile holding a dead PID."""
+        # Arrange — write an impossibly high PID (guaranteed dead on Linux)
+        lockfile = tmp_path / "hub.lock"
+        dead_pid = 99999999
+        lockfile.write_text(str(dead_pid))
+        monkeypatch.setattr(_hub_standalone_mod, "_LOCKFILE", lockfile)
+
+        # Act — should NOT raise; stale lockfile is safe to overwrite
+        _acquire_lockfile()
+
+        # Assert — lockfile now holds current PID
+        assert lockfile.exists()
+        assert lockfile.read_text().strip() == str(os.getpid())
+
+        # Cleanup
+        _release_lockfile()
+
+
+# ---------------------------------------------------------------------------
+# test_health_endpoint_includes_adapters
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    async def test_health_endpoint_ok(self) -> None:
+        """GET /health returns 200 ok=True without auth."""
+        # Arrange
+        import httpx
+
+        from lyra.bootstrap.health import create_health_app
+        from lyra.core.hub import Hub
+
+        hub = Hub()
+        app = create_health_app(hub)
+
+        # Act
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/health")
+
+        # Assert
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("ok") is True
+
+    async def test_health_detail_includes_adapters_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GET /health/detail returns a dict with 'adapters' key when auth passes."""
+        # Arrange — write a known health secret to tmp_path
+        import httpx
+
+        from lyra.bootstrap.health import create_health_app
+        from lyra.core.hub import Hub
+
+        secret = "test-secret-abc"
+        secret_dir = tmp_path / ".lyra" / "secrets"
+        secret_dir.mkdir(parents=True)
+        (secret_dir / "health_secret").write_text(secret)
+
+        # Patch Path.home() so _read_secret picks up our temp secret
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        hub = Hub()
+        app = create_health_app(hub)
+
+        # Act
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/health/detail", headers={"Authorization": f"Bearer {secret}"}
+            )
+
+        # Assert
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "adapters" in body, f"Expected 'adapters' key in health detail; got {body}"
+        assert isinstance(body["adapters"], int)
+
+    async def test_health_detail_unauthorized_without_secret(self) -> None:
+        """GET /health/detail returns 401 when Authorization header is absent."""
+        # Arrange
+        import httpx
+
+        from lyra.bootstrap.health import create_health_app
+        from lyra.core.hub import Hub
+
+        hub = Hub()
+        app = create_health_app(hub)
+
+        # Act
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/health/detail")
+
+        # Assert
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _test_config() -> dict:
+    """Minimal config dict that mirrors the structure of config.toml."""
+    return {
+        "defaults": {"cwd": "/tmp"},
+        "admin": {"user_ids": ["test_admin"]},
+        "telegram": {"bots": [{"bot_id": "test_bot", "agent": "test_agent"}]},
+        "discord": {"bots": []},
+        "auth": {
+            "telegram_bots": [{"bot_id": "test_bot", "owner_id": "test_admin"}]
+        },
+    }

--- a/tests/nats/test_hub_standalone.py
+++ b/tests/nats/test_hub_standalone.py
@@ -12,9 +12,11 @@ import sys
 from pathlib import Path
 
 import pytest
+from nats.aio.client import Client as NATS
 
 import lyra.bootstrap.hub_standalone as _hub_standalone_mod
 from lyra.bootstrap.hub_standalone import _acquire_lockfile, _release_lockfile
+from tests.nats.conftest import requires_nats_server
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +189,187 @@ class TestHealthEndpoint:
 
         # Assert
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestStandaloneHubPipeline — SC-17: full pipeline integration
+# ---------------------------------------------------------------------------
+
+
+@requires_nats_server
+class TestStandaloneHubPipeline:
+    """SC-17: publish InboundMessage to NATS → Hub processes → staging queue drained.
+
+    Wires NatsBus directly into Hub without the full bootstrap, bypassing the
+    config/store/agent complexity while still exercising the real NATS transport
+    and Hub.run() consumer loop.
+    """
+
+    async def test_nats_inbound_delivered_to_hub_run(
+        self, nc: NATS, nats_server_url: str
+    ) -> None:
+        """Hub.run() consumes a message published to NATS inbound subject."""
+        import asyncio
+
+        import nats as nats_lib
+
+        from lyra.core.hub import Hub
+        from lyra.core.message import InboundMessage, Platform
+        from lyra.core.trust import TrustLevel
+        from lyra.nats._serialize import serialize
+        from lyra.nats.nats_bus import NatsBus
+
+        # Arrange — separate NATS connection for the Hub (mirrors production)
+        hub_nc = await nats_lib.connect(nats_server_url)
+
+        bot_id = "test_bot"
+        platform = Platform.TELEGRAM
+        inbound_subject = f"lyra.inbound.{platform.value}.{bot_id}"
+
+        inbound_bus: NatsBus[InboundMessage] = NatsBus(
+            nc=hub_nc, bot_id=bot_id, item_type=InboundMessage
+        )
+        inbound_bus.register(platform, bot_id=bot_id)
+        await inbound_bus.start()
+
+        hub = Hub(inbound_bus=inbound_bus)
+
+        test_msg = InboundMessage(
+            id="sc17-msg-001",
+            platform=platform.value,
+            bot_id=bot_id,
+            scope_id="chat:999",
+            user_id="user:sc17",
+            user_name="SC17User",
+            is_mention=False,
+            text="integration test",
+            text_raw="integration test",
+            trust_level=TrustLevel.PUBLIC,
+        )
+
+        try:
+            # Act — start Hub consumer loop, then publish via external NATS client
+            hub_task = asyncio.create_task(hub.run(), name="hub-run")
+
+            # Give Hub.run() a moment to enter its get() await
+            await asyncio.sleep(0.05)
+
+            payload = serialize(test_msg)
+            await nc.publish(inbound_subject, payload)
+            await nc.flush()
+
+            # Wait up to 2 s for the staging queue to be drained by Hub.run()
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while asyncio.get_event_loop().time() < deadline:
+                if inbound_bus.staging_qsize() == 0:
+                    break
+                await asyncio.sleep(0.05)
+
+            # Assert — staging queue is empty: Hub.run() consumed the message
+            assert inbound_bus.staging_qsize() == 0, (
+                "NatsBus staging queue not drained — Hub.run() did not consume"
+                " the inbound message published to NATS"
+            )
+        finally:
+            hub_task.cancel()
+            try:
+                await hub_task
+            except asyncio.CancelledError:
+                pass
+            await inbound_bus.stop()
+            if hub_nc.is_connected:
+                await hub_nc.drain()
+
+    async def test_trust_re_resolution_invoked(
+        self, nc: NATS, nats_server_url: str
+    ) -> None:
+        """ResolveTrustMiddleware calls Authenticator.resolve() for every inbound message.
+
+        Publishes an InboundMessage via NATS and verifies that the registered
+        Authenticator's resolve() method is called — confirming the C3 trust
+        re-resolution path runs in the standalone Hub pipeline.
+        """
+        import asyncio
+        from unittest.mock import MagicMock
+
+        import nats as nats_lib
+
+        from lyra.core.authenticator import Authenticator
+        from lyra.core.hub import Hub
+        from lyra.core.identity import Identity
+        from lyra.core.message import InboundMessage, Platform
+        from lyra.core.trust import TrustLevel
+        from lyra.nats._serialize import serialize
+        from lyra.nats.nats_bus import NatsBus
+
+        # Arrange — Hub with NatsBus and a mock Authenticator
+        hub_nc = await nats_lib.connect(nats_server_url)
+
+        bot_id = "trust_bot"
+        platform = Platform.TELEGRAM
+        inbound_subject = f"lyra.inbound.{platform.value}.{bot_id}"
+
+        inbound_bus: NatsBus[InboundMessage] = NatsBus(
+            nc=hub_nc, bot_id=bot_id, item_type=InboundMessage
+        )
+        inbound_bus.register(platform, bot_id=bot_id)
+        await inbound_bus.start()
+
+        hub = Hub(inbound_bus=inbound_bus)
+
+        # Mock authenticator: returns PUBLIC identity for any user
+        mock_auth = MagicMock(spec=Authenticator)
+        mock_auth.resolve.return_value = Identity(
+            user_id="user:trust", trust_level=TrustLevel.PUBLIC, is_admin=False
+        )
+        hub.register_authenticator(platform, bot_id, mock_auth)
+
+        test_msg = InboundMessage(
+            id="trust-msg-001",
+            platform=platform.value,
+            bot_id=bot_id,
+            scope_id="chat:trust",
+            user_id="user:trust",
+            user_name="TrustUser",
+            is_mention=False,
+            text="trust test",
+            text_raw="trust test",
+            trust_level=TrustLevel.PUBLIC,
+        )
+
+        try:
+            # Act — start Hub, publish message via NATS
+            hub_task = asyncio.create_task(hub.run(), name="hub-run-trust")
+
+            await asyncio.sleep(0.05)
+
+            payload = serialize(test_msg)
+            await nc.publish(inbound_subject, payload)
+            await nc.flush()
+
+            # Wait for the message to be consumed from the staging queue
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while asyncio.get_event_loop().time() < deadline:
+                if inbound_bus.staging_qsize() == 0:
+                    break
+                await asyncio.sleep(0.05)
+
+            # Give Hub.run() a moment to finish pipeline processing after get()
+            await asyncio.sleep(0.1)
+
+            # Assert — Authenticator.resolve() was called with the user_id from the message
+            mock_auth.resolve.assert_called_once()
+            call_args = mock_auth.resolve.call_args
+            assert call_args.args[0] == "user:trust" or call_args.kwargs.get("user_id") == "user:trust"
+        finally:
+            hub_task.cancel()
+            try:
+                await hub_task
+            except asyncio.CancelledError:
+                pass
+            await inbound_bus.stop()
+            if hub_nc.is_connected:
+                await hub_nc.drain()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nats/test_nats_bus_multibot.py
+++ b/tests/nats/test_nats_bus_multibot.py
@@ -1,0 +1,243 @@
+"""Tests for NatsBus multi-bot support.
+
+Covers (platform, bot_id) keying: multiple bot_ids on the same platform,
+independent subjects, and backward-compat fallback to the constructor's bot_id.
+
+Tests requiring nats-server are automatically skipped when the binary is not
+found in PATH (same convention as test_nats_bus.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from nats.aio.client import Client as NATS
+
+from lyra.core.message import InboundMessage, Platform
+from lyra.core.trust import TrustLevel
+from lyra.nats.nats_bus import NatsBus
+from tests.nats.conftest import requires_nats_server
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_msg(platform: Platform = Platform.TELEGRAM, bot_id: str = "main") -> InboundMessage:
+    if platform == Platform.TELEGRAM:
+        scope = "chat:1"
+        meta: dict = {"chat_id": 1, "topic_id": None, "message_id": None, "is_group": False}
+    else:
+        scope = "channel:2"
+        meta = {
+            "guild_id": 1,
+            "channel_id": 2,
+            "message_id": 3,
+            "thread_id": None,
+            "channel_type": "text",
+        }
+    return InboundMessage(
+        id="msg-1",
+        platform=platform.value,
+        bot_id=bot_id,
+        scope_id=scope,
+        user_id="user:1",
+        user_name="Alice",
+        is_mention=False,
+        text="hello",
+        text_raw="hello",
+        timestamp=datetime.now(timezone.utc),
+        platform_meta=meta,
+        trust_level=TrustLevel.TRUSTED,
+    )
+
+
+def _make_bus(nc: NATS, bot_id: str = "main") -> NatsBus:
+    return NatsBus(nc=nc, bot_id=bot_id, item_type=InboundMessage)
+
+
+# ---------------------------------------------------------------------------
+# TestMultiBotRegistration — (platform, bot_id) keying
+# ---------------------------------------------------------------------------
+
+
+@requires_nats_server
+class TestMultiBotRegistration:
+    async def test_two_bot_ids_same_platform_both_subscribed(self, nc: NATS) -> None:
+        """Registering two bot_ids on the same platform creates two subscriptions."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM, bot_id="bot-a")
+        bus.register(Platform.TELEGRAM, bot_id="bot-b")
+
+        await bus.start()
+        try:
+            # Assert — two distinct subscriptions keyed by (platform, bot_id)
+            assert (Platform.TELEGRAM, "bot-a") in bus._subscriptions
+            assert (Platform.TELEGRAM, "bot-b") in bus._subscriptions
+            assert len(bus._subscriptions) == 2
+        finally:
+            await bus.stop()
+
+    async def test_messages_on_separate_subjects_both_arrive_in_staging(
+        self, nc: NATS
+    ) -> None:
+        """Messages published to each (platform, bot_id) subject both land in staging."""
+        # Arrange
+        publisher = _make_bus(nc)
+        subscriber = _make_bus(nc)
+
+        subscriber.register(Platform.TELEGRAM, bot_id="bot-a")
+        subscriber.register(Platform.TELEGRAM, bot_id="bot-b")
+        await subscriber.start()
+
+        msg_a = _make_msg(Platform.TELEGRAM, bot_id="bot-a")
+        msg_b = _make_msg(Platform.TELEGRAM, bot_id="bot-b")
+
+        # We need a publisher that knows about each bot_id; publish directly via nc
+        # to bypass NatsBus.put() which only uses the first matching registration.
+        import lyra.nats._serialize as _s
+
+        try:
+            # Act — publish to both subjects independently
+            await nc.publish(
+                f"lyra.inbound.{Platform.TELEGRAM.value}.bot-a", _s.serialize(msg_a)
+            )
+            await nc.publish(
+                f"lyra.inbound.{Platform.TELEGRAM.value}.bot-b", _s.serialize(msg_b)
+            )
+
+            # Allow NATS delivery
+            await asyncio.sleep(0.15)
+
+            # Assert — staging queue received both messages
+            assert subscriber.staging_qsize() == 2
+
+            received_ids = set()
+            for _ in range(2):
+                item = await asyncio.wait_for(subscriber.get(), timeout=2.0)
+                received_ids.add(item.bot_id)
+
+            assert "bot-a" in received_ids
+            assert "bot-b" in received_ids
+        finally:
+            await subscriber.stop()
+
+    async def test_stop_clears_all_multibot_subscriptions(self, nc: NATS) -> None:
+        """stop() clears all subscriptions, including multi-bot ones."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM, bot_id="bot-a")
+        bus.register(Platform.TELEGRAM, bot_id="bot-b")
+        await bus.start()
+
+        assert len(bus._subscriptions) == 2
+
+        # Act
+        await bus.stop()
+
+        # Assert
+        assert len(bus._subscriptions) == 0
+
+    async def test_restart_after_stop_resubscribes_all(self, nc: NATS) -> None:
+        """stop() then start() re-creates all (platform, bot_id) subscriptions."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM, bot_id="bot-a")
+        bus.register(Platform.TELEGRAM, bot_id="bot-b")
+        await bus.start()
+        await bus.stop()
+
+        # Act
+        await bus.start()
+        try:
+            assert (Platform.TELEGRAM, "bot-a") in bus._subscriptions
+            assert (Platform.TELEGRAM, "bot-b") in bus._subscriptions
+        finally:
+            await bus.stop()
+
+    async def test_registered_platforms_deduplicates(self, nc: NATS) -> None:
+        """registered_platforms() returns each Platform once even with multiple bot_ids."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM, bot_id="bot-a")
+        bus.register(Platform.TELEGRAM, bot_id="bot-b")
+        bus.register(Platform.DISCORD, bot_id="bot-a")
+
+        # Assert — only two distinct Platform values
+        platforms = bus.registered_platforms()
+        assert platforms == frozenset({Platform.TELEGRAM, Platform.DISCORD})
+
+
+# ---------------------------------------------------------------------------
+# TestMultiBotBackwardCompat — fallback to constructor bot_id
+# ---------------------------------------------------------------------------
+
+
+@requires_nats_server
+class TestMultiBotBackwardCompat:
+    async def test_register_without_bot_id_uses_constructor_bot_id(
+        self, nc: NATS
+    ) -> None:
+        """register(platform) without bot_id falls back to constructor's bot_id."""
+        # Arrange
+        bus = _make_bus(nc, bot_id="main")
+        bus.register(Platform.TELEGRAM)  # no bot_id argument
+
+        await bus.start()
+        try:
+            # Assert — subscription keyed as (TELEGRAM, "main")
+            assert (Platform.TELEGRAM, "main") in bus._subscriptions
+        finally:
+            await bus.stop()
+
+    async def test_put_without_explicit_bot_id_uses_first_registration(
+        self, nc: NATS
+    ) -> None:
+        """put() routes to the first matching registration's bot_id."""
+        # Arrange
+        publisher = _make_bus(nc, bot_id="main")
+        publisher.register(Platform.TELEGRAM)  # falls back to "main"
+
+        subscriber = _make_bus(nc, bot_id="main")
+        subscriber.register(Platform.TELEGRAM)  # falls back to "main"
+        await subscriber.start()
+
+        msg = _make_msg(Platform.TELEGRAM)
+
+        try:
+            # Act — put() should publish to lyra.inbound.telegram.main
+            await publisher.put(Platform.TELEGRAM, msg)
+            received = await asyncio.wait_for(subscriber.get(), timeout=2.0)
+
+            # Assert
+            assert received.id == msg.id
+            assert received.platform == msg.platform
+        finally:
+            await subscriber.stop()
+
+    def test_register_without_bot_id_in_registrations(self, nc: NATS) -> None:
+        """register(platform) without bot_id stores (platform, constructor_bot_id)."""
+        # Arrange
+        bus = _make_bus(nc, bot_id="my-bot")
+        bus.register(Platform.TELEGRAM)
+
+        # Assert — registration is (TELEGRAM, "my-bot"), not (TELEGRAM, None)
+        assert (Platform.TELEGRAM, "my-bot") in bus._registrations
+
+    async def test_mix_explicit_and_implicit_bot_ids(self, nc: NATS) -> None:
+        """register() with and without bot_id can coexist."""
+        # Arrange
+        bus = _make_bus(nc, bot_id="default")
+        bus.register(Platform.TELEGRAM)               # uses "default"
+        bus.register(Platform.TELEGRAM, bot_id="alt") # explicit
+
+        await bus.start()
+        try:
+            assert (Platform.TELEGRAM, "default") in bus._subscriptions
+            assert (Platform.TELEGRAM, "alt") in bus._subscriptions
+            assert len(bus._subscriptions) == 2
+        finally:
+            await bus.stop()

--- a/tests/nats/test_nats_channel_proxy.py
+++ b/tests/nats/test_nats_channel_proxy.py
@@ -1,0 +1,420 @@
+"""Tests for NatsChannelProxy — ChannelAdapter over NATS.
+
+Uses unittest.mock.AsyncMock for the NATS client so no real NATS server is
+needed. Each test verifies subject routing and envelope structure independently.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lyra.core.message import (
+    InboundMessage,
+    OutboundAttachment,
+    OutboundAudio,
+    OutboundAudioChunk,
+    OutboundMessage,
+    Platform,
+)
+from lyra.core.render_events import TextRenderEvent, ToolSummaryRenderEvent
+from lyra.core.trust import TrustLevel
+from lyra.nats.nats_channel_proxy import NatsChannelProxy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_nc() -> AsyncMock:
+    """Return a mock NATS client with an async publish method."""
+    nc = MagicMock()
+    nc.publish = AsyncMock()
+    return nc
+
+
+def _make_inbound(msg_id: str = "msg-1") -> InboundMessage:
+    """Minimal valid InboundMessage for use in tests."""
+    return InboundMessage(
+        id=msg_id,
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:123",
+        user_id="user-42",
+        user_name="Alice",
+        is_mention=False,
+        text="hello",
+        text_raw="hello",
+        trust_level=TrustLevel.PUBLIC,
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+async def _async_iter(*items):
+    """Yield items from an async iterator."""
+    for item in items:
+        yield item
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_init_stores_attributes() -> None:
+    """NatsChannelProxy stores nc, platform, and bot_id without I/O."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    assert proxy._nc is nc
+    assert proxy._platform is Platform.TELEGRAM
+    assert proxy._bot_id == "main"
+
+
+# ---------------------------------------------------------------------------
+# normalize / normalize_audio — must raise NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_raises() -> None:
+    """normalize() raises NotImplementedError — proxy does not handle inbound."""
+    proxy = NatsChannelProxy(nc=_make_nc(), platform=Platform.TELEGRAM, bot_id="main")
+    with pytest.raises(
+        NotImplementedError, match="does not normalize inbound messages"
+    ):
+        proxy.normalize({})
+
+
+def test_normalize_audio_raises() -> None:
+    """normalize_audio() raises NotImplementedError."""
+    proxy = NatsChannelProxy(nc=_make_nc(), platform=Platform.TELEGRAM, bot_id="main")
+    with pytest.raises(NotImplementedError, match="does not normalize inbound audio"):
+        proxy.normalize_audio({}, b"", "audio/ogg", trust_level=TrustLevel.PUBLIC)
+
+
+# ---------------------------------------------------------------------------
+# send()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_publishes_to_correct_subject() -> None:
+    """send() publishes to lyra.outbound.<platform>.<bot_id>."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-abc")
+    outbound = OutboundMessage.from_text("Hi there")
+
+    await proxy.send(inbound, outbound)
+
+    nc.publish.assert_awaited_once()
+    subject, payload = nc.publish.call_args.args
+    assert subject == "lyra.outbound.telegram.main"
+
+
+@pytest.mark.asyncio
+async def test_send_envelope_structure() -> None:
+    """send() envelope has type, msg_id, and outbound fields."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.DISCORD, bot_id="bot2")
+    inbound = _make_inbound("msg-xyz")
+    outbound = OutboundMessage.from_text("Response text")
+
+    await proxy.send(inbound, outbound)
+
+    subject, payload = nc.publish.call_args.args
+    envelope = json.loads(payload.decode("utf-8"))
+
+    assert envelope["type"] == "outbound"
+    assert envelope["msg_id"] == "msg-xyz"
+    assert "outbound" in envelope
+    assert isinstance(envelope["outbound"], dict)
+    # Verify outbound content was serialized
+    assert envelope["outbound"]["content"] == ["Response text"]
+
+
+@pytest.mark.asyncio
+async def test_send_subject_uses_platform_value() -> None:
+    """send() uses Platform.value (string) in subject, not enum name."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.DISCORD, bot_id="main")
+    await proxy.send(_make_inbound(), OutboundMessage.from_text("x"))
+
+    subject, _ = nc.publish.call_args.args
+    assert "discord" in subject
+    assert "DISCORD" not in subject
+
+
+# ---------------------------------------------------------------------------
+# send_streaming()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_publishes_chunks_with_incrementing_seq() -> None:
+    """send_streaming() assigns seq numbers starting from 0."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-stream")
+
+    tool_event = ToolSummaryRenderEvent(bash_commands=["make test"], is_complete=False)
+    text_event = TextRenderEvent(text="Done", is_final=True)
+
+    await proxy.send_streaming(inbound, _async_iter(tool_event, text_event))
+
+    assert nc.publish.await_count == 2
+    calls = nc.publish.call_args_list
+
+    chunk0 = json.loads(calls[0].args[1].decode("utf-8"))
+    chunk1 = json.loads(calls[1].args[1].decode("utf-8"))
+
+    assert chunk0["seq"] == 0
+    assert chunk1["seq"] == 1
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_subject_includes_msg_id() -> None:
+    """send_streaming() publishes to stream subject with msg_id suffix."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-42")
+
+    await proxy.send_streaming(
+        inbound, _async_iter(TextRenderEvent(text="Hi", is_final=True))
+    )
+
+    subject, _ = nc.publish.call_args.args
+    assert subject == "lyra.outbound.stream.telegram.main.msg-42"
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_done_true_on_final_text_event() -> None:
+    """send_streaming() sets done=True when TextRenderEvent.is_final=True."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound()
+
+    await proxy.send_streaming(
+        inbound, _async_iter(TextRenderEvent(text="Done", is_final=True))
+    )
+
+    _, payload = nc.publish.call_args.args
+    chunk = json.loads(payload.decode("utf-8"))
+    assert chunk["done"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_done_false_on_non_final_event() -> None:
+    """send_streaming() sets done=False when is_final/is_complete are False."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound()
+
+    await proxy.send_streaming(
+        inbound, _async_iter(TextRenderEvent(text="Partial", is_final=False))
+    )
+
+    _, payload = nc.publish.call_args.args
+    chunk = json.loads(payload.decode("utf-8"))
+    assert chunk["done"] is False
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_event_type_text() -> None:
+    """send_streaming() sets event_type='text' for TextRenderEvent."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound()
+
+    await proxy.send_streaming(
+        inbound, _async_iter(TextRenderEvent(text="Hello", is_final=True))
+    )
+
+    _, payload = nc.publish.call_args.args
+    chunk = json.loads(payload.decode("utf-8"))
+    assert chunk["event_type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_event_type_tool_summary() -> None:
+    """send_streaming() sets event_type='tool_summary' for ToolSummaryRenderEvent."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound()
+
+    await proxy.send_streaming(
+        inbound,
+        _async_iter(ToolSummaryRenderEvent(bash_commands=["ls"], is_complete=True)),
+    )
+
+    _, payload = nc.publish.call_args.args
+    chunk = json.loads(payload.decode("utf-8"))
+    assert chunk["event_type"] == "tool_summary"
+    assert chunk["done"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_chunk_has_msg_id_and_type() -> None:
+    """Each chunk envelope has type='stream_chunk' and the inbound msg_id."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-check")
+
+    await proxy.send_streaming(
+        inbound, _async_iter(TextRenderEvent(text="x", is_final=True))
+    )
+
+    _, payload = nc.publish.call_args.args
+    chunk = json.loads(payload.decode("utf-8"))
+    assert chunk["type"] == "stream_chunk"
+    assert chunk["msg_id"] == "msg-check"
+    assert "payload" in chunk
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_drains_iterator_on_publish_failure() -> None:
+    """On NATS publish failure, remaining events are drained (no hang)."""
+    nc = _make_nc()
+    nc.publish = AsyncMock(side_effect=Exception("NATS connection lost"))
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound()
+
+    drained = []
+
+    async def _events():
+        yield TextRenderEvent(text="first", is_final=False)
+        yield TextRenderEvent(text="second", is_final=False)
+        drained.append("second")
+        yield TextRenderEvent(text="third", is_final=True)
+        drained.append("third")
+
+    # Should not raise; should drain remaining events
+    await proxy.send_streaming(inbound, _events())
+
+    # The second and third events must have been drained without publishing
+    assert "second" in drained
+    assert "third" in drained
+
+
+# ---------------------------------------------------------------------------
+# render_attachment()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_attachment_publishes_to_outbound_subject() -> None:
+    """render_attachment() publishes to lyra.outbound.<platform>.<bot_id>."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-att")
+    attachment = OutboundAttachment(
+        data=b"PNG",
+        type="image",
+        mime_type="image/png",
+        filename="img.png",
+    )
+
+    await proxy.render_attachment(attachment, inbound)
+
+    nc.publish.assert_awaited_once()
+    subject, payload = nc.publish.call_args.args
+    assert subject == "lyra.outbound.telegram.main"
+
+    envelope = json.loads(payload.decode("utf-8"))
+    assert envelope["type"] == "attachment"
+    assert envelope["msg_id"] == "msg-att"
+    assert "attachment" in envelope
+    assert isinstance(envelope["attachment"], dict)
+    assert envelope["attachment"]["type"] == "image"
+    assert envelope["attachment"]["mime_type"] == "image/png"
+
+
+# ---------------------------------------------------------------------------
+# render_audio() — warning, no publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_audio_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """render_audio() logs a warning and does not publish to NATS."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-audio")
+    audio = OutboundAudio(audio_bytes=b"\x00\x01", mime_type="audio/ogg")
+
+    with caplog.at_level(logging.WARNING, logger="lyra.nats.nats_channel_proxy"):
+        await proxy.render_audio(audio, inbound)
+
+    nc.publish.assert_not_awaited()
+    assert any("audio-over-NATS" in r.message for r in caplog.records)
+    assert any("msg-audio" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# render_audio_stream() — drain + warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_audio_stream_drains_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """render_audio_stream() drains the iterator and logs a warning."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-astream")
+
+    consumed = []
+
+    async def _chunks():
+        for i in range(3):
+            chunk = OutboundAudioChunk(
+                chunk_bytes=bytes([i]),
+                session_id="s1",
+                chunk_index=i,
+                is_final=(i == 2),
+            )
+            consumed.append(i)
+            yield chunk
+
+    with caplog.at_level(logging.WARNING, logger="lyra.nats.nats_channel_proxy"):
+        await proxy.render_audio_stream(_chunks(), inbound)
+
+    nc.publish.assert_not_awaited()
+    assert consumed == [0, 1, 2]
+    assert any("audio-over-NATS" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# render_voice_stream() — drain + warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_voice_stream_drains_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """render_voice_stream() drains the iterator and logs a warning."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-vstream")
+
+    consumed = []
+
+    async def _chunks():
+        for i in range(2):
+            consumed.append(i)
+            yield OutboundAudioChunk(
+                chunk_bytes=bytes([i]),
+                session_id="s2",
+                chunk_index=i,
+            )
+
+    with caplog.at_level(logging.WARNING, logger="lyra.nats.nats_channel_proxy"):
+        await proxy.render_voice_stream(_chunks(), inbound)
+
+    nc.publish.assert_not_awaited()
+    assert consumed == [0, 1]
+    assert any("audio-over-NATS" in r.message for r in caplog.records)

--- a/tests/nats/test_serialize_outbound.py
+++ b/tests/nats/test_serialize_outbound.py
@@ -1,0 +1,215 @@
+"""Serialization round-trip tests for outbound message types and render events.
+
+Verifies that serialize() → deserialize() produces structurally equivalent
+objects for all types published by NatsChannelProxy over NATS.
+"""
+from __future__ import annotations
+
+from lyra.core.message import OutboundAttachment, OutboundMessage
+from lyra.core.render_events import (
+    FileEditSummary,
+    SilentCounts,
+    TextRenderEvent,
+    ToolSummaryRenderEvent,
+)
+from lyra.nats._serialize import deserialize, serialize
+
+# ---------------------------------------------------------------------------
+# OutboundMessage round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_outbound_message_text_roundtrip() -> None:
+    """Plain-text OutboundMessage survives serialize → deserialize."""
+    original = OutboundMessage.from_text("Hello from hub")
+    data = serialize(original)
+    recovered = deserialize(data, OutboundMessage)
+
+    assert recovered.content == original.content
+    assert recovered.is_final == original.is_final
+    assert recovered.intermediate == original.intermediate
+    assert recovered.buttons == original.buttons
+    assert recovered.edit_id == original.edit_id
+
+
+def test_outbound_message_with_metadata_roundtrip() -> None:
+    """OutboundMessage with metadata dict survives round-trip."""
+    original = OutboundMessage.from_text("With meta")
+    original.metadata["reply_message_id"] = "42"
+    data = serialize(original)
+    recovered = deserialize(data, OutboundMessage)
+
+    assert recovered.metadata.get("reply_message_id") == "42"
+
+
+def test_outbound_message_intermediate_roundtrip() -> None:
+    """OutboundMessage with intermediate=True survives round-trip."""
+    original = OutboundMessage(
+        content=["Thinking..."], intermediate=True, is_final=False
+    )
+    data = serialize(original)
+    recovered = deserialize(data, OutboundMessage)
+
+    assert recovered.intermediate is True
+    assert recovered.is_final is False
+    assert recovered.content == ["Thinking..."]
+
+
+# ---------------------------------------------------------------------------
+# TextRenderEvent round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_text_render_event_roundtrip() -> None:
+    """TextRenderEvent survives serialize → deserialize."""
+    original = TextRenderEvent(text="Final answer", is_final=True, is_error=False)
+    data = serialize(original)
+    recovered = deserialize(data, TextRenderEvent)
+
+    assert recovered.text == "Final answer"
+    assert recovered.is_final is True
+    assert recovered.is_error is False
+
+
+def test_text_render_event_error_roundtrip() -> None:
+    """TextRenderEvent with is_error=True survives round-trip."""
+    original = TextRenderEvent(
+        text="Something went wrong", is_final=True, is_error=True
+    )
+    data = serialize(original)
+    recovered = deserialize(data, TextRenderEvent)
+
+    assert recovered.is_error is True
+    assert recovered.text == "Something went wrong"
+
+
+def test_text_render_event_not_final_roundtrip() -> None:
+    """TextRenderEvent with is_final=False survives round-trip."""
+    original = TextRenderEvent(text="Partial...", is_final=False)
+    data = serialize(original)
+    recovered = deserialize(data, TextRenderEvent)
+
+    assert recovered.is_final is False
+    assert recovered.text == "Partial..."
+
+
+# ---------------------------------------------------------------------------
+# ToolSummaryRenderEvent round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_tool_summary_render_event_empty_roundtrip() -> None:
+    """Empty ToolSummaryRenderEvent survives serialize → deserialize."""
+    original = ToolSummaryRenderEvent()
+    data = serialize(original)
+    recovered = deserialize(data, ToolSummaryRenderEvent)
+
+    assert recovered.bash_commands == []
+    assert recovered.web_fetches == []
+    assert recovered.agent_calls == []
+    assert recovered.is_complete is False
+
+
+def test_tool_summary_render_event_with_data_roundtrip() -> None:
+    """ToolSummaryRenderEvent with populated fields survives round-trip.
+
+    Note: the deserializer handles list[X] but not dict[str, V] with typed
+    values — files dict values come back as raw dicts (JSON objects). The
+    scalar and list fields round-trip fully; SilentCounts (a nested dataclass)
+    also round-trips because the field type hint is resolved at decode time.
+    """
+    file_summary = FileEditSummary(
+        path="/src/foo.py", edits=["added function bar"], count=1
+    )
+    silent = SilentCounts(reads=3, greps=2, globs=1)
+    original = ToolSummaryRenderEvent(
+        files={"/src/foo.py": file_summary},
+        bash_commands=["make test"],
+        web_fetches=["https://example.com"],
+        agent_calls=["sub-agent-1"],
+        silent_counts=silent,
+        is_complete=True,
+    )
+    data = serialize(original)
+    recovered = deserialize(data, ToolSummaryRenderEvent)
+
+    assert recovered.is_complete is True
+    assert recovered.bash_commands == ["make test"]
+    assert recovered.web_fetches == ["https://example.com"]
+    assert recovered.agent_calls == ["sub-agent-1"]
+    assert recovered.silent_counts.reads == 3
+    assert recovered.silent_counts.greps == 2
+    assert recovered.silent_counts.globs == 1
+    # files dict keys are preserved; values come back as raw dicts because
+    # dict[str, FileEditSummary] value types are not rehydrated by _decode_concrete
+    assert "/src/foo.py" in recovered.files
+    recovered_file = recovered.files["/src/foo.py"]
+    # Accept both reconstructed dataclass and raw dict (serializer limitation)
+    if isinstance(recovered_file, dict):
+        assert recovered_file["path"] == "/src/foo.py"
+        assert recovered_file["count"] == 1
+    else:
+        assert recovered_file.path == "/src/foo.py"
+        assert recovered_file.count == 1
+
+
+# ---------------------------------------------------------------------------
+# OutboundAttachment round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_outbound_attachment_roundtrip() -> None:
+    """OutboundAttachment with bytes data survives serialize → deserialize."""
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16  # fake PNG header + padding
+    original = OutboundAttachment(
+        data=raw,
+        type="image",
+        mime_type="image/png",
+        filename="diagram.png",
+        caption="Architecture diagram",
+        reply_to_id="msg-99",
+    )
+    data = serialize(original)
+    recovered = deserialize(data, OutboundAttachment)
+
+    assert recovered.data == raw
+    assert recovered.type == "image"
+    assert recovered.mime_type == "image/png"
+    assert recovered.filename == "diagram.png"
+    assert recovered.caption == "Architecture diagram"
+    assert recovered.reply_to_id == "msg-99"
+
+
+def test_outbound_attachment_document_roundtrip() -> None:
+    """OutboundAttachment of type 'document' round-trips cleanly."""
+    payload = b"PDF content"
+    original = OutboundAttachment(
+        data=payload,
+        type="document",
+        mime_type="application/pdf",
+        filename="report.pdf",
+    )
+    data = serialize(original)
+    recovered = deserialize(data, OutboundAttachment)
+
+    assert recovered.data == payload
+    assert recovered.type == "document"
+    assert recovered.filename == "report.pdf"
+    assert recovered.caption is None
+    assert recovered.reply_to_id is None
+
+
+def test_outbound_attachment_file_no_optional_fields_roundtrip() -> None:
+    """OutboundAttachment with minimal fields round-trips cleanly."""
+    original = OutboundAttachment(
+        data=b"binary",
+        type="file",
+        mime_type="application/octet-stream",
+    )
+    data = serialize(original)
+    recovered = deserialize(data, OutboundAttachment)
+
+    assert recovered.data == b"binary"
+    assert recovered.type == "file"
+    assert recovered.filename is None
+    assert recovered.caption is None


### PR DESCRIPTION
## Summary
- Extract Hub into a standalone process (`lyra hub`) communicating with adapters via NatsBus, enabling Hub state to survive adapter restarts (realized after C5 rewires adapters)
- Hub accepts injected `Bus[T]` instances (backward-compatible); `NatsChannelProxy` implements `ChannelAdapter` Protocol for NATS outbound dispatch
- NatsBus extended with multi-bot `(platform, bot_id)` subscription keying

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #457: extract Hub into standalone lyra_hub process | Open |
| Frame | [457-extract-hub-standalone-process-frame.mdx](artifacts/frames/457-extract-hub-standalone-process-frame.mdx) | Approved |
| Analysis | [457-extract-hub-standalone-process-analysis.mdx](artifacts/analyses/457-extract-hub-standalone-process-analysis.mdx) | Approved (Shape 1: Bus Injection + NatsChannelProxy) |
| Spec | [457-extract-hub-standalone-process-spec.mdx](artifacts/specs/457-extract-hub-standalone-process-spec.mdx) | Approved (17 acceptance criteria, 3 slices) |
| Plan | [457-extract-hub-standalone-process-plan.mdx](artifacts/plans/457-extract-hub-standalone-process-plan.mdx) | Approved (20 micro-tasks, 7/10 complexity) |
| Implementation | 5 commits on `feat/457-extract-hub-standalone` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2278 passed, 6 new test files) | Passed |

## Key Changes

### Slice S1: Foundation
- `Bus[T].register()` gains optional `bot_id` param — `LocalBus` ignores, `NatsBus` uses for subscription keying
- `Hub` constructor accepts optional `inbound_bus` / `inbound_audio_bus` injection (defaults to `LocalBus`)
- `Hub.register_adapter()` passes `bot_id` to `bus.register()`
- Lifecycle helpers extracted from `multibot_lifecycle.py` for reuse

### Slice S2: NatsChannelProxy + multi-bot NatsBus
- `NatsBus` subscriptions keyed by `(platform, bot_id)` — supports multiple bots per platform
- `NatsChannelProxy` implements all 8 `ChannelAdapter` Protocol methods:
  - `send()` → `lyra.outbound.{platform}.{bot_id}` with JSON envelope
  - `send_streaming()` → chunked stream with `{seq, event_type, payload, done}`
  - `render_attachment()` → attachment envelope
  - Audio methods → stub with warning + iterator drain (C5 scope)
- `OutboundMessage` / `RenderEvent` serialization round-trip verified

### Slice S3: Standalone Bootstrap + CLI
- `hub_standalone.py` — standalone bootstrap parallel to `multibot.py`, reusing stores/agents/config
- `lyra hub` CLI command (Typer sub-app)
- `NATS_URL` guard — clear error when absent/unreachable
- PID lockfile (`~/.lyra/hub.lock`) prevents dual Hub on same vault
- Health endpoint `/health/detail` gains `"adapters"` count

## Test Plan
- [ ] `uv run python -m pytest tests/ -x --no-cov` — all 2278 tests pass
- [ ] `uv run python -m pyright src/lyra/core/bus.py src/lyra/core/hub/hub.py src/lyra/nats/ src/lyra/bootstrap/hub_standalone.py` — 0 errors
- [ ] Existing embedded mode (`lyra start --adapter all`) unchanged — zero regression
- [ ] New test files: `test_bus_injection.py`, `test_lifecycle_helpers.py`, `test_nats_bus_multibot.py`, `test_serialize_outbound.py`, `test_nats_channel_proxy.py`, `test_hub_standalone.py`

Closes #457

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`