### PR TITLE
fix(stt): sanitise file path before forwarding to voicecli

### DIFF
--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -54,8 +55,11 @@ class STTService:
 
     async def transcribe(self, path: Path | str) -> TranscriptionResult:
         resolved = Path(path).resolve()
-        if ".." in Path(path).parts:
-            raise ValueError(f"Path traversal not allowed: {path}")
+        _tmpdir = Path(tempfile.gettempdir()).resolve()
+        if not resolved.is_relative_to(_tmpdir):
+            raise ValueError(
+                f"Path outside allowed directory ({_tmpdir}): {resolved}"
+            )
         if resolved.suffix.lower() not in _ALLOWED_AUDIO_EXTENSIONS:
             raise ValueError(
                 f"Unsupported audio extension {resolved.suffix!r},"

--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 log = logging.getLogger(__name__)
 
 WHISPER_NOISE_TOKENS = {"[music]", "[applause]", "[laughter]", "[silence]", "[noise]"}
+_ALLOWED_AUDIO_EXTENSIONS = {".ogg", ".mp3", ".wav", ".m4a", ".webm", ".flac", ".opus"}
 
 
 @dataclass
@@ -52,7 +53,17 @@ class STTService:
         log.debug("STTService init: model=%s (via voiceCLI)", self._model)
 
     async def transcribe(self, path: Path | str) -> TranscriptionResult:
-        return await asyncio.to_thread(self._transcribe_sync, str(path))
+        resolved = Path(path).resolve()
+        if ".." in Path(path).parts:
+            raise ValueError(f"Path traversal not allowed: {path}")
+        if resolved.suffix.lower() not in _ALLOWED_AUDIO_EXTENSIONS:
+            raise ValueError(
+                f"Unsupported audio extension {resolved.suffix!r},"
+                f" expected one of {sorted(_ALLOWED_AUDIO_EXTENSIONS)}"
+            )
+        if not resolved.is_file():
+            raise FileNotFoundError(f"Audio file not found: {resolved}")
+        return await asyncio.to_thread(self._transcribe_sync, str(resolved))
 
     def _transcribe_sync(self, path: str) -> TranscriptionResult:
         try:

--- a/tests/stt/test_stt_service.py
+++ b/tests/stt/test_stt_service.py
@@ -86,17 +86,34 @@ def audio_ogg(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_transcribe_rejects_path_traversal(tmp_path):
+async def test_transcribe_rejects_path_outside_tempdir():
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
-    malicious = tmp_path / ".." / ".." / "etc" / "passwd"
-    with pytest.raises(ValueError, match="Path traversal not allowed"):
-        await svc.transcribe(malicious)
+    with pytest.raises(ValueError, match="Path outside allowed directory"):
+        await svc.transcribe("/etc/passwd.ogg")
+
+
+@pytest.mark.asyncio
+async def test_transcribe_rejects_path_outside_tempdir_string():
+    """String input with traversal is also rejected."""
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    with pytest.raises(ValueError, match="Path outside allowed directory"):
+        await svc.transcribe("/home/../etc/passwd.ogg")
 
 
 @pytest.mark.asyncio
 async def test_transcribe_rejects_bad_extension(tmp_path):
     f = tmp_path / "secret.txt"
     f.write_bytes(b"secret data")
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    with pytest.raises(ValueError, match="Unsupported audio extension"):
+        await svc.transcribe(f)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["noext", "audio.ogg.bak", "file.exe"])
+async def test_transcribe_rejects_various_bad_extensions(tmp_path, name):
+    f = tmp_path / name
+    f.write_bytes(b"\x00")
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
     with pytest.raises(ValueError, match="Unsupported audio extension"):
         await svc.transcribe(f)
@@ -110,18 +127,33 @@ async def test_transcribe_rejects_missing_file(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_transcribe_accepts_all_valid_extensions(tmp_path):
-    """All allowed extensions pass validation."""
+@pytest.mark.parametrize(
+    "ext",
+    [".ogg", ".mp3", ".wav", ".m4a", ".webm", ".flac", ".opus", ".OGG"],
+)
+async def test_transcribe_accepts_valid_extensions(tmp_path, ext):
+    """All allowed extensions (including uppercase) pass validation."""
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
-    for ext in (".ogg", ".mp3", ".wav", ".m4a", ".webm", ".flac", ".opus"):
-        f = tmp_path / f"audio{ext}"
-        f.write_bytes(b"\x00")
-        # File exists + valid extension → validation passes, reaches _transcribe_sync
-        with patch.object(svc, "_transcribe_sync", return_value=TranscriptionResult(
-            text="ok", language="en", duration_seconds=0.0
-        )):
-            result = await svc.transcribe(f)
-            assert result.text == "ok"
+    f = tmp_path / f"audio{ext}"
+    f.write_bytes(b"\x00")
+    with patch.object(svc, "_transcribe_sync", return_value=TranscriptionResult(
+        text="ok", language="en", duration_seconds=0.0
+    )):
+        result = await svc.transcribe(f)
+        assert result.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_accepts_string_path(tmp_path):
+    """String paths inside tempdir are accepted."""
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    f = tmp_path / "voice.ogg"
+    f.write_bytes(b"\x00")
+    with patch.object(svc, "_transcribe_sync", return_value=TranscriptionResult(
+        text="ok", language="en", duration_seconds=0.0
+    )):
+        result = await svc.transcribe(str(f))
+        assert result.text == "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/stt/test_stt_service.py
+++ b/tests/stt/test_stt_service.py
@@ -73,6 +73,58 @@ def test_is_whisper_noise(text, expected):
 
 
 # ---------------------------------------------------------------------------
+# Path sanitisation (transcribe input validation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def audio_ogg(tmp_path):
+    """Create a real .ogg temp file for path validation tests."""
+    f = tmp_path / "test.ogg"
+    f.write_bytes(b"\x00")
+    return f
+
+
+@pytest.mark.asyncio
+async def test_transcribe_rejects_path_traversal(tmp_path):
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    malicious = tmp_path / ".." / ".." / "etc" / "passwd"
+    with pytest.raises(ValueError, match="Path traversal not allowed"):
+        await svc.transcribe(malicious)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_rejects_bad_extension(tmp_path):
+    f = tmp_path / "secret.txt"
+    f.write_bytes(b"secret data")
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    with pytest.raises(ValueError, match="Unsupported audio extension"):
+        await svc.transcribe(f)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_rejects_missing_file(tmp_path):
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    with pytest.raises(FileNotFoundError, match="Audio file not found"):
+        await svc.transcribe(tmp_path / "nonexistent.ogg")
+
+
+@pytest.mark.asyncio
+async def test_transcribe_accepts_all_valid_extensions(tmp_path):
+    """All allowed extensions pass validation."""
+    svc = STTService(STTConfig(model_size="large-v3-turbo"))
+    for ext in (".ogg", ".mp3", ".wav", ".m4a", ".webm", ".flac", ".opus"):
+        f = tmp_path / f"audio{ext}"
+        f.write_bytes(b"\x00")
+        # File exists + valid extension → validation passes, reaches _transcribe_sync
+        with patch.object(svc, "_transcribe_sync", return_value=TranscriptionResult(
+            text="ok", language="en", duration_seconds=0.0
+        )):
+            result = await svc.transcribe(f)
+            assert result.text == "ok"
+
+
+# ---------------------------------------------------------------------------
 # STTService init
 # ---------------------------------------------------------------------------
 
@@ -99,7 +151,7 @@ def _make_vc_result(text="Hello world", language: str | None = "en", segments=No
 
 @requires_voicecli
 @pytest.mark.asyncio
-async def test_transcribe_returns_transcription_result():
+async def test_transcribe_returns_transcription_result(audio_ogg):
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
 
     with (
@@ -109,7 +161,7 @@ async def test_transcribe_returns_transcription_result():
             "voicecli.transcribe.transcribe", return_value=_make_vc_result()
         ) as mock_t,
     ):
-        result = await svc.transcribe("/tmp/fake.ogg")
+        result = await svc.transcribe(audio_ogg)
 
     assert isinstance(result, TranscriptionResult)
     assert result.text == "Hello world"
@@ -120,7 +172,7 @@ async def test_transcribe_returns_transcription_result():
 
 @requires_voicecli
 @pytest.mark.asyncio
-async def test_transcribe_passes_vocab_as_prompt():
+async def test_transcribe_passes_vocab_as_prompt(audio_ogg):
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
 
     with (
@@ -130,7 +182,7 @@ async def test_transcribe_passes_vocab_as_prompt():
             "voicecli.transcribe.transcribe", return_value=_make_vc_result()
         ) as mock_t,
     ):
-        await svc.transcribe("/tmp/fake.ogg")
+        await svc.transcribe(audio_ogg)
 
     _, kwargs = mock_t.call_args
     assert kwargs.get("initial_prompt") == "Lyra, Roxabi."
@@ -138,7 +190,7 @@ async def test_transcribe_passes_vocab_as_prompt():
 
 @requires_voicecli
 @pytest.mark.asyncio
-async def test_transcribe_none_language_becomes_unknown():
+async def test_transcribe_none_language_becomes_unknown(audio_ogg):
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
 
     with (
@@ -149,14 +201,14 @@ async def test_transcribe_none_language_becomes_unknown():
             return_value=_make_vc_result(language=None),
         ),
     ):
-        result = await svc.transcribe("/tmp/fake.ogg")
+        result = await svc.transcribe(audio_ogg)
 
     assert result.language == "unknown"
 
 
 @requires_voicecli
 @pytest.mark.asyncio
-async def test_transcribe_empty_segments_duration_zero():
+async def test_transcribe_empty_segments_duration_zero(audio_ogg):
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
 
     with (
@@ -167,14 +219,14 @@ async def test_transcribe_empty_segments_duration_zero():
             return_value=_make_vc_result(segments=[]),
         ),
     ):
-        result = await svc.transcribe("/tmp/fake.ogg")
+        result = await svc.transcribe(audio_ogg)
 
     assert result.duration_seconds == 0.0
 
 
 @requires_voicecli
 @pytest.mark.asyncio
-async def test_transcribe_propagates_error():
+async def test_transcribe_propagates_error(audio_ogg):
     svc = STTService(STTConfig(model_size="large-v3-turbo"))
 
     with (
@@ -186,7 +238,7 @@ async def test_transcribe_propagates_error():
         ),
     ):
         with pytest.raises(RuntimeError, match="model load failed"):
-            await svc.transcribe("/tmp/fake.ogg")
+            await svc.transcribe(audio_ogg)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reject directory traversal (`..`), non-audio extensions, and missing files at the `transcribe()` boundary before delegating to voiceCLI
- Resolve path to absolute before forwarding downstream

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #516: fix(stt): sanitise file path before forwarding to voicecli | Open |
| Implementation | 1 commit on `feat/516-stt-sanitise-path` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new) | Passed |

## Test Plan
- [x] Path with `..` components raises `ValueError`
- [x] Non-audio extension (`.txt`) raises `ValueError`
- [x] Missing `.ogg` file raises `FileNotFoundError`
- [x] All valid extensions (`.ogg`, `.mp3`, `.wav`, `.m4a`, `.webm`, `.flac`, `.opus`) pass validation
- [x] Existing async tests updated to use real temp files via `audio_ogg` fixture

Closes #516

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`