### PR TITLE
feat(adapters): rewire Telegram + Discord as thin NATS clients (#458)

### DIFF
--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, Any, cast
 import discord
 
 if TYPE_CHECKING:
-    from lyra.core.hub import Hub
+    from lyra.core.bus import Bus
     from lyra.core.render_events import RenderEvent
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 
 from lyra.adapters import discord_audio  # noqa: I001
 from lyra.adapters import discord_audio_outbound
@@ -72,9 +73,10 @@ class DiscordAdapter(discord.Client):
 
     def __init__(  # noqa: PLR0913 — DI constructor, each arg is a required dependency
         self,
-        hub: "Hub",
         bot_id: str = "main",
         *,
+        inbound_bus: "Bus[InboundMessage]",
+        inbound_audio_bus: "Bus[InboundAudio]",
         intents: discord.Intents | None = None,
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
@@ -99,7 +101,8 @@ class DiscordAdapter(discord.Client):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        self._hub = hub
+        self._inbound_bus = inbound_bus
+        self._inbound_audio_bus = inbound_audio_bus
         self._bot_id = bot_id
         self._circuit_registry = circuit_registry
         self._msg_manager = msg_manager
@@ -118,6 +121,10 @@ class DiscordAdapter(discord.Client):
         self._watch_channels: frozenset[int] = watch_channels
         self._thread_sessions: dict[str, tuple[str, str]] = {}
         self._vsm: VoiceSessionManager = VoiceSessionManager()
+        self._outbound_listener: "NatsOutboundListener | None" = None
+        # Injectable identity resolver for slash command trust (set by wiring layer).
+        # Falls back to PUBLIC trust when not set (standalone/test mode).
+        self._resolve_identity_fn: Any = None
 
     def _msg(self, key: str, fallback: str) -> str:
         """Return a localised message string, falling back when no manager."""
@@ -149,11 +156,18 @@ class DiscordAdapter(discord.Client):
         if send_to_id is not None:
             self._cancel_typing(send_to_id)
 
+    async def astart(self) -> None:
+        """Start the outbound listener if wired (NATS mode only)."""
+        if self._outbound_listener is not None:
+            await self._outbound_listener.start()
+
     async def close(self) -> None:
-        """Cancel pending typing tasks, drain voice, close ThreadStore."""
+        """Cancel pending typing tasks, drain voice, close ThreadStore, stop outbound listener."""
         await self._typing.cancel_all()
         await self._vsm.leave_all()
-        # Close adapter-owned ThreadStore (#417 / S4)
+        if self._outbound_listener is not None:
+            await self._outbound_listener.stop()
+        # Close adapter-owned ThreadStore
         if self._thread_store is not None:
             try:
                 await self._thread_store.close()

--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -10,9 +10,9 @@ from typing import TYPE_CHECKING, Any, cast
 import discord
 
 if TYPE_CHECKING:
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
     from lyra.core.bus import Bus
     from lyra.core.render_events import RenderEvent
-    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 
 from lyra.adapters import discord_audio  # noqa: I001
 from lyra.adapters import discord_audio_outbound
@@ -162,7 +162,7 @@ class DiscordAdapter(discord.Client):
             await self._outbound_listener.start()
 
     async def close(self) -> None:
-        """Cancel pending typing tasks, drain voice, close ThreadStore, stop outbound listener."""
+        """Cancel typing tasks, drain voice, close ThreadStore, stop listener."""
         await self._typing.cancel_all()
         await self._vsm.leave_all()
         if self._outbound_listener is not None:

--- a/src/lyra/adapters/discord_audio.py
+++ b/src/lyra/adapters/discord_audio.py
@@ -219,7 +219,7 @@ async def handle_audio(  # noqa: C901 — audio gate mirrors text gate with inde
 
     adapter._start_typing(message.channel.id)
     await push_to_hub_guarded(
-        inbound_bus=adapter._hub.inbound_audio_bus,
+        inbound_bus=adapter._inbound_audio_bus,
         platform=Platform.DISCORD,
         msg=hub_audio,
         circuit_registry=adapter._circuit_registry,

--- a/src/lyra/adapters/discord_audio.py
+++ b/src/lyra/adapters/discord_audio.py
@@ -218,6 +218,8 @@ async def handle_audio(  # noqa: C901 — audio gate mirrors text gate with inde
         await message.reply(text)
 
     adapter._start_typing(message.channel.id)
+    if adapter._outbound_listener is not None:
+        adapter._outbound_listener.cache_inbound(hub_audio)
     await push_to_hub_guarded(
         inbound_bus=adapter._inbound_audio_bus,
         platform=Platform.DISCORD,

--- a/src/lyra/adapters/discord_inbound.py
+++ b/src/lyra/adapters/discord_inbound.py
@@ -252,8 +252,11 @@ async def _push_to_hub(
         if source_message is not None:
             await source_message.reply(text)
 
+    if adapter._outbound_listener is not None:
+        adapter._outbound_listener.cache_inbound(hub_msg)
+
     await push_to_hub_guarded(
-        inbound_bus=adapter._hub.inbound_bus,
+        inbound_bus=adapter._inbound_bus,
         platform=Platform.DISCORD,
         msg=hub_msg,
         circuit_registry=adapter._circuit_registry,

--- a/src/lyra/adapters/discord_voice_commands.py
+++ b/src/lyra/adapters/discord_voice_commands.py
@@ -147,7 +147,9 @@ def _resolve_slash_trust(adapter: "DiscordAdapter", user_id: str) -> TrustLevel:
     Slash commands are out-of-band Discord interactions that don't flow through
     the inbound message bus. Trust is delegated to the Hub authenticator (C3).
     """
-    identity = adapter._hub.resolve_identity(user_id, "discord", adapter._bot_id)
+    if adapter._resolve_identity_fn is None:
+        return TrustLevel.PUBLIC
+    identity = adapter._resolve_identity_fn(user_id, "discord", adapter._bot_id)
     if identity.trust_level == TrustLevel.BLOCKED:
         return TrustLevel.BLOCKED
     return identity.trust_level

--- a/src/lyra/adapters/discord_voice_commands.py
+++ b/src/lyra/adapters/discord_voice_commands.py
@@ -148,6 +148,11 @@ def _resolve_slash_trust(adapter: "DiscordAdapter", user_id: str) -> TrustLevel:
     the inbound message bus. Trust is delegated to the Hub authenticator (C3).
     """
     if adapter._resolve_identity_fn is None:
+        log.warning(
+            "_resolve_slash_trust: no identity resolver wired (NATS mode?)"
+            " — falling back to TrustLevel.PUBLIC for user_id=%s",
+            user_id,
+        )
         return TrustLevel.PUBLIC
     identity = adapter._resolve_identity_fn(user_id, "discord", adapter._bot_id)
     if identity.trust_level == TrustLevel.BLOCKED:

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -19,7 +19,7 @@ from lyra.core.message import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from lyra.core.hub.hub_protocol import ChannelAdapter
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class NatsOutboundListener:
         nc: NATS,
         platform: Platform,
         bot_id: str,
-        adapter: Any,
+        adapter: "ChannelAdapter",
     ) -> None:
         self._nc = nc
         self._platform = platform
@@ -50,8 +50,8 @@ class NatsOutboundListener:
         self._adapter = adapter
         self._cache: dict[str, InboundMessage] = {}
         self._stream_queues: dict[str, asyncio.Queue[dict]] = {}
-        self._stream_tasks: dict[str, asyncio.Task] = {}
-        self._sub = None
+        self._stream_tasks: dict[str, asyncio.Task[None]] = {}
+        self._sub: Any = None  # nats.aio.subscription.Subscription | None
 
     def cache_inbound(self, msg: InboundMessage) -> None:
         """Store msg so it can be retrieved later by stream_id."""
@@ -98,8 +98,12 @@ class NatsOutboundListener:
                 stream_id,
             )
             return
+        outbound_data = data.get("outbound")
+        if outbound_data is None:
+            log.warning("NatsOutboundListener: missing 'outbound' key in send envelope")
+            return
         try:
-            outbound = OutboundMessage(**data["outbound"])
+            outbound = OutboundMessage(**outbound_data)
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize outbound message")
             return
@@ -114,8 +118,12 @@ class NatsOutboundListener:
                 "NatsOutboundListener: unknown stream_id=%r for attachment", stream_id
             )
             return
+        attachment_data = data.get("attachment")
+        if attachment_data is None:
+            log.warning("NatsOutboundListener: missing 'attachment' key in envelope")
+            return
         try:
-            attachment = OutboundAttachment(**data["attachment"])
+            attachment = OutboundAttachment(**attachment_data)
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize attachment")
             return
@@ -123,7 +131,10 @@ class NatsOutboundListener:
         self._cache.pop(stream_id, None)
 
     async def _handle_chunk(self, data: dict) -> None:
-        stream_id = data["stream_id"]
+        stream_id = data.get("stream_id")
+        if stream_id is None:
+            log.warning("NatsOutboundListener: chunk envelope missing stream_id")
+            return
         q = self._stream_queues.setdefault(stream_id, asyncio.Queue())
         await q.put(data)
         # Launch a drain task on first chunk; subsequent chunks just enqueue

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -160,8 +160,19 @@ class NatsOutboundListener:
         from lyra.core.render_events import TextRenderEvent
 
         async def _events():
+            expected_seq = 0
             while True:
                 chunk = await q.get()
+                seq = chunk.get("seq")
+                if seq is not None and seq != expected_seq:
+                    log.warning(
+                        "NatsOutboundListener: out-of-order chunk"
+                        " stream_id=%r expected_seq=%d got_seq=%d",
+                        stream_id,
+                        expected_seq,
+                        seq,
+                    )
+                expected_seq += 1
                 event_type = chunk.get("event_type", "text")
                 payload = chunk.get("payload", {})
                 is_done = chunk.get("done", False)

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -92,7 +92,7 @@ class NatsOutboundListener:
     async def _handle_send(self, data: dict) -> None:
         stream_id = data.get("stream_id")
         original_msg = self._cache.get(stream_id) if stream_id else None
-        if original_msg is None:
+        if stream_id is None or original_msg is None:
             log.warning(
                 "NatsOutboundListener: unknown stream_id=%r for send",
                 stream_id,
@@ -109,7 +109,7 @@ class NatsOutboundListener:
     async def _handle_attachment(self, data: dict) -> None:
         stream_id = data.get("stream_id")
         original_msg = self._cache.get(stream_id) if stream_id else None
-        if original_msg is None:
+        if stream_id is None or original_msg is None:
             log.warning(
                 "NatsOutboundListener: unknown stream_id=%r for attachment", stream_id
             )

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 
 from lyra.core.message import (
+    InboundAudio,
     InboundMessage,
     OutboundAttachment,
     OutboundMessage,
@@ -48,12 +49,12 @@ class NatsOutboundListener:
         self._platform = platform
         self._bot_id = bot_id
         self._adapter = adapter
-        self._cache: dict[str, InboundMessage] = {}
+        self._cache: dict[str, InboundMessage | InboundAudio] = {}
         self._stream_queues: dict[str, asyncio.Queue[dict]] = {}
         self._stream_tasks: dict[str, asyncio.Task[None]] = {}
         self._sub: Any = None  # nats.aio.subscription.Subscription | None
 
-    def cache_inbound(self, msg: InboundMessage) -> None:
+    def cache_inbound(self, msg: InboundMessage | InboundAudio) -> None:
         """Store msg so it can be retrieved later by stream_id."""
         self._cache[msg.id] = msg
 
@@ -107,7 +108,7 @@ class NatsOutboundListener:
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize outbound message")
             return
-        await self._adapter.send(original_msg, outbound)
+        await self._adapter.send(cast(InboundMessage, original_msg), outbound)
         self._cache.pop(stream_id, None)
 
     async def _handle_attachment(self, data: dict) -> None:
@@ -127,7 +128,9 @@ class NatsOutboundListener:
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize attachment")
             return
-        await self._adapter.render_attachment(attachment, original_msg)
+        await self._adapter.render_attachment(
+            attachment, cast(InboundMessage, original_msg)
+        )
         self._cache.pop(stream_id, None)
 
     async def _handle_chunk(self, data: dict) -> None:
@@ -182,7 +185,9 @@ class NatsOutboundListener:
                     break
 
         try:
-            await self._adapter.send_streaming(original_msg, _events())
+            await self._adapter.send_streaming(
+                cast(InboundMessage, original_msg), _events()
+            )
         except Exception:
             log.exception(
                 "NatsOutboundListener: send_streaming failed for stream_id=%r",

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -1,0 +1,164 @@
+"""NatsOutboundListener — subscribes to lyra.outbound.{platform}.{bot_id} and dispatches
+outbound messages back to the adapter (send / send_streaming / render_attachment).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+
+from lyra.core.message import InboundMessage, OutboundAttachment, OutboundMessage, Platform
+from lyra.nats._serialize import serialize
+
+if TYPE_CHECKING:
+    from lyra.adapters.discord import DiscordAdapter
+    from lyra.adapters.telegram import TelegramAdapter
+
+log = logging.getLogger(__name__)
+
+
+class NatsOutboundListener:
+    """Subscribes to NATS outbound subject and dispatches to the platform adapter.
+
+    Three envelope types:
+    - send:       {"type": "send", "stream_id": ..., "outbound": {...}}
+    - attachment: {"type": "attachment", "stream_id": ..., "attachment": {...}}
+    - chunk:      {"stream_id": ..., "seq": N, "event_type": ..., "payload": {...}, "done": bool}
+
+    Inbound message cache: populated by cache_inbound() before push_to_hub_guarded.
+    Used to correlate stream_id → original InboundMessage for reply routing.
+    """
+
+    def __init__(
+        self,
+        nc: NATS,
+        platform: Platform,
+        bot_id: str,
+        adapter: Any,
+    ) -> None:
+        self._nc = nc
+        self._platform = platform
+        self._bot_id = bot_id
+        self._adapter = adapter
+        self._cache: dict[str, InboundMessage] = {}
+        self._stream_queues: dict[str, asyncio.Queue[dict]] = {}
+        self._stream_tasks: dict[str, asyncio.Task] = {}
+        self._sub = None
+
+    def cache_inbound(self, msg: InboundMessage) -> None:
+        """Store msg so it can be retrieved later by stream_id."""
+        self._cache[msg.id] = msg
+
+    async def start(self) -> None:
+        """Subscribe to the outbound NATS subject."""
+        subject = f"lyra.outbound.{self._platform.value}.{self._bot_id}"
+        self._sub = await self._nc.subscribe(subject, cb=self._handle)
+
+    async def stop(self) -> None:
+        """Unsubscribe from NATS."""
+        if self._sub is not None:
+            await self._sub.unsubscribe()
+            self._sub = None
+        # cancel pending stream tasks
+        for task in list(self._stream_tasks.values()):
+            task.cancel()
+        self._stream_tasks.clear()
+        self._stream_queues.clear()
+
+    async def _handle(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data)
+        except Exception:
+            log.warning("NatsOutboundListener: failed to decode message")
+            return
+        msg_type = data.get("type")
+        if msg_type == "send":
+            await self._handle_send(data)
+        elif msg_type == "attachment":
+            await self._handle_attachment(data)
+        elif "stream_id" in data and "seq" in data:
+            await self._handle_chunk(data)
+        else:
+            log.warning("NatsOutboundListener: unknown envelope type=%r", msg_type)
+
+    async def _handle_send(self, data: dict) -> None:
+        stream_id = data.get("stream_id")
+        original_msg = self._cache.get(stream_id) if stream_id else None
+        if original_msg is None:
+            log.warning(
+                "NatsOutboundListener: unknown stream_id=%r for send envelope", stream_id
+            )
+            return
+        try:
+            outbound = OutboundMessage(**data["outbound"])
+        except Exception:
+            log.warning("NatsOutboundListener: failed to deserialize outbound message")
+            return
+        await self._adapter.send(original_msg, outbound)
+        self._cache.pop(stream_id, None)
+
+    async def _handle_attachment(self, data: dict) -> None:
+        stream_id = data.get("stream_id")
+        original_msg = self._cache.get(stream_id) if stream_id else None
+        if original_msg is None:
+            log.warning(
+                "NatsOutboundListener: unknown stream_id=%r for attachment", stream_id
+            )
+            return
+        try:
+            attachment = OutboundAttachment(**data["attachment"])
+        except Exception:
+            log.warning("NatsOutboundListener: failed to deserialize attachment")
+            return
+        await self._adapter.render_attachment(attachment, original_msg)
+        self._cache.pop(stream_id, None)
+
+    async def _handle_chunk(self, data: dict) -> None:
+        stream_id = data["stream_id"]
+        q = self._stream_queues.setdefault(stream_id, asyncio.Queue())
+        await q.put(data)
+        # Launch a drain task on first chunk; subsequent chunks just enqueue
+        if stream_id not in self._stream_tasks:
+            self._stream_tasks[stream_id] = asyncio.create_task(
+                self._drain_stream(stream_id, q)
+            )
+
+    async def _drain_stream(self, stream_id: str, q: asyncio.Queue[dict]) -> None:
+        """Drain a stream queue and call adapter.send_streaming()."""
+        original_msg = self._cache.get(stream_id)
+        if original_msg is None:
+            log.warning(
+                "NatsOutboundListener: unknown stream_id=%r for streaming", stream_id
+            )
+            # drain queue silently
+            while not q.empty():
+                await q.get()
+            self._stream_tasks.pop(stream_id, None)
+            self._stream_queues.pop(stream_id, None)
+            return
+
+        from lyra.core.render_events import TextRenderEvent
+
+        async def _events():
+            while True:
+                chunk = await q.get()
+                event_type = chunk.get("event_type", "text")
+                payload = chunk.get("payload", {})
+                is_done = chunk.get("done", False)
+                if event_type == "text":
+                    yield TextRenderEvent(**payload)
+                if is_done:
+                    break
+
+        try:
+            await self._adapter.send_streaming(original_msg, _events())
+        except Exception:
+            log.exception("NatsOutboundListener: send_streaming failed for stream_id=%r", stream_id)
+        finally:
+            self._cache.pop(stream_id, None)
+            self._stream_tasks.pop(stream_id, None)
+            self._stream_queues.pop(stream_id, None)

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -11,12 +11,15 @@ from typing import TYPE_CHECKING, Any
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 
-from lyra.core.message import InboundMessage, OutboundAttachment, OutboundMessage, Platform
-from lyra.nats._serialize import serialize
+from lyra.core.message import (
+    InboundMessage,
+    OutboundAttachment,
+    OutboundMessage,
+    Platform,
+)
 
 if TYPE_CHECKING:
-    from lyra.adapters.discord import DiscordAdapter
-    from lyra.adapters.telegram import TelegramAdapter
+    pass
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +30,8 @@ class NatsOutboundListener:
     Three envelope types:
     - send:       {"type": "send", "stream_id": ..., "outbound": {...}}
     - attachment: {"type": "attachment", "stream_id": ..., "attachment": {...}}
-    - chunk:      {"stream_id": ..., "seq": N, "event_type": ..., "payload": {...}, "done": bool}
+    - chunk:      {"stream_id": ..., "seq": N, "event_type": ..., "payload": {...},
+                   "done": bool}
 
     Inbound message cache: populated by cache_inbound() before push_to_hub_guarded.
     Used to correlate stream_id → original InboundMessage for reply routing.
@@ -90,7 +94,8 @@ class NatsOutboundListener:
         original_msg = self._cache.get(stream_id) if stream_id else None
         if original_msg is None:
             log.warning(
-                "NatsOutboundListener: unknown stream_id=%r for send envelope", stream_id
+                "NatsOutboundListener: unknown stream_id=%r for send",
+                stream_id,
             )
             return
         try:
@@ -157,7 +162,10 @@ class NatsOutboundListener:
         try:
             await self._adapter.send_streaming(original_msg, _events())
         except Exception:
-            log.exception("NatsOutboundListener: send_streaming failed for stream_id=%r", stream_id)
+            log.exception(
+                "NatsOutboundListener: send_streaming failed for stream_id=%r",
+                stream_id,
+            )
         finally:
             self._cache.pop(stream_id, None)
             self._stream_tasks.pop(stream_id, None)

--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -15,9 +15,9 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
     from lyra.core.bus import Bus
     from lyra.core.render_events import RenderEvent
-    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 
 from lyra.adapters import telegram_audio  # noqa: I001
 from lyra.adapters._shared import TypingTaskManager, resolve_msg

--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -79,20 +79,15 @@ def load_config() -> TelegramConfig:
 
 def _make_verifier(secret: str):
     """Return a FastAPI dependency that validates the Telegram webhook secret."""
-
     async def verify(request: Request) -> None:
         incoming = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
         if not secret or not hmac.compare_digest(incoming, secret):
             raise HTTPException(status_code=401, detail="Unauthorized")
-
     return verify
 
 
 class TelegramAdapter:
-    """Telegram channel adapter — aiogram v3 webhook style.
-
-    Never logs the bot token. Webhook route validates secret token header.
-    """
+    """Telegram adapter — aiogram v3 webhook. Never logs the bot token."""
 
     def __init__(  # noqa: PLR0913 — DI constructor
         self,
@@ -147,7 +142,6 @@ class TelegramAdapter:
         self._typing = TypingTaskManager()
         self._bot: Any = None
         self._dp: Any = None
-
         from aiogram import Dispatcher, F
 
         self._dp = Dispatcher()
@@ -174,11 +168,7 @@ class TelegramAdapter:
         self._bot = value
 
     async def resolve_identity(self) -> None:
-        """Discover the bot's username via the Telegram API (getMe).
-
-        Must be called once after the bot is available — analogous to
-        Discord's ``on_ready()`` which populates ``_bot_user``.
-        """
+        """Discover the bot's username via getMe — call once after startup."""
         me = await self.bot.get_me()
         self._bot_username = me.username
         log.info(
@@ -240,7 +230,6 @@ class TelegramAdapter:
         self._typing.cancel(chat_id)
 
     async def astart(self) -> None:
-        """Start the outbound listener if wired (NATS mode only)."""
         if self._outbound_listener is not None:
             await self._outbound_listener.start()
 

--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -15,8 +15,9 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
-    from lyra.core.hub import Hub
+    from lyra.core.bus import Bus
     from lyra.core.render_events import RenderEvent
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 
 from lyra.adapters import telegram_audio  # noqa: I001
 from lyra.adapters._shared import TypingTaskManager, resolve_msg
@@ -97,7 +98,8 @@ class TelegramAdapter:
         self,
         bot_id: str,
         token: str,
-        hub: Hub,
+        inbound_bus: "Bus[InboundMessage]",
+        inbound_audio_bus: "Bus[InboundAudio]",
         webhook_secret: str = "",
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
@@ -120,7 +122,8 @@ class TelegramAdapter:
                 "webhook_secret is empty — all webhook requests will be rejected"
             )
         self._bot_username: str | None = None
-        self._hub: Hub = hub
+        self._inbound_bus = inbound_bus
+        self._inbound_audio_bus = inbound_audio_bus
         self._circuit_registry = circuit_registry
         self._msg_manager = msg_manager
         self._auth: Authenticator = auth
@@ -155,6 +158,7 @@ class TelegramAdapter:
 
         self.app = FastAPI()
         self._register_routes()
+        self._outbound_listener: "NatsOutboundListener | None" = None
 
     @property
     def bot(self) -> Any:
@@ -235,8 +239,15 @@ class TelegramAdapter:
     def _cancel_typing(self, chat_id: int) -> None:
         self._typing.cancel(chat_id)
 
+    async def astart(self) -> None:
+        """Start the outbound listener if wired (NATS mode only)."""
+        if self._outbound_listener is not None:
+            await self._outbound_listener.start()
+
     async def close(self) -> None:
         await self._typing.cancel_all()
+        if self._outbound_listener is not None:
+            await self._outbound_listener.stop()
 
     # --- Thin delegates to submodules ---
 

--- a/src/lyra/adapters/telegram_inbound.py
+++ b/src/lyra/adapters/telegram_inbound.py
@@ -42,8 +42,11 @@ async def _push_to_hub(
             return
         await adapter.bot.send_message(chat_id, text)
 
+    if adapter._outbound_listener is not None:
+        adapter._outbound_listener.cache_inbound(hub_msg)
+
     await push_to_hub_guarded(
-        inbound_bus=adapter._hub.inbound_bus,
+        inbound_bus=adapter._inbound_bus,
         platform=Platform.TELEGRAM,
         msg=hub_msg,
         circuit_registry=adapter._circuit_registry,
@@ -173,7 +176,7 @@ async def handle_voice_message(adapter: TelegramAdapter, msg: Any) -> None:
             )
 
         await push_to_hub_guarded(
-            inbound_bus=adapter._hub.inbound_audio_bus,
+            inbound_bus=adapter._inbound_audio_bus,
             platform=Platform.TELEGRAM,
             msg=hub_audio,
             circuit_registry=adapter._circuit_registry,

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -11,19 +11,17 @@ import asyncio
 import logging
 import os
 import sys
-from typing import Any
 
 import nats
 
 from lyra.adapters.nats_outbound_listener import NatsOutboundListener
-from lyra.core.bus import Bus
-from lyra.core.message import InboundMessage, InboundAudio, Platform
-from lyra.core.bus import LocalBus
+from lyra.core.bus import Bus, LocalBus
+from lyra.core.message import InboundAudio, InboundMessage, Platform
 
 log = logging.getLogger(__name__)
 
 
-async def _bootstrap_adapter_standalone(
+async def _bootstrap_adapter_standalone(  # noqa: PLR0915
     raw_config: dict,
     platform: str,
     *,
@@ -51,7 +49,9 @@ async def _bootstrap_adapter_standalone(
         from lyra.adapters.telegram import TelegramAdapter
         from lyra.config import TelegramMultiConfig
 
-        tg_multi_cfg = TelegramMultiConfig.model_validate(raw_config.get("telegram", {}))
+        tg_multi_cfg = TelegramMultiConfig.model_validate(
+            raw_config.get("telegram", {})
+        )
         if not tg_multi_cfg.bots:
             sys.exit("No telegram bots configured")
 
@@ -68,8 +68,14 @@ async def _bootstrap_adapter_standalone(
 
             inbound_audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
 
-            token = os.environ.get(f"TELEGRAM_TOKEN_{bot_id.upper()}") or os.environ.get("TELEGRAM_TOKEN", "")
-            webhook_secret = os.environ.get(f"TELEGRAM_WEBHOOK_SECRET_{bot_id.upper()}") or os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
+            token = (
+                os.environ.get(f"TELEGRAM_TOKEN_{bot_id.upper()}")
+                or os.environ.get("TELEGRAM_TOKEN", "")
+            )
+            webhook_secret = (
+                os.environ.get(f"TELEGRAM_WEBHOOK_SECRET_{bot_id.upper()}")
+                or os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
+            )
 
             adapter = TelegramAdapter(
                 bot_id=bot_id,
@@ -131,7 +137,10 @@ async def _bootstrap_adapter_standalone(
 
             inbound_audio_bus_dc: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
 
-            token = os.environ.get(f"DISCORD_TOKEN_{bot_id.upper()}") or os.environ.get("DISCORD_TOKEN", "")
+            token = (
+                os.environ.get(f"DISCORD_TOKEN_{bot_id.upper()}")
+                or os.environ.get("DISCORD_TOKEN", "")
+            )
 
             adapter_dc = DiscordAdapter(
                 bot_id=bot_id,

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -15,7 +15,8 @@ import sys
 import nats
 
 from lyra.adapters.nats_outbound_listener import NatsOutboundListener
-from lyra.core.bus import Bus, LocalBus
+from lyra.core.bus import Bus
+from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import InboundAudio, InboundMessage, Platform
 
 log = logging.getLogger(__name__)

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -46,129 +46,135 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915
 
     from lyra.nats.nats_bus import NatsBus
 
-    if platform == "telegram":
-        from lyra.adapters.telegram import TelegramAdapter
-        from lyra.config import TelegramMultiConfig
+    # nc.close() is deferred to the outer finally so the shared connection stays
+    # alive for all bots in the loop (previously closed per-iteration — bug).
+    try:
+        if platform == "telegram":
+            from lyra.adapters.telegram import TelegramAdapter
+            from lyra.config import TelegramMultiConfig
 
-        tg_multi_cfg = TelegramMultiConfig.model_validate(
-            raw_config.get("telegram", {})
-        )
-        if not tg_multi_cfg.bots:
-            sys.exit("No telegram bots configured")
-
-        for bot_cfg in tg_multi_cfg.bots:
-            bot_id = bot_cfg.bot_id
-
-            inbound_bus: Bus[InboundMessage] = NatsBus(  # type: ignore[type-arg]
-                nc=nc,
-                bot_id=bot_id,
-                item_type=InboundMessage,
+            tg_multi_cfg = TelegramMultiConfig.model_validate(
+                raw_config.get("telegram", {})
             )
-            inbound_bus.register(platform_enum)
-            await inbound_bus.start()
+            if not tg_multi_cfg.bots:
+                sys.exit("No telegram bots configured")
 
-            inbound_audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+            for bot_cfg in tg_multi_cfg.bots:
+                bot_id = bot_cfg.bot_id
 
-            token = (
-                os.environ.get(f"TELEGRAM_TOKEN_{bot_id.upper()}")
-                or os.environ.get("TELEGRAM_TOKEN", "")
-            )
-            webhook_secret = (
-                os.environ.get(f"TELEGRAM_WEBHOOK_SECRET_{bot_id.upper()}")
-                or os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
-            )
-
-            adapter = TelegramAdapter(
-                bot_id=bot_id,
-                token=token,
-                inbound_bus=inbound_bus,
-                inbound_audio_bus=inbound_audio_bus,
-                webhook_secret=webhook_secret,
-            )
-            await adapter.resolve_identity()
-
-            listener = NatsOutboundListener(nc, platform_enum, bot_id, adapter)
-            adapter._outbound_listener = listener
-            await adapter.astart()
-
-            log.info(
-                "adapter_standalone: Telegram bot_id=%s ready (NATS mode)", bot_id
-            )
-
-            # Run uvicorn server
-            try:
-                import uvicorn
-                config = uvicorn.Config(
-                    adapter.app,
-                    host="0.0.0.0",
-                    port=int(os.environ.get("LYRA_WEBHOOK_PORT", "8080")),
+                inbound_bus: Bus[InboundMessage] = NatsBus(  # type: ignore[type-arg]
+                    nc=nc,
+                    bot_id=bot_id,
+                    item_type=InboundMessage,
                 )
-                server = uvicorn.Server(config)
-                if _stop is not None:
-                    # Test mode: run until stop event
-                    serve_task = asyncio.create_task(server.serve())
-                    await _stop.wait()
-                    server.should_exit = True
-                    await serve_task
-                else:
-                    await server.serve()
-            finally:
-                await adapter.close()
-                await inbound_bus.stop()
-                await nc.close()
+                inbound_bus.register(platform_enum)
+                await inbound_bus.start()
 
-    elif platform == "discord":
-        from lyra.adapters.discord import DiscordAdapter
-        from lyra.config import DiscordMultiConfig
+                inbound_audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
 
-        dc_multi_cfg = DiscordMultiConfig.model_validate(raw_config.get("discord", {}))
-        if not dc_multi_cfg.bots:
-            sys.exit("No discord bots configured")
+                token = (
+                    os.environ.get(f"TELEGRAM_TOKEN_{bot_id.upper()}")
+                    or os.environ.get("TELEGRAM_TOKEN", "")
+                )
+                webhook_secret = (
+                    os.environ.get(f"TELEGRAM_WEBHOOK_SECRET_{bot_id.upper()}")
+                    or os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
+                )
 
-        for bot_cfg in dc_multi_cfg.bots:
-            bot_id = bot_cfg.bot_id
+                adapter = TelegramAdapter(
+                    bot_id=bot_id,
+                    token=token,
+                    inbound_bus=inbound_bus,
+                    inbound_audio_bus=inbound_audio_bus,
+                    webhook_secret=webhook_secret,
+                )
+                await adapter.resolve_identity()
 
-            inbound_bus_dc: Bus[InboundMessage] = NatsBus(  # type: ignore[type-arg]
-                nc=nc,
-                bot_id=bot_id,
-                item_type=InboundMessage,
+                listener = NatsOutboundListener(nc, platform_enum, bot_id, adapter)
+                adapter._outbound_listener = listener
+                await adapter.astart()
+
+                log.info(
+                    "adapter_standalone: Telegram bot_id=%s ready (NATS mode)", bot_id
+                )
+
+                try:
+                    import uvicorn
+                    config = uvicorn.Config(
+                        adapter.app,
+                        host="0.0.0.0",
+                        port=int(os.environ.get("LYRA_WEBHOOK_PORT", "8080")),
+                    )
+                    server = uvicorn.Server(config)
+                    if _stop is not None:
+                        # Test mode: run until stop event
+                        serve_task = asyncio.create_task(server.serve())
+                        await _stop.wait()
+                        server.should_exit = True
+                        await serve_task
+                    else:
+                        await server.serve()
+                finally:
+                    await adapter.close()
+                    await inbound_bus.stop()
+
+        elif platform == "discord":
+            from lyra.adapters.discord import DiscordAdapter
+            from lyra.config import DiscordMultiConfig
+
+            dc_multi_cfg = DiscordMultiConfig.model_validate(
+                raw_config.get("discord", {})
             )
-            inbound_bus_dc.register(platform_enum)
-            await inbound_bus_dc.start()
+            if not dc_multi_cfg.bots:
+                sys.exit("No discord bots configured")
 
-            inbound_audio_bus_dc: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+            for bot_cfg in dc_multi_cfg.bots:
+                bot_id = bot_cfg.bot_id
 
-            token = (
-                os.environ.get(f"DISCORD_TOKEN_{bot_id.upper()}")
-                or os.environ.get("DISCORD_TOKEN", "")
-            )
+                inbound_bus_dc: Bus[InboundMessage] = NatsBus(  # type: ignore[type-arg]
+                    nc=nc,
+                    bot_id=bot_id,
+                    item_type=InboundMessage,
+                )
+                inbound_bus_dc.register(platform_enum)
+                await inbound_bus_dc.start()
 
-            adapter_dc = DiscordAdapter(
-                bot_id=bot_id,
-                inbound_bus=inbound_bus_dc,
-                inbound_audio_bus=inbound_audio_bus_dc,
-                auto_thread=bot_cfg.auto_thread,
-                thread_hot_hours=bot_cfg.thread_hot_hours,
-            )
+                inbound_audio_bus_dc: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
 
-            listener_dc = NatsOutboundListener(nc, platform_enum, bot_id, adapter_dc)
-            adapter_dc._outbound_listener = listener_dc
-            await adapter_dc.astart()
+                token = (
+                    os.environ.get(f"DISCORD_TOKEN_{bot_id.upper()}")
+                    or os.environ.get("DISCORD_TOKEN", "")
+                )
 
-            log.info(
-                "adapter_standalone: Discord bot_id=%s ready (NATS mode)", bot_id
-            )
+                adapter_dc = DiscordAdapter(
+                    bot_id=bot_id,
+                    inbound_bus=inbound_bus_dc,
+                    inbound_audio_bus=inbound_audio_bus_dc,
+                    auto_thread=bot_cfg.auto_thread,
+                    thread_hot_hours=bot_cfg.thread_hot_hours,
+                )
 
-            try:
-                if _stop is not None:
-                    start_task = asyncio.create_task(adapter_dc.start(token))
-                    await _stop.wait()
-                    await adapter_dc.close()
-                    start_task.cancel()
-                else:
-                    await adapter_dc.start(token)
-            finally:
-                await inbound_bus_dc.stop()
-                await nc.close()
-    else:
-        sys.exit(f"Unknown platform: {platform!r}")
+                listener_dc = NatsOutboundListener(
+                    nc, platform_enum, bot_id, adapter_dc
+                )
+                adapter_dc._outbound_listener = listener_dc
+                await adapter_dc.astart()
+
+                log.info(
+                    "adapter_standalone: Discord bot_id=%s ready (NATS mode)", bot_id
+                )
+
+                try:
+                    if _stop is not None:
+                        start_task = asyncio.create_task(adapter_dc.start(token))
+                        await _stop.wait()
+                        await adapter_dc.close()
+                        start_task.cancel()
+                    else:
+                        await adapter_dc.start(token)
+                finally:
+                    await inbound_bus_dc.stop()
+        else:
+            sys.exit(f"Unknown platform: {platform!r}")
+    finally:
+        await nc.close()

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -71,6 +71,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915
                 await inbound_bus.start()
 
                 inbound_audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+                inbound_audio_bus.register(platform_enum)
 
                 token = (
                     os.environ.get(f"TELEGRAM_TOKEN_{bot_id.upper()}")
@@ -102,7 +103,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915
                     import uvicorn
                     config = uvicorn.Config(
                         adapter.app,
-                        host="0.0.0.0",
+                        host=os.environ.get("LYRA_WEBHOOK_HOST", "0.0.0.0"),
                         port=int(os.environ.get("LYRA_WEBHOOK_PORT", "8080")),
                     )
                     server = uvicorn.Server(config)
@@ -140,6 +141,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915
                 await inbound_bus_dc.start()
 
                 inbound_audio_bus_dc: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+                inbound_audio_bus_dc.register(platform_enum)
 
                 token = (
                     os.environ.get(f"DISCORD_TOKEN_{bot_id.upper()}")

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -1,0 +1,164 @@
+"""Standalone adapter bootstrap — runs TelegramAdapter or DiscordAdapter as a pure
+NATS client, without a local Hub instance.
+
+Entry point: _bootstrap_adapter_standalone(raw_config, platform)
+
+Used by lyra_telegram and lyra_discord supervisor programs in NATS mode (ADR-037).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+import nats
+
+from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+from lyra.core.bus import Bus
+from lyra.core.message import InboundMessage, InboundAudio, Platform
+from lyra.core.bus import LocalBus
+
+log = logging.getLogger(__name__)
+
+
+async def _bootstrap_adapter_standalone(
+    raw_config: dict,
+    platform: str,
+    *,
+    _stop: asyncio.Event | None = None,
+) -> None:
+    """Bootstrap a standalone adapter process connected to NATS.
+
+    Args:
+        raw_config: Parsed config dict (lyra config.toml content).
+        platform: "telegram" or "discord".
+        _stop: Optional event for graceful shutdown (tests inject this).
+    """
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit("NATS_URL required for standalone adapter mode")
+
+    nc = await nats.connect(nats_url)
+    log.info("adapter_standalone: connected to NATS at %s", nats_url)
+
+    platform_enum = Platform(platform)
+
+    from lyra.nats.nats_bus import NatsBus
+
+    if platform == "telegram":
+        from lyra.adapters.telegram import TelegramAdapter
+        from lyra.config import TelegramMultiConfig
+
+        tg_multi_cfg = TelegramMultiConfig.model_validate(raw_config.get("telegram", {}))
+        if not tg_multi_cfg.bots:
+            sys.exit("No telegram bots configured")
+
+        for bot_cfg in tg_multi_cfg.bots:
+            bot_id = bot_cfg.bot_id
+
+            inbound_bus: Bus[InboundMessage] = NatsBus(  # type: ignore[type-arg]
+                nc=nc,
+                bot_id=bot_id,
+                item_type=InboundMessage,
+            )
+            inbound_bus.register(platform_enum)
+            await inbound_bus.start()
+
+            inbound_audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+
+            token = os.environ.get(f"TELEGRAM_TOKEN_{bot_id.upper()}") or os.environ.get("TELEGRAM_TOKEN", "")
+            webhook_secret = os.environ.get(f"TELEGRAM_WEBHOOK_SECRET_{bot_id.upper()}") or os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
+
+            adapter = TelegramAdapter(
+                bot_id=bot_id,
+                token=token,
+                inbound_bus=inbound_bus,
+                inbound_audio_bus=inbound_audio_bus,
+                webhook_secret=webhook_secret,
+            )
+            await adapter.resolve_identity()
+
+            listener = NatsOutboundListener(nc, platform_enum, bot_id, adapter)
+            adapter._outbound_listener = listener
+            await adapter.astart()
+
+            log.info(
+                "adapter_standalone: Telegram bot_id=%s ready (NATS mode)", bot_id
+            )
+
+            # Run uvicorn server
+            try:
+                import uvicorn
+                config = uvicorn.Config(
+                    adapter.app,
+                    host="0.0.0.0",
+                    port=int(os.environ.get("LYRA_WEBHOOK_PORT", "8080")),
+                )
+                server = uvicorn.Server(config)
+                if _stop is not None:
+                    # Test mode: run until stop event
+                    serve_task = asyncio.create_task(server.serve())
+                    await _stop.wait()
+                    server.should_exit = True
+                    await serve_task
+                else:
+                    await server.serve()
+            finally:
+                await adapter.close()
+                await inbound_bus.stop()
+                await nc.close()
+
+    elif platform == "discord":
+        from lyra.adapters.discord import DiscordAdapter
+        from lyra.config import DiscordMultiConfig
+
+        dc_multi_cfg = DiscordMultiConfig.model_validate(raw_config.get("discord", {}))
+        if not dc_multi_cfg.bots:
+            sys.exit("No discord bots configured")
+
+        for bot_cfg in dc_multi_cfg.bots:
+            bot_id = bot_cfg.bot_id
+
+            inbound_bus_dc: Bus[InboundMessage] = NatsBus(  # type: ignore[type-arg]
+                nc=nc,
+                bot_id=bot_id,
+                item_type=InboundMessage,
+            )
+            inbound_bus_dc.register(platform_enum)
+            await inbound_bus_dc.start()
+
+            inbound_audio_bus_dc: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+
+            token = os.environ.get(f"DISCORD_TOKEN_{bot_id.upper()}") or os.environ.get("DISCORD_TOKEN", "")
+
+            adapter_dc = DiscordAdapter(
+                bot_id=bot_id,
+                inbound_bus=inbound_bus_dc,
+                inbound_audio_bus=inbound_audio_bus_dc,
+                auto_thread=bot_cfg.auto_thread,
+                thread_hot_hours=bot_cfg.thread_hot_hours,
+            )
+
+            listener_dc = NatsOutboundListener(nc, platform_enum, bot_id, adapter_dc)
+            adapter_dc._outbound_listener = listener_dc
+            await adapter_dc.astart()
+
+            log.info(
+                "adapter_standalone: Discord bot_id=%s ready (NATS mode)", bot_id
+            )
+
+            try:
+                if _stop is not None:
+                    start_task = asyncio.create_task(adapter_dc.start(token))
+                    await _stop.wait()
+                    await adapter_dc.close()
+                    start_task.cancel()
+                else:
+                    await adapter_dc.start(token)
+            finally:
+                await inbound_bus_dc.stop()
+                await nc.close()
+    else:
+        sys.exit(f"Unknown platform: {platform!r}")

--- a/src/lyra/bootstrap/multibot_wiring.py
+++ b/src/lyra/bootstrap/multibot_wiring.py
@@ -65,7 +65,8 @@ async def wire_telegram_adapters(  # noqa: PLR0913 — wiring requires all deps
         adapter = TelegramAdapter(
             bot_id=bot_cfg.bot_id,
             token=tg_token,
-            hub=hub,
+            inbound_bus=hub.inbound_bus,
+            inbound_audio_bus=hub.inbound_audio_bus,
             webhook_secret=tg_webhook_secret or "",
             circuit_registry=circuit_registry,
             msg_manager=msg_manager,
@@ -171,8 +172,9 @@ async def wire_discord_adapters(  # noqa: PLR0913, C901 — wiring requires all 
                 watch_channels = _parse_channel_ids("watch_channels")
 
             adapter = DiscordAdapter(
-                hub=hub,
                 bot_id=bot_cfg.bot_id,
+                inbound_bus=hub.inbound_bus,
+                inbound_audio_bus=hub.inbound_audio_bus,
                 circuit_registry=circuit_registry,
                 msg_manager=msg_manager,
                 auto_thread=bot_cfg.auto_thread,
@@ -180,6 +182,8 @@ async def wire_discord_adapters(  # noqa: PLR0913, C901 — wiring requires all 
                 thread_store=thread_store,
                 watch_channels=watch_channels,
             )
+            # Wire identity resolver for slash command trust (voice commands).
+            adapter._resolve_identity_fn = hub.resolve_identity
             # C3: Hub is the trust authority — register here, not on adapter.
             hub.register_authenticator(Platform.DISCORD, bot_cfg.bot_id, auth)
             hub.register_adapter(Platform.DISCORD, bot_cfg.bot_id, adapter)

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -85,8 +85,8 @@ class NatsChannelProxy:
         """Publish an outbound text message to NATS."""
         subject = f"lyra.outbound.{self._platform.value}.{self._bot_id}"
         envelope = {
-            "type": "outbound",
-            "msg_id": original_msg.id,
+            "type": "send",
+            "stream_id": original_msg.id,
             "outbound": json.loads(serialize(outbound).decode("utf-8")),
         }
         payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
@@ -99,9 +99,7 @@ class NatsChannelProxy:
         outbound: OutboundMessage | None = None,
     ) -> None:
         """Publish streaming render events to NATS as chunked messages."""
-        subject = (
-            f"lyra.outbound.stream.{self._platform.value}.{self._bot_id}.{_safe_subject_token(original_msg.id)}"
-        )
+        subject = f"lyra.outbound.{self._platform.value}.{self._bot_id}"
         seq = 0
         try:
             async for event in events:
@@ -109,8 +107,7 @@ class NatsChannelProxy:
                     "text" if isinstance(event, TextRenderEvent) else "tool_summary"
                 )
                 chunk = {
-                    "type": "stream_chunk",
-                    "msg_id": original_msg.id,
+                    "stream_id": original_msg.id,
                     "seq": seq,
                     "event_type": event_type,
                     "payload": json.loads(serialize(event).decode("utf-8")),
@@ -180,7 +177,7 @@ class NatsChannelProxy:
         subject = f"lyra.outbound.{self._platform.value}.{self._bot_id}"
         envelope = {
             "type": "attachment",
-            "msg_id": inbound.id,
+            "stream_id": inbound.id,
             "attachment": json.loads(serialize(msg).decode("utf-8")),
         }
         payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -121,6 +121,20 @@ class NatsChannelProxy:
                     json.dumps(chunk, ensure_ascii=False).encode("utf-8"),
                 )
                 seq += 1
+            # Always publish a terminal sentinel so NatsOutboundListener._drain_stream
+            # exits cleanly even when the events iterator was empty or the last event
+            # did not set is_final=True.
+            terminal = {
+                "stream_id": original_msg.id,
+                "seq": seq,
+                "event_type": "stream_end",
+                "payload": {},
+                "done": True,
+            }
+            await self._nc.publish(
+                subject,
+                json.dumps(terminal, ensure_ascii=False).encode("utf-8"),
+            )
         except Exception:
             log.exception(
                 "NatsChannelProxy: NATS publish failed during streaming,"

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -73,8 +73,12 @@ def make_dc_msg(channel_id: int = 99, message_id: int = 55) -> InboundMessage:
 
 
 def make_tg_adapter() -> TelegramAdapter:
-    hub = MagicMock()
-    adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="tok",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+    )
     bot_mock = AsyncMock()
     bot_mock.send_voice = AsyncMock()
     adapter.bot = bot_mock
@@ -82,8 +86,11 @@ def make_tg_adapter() -> TelegramAdapter:
 
 
 def make_dc_adapter() -> DiscordAdapter:
-    hub = MagicMock()
-    return DiscordAdapter(hub=hub, bot_id="main")
+    return DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+    )
 
 
 def make_dc_inbound_msg(
@@ -204,8 +211,12 @@ def make_dc_attach_msg(
 
 def make_tg_attach_adapter() -> TelegramAdapter:
     """TelegramAdapter with send_photo/send_video/send_document mocked."""
-    hub = MagicMock()
-    adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="tok",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+    )
     bot_mock = AsyncMock()
     bot_mock.send_photo = AsyncMock()
     bot_mock.send_video = AsyncMock()
@@ -216,8 +227,11 @@ def make_tg_attach_adapter() -> TelegramAdapter:
 
 def make_dc_attach_adapter() -> DiscordAdapter:
     """DiscordAdapter for render_attachment tests."""
-    hub = MagicMock()
-    return DiscordAdapter(hub=hub, bot_id="main")
+    return DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -226,10 +240,13 @@ def make_dc_attach_adapter() -> DiscordAdapter:
 
 
 def _make_telegram_adapter() -> TelegramAdapter:
-    """Build a TelegramAdapter with a MagicMock hub (no bot attached)."""
-    hub = MagicMock()
+    """Build a TelegramAdapter with mock buses (no bot attached)."""
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     return adapter
 
@@ -261,6 +278,36 @@ def _make_open_registry(service: str) -> CircuitRegistry:
             cb.record_failure()  # trips to OPEN
         registry.register(cb)
     return registry
+
+
+@pytest.fixture
+def mock_inbound_bus():
+    bus = MagicMock()
+    bus.put = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def telegram_adapter(mock_inbound_bus):
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="tok",
+        inbound_bus=mock_inbound_bus,
+        inbound_audio_bus=MagicMock(),
+    )
+    bot_mock = AsyncMock()
+    bot_mock.send_voice = AsyncMock()
+    adapter.bot = bot_mock
+    return adapter
+
+
+@pytest.fixture
+def discord_adapter(mock_inbound_bus):
+    return DiscordAdapter(
+        bot_id="main",
+        inbound_bus=mock_inbound_bus,
+        inbound_audio_bus=MagicMock(),
+    )
 
 
 _original_extract_cookies = httpx.Cookies.extract_cookies

--- a/tests/adapters/test_discord_app_commands.py
+++ b/tests/adapters/test_discord_app_commands.py
@@ -93,8 +93,11 @@ class TestOnReadySync:
         """If tree.sync() raises, on_ready should log warning and continue."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="test")
+        adapter = DiscordAdapter(
+            bot_id="test",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         adapter._bot_user = MagicMock()
         adapter._bot_user.id = 12345
 
@@ -128,8 +131,11 @@ class TestOnReadySync:
     async def test_sync_called_per_guild(self) -> None:
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="test")
+        adapter = DiscordAdapter(
+            bot_id="test",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         adapter._bot_user = MagicMock()
         adapter._bot_user.id = 12345
 

--- a/tests/adapters/test_discord_attachments.py
+++ b/tests/adapters/test_discord_attachments.py
@@ -15,8 +15,7 @@ class TestDiscordAttachments:
     def _make_adapter(self):
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+        adapter = DiscordAdapter(bot_id="main", inbound_bus=MagicMock(), inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
         return adapter
 

--- a/tests/adapters/test_discord_attachments.py
+++ b/tests/adapters/test_discord_attachments.py
@@ -15,7 +15,12 @@ class TestDiscordAttachments:
     def _make_adapter(self):
         from lyra.adapters.discord import DiscordAdapter
 
-        adapter = DiscordAdapter(bot_id="main", inbound_bus=MagicMock(), inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+            intents=discord.Intents.none(),
+        )
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
         return adapter
 

--- a/tests/adapters/test_discord_audio.py
+++ b/tests/adapters/test_discord_audio.py
@@ -48,9 +48,12 @@ def _make_discord_msg(
 
 
 def _make_adapter() -> DiscordAdapter:
-    hub = MagicMock()
     return DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
 
@@ -113,12 +116,16 @@ def test_normalize_audio_thread_scope_id() -> None:
 @pytest.mark.asyncio
 async def test_on_message_enqueues_audio_on_audio_bus() -> None:
     """on_message() downloads audio and enqueues on inbound_audio_bus."""
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_audio_bus = MagicMock()
-    hub.inbound_audio_bus.put = AsyncMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
+    inbound_audio_bus = MagicMock()
+    inbound_audio_bus.put = AsyncMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=inbound_audio_bus,
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     # Use a valid OGG magic header so the magic-byte check passes.
@@ -140,8 +147,8 @@ async def test_on_message_enqueues_audio_on_audio_bus() -> None:
     # Audio bytes downloaded
     attachment_obj.read.assert_called_once()
     # Enqueued on audio bus (not text bus)
-    hub.inbound_audio_bus.put.assert_called_once()
-    hub.inbound_bus.put.assert_not_called()
+    inbound_audio_bus.put.assert_called_once()
+    inbound_bus.put.assert_not_called()
     # No unsupported reply sent
     msg.reply.assert_not_called()
 
@@ -149,10 +156,16 @@ async def test_on_message_enqueues_audio_on_audio_bus() -> None:
 @pytest.mark.asyncio
 async def test_on_message_audio_download_failure_returns_cleanly() -> None:
     """on_message() handles download failure gracefully — no enqueue, no crash."""
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_audio_bus = MagicMock()
-    adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
+    inbound_audio_bus = MagicMock()
+    inbound_audio_bus.put = AsyncMock()
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=inbound_audio_bus,
+        intents=discord.Intents.none(),
+    )
 
     attachment_obj = SimpleNamespace(
         content_type="audio/ogg",
@@ -165,19 +178,20 @@ async def test_on_message_audio_download_failure_returns_cleanly() -> None:
 
     await adapter.on_message(msg)
 
-    hub.inbound_audio_bus.put.assert_not_called()
-    hub.inbound_bus.put.assert_not_called()
+    inbound_audio_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()
     msg.reply.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_on_message_audio_too_large_sends_reply() -> None:
     """on_message() rejects oversized audio with user-facing reply."""
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_audio_bus = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     attachment_obj = SimpleNamespace(
@@ -193,7 +207,6 @@ async def test_on_message_audio_too_large_sends_reply() -> None:
 
     # Should NOT download
     attachment_obj.read.assert_not_called()
-    hub.inbound_audio_bus.put.assert_not_called()
     # Should reply with too-large message
     msg.reply.assert_called_once()
 
@@ -201,10 +214,12 @@ async def test_on_message_audio_too_large_sends_reply() -> None:
 @pytest.mark.asyncio
 async def test_on_message_does_not_call_normalize_audio_for_non_audio() -> None:
     """on_message() does not call normalize_audio() for non-audio attachments."""
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     image_attachment = SimpleNamespace(
@@ -238,10 +253,14 @@ async def test_on_message_does_not_call_normalize_audio_for_non_audio() -> None:
 @pytest.mark.asyncio
 async def test_on_message_returns_after_audio_skips_text_path() -> None:
     """on_message() must not enqueue a text hub_msg when audio is processed."""
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     attachment_obj = SimpleNamespace(
@@ -255,4 +274,4 @@ async def test_on_message_returns_after_audio_skips_text_path() -> None:
 
     await adapter.on_message(msg)
 
-    hub.inbound_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -57,16 +57,15 @@ class TestDiscordAdapterInbound:
         """All users reach the bus with trust_level=PUBLIC (Hub resolves trust)."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
+        adapter = DiscordAdapter(bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
         await adapter.on_message(_make_discord_msg_ns())
 
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform, msg = hub.inbound_bus.put.call_args[0]
+        inbound_bus.put.assert_awaited_once()
+        _platform, msg = inbound_bus.put.call_args[0]
         assert msg.trust_level == TrustLevel.PUBLIC
         assert msg.is_admin is False
 
@@ -77,9 +76,8 @@ class TestDiscordAdapterInbound:
 
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+        inbound_bus = MagicMock()
+        adapter = DiscordAdapter(bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
         bot_msg = SimpleNamespace(
@@ -98,24 +96,23 @@ class TestDiscordAdapterInbound:
             await adapter.on_message(bot_msg)
 
         mock_norm.assert_not_called()
-        hub.inbound_bus.put.assert_not_called()
+        inbound_bus.put.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_user_with_roles_forwarded_with_public_trust(self) -> None:
         """User with roles is forwarded with PUBLIC trust (roles irrelevant at adapter)."""  # noqa: E501
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main", intents=discord.Intents.none())
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
+        adapter = DiscordAdapter(bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
         msg_ns = _make_discord_msg_ns(roles=["123456"])
         await adapter.on_message(msg_ns)
 
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform, msg = hub.inbound_bus.put.call_args[0]
+        inbound_bus.put.assert_awaited_once()
+        _platform, msg = inbound_bus.put.call_args[0]
         assert msg.trust_level == TrustLevel.PUBLIC
 
 

--- a/tests/adapters/test_discord_auth.py
+++ b/tests/adapters/test_discord_auth.py
@@ -59,7 +59,12 @@ class TestDiscordAdapterInbound:
 
         inbound_bus = MagicMock()
         inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
+            intents=discord.Intents.none(),
+        )
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
         await adapter.on_message(_make_discord_msg_ns())
@@ -77,7 +82,12 @@ class TestDiscordAdapterInbound:
         from lyra.adapters.discord import DiscordAdapter
 
         inbound_bus = MagicMock()
-        adapter = DiscordAdapter(bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
+            intents=discord.Intents.none(),
+        )
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
         bot_msg = SimpleNamespace(
@@ -105,7 +115,12 @@ class TestDiscordAdapterInbound:
 
         inbound_bus = MagicMock()
         inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none())
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
+            intents=discord.Intents.none(),
+        )
         adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
         msg_ns = _make_discord_msg_ns(roles=["123456"])

--- a/tests/adapters/test_discord_edge.py
+++ b/tests/adapters/test_discord_edge.py
@@ -71,12 +71,11 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
 
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none(), auth=_ALLOW_ALL
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -117,13 +116,13 @@ async def test_on_message_drops_silently_when_hub_circuit_open() -> None:
     # Arrange
     registry = _make_open_registry("hub")
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
 
     adapter = DiscordAdapter(
-        hub=hub,
         bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
         intents=discord.Intents.none(),
         circuit_registry=registry,
         auth=_ALLOW_ALL,
@@ -146,7 +145,7 @@ async def test_on_message_drops_silently_when_hub_circuit_open() -> None:
     await adapter.on_message(discord_msg)
 
     # Assert — inbound_bus.put must NOT be called; message filtered before circuit check
-    hub.inbound_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -157,13 +156,13 @@ async def test_on_message_notifies_user_when_hub_circuit_open_dm() -> None:
     # Arrange — hub circuit is OPEN
     registry = _make_open_registry("hub")
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
 
     adapter = DiscordAdapter(
-        hub=hub,
         bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
         intents=discord.Intents.none(),
         circuit_registry=registry,
         auth=_ALLOW_ALL,
@@ -188,7 +187,7 @@ async def test_on_message_notifies_user_when_hub_circuit_open_dm() -> None:
     await adapter.on_message(discord_msg)
 
     # Assert — inbound_bus.put must NOT be called (message dropped)
-    hub.inbound_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()
     # Assert — user receives a circuit-open notification via reply
     reply_mock.assert_called_once()
     sent_text = reply_mock.call_args.args[0]
@@ -211,10 +210,10 @@ async def test_send_skips_when_discord_circuit_open() -> None:
     # Arrange
     registry = _make_open_registry("discord")
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub,
         bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
         intents=discord.Intents.none(),
         circuit_registry=registry,
     )
@@ -271,13 +270,13 @@ async def test_discord_msg_manager_injection_backpressure_ack() -> None:
 
     import asyncio
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     adapter = DiscordAdapter(
-        hub=hub,
         bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
         intents=discord.Intents.none(),
         msg_manager=mm,
         auth=_ALLOW_ALL,
@@ -316,9 +315,8 @@ def test_normalize_empty_text() -> None:
     from lyra.adapters.discord import DiscordAdapter
     from lyra.core.message import InboundMessage
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main", inbound_bus=MagicMock(), inbound_audio_bus=MagicMock(), intents=discord.Intents.none(), auth=_ALLOW_ALL
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
     discord_msg = SimpleNamespace(

--- a/tests/adapters/test_discord_edge.py
+++ b/tests/adapters/test_discord_edge.py
@@ -75,7 +75,11 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
     inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     adapter = DiscordAdapter(
-        bot_id="main", inbound_bus=inbound_bus, inbound_audio_bus=MagicMock(), intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -316,7 +320,11 @@ def test_normalize_empty_text() -> None:
     from lyra.core.message import InboundMessage
 
     adapter = DiscordAdapter(
-        bot_id="main", inbound_bus=MagicMock(), inbound_audio_bus=MagicMock(), intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
     discord_msg = SimpleNamespace(

--- a/tests/adapters/test_discord_normalize.py
+++ b/tests/adapters/test_discord_normalize.py
@@ -21,9 +21,12 @@ def test_normalize_builds_correct_discord_context() -> None:
     from lyra.adapters.discord import DiscordAdapter  # ImportError expected in RED
     from lyra.core.message import InboundMessage
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -57,9 +60,12 @@ def test_is_mention_true_when_bot_in_mentions() -> None:
     """bot_user present in message.mentions → is_mention is True."""
     from lyra.adapters.discord import DiscordAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -88,9 +94,12 @@ def test_is_mention_false_when_bot_not_in_mentions() -> None:
     """bot_user absent from message.mentions → is_mention is False."""
     from lyra.adapters.discord import DiscordAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -119,9 +128,12 @@ def test_normalize_bot_user_none_is_mention_false() -> None:
     """When _bot_user is None (pre-on_ready), is_mention must be False — never raise."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     # _bot_user stays None (default, before on_ready fires)
 
@@ -149,9 +161,12 @@ def test_mention_prefix_stripped_from_content() -> None:
     """@mention prefix (<@id>) is stripped from text before delivery."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -176,9 +191,12 @@ def test_mention_prefix_stripped_nickname_variant() -> None:
     """@mention prefix with nickname format (<@!id>) is also stripped."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -208,9 +226,12 @@ def test_normalize_dm_no_guild() -> None:
     from lyra.adapters.discord import DiscordAdapter
     from lyra.core.message import InboundMessage
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -241,9 +262,12 @@ def test_normalize_uses_display_name_when_present() -> None:
     """When author has display_name, it takes precedence over name."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -268,9 +292,12 @@ def test_normalize_falls_back_to_name_when_display_name_none() -> None:
     """When display_name is None, falls back to name."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -305,9 +332,12 @@ def test_discord_token_not_in_logs(
     secret_token = "super-secret-discord-token-xyz"
     monkeypatch.setenv("DISCORD_TOKEN", secret_token)
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     with caplog.at_level(logging.DEBUG):
@@ -340,9 +370,12 @@ def test_normalize_guild_channel_user_scoped_scope_id() -> None:
     from lyra.adapters.discord import DiscordAdapter
     from lyra.core.message import InboundMessage
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -367,9 +400,12 @@ def test_normalize_dm_scope_id_unchanged() -> None:
     """Discord DM (guild=None) → scope_id has no user suffix (regression)."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -392,9 +428,12 @@ def test_normalize_thread_scope_id_unchanged() -> None:
     """Discord thread → scope_id uses thread: prefix, no user suffix (regression)."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -421,9 +460,12 @@ def test_two_users_same_guild_channel_get_distinct_pool_ids() -> None:
     from lyra.core.hub.hub_protocol import RoutingKey
     from lyra.core.message import Platform
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 

--- a/tests/adapters/test_discord_outbound.py
+++ b/tests/adapters/test_discord_outbound.py
@@ -25,9 +25,12 @@ def _make_discord_adapter():
     """Build a DiscordAdapter with a MagicMock hub."""
     from lyra.adapters.discord import DiscordAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     return DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
 
@@ -43,12 +46,15 @@ async def test_own_message_is_filtered() -> None:
 
     from lyra.adapters.discord import DiscordAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
 
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -65,7 +71,7 @@ async def test_own_message_is_filtered() -> None:
 
     await adapter.on_message(discord_msg)
 
-    hub.inbound_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -78,9 +84,12 @@ async def test_send_reply_on_mention() -> None:
     """adapter.send() calls msg.reply(text) when is_mention=True."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -107,9 +116,12 @@ async def test_send_reply_on_no_mention() -> None:
     """send() still replies to the trigger message even when is_mention=False."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -136,9 +148,12 @@ async def test_send_stores_reply_message_id_channel_send() -> None:
     """send() via msg.reply() stores sent message id in metadata."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     sent_msg = SimpleNamespace(id=888)
@@ -167,9 +182,12 @@ async def test_send_stores_reply_message_id_msg_reply() -> None:
     """send() via msg.reply() stores sent message id in outbound.metadata."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     sent_msg = SimpleNamespace(id=7777)
@@ -198,9 +216,12 @@ async def test_send_no_reply_message_id_on_failure() -> None:
     """send() must NOT set reply_message_id in metadata when the send call throws."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -27,13 +27,13 @@ class TestDiscordAutoThread:
         from lyra.adapters.discord import DiscordAdapter
 
         # Arrange
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -68,9 +68,9 @@ class TestDiscordAutoThread:
         # Assert — create_thread was called once
         create_thread_mock.assert_awaited_once()
 
-        # Assert — hub.inbound_bus.put was called and the InboundMessage has thread_id
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
+        # Assert — inbound_bus.put was called and the InboundMessage has thread_id
+        inbound_bus.put.assert_awaited_once()
+        _platform_arg, hub_msg = inbound_bus.put.call_args[0]
         assert hub_msg.platform_meta["thread_id"] == 9999
         assert hub_msg.scope_id == "thread:9999"
 
@@ -80,13 +80,13 @@ class TestDiscordAutoThread:
         from lyra.adapters.discord import DiscordAdapter
 
         # Arrange
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -124,13 +124,13 @@ class TestDiscordAutoThread:
         from lyra.adapters.discord import DiscordAdapter
 
         # Arrange
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=False,
             auth=_ALLOW_ALL,
@@ -164,13 +164,13 @@ class TestDiscordAutoThread:
         from lyra.adapters.discord import DiscordAdapter
 
         # Arrange
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -198,7 +198,7 @@ class TestDiscordAutoThread:
         await adapter.on_message(discord_msg)
 
         # Assert — message still processed (bus.put called)
-        hub.inbound_bus.put.assert_awaited_once()
+        inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_auto_thread_exception_recovers_partial_thread(self) -> None:
@@ -206,13 +206,13 @@ class TestDiscordAutoThread:
         from lyra.adapters.discord import DiscordAdapter
 
         # Arrange
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -248,8 +248,8 @@ class TestDiscordAutoThread:
         await adapter.on_message(discord_msg)
 
         # Assert — message processed with recovered thread scope
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
+        inbound_bus.put.assert_awaited_once()
+        _platform_arg, hub_msg = inbound_bus.put.call_args[0]
         assert hub_msg.scope_id == "thread:8888"
         assert hub_msg.platform_meta["thread_id"] == 8888
         assert 8888 in adapter._owned_threads

--- a/tests/adapters/test_discord_typing.py
+++ b/tests/adapters/test_discord_typing.py
@@ -64,9 +64,12 @@ async def test_start_typing_creates_background_task() -> None:
 
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     mock_channel = AsyncMock()
     mock_channel.typing = AsyncMock()
@@ -89,9 +92,12 @@ async def test_cancel_typing_cancels_task() -> None:
 
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     mock_channel = AsyncMock()
     mock_channel.typing = AsyncMock()
@@ -111,9 +117,12 @@ async def test_send_cancels_typing_task_at_start() -> None:
     """send() calls _cancel_typing() before writing the response."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -143,9 +152,12 @@ async def test_send_streaming_cancels_typing_task_at_start() -> None:
     """send_streaming() calls _cancel_typing() before writing the response."""
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
 
     mock_placeholder = AsyncMock()
@@ -192,12 +204,15 @@ async def test_on_message_does_not_cancel_typing_when_message_queued() -> None:
     """
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock()  # succeeds — no QueueFull
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()  # succeeds — no QueueFull
 
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -237,12 +252,15 @@ async def test_on_message_cancels_typing_when_message_dropped_queue_full() -> No
 
     from lyra.adapters.discord import DiscordAdapter
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock(side_effect=_asyncio.QueueFull())
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock(side_effect=_asyncio.QueueFull())
 
     adapter = DiscordAdapter(
-        hub=hub, bot_id="main", intents=discord.Intents.none(), auth=_ALLOW_ALL
+        bot_id="main",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 

--- a/tests/adapters/test_discord_voice_commands.py
+++ b/tests/adapters/test_discord_voice_commands.py
@@ -63,8 +63,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_transient_calls_vsm_join(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -80,8 +83,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_slash_prefix_calls_vsm_join(self) -> None:
         # Arrange — /join (slash prefix) must route identically to !join
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -97,8 +103,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_stay_calls_vsm_join_persistent(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -114,8 +123,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_stay_case_insensitive_is_persistent(self) -> None:
         # Arrange — "!join STAY" (uppercase) must map to PERSISTENT
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -132,8 +144,11 @@ class TestHandleVoiceCommand:
     async def test_join_stay_with_extra_args_is_persistent(self) -> None:
         # Arrange — "!join stay please" should still be PERSISTENT
         # (prefix match on first token)
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -149,8 +164,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_leave_with_active_session_disconnects_and_replies(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         leave_mock = AsyncMock()
         adapter._vsm.leave = leave_mock
         adapter._vsm.get = MagicMock(return_value=MagicMock())  # session exists
@@ -167,8 +185,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_leave_without_session_replies_not_in_channel(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         leave_mock = AsyncMock()
         adapter._vsm.leave = leave_mock
         adapter._vsm.get = MagicMock(return_value=None)  # no session
@@ -185,8 +206,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_non_voice_command_returns_false(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         leave_mock = AsyncMock()
         adapter._vsm.join = join_mock
@@ -204,8 +228,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_user_not_in_voice_channel_replies_error(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         msg = _make_message("!join", author_voice_channel=None)
@@ -221,8 +248,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_user_no_voice_state_replies_error(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         msg = _make_message("!join")
@@ -239,8 +269,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_join_already_active_replies_error(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock(side_effect=VoiceAlreadyActiveError("1"))
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -258,8 +291,11 @@ class TestHandleVoiceCommand:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         # Arrange — inner reply() raises; log.warning must fire, True must return
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock(side_effect=VoiceAlreadyActiveError("1"))
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -279,8 +315,11 @@ class TestHandleVoiceCommand:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock(side_effect=VoiceDependencyError("libopus missing"))
         adapter._vsm.join = join_mock
         voice_ch = MagicMock()
@@ -298,8 +337,11 @@ class TestHandleVoiceCommand:
     @pytest.mark.asyncio
     async def test_other_command_returns_false(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         join_mock = AsyncMock()
         adapter._vsm.join = join_mock
         msg = _make_message("!help")
@@ -319,11 +361,14 @@ class TestHandleVoiceCommand:
 class TestOnMessageVoiceCommandWiring:
     @pytest.mark.asyncio
     async def test_voice_command_in_guild_skips_hub_push(self) -> None:
-        # Arrange — !join in a guild text channel should NOT reach hub.inbound_bus
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        # Arrange — !join in a guild text channel should NOT reach inbound_bus
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
+        )
         adapter._auth = _ALLOW_ALL  # permit the message
         # Mock _handle_voice_command to return True (simulates voice command handled)
         adapter._handle_voice_command = AsyncMock(return_value=True)
@@ -342,5 +387,5 @@ class TestOnMessageVoiceCommandWiring:
         # Act
         await adapter.on_message(message)
 
-        # Assert — hub inbound bus was NOT called
-        hub.inbound_bus.put.assert_not_called()
+        # Assert — inbound bus was NOT called
+        inbound_bus.put.assert_not_called()

--- a/tests/adapters/test_discord_voice_session.py
+++ b/tests/adapters/test_discord_voice_session.py
@@ -248,8 +248,11 @@ class TestVoiceSessionManager:
 
 
 def _make_adapter_with_bot() -> DiscordAdapter:
-    hub = MagicMock()
-    adapter = DiscordAdapter(hub=hub, bot_id="main")
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+    )
     bot_user = MagicMock()
     bot_user.id = 999
     adapter._bot_user = bot_user
@@ -303,8 +306,11 @@ class TestOnVoiceStateUpdate:
 
     @pytest.mark.asyncio
     async def test_bot_not_ready_does_not_invalidate(self) -> None:
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         # _bot_user is None (not ready yet)
         adapter._vsm.invalidate = MagicMock()
         member = _make_member(member_id=999, guild_id=1)

--- a/tests/adapters/test_discord_voice_streaming.py
+++ b/tests/adapters/test_discord_voice_streaming.py
@@ -243,8 +243,11 @@ class TestRenderVoiceStream:
     @pytest.mark.asyncio
     async def test_render_voice_stream_calls_vsm_stream(self) -> None:
         # Arrange
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         adapter._vsm.stream = AsyncMock()
         inbound = _make_discord_inbound(platform_meta={"guild_id": "1"})
 
@@ -264,8 +267,11 @@ class TestRenderVoiceStream:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         # Arrange — inbound platform is telegram, not discord
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         adapter._vsm.stream = AsyncMock()
 
         inbound = InboundMessage(
@@ -299,8 +305,11 @@ class TestRenderVoiceStream:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         # Arrange — platform_meta has no guild_id
-        hub = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
         adapter._vsm.stream = AsyncMock()
         inbound = _make_discord_inbound(platform_meta={})
 

--- a/tests/adapters/test_discord_watch.py
+++ b/tests/adapters/test_discord_watch.py
@@ -20,13 +20,13 @@ class TestWatchChannels:
         """Message in a watch channel is processed even without @mention."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -59,20 +59,20 @@ class TestWatchChannels:
 
         await adapter.on_message(discord_msg)
 
-        hub.inbound_bus.put.assert_awaited_once()
+        inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_watch_channel_creates_auto_thread(self) -> None:
         """Watch channel message triggers auto-thread creation."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -106,8 +106,8 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         create_thread_mock.assert_awaited_once()
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform_arg, hub_msg = hub.inbound_bus.put.call_args[0]
+        inbound_bus.put.assert_awaited_once()
+        _platform_arg, hub_msg = inbound_bus.put.call_args[0]
         assert hub_msg.platform_meta["thread_id"] == 8888
 
     @pytest.mark.asyncio
@@ -115,13 +115,13 @@ class TestWatchChannels:
         """Message in a non-watch channel without mention is still filtered out."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -144,20 +144,20 @@ class TestWatchChannels:
 
         await adapter.on_message(discord_msg)
 
-        hub.inbound_bus.put.assert_not_called()
+        inbound_bus.put.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_watch_channel_auto_thread_disabled(self) -> None:
         """Watch channel + auto_thread=False: message processed, no thread created."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=False,
             auth=_ALLOW_ALL,
@@ -189,7 +189,7 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         # Message still processed even though auto_thread=False
-        hub.inbound_bus.put.assert_awaited_once()
+        inbound_bus.put.assert_awaited_once()
         # No thread created
         create_thread_mock.assert_not_awaited()
 
@@ -198,13 +198,13 @@ class TestWatchChannels:
         """Thread message uses owned-thread path, not watch channel."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -232,20 +232,20 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         # Processed via owned-thread path, not watch channel
-        hub.inbound_bus.put.assert_awaited_once()
+        inbound_bus.put.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_watch_channel_create_thread_exception_fallback(self) -> None:
         """Watch channel + create_thread raises: message still processed."""
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
 
         adapter = DiscordAdapter(
-            hub=hub,
             bot_id="main",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
             intents=discord.Intents.none(),
             auto_thread=True,
             auth=_ALLOW_ALL,
@@ -277,4 +277,4 @@ class TestWatchChannels:
         await adapter.on_message(discord_msg)
 
         # Message still processed despite create_thread failure
-        hub.inbound_bus.put.assert_awaited_once()
+        inbound_bus.put.assert_awaited_once()

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -1,7 +1,6 @@
 """Tests for NatsOutboundListener — NATS-to-adapter dispatch."""
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -116,8 +115,8 @@ async def test_attachment_envelope_dispatches_to_render_attachment() -> None:
 
 
 @pytest.mark.asyncio
-async def test_done_flag_evicts_cache_entry() -> None:
-    """send envelope with done=True for stream_id -> cache entry removed after dispatch."""  # noqa: E501
+async def test_send_evicts_cache_entry() -> None:
+    """send envelope -> cache entry removed after dispatch (eviction is unconditional)."""  # noqa: E501
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 
     nc = AsyncMock()
@@ -162,8 +161,10 @@ async def test_chunk_envelope_triggers_send_streaming() -> None:
     }
     await listener._handle(_make_nats_msg(chunk))
 
-    # Give the drain task a chance to run
-    await asyncio.sleep(0.05)
+    # Await the drain task directly — avoids flaky sleep-based synchronization
+    task = listener._stream_tasks.get(msg.id)
+    if task:
+        await task
 
     adapter.send_streaming.assert_called_once()
 

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.core.message import InboundMessage, OutboundMessage, OutboundAttachment, Platform
+from lyra.core.message import InboundMessage, Platform
 from lyra.core.trust import TrustLevel
 
 
@@ -24,7 +24,9 @@ def _make_tg_msg(msg_id: str = "msg-1") -> InboundMessage:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={"chat_id": 42, "message_id": 10, "topic_id": None, "is_group": False},
+        platform_meta={
+            "chat_id": 42, "message_id": 10, "topic_id": None, "is_group": False
+        },
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -47,7 +49,6 @@ async def test_send_envelope_dispatches_to_adapter_send() -> None:
     msg = _make_tg_msg()
     listener.cache_inbound(msg)
 
-    outbound = OutboundMessage.from_text("hello")
     # Serialize outbound using the same approach as NatsChannelProxy
     envelope = {
         "type": "send",
@@ -116,7 +117,7 @@ async def test_attachment_envelope_dispatches_to_render_attachment() -> None:
 
 @pytest.mark.asyncio
 async def test_done_flag_evicts_cache_entry() -> None:
-    """send envelope with done=True for stream_id -> cache entry removed after dispatch."""
+    """send envelope with done=True for stream_id -> cache entry removed after dispatch."""  # noqa: E501
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 
     nc = AsyncMock()

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -1,0 +1,188 @@
+"""Tests for NatsOutboundListener — NATS-to-adapter dispatch."""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lyra.core.message import InboundMessage, OutboundMessage, OutboundAttachment, Platform
+from lyra.core.trust import TrustLevel
+
+
+def _make_tg_msg(msg_id: str = "msg-1") -> InboundMessage:
+    return InboundMessage(
+        id=msg_id,
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:42",
+        user_id="tg:user:1",
+        user_name="Alice",
+        is_mention=False,
+        text="hi",
+        text_raw="hi",
+        timestamp=datetime.now(timezone.utc),
+        platform_meta={"chat_id": 42, "message_id": 10, "topic_id": None, "is_group": False},
+        trust_level=TrustLevel.TRUSTED,
+    )
+
+
+def _make_nats_msg(data: dict) -> MagicMock:
+    msg = MagicMock()
+    msg.data = json.dumps(data).encode("utf-8")
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_send_envelope_dispatches_to_adapter_send() -> None:
+    """cache_inbound + send envelope -> adapter.send() called once."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg()
+    listener.cache_inbound(msg)
+
+    outbound = OutboundMessage.from_text("hello")
+    # Serialize outbound using the same approach as NatsChannelProxy
+    envelope = {
+        "type": "send",
+        "stream_id": msg.id,
+        "outbound": {
+            "content": ["hello"],
+            "buttons": [],
+            "metadata": {},
+        },
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    adapter.send.assert_called_once()
+    call_original_msg, call_outbound = adapter.send.call_args[0]
+    assert call_original_msg is msg
+
+
+@pytest.mark.asyncio
+async def test_send_unknown_stream_id_logs_warning_no_crash() -> None:
+    """Unknown stream_id in send envelope -> warning logged, no crash."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    envelope = {
+        "type": "send",
+        "stream_id": "nonexistent-id",
+        "outbound": {"content": ["hi"], "buttons": [], "metadata": {}},
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attachment_envelope_dispatches_to_render_attachment() -> None:
+    """Attachment envelope -> adapter.render_attachment() called once."""
+    import base64
+
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-attach")
+    listener.cache_inbound(msg)
+
+    # OutboundAttachment.data is bytes, serialized as b64:<base64> in JSON wire format
+    b64_data = "b64:" + base64.b64encode(b"PNG").decode("ascii")
+    envelope = {
+        "type": "attachment",
+        "stream_id": msg.id,
+        "attachment": {
+            "data": b64_data,
+            "type": "image",
+            "mime_type": "image/png",
+        },
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    adapter.render_attachment.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_done_flag_evicts_cache_entry() -> None:
+    """send envelope with done=True for stream_id -> cache entry removed after dispatch."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-evict")
+    listener.cache_inbound(msg)
+
+    assert msg.id in listener._cache
+
+    envelope = {
+        "type": "send",
+        "stream_id": msg.id,
+        "outbound": {"content": ["hi"], "buttons": [], "metadata": {}},
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    assert msg.id not in listener._cache
+
+
+@pytest.mark.asyncio
+async def test_chunk_envelope_triggers_send_streaming() -> None:
+    """Chunk envelopes reassemble into a stream and call adapter.send_streaming()."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    adapter.send_streaming = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-stream")
+    listener.cache_inbound(msg)
+
+    # Send a single done chunk
+    chunk = {
+        "stream_id": msg.id,
+        "seq": 0,
+        "event_type": "text",
+        "payload": {"text": "hello", "is_final": True},
+        "done": True,
+    }
+    await listener._handle(_make_nats_msg(chunk))
+
+    # Give the drain task a chance to run
+    await asyncio.sleep(0.05)
+
+    adapter.send_streaming.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_and_stop_unsubscribes() -> None:
+    """start() subscribes to NATS subject; stop() unsubscribes."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    mock_sub = AsyncMock()
+    nc = AsyncMock()
+    nc.subscribe = AsyncMock(return_value=mock_sub)
+
+    adapter = MagicMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    await listener.start()
+    nc.subscribe.assert_called_once()
+    subject = nc.subscribe.call_args[0][0]
+    assert subject == "lyra.outbound.telegram.main"
+
+    await listener.stop()
+    mock_sub.unsubscribe.assert_called_once()

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -62,7 +62,7 @@ async def test_send_envelope_dispatches_to_adapter_send() -> None:
     await listener._handle(_make_nats_msg(envelope))
 
     adapter.send.assert_called_once()
-    call_original_msg, call_outbound = adapter.send.call_args[0]
+    call_original_msg, _call_outbound = adapter.send.call_args[0]
     assert call_original_msg is msg
 
 

--- a/tests/adapters/test_streaming.py
+++ b/tests/adapters/test_streaming.py
@@ -81,12 +81,11 @@ class TestTelegramStreaming:
     def _make_adapter(self):
         from lyra.adapters.telegram import TelegramAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
         adapter = TelegramAdapter(
             bot_id="main",
             token="fake-token",
-            hub=hub,
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
             webhook_secret="secret",
         )
         mock_bot = AsyncMock()
@@ -301,9 +300,11 @@ class TestDiscordStreaming:
     def _make_adapter(self):
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
 
         mock_placeholder = AsyncMock()
         mock_placeholder.edit = AsyncMock()
@@ -470,10 +471,12 @@ class TestTelegramIntermediateText:
     def _make_adapter(self):
         from lyra.adapters.telegram import TelegramAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
         adapter = TelegramAdapter(
-            bot_id="main", token="fake-token", hub=hub, webhook_secret="secret"
+            bot_id="main",
+            token="fake-token",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+            webhook_secret="secret",
         )
         mock_bot = AsyncMock()
         placeholder = MagicMock()
@@ -536,9 +539,11 @@ class TestDiscordIntermediateText:
     def _make_adapter(self):
         from lyra.adapters.discord import DiscordAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        adapter = DiscordAdapter(hub=hub, bot_id="main")
+        adapter = DiscordAdapter(
+            bot_id="main",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
 
         mock_placeholder = AsyncMock()
         mock_placeholder.edit = AsyncMock()
@@ -651,9 +656,13 @@ async def test_telegram_streaming_fallback_sends_all_chunks() -> None:
     """
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, webhook_secret="s")
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="tok",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        webhook_secret="s",
+    )
     fallback_msgs = [MagicMock(message_id=i) for i in range(1, 4)]
     bot = AsyncMock()
     # First send_message raises (placeholder) → triggers fallback path

--- a/tests/adapters/test_telegram_attachments.py
+++ b/tests/adapters/test_telegram_attachments.py
@@ -17,8 +17,12 @@ class TestTelegramAttachments:
     def _make_adapter(self):
         from lyra.adapters.telegram import TelegramAdapter
 
-        hub = MagicMock()
-        return TelegramAdapter(bot_id="main", token="test-token-secret", hub=hub)
+        return TelegramAdapter(
+            bot_id="main",
+            token="test-token-secret",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+        )
 
     def _make_msg(  # noqa: PLR0913 — test factory with optional overrides
         self,

--- a/tests/adapters/test_telegram_auth.py
+++ b/tests/adapters/test_telegram_auth.py
@@ -49,8 +49,12 @@ async def test_missing_secret_returns_401() -> None:
 
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
-    adapter = TelegramAdapter(bot_id="main", token="test-token-secret", hub=hub)
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+    )
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=adapter.app)
@@ -95,11 +99,11 @@ async def test_get_status_endpoint_returns_all_circuits() -> None:
             CircuitBreaker(name, failure_threshold=3, recovery_timeout=60)
         )
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
         bot_id="main",
         token="test-token-secret",
-        hub=hub,
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
         webhook_secret="secret",
         circuit_registry=registry,
     )
@@ -134,16 +138,20 @@ class TestTelegramAdapterInbound:
         """All users reach the bus with trust_level=PUBLIC (Hub resolves trust)."""
         from lyra.adapters.telegram import TelegramAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        hub.inbound_bus.put = AsyncMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
+        adapter = TelegramAdapter(
+            bot_id="main",
+            token="tok",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
+        )
         adapter.bot = AsyncMock()
 
         await adapter._on_message(_make_aiogram_msg())
 
-        hub.inbound_bus.put.assert_awaited_once()
-        _platform, msg = hub.inbound_bus.put.call_args[0]
+        inbound_bus.put.assert_awaited_once()
+        _platform, msg = inbound_bus.put.call_args[0]
         assert msg.trust_level == TrustLevel.PUBLIC
         assert msg.is_admin is False
 
@@ -154,9 +162,14 @@ class TestTelegramAdapterInbound:
 
         from lyra.adapters.telegram import TelegramAdapter
 
-        hub = MagicMock()
-        hub.inbound_bus = MagicMock()
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+        inbound_bus = MagicMock()
+        inbound_bus.put = AsyncMock()
+        adapter = TelegramAdapter(
+            bot_id="main",
+            token="tok",
+            inbound_bus=inbound_bus,
+            inbound_audio_bus=MagicMock(),
+        )
 
         bot_msg = SimpleNamespace(
             chat=SimpleNamespace(id=123, type="private"),
@@ -172,7 +185,7 @@ class TestTelegramAdapterInbound:
             await adapter._on_message(bot_msg)
 
         mock_norm.assert_not_called()
-        hub.inbound_bus.put.assert_not_called()
+        inbound_bus.put.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_voice_message_forwarded_with_public_trust(self) -> None:
@@ -181,10 +194,14 @@ class TestTelegramAdapterInbound:
 
         from lyra.adapters.telegram import TelegramAdapter
 
-        hub = MagicMock()
-        hub.inbound_audio_bus = MagicMock()
-        hub.inbound_audio_bus.registered_platforms = MagicMock(return_value=[])
-        adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub)
+        inbound_audio_bus = MagicMock()
+        inbound_audio_bus.registered_platforms = MagicMock(return_value=[])
+        adapter = TelegramAdapter(
+            bot_id="main",
+            token="tok",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=inbound_audio_bus,
+        )
         adapter.bot = AsyncMock()
 
         voice_msg = SimpleNamespace(

--- a/tests/adapters/test_telegram_normalize_fields.py
+++ b/tests/adapters/test_telegram_normalize_fields.py
@@ -24,9 +24,12 @@ def test_normalize_private_chat_context() -> None:
     """normalize() on a private-chat message produces correct platform_meta."""
     from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
 
     aiogram_msg = SimpleNamespace(
@@ -61,9 +64,12 @@ def test_is_mention_false_in_private_chat() -> None:
     """Private chat → is_mention=False regardless of entities."""
     from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
 
     aiogram_msg = SimpleNamespace(
@@ -84,9 +90,12 @@ def test_is_mention_true_when_entity_at_offset_zero() -> None:
     """Group chat with @mention entity at offset 0 matching bot username → True."""
     from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_username = "lyra_bot"  # simulate resolve_identity()
 
@@ -115,9 +124,12 @@ def test_token_not_in_logs(caplog: pytest.LogCaptureFixture) -> None:
     """After _normalize(), no log record contains the bot token string."""
     from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
 
     aiogram_msg = SimpleNamespace(
@@ -146,9 +158,12 @@ def test_normalize_captures_message_id() -> None:
     from lyra.adapters.telegram import TelegramAdapter
 
     # Arrange
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -177,9 +192,12 @@ def test_normalize_message_id_none_when_absent() -> None:
     from lyra.adapters.telegram import TelegramAdapter
 
     # Arrange
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -209,9 +227,12 @@ def test_normalize_captures_topic_and_message_id_for_forum() -> None:
     from lyra.adapters.telegram import TelegramAdapter
 
     # Arrange
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=456, type="supergroup"),
@@ -238,9 +259,12 @@ def test_normalize_empty_text() -> None:
     """normalize() with text=None produces msg.text == \"\"."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -266,9 +290,12 @@ def test_normalize_sets_reply_to_id_when_reply_present() -> None:
 
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     reply_msg = SimpleNamespace(message_id=77)
     aiogram_msg = SimpleNamespace(
@@ -291,9 +318,12 @@ def test_normalize_reply_to_id_none_when_no_reply() -> None:
     """normalize() sets reply_to_id to None when raw.reply_to_message is absent."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -320,9 +350,12 @@ def test_normalize_group_chat_user_scoped_scope_id() -> None:
     """Group chat → scope_id includes user_id suffix."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_username = "lyra_bot"
 
@@ -347,9 +380,12 @@ def test_normalize_group_chat_no_mention_still_user_scoped() -> None:
     """Group chat without @mention → scope_id still includes user_id suffix."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
 
     aiogram_msg = SimpleNamespace(
@@ -372,9 +408,12 @@ def test_normalize_forum_topic_user_scoped_scope_id() -> None:
     """Forum topic in supergroup → scope_id includes topic AND user_id suffix."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_username = "lyra_bot"
 
@@ -398,9 +437,12 @@ def test_normalize_private_chat_scope_id_unchanged() -> None:
     """Private chat → scope_id has no user suffix (regression)."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
 
     aiogram_msg = SimpleNamespace(
@@ -424,9 +466,12 @@ def test_two_users_same_group_get_distinct_pool_ids() -> None:
     from lyra.core.hub.hub_protocol import RoutingKey
     from lyra.core.message import Platform
 
-    hub = MagicMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter._bot_username = "lyra_bot"
 

--- a/tests/adapters/test_telegram_on_message.py
+++ b/tests/adapters/test_telegram_on_message.py
@@ -53,15 +53,18 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
 
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     bot = AsyncMock()
     bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
 
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter.bot = bot
 
@@ -93,9 +96,8 @@ async def test_telegram_msg_manager_injection_backpressure_ack() -> None:
 
     import asyncio
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock(side_effect=asyncio.QueueFull())
 
     bot = AsyncMock()
     bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
@@ -103,7 +105,8 @@ async def test_telegram_msg_manager_injection_backpressure_ack() -> None:
     adapter = TelegramAdapter(
         bot_id="main",
         token="test-token-secret",
-        hub=hub,
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
         msg_manager=mm,
         auth=_ALLOW_ALL,
     )
@@ -136,10 +139,14 @@ async def test_on_message_drops_bot_text_message() -> None:
     """_on_message drops messages when from_user.is_bot=True."""
     from lyra.adapters.telegram import TelegramAdapter
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     bot_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -151,7 +158,7 @@ async def test_on_message_drops_bot_text_message() -> None:
         entities=None,
     )
     await adapter._on_message(bot_msg)
-    hub.inbound_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -167,9 +174,8 @@ async def test_on_message_drops_and_notifies_when_hub_circuit_open() -> None:
     # Arrange
     registry = _make_open_registry("hub")
 
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_bus.put = AsyncMock()
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
 
     bot = AsyncMock()
     bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
@@ -178,7 +184,8 @@ async def test_on_message_drops_and_notifies_when_hub_circuit_open() -> None:
     adapter = TelegramAdapter(
         bot_id="main",
         token="test-token-secret",
-        hub=hub,
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=MagicMock(),
         circuit_registry=registry,
         auth=_ALLOW_ALL,
     )
@@ -198,7 +205,7 @@ async def test_on_message_drops_and_notifies_when_hub_circuit_open() -> None:
     await adapter._on_message(aiogram_msg)
 
     # Assert — inbound_bus.put must NOT be called (message dropped)
-    hub.inbound_bus.put.assert_not_called()
+    inbound_bus.put.assert_not_called()
     # Assert — user receives a circuit-open notification
     bot.send_message.assert_called_once()
     call_kwargs = bot.send_message.call_args

--- a/tests/adapters/test_telegram_outbound_send.py
+++ b/tests/adapters/test_telegram_outbound_send.py
@@ -32,11 +32,14 @@ async def test_send_calls_bot_send_message() -> None:
     """
     from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     bot = AsyncMock()
 
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter.bot = bot
 
@@ -84,11 +87,14 @@ async def test_send_skips_when_platform_context_is_not_telegram(
     bot.send_message."""
     from lyra.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
-    hub = MagicMock()
     bot = AsyncMock()
 
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter.bot = bot
 
@@ -131,13 +137,16 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
     from lyra.adapters.telegram import TelegramAdapter
 
     # Arrange
-    hub = MagicMock()
     bot = AsyncMock()
     sent_msg = SimpleNamespace(message_id=888)
     bot.send_message.return_value = sent_msg
 
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter.bot = bot
 
@@ -196,14 +205,14 @@ async def test_send_always_delivers_regardless_of_circuit_state() -> None:
             cb.record_failure()  # trips to OPEN
         registry.register(cb)
 
-    hub = MagicMock()
     bot = AsyncMock()
     bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
     adapter = TelegramAdapter(
         bot_id="main",
         token="test-token-secret",
-        hub=hub,
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
         circuit_registry=registry,
     )
     adapter.bot = bot

--- a/tests/adapters/test_telegram_typing.py
+++ b/tests/adapters/test_telegram_typing.py
@@ -126,14 +126,17 @@ async def test_send_cancels_typing_task() -> None:
     from lyra.core.message import InboundMessage, OutboundMessage
 
     # Arrange
-    hub = MagicMock()
     bot = AsyncMock()
     sent_mock = MagicMock()
     sent_mock.message_id = 1
     bot.send_message = AsyncMock(return_value=sent_mock)
 
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter.bot = bot
 
@@ -189,14 +192,17 @@ async def test_send_streaming_cancels_typing_task_after_placeholder() -> None:
     from lyra.core.message import InboundMessage
 
     # Arrange
-    hub = MagicMock()
     bot = AsyncMock()
     placeholder_mock = MagicMock()
     placeholder_mock.message_id = 10
     bot.send_message = AsyncMock(return_value=placeholder_mock)
 
     adapter = TelegramAdapter(
-        bot_id="main", token="test-token-secret", hub=hub, auth=_ALLOW_ALL
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=MagicMock(),
+        inbound_audio_bus=MagicMock(),
+        auth=_ALLOW_ALL,
     )
     adapter.bot = bot
 

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -42,16 +42,25 @@ def _make_voice_msg(  # noqa: PLR0913 — test factory with optional overrides
 
 
 def _make_adapter() -> tuple[TelegramAdapter, MagicMock]:
-    hub = MagicMock()
-    hub.inbound_bus = MagicMock()
-    hub.inbound_audio_bus = MagicMock()
-    hub.inbound_audio_bus.put = AsyncMock()
-    adapter = TelegramAdapter(bot_id="main", token="tok", hub=hub, auth=_ALLOW_ALL)
+    inbound_bus = MagicMock()
+    inbound_bus.put = AsyncMock()
+    inbound_audio_bus = MagicMock()
+    inbound_audio_bus.put = AsyncMock()
+    buses = MagicMock()
+    buses.inbound_bus = inbound_bus
+    buses.inbound_audio_bus = inbound_audio_bus
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="tok",
+        inbound_bus=inbound_bus,
+        inbound_audio_bus=inbound_audio_bus,
+        auth=_ALLOW_ALL,
+    )
     bot_mock = AsyncMock()
     bot_mock.send_chat_action = AsyncMock()
     bot_mock.send_message = AsyncMock()
     adapter.bot = bot_mock
-    return adapter, hub
+    return adapter, buses
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +71,7 @@ def _make_adapter() -> tuple[TelegramAdapter, MagicMock]:
 @pytest.mark.asyncio
 async def test_voice_message_enqueues_on_audio_bus(tmp_path: Path) -> None:
     """Voice message → downloads audio and enqueues on inbound_audio_bus."""
-    adapter, hub = _make_adapter()
+    adapter, buses = _make_adapter()
 
     # Create a temp file to simulate download
     audio_file = tmp_path / "voice.ogg"
@@ -76,8 +85,8 @@ async def test_voice_message_enqueues_on_audio_bus(tmp_path: Path) -> None:
         await adapter._on_voice_message(_make_voice_msg())
 
     # Enqueued on audio bus (not text bus)
-    hub.inbound_audio_bus.put.assert_called_once()
-    hub.inbound_bus.put.assert_not_called()
+    buses.inbound_audio_bus.put.assert_called_once()
+    buses.inbound_bus.put.assert_not_called()
     # No unsupported reply sent
     adapter.bot.send_message.assert_not_called()
 
@@ -90,14 +99,14 @@ async def test_voice_message_enqueues_on_audio_bus(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_voice_from_bot_is_ignored() -> None:
     """Voice messages from other bots are silently dropped."""
-    adapter, hub = _make_adapter()
+    adapter, buses = _make_adapter()
     msg = _make_voice_msg()
     msg.from_user = SimpleNamespace(id=99, full_name="BotUser", is_bot=True)
 
     await adapter._on_voice_message(msg)
 
-    hub.inbound_bus.put.assert_not_called()
-    hub.inbound_audio_bus.put.assert_not_called()
+    buses.inbound_bus.put.assert_not_called()
+    buses.inbound_audio_bus.put.assert_not_called()
     adapter.bot.send_message.assert_not_called()
 
 
@@ -109,34 +118,34 @@ async def test_voice_from_bot_is_ignored() -> None:
 @pytest.mark.asyncio
 async def test_voice_message_no_voice_object_returns_early() -> None:
     """Message with voice=None, audio=None, video_note=None → early return."""
-    adapter, hub = _make_adapter()
+    adapter, buses = _make_adapter()
     msg = _make_voice_msg()
     msg.voice = None
     msg.audio = None
 
     await adapter._on_voice_message(msg)
 
-    hub.inbound_audio_bus.put.assert_not_called()
+    buses.inbound_audio_bus.put.assert_not_called()
     adapter.bot.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_voice_message_no_file_id_returns_early() -> None:
     """Voice object with file_id=None → early return."""
-    adapter, hub = _make_adapter()
+    adapter, buses = _make_adapter()
     msg = _make_voice_msg()
     msg.voice = SimpleNamespace(file_id=None, duration=3)
 
     await adapter._on_voice_message(msg)
 
-    hub.inbound_audio_bus.put.assert_not_called()
+    buses.inbound_audio_bus.put.assert_not_called()
     adapter.bot.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_voice_message_too_large_sends_reply() -> None:
     """_download_audio raises ValueError → user gets 'too large' reply."""
-    adapter, hub = _make_adapter()
+    adapter, buses = _make_adapter()
 
     with patch(
         "lyra.adapters.telegram_inbound._download_audio",
@@ -145,7 +154,7 @@ async def test_voice_message_too_large_sends_reply() -> None:
     ):
         await adapter._on_voice_message(_make_voice_msg())
 
-    hub.inbound_audio_bus.put.assert_not_called()
+    buses.inbound_audio_bus.put.assert_not_called()
     adapter.bot.send_message.assert_called_once()
 
 
@@ -184,7 +193,7 @@ async def test_voice_too_large_no_reply_when_no_message_id() -> None:
 @pytest.mark.asyncio
 async def test_voice_message_download_error_returns_silently() -> None:
     """_download_audio raises generic exception → log + return, no enqueue."""
-    adapter, hub = _make_adapter()
+    adapter, buses = _make_adapter()
 
     with patch(
         "lyra.adapters.telegram_inbound._download_audio",
@@ -193,7 +202,7 @@ async def test_voice_message_download_error_returns_silently() -> None:
     ):
         await adapter._on_voice_message(_make_voice_msg())
 
-    hub.inbound_audio_bus.put.assert_not_called()
+    buses.inbound_audio_bus.put.assert_not_called()
     adapter.bot.send_message.assert_not_called()
 
 

--- a/tests/bootstrap/test_adapter_standalone.py
+++ b/tests/bootstrap/test_adapter_standalone.py
@@ -1,0 +1,154 @@
+"""Tests for _bootstrap_adapter_standalone — NATS-mode adapter process bootstrap."""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_raw_config(platform: str) -> dict:
+    if platform == "telegram":
+        return {"telegram": {"bots": [{"bot_id": "main"}]}}
+    return {"discord": {"bots": [
+        {"bot_id": "main", "auto_thread": False, "thread_hot_hours": 4}
+    ]}}
+
+
+@pytest.mark.asyncio
+async def test_telegram_bootstrap_wires_listener_and_calls_astart() -> None:
+    """Telegram standalone bootstrap: NatsOutboundListener wired, astart() called."""
+    from lyra.bootstrap.adapter_standalone import _bootstrap_adapter_standalone
+
+    stop = asyncio.Event()
+    stop.set()  # return immediately
+
+    mock_nc = AsyncMock()
+    mock_nc.subscribe = AsyncMock(return_value=AsyncMock())
+
+    mock_adapter = AsyncMock()
+    mock_adapter.resolve_identity = AsyncMock()
+    mock_adapter.astart = AsyncMock()
+    mock_adapter.close = AsyncMock()
+    mock_adapter.app = MagicMock()
+
+    mock_listener = AsyncMock()
+    mock_listener.start = AsyncMock()
+
+    mock_inbound_bus = AsyncMock()
+    mock_inbound_bus.register = MagicMock()
+    mock_inbound_bus.start = AsyncMock()
+    mock_inbound_bus.stop = AsyncMock()
+
+    mock_server = AsyncMock()
+    mock_server.serve = AsyncMock(return_value=None)
+
+    with (
+        patch("nats.connect", AsyncMock(return_value=mock_nc)),
+        patch(
+            "lyra.nats.nats_bus.NatsBus",
+            return_value=mock_inbound_bus,
+        ),
+        patch(
+            "lyra.adapters.telegram.TelegramAdapter",
+            return_value=mock_adapter,
+        ),
+        patch(
+            "lyra.bootstrap.adapter_standalone.NatsOutboundListener",
+            return_value=mock_listener,
+        ),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("uvicorn.Server", return_value=mock_server),
+        patch.dict(os.environ, {"NATS_URL": "nats://localhost:4222",
+                                "TELEGRAM_TOKEN": "t"}),
+    ):
+        await _bootstrap_adapter_standalone(
+            _make_raw_config("telegram"), "telegram", _stop=stop
+        )
+
+    # Listener was wired and started via astart()
+    mock_adapter.astart.assert_awaited_once()
+    mock_nc.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_bootstrap_wires_listener_and_calls_astart() -> None:
+    """Discord standalone bootstrap: NatsOutboundListener wired, astart() called."""
+    from lyra.bootstrap.adapter_standalone import _bootstrap_adapter_standalone
+
+    stop = asyncio.Event()
+    stop.set()
+
+    mock_nc = AsyncMock()
+
+    mock_adapter_dc = AsyncMock()
+    mock_adapter_dc.astart = AsyncMock()
+    mock_adapter_dc.close = AsyncMock()
+    mock_adapter_dc.start = AsyncMock(return_value=None)
+
+    mock_listener_dc = AsyncMock()
+
+    mock_inbound_bus_dc = AsyncMock()
+    mock_inbound_bus_dc.register = MagicMock()
+    mock_inbound_bus_dc.start = AsyncMock()
+    mock_inbound_bus_dc.stop = AsyncMock()
+
+    with (
+        patch("nats.connect", AsyncMock(return_value=mock_nc)),
+        patch(
+            "lyra.nats.nats_bus.NatsBus",
+            return_value=mock_inbound_bus_dc,
+        ),
+        patch(
+            "lyra.adapters.discord.DiscordAdapter",
+            return_value=mock_adapter_dc,
+        ),
+        patch(
+            "lyra.bootstrap.adapter_standalone.NatsOutboundListener",
+            return_value=mock_listener_dc,
+        ),
+        patch.dict(os.environ, {"NATS_URL": "nats://localhost:4222",
+                                "DISCORD_TOKEN": "d"}),
+    ):
+        await _bootstrap_adapter_standalone(
+            _make_raw_config("discord"), "discord", _stop=stop
+        )
+
+    mock_adapter_dc.astart.assert_awaited_once()
+    mock_nc.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_nats_url_missing_exits() -> None:
+    """Missing NATS_URL env var → sys.exit before any NATS connection."""
+    from lyra.bootstrap.adapter_standalone import _bootstrap_adapter_standalone
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        await _bootstrap_adapter_standalone({}, "telegram")
+
+
+@pytest.mark.asyncio
+async def test_nc_close_called_even_on_exception() -> None:
+    """nc.close() is called in finally block even when bootstrap raises."""
+    from lyra.bootstrap.adapter_standalone import _bootstrap_adapter_standalone
+
+    mock_nc = AsyncMock()
+
+    with (
+        patch("nats.connect", AsyncMock(return_value=mock_nc)),
+        patch(
+            "lyra.nats.nats_bus.NatsBus",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch.dict(os.environ, {"NATS_URL": "nats://localhost:4222"}),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await _bootstrap_adapter_standalone(
+            _make_raw_config("telegram"), "telegram"
+        )
+
+    mock_nc.close.assert_awaited_once()

--- a/tests/bootstrap/test_multibot_wiring.py
+++ b/tests/bootstrap/test_multibot_wiring.py
@@ -71,6 +71,41 @@ async def test_wire_telegram_adapters_registers_authenticator() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wire_telegram_no_nats_listener_in_dev_mode() -> None:
+    """wire_telegram_adapters() does NOT create NatsOutboundListener (dev mode only)."""
+    from lyra.bootstrap.multibot_wiring import wire_telegram_adapters
+    from lyra.core.circuit_breaker import CircuitRegistry
+
+    hub = Hub()
+    bot_cfg = TelegramBotConfig(bot_id="main")
+    auth = Authenticator(store=None, role_map={}, default=TrustLevel.PUBLIC)
+
+    cred_store = MagicMock()
+    cred_store.get_full = AsyncMock(return_value=("fake-token", "fake-secret"))
+
+    mock_adapter_instance = MagicMock()
+    mock_adapter_instance.resolve_identity = AsyncMock()
+    mock_adapter_instance._outbound_listener = None
+
+    with patch(
+        "lyra.bootstrap.multibot_wiring.TelegramAdapter",
+        return_value=mock_adapter_instance,
+    ):
+        adapters, _ = await wire_telegram_adapters(
+            hub=hub,
+            tg_bot_auths=[(bot_cfg, auth)],
+            bot_agent_map={("telegram", "main"): "lyra_default"},
+            cred_store=cred_store,
+            circuit_registry=CircuitRegistry(),
+            msg_manager=MagicMock(),
+        )
+
+    assert len(adapters) == 1
+    # In dev/embedded mode, no NATS listener is attached
+    assert mock_adapter_instance._outbound_listener is None
+
+
+@pytest.mark.asyncio
 async def test_wire_telegram_adapters_skips_missing_agent_mapping() -> None:
     """wire_telegram_adapters() skips bots not in bot_agent_map without raising."""
     from lyra.bootstrap.multibot_wiring import wire_telegram_adapters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,8 +88,8 @@ class _FakeTgAdapter:
 
 
 class _FakeDcAdapter:
-    def __init__(self, hub: Hub, **kwargs: object) -> None:
-        self._hub = hub
+    def __init__(self, **kwargs: object) -> None:
+        pass
 
     async def start(self, token: str) -> None:
         await asyncio.sleep(1_000)
@@ -191,7 +191,7 @@ def patch_bootstrap_common(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     monkeypatch.setattr(
         wiring_mod,
         "DiscordAdapter",
-        lambda **kwargs: _FakeDcAdapter(hub=MagicMock()),
+        lambda **kwargs: _FakeDcAdapter(),
     )
 
     mock_tg_auth = MagicMock()
@@ -220,10 +220,18 @@ def patch_all(
     """
     captured: list[Hub] = []
 
+    _OriginalHub = Hub
+
+    class CapturingHub(_OriginalHub):  # type: ignore[misc]
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
+            captured.append(self)
+
+    monkeypatch.setattr(multibot_mod, "Hub", CapturingHub)
+
     class CapturingDcAdapter(_FakeDcAdapter):
-        def __init__(self, hub: Hub, **kwargs: object) -> None:
-            captured.append(hub)
-            super().__init__(hub, **kwargs)
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
 
     mock_tg_auth, mock_dc_auth = MagicMock(), MagicMock()
     _auth_results = iter([mock_tg_auth, mock_dc_auth])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import asyncio
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -223,7 +224,7 @@ def patch_all(
     _OriginalHub = Hub
 
     class CapturingHub(_OriginalHub):  # type: ignore[misc]
-        def __init__(self, **kwargs: object) -> None:
+        def __init__(self, **kwargs: Any) -> None:
             super().__init__(**kwargs)
             captured.append(self)
 

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -34,11 +34,11 @@ class TestTelegramNormalizeRouting:
     def test_routing_populated(self) -> None:
         from lyra.adapters.telegram import _ALLOW_ALL, TelegramAdapter
 
-        hub = MagicMock()
         adapter = TelegramAdapter(
             bot_id="main",
             token="fake",
-            hub=hub,
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
             auth=_ALLOW_ALL,
         )
 
@@ -69,11 +69,11 @@ class TestTelegramNormalizeRouting:
     def test_routing_with_topic(self) -> None:
         from lyra.adapters.telegram import _ALLOW_ALL, TelegramAdapter
 
-        hub = MagicMock()
         adapter = TelegramAdapter(
             bot_id="main",
             token="fake",
-            hub=hub,
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
             auth=_ALLOW_ALL,
         )
 
@@ -102,8 +102,7 @@ class TestTelegramNormalizeRouting:
         """RoutingContext.platform_meta must not alias InboundMessage.platform_meta."""
         from lyra.adapters.telegram import _ALLOW_ALL, TelegramAdapter
 
-        hub = MagicMock()
-        adapter = TelegramAdapter(bot_id="main", token="fake", hub=hub, auth=_ALLOW_ALL)
+        adapter = TelegramAdapter(bot_id="main", token="fake", inbound_bus=MagicMock(), inbound_audio_bus=MagicMock(), auth=_ALLOW_ALL)
 
         raw = SimpleNamespace(
             from_user=SimpleNamespace(id=42, full_name="Alice"),

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -102,7 +102,13 @@ class TestTelegramNormalizeRouting:
         """RoutingContext.platform_meta must not alias InboundMessage.platform_meta."""
         from lyra.adapters.telegram import _ALLOW_ALL, TelegramAdapter
 
-        adapter = TelegramAdapter(bot_id="main", token="fake", inbound_bus=MagicMock(), inbound_audio_bus=MagicMock(), auth=_ALLOW_ALL)
+        adapter = TelegramAdapter(
+            bot_id="main",
+            token="fake",
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
+            auth=_ALLOW_ALL,
+        )
 
         raw = SimpleNamespace(
             from_user=SimpleNamespace(id=42, full_name="Alice"),

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -141,9 +141,7 @@ class TestDiscordNormalizeRouting:
     def test_routing_populated(self) -> None:
         from lyra.adapters.discord import _ALLOW_ALL, DiscordAdapter
 
-        hub = MagicMock()
         adapter = DiscordAdapter.__new__(DiscordAdapter)
-        adapter._hub = hub
         adapter._bot_id = "main"
         adapter._bot_user = None
         adapter._mention_re = None

--- a/tests/nats/test_nats_channel_proxy.py
+++ b/tests/nats/test_nats_channel_proxy.py
@@ -116,7 +116,7 @@ async def test_send_publishes_to_correct_subject() -> None:
 
 @pytest.mark.asyncio
 async def test_send_envelope_structure() -> None:
-    """send() envelope has type, msg_id, and outbound fields."""
+    """send() envelope has type=send, stream_id, and outbound fields."""
     nc = _make_nc()
     proxy = NatsChannelProxy(nc=nc, platform=Platform.DISCORD, bot_id="bot2")
     inbound = _make_inbound("msg-xyz")
@@ -127,8 +127,9 @@ async def test_send_envelope_structure() -> None:
     _subject, payload = nc.publish.call_args.args
     envelope = json.loads(payload.decode("utf-8"))
 
-    assert envelope["type"] == "outbound"
-    assert envelope["msg_id"] == "msg-xyz"
+    assert envelope["type"] == "send"
+    assert envelope["stream_id"] == "msg-xyz"
+    assert "msg_id" not in envelope
     assert "outbound" in envelope
     assert isinstance(envelope["outbound"], dict)
     # Verify outbound content was serialized
@@ -175,8 +176,8 @@ async def test_send_streaming_publishes_chunks_with_incrementing_seq() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_streaming_subject_includes_msg_id() -> None:
-    """send_streaming() publishes to stream subject with msg_id suffix."""
+async def test_send_streaming_subject_is_single_outbound_subject() -> None:
+    """send_streaming() publishes to single outbound subject, not stream.* subject."""
     nc = _make_nc()
     proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
     inbound = _make_inbound("msg-42")
@@ -186,7 +187,8 @@ async def test_send_streaming_subject_includes_msg_id() -> None:
     )
 
     subject, _ = nc.publish.call_args.args
-    assert subject == "lyra.outbound.stream.telegram.main.msg-42"
+    assert subject == "lyra.outbound.telegram.main"
+    assert "stream" not in subject
 
 
 @pytest.mark.asyncio
@@ -256,8 +258,8 @@ async def test_send_streaming_event_type_tool_summary() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_streaming_chunk_has_msg_id_and_type() -> None:
-    """Each chunk envelope has type='stream_chunk' and the inbound msg_id."""
+async def test_send_streaming_chunk_has_stream_id_no_type() -> None:
+    """Each chunk envelope has stream_id (not msg_id) and no 'type' key."""
     nc = _make_nc()
     proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
     inbound = _make_inbound("msg-check")
@@ -268,8 +270,9 @@ async def test_send_streaming_chunk_has_msg_id_and_type() -> None:
 
     _, payload = nc.publish.call_args.args
     chunk = json.loads(payload.decode("utf-8"))
-    assert chunk["type"] == "stream_chunk"
-    assert chunk["msg_id"] == "msg-check"
+    assert "type" not in chunk
+    assert chunk["stream_id"] == "msg-check"
+    assert "msg_id" not in chunk
     assert "payload" in chunk
 
 
@@ -324,7 +327,8 @@ async def test_render_attachment_publishes_to_outbound_subject() -> None:
 
     envelope = json.loads(payload.decode("utf-8"))
     assert envelope["type"] == "attachment"
-    assert envelope["msg_id"] == "msg-att"
+    assert envelope["stream_id"] == "msg-att"
+    assert "msg_id" not in envelope
     assert "attachment" in envelope
     assert isinstance(envelope["attachment"], dict)
     assert envelope["attachment"]["type"] == "image"
@@ -418,3 +422,47 @@ async def test_render_voice_stream_drains_and_logs(
     nc.publish.assert_not_awaited()
     assert consumed == [0, 1]
     assert any("audio-over-NATS" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# New API tests: stream_id / type=send / single subject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_includes_stream_id() -> None:
+    """send() envelope uses stream_id (not msg_id) and type=send."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-stream-id-check")
+    outbound = OutboundMessage.from_text("hi")
+
+    await proxy.send(inbound, outbound)
+
+    call_args = nc.publish.call_args
+    subject = call_args.args[0]
+    envelope = json.loads(call_args.args[1])
+    assert envelope["stream_id"] == inbound.id
+    assert envelope["type"] == "send"
+    assert "msg_id" not in envelope
+
+
+@pytest.mark.asyncio
+async def test_send_streaming_uses_single_subject() -> None:
+    """send_streaming() publishes to single outbound subject, not stream.* subject."""
+    nc = _make_nc()
+    proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
+    inbound = _make_inbound("msg-single-subject")
+
+    await proxy.send_streaming(
+        inbound, _async_iter(TextRenderEvent(text="hi", is_final=True))
+    )
+
+    assert nc.publish.await_count >= 1
+    subject = nc.publish.call_args_list[0].args[0]
+    assert "stream" not in subject
+    assert subject == f"lyra.outbound.{proxy._platform.value}.{proxy._bot_id}"
+    envelope = json.loads(nc.publish.call_args_list[0].args[1])
+    assert "stream_id" in envelope
+    assert "seq" in envelope
+    assert "type" not in envelope  # chunks don't have type key

--- a/tests/nats/test_nats_channel_proxy.py
+++ b/tests/nats/test_nats_channel_proxy.py
@@ -440,7 +440,6 @@ async def test_send_includes_stream_id() -> None:
     await proxy.send(inbound, outbound)
 
     call_args = nc.publish.call_args
-    subject = call_args.args[0]
     envelope = json.loads(call_args.args[1])
     assert envelope["stream_id"] == inbound.id
     assert envelope["type"] == "send"

--- a/tests/nats/test_nats_channel_proxy.py
+++ b/tests/nats/test_nats_channel_proxy.py
@@ -165,7 +165,8 @@ async def test_send_streaming_publishes_chunks_with_incrementing_seq() -> None:
 
     await proxy.send_streaming(inbound, _async_iter(tool_event, text_event))
 
-    assert nc.publish.await_count == 2
+    # 2 event chunks + 1 terminal sentinel = 3 publishes
+    assert nc.publish.await_count == 3
     calls = nc.publish.call_args_list
 
     chunk0 = json.loads(calls[0].args[1].decode("utf-8"))
@@ -218,7 +219,8 @@ async def test_send_streaming_done_false_on_non_final_event() -> None:
         inbound, _async_iter(TextRenderEvent(text="Partial", is_final=False))
     )
 
-    _, payload = nc.publish.call_args.args
+    # call_args_list[0] is the event chunk; last call is the terminal sentinel
+    _, payload = nc.publish.call_args_list[0].args
     chunk = json.loads(payload.decode("utf-8"))
     assert chunk["done"] is False
 
@@ -234,7 +236,7 @@ async def test_send_streaming_event_type_text() -> None:
         inbound, _async_iter(TextRenderEvent(text="Hello", is_final=True))
     )
 
-    _, payload = nc.publish.call_args.args
+    _, payload = nc.publish.call_args_list[0].args
     chunk = json.loads(payload.decode("utf-8"))
     assert chunk["event_type"] == "text"
 
@@ -251,7 +253,7 @@ async def test_send_streaming_event_type_tool_summary() -> None:
         _async_iter(ToolSummaryRenderEvent(bash_commands=["ls"], is_complete=True)),
     )
 
-    _, payload = nc.publish.call_args.args
+    _, payload = nc.publish.call_args_list[0].args
     chunk = json.loads(payload.decode("utf-8"))
     assert chunk["event_type"] == "tool_summary"
     assert chunk["done"] is True

--- a/tests/test_bootstrap_credential_resolution.py
+++ b/tests/test_bootstrap_credential_resolution.py
@@ -127,12 +127,12 @@ class TestCredentialResolution:
         monkeypatch.setattr(
             main_mod,
             "DiscordAdapter",
-            lambda hub, **kwargs: CapturingDcAdapter(hub=hub),
+            lambda **kwargs: CapturingDcAdapter(),
         )
         monkeypatch.setattr(
             wiring_mod,
             "DiscordAdapter",
-            lambda hub, **kwargs: CapturingDcAdapter(hub=hub),
+            lambda **kwargs: CapturingDcAdapter(),
         )
         monkeypatch.setattr(
             main_mod,

--- a/tests/tts/test_voice_command.py
+++ b/tests/tts/test_voice_command.py
@@ -286,11 +286,11 @@ class TestTelegramAdapterRenderAudio:
     def _make_adapter(self) -> TelegramAdapter:
         from lyra.adapters.telegram import _ALLOW_ALL
 
-        hub = MagicMock()
         adapter = TelegramAdapter(
             bot_id="main",
             token="test-token",
-            hub=hub,
+            inbound_bus=MagicMock(),
+            inbound_audio_bus=MagicMock(),
             auth=_ALLOW_ALL,
         )
         adapter.bot = AsyncMock()


### PR DESCRIPTION
## Summary
- Decouple `TelegramAdapter` and `DiscordAdapter` from `Hub` — replace `hub: Hub` constructor param with `inbound_bus: Bus[InboundMessage]` + `inbound_audio_bus: Bus[InboundAudio]`, making adapters pure I/O translators
- Add `NatsOutboundListener` — subscribes to `lyra.outbound.{platform}.{bot_id}` and dispatches send/attachment/streaming envelopes back to the adapter
- Add `adapter_standalone.py` bootstrap entry-point for standalone per-platform adapter processes
- Align NATS envelope format: `stream_id` (was `msg_id`), single subject for streaming (was per-message subject), typed chunk envelope with `seq`/`done`/`event_type`
- Inject `_resolve_identity_fn` on `DiscordAdapter` from wiring layer for slash-command trust without Hub coupling

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #458: feat(adapters): rewire Telegram + Discord adapters as thin NATS clients | Open |
| Analysis | Skipped (F-lite) | — |
| Spec | [458-adapters-nats-rewire-spec.mdx](artifacts/specs/458-adapters-nats-rewire-spec.mdx) | Present |
| Plan | [458-adapters-nats-rewire-plan.mdx](artifacts/plans/458-adapters-nats-rewire-plan.mdx) | Present |
| Implementation | 1 commit on `feat/458-adapters-nats-rewire` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (27 test files touched, 2333 passed) | Passed |

## Test Plan
- [ ] `uv run pytest` — all 2333 tests pass, 42 skipped
- [ ] `TelegramAdapter` / `DiscordAdapter` constructors accept `inbound_bus` + `inbound_audio_bus`, reject `hub=`
- [ ] `NatsOutboundListener`: send, attachment, streaming dispatch to adapter methods
- [ ] NATS channel proxy: envelope format uses `stream_id`, single outbound subject for streaming
- [ ] Bootstrap wiring: adapters created with bus params; identity fn injected on Discord adapter
- [ ] `patch_all` / `patch_bootstrap_common` helpers updated — no regressions in bootstrap tests

Closes #458

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`