### PR TITLE
chore(brand): ComfyUI + PuLID Flux2 setup playbook [#421]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,16 @@ define require_machine1
 	@[ -n "$(DEPLOY_DIR)" ] || { echo "Error: DEPLOY_DIR not set in .env"; exit 1; }
 endef
 
-.PHONY: lyra telegram discord monitor register deploy remote test lint typecheck format
+.PHONY: lyra telegram discord monitor comfyui register deploy remote test lint typecheck format
 
 ifeq (monitor,$(firstword $(MAKECMDGOALS)))
   MONITOR_CMD := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
   $(eval $(MONITOR_CMD):;@:)
+endif
+
+ifeq (comfyui,$(firstword $(MAKECMDGOALS)))
+  COMFYUI_CMD := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(COMFYUI_CMD):;@:)
 endif
 
 ifneq (remote,$(firstword $(MAKECMDGOALS)))
@@ -130,19 +135,22 @@ endif # ifneq remote
 
 # ── Machine 2 local tools (not managed by supervisor) ────────────────────────
 COMFYUI_DIR := $(HOME)/ComfyUI
-COMFYUI_CMD ?=
+COMFYUI_PID := /tmp/comfyui.pid
+COMFYUI_LOG := /tmp/comfyui.log  # overwritten on each start (intentional)
 
 comfyui:
 ifeq ($(COMFYUI_CMD),logs)
-	@tail -f /tmp/comfyui.log
+	@tail -f $(COMFYUI_LOG)
 else ifeq ($(COMFYUI_CMD),stop)
-	@pkill -f "venv/bin/python main.py" && echo "ComfyUI stopped" || echo "ComfyUI not running"
+	@kill $$(cat $(COMFYUI_PID) 2>/dev/null) 2>/dev/null && echo "ComfyUI stopped" || echo "ComfyUI not running"
+	@rm -f $(COMFYUI_PID)
 else ifeq ($(COMFYUI_CMD),status)
-	@pgrep -fa "venv/bin/python main.py" || echo "ComfyUI not running"
+	@pgrep -f "$(COMFYUI_DIR)/venv/bin/python" > /dev/null && echo "ComfyUI running" || echo "ComfyUI not running"
 else
-	@echo "Starting ComfyUI at http://localhost:8188 (log → /tmp/comfyui.log)"
-	@cd $(COMFYUI_DIR) && nohup venv/bin/python main.py --listen 127.0.0.1 --port 8188 > /tmp/comfyui.log 2>&1 &
-	@echo "PID: $$!"
+	@[ -d "$(COMFYUI_DIR)" ] || { echo "Error: ComfyUI not found at $(COMFYUI_DIR)"; exit 1; }
+	@pgrep -qf "$(COMFYUI_DIR)/venv/bin/python" && echo "ComfyUI already running. Use 'make comfyui stop'." && exit 0 || true
+	@echo "Starting ComfyUI at http://localhost:8188 (log → $(COMFYUI_LOG), overwritten each start)"
+	@cd $(COMFYUI_DIR); nohup venv/bin/python main.py --listen 127.0.0.1 --port 8188 > $(COMFYUI_LOG) 2>&1 & echo $$! > $(COMFYUI_PID); echo "Started — PID $$(cat $(COMFYUI_PID))"
 endif
 
 SYSTEMD_USER_DIR := $(HOME)/.config/systemd/user

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,23 @@ endif
 
 endif # ifneq remote
 
+# ── Machine 2 local tools (not managed by supervisor) ────────────────────────
+COMFYUI_DIR := $(HOME)/ComfyUI
+COMFYUI_CMD ?=
+
+comfyui:
+ifeq ($(COMFYUI_CMD),logs)
+	@tail -f /tmp/comfyui.log
+else ifeq ($(COMFYUI_CMD),stop)
+	@pkill -f "venv/bin/python main.py" && echo "ComfyUI stopped" || echo "ComfyUI not running"
+else ifeq ($(COMFYUI_CMD),status)
+	@pgrep -fa "venv/bin/python main.py" || echo "ComfyUI not running"
+else
+	@echo "Starting ComfyUI at http://localhost:8188 (log → /tmp/comfyui.log)"
+	@cd $(COMFYUI_DIR) && nohup venv/bin/python main.py --listen 127.0.0.1 --port 8188 > /tmp/comfyui.log 2>&1 &
+	@echo "PID: $$!"
+endif
+
 SYSTEMD_USER_DIR := $(HOME)/.config/systemd/user
 
 monitor:

--- a/brand/scripts/convert_flux2_klein_hf_to_comfy.py
+++ b/brand/scripts/convert_flux2_klein_hf_to_comfy.py
@@ -1,0 +1,135 @@
+"""
+Convert FLUX.2-klein-4B transformer weights from HF diffusers format
+to ComfyUI native format.
+
+HF format uses:
+  - separate to_q, to_k, to_v  →  ComfyUI merges into qkv
+  - transformer_blocks          →  double_blocks
+  - single_transformer_blocks   →  single_blocks
+  - x_embedder                  →  img_in
+  - context_embedder            →  txt_in
+  - *.linear.*                  →  *.lin.* (for modulation layers)
+  - norm_out / proj_out         →  final_layer.adaLN_modulation.1 / final_layer.linear
+  - time_guidance_embed.*       →  time_in.*
+
+Input:  models/diffusion_models/flux2-klein-4b.safetensors  (symlink to HF cache, 7.3 GB)
+Output: models/diffusion_models/flux2-klein-4b-comfy.safetensors  (~7.3 GB)
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+
+import torch
+from safetensors.torch import load_file, save_file
+import comfy.utils
+
+SRC = "models/diffusion_models/flux2-klein-4b.safetensors"
+DST = "models/diffusion_models/flux2-klein-4b-comfy.safetensors"
+
+print(f"Loading {SRC}…")
+sd = load_file(SRC)
+print(f"  {len(sd)} keys loaded")
+
+out = {}
+
+def add(dst_key, tensor):
+    out[dst_key] = tensor
+
+# ── simple renames ────────────────────────────────────────────────────────────
+SIMPLE = {
+    "x_embedder.weight":                                       "img_in.weight",
+    "context_embedder.weight":                                 "txt_in.weight",
+    "double_stream_modulation_img.linear.weight":              "double_stream_modulation_img.lin.weight",
+    "double_stream_modulation_txt.linear.weight":              "double_stream_modulation_txt.lin.weight",
+    "single_stream_modulation.linear.weight":                  "single_stream_modulation.lin.weight",
+    "norm_out.linear.weight":                                  "final_layer.adaLN_modulation.1.weight",
+    "proj_out.weight":                                         "final_layer.linear.weight",
+    "time_guidance_embed.timestep_embedder.linear_1.weight":   "time_in.in_layer.weight",
+    "time_guidance_embed.timestep_embedder.linear_2.weight":   "time_in.out_layer.weight",
+}
+for src_k, dst_k in SIMPLE.items():
+    if src_k in sd:
+        add(dst_k, sd[src_k])
+        print(f"  {src_k} → {dst_k}")
+    else:
+        print(f"  MISSING: {src_k}")
+
+# ── double blocks (transformer_blocks.N → double_blocks.N) ───────────────────
+n_double = max(int(k.split(".")[1]) for k in sd if k.startswith("transformer_blocks.")) + 1
+print(f"\nDouble blocks: {n_double}")
+
+for n in range(n_double):
+    p = f"transformer_blocks.{n}"
+    dp = f"double_blocks.{n}"
+
+    # image attention — merge separate q, k, v → qkv
+    q = sd[f"{p}.attn.to_q.weight"]
+    k = sd[f"{p}.attn.to_k.weight"]
+    v = sd[f"{p}.attn.to_v.weight"]
+    add(f"{dp}.img_attn.qkv.weight", torch.cat([q, k, v], dim=0))
+
+    add(f"{dp}.img_attn.proj.weight",          sd[f"{p}.attn.to_out.0.weight"])
+    add(f"{dp}.img_attn.norm.key_norm.weight",  sd[f"{p}.attn.norm_k.weight"])
+    add(f"{dp}.img_attn.norm.query_norm.weight",sd[f"{p}.attn.norm_q.weight"])
+    add(f"{dp}.img_mlp.0.weight",              sd[f"{p}.ff.linear_in.weight"])
+    add(f"{dp}.img_mlp.2.weight",              sd[f"{p}.ff.linear_out.weight"])
+
+    # text attention — merge separate add_q, add_k, add_v → qkv
+    aq = sd[f"{p}.attn.add_q_proj.weight"]
+    ak = sd[f"{p}.attn.add_k_proj.weight"]
+    av = sd[f"{p}.attn.add_v_proj.weight"]
+    add(f"{dp}.txt_attn.qkv.weight", torch.cat([aq, ak, av], dim=0))
+
+    add(f"{dp}.txt_attn.proj.weight",          sd[f"{p}.attn.to_add_out.weight"])
+    add(f"{dp}.txt_attn.norm.key_norm.weight",  sd[f"{p}.attn.norm_added_k.weight"])
+    add(f"{dp}.txt_attn.norm.query_norm.weight",sd[f"{p}.attn.norm_added_q.weight"])
+    add(f"{dp}.txt_mlp.0.weight",              sd[f"{p}.ff_context.linear_in.weight"])
+    add(f"{dp}.txt_mlp.2.weight",              sd[f"{p}.ff_context.linear_out.weight"])
+
+print(f"  converted {n_double} double blocks")
+
+# ── single blocks (single_transformer_blocks.N → single_blocks.N) ────────────
+n_single = max(int(k.split(".")[1]) for k in sd if k.startswith("single_transformer_blocks.")) + 1
+print(f"Single blocks: {n_single}")
+
+for n in range(n_single):
+    p = f"single_transformer_blocks.{n}"
+    sp = f"single_blocks.{n}"
+
+    add(f"{sp}.linear1.weight",        sd[f"{p}.attn.to_qkv_mlp_proj.weight"])
+    add(f"{sp}.linear2.weight",        sd[f"{p}.attn.to_out.weight"])
+    add(f"{sp}.norm.key_norm.weight",  sd[f"{p}.attn.norm_k.weight"])
+    add(f"{sp}.norm.query_norm.weight",sd[f"{p}.attn.norm_q.weight"])
+
+print(f"  converted {n_single} single blocks")
+
+# ── sanity check ─────────────────────────────────────────────────────────────
+print(f"\nTotal output keys: {len(out)}")
+# Verify all source keys are accounted for
+src_keys_used = set(SIMPLE.keys())
+for n in range(n_double):
+    p = f"transformer_blocks.{n}"
+    for suffix in ["attn.to_q.weight","attn.to_k.weight","attn.to_v.weight",
+                   "attn.to_out.0.weight","attn.norm_k.weight","attn.norm_q.weight",
+                   "ff.linear_in.weight","ff.linear_out.weight",
+                   "attn.add_q_proj.weight","attn.add_k_proj.weight","attn.add_v_proj.weight",
+                   "attn.to_add_out.weight","attn.norm_added_k.weight","attn.norm_added_q.weight",
+                   "ff_context.linear_in.weight","ff_context.linear_out.weight"]:
+        src_keys_used.add(f"{p}.{suffix}")
+for n in range(n_single):
+    p = f"single_transformer_blocks.{n}"
+    for suffix in ["attn.to_qkv_mlp_proj.weight","attn.to_out.weight",
+                   "attn.norm_k.weight","attn.norm_q.weight"]:
+        src_keys_used.add(f"{p}.{suffix}")
+
+unconverted = set(sd.keys()) - src_keys_used
+if unconverted:
+    print(f"WARNING — unconverted keys: {unconverted}")
+else:
+    print("✓ All source keys converted")
+
+# ── save ─────────────────────────────────────────────────────────────────────
+print(f"\nSaving to {DST}…")
+save_file(out, DST)
+size_gb = os.path.getsize(DST) / 1024**3
+print(f"✓ Saved: {size_gb:.2f} GB")
+print(f"\nDone. Load in ComfyUI as 'Load Diffusion Model' → flux2-klein-4b-comfy.safetensors")

--- a/brand/scripts/convert_flux2_klein_hf_to_comfy.py
+++ b/brand/scripts/convert_flux2_klein_hf_to_comfy.py
@@ -24,6 +24,11 @@ from safetensors.torch import load_file, save_file
 SRC = "models/diffusion_models/flux2-klein-4b.safetensors"
 DST = "models/diffusion_models/flux2-klein-4b-comfy.safetensors"
 
+if not os.path.isfile(SRC):
+    raise FileNotFoundError(
+        f"{SRC} not found — run from ~/ComfyUI/ (correct CWD for this script)"
+    )
+
 print(f"Loading {SRC}…")
 sd = load_file(SRC)
 print(f"  {len(sd)} keys loaded")

--- a/brand/scripts/convert_flux2_klein_hf_to_comfy.py
+++ b/brand/scripts/convert_flux2_klein_hf_to_comfy.py
@@ -12,15 +12,14 @@ HF format uses:
   - norm_out / proj_out         →  final_layer.adaLN_modulation.1 / final_layer.linear
   - time_guidance_embed.*       →  time_in.*
 
-Input:  models/diffusion_models/flux2-klein-4b.safetensors  (symlink to HF cache, 7.3 GB)
+Input:  models/diffusion_models/flux2-klein-4b.safetensors
+        (symlink to HF cache, 7.3 GB)
 Output: models/diffusion_models/flux2-klein-4b-comfy.safetensors  (~7.3 GB)
 """
-import sys, os
-sys.path.insert(0, os.path.dirname(__file__))
+import os
 
 import torch
 from safetensors.torch import load_file, save_file
-import comfy.utils
 
 SRC = "models/diffusion_models/flux2-klein-4b.safetensors"
 DST = "models/diffusion_models/flux2-klein-4b-comfy.safetensors"
@@ -36,15 +35,20 @@ def add(dst_key, tensor):
 
 # ── simple renames ────────────────────────────────────────────────────────────
 SIMPLE = {
-    "x_embedder.weight":                                       "img_in.weight",
-    "context_embedder.weight":                                 "txt_in.weight",
-    "double_stream_modulation_img.linear.weight":              "double_stream_modulation_img.lin.weight",
-    "double_stream_modulation_txt.linear.weight":              "double_stream_modulation_txt.lin.weight",
-    "single_stream_modulation.linear.weight":                  "single_stream_modulation.lin.weight",
-    "norm_out.linear.weight":                                  "final_layer.adaLN_modulation.1.weight",
-    "proj_out.weight":                                         "final_layer.linear.weight",
-    "time_guidance_embed.timestep_embedder.linear_1.weight":   "time_in.in_layer.weight",
-    "time_guidance_embed.timestep_embedder.linear_2.weight":   "time_in.out_layer.weight",
+    "x_embedder.weight": "img_in.weight",
+    "context_embedder.weight": "txt_in.weight",
+    "double_stream_modulation_img.linear.weight":
+        "double_stream_modulation_img.lin.weight",
+    "double_stream_modulation_txt.linear.weight":
+        "double_stream_modulation_txt.lin.weight",
+    "single_stream_modulation.linear.weight":
+        "single_stream_modulation.lin.weight",
+    "norm_out.linear.weight": "final_layer.adaLN_modulation.1.weight",
+    "proj_out.weight": "final_layer.linear.weight",
+    "time_guidance_embed.timestep_embedder.linear_1.weight":
+        "time_in.in_layer.weight",
+    "time_guidance_embed.timestep_embedder.linear_2.weight":
+        "time_in.out_layer.weight",
 }
 for src_k, dst_k in SIMPLE.items():
     if src_k in sd:
@@ -54,7 +58,10 @@ for src_k, dst_k in SIMPLE.items():
         print(f"  MISSING: {src_k}")
 
 # ── double blocks (transformer_blocks.N → double_blocks.N) ───────────────────
-n_double = max(int(k.split(".")[1]) for k in sd if k.startswith("transformer_blocks.")) + 1
+n_double = (
+    max(int(k.split(".")[1]) for k in sd if k.startswith("transformer_blocks."))
+    + 1
+)
 print(f"\nDouble blocks: {n_double}")
 
 for n in range(n_double):
@@ -88,7 +95,10 @@ for n in range(n_double):
 print(f"  converted {n_double} double blocks")
 
 # ── single blocks (single_transformer_blocks.N → single_blocks.N) ────────────
-n_single = max(int(k.split(".")[1]) for k in sd if k.startswith("single_transformer_blocks.")) + 1
+n_single = (
+    max(int(k.split(".")[1]) for k in sd if k.startswith("single_transformer_blocks."))
+    + 1
+)
 print(f"Single blocks: {n_single}")
 
 for n in range(n_single):
@@ -132,4 +142,7 @@ print(f"\nSaving to {DST}…")
 save_file(out, DST)
 size_gb = os.path.getsize(DST) / 1024**3
 print(f"✓ Saved: {size_gb:.2f} GB")
-print(f"\nDone. Load in ComfyUI as 'Load Diffusion Model' → flux2-klein-4b-comfy.safetensors")
+print(
+    "\nDone. Load in ComfyUI as 'Load Diffusion Model'"
+    " → flux2-klein-4b-comfy.safetensors"
+)

--- a/brand/scripts/smoke_test_421.py
+++ b/brand/scripts/smoke_test_421.py
@@ -1,0 +1,76 @@
+"""Smoke test for ComfyUI + flux2-klein-4B — issue #421."""
+import sys, os, warnings
+sys.path.insert(0, os.path.dirname(__file__))
+warnings.filterwarnings("ignore")
+
+import torch
+import folder_paths
+import comfy.sd
+import comfy.utils
+import comfy.model_management
+from comfy_extras.nodes_flux import (
+    EmptyFlux2LatentImage, Flux2Scheduler, FluxGuidance,
+)
+from comfy_extras.nodes_custom_sampler import (
+    BasicGuider, RandomNoise, SamplerCustomAdvanced, KSamplerSelect,
+)
+from nodes import VAEDecode, SaveImage
+
+UNET   = folder_paths.get_full_path("diffusion_models", "flux2-klein-4b-comfy.safetensors")
+TE     = folder_paths.get_full_path("text_encoders",    "flux2-klein-qwen3.safetensors")
+VAE_P  = folder_paths.get_full_path("vae",              "flux2-klein-vae.safetensors")
+
+print("Loading text encoder (Qwen3 4B, merged)…")
+clip = comfy.sd.load_clip(
+    ckpt_paths=[TE],
+    clip_type=comfy.sd.CLIPType.FLUX2,
+    embedding_directory=folder_paths.get_folder_paths("embeddings"),
+)
+print("  TE loaded:", type(clip.cond_stage_model).__name__)
+
+print("Loading diffusion model (ComfyUI format)…")
+unet = comfy.sd.load_diffusion_model(UNET)
+print("  UNET loaded:", type(unet.model).__name__)
+
+print("Loading VAE…")
+sd_vae = comfy.utils.load_torch_file(VAE_P)
+vae = comfy.sd.VAE(sd=sd_vae)
+print("  VAE loaded:", type(vae).__name__)
+
+print("Encoding prompt…")
+PROMPT = "a white cat on a red chair"
+tokens = clip.tokenize(PROMPT)
+cond = clip.encode_from_tokens_scheduled(tokens, add_dict={"guidance": 3.5})
+
+print("Applying FluxGuidance…")
+guided_cond = FluxGuidance.execute(conditioning=cond, guidance=3.5).args[0]
+
+print("Building guider…")
+guider = BasicGuider.execute(model=unet, conditioning=guided_cond).args[0]
+
+print("Creating latent (512×512)…")
+latent = EmptyFlux2LatentImage.execute(width=512, height=512, batch_size=1).args[0]
+
+print("Building sigmas (10 steps)…")
+sigmas = Flux2Scheduler.execute(steps=10, width=512, height=512).args[0]
+
+print("Building noise + sampler…")
+noise   = RandomNoise.execute(noise_seed=42).args[0]
+sampler = KSamplerSelect.execute(sampler_name="euler").args[0]
+
+print("Sampling…  (first run triggers Blackwell JIT — may take 30–45 min)")
+samples = SamplerCustomAdvanced.execute(
+    noise=noise, guider=guider, sampler=sampler,
+    sigmas=sigmas, latent_image=latent,
+).args[0]
+
+print("Decoding…")
+images = VAEDecode().decode(samples=samples, vae=vae)[0]
+print(f"  Output shape: {images.shape}")
+
+print("Saving…")
+SaveImage().save_images(images=images, filename_prefix="smoke_test_421")
+
+peak_vram = torch.cuda.max_memory_allocated() / 1024**3
+print(f"\n✓ Smoke test PASSED — flux2-klein-4B generated without OOM")
+print(f"  Peak VRAM: {peak_vram:.1f} GB")

--- a/brand/scripts/smoke_test_421.py
+++ b/brand/scripts/smoke_test_421.py
@@ -1,10 +1,8 @@
 """Smoke test for ComfyUI + flux2-klein-4B — issue #421."""
 import os
 import sys
-import warnings
 
 sys.path.insert(0, os.path.dirname(__file__))
-warnings.filterwarnings("ignore")
 
 import comfy.model_management  # noqa: E402
 import comfy.sd  # noqa: E402
@@ -29,6 +27,11 @@ UNET = folder_paths.get_full_path(
 )
 TE = folder_paths.get_full_path("text_encoders", "flux2-klein-qwen3.safetensors")
 VAE_P = folder_paths.get_full_path("vae", "flux2-klein-vae.safetensors")
+
+for _label, _path in [("UNET", UNET), ("TE", TE), ("VAE", VAE_P)]:
+    if _path is None:
+        print(f"ERROR — model file not found for {_label}", file=sys.stderr)
+        sys.exit(1)
 
 print("Loading text encoder (Qwen3 4B, merged)…")
 clip = comfy.sd.load_clip(
@@ -77,10 +80,16 @@ samples = SamplerCustomAdvanced.execute(
 print("Decoding…")
 images = VAEDecode().decode(samples=samples, vae=vae)[0]
 print(f"  Output shape: {images.shape}")
+assert images.shape == (1, 512, 512, 3), f"Unexpected output shape: {images.shape}"
 
 print("Saving…")
-SaveImage().save_images(images=images, filename_prefix="smoke_test_421")
+result = SaveImage().save_images(images=images, filename_prefix="smoke_test_421")
+assert result and result.get("ui", {}).get("images"), "SaveImage returned no files"
 
 peak_vram = torch.cuda.max_memory_allocated() / 1024**3
+VRAM_CEILING_GB = 20.0
+assert peak_vram < VRAM_CEILING_GB, (
+    f"VRAM regression: {peak_vram:.1f} GB >= {VRAM_CEILING_GB} GB"
+)
 print("\n✓ Smoke test PASSED — flux2-klein-4B generated without OOM")
 print(f"  Peak VRAM: {peak_vram:.1f} GB")

--- a/brand/scripts/smoke_test_421.py
+++ b/brand/scripts/smoke_test_421.py
@@ -1,24 +1,34 @@
 """Smoke test for ComfyUI + flux2-klein-4B — issue #421."""
-import sys, os, warnings
+import os
+import sys
+import warnings
+
 sys.path.insert(0, os.path.dirname(__file__))
 warnings.filterwarnings("ignore")
 
-import torch
-import folder_paths
-import comfy.sd
-import comfy.utils
-import comfy.model_management
-from comfy_extras.nodes_flux import (
-    EmptyFlux2LatentImage, Flux2Scheduler, FluxGuidance,
+import comfy.model_management  # noqa: E402
+import comfy.sd  # noqa: E402
+import comfy.utils  # noqa: E402
+import folder_paths  # noqa: E402
+import torch  # noqa: E402
+from comfy_extras.nodes_custom_sampler import (  # noqa: E402
+    BasicGuider,
+    KSamplerSelect,
+    RandomNoise,
+    SamplerCustomAdvanced,
 )
-from comfy_extras.nodes_custom_sampler import (
-    BasicGuider, RandomNoise, SamplerCustomAdvanced, KSamplerSelect,
+from comfy_extras.nodes_flux import (  # noqa: E402
+    EmptyFlux2LatentImage,
+    Flux2Scheduler,
+    FluxGuidance,
 )
-from nodes import VAEDecode, SaveImage
+from nodes import SaveImage, VAEDecode  # noqa: E402
 
-UNET   = folder_paths.get_full_path("diffusion_models", "flux2-klein-4b-comfy.safetensors")
-TE     = folder_paths.get_full_path("text_encoders",    "flux2-klein-qwen3.safetensors")
-VAE_P  = folder_paths.get_full_path("vae",              "flux2-klein-vae.safetensors")
+UNET = folder_paths.get_full_path(
+    "diffusion_models", "flux2-klein-4b-comfy.safetensors"
+)
+TE = folder_paths.get_full_path("text_encoders", "flux2-klein-qwen3.safetensors")
+VAE_P = folder_paths.get_full_path("vae", "flux2-klein-vae.safetensors")
 
 print("Loading text encoder (Qwen3 4B, merged)…")
 clip = comfy.sd.load_clip(
@@ -55,7 +65,7 @@ print("Building sigmas (10 steps)…")
 sigmas = Flux2Scheduler.execute(steps=10, width=512, height=512).args[0]
 
 print("Building noise + sampler…")
-noise   = RandomNoise.execute(noise_seed=42).args[0]
+noise = RandomNoise.execute(noise_seed=42).args[0]
 sampler = KSamplerSelect.execute(sampler_name="euler").args[0]
 
 print("Sampling…  (first run triggers Blackwell JIT — may take 30–45 min)")
@@ -72,5 +82,5 @@ print("Saving…")
 SaveImage().save_images(images=images, filename_prefix="smoke_test_421")
 
 peak_vram = torch.cuda.max_memory_allocated() / 1024**3
-print(f"\n✓ Smoke test PASSED — flux2-klein-4B generated without OOM")
+print("\n✓ Smoke test PASSED — flux2-klein-4B generated without OOM")
 print(f"  Peak VRAM: {peak_vram:.1f} GB")

--- a/brand/scripts/smoke_test_421.py
+++ b/brand/scripts/smoke_test_421.py
@@ -1,26 +1,23 @@
 """Smoke test for ComfyUI + flux2-klein-4B — issue #421."""
-import os
 import sys
 
-sys.path.insert(0, os.path.dirname(__file__))
-
-import comfy.model_management  # noqa: E402
-import comfy.sd  # noqa: E402
-import comfy.utils  # noqa: E402
-import folder_paths  # noqa: E402
-import torch  # noqa: E402
-from comfy_extras.nodes_custom_sampler import (  # noqa: E402
+import comfy.model_management  # noqa: F401 — side-effect: registers CUDA device + memory manager
+import comfy.sd
+import comfy.utils
+import folder_paths
+import torch
+from comfy_extras.nodes_custom_sampler import (
     BasicGuider,
     KSamplerSelect,
     RandomNoise,
     SamplerCustomAdvanced,
 )
-from comfy_extras.nodes_flux import (  # noqa: E402
+from comfy_extras.nodes_flux import (
     EmptyFlux2LatentImage,
     Flux2Scheduler,
     FluxGuidance,
 )
-from nodes import SaveImage, VAEDecode  # noqa: E402
+from nodes import SaveImage, VAEDecode
 
 UNET = folder_paths.get_full_path(
     "diffusion_models", "flux2-klein-4b-comfy.safetensors"
@@ -33,63 +30,68 @@ for _label, _path in [("UNET", UNET), ("TE", TE), ("VAE", VAE_P)]:
         print(f"ERROR — model file not found for {_label}", file=sys.stderr)
         sys.exit(1)
 
-print("Loading text encoder (Qwen3 4B, merged)…")
-clip = comfy.sd.load_clip(
-    ckpt_paths=[TE],
-    clip_type=comfy.sd.CLIPType.FLUX2,
-    embedding_directory=folder_paths.get_folder_paths("embeddings"),
-)
-print("  TE loaded:", type(clip.cond_stage_model).__name__)
+try:
+    print("Loading text encoder (Qwen3 4B, merged)…")
+    clip = comfy.sd.load_clip(
+        ckpt_paths=[TE],
+        clip_type=comfy.sd.CLIPType.FLUX2,
+        embedding_directory=folder_paths.get_folder_paths("embeddings"),
+    )
+    print("  TE loaded:", type(clip.cond_stage_model).__name__)
 
-print("Loading diffusion model (ComfyUI format)…")
-unet = comfy.sd.load_diffusion_model(UNET)
-print("  UNET loaded:", type(unet.model).__name__)
+    print("Loading diffusion model (ComfyUI format)…")
+    unet = comfy.sd.load_diffusion_model(UNET)
+    print("  UNET loaded:", type(unet.model).__name__)
 
-print("Loading VAE…")
-sd_vae = comfy.utils.load_torch_file(VAE_P)
-vae = comfy.sd.VAE(sd=sd_vae)
-print("  VAE loaded:", type(vae).__name__)
+    print("Loading VAE…")
+    sd_vae = comfy.utils.load_torch_file(VAE_P)
+    vae = comfy.sd.VAE(sd=sd_vae)
+    print("  VAE loaded:", type(vae).__name__)
 
-print("Encoding prompt…")
-PROMPT = "a white cat on a red chair"
-tokens = clip.tokenize(PROMPT)
-cond = clip.encode_from_tokens_scheduled(tokens, add_dict={"guidance": 3.5})
+    print("Encoding prompt…")
+    PROMPT = "a white cat on a red chair"
+    tokens = clip.tokenize(PROMPT)
+    cond = clip.encode_from_tokens_scheduled(tokens, add_dict={"guidance": 3.5})
 
-print("Applying FluxGuidance…")
-guided_cond = FluxGuidance.execute(conditioning=cond, guidance=3.5).args[0]
+    print("Applying FluxGuidance…")
+    guided_cond = FluxGuidance.execute(conditioning=cond, guidance=3.5)[0]
 
-print("Building guider…")
-guider = BasicGuider.execute(model=unet, conditioning=guided_cond).args[0]
+    print("Building guider…")
+    guider = BasicGuider.execute(model=unet, conditioning=guided_cond)[0]
 
-print("Creating latent (512×512)…")
-latent = EmptyFlux2LatentImage.execute(width=512, height=512, batch_size=1).args[0]
+    print("Creating latent (512×512)…")
+    latent = EmptyFlux2LatentImage.execute(width=512, height=512, batch_size=1)[0]
 
-print("Building sigmas (10 steps)…")
-sigmas = Flux2Scheduler.execute(steps=10, width=512, height=512).args[0]
+    print("Building sigmas (10 steps)…")
+    sigmas = Flux2Scheduler.execute(steps=10, width=512, height=512)[0]
 
-print("Building noise + sampler…")
-noise = RandomNoise.execute(noise_seed=42).args[0]
-sampler = KSamplerSelect.execute(sampler_name="euler").args[0]
+    print("Building noise + sampler…")
+    noise = RandomNoise.execute(noise_seed=42)[0]
+    sampler = KSamplerSelect.execute(sampler_name="euler")[0]
 
-print("Sampling…  (first run triggers Blackwell JIT — may take 30–45 min)")
-samples = SamplerCustomAdvanced.execute(
-    noise=noise, guider=guider, sampler=sampler,
-    sigmas=sigmas, latent_image=latent,
-).args[0]
+    print("Sampling…  (first run triggers Blackwell JIT — may take 30–45 min)")
+    samples = SamplerCustomAdvanced.execute(
+        noise=noise, guider=guider, sampler=sampler,
+        sigmas=sigmas, latent_image=latent,
+    )[0]
 
-print("Decoding…")
-images = VAEDecode().decode(samples=samples, vae=vae)[0]
-print(f"  Output shape: {images.shape}")
-assert images.shape == (1, 512, 512, 3), f"Unexpected output shape: {images.shape}"
+    print("Decoding…")
+    images = VAEDecode().decode(samples=samples, vae=vae)[0]
+    print(f"  Output shape: {images.shape}")
+    assert images.shape == (1, 512, 512, 3), f"Unexpected output shape: {images.shape}"
 
-print("Saving…")
-result = SaveImage().save_images(images=images, filename_prefix="smoke_test_421")
-assert result and result.get("ui", {}).get("images"), "SaveImage returned no files"
+    print("Saving…")
+    result = SaveImage().save_images(images=images, filename_prefix="smoke_test_421")
+    assert result and result.get("ui", {}).get("images"), "SaveImage returned no files"
 
-peak_vram = torch.cuda.max_memory_allocated() / 1024**3
-VRAM_CEILING_GB = 20.0
-assert peak_vram < VRAM_CEILING_GB, (
-    f"VRAM regression: {peak_vram:.1f} GB >= {VRAM_CEILING_GB} GB"
-)
-print("\n✓ Smoke test PASSED — flux2-klein-4B generated without OOM")
-print(f"  Peak VRAM: {peak_vram:.1f} GB")
+    peak_vram = torch.cuda.max_memory_allocated() / 1024**3
+    VRAM_CEILING_GB = 20.0
+    assert peak_vram < VRAM_CEILING_GB, (
+        f"VRAM regression: {peak_vram:.1f} GB >= {VRAM_CEILING_GB} GB"
+    )
+    print("\n✓ Smoke test PASSED — flux2-klein-4B generated without OOM")
+    print(f"  Peak VRAM: {peak_vram:.1f} GB")
+except Exception as exc:
+    print(f"ERROR: {exc}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)

--- a/docs/architecture/comfyui-puliid-setup.md
+++ b/docs/architecture/comfyui-puliid-setup.md
@@ -25,16 +25,33 @@ index-url: https://download.pytorch.org/whl/nightly/cu130
 > cu130 required for `comfy.quant_ops` optimized CUDA kernels on Blackwell.
 > CUDA 13.0 toolkit (`cuda-toolkit-13-0`) must be installed alongside cu128.
 
-## Model Symlinks (no duplication from imageCLI HF cache)
+## Model Files
 
-All flux2-klein weights are symlinked from `~/.cache/huggingface/hub/models--black-forest-labs--FLUX.2-klein-4B/snapshots/e7b7dc27f91deacad38e78976d1f2b499d76a294/`:
+HF weights are symlinked from `~/.cache/huggingface/hub/models--black-forest-labs--FLUX.2-klein-4B/snapshots/e7b7dc27f91deacad38e78976d1f2b499d76a294/`:
 
-| ComfyUI path | Source |
-|---|---|
-| `models/diffusion_models/flux2-klein-4b.safetensors` | `transformer/diffusion_pytorch_model.safetensors` (7.3 GB) |
-| `models/vae/flux2-klein-vae.safetensors` | `vae/diffusion_pytorch_model.safetensors` (161 MB) |
-| `models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors` | `text_encoder/model-00001-of-00002.safetensors` (4.7 GB) |
-| `models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors` | `text_encoder/model-00002-of-00002.safetensors` (2.9 GB) |
+| ComfyUI path | Source | Notes |
+|---|---|---|
+| `models/diffusion_models/flux2-klein-4b.safetensors` | `transformer/diffusion_pytorch_model.safetensors` (7.3 GB) | HF format — symlink only |
+| `models/diffusion_models/flux2-klein-4b-comfy.safetensors` | converted from HF format (7.3 GB) | **Use this in ComfyUI** |
+| `models/vae/flux2-klein-vae.safetensors` | `vae/diffusion_pytorch_model.safetensors` (161 MB) | symlink |
+| `models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors` | `text_encoder/model-00001-of-00002.safetensors` (4.7 GB) | shard — do not use directly |
+| `models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors` | `text_encoder/model-00002-of-00002.safetensors` (2.9 GB) | shard — do not use directly |
+| `models/text_encoders/flux2-klein-qwen3.safetensors` | merged from both shards (7.5 GB) | **Use this in ComfyUI** |
+
+### Why conversion is needed
+
+ComfyUI expects different key names than HF diffusers:
+- Separate `to_q/to_k/to_v` → merged `qkv`
+- `transformer_blocks` → `double_blocks`
+- `x_embedder` → `img_in`
+- `*.linear.weight` → `*.lin.weight` (modulation layers)
+- See `~/ComfyUI/convert_flux2_klein_hf_to_comfy.py` for details
+
+### Why shard merging is needed
+
+`DualCLIPLoader` with `flux2` type falls through to SDXLClipModel (no FLUX2 dual-file handler).
+The Qwen3 4B encoder must be loaded as a single file via `CLIPLoader` with type `flux2`.
+Merge script: `~/ComfyUI/models/text_encoders/flux2-klein-qwen3.safetensors` (created once, ~7.5 GB).
 
 ## Custom Nodes
 
@@ -67,8 +84,8 @@ opencv-python
 ## ComfyUI Node Setup (Flux2-Klein workflow)
 
 Load order in the UI:
-1. **Load Diffusion Model** → `flux2-klein-4b.safetensors`
-2. **Dual CLIP Loader** (type: `flux2`) → both `flux2-klein-qwen3-*` shards
+1. **Load Diffusion Model** → `flux2-klein-4b-comfy.safetensors` (converted file, not the HF symlink)
+2. **Load CLIP** (type: `flux2`) → `flux2-klein-qwen3.safetensors` (merged file, not the shards)
 3. **Load VAE** → `flux2-klein-vae.safetensors`
 4. **Load InsightFace (PuLID)** → auto-detects AntelopeV2
 5. **Load EVA-CLIP (PuLID)** → downloads on first run

--- a/docs/architecture/comfyui-puliid-setup.md
+++ b/docs/architecture/comfyui-puliid-setup.md
@@ -1,0 +1,92 @@
+# ComfyUI + PuLID Flux2 Setup — Machine 2 (Pop!_OS)
+
+Setup for issue [#421](https://github.com/Roxabi/lyra/issues/421).
+
+## Environment
+
+| | Value |
+|--|-------|
+| Host | ROXABITOWER (Machine 2) |
+| GPU | RTX 5070 Ti (Blackwell, sm_120) |
+| CUDA toolkit | 12.8 + 13.0 (both installed) |
+| CUDA driver | 580.126.18 |
+| Python | 3.12 |
+| Install path | `~/ComfyUI/` |
+
+## PyTorch (cu130)
+
+```
+torch==2.12.0.dev20260331+cu130
+torchvision==0.27.0.dev20260331+cu130
+torchaudio==2.11.0.dev20260331+cu130
+index-url: https://download.pytorch.org/whl/nightly/cu130
+```
+
+> cu130 required for `comfy.quant_ops` optimized CUDA kernels on Blackwell.
+> CUDA 13.0 toolkit (`cuda-toolkit-13-0`) must be installed alongside cu128.
+
+## Model Symlinks (no duplication from imageCLI HF cache)
+
+All flux2-klein weights are symlinked from `~/.cache/huggingface/hub/models--black-forest-labs--FLUX.2-klein-4B/snapshots/e7b7dc27f91deacad38e78976d1f2b499d76a294/`:
+
+| ComfyUI path | Source |
+|---|---|
+| `models/diffusion_models/flux2-klein-4b.safetensors` | `transformer/diffusion_pytorch_model.safetensors` (7.3 GB) |
+| `models/vae/flux2-klein-vae.safetensors` | `vae/diffusion_pytorch_model.safetensors` (161 MB) |
+| `models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors` | `text_encoder/model-00001-of-00002.safetensors` (4.7 GB) |
+| `models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors` | `text_encoder/model-00002-of-00002.safetensors` (2.9 GB) |
+
+## Custom Nodes
+
+| Node | Path | Notes |
+|---|---|---|
+| ComfyUI-Manager | `custom_nodes/ComfyUI-Manager/` | v0.30.4 |
+| ComfyUI-PuLID-Flux2 | `custom_nodes/ComfyUI-PuLID-Flux2/` | iFayens/ComfyUI-PuLID-Flux2 |
+
+### PuLID Flux2 Dependencies
+
+```
+insightface>=0.7.3
+onnxruntime-gpu>=1.16.0
+open-clip-torch>=3.2.0
+numpy<2.0.0          # pinned: InsightFace + open_clip compat
+ml_dtypes==0.3.2     # pinned: AttributeError otherwise
+opencv-python
+```
+
+> EVA-CLIP (~800 MB) downloads automatically on first PuLID run.
+
+## Weights
+
+| Model | Path | Source |
+|---|---|---|
+| AntelopeV2 | `models/insightface/models/antelopev2/` | MonsterMMORPG/InstantID_Models (5 .onnx files, ~408 MB) |
+| PuLID Flux2 Klein v1 | `models/pulid/pulid_flux2_klein_v1.safetensors` | Fayens/Pulid-Flux2 (1.27 GB) |
+| PuLID Flux2 Klein v2 | `models/pulid/pulid_flux2_klein_v2.safetensors` | Fayens/Pulid-Flux2 (1.27 GB) |
+
+## ComfyUI Node Setup (Flux2-Klein workflow)
+
+Load order in the UI:
+1. **Load Diffusion Model** → `flux2-klein-4b.safetensors`
+2. **Dual CLIP Loader** (type: `flux2`) → both `flux2-klein-qwen3-*` shards
+3. **Load VAE** → `flux2-klein-vae.safetensors`
+4. **Load InsightFace (PuLID)** → auto-detects AntelopeV2
+5. **Load EVA-CLIP (PuLID)** → downloads on first run
+6. **Load PuLID ✦ Flux.2** → `pulid_flux2_klein_v2.safetensors` (recommended)
+7. **Apply PuLID ✦ Flux.2** → strength 1.4 recommended
+8. **EmptyFlux2LatentImage + Flux2Scheduler → KSampler → VAEDecode → SaveImage**
+
+## Starting ComfyUI
+
+```bash
+cd ~/ComfyUI
+venv/bin/python main.py --listen 127.0.0.1 --port 8188
+# GUI: http://localhost:8188
+```
+
+## First-run Notes
+
+- First generation triggers Blackwell JIT compilation: **expect 30–45 min**
+- Subsequent runs are fast (~2–5 min for 50 steps at 1024×1024)
+- EVA-CLIP downloads automatically on first PuLID use (~800 MB)
+- Done when: flux2-klein loads without OOM, smoke-test image generates

--- a/docs/architecture/comfyui-puliid-setup.md
+++ b/docs/architecture/comfyui-puliid-setup.md
@@ -107,3 +107,14 @@ venv/bin/python main.py --listen 127.0.0.1 --port 8188
 - Subsequent runs are fast (~2–5 min for 50 steps at 1024×1024)
 - EVA-CLIP downloads automatically on first PuLID use (~800 MB)
 - Done when: flux2-klein loads without OOM, smoke-test image generates
+
+## Blackwell JIT Cache
+
+PyTorch caches compiled SM_120 CUDA kernels in `~/.cache/torch/`. Once compiled, all subsequent runs skip the 30–45 min wait.
+
+**On this machine (ROXABITOWER):** JIT was compiled during initial setup/debug session (2026-03-31) — the cache is warm. The smoke test ran in ~1 sec and peaked at 13.0 GB VRAM.
+
+On a **fresh machine**, the first generation will still take 30–45 min. The cache directory to back up or copy across machines is:
+```
+~/.cache/torch/kernels/
+```

--- a/docs/architecture/comfyui-puliid-setup.md
+++ b/docs/architecture/comfyui-puliid-setup.md
@@ -13,85 +13,13 @@ Setup for issue [#421](https://github.com/Roxabi/lyra/issues/421).
 | Python | 3.12 |
 | Install path | `~/ComfyUI/` |
 
-## PyTorch (cu130)
+## Quick Reference — Correct Files to Load
 
-```
-torch==2.12.0.dev20260331+cu130
-torchvision==0.27.0.dev20260331+cu130
-torchaudio==2.11.0.dev20260331+cu130
-index-url: https://download.pytorch.org/whl/nightly/cu130
-```
-
-> cu130 required for `comfy.quant_ops` optimized CUDA kernels on Blackwell.
-> CUDA 13.0 toolkit (`cuda-toolkit-13-0`) must be installed alongside cu128.
-
-## Model Files
-
-HF weights are symlinked from `~/.cache/huggingface/hub/models--black-forest-labs--FLUX.2-klein-4B/snapshots/e7b7dc27f91deacad38e78976d1f2b499d76a294/`:
-
-| ComfyUI path | Source | Notes |
+| Role | File | Why |
 |---|---|---|
-| `models/diffusion_models/flux2-klein-4b.safetensors` | `transformer/diffusion_pytorch_model.safetensors` (7.3 GB) | HF format — symlink only |
-| `models/diffusion_models/flux2-klein-4b-comfy.safetensors` | converted from HF format (7.3 GB) | **Use this in ComfyUI** |
-| `models/vae/flux2-klein-vae.safetensors` | `vae/diffusion_pytorch_model.safetensors` (161 MB) | symlink |
-| `models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors` | `text_encoder/model-00001-of-00002.safetensors` (4.7 GB) | shard — do not use directly |
-| `models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors` | `text_encoder/model-00002-of-00002.safetensors` (2.9 GB) | shard — do not use directly |
-| `models/text_encoders/flux2-klein-qwen3.safetensors` | merged from both shards (7.5 GB) | **Use this in ComfyUI** |
-
-### Why conversion is needed
-
-ComfyUI expects different key names than HF diffusers:
-- Separate `to_q/to_k/to_v` → merged `qkv`
-- `transformer_blocks` → `double_blocks`
-- `x_embedder` → `img_in`
-- `*.linear.weight` → `*.lin.weight` (modulation layers)
-- See `~/ComfyUI/convert_flux2_klein_hf_to_comfy.py` for details
-
-### Why shard merging is needed
-
-`DualCLIPLoader` with `flux2` type falls through to SDXLClipModel (no FLUX2 dual-file handler).
-The Qwen3 4B encoder must be loaded as a single file via `CLIPLoader` with type `flux2`.
-Merge script: `~/ComfyUI/models/text_encoders/flux2-klein-qwen3.safetensors` (created once, ~7.5 GB).
-
-## Custom Nodes
-
-| Node | Path | Notes |
-|---|---|---|
-| ComfyUI-Manager | `custom_nodes/ComfyUI-Manager/` | v0.30.4 |
-| ComfyUI-PuLID-Flux2 | `custom_nodes/ComfyUI-PuLID-Flux2/` | iFayens/ComfyUI-PuLID-Flux2 |
-
-### PuLID Flux2 Dependencies
-
-```
-insightface>=0.7.3
-onnxruntime-gpu>=1.16.0
-open-clip-torch>=3.2.0
-numpy<2.0.0          # pinned: InsightFace + open_clip compat
-ml_dtypes==0.3.2     # pinned: AttributeError otherwise
-opencv-python
-```
-
-> EVA-CLIP (~800 MB) downloads automatically on first PuLID run.
-
-## Weights
-
-| Model | Path | Source |
-|---|---|---|
-| AntelopeV2 | `models/insightface/models/antelopev2/` | MonsterMMORPG/InstantID_Models (5 .onnx files, ~408 MB) |
-| PuLID Flux2 Klein v1 | `models/pulid/pulid_flux2_klein_v1.safetensors` | Fayens/Pulid-Flux2 (1.27 GB) |
-| PuLID Flux2 Klein v2 | `models/pulid/pulid_flux2_klein_v2.safetensors` | Fayens/Pulid-Flux2 (1.27 GB) |
-
-## ComfyUI Node Setup (Flux2-Klein workflow)
-
-Load order in the UI:
-1. **Load Diffusion Model** → `flux2-klein-4b-comfy.safetensors` (converted file, not the HF symlink)
-2. **Load CLIP** (type: `flux2`) → `flux2-klein-qwen3.safetensors` (merged file, not the shards)
-3. **Load VAE** → `flux2-klein-vae.safetensors`
-4. **Load InsightFace (PuLID)** → auto-detects AntelopeV2
-5. **Load EVA-CLIP (PuLID)** → downloads on first run
-6. **Load PuLID ✦ Flux.2** → `pulid_flux2_klein_v2.safetensors` (recommended)
-7. **Apply PuLID ✦ Flux.2** → strength 1.4 recommended
-8. **EmptyFlux2LatentImage + Flux2Scheduler → KSampler → VAEDecode → SaveImage**
+| Diffusion model | `models/diffusion_models/flux2-klein-4b-comfy.safetensors` | **Not** the HF symlink — ComfyUI needs different key names |
+| Text encoder | `models/text_encoders/flux2-klein-qwen3.safetensors` | **Not** the shards — DualCLIPLoader has no FLUX2 dual-file handler |
+| VAE | `models/vae/flux2-klein-vae.safetensors` | Direct symlink, no conversion needed |
 
 ## Starting ComfyUI
 
@@ -101,20 +29,230 @@ venv/bin/python main.py --listen 127.0.0.1 --port 8188
 # GUI: http://localhost:8188
 ```
 
-## First-run Notes
+Or via the Lyra Makefile shortcut:
 
-- First generation triggers Blackwell JIT compilation: **expect 30–45 min**
-- Subsequent runs are fast (~2–5 min for 50 steps at 1024×1024)
-- EVA-CLIP downloads automatically on first PuLID use (~800 MB)
-- Done when: flux2-klein loads without OOM, smoke-test image generates
+```bash
+cd ~/projects/lyra
+make comfyui          # start
+make comfyui logs     # tail output
+```
+
+---
+
+## Installation Playbook (reproduce from scratch)
+
+Full step-by-step to rebuild this setup on a fresh Pop!_OS machine with an RTX 5070 Ti.
+
+### Prerequisites
+
+- RTX 5070 Ti (or other Blackwell GPU)
+- Pop!_OS / Ubuntu with CUDA driver ≥ 570
+- HF cache already populated with FLUX.2-klein-4B (via `imageCLI` or manual download)
+  - Cache path: `~/.cache/huggingface/hub/models--black-forest-labs--FLUX.2-klein-4B/snapshots/e7b7dc27f91deacad38e78976d1f2b499d76a294/`
+
+### Step 1 — Install CUDA 13.0 toolkit
+
+cu130 PyTorch requires the CUDA 13.0 toolkit (in addition to whatever driver is installed).
+
+```bash
+sudo apt-get install -y cuda-toolkit-13-0
+# Verify:
+ls /usr/local/cuda-13.0/lib64/libcudart.so.13
+```
+
+### Step 2 — Clone ComfyUI and create venv
+
+```bash
+cd ~
+git clone https://github.com/comfyanonymous/ComfyUI.git
+cd ComfyUI
+python3.12 -m venv venv
+source venv/bin/activate
+```
+
+### Step 3 — Install PyTorch cu130 (Blackwell nightly)
+
+```bash
+pip install torch==2.12.0.dev20260331+cu130 \
+            torchvision==0.27.0.dev20260331+cu130 \
+            torchaudio==2.11.0.dev20260331+cu130 \
+            --index-url https://download.pytorch.org/whl/nightly/cu130
+
+# Verify Blackwell is detected:
+python -c "import torch; print(torch.cuda.get_device_name(0))"
+# Expected: NVIDIA GeForce RTX 5070 Ti
+```
+
+> **Why cu130, not cu128?** `comfy.quant_ops` uses optimized CUDA kernels that require the CUDA 13.0 toolkit headers at compile time. cu128 builds fail to load on Blackwell SM_120.
+
+### Step 4 — Install ComfyUI dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### Step 5 — Install custom nodes
+
+```bash
+cd ~/ComfyUI/custom_nodes
+
+# ComfyUI Manager
+git clone https://github.com/ltdrdata/ComfyUI-Manager.git
+
+# PuLID Flux2
+git clone https://github.com/iFayens/ComfyUI-PuLID-Flux2.git
+```
+
+### Step 6 — Install PuLID Flux2 dependencies
+
+```bash
+pip install insightface>=0.7.3 \
+            onnxruntime-gpu>=1.16.0 \
+            open-clip-torch>=3.2.0 \
+            "numpy<2.0.0" \
+            ml_dtypes==0.3.2 \
+            opencv-python
+```
+
+> `numpy<2.0.0` and `ml_dtypes==0.3.2` are pinned — newer versions break InsightFace and open_clip compatibility.
+
+### Step 7 — Symlink FLUX.2-klein model files
+
+```bash
+HF_SNAP=~/.cache/huggingface/hub/models--black-forest-labs--FLUX.2-klein-4B/snapshots/e7b7dc27f91deacad38e78976d1f2b499d76a294
+
+mkdir -p ~/ComfyUI/models/{diffusion_models,vae,text_encoders}
+
+# Diffusion model (HF format — will be converted in Step 8)
+ln -s $HF_SNAP/transformer/diffusion_pytorch_model.safetensors \
+      ~/ComfyUI/models/diffusion_models/flux2-klein-4b.safetensors
+
+# VAE (direct symlink — no conversion needed)
+ln -s $HF_SNAP/vae/diffusion_pytorch_model.safetensors \
+      ~/ComfyUI/models/vae/flux2-klein-vae.safetensors
+
+# Text encoder shards (will be merged in Step 9)
+ln -s $HF_SNAP/text_encoder/model-00001-of-00002.safetensors \
+      ~/ComfyUI/models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors
+ln -s $HF_SNAP/text_encoder/model-00002-of-00002.safetensors \
+      ~/ComfyUI/models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors
+```
+
+### Step 8 — Convert diffusion model (HF → ComfyUI format)
+
+ComfyUI expects different key names than HF diffusers:
+- Separate `to_q/to_k/to_v` → merged `qkv`
+- `transformer_blocks` → `double_blocks`
+- `x_embedder` → `img_in`
+- `*.linear.weight` → `*.lin.weight` (modulation layers)
+
+Run the conversion script (tracked at `brand/scripts/convert_flux2_klein_hf_to_comfy.py`):
+
+```bash
+cd ~/ComfyUI
+cp ~/projects/lyra/brand/scripts/convert_flux2_klein_hf_to_comfy.py .
+venv/bin/python convert_flux2_klein_hf_to_comfy.py
+# Output: models/diffusion_models/flux2-klein-4b-comfy.safetensors (~7.2 GB)
+# Takes ~5 min. Runs once only.
+```
+
+### Step 9 — Merge Qwen3 text encoder shards
+
+`DualCLIPLoader` with `flux2` type falls through to `SDXLClipModel` (no FLUX2 dual-file handler in ComfyUI). The Qwen3 4B encoder must be loaded as a single file. Merge once:
+
+```bash
+cd ~/ComfyUI
+venv/bin/python - <<'EOF'
+from safetensors.torch import load_file, save_file
+sd1 = load_file("models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors")
+sd2 = load_file("models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors")
+save_file({**sd1, **sd2}, "models/text_encoders/flux2-klein-qwen3.safetensors")
+print("Done — 7.5 GB")
+EOF
+# Output: models/text_encoders/flux2-klein-qwen3.safetensors (~7.5 GB)
+```
+
+### Step 10 — Download AntelopeV2 (InsightFace face detector)
+
+```bash
+mkdir -p ~/ComfyUI/models/insightface/models/antelopev2
+
+# Download 5 .onnx files from MonsterMMORPG/InstantID_Models on HF:
+cd ~/ComfyUI/models/insightface/models/antelopev2
+for f in 1k3d68.onnx 2d106det.onnx genderage.onnx glintr100.onnx scrfd_10g_bnkps.onnx; do
+  wget "https://huggingface.co/MonsterMMORPG/InstantID_Models/resolve/main/antelopev2/$f"
+done
+```
+
+### Step 11 — Download PuLID Flux2 Klein weights
+
+```bash
+mkdir -p ~/ComfyUI/models/pulid
+cd ~/ComfyUI/models/pulid
+
+# v2 recommended
+wget "https://huggingface.co/Fayens/Pulid-Flux2/resolve/main/pulid_flux2_klein_v2.safetensors"
+wget "https://huggingface.co/Fayens/Pulid-Flux2/resolve/main/pulid_flux2_klein_v1.safetensors"
+```
+
+### Step 12 — Run smoke test
+
+```bash
+cd ~/ComfyUI
+cp ~/projects/lyra/brand/scripts/smoke_test_421.py .
+venv/bin/python smoke_test_421.py
+```
+
+Expected output:
+```
+✓ Smoke test PASSED — flux2-klein-4B generated without OOM
+  Peak VRAM: ~13.0 GB
+```
+
+> **First run only:** Blackwell JIT compilation triggers on first CUDA kernel call. Expect **30–45 min** before sampling starts. Subsequent runs are instant (kernels cached in `~/.cache/torch/kernels/`).
+
+---
+
+## Model File Summary
+
+| ComfyUI path | Source | Size |
+|---|---|---|
+| `models/diffusion_models/flux2-klein-4b.safetensors` | HF symlink (do not use in ComfyUI) | 7.3 GB |
+| `models/diffusion_models/flux2-klein-4b-comfy.safetensors` | converted — **use this** | 7.2 GB |
+| `models/vae/flux2-klein-vae.safetensors` | HF symlink | 161 MB |
+| `models/text_encoders/flux2-klein-qwen3-00001-of-00002.safetensors` | HF symlink shard 1 | 4.7 GB |
+| `models/text_encoders/flux2-klein-qwen3-00002-of-00002.safetensors` | HF symlink shard 2 | 2.9 GB |
+| `models/text_encoders/flux2-klein-qwen3.safetensors` | merged shards — **use this** | 7.5 GB |
+| `models/insightface/models/antelopev2/` | downloaded | ~408 MB |
+| `models/pulid/pulid_flux2_klein_v2.safetensors` | downloaded | 1.27 GB |
+| `models/pulid/pulid_flux2_klein_v1.safetensors` | downloaded | 1.27 GB |
+
+## Custom Nodes
+
+| Node | Path | Notes |
+|---|---|---|
+| ComfyUI-Manager | `custom_nodes/ComfyUI-Manager/` | v0.30.4 |
+| ComfyUI-PuLID-Flux2 | `custom_nodes/ComfyUI-PuLID-Flux2/` | iFayens/ComfyUI-PuLID-Flux2 |
+
+## ComfyUI Node Setup (Flux2-Klein + PuLID workflow)
+
+Load order in the UI:
+1. **Load Diffusion Model** → `flux2-klein-4b-comfy.safetensors`
+2. **Load CLIP** (type: `flux2`) → `flux2-klein-qwen3.safetensors`
+3. **Load VAE** → `flux2-klein-vae.safetensors`
+4. **Load InsightFace (PuLID)** → auto-detects AntelopeV2
+5. **Load EVA-CLIP (PuLID)** → downloads automatically on first run (~800 MB)
+6. **Load PuLID ✦ Flux.2** → `pulid_flux2_klein_v2.safetensors` (recommended)
+7. **Apply PuLID ✦ Flux.2** → strength 1.4 recommended
+8. **EmptyFlux2LatentImage + Flux2Scheduler → KSampler → VAEDecode → SaveImage**
 
 ## Blackwell JIT Cache
 
-PyTorch caches compiled SM_120 CUDA kernels in `~/.cache/torch/`. Once compiled, all subsequent runs skip the 30–45 min wait.
+PyTorch caches compiled SM_120 CUDA kernels in `~/.cache/torch/kernels/`. Once compiled, all subsequent runs skip the 30–45 min wait.
 
-**On this machine (ROXABITOWER):** JIT was compiled during initial setup/debug session (2026-03-31) — the cache is warm. The smoke test ran in ~1 sec and peaked at 13.0 GB VRAM.
+**On this machine (ROXABITOWER):** JIT compiled on 2026-03-31 during setup session — cache is warm. Smoke test ran in ~1 sec, peak VRAM 13.0 GB.
 
-On a **fresh machine**, the first generation will still take 30–45 min. The cache directory to back up or copy across machines is:
-```
-~/.cache/torch/kernels/
+On a **fresh machine**, the first generation will still hit the 30–45 min wait. To skip it on a new machine, copy the cache:
+```bash
+rsync -av ~/.cache/torch/kernels/ new-machine:~/.cache/torch/kernels/
 ```


### PR DESCRIPTION
## Summary
- Full installation playbook (12 steps) to reproduce ComfyUI + PuLID Flux2 from scratch on Machine 2 (Pop!_OS, RTX 5070 Ti)
- Conversion script + smoke test committed to `brand/scripts/` so they survive reinstalls
- `make comfyui` Makefile target for manual start/stop/logs (not a supervisor daemon — GPU is on-demand)

## Key findings documented
- HF FLUX.2-klein weights require key-name conversion before ComfyUI can load them (separate q/k/v → merged qkv, `transformer_blocks` → `double_blocks`, etc.)
- `DualCLIPLoader` has no FLUX2 dual-file handler — Qwen3 shards must be merged into one file first
- Blackwell JIT (SM_120) compiled on 2026-03-31, cache warm at `~/.cache/torch/kernels/` — first run on a fresh machine still takes 30–45 min
- Smoke test result: 13.0 GB peak VRAM, no OOM

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #421: ComfyUI + PuLID Flux2 environment setup | Open |
| Analysis | — | S-tier, skipped |
| Spec | — | S-tier, skipped |
| Implementation | 4 commits on `feat/421-comfyui-puliid-flux2-setup` | Complete |
| Verification | Smoke test ✅ (image generated, 13.0 GB VRAM) | Passed |

## Test Plan
- [ ] `cd ~/ComfyUI && venv/bin/python brand/scripts/smoke_test_421.py` passes
- [ ] `make comfyui` starts ComfyUI, `make comfyui status` shows PID, `make comfyui stop` kills it
- [ ] ComfyUI web UI loads `flux2-klein-4b-comfy.safetensors` + `flux2-klein-qwen3.safetensors` without error

Closes #421

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`