### PR TITLE
fix(stt): make daemon detection per-call instead of one-shot flag

### DIFF
--- a/src/lyra/monitoring/checks.py
+++ b/src/lyra/monitoring/checks.py
@@ -21,7 +21,10 @@ def check_process(service_name: str) -> CheckResult:
     supervisorctl is not available.
     """
     now = datetime.now(timezone.utc)
-    sctl = Path.home() / "projects" / "lyra" / "deploy" / "supervisor" / "supervisorctl.sh"
+    sctl = (
+        Path.home() / "projects" / "lyra" / "deploy"
+        / "supervisor" / "supervisorctl.sh"
+    )
 
     if sctl.exists():
         try:

--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -89,7 +89,18 @@ class STTService:
                 kwargs["language_detection_segments"] = self._detection_segments
             if self._detection_fallback is not None:
                 kwargs["language_fallback"] = self._detection_fallback
-            vc_result = _transcribe(Path(path), **kwargs)
+            try:
+                vc_result = _transcribe(Path(path), **kwargs)
+            except (ConnectionError, OSError):
+                if self._daemon_active:
+                    self._daemon_active = False
+                    log.warning(
+                        "STT daemon connection failed — retrying"
+                        " with in-process model",
+                    )
+                    vc_result = _transcribe(Path(path), **kwargs)
+                else:
+                    raise
 
             duration = (
                 max((seg["end"] for seg in vc_result.segments), default=0.0)

--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -48,7 +48,7 @@ class STTService:
         self._detection_threshold = config.language_detection_threshold
         self._detection_segments = config.language_detection_segments
         self._detection_fallback = config.language_fallback
-        self._daemon_detected = False
+        self._daemon_active = False
         log.debug("STTService init: model=%s (via voiceCLI)", self._model)
 
     async def transcribe(self, path: Path | str) -> TranscriptionResult:
@@ -64,18 +64,23 @@ class STTService:
                 transcribe as _transcribe,
             )
 
-            if not self._daemon_detected:
-                from voicecli.stt_daemon import SOCKET_PATH  # type: ignore[import-untyped]  # noqa: I001
+            from voicecli.stt_daemon import SOCKET_PATH  # type: ignore[import-untyped]  # noqa: I001
 
-                if SOCKET_PATH.exists():
-                    from voicecli.transcribe import unload_model  # type: ignore[import-untyped]  # noqa: I001
+            daemon_up = SOCKET_PATH.exists()
+            if daemon_up and not self._daemon_active:
+                from voicecli.transcribe import unload_model  # type: ignore[import-untyped]  # noqa: I001
 
-                    unload_model()
-                    self._daemon_detected = True
-                    log.info(
-                        "STT daemon detected — unloaded local model,"
-                        " deferring to daemon",
-                    )
+                unload_model()
+                self._daemon_active = True
+                log.info(
+                    "STT daemon detected — unloaded local model,"
+                    " deferring to daemon",
+                )
+            elif not daemon_up and self._daemon_active:
+                self._daemon_active = False
+                log.warning(
+                    "STT daemon socket gone — falling back to in-process model",
+                )
 
             initial_prompt = vocab_to_prompt(load_vocab())
             kwargs: dict = dict(model=self._model, initial_prompt=initial_prompt)

--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -60,11 +60,10 @@ class STTService:
                 load_vocab,
                 vocab_to_prompt,
             )
+            from voicecli.stt_daemon import SOCKET_PATH
             from voicecli.transcribe import (
                 transcribe as _transcribe,
             )
-
-            from voicecli.stt_daemon import SOCKET_PATH  # type: ignore[import-untyped]  # noqa: I001
 
             daemon_up = SOCKET_PATH.exists()
             if daemon_up and not self._daemon_active:

--- a/tests/stt/test_stt_service.py
+++ b/tests/stt/test_stt_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -265,3 +266,93 @@ def test_transcribe_sync_no_detection_params_when_none():
     assert "language_detection_threshold" not in captured_kwargs
     assert "language_detection_segments" not in captured_kwargs
     assert "language_fallback" not in captured_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Daemon detection state machine (per-call socket check)
+# ---------------------------------------------------------------------------
+
+_SOCKET_PATCH = "voicecli.stt_daemon.SOCKET_PATH"
+_UNLOAD_PATCH = "voicecli.transcribe.unload_model"
+
+
+def _stt_service() -> STTService:
+    return STTService(STTConfig(model_size="large-v3-turbo"))
+
+
+def _mock_socket(exists: bool) -> MagicMock:
+    """Return a mock Path whose .exists() returns the given value."""
+    sock = MagicMock(spec=Path)
+    sock.exists.return_value = exists
+    return sock
+
+
+@requires_voicecli
+def test_daemon_appears_unloads_model():
+    """Transition 1: daemon_up=True, _daemon_active=False → unload + activate."""
+    svc = _stt_service()
+    assert svc._daemon_active is False
+
+    with (
+        patch(_SOCKET_PATCH, _mock_socket(True)),
+        patch(_UNLOAD_PATCH) as mock_unload,
+        patch("voicecli.config.load_vocab", return_value=[]),
+        patch("voicecli.config.vocab_to_prompt", return_value=""),
+        patch("voicecli.transcribe.transcribe", return_value=_make_vc_result()),
+    ):
+        svc._transcribe_sync("/tmp/fake.ogg")
+
+    mock_unload.assert_called_once()
+    assert svc._daemon_active is True
+
+
+@requires_voicecli
+def test_daemon_disappears_falls_back():
+    """Transition 2: daemon_up=False, _daemon_active=True → reset + warn."""
+    svc = _stt_service()
+    svc._daemon_active = True
+
+    with (
+        patch(_SOCKET_PATCH, _mock_socket(False)),
+        patch("voicecli.config.load_vocab", return_value=[]),
+        patch("voicecli.config.vocab_to_prompt", return_value=""),
+        patch("voicecli.transcribe.transcribe", return_value=_make_vc_result()),
+    ):
+        svc._transcribe_sync("/tmp/fake.ogg")
+
+    assert svc._daemon_active is False
+
+
+@requires_voicecli
+def test_daemon_already_active_no_op():
+    """Transition 3: daemon_up=True, _daemon_active=True → no unload call."""
+    svc = _stt_service()
+    svc._daemon_active = True
+
+    with (
+        patch(_SOCKET_PATCH, _mock_socket(True)),
+        patch(_UNLOAD_PATCH) as mock_unload,
+        patch("voicecli.config.load_vocab", return_value=[]),
+        patch("voicecli.config.vocab_to_prompt", return_value=""),
+        patch("voicecli.transcribe.transcribe", return_value=_make_vc_result()),
+    ):
+        svc._transcribe_sync("/tmp/fake.ogg")
+
+    mock_unload.assert_not_called()
+    assert svc._daemon_active is True
+
+
+@requires_voicecli
+def test_no_daemon_no_flag_no_op():
+    """Transition 4: daemon_up=False, _daemon_active=False → no state change."""
+    svc = _stt_service()
+
+    with (
+        patch(_SOCKET_PATCH, _mock_socket(False)),
+        patch("voicecli.config.load_vocab", return_value=[]),
+        patch("voicecli.config.vocab_to_prompt", return_value=""),
+        patch("voicecli.transcribe.transcribe", return_value=_make_vc_result()),
+    ):
+        svc._transcribe_sync("/tmp/fake.ogg")
+
+    assert svc._daemon_active is False

--- a/tests/stt/test_stt_service.py
+++ b/tests/stt/test_stt_service.py
@@ -356,3 +356,34 @@ def test_no_daemon_no_flag_no_op():
         svc._transcribe_sync("/tmp/fake.ogg")
 
     assert svc._daemon_active is False
+
+
+@requires_voicecli
+def test_daemon_connection_fails_retries_in_process():
+    """TOCTOU recovery: daemon socket exists but connection fails → retry in-process."""
+    svc = _stt_service()
+    svc._daemon_active = True
+
+    call_count = 0
+
+    def _transcribe_with_failure(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("daemon socket gone")
+        return _make_vc_result()
+
+    with (
+        patch(_SOCKET_PATCH, _mock_socket(True)),
+        patch("voicecli.config.load_vocab", return_value=[]),
+        patch("voicecli.config.vocab_to_prompt", return_value=""),
+        patch(
+            "voicecli.transcribe.transcribe",
+            side_effect=_transcribe_with_failure,
+        ),
+    ):
+        result = svc._transcribe_sync("/tmp/fake.ogg")
+
+    assert call_count == 2
+    assert svc._daemon_active is False
+    assert result.text == "Hello world"


### PR DESCRIPTION
## Summary

- Check `SOCKET_PATH.exists()` on every transcription call instead of caching result in a one-shot `_daemon_detected` flag
- If STT daemon crashes after first detection, service now falls back to in-process model loading on the next call
- Logs warning when daemon socket disappears for observability

Closes #514

## Test plan

- [x] All 241 STT tests pass
- [ ] Manual: start lyra with STT daemon running, send voice note → uses daemon
- [ ] Manual: kill STT daemon, send another voice note → falls back to in-process model
- [ ] Manual: restart STT daemon → next call routes back to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)