### PR TITLE
refactor(deploy): move provision and setup scripts to lyra/deploy/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ See `docs/ARCHITECTURE.md` for full context.
 | `docs/ROADMAP.md` | Roadmap and priorities |
 | `docs/GETTING-STARTED.md` | Machine 1 setup guide |
 | `artifacts/` | Frames, specs, plans, analyses, explorations (dev-core) |
-| `~/projects/lyra-stack/scripts/provision.sh` | Machine 1 post-install provisioning script (sibling repo) |
+| `deploy/provision.sh` | Machine 1 post-install provisioning script |
 
 ## Local infrastructure
 
@@ -105,7 +105,7 @@ _Fact-checked 2026-03-17 against `src/lyra/`, `docs/`, and git history._
 |---|-------|--------|
 | 1 | Key docs exist (`ARCHITECTURE.md`, `CONFIGURATION.md`, `ROADMAP.md`, `GETTING-STARTED.md`) | ✅ Confirmed |
 | 2 | `artifacts/` (analyses, explorations, frames, plans, specs) | ✅ Confirmed |
-| 3 | `lyra-stack/scripts/provision.sh` (relative path) | ❌ Fixed → `~/projects/lyra-stack/scripts/provision.sh` — `lyra-stack` is a sibling repo, not inside this project |
+| 3 | `provision.sh` location | ✅ Fixed → `deploy/provision.sh` — now lives in the lyra repo |
 | 4 | "TOML files in `src/lyra/agents/`" as the only location | ❌ Fixed → Two locations: `~/.lyra/agents/` (user-level, higher precedence) and `src/lyra/agents/` (system defaults) |
 | 5 | `workspaces` "each key becomes a `/<key>` slash command" | ❌ Fixed → command is `/workspace <key>`, not `/<key>` (verified in `workspace_commands.py`) |
 | 6 | `~/.lyra/auth.db` as agent store | ✅ Confirmed (`cli_agent.py:31`) |

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Lyra by Roxabi — Machine 1 post-install provisioning script
+# Usage: curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra/staging/deploy/provision.sh | bash
+#        curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra/staging/deploy/provision.sh | ADMIN_USER=yourname bash
+#        curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra/staging/deploy/provision.sh | ADMIN_USER=yourname AGENT_USER=myagent bash
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+source "$HOME/.local/bin/env" 2>/dev/null || true  # uv
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}[+]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
+error()   { echo -e "${RED}[x]${NC} $1"; exit 1; }
+section() { echo -e "\n${GREEN}=== $1 ===${NC}"; }
+
+# Admin user (defaults to current user, override with ADMIN_USER=yourname)
+ADMIN_USER="${ADMIN_USER:-$(whoami)}"
+# Agent user (defaults to lyra, override with AGENT_USER=anotherame)
+AGENT_USER="${AGENT_USER:-lyra}"
+info "Running setup for admin: $ADMIN_USER, agent: $AGENT_USER"
+
+# ── System packages ──────────────────────────────────────────────────────────
+
+section "System update"
+sudo apt update && sudo apt upgrade -y
+
+section "Base packages"
+sudo apt install -y \
+  curl wget git htop nvtop \
+  fail2ban ufw \
+  build-essential python3-dev portaudio19-dev \
+  ffmpeg wtype wl-clipboard \
+  libgirepository-2.0-dev libcairo2-dev
+
+section "moviepy (dedicated venv)"
+MOVIEPY_VENV="$HOME/.venvs/moviepy"
+if [ -x "$MOVIEPY_VENV/bin/python" ]; then
+  info "moviepy venv already exists."
+else
+  python3 -m venv "$MOVIEPY_VENV"
+  "$MOVIEPY_VENV/bin/pip" install moviepy
+  info "moviepy installed in $MOVIEPY_VENV (use $MOVIEPY_VENV/bin/python to run scripts)."
+fi
+
+section "NVIDIA drivers"
+if nvidia-smi &>/dev/null; then
+  warn "NVIDIA drivers already installed, skipping."
+else
+  sudo apt install -y nvidia-driver-550
+  warn "Reboot required after script finishes to activate NVIDIA drivers."
+  NEEDS_REBOOT=true
+fi
+
+# ── Security ─────────────────────────────────────────────────────────────────
+
+section "SSH hardening"
+SSHD_CONF="/etc/ssh/sshd_config.d/lyra.conf"
+if [ -f "$SSHD_CONF" ]; then
+  info "SSH hardening already configured."
+else
+  sudo tee "$SSHD_CONF" > /dev/null << 'EOF'
+PermitRootLogin no
+PasswordAuthentication no
+PubkeyAuthentication yes
+EOF
+  sudo systemctl restart ssh
+  info "SSH: password auth disabled, key-only."
+fi
+
+section "Firewall (ufw)"
+if sudo ufw status | grep -q "Status: active"; then
+  info "UFW already active."
+else
+  sudo ufw default deny incoming
+  sudo ufw default allow outgoing
+  sudo ufw allow ssh
+  sudo ufw --force enable
+  info "UFW enabled: only SSH allowed inbound."
+fi
+
+section "fail2ban"
+if systemctl is-active --quiet fail2ban; then
+  info "fail2ban already active."
+else
+  sudo systemctl enable fail2ban
+  sudo systemctl start fail2ban
+  info "fail2ban active."
+fi
+
+# ── Boot ─────────────────────────────────────────────────────────────────────
+
+section "GRUB — default Linux"
+GRUB_CHANGED=false
+if ! grep -q "GRUB_DISABLE_OS_PROBER=false" /etc/default/grub; then
+  echo 'GRUB_DISABLE_OS_PROBER=false' | sudo tee -a /etc/default/grub > /dev/null
+  GRUB_CHANGED=true
+fi
+if ! grep -q "^GRUB_DEFAULT=0" /etc/default/grub; then
+  sudo sed -i 's/^GRUB_DEFAULT=.*/GRUB_DEFAULT=0/' /etc/default/grub
+  GRUB_CHANGED=true
+fi
+if ! grep -q "^GRUB_TIMEOUT=5" /etc/default/grub; then
+  sudo sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub
+  GRUB_CHANGED=true
+fi
+if [ "$GRUB_CHANGED" = true ]; then
+  sudo update-grub
+  info "GRUB updated: Linux default, Windows detectable."
+else
+  info "GRUB already configured."
+fi
+
+# ── Users ────────────────────────────────────────────────────────────────────
+
+section "Agent account ($AGENT_USER)"
+if id "$AGENT_USER" &>/dev/null; then
+  warn "User '$AGENT_USER' already exists, skipping."
+else
+  sudo useradd -m -s /bin/bash -c "Lyra by Roxabi AI agent" "$AGENT_USER"
+  sudo passwd -l "$AGENT_USER"
+  sudo mkdir -p /home/"$AGENT_USER"/.ssh
+  sudo chmod 700 /home/"$AGENT_USER"/.ssh
+  sudo chown -R "$AGENT_USER":"$AGENT_USER" /home/"$AGENT_USER"/.ssh
+  sudo chmod 750 /home/"$ADMIN_USER"
+  info "User '$AGENT_USER' created (bash, no sudo, isolated home)."
+  warn "Add your agent SSH public key to /home/$AGENT_USER/.ssh/authorized_keys"
+fi
+
+# ── GitHub SSH ───────────────────────────────────────────────────────────────
+
+section "GitHub SSH host key"
+if ssh-keygen -F github.com &>/dev/null; then
+  info "GitHub host key already in known_hosts."
+else
+  ssh-keyscan github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null
+  info "GitHub host key added to known_hosts."
+fi
+
+# Verify GitHub SSH authentication
+if ssh -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+  info "GitHub SSH authentication OK."
+else
+  warn "GitHub SSH not authenticated. Add your SSH key at https://github.com/settings/keys"
+  warn "Your public key: $(cat "$HOME/.ssh/id_ed25519.pub" 2>/dev/null || echo 'no key found — run ssh-keygen first')"
+fi
+
+# ── Dev tools ────────────────────────────────────────────────────────────────
+
+section "uv (Python package manager)"
+if command -v uv &>/dev/null; then
+  info "uv already installed ($(uv --version))."
+else
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  info "uv installed ($(uv --version))."
+fi
+
+section "supervisord (process manager)"
+if command -v supervisord &>/dev/null; then
+  info "supervisord already installed."
+else
+  uv tool install supervisor
+  info "supervisord installed."
+fi
+
+section "systemd user unit (lyra-stack auto-start)"
+UNIT_DIR="$HOME/.config/systemd/user"
+UNIT_FILE="$UNIT_DIR/lyra-stack.service"
+mkdir -p "$UNIT_DIR"
+if [ -f "$UNIT_FILE" ]; then
+  info "lyra-stack.service already exists."
+else
+  cat > "$UNIT_FILE" << 'UNIT'
+[Unit]
+Description=lyra-stack supervisord (TTS, STT, Lyra daemons)
+After=graphical-session.target
+
+[Service]
+Type=forking
+PIDFile=%h/projects/lyra-stack/supervisord.pid
+ExecStart=%h/projects/lyra-stack/scripts/start.sh
+ExecStop=%h/.local/bin/supervisorctl -c %h/projects/lyra-stack/supervisord.conf shutdown
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+UNIT
+  info "lyra-stack.service created."
+fi
+
+# Enable linger so user services start without login session
+loginctl enable-linger "$ADMIN_USER" 2>/dev/null || true
+info "Linger enabled for $ADMIN_USER (services auto-start on boot)."
+
+# Note: lyra-monitor.timer (health monitoring) is installed by `make register`
+# in the lyra repo, not by provision.sh. It requires secrets in .env first.
+# After setup: cd ~/projects/lyra && make register && make monitor enable
+
+section "Node.js"
+if command -v node &>/dev/null; then
+  info "Node.js already installed ($(node --version))."
+else
+  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+  sudo apt install -y nodejs
+  info "Node.js installed ($(node --version))."
+fi
+
+section "Claude Code CLI"
+if command -v claude &>/dev/null; then
+  info "Claude CLI already installed."
+else
+  npm install -g @anthropic-ai/claude-code
+  info "Claude CLI installed. Run 'claude' to authenticate."
+fi
+
+section "agent-browser (headless browser for Claude Code)"
+if command -v agent-browser &>/dev/null; then
+  info "agent-browser already installed."
+else
+  npm install -g agent-browser && agent-browser install
+  info "agent-browser installed."
+fi
+
+# ── External tools ───────────────────────────────────────────────────────────
+
+section "External tools (ADR-010: Install, Wrap, Declare)"
+
+if command -v imagecli &>/dev/null; then
+  info "imagecli already installed."
+else
+  out=$(uv tool install git+https://github.com/roxabi/imageCLI 2>&1) && info "imagecli installed." || warn "imagecli install failed: $out"
+fi
+
+# Google Workspace CLI — see issue #65.
+if command -v gws &>/dev/null; then
+  info "gws already installed."
+else
+  warn "gws not installed. See: https://github.com/googleworkspace/cli"
+fi
+
+# ── Git config ───────────────────────────────────────────────────────────────
+
+section "Git config"
+if git config --global user.name &>/dev/null; then
+  info "Git user.name: $(git config --global user.name)"
+else
+  read -rp "Git user.name: " GIT_NAME
+  git config --global user.name "$GIT_NAME"
+fi
+if git config --global user.email &>/dev/null; then
+  info "Git user.email: $(git config --global user.email)"
+else
+  read -rp "Git user.email: " GIT_EMAIL
+  git config --global user.email "$GIT_EMAIL"
+fi
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+
+section "Done"
+info "Provisioning complete — admin: $ADMIN_USER, agent: $AGENT_USER"
+
+if [ "${NEEDS_REBOOT:-false}" = true ]; then
+  warn "NVIDIA drivers installed — reboot now: sudo reboot"
+  warn "After reboot, continue with the next step."
+else
+  echo ""
+  info "Next steps:"
+  echo "  1. Clone lyra-stack (supervisord hub) and lyra, then run setup:"
+  echo ""
+  echo "     git clone git@github.com:Roxabi/lyra-stack.git ~/projects/lyra-stack"
+  echo "     git clone git@github.com:Roxabi/lyra.git ~/projects/lyra"
+  echo "     cd ~/projects/lyra && python deploy/setup.py"
+  echo ""
+  echo "  2. Enable auto-start on boot:"
+  echo ""
+  echo "     systemctl --user daemon-reload"
+  echo "     systemctl --user enable lyra-stack.service"
+  echo ""
+  echo "  3. Authenticate Claude CLI:"
+  echo ""
+  echo "     claude"
+  echo ""
+  echo "  Optional — multi-machine NATS setup:"
+  echo ""
+  echo "     cd ~/projects/lyra-stack && make nats-install"
+  echo ""
+fi

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -275,7 +275,7 @@ else
   echo ""
   echo "     git clone git@github.com:Roxabi/lyra-stack.git ~/projects/lyra-stack"
   echo "     git clone git@github.com:Roxabi/lyra.git ~/projects/lyra"
-  echo "     cd ~/projects/lyra && python deploy/setup.py"
+  echo "     cd ~/projects/lyra && python3 deploy/setup.py"
   echo ""
   echo "  2. Enable auto-start on boot:"
   echo ""

--- a/deploy/setup.py
+++ b/deploy/setup.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""lyra-stack setup — clone and register modules, scaffold config, start supervisord."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+LYRA_STACK_DIR = Path(
+    os.environ.get("LYRA_STACK_DIR", Path.home() / "projects" / "lyra-stack")
+)
+STACK_FILE = Path(os.environ.get("STACK_FILE", LYRA_STACK_DIR / "stack.toml"))
+
+
+def run(cmd: str, cwd: Path | None = None, check: bool = True) -> int:
+    sys.stdout.flush()
+    result = subprocess.run(cmd, shell=True, cwd=cwd)
+    if check and result.returncode != 0:
+        print(f"  ✗  Command failed: {cmd}")
+        sys.exit(result.returncode)
+    return result.returncode
+
+
+def ask(prompt: str, default: bool = True) -> bool:
+    hint = "Y/n" if default else "y/N"
+    try:
+        resp = input(f"{prompt} [{hint}] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        sys.exit(0)
+    if not resp:
+        return default
+    return resp in ("y", "yes")
+
+
+def check_prereqs() -> bool:
+    checks = {
+        "git": ("git --version", None),
+        "uv": (
+            "uv --version",
+            "https://docs.astral.sh/uv/getting-started/installation/",
+        ),
+        "supervisord": (
+            "supervisord --version",
+            "Run: uv tool install supervisor",
+        ),
+        "claude": (
+            "claude --version",
+            "Run: npm install -g @anthropic-ai/claude-code",
+        ),
+        "ssh": ("ssh -T git@github.com", None),  # exits 1 on success for GitHub
+    }
+    print("Checking prerequisites...")
+    failed = []
+    for name, (cmd, install_url) in checks.items():
+        result = subprocess.run(cmd, shell=True, capture_output=True)
+        ok = result.returncode in (0, 1) if name == "ssh" else result.returncode == 0
+        print(
+            f"  {'✓' if ok else '✗'}  {name}"
+            + (f"  →  {install_url}" if not ok and install_url else "")
+        )
+        if not ok:
+            failed.append(name)
+    if failed:
+        print("\nFix the above before running setup.")
+        print("Tip: run deploy/provision.sh to install all prerequisites.")
+        return False
+    return True
+
+
+# ── Config scaffolding ───────────────────────────────────────────────────────
+
+
+def scaffold_env(lyra_dir: Path) -> None:
+    """Copy .env.example → .env if missing."""
+    env_file = lyra_dir / ".env"
+    example = lyra_dir / ".env.example"
+    if env_file.exists():
+        print("  ✓  .env already exists")
+        return
+    if not example.exists():
+        print("  ✗  .env.example not found — skipping")
+        return
+    shutil.copy(example, env_file)
+    print("  ✓  .env created from .env.example")
+    print("       → Edit ~/projects/lyra/.env and fill in your tokens")
+
+
+def scaffold_config_toml(lyra_dir: Path) -> None:
+    """Copy config.toml.example → config.toml if missing."""
+    config_file = lyra_dir / "config.toml"
+    example = lyra_dir / "config.toml.example"
+    if config_file.exists():
+        print("  ✓  config.toml already exists")
+        return
+    if not example.exists():
+        print("  ✗  config.toml.example not found — skipping")
+        return
+    shutil.copy(example, config_file)
+    print("  ✓  config.toml created from config.toml.example")
+    print("       → Edit ~/projects/lyra/config.toml and fill in your user IDs")
+
+
+def setup_plugins(
+    lyra_dir: Path | None,
+    voicecli_dir: Path | None,
+    include_optional: bool,
+) -> None:
+    """Register Claude Code marketplaces and install plugins."""
+
+    result = subprocess.run("claude --version", shell=True, capture_output=True)
+    if result.returncode != 0:
+        print("  ✗  claude CLI not found — skipping plugin setup")
+        return
+
+    print()
+    print("Claude Code plugins")
+    print("─" * 40)
+    print()
+
+    # ── Register marketplaces ─────────────────────────────────────────────────
+
+    marketplace_out = subprocess.run(
+        "claude plugin marketplace list", shell=True, capture_output=True, text=True
+    ).stdout
+
+    # Local project marketplaces
+    for label, path in [("lyra-marketplace", lyra_dir), ("voicecli-marketplace", voicecli_dir)]:
+        if not path or not path.exists():
+            continue
+        if label in marketplace_out:
+            print(f"  ✓  {label}  (already registered)")
+        else:
+            r = subprocess.run(
+                f"claude plugin marketplace add {path}",
+                shell=True, capture_output=True, text=True,
+            )
+            if r.returncode == 0:
+                print(f"  ✓  {label} registered")
+            else:
+                print(f"  !  {label}: {r.stderr.strip() or r.stdout.strip()}")
+
+    # agent-browser external marketplace
+    if "agent-browser" not in marketplace_out:
+        r = subprocess.run(
+            "claude plugin marketplace add https://github.com/vercel-labs/agent-browser",
+            shell=True, capture_output=True, text=True,
+        )
+        if r.returncode == 0:
+            print("  ✓  agent-browser marketplace registered")
+        else:
+            print(f"  !  agent-browser marketplace: {r.stderr.strip() or r.stdout.strip()}")
+    else:
+        print("  ✓  agent-browser  (already registered)")
+
+    print()
+
+    # ── Mandatory plugins ─────────────────────────────────────────────────────
+
+    print("  Mandatory:")
+    mandatory = [
+        ("web-intel",      "roxabi-marketplace",  "URL scraping & analysis"),
+        ("agent-browser",  "agent-browser",       "headless browser (auth, interactive pages)"),
+        ("lyra-send",      "lyra-marketplace",    "proactive messaging (Telegram & Discord)"),
+        ("refine-agent",   "lyra-marketplace",    "agent profile management"),
+    ]
+    for name, marketplace, desc in mandatory:
+        r = subprocess.run(
+            f"claude plugin install {name}@{marketplace}",
+            shell=True, capture_output=True, text=True,
+        )
+        ok = r.returncode == 0 or "already installed" in r.stdout
+        print(f"    {'✓' if ok else '!'}  {name}@{marketplace} — {desc}")
+        if not ok:
+            print(f"         {r.stderr.strip() or r.stdout.strip()}")
+
+    print()
+
+    # ── Conditional: voice-cli (only if voiceCLI was installed) ──────────────
+
+    if voicecli_dir and voicecli_dir.exists():
+        r = subprocess.run(
+            "claude plugin install voice-cli@voicecli-marketplace",
+            shell=True, capture_output=True, text=True,
+        )
+        ok = r.returncode == 0 or "already installed" in r.stdout
+        print(f"  {'✓' if ok else '!'}  voice-cli@voicecli-marketplace — VoiceCLI TTS/STT integration")
+        print()
+
+    # ── Optional plugins ──────────────────────────────────────────────────────
+
+    print("  Optional:")
+    optional_plugins = [
+        ("dev-core",          "roxabi-marketplace", "full dev workflow (frame→spec→plan→implement→ship)"),
+        ("visual-explainer",  "roxabi-marketplace", "HTML diagrams & data visualizations"),
+        ("compress",          "roxabi-marketplace", "compact agent/skill definitions, save tokens"),
+    ]
+    for name, marketplace, desc in optional_plugins:
+        if include_optional or ask(f"    Install {name}? ({desc})", default=True):
+            r = subprocess.run(
+                f"claude plugin install {name}@{marketplace}",
+                shell=True, capture_output=True, text=True,
+            )
+            ok = r.returncode == 0 or "already installed" in r.stdout
+            print(f"    {'✓' if ok else '!'}  {name}@{marketplace}")
+            if not ok:
+                print(f"         {r.stderr.strip() or r.stdout.strip()}")
+        else:
+            print(f"    skip  {name}")
+
+    print()
+
+
+def bootstrap_forge() -> None:
+    """Create ~/.roxabi/forge/ structure and copy server files from roxabi-plugins."""
+    agent_dir = Path.home() / ".roxabi/forge"
+    forge_src = Path.home() / "projects" / "roxabi-plugins" / "forge"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create per-project exploration directories
+    for subdir in ("lyra/brand", "lyra/visuals", "lyra/diagrams", "_shared/diagrams"):
+        (agent_dir / subdir).mkdir(parents=True, exist_ok=True)
+
+    for name in ("serve.py", "gen-manifest.py", "index.html"):
+        src = forge_src / name
+        dst = agent_dir / name
+        if not src.exists():
+            continue
+        if dst.exists():
+            # Update if source is newer
+            if src.stat().st_mtime <= dst.stat().st_mtime:
+                continue
+        shutil.copy2(src, dst)
+
+    # Register forge conf symlink
+    conf_src = forge_src / "conf.d" / "forge.conf"
+    conf_dst = LYRA_STACK_DIR / "conf.d" / "forge.conf"
+    if conf_src.exists() and not conf_dst.exists():
+        conf_dst.parent.mkdir(parents=True, exist_ok=True)
+        conf_dst.symlink_to(conf_src)
+
+    print("  ✓  Forge gallery bootstrapped (~/.roxabi/forge/)")
+
+
+def symlink_voicecli(voicecli_dir: Path) -> None:
+    """Symlink voicecli venv binary to ~/.local/bin/."""
+    venv_bin = voicecli_dir / ".venv" / "bin" / "voicecli"
+    local_bin = Path.home() / ".local" / "bin" / "voicecli"
+    if local_bin.exists() or local_bin.is_symlink():
+        print("  ✓  voicecli already on PATH")
+        return
+    if not venv_bin.exists():
+        print("  ✗  voicecli venv binary not found — skipping symlink")
+        return
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.symlink_to(venv_bin)
+    print(f"  ✓  voicecli symlinked → {local_bin}")
+
+
+def init_agents(lyra_dir: Path) -> None:
+    """Run lyra agent init to seed the DB from TOML files."""
+    agent_init = lyra_dir / ".venv" / "bin" / "lyra"
+    if not agent_init.exists():
+        print("  ✗  lyra CLI not found in venv — skipping agent init")
+        return
+    result = subprocess.run(
+        f"{agent_init} agent init",
+        shell=True,
+        cwd=lyra_dir,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print("  ✓  lyra agent init — agents seeded into DB")
+    else:
+        # Non-fatal — may fail if DB already has agents
+        print(f"  !  lyra agent init skipped ({result.stderr.strip() or 'already initialized'})")
+
+
+def create_log_dirs() -> None:
+    """Create XDG-compliant log directories."""
+    state = Path.home() / ".local" / "state"
+    for app in ("lyra", "voicecli", "lyra-stack"):
+        log_dir = state / app / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+    print("  ✓  Log directories created (~/.local/state/*/logs/)")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    include_optional = "--all" in sys.argv
+
+    with open(STACK_FILE, "rb") as f:
+        config = tomllib.load(f)
+
+    modules = config.get("modules", {})
+
+    print("\nlyra-stack setup")
+    print("─" * 40)
+    print()
+
+    if not check_prereqs():
+        sys.exit(1)
+
+    print()
+
+    # ── Phase 1: Clone + install + register ──────────────────────────────────
+
+    lyra_dir = None
+    voicecli_dir = None
+
+    installed_optional: set[str] = set()
+
+    for name, module in modules.items():
+        optional = module.get("optional", False)
+        path = Path(module["path"]).expanduser()
+
+        if name == "lyra":
+            lyra_dir = path
+        elif name == "voiceCLI":
+            voicecli_dir = path
+
+        # Optional modules: ask unless --all was passed
+        if optional and not include_optional:
+            if path.exists():
+                print(f"  ✓  {name}  (already at {path})")
+            elif not ask(f"  Install {name}? (optional)", default=False):
+                print(f"  skip  {name}")
+                continue
+        elif not optional:
+            pass  # required — always install
+
+        if path.exists():
+            if name not in ("lyra",):  # lyra already printed above if optional check passed
+                print(f"  ✓  {name}  (already at {path})")
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            run(f"git clone {module['repo']} {path}")
+            tag = module.get("tag", "").strip()
+            if tag:
+                print(f"       pinning to {tag}...")
+                run(f"git checkout {tag}", cwd=path)
+
+        print("       installing...")
+        run(module.get("install", "uv sync"), cwd=path)
+
+        if module.get("register", True):
+            print("       registering...")
+            env = {**os.environ, "LYRA_STACK_DIR": str(LYRA_STACK_DIR)}
+            subprocess.run("make register", shell=True, cwd=path, env=env, check=True)
+        else:
+            print("       skipping registration (no daemon)")
+
+        if optional:
+            installed_optional.add(name)
+        print()
+
+    # If voiceCLI was installed, re-sync lyra with the voice extra
+    if "voiceCLI" in installed_optional and lyra_dir and lyra_dir.exists():
+        print("       re-syncing lyra with voice support...")
+        run("uv sync --extra voice", cwd=lyra_dir)
+        print()
+
+    # ── Phase 2: Post-setup scaffolding ──────────────────────────────────────
+
+    print("Post-setup")
+    print("─" * 40)
+    print()
+
+    create_log_dirs()
+
+    if ask("  Install forge gallery? (optional)", default=False):
+        bootstrap_forge()
+    else:
+        print("  skip  forge")
+
+    if voicecli_dir and voicecli_dir.exists():
+        symlink_voicecli(voicecli_dir)
+
+    if lyra_dir and lyra_dir.exists():
+        scaffold_env(lyra_dir)
+        scaffold_config_toml(lyra_dir)
+        init_agents(lyra_dir)
+
+    print()
+
+    # ── Phase 3: Claude Code plugins ─────────────────────────────────────────
+
+    setup_plugins(lyra_dir, voicecli_dir, include_optional)
+
+    # ── Phase 4: Start supervisord + enable systemd ───────────────────────────
+
+    print("Starting supervisord...")
+    run(str(LYRA_STACK_DIR / "scripts" / "start.sh"))
+
+    print()
+    print("Enabling systemd auto-start...")
+    run("systemctl --user daemon-reload", check=False)
+    run("systemctl --user enable lyra-stack.service", check=False)
+    run("loginctl enable-linger $(whoami)", check=False)
+    print("  ✓  lyra-stack.service enabled (auto-starts on boot)")
+
+    # Enable monitoring timer (installed by make register)
+    print()
+    print("Enabling monitoring timer...")
+    run("systemctl --user enable lyra-monitor.timer", check=False)
+    print("  ✓  lyra-monitor.timer enabled")
+    print("     Run 'make monitor enable' to start, after adding secrets to .env")
+
+    print()
+    print("─" * 40)
+    print("Setup complete!")
+    print()
+    print("  make ps                              status of all services")
+    print("  systemctl --user status lyra-stack    systemd unit status")
+    print("  make lyra reload                     restart lyra")
+    print("  make tts reload                      restart voicecli_tts")
+    print("  make stt reload                      restart voicecli_stt")
+    print("  make monitor status                  health monitoring timer")
+    print()
+
+    # ── Remaining manual steps ───────────────────────────────────────────────
+
+    manual_steps = []
+
+    if lyra_dir:
+        env_file = lyra_dir / ".env"
+        config_file = lyra_dir / "config.toml"
+        if env_file.exists():
+            # Check if tokens are filled in
+            content = env_file.read_text()
+            if "TELEGRAM_TOKEN=\n" in content or "TELEGRAM_TOKEN=" not in content:
+                manual_steps.append(
+                    f"Fill in bot tokens:\n"
+                    f"     nano {lyra_dir}/.env\n"
+                    f"     → TELEGRAM_TOKEN, DISCORD_TOKEN, etc.\n"
+                    f"     → Get Telegram token from @BotFather\n"
+                    f"     → Get Discord token from discord.com/developers"
+                )
+        if config_file.exists():
+            content = config_file.read_text()
+            if "owner_users = []" in content:
+                manual_steps.append(
+                    f"Fill in your user IDs:\n"
+                    f"     nano {lyra_dir}/config.toml\n"
+                    f"     → Telegram ID: message @userinfobot\n"
+                    f"     → Discord ID: Settings → Advanced → Developer Mode"
+                )
+
+    # Check if Claude is authenticated
+    result = subprocess.run(
+        "claude --version", shell=True, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        manual_steps.append("Install and authenticate Claude CLI:\n     claude")
+    else:
+        # Claude is installed but might not be authenticated
+        manual_steps.append(
+            "Authenticate Claude CLI (if not already done):\n     claude"
+        )
+
+    manual_steps.append(
+        "Add bot tokens to the credential store:\n"
+        "     cd ~/projects/lyra && lyra bot add"
+    )
+
+    manual_steps.append(
+        "Set up health monitoring:\n"
+        "     1. Add to .env: TELEGRAM_TOKEN, TELEGRAM_ADMIN_CHAT_ID\n"
+        "     2. Create health secret:\n"
+        "        mkdir -p ~/.lyra/secrets\n"
+        '        openssl rand -hex 32 > ~/.lyra/secrets/health_secret\n'
+        "        chmod 600 ~/.lyra/secrets/health_secret\n"
+        "     3. Add LYRA_HEALTH_SECRET=$(cat ~/.lyra/secrets/health_secret) to .env\n"
+        "     4. make monitor enable"
+    )
+
+    if manual_steps:
+        print("Remaining manual steps:")
+        print()
+        for i, step in enumerate(manual_steps, 1):
+            print(f"  {i}. {step}")
+            print()
+
+    if include_optional is False and any(m.get("optional") for m in modules.values()):
+        print(
+            "  make setup ARGS=--all    include optional modules (imageCLI, roxabi-vault)"
+        )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -170,7 +170,7 @@ ssh yourname@<MACHINE_1_IP>
 
 git clone git@github.com:Roxabi/lyra-stack.git ~/projects/lyra-stack
 git clone git@github.com:Roxabi/lyra.git ~/projects/lyra
-cd ~/projects/lyra && python deploy/setup.py
+cd ~/projects/lyra && python3 deploy/setup.py
 ```
 
 `make setup` will:
@@ -402,7 +402,7 @@ ssh -i ~/.ssh/lyra_agent lyra@<MACHINE_1_IP> "id && git --version"
 | Config | `~/projects/lyra/config.toml` |
 | Credentials | `~/.lyra/auth.db` (encrypted, via `lyra bot add`) |
 | Logs | `~/.local/state/lyra/logs/` |
-| Diagrams | `~/.agent/` (if installed) |
+| Diagrams | `~/.roxabi/forge/` (if installed) |
 | Firewall | UFW, SSH only |
 
 **Daily commands** (from `~/projects/lyra-stack`):

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -117,7 +117,7 @@ ssh-copy-id yourname@<MACHINE_1_IP>
 
 ```bash
 ssh yourname@<MACHINE_1_IP>
-curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra-stack/main/scripts/provision.sh | ADMIN_USER=yourname bash
+curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra/staging/deploy/provision.sh | ADMIN_USER=yourname bash
 ```
 
 The script handles:
@@ -169,7 +169,8 @@ ssh yourname@<MACHINE_1_IP>
 # https://github.com/settings/keys → paste output of: cat ~/.ssh/id_ed25519.pub
 
 git clone git@github.com:Roxabi/lyra-stack.git ~/projects/lyra-stack
-cd ~/projects/lyra-stack && make setup
+git clone git@github.com:Roxabi/lyra.git ~/projects/lyra
+cd ~/projects/lyra && python deploy/setup.py
 ```
 
 `make setup` will:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ reportUnknownLambdaType = "none"
 reportMissingTypeArgument = "none"
 
 [tool.ruff]
-exclude = [".claude/worktrees"]
+exclude = [".claude/worktrees", "deploy"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "C901", "PLR0913", "PLR0915"]


### PR DESCRIPTION
## Summary

- Move `provision.sh` and `setup.py` from `lyra-stack/scripts/` into `lyra/deploy/`
- Update curl URLs, clone instructions, and doc references to point to new locations
- `bootstrap_forge()` in setup.py now sources from `roxabi-plugins/forge/` instead of `lyra-stack/forge/`

Closes #506

## Test plan

- [ ] `bash deploy/provision.sh` runs without path errors on a fresh machine
- [ ] `python deploy/setup.py` reads `stack.toml` from lyra-stack and completes setup
- [ ] CLAUDE.md and GETTING-STARTED.md references are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)