### PR TITLE
refactor(voice): decouple STT/TTS from hub into NATS adapter services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ define require_machine1
 	@[ -n "$(DEPLOY_DIR)" ] || { echo "Error: DEPLOY_DIR not set in .env"; exit 1; }
 endef
 
-.PHONY: lyra telegram discord monitor register deploy remote nats-install test lint typecheck format
+.PHONY: lyra telegram discord lyra-stt lyra-tts monitor register deploy remote nats-install test lint typecheck format
 
 # ── Supervisor services ──────────────────────────────────────────────────────
 
@@ -44,6 +44,18 @@ discord:
 ifndef _IS_LYRA_SUBCMD
 	$(ensure_hub)
 	@$(HUB_SVC) lyra_discord $(SVC_CMD)
+endif
+
+lyra-stt:
+ifndef _IS_LYRA_SUBCMD
+	$(ensure_hub)
+	@$(HUB_SVC) lyra_stt $(SVC_CMD)
+endif
+
+lyra-tts:
+ifndef _IS_LYRA_SUBCMD
+	$(ensure_hub)
+	@$(HUB_SVC) lyra_tts $(SVC_CMD)
 endif
 
 # ── Monitor (systemd timer, not supervisor) ──────────────────────────────────
@@ -70,6 +82,8 @@ register:
 	$(call hub-link-conf,lyra_hub,supervisor/conf.d/lyra_hub.conf)
 	$(call hub-link-conf,lyra_telegram,supervisor/conf.d/lyra_telegram.conf)
 	$(call hub-link-conf,lyra_discord,supervisor/conf.d/lyra_discord.conf)
+	$(call hub-link-conf,lyra_stt,deploy/supervisor/conf.d/lyra_stt.conf)
+	$(call hub-link-conf,lyra_tts,deploy/supervisor/conf.d/lyra_tts.conf)
 	@mkdir -p "$(HOME)/.local/state/lyra/logs"
 	$(hub_reread)
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ remote:
 	  hub)      PROGS="lyra_hub" ;; \
 	  telegram) PROGS="lyra_telegram" ;; \
 	  discord)  PROGS="lyra_discord" ;; \
+	  stt)      PROGS="lyra_stt" ;; \
+	  tts)      PROGS="lyra_tts" ;; \
 	  reload|start|stop|status|logs|errors|"") \
 	    ACTION="$$SVC"; PROGS="lyra_hub lyra_telegram lyra_discord" ;; \
 	  *) echo "Unknown service: $$SVC"; exit 1 ;; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SUPERVISOR_HUB ?= $(HOME)/projects
-HUB_SERVICES   := lyra telegram discord
+HUB_SERVICES   := lyra telegram discord lyra-stt lyra-tts
 -include $(SUPERVISOR_HUB)/hub.mk
 
 # Sub-command parsing for multi-word targets (remote, monitor, deploy).
@@ -82,8 +82,8 @@ register:
 	$(call hub-link-conf,lyra_hub,supervisor/conf.d/lyra_hub.conf)
 	$(call hub-link-conf,lyra_telegram,supervisor/conf.d/lyra_telegram.conf)
 	$(call hub-link-conf,lyra_discord,supervisor/conf.d/lyra_discord.conf)
-	$(call hub-link-conf,lyra_stt,deploy/supervisor/conf.d/lyra_stt.conf)
-	$(call hub-link-conf,lyra_tts,deploy/supervisor/conf.d/lyra_tts.conf)
+	$(call hub-link-conf,lyra_stt,supervisor/conf.d/lyra_stt.conf)
+	$(call hub-link-conf,lyra_tts,supervisor/conf.d/lyra_tts.conf)
 	@mkdir -p "$(HOME)/.local/state/lyra/logs"
 	$(hub_reread)
 	@echo ""

--- a/deploy/nats/nats-local.conf
+++ b/deploy/nats/nats-local.conf
@@ -12,6 +12,6 @@ port: 4222
 pid_file: "/run/nats-server/nats-server.pid"
 
 max_connections: 20
-max_payload:     8388608  # 8 MB
+max_payload:     52428800  # 50 MB — supports large audio, images, video over NATS
 
 logtime: true

--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -34,7 +34,7 @@ include "/etc/nats/nkeys/auth.conf"
 
 # ── Resource limits ────────────────────────────────────────────────────────
 max_connections: 20      # 3 nkey clients + headroom; reject unexpected connections fast
-max_payload:     8388608 # 8MB — generous for LLM request/response payloads
+max_payload:     52428800 # 50MB — supports large audio, images, video over NATS
 
 # ── Monitoring ─────────────────────────────────────────────────────────────
 # Disabled until Slice A3 (lyra-monitor health probe) is implemented.

--- a/deploy/supervisor/conf.d/README.md
+++ b/deploy/supervisor/conf.d/README.md
@@ -2,6 +2,18 @@
 
 This directory contains supervisor configs for **production only** (roxabituwer, RTX 3080 10GB).
 
+## Programs
+
+| Program | Purpose | Notes |
+|---------|---------|-------|
+| `lyra_hub` | Hub process (NATS-connected) | Requires NATS |
+| `lyra_telegram` | Telegram adapter | Requires NATS |
+| `lyra_discord` | Discord adapter | Requires NATS |
+| `lyra_stt` | STT NATS adapter (voicecli) | Requires NATS + voicecli + RTX 3080 VRAM |
+| `lyra_tts` | TTS NATS adapter (voicecli) | Requires NATS + voicecli + RTX 3080 VRAM |
+| `voicecli_stt` | voicecli STT Unix-socket daemon | Optional inner daemon for lyra_stt |
+| `voicecli_tts` | voicecli TTS Unix-socket daemon | Optional inner daemon for lyra_tts |
+
 ## Intentionally absent (local-only)
 
 | Program | Reason |

--- a/deploy/supervisor/conf.d/lyra_stt.conf
+++ b/deploy/supervisor/conf.d/lyra_stt.conf
@@ -1,0 +1,17 @@
+[program:lyra_stt]
+command=%(ENV_HOME)s/projects/lyra/supervisor/scripts/run_adapter.sh stt
+directory=%(ENV_HOME)s/projects/lyra
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s"
+autostart=false
+autorestart=true
+startsecs=5
+startretries=3
+stopwaitsecs=75
+stopasgroup=true
+killasgroup=true
+stdout_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_stt.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stderr_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_stt_error.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=3

--- a/deploy/supervisor/conf.d/lyra_tts.conf
+++ b/deploy/supervisor/conf.d/lyra_tts.conf
@@ -1,0 +1,17 @@
+[program:lyra_tts]
+command=%(ENV_HOME)s/projects/lyra/supervisor/scripts/run_adapter.sh tts
+directory=%(ENV_HOME)s/projects/lyra
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s"
+autostart=false
+autorestart=true
+startsecs=5
+startretries=3
+stopwaitsecs=75
+stopasgroup=true
+killasgroup=true
+stdout_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_tts.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stderr_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_tts_error.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=3

--- a/src/lyra/agents/anthropic_agent.py
+++ b/src/lyra/agents/anthropic_agent.py
@@ -27,8 +27,8 @@ _AGENTS_DIR = Path(__file__).resolve().parent
 
 if TYPE_CHECKING:
     from lyra.core.stores.agent_store import AgentStore
-    from lyra.stt import STTService
-    from lyra.tts import TTSService
+    from lyra.stt import STTProtocol
+    from lyra.tts import TtsProtocol
 
 log = logging.getLogger(__name__)
 
@@ -47,8 +47,8 @@ class AnthropicAgent(AgentBase):
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
         runtime_config: RuntimeConfig | None = None,
-        stt: "STTService | None" = None,
-        tts: "TTSService | None" = None,
+        stt: "STTProtocol | None" = None,
+        tts: "TtsProtocol | None" = None,
         agents_dir: Path | None = None,
         smart_routing_decorator: object | None = None,
         agent_store: "AgentStore | None" = None,

--- a/src/lyra/agents/simple_agent.py
+++ b/src/lyra/agents/simple_agent.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 
     from lyra.core.render_events import RenderEvent
     from lyra.core.stores.agent_store import AgentStore
-    from lyra.stt import STTService
-    from lyra.tts import TTSService
+    from lyra.stt import STTProtocol
+    from lyra.tts import TtsProtocol
 
 log = logging.getLogger(__name__)
 
@@ -65,8 +65,8 @@ class SimpleAgent(AgentBase):
         provider: LlmProvider,
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
-        stt: "STTService | None" = None,
-        tts: "TTSService | None" = None,
+        stt: "STTProtocol | None" = None,
+        tts: "TtsProtocol | None" = None,
         runtime_config: RuntimeConfig | None = None,
         agents_dir: Path | None = None,
         agent_store: "AgentStore | None" = None,

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -86,9 +86,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             finally:
                 await cred_store.close()
 
-            wired: list[
-                tuple[TelegramAdapter, Bus[InboundMessage], Bus[InboundAudio]]
-            ] = []
+            wired: list[tuple] = []  # (TelegramAdapter, Bus, Bus)
 
             for bot_cfg in tg_multi_cfg.bots:
                 bot_id = bot_cfg.bot_id
@@ -222,9 +220,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             dc_thread_store = ThreadStore(db_path=vault_dir / "discord.db")
             await dc_thread_store.connect()
 
-            wired_dc: list[
-                tuple[DiscordAdapter, str, Bus[InboundMessage], Bus[InboundAudio]]
-            ] = []
+            wired_dc: list[tuple] = []  # (DiscordAdapter, str, Bus, Bus)
 
             for bot_cfg in dc_multi_cfg.bots:
                 bot_id = bot_cfg.bot_id
@@ -265,9 +261,8 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 adapter_dc._outbound_listener = listener_dc
                 await adapter_dc.astart()
 
-                wired_dc.append(
-                    (adapter_dc, token, inbound_bus_dc, inbound_audio_bus_dc)
-                )
+                abus_dc = inbound_audio_bus_dc
+                wired_dc.append((adapter_dc, token, inbound_bus_dc, abus_dc))
                 log.info(
                     "adapter_standalone: Discord bot_id=%s ready (NATS mode)", bot_id
                 )
@@ -301,6 +296,5 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
 
         else:
             sys.exit(f"Unknown platform: {platform!r}")
-
     finally:
         await nc.close()

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -86,7 +86,9 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             finally:
                 await cred_store.close()
 
-            wired: list[tuple[TelegramAdapter, Bus[InboundMessage], Bus[InboundAudio]]] = []
+            wired: list[
+                tuple[TelegramAdapter, Bus[InboundMessage], Bus[InboundAudio]]
+            ] = []
 
             for bot_cfg in tg_multi_cfg.bots:
                 bot_id = bot_cfg.bot_id
@@ -220,7 +222,9 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             dc_thread_store = ThreadStore(db_path=vault_dir / "discord.db")
             await dc_thread_store.connect()
 
-            wired_dc: list[tuple[DiscordAdapter, str, Bus[InboundMessage], Bus[InboundAudio]]] = []
+            wired_dc: list[
+                tuple[DiscordAdapter, str, Bus[InboundMessage], Bus[InboundAudio]]
+            ] = []
 
             for bot_cfg in dc_multi_cfg.bots:
                 bot_id = bot_cfg.bot_id
@@ -261,7 +265,9 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 adapter_dc._outbound_listener = listener_dc
                 await adapter_dc.astart()
 
-                wired_dc.append((adapter_dc, token, inbound_bus_dc, inbound_audio_bus_dc))
+                wired_dc.append(
+                    (adapter_dc, token, inbound_bus_dc, inbound_audio_bus_dc)
+                )
                 log.info(
                     "adapter_standalone: Discord bot_id=%s ready (NATS mode)", bot_id
                 )

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -21,7 +21,6 @@ import nats
 
 from lyra.adapters.nats_outbound_listener import NatsOutboundListener
 from lyra.core.bus import Bus
-from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import InboundAudio, InboundMessage, Platform
 from lyra.core.stores.credential_store import CredentialStore, LyraKeyring
 
@@ -87,7 +86,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             finally:
                 await cred_store.close()
 
-            wired: list[tuple[TelegramAdapter, Bus[InboundMessage]]] = []
+            wired: list[tuple[TelegramAdapter, Bus[InboundMessage], Bus[InboundAudio]]] = []
 
             for bot_cfg in tg_multi_cfg.bots:
                 bot_id = bot_cfg.bot_id
@@ -103,8 +102,14 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 inbound_bus.register(platform_enum)
                 await inbound_bus.start()
 
-                inbound_audio_bus: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+                inbound_audio_bus: Bus[InboundAudio] = NatsBus(  # type: ignore[type-arg]
+                    nc=nc,
+                    bot_id=bot_id,
+                    item_type=InboundAudio,
+                    subject_prefix="lyra.inbound.audio",
+                )
                 inbound_audio_bus.register(platform_enum)
+                await inbound_audio_bus.start()
 
                 adapter = TelegramAdapter(
                     bot_id=bot_id,
@@ -119,7 +124,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 adapter._outbound_listener = listener
                 await adapter.astart()
 
-                wired.append((adapter, inbound_bus))
+                wired.append((adapter, inbound_bus, inbound_audio_bus))
                 log.info(
                     "adapter_standalone: Telegram bot_id=%s ready (NATS mode)", bot_id
                 )
@@ -139,17 +144,18 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                     a.dp.start_polling(a.bot, handle_signals=False),
                     name=f"telegram:{a._bot_id}",
                 )
-                for a, _ in wired
+                for a, _, _ in wired
             ]
             try:
                 await stop.wait()
-                for a, _ in wired:
+                for a, _, _ in wired:
                     await a.dp.stop_polling()
                 await asyncio.gather(*poll_tasks, return_exceptions=True)
             finally:
-                for a, ibus in wired:
+                for a, ibus, abus in wired:
                     await a.close()
                     await ibus.stop()
+                    await abus.stop()
 
         elif platform == "discord":
             from lyra.adapters.discord import DiscordAdapter
@@ -214,7 +220,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             dc_thread_store = ThreadStore(db_path=vault_dir / "discord.db")
             await dc_thread_store.connect()
 
-            wired_dc: list[tuple[DiscordAdapter, str, Bus[InboundMessage]]] = []
+            wired_dc: list[tuple[DiscordAdapter, str, Bus[InboundMessage], Bus[InboundAudio]]] = []
 
             for bot_cfg in dc_multi_cfg.bots:
                 bot_id = bot_cfg.bot_id
@@ -230,8 +236,14 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 inbound_bus_dc.register(platform_enum)
                 await inbound_bus_dc.start()
 
-                inbound_audio_bus_dc: Bus[InboundAudio] = LocalBus(name="inbound-audio")  # type: ignore[type-arg]
+                inbound_audio_bus_dc: Bus[InboundAudio] = NatsBus(  # type: ignore[type-arg]
+                    nc=nc,
+                    bot_id=bot_id,
+                    item_type=InboundAudio,
+                    subject_prefix="lyra.inbound.audio",
+                )
                 inbound_audio_bus_dc.register(platform_enum)
+                await inbound_audio_bus_dc.start()
 
                 adapter_dc = DiscordAdapter(
                     bot_id=bot_id,
@@ -249,7 +261,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 adapter_dc._outbound_listener = listener_dc
                 await adapter_dc.astart()
 
-                wired_dc.append((adapter_dc, token, inbound_bus_dc))
+                wired_dc.append((adapter_dc, token, inbound_bus_dc, inbound_audio_bus_dc))
                 log.info(
                     "adapter_standalone: Discord bot_id=%s ready (NATS mode)", bot_id
                 )
@@ -269,16 +281,17 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                     a.start(tok),
                     name=f"discord:{a._bot_id}",
                 )
-                for a, tok, _ in wired_dc
+                for a, tok, _, _ in wired_dc
             ]
             try:
                 await stop_dc.wait()
-                for a, _, _ in wired_dc:
+                for a, _, _, _ in wired_dc:
                     await a.close()
                 await asyncio.gather(*start_tasks, return_exceptions=True)
             finally:
-                for _, _, ibus in wired_dc:
+                for _, _, ibus, abus in wired_dc:
                     await ibus.stop()
+                    await abus.stop()
 
         else:
             sys.exit(f"Unknown platform: {platform!r}")

--- a/src/lyra/bootstrap/agent_factory.py
+++ b/src/lyra/bootstrap/agent_factory.py
@@ -8,9 +8,6 @@ import os
 # Re-exported for backward compatibility (tests import these from agent_factory)
 from lyra.bootstrap.bot_agent_map import resolve_bot_agent_map  # noqa: F401
 from lyra.bootstrap.config import LlmConfig
-from lyra.bootstrap.voice_overlay import (
-    apply_agent_stt_overlay as apply_agent_stt_overlay,  # noqa: F401
-)
 from lyra.core.agent import Agent, AgentBase
 from lyra.core.agent_config import SmartRoutingConfig
 from lyra.core.circuit_breaker import CircuitRegistry
@@ -20,8 +17,8 @@ from lyra.core.stores.agent_store import AgentStore
 from lyra.llm.base import LlmProvider
 from lyra.llm.registry import ProviderRegistry
 from lyra.llm.smart_routing import SmartRoutingDecorator
-from lyra.stt import STTService
-from lyra.tts import TTSService
+from lyra.stt import STTProtocol
+from lyra.tts import TtsProtocol
 
 log = logging.getLogger(__name__)
 
@@ -156,8 +153,8 @@ def _create_agent(  # noqa: PLR0913 — factory with optional overrides for each
     cli_pool: CliPool | None,
     circuit_registry: CircuitRegistry | None = None,
     msg_manager: MessageManager | None = None,
-    stt: STTService | None = None,
-    tts: TTSService | None = None,
+    stt: STTProtocol | None = None,
+    tts: TtsProtocol | None = None,
     provider_registry: ProviderRegistry | None = None,
     smart_routing_decorator: SmartRoutingDecorator | None = None,
     agent_store: AgentStore | None = None,
@@ -214,8 +211,8 @@ def _resolve_agents(  # noqa: PLR0913
     cli_pool: CliPool | None,
     circuit_registry: CircuitRegistry,
     msg_manager: MessageManager,
-    stt_service: STTService | None,
-    tts_service: TTSService | None = None,
+    stt_service: STTProtocol | None,
+    tts_service: TtsProtocol | None = None,
     agent_store: AgentStore | None = None,
     llm_cfg: LlmConfig | None = None,
 ) -> dict[str, AgentBase]:

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -34,7 +34,7 @@ from lyra.bootstrap.lifecycle_helpers import (
 )
 from lyra.bootstrap.multibot_stores import open_stores
 from lyra.bootstrap.multibot_wiring import _build_bot_auths
-from lyra.bootstrap.voice_overlay import init_stt, init_tts
+from lyra.bootstrap.voice_overlay import init_nats_stt, init_nats_tts
 from lyra.config import load_multibot_config
 from lyra.core.agent import Agent
 from lyra.core.agent_loader import agent_row_to_config
@@ -42,7 +42,6 @@ from lyra.core.cli_pool import CliPool
 from lyra.core.hub import Hub
 from lyra.core.hub.event_bus import PipelineEventBus
 from lyra.core.hub.outbound_dispatcher import OutboundDispatcher
-from lyra.core.inbound_bus import LocalBus
 from lyra.core.message import InboundAudio, InboundMessage, Platform
 from lyra.core.stores.pairing import PairingManager, set_pairing_manager
 from lyra.nats.nats_bus import NatsBus
@@ -159,8 +158,9 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
     inbound_bus: NatsBus[InboundMessage] = NatsBus(
         nc=nc, bot_id="hub", item_type=InboundMessage
     )
-    # Audio is not routed over NATS in C4 — use a local bus as a no-op sink
-    inbound_audio_bus: LocalBus[InboundAudio] = LocalBus(name="inbound-audio")
+    inbound_audio_bus: NatsBus[InboundAudio] = NatsBus(
+        nc=nc, bot_id="hub", item_type=InboundAudio, subject_prefix="lyra.inbound.audio"
+    )
 
     vault_dir = Path(os.environ.get("LYRA_VAULT_DIR", str(Path.home() / ".lyra")))
     vault_dir.mkdir(parents=True, exist_ok=True)
@@ -254,9 +254,9 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
             await pm.connect()
             set_pairing_manager(pm)
 
-        # STT / TTS services (audio not over NATS in C4, but agent may still need them)
-        stt_service = init_stt(first_agent_config)
-        tts_service = init_tts(stt_service)
+        # STT / TTS via NATS clients (hub talks to voicecli adapters over NATS)
+        stt_service = init_nats_stt(nc)
+        tts_service = init_nats_tts(nc, stt_service)
 
         cli_pool_cfg = _load_cli_pool_config(raw_config)
         hub_cfg = _load_hub_config(raw_config)

--- a/src/lyra/bootstrap/multibot.py
+++ b/src/lyra/bootstrap/multibot.py
@@ -32,7 +32,6 @@ from lyra.bootstrap.multibot_wiring import (
     wire_discord_adapters,
     wire_telegram_adapters,
 )
-# Voice is NATS-only after ADR-039 — multibot mode sets stt/tts to None
 from lyra.config import (
     DiscordMultiConfig,
     TelegramMultiConfig,

--- a/src/lyra/bootstrap/multibot.py
+++ b/src/lyra/bootstrap/multibot.py
@@ -32,7 +32,7 @@ from lyra.bootstrap.multibot_wiring import (
     wire_discord_adapters,
     wire_telegram_adapters,
 )
-from lyra.bootstrap.voice_overlay import init_stt, init_tts
+# Voice is NATS-only after ADR-039 — multibot mode sets stt/tts to None
 from lyra.config import (
     DiscordMultiConfig,
     TelegramMultiConfig,
@@ -149,9 +149,9 @@ async def _bootstrap_multibot(  # noqa: C901, PLR0915 — startup wiring
             await pm.connect()
             set_pairing_manager(pm)
 
-        # STT / TTS services
-        stt_service = init_stt(first_agent_config)
-        tts_service = init_tts(stt_service)
+        # STT / TTS are NATS-only (ADR-039) — multibot mode does not support voice
+        stt_service = None
+        tts_service = None
 
         cli_pool_cfg = _load_cli_pool_config(raw_config)
         hub_cfg = _load_hub_config(raw_config)

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -91,7 +91,7 @@ async def _bootstrap_stt_adapter_standalone(
             finally:
                 Path(tmp_path_str).unlink(missing_ok=True)
 
-        except Exception as exc:
+        except Exception:
             log.exception(
                 "stt_adapter: transcription failed (request_id=%s)",
                 data.get("request_id", "?"),

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -44,9 +44,9 @@ async def _bootstrap_stt_adapter_standalone(
     nc = await nats.connect(nats_url)
     log.info("stt_adapter: connected to NATS at %s", nats_url)
 
-    stt_cfg = load_stt_config()
-    stt_service = STTService(stt_cfg)
-    log.info("stt_adapter: STTService ready (model=%s)", stt_cfg.model_size)
+    base_stt_cfg = load_stt_config()
+    stt_service = STTService(base_stt_cfg)
+    log.info("stt_adapter: STTService ready (model=%s)", base_stt_cfg.model_size)
 
     async def handler(msg: nats.aio.msg.Msg) -> None:
         data: dict = {}
@@ -60,6 +60,20 @@ async def _bootstrap_stt_adapter_standalone(
             audio_bytes = base64.b64decode(audio_b64)
             mime_type = data.get("mime_type", "audio/ogg")
 
+            # Apply per-request STT config overrides from hub (detection params)
+            svc = stt_service
+            overrides: dict = {}
+            for key in (
+                "language_detection_threshold",
+                "language_detection_segments",
+                "language_fallback",
+            ):
+                if data.get(key) is not None:
+                    overrides[key] = data[key]
+            if overrides:
+                cfg = base_stt_cfg.model_copy(update=overrides)
+                svc = STTService(cfg)
+
             suffix = _mime_to_ext(mime_type)
             fd, tmp_path_str = tempfile.mkstemp(suffix=suffix)
             try:
@@ -67,7 +81,7 @@ async def _bootstrap_stt_adapter_standalone(
                 os.close(fd)
                 tmp_path = Path(tmp_path_str)
 
-                result: TranscriptionResult = await stt_service.transcribe(tmp_path)
+                result: TranscriptionResult = await svc.transcribe(tmp_path)
 
                 response = {
                     "request_id": request_id,

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -26,7 +26,7 @@ SUBJECT = "lyra.voice.stt.request"
 QUEUE_GROUP = "stt-workers"
 
 
-async def _bootstrap_stt_adapter_standalone(
+async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
     raw_config: dict,
     *,
     _stop: asyncio.Event | None = None,

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -48,7 +48,7 @@ async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
     stt_service = STTService(base_stt_cfg)
     log.info("stt_adapter: STTService ready (model=%s)", base_stt_cfg.model_size)
 
-    async def handler(msg: nats.aio.msg.Msg) -> None:
+    async def handler(msg) -> None:  # nats.aio.msg.Msg
         data: dict = {}
         response: dict
         try:

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import nats
 
-from lyra.stt import STTConfig, STTService, TranscriptionResult, load_stt_config
+from lyra.stt import STTService, TranscriptionResult, load_stt_config
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +55,8 @@ async def _bootstrap_stt_adapter_standalone(
             data = json.loads(msg.data)
             request_id = data.get("request_id", "unknown")
             audio_b64 = data["audio_b64"]
+            if len(audio_b64) > 10_000_000:
+                raise ValueError("audio payload too large")
             audio_bytes = base64.b64decode(audio_b64)
             mime_type = data.get("mime_type", "audio/ogg")
 
@@ -85,7 +87,7 @@ async def _bootstrap_stt_adapter_standalone(
             response = {
                 "request_id": data.get("request_id", "unknown"),
                 "ok": False,
-                "error": str(exc),
+                "error": "transcription_failed",
             }
 
         if msg.reply:

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -1,0 +1,124 @@
+"""Standalone STT adapter — NATS request-reply wrapper around STTService.
+
+Runs as a separate supervisor process (lyra_stt). Subscribes to
+lyra.voice.stt.request, transcribes audio via voicecli, responds to
+the reply-to inbox. The hub never imports voicecli — this process does.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import signal
+import sys
+import tempfile
+from pathlib import Path
+
+import nats
+
+from lyra.stt import STTConfig, STTService, TranscriptionResult, load_stt_config
+
+log = logging.getLogger(__name__)
+
+SUBJECT = "lyra.voice.stt.request"
+QUEUE_GROUP = "stt-workers"
+
+
+async def _bootstrap_stt_adapter_standalone(
+    raw_config: dict,
+    *,
+    _stop: asyncio.Event | None = None,
+) -> None:
+    """Bootstrap a standalone STT adapter process connected to NATS.
+
+    Args:
+        raw_config: Parsed config dict (lyra config.toml content).
+        _stop: Optional event for graceful shutdown (tests inject this).
+    """
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit("NATS_URL required for standalone STT adapter")
+
+    nc = await nats.connect(nats_url)
+    log.info("stt_adapter: connected to NATS at %s", nats_url)
+
+    stt_cfg = load_stt_config()
+    stt_service = STTService(stt_cfg)
+    log.info("stt_adapter: STTService ready (model=%s)", stt_cfg.model_size)
+
+    async def handler(msg: nats.aio.msg.Msg) -> None:
+        data: dict = {}
+        response: dict
+        try:
+            data = json.loads(msg.data)
+            request_id = data.get("request_id", "unknown")
+            audio_b64 = data["audio_b64"]
+            audio_bytes = base64.b64decode(audio_b64)
+            mime_type = data.get("mime_type", "audio/ogg")
+
+            suffix = _mime_to_ext(mime_type)
+            fd, tmp_path_str = tempfile.mkstemp(suffix=suffix)
+            try:
+                os.write(fd, audio_bytes)
+                os.close(fd)
+                tmp_path = Path(tmp_path_str)
+
+                result: TranscriptionResult = await stt_service.transcribe(tmp_path)
+
+                response = {
+                    "request_id": request_id,
+                    "ok": True,
+                    "text": result.text,
+                    "language": result.language,
+                    "duration_seconds": result.duration_seconds,
+                }
+            finally:
+                Path(tmp_path_str).unlink(missing_ok=True)
+
+        except Exception as exc:
+            log.exception(
+                "stt_adapter: transcription failed (request_id=%s)",
+                data.get("request_id", "?"),
+            )
+            response = {
+                "request_id": data.get("request_id", "unknown"),
+                "ok": False,
+                "error": str(exc),
+            }
+
+        if msg.reply:
+            await nc.publish(
+                msg.reply,
+                json.dumps(response, ensure_ascii=False).encode("utf-8"),
+            )
+
+    sub = await nc.subscribe(SUBJECT, queue=QUEUE_GROUP, cb=handler)
+    log.info("stt_adapter: subscribed to %s (queue=%s)", SUBJECT, QUEUE_GROUP)
+
+    stop = _stop if _stop is not None else asyncio.Event()
+    if _stop is None:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, stop.set)
+
+    await stop.wait()
+    log.info("stt_adapter: shutdown signal received")
+
+    await sub.unsubscribe()
+    await nc.close()
+    log.info("stt_adapter: stopped")
+
+
+def _mime_to_ext(mime_type: str) -> str:
+    """Map a MIME type to a file extension for the temp audio file."""
+    return {
+        "audio/ogg": ".ogg",
+        "audio/mpeg": ".mp3",
+        "audio/mp4": ".m4a",
+        "audio/wav": ".wav",
+        "audio/x-wav": ".wav",
+        "audio/webm": ".webm",
+        "audio/flac": ".flac",
+    }.get(mime_type, ".ogg")

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -55,8 +55,6 @@ async def _bootstrap_stt_adapter_standalone(
             data = json.loads(msg.data)
             request_id = data.get("request_id", "unknown")
             audio_b64 = data["audio_b64"]
-            if len(audio_b64) > 10_000_000:
-                raise ValueError("audio payload too large")
             audio_bytes = base64.b64decode(audio_b64)
             mime_type = data.get("mime_type", "audio/ogg")
 

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -13,6 +13,7 @@ import logging
 import os
 import signal
 import sys
+from dataclasses import dataclass
 
 import nats
 
@@ -22,6 +23,36 @@ log = logging.getLogger(__name__)
 
 SUBJECT = "lyra.voice.tts.request"
 QUEUE_GROUP = "tts-workers"
+
+# Fields the hub serializes from AgentTTSConfig into the NATS request.
+_AGENT_TTS_FIELDS = (
+    "engine", "voice", "language", "accent", "personality", "speed",
+    "emotion", "exaggeration", "cfg_weight", "segment_gap", "crossfade",
+    "chunk_size", "default_language", "languages",
+)
+
+
+@dataclass
+class _NatsTtsConfig:
+    """Lightweight stand-in for AgentTTSConfig — populated from NATS request fields.
+
+    TTSService._build_generate_kwargs uses getattr(agent_tts, field, None) so any
+    object with matching attributes works. This avoids importing the hub-layer type.
+    """
+    engine: str | None = None
+    voice: str | None = None
+    language: str | None = None
+    accent: str | None = None
+    personality: str | None = None
+    speed: float | None = None
+    emotion: str | None = None
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    segment_gap: float | None = None
+    crossfade: float | None = None
+    chunk_size: int | None = None
+    default_language: str | None = None
+    languages: list[str] | None = None
 
 
 async def _bootstrap_tts_adapter_standalone(
@@ -54,13 +85,13 @@ async def _bootstrap_tts_adapter_standalone(
             request_id = data.get("request_id", "unknown")
             text = data["text"]
 
-            # Extract flat TTS kwargs from request.
-            # The adapter does NOT import AgentTTSConfig (hub-layer type).
-            # language, voice, and fallback_language are passed directly to
-            # TTSService.synthesize() which accepts them as explicit overrides.
-            # engine, accent, personality, etc. come from the global TTS config
-            # (env vars) for this first pass — a future enhancement can expose
-            # them as explicit kwargs once TTSService.synthesize() supports them.
+            # Build a lightweight TTS config from the flat NATS request fields.
+            # This mirrors AgentTTSConfig without importing the hub-layer type.
+            tts_config_kwargs = {
+                k: data[k] for k in _AGENT_TTS_FIELDS if data.get(k) is not None
+            }
+            agent_tts = _NatsTtsConfig(**tts_config_kwargs) if tts_config_kwargs else None
+
             synth_kwargs: dict = {}
             for key in ("language", "voice", "fallback_language"):
                 if data.get(key) is not None:
@@ -68,7 +99,7 @@ async def _bootstrap_tts_adapter_standalone(
 
             result: SynthesisResult = await tts_service.synthesize(
                 text,
-                agent_tts=None,
+                agent_tts=agent_tts,
                 **synth_kwargs,
             )
 

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -77,7 +77,7 @@ async def _bootstrap_tts_adapter_standalone(
     tts_service = TTSService(tts_cfg)
     log.info("tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default")
 
-    async def handler(msg: nats.aio.msg.Msg) -> None:
+    async def handler(msg) -> None:  # nats.aio.msg.Msg
         data: dict = {}
         response: dict
         try:
@@ -101,7 +101,7 @@ async def _bootstrap_tts_adapter_standalone(
 
             result: SynthesisResult = await tts_service.synthesize(
                 text,
-                agent_tts=agent_tts,
+                agent_tts=agent_tts,  # type: ignore[arg-type]  # duck-typed stand-in
                 **synth_kwargs,
             )
 

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -16,7 +16,7 @@ import sys
 
 import nats
 
-from lyra.tts import SynthesisResult, TTSConfig, TTSService, load_tts_config
+from lyra.tts import SynthesisResult, TTSService, load_tts_config
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ async def _bootstrap_tts_adapter_standalone(
             response = {
                 "request_id": data.get("request_id", "unknown"),
                 "ok": False,
-                "error": str(exc),
+                "error": "synthesis_failed",
             }
 
         if msg.reply:

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -90,7 +90,9 @@ async def _bootstrap_tts_adapter_standalone(
             tts_config_kwargs = {
                 k: data[k] for k in _AGENT_TTS_FIELDS if data.get(k) is not None
             }
-            agent_tts = _NatsTtsConfig(**tts_config_kwargs) if tts_config_kwargs else None
+            agent_tts = (
+                _NatsTtsConfig(**tts_config_kwargs) if tts_config_kwargs else None
+            )
 
             synth_kwargs: dict = {}
             for key in ("language", "voice", "fallback_language"):
@@ -112,7 +114,7 @@ async def _bootstrap_tts_adapter_standalone(
                 "waveform_b64": result.waveform_b64,
             }
 
-        except Exception as exc:
+        except Exception:
             log.exception(
                 "tts_adapter: synthesis failed (request_id=%s)",
                 data.get("request_id", "?"),

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -1,0 +1,115 @@
+"""Standalone TTS adapter — NATS request-reply wrapper around TTSService.
+
+Runs as a separate supervisor process (lyra_tts). Subscribes to
+lyra.voice.tts.request, synthesizes speech via voicecli, responds to
+the reply-to inbox. The hub never imports voicecli — this process does.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import signal
+import sys
+
+import nats
+
+from lyra.tts import SynthesisResult, TTSConfig, TTSService, load_tts_config
+
+log = logging.getLogger(__name__)
+
+SUBJECT = "lyra.voice.tts.request"
+QUEUE_GROUP = "tts-workers"
+
+
+async def _bootstrap_tts_adapter_standalone(
+    raw_config: dict,
+    *,
+    _stop: asyncio.Event | None = None,
+) -> None:
+    """Bootstrap a standalone TTS adapter process connected to NATS.
+
+    Args:
+        raw_config: Parsed config dict (lyra config.toml content).
+        _stop: Optional event for graceful shutdown (tests inject this).
+    """
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit("NATS_URL required for standalone TTS adapter")
+
+    nc = await nats.connect(nats_url)
+    log.info("tts_adapter: connected to NATS at %s", nats_url)
+
+    tts_cfg = load_tts_config()
+    tts_service = TTSService(tts_cfg)
+    log.info("tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default")
+
+    async def handler(msg: nats.aio.msg.Msg) -> None:
+        data: dict = {}
+        response: dict
+        try:
+            data = json.loads(msg.data)
+            request_id = data.get("request_id", "unknown")
+            text = data["text"]
+
+            # Extract flat TTS kwargs from request.
+            # The adapter does NOT import AgentTTSConfig (hub-layer type).
+            # language, voice, and fallback_language are passed directly to
+            # TTSService.synthesize() which accepts them as explicit overrides.
+            # engine, accent, personality, etc. come from the global TTS config
+            # (env vars) for this first pass — a future enhancement can expose
+            # them as explicit kwargs once TTSService.synthesize() supports them.
+            synth_kwargs: dict = {}
+            for key in ("language", "voice", "fallback_language"):
+                if data.get(key) is not None:
+                    synth_kwargs[key] = data[key]
+
+            result: SynthesisResult = await tts_service.synthesize(
+                text,
+                agent_tts=None,
+                **synth_kwargs,
+            )
+
+            response = {
+                "request_id": request_id,
+                "ok": True,
+                "audio_b64": base64.b64encode(result.audio_bytes).decode("ascii"),
+                "mime_type": result.mime_type,
+                "duration_ms": result.duration_ms,
+                "waveform_b64": result.waveform_b64,
+            }
+
+        except Exception as exc:
+            log.exception(
+                "tts_adapter: synthesis failed (request_id=%s)",
+                data.get("request_id", "?"),
+            )
+            response = {
+                "request_id": data.get("request_id", "unknown"),
+                "ok": False,
+                "error": str(exc),
+            }
+
+        if msg.reply:
+            await nc.publish(
+                msg.reply,
+                json.dumps(response, ensure_ascii=False).encode("utf-8"),
+            )
+
+    sub = await nc.subscribe(SUBJECT, queue=QUEUE_GROUP, cb=handler)
+    log.info("tts_adapter: subscribed to %s (queue=%s)", SUBJECT, QUEUE_GROUP)
+
+    stop = _stop if _stop is not None else asyncio.Event()
+    if _stop is None:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, stop.set)
+
+    await stop.wait()
+    log.info("tts_adapter: shutdown signal received")
+
+    await sub.unsubscribe()
+    await nc.close()
+    log.info("tts_adapter: stopped")

--- a/src/lyra/bootstrap/voice_overlay.py
+++ b/src/lyra/bootstrap/voice_overlay.py
@@ -7,7 +7,7 @@ import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from nats import NATS
+    from nats.aio.client import Client as NATS
 
     from lyra.nats.nats_stt_client import NatsSttClient
     from lyra.nats.nats_tts_client import NatsTtsClient

--- a/src/lyra/bootstrap/voice_overlay.py
+++ b/src/lyra/bootstrap/voice_overlay.py
@@ -1,4 +1,4 @@
-"""Voice overlay helpers — STT config overlay and service initialisation."""
+"""Voice overlay helpers — NATS STT/TTS client initialisation."""
 
 from __future__ import annotations
 
@@ -7,68 +7,33 @@ import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lyra.core.agent_config import Agent
+    from nats import NATS
 
-from lyra.core.agent_config import AgentSTTConfig
-from lyra.stt import STTConfig, STTService, load_stt_config
-from lyra.tts import TTSService, load_tts_config
+    from lyra.nats.nats_stt_client import NatsSttClient
+    from lyra.nats.nats_tts_client import NatsTtsClient
 
 log = logging.getLogger(__name__)
 
 
-def apply_agent_stt_overlay(
-    agent_stt: AgentSTTConfig | None,
-    stt_cfg: STTConfig,
-) -> STTConfig:
-    """Overlay non-None fields from AgentSTTConfig onto STTConfig.
-
-    None fields in agent_stt are skipped — voicecli global defaults remain in effect.
-    Returns an updated STTConfig (via model_copy).
-    """
-    if agent_stt is None:
-        return stt_cfg
-    a = agent_stt
-    updates: dict[str, object] = {}
-    if a.language_detection_threshold is not None:
-        updates["language_detection_threshold"] = a.language_detection_threshold
-    if a.language_detection_segments is not None:
-        updates["language_detection_segments"] = a.language_detection_segments
-    if a.language_fallback is not None:
-        updates["language_fallback"] = a.language_fallback
-    return stt_cfg.model_copy(update=updates) if updates else stt_cfg
-
-
-def init_stt(first_agent_config: "Agent") -> STTService | None:
-    """Initialise STT service if STT_MODEL_SIZE is set."""
+def init_nats_stt(nc: "NATS") -> "NatsSttClient | None":
+    """Initialise NATS STT client if STT_MODEL_SIZE is set."""
     if not os.environ.get("STT_MODEL_SIZE"):
         return None
-    try:
-        agent_stt = first_agent_config.voice.stt if first_agent_config.voice else None
-        stt_cfg = apply_agent_stt_overlay(agent_stt, load_stt_config())
-        stt_service = STTService(stt_cfg)
-        log.info("STT enabled: model=%s (via voiceCLI)", stt_cfg.model_size)
-        return stt_service
-    except ValueError as exc:
-        raise SystemExit(f"Invalid STT configuration: {exc}") from exc
+    from lyra.nats.nats_stt_client import NatsSttClient
+
+    model = os.environ.get("STT_MODEL_SIZE", "large-v3-turbo")
+    client = NatsSttClient(nc=nc, model=model)
+    log.info("STT enabled via NATS (model=%s)", model)
+    return client
 
 
-def init_tts(
-    stt_service: STTService | None,
-) -> TTSService | None:
-    """Initialise TTS service from global env-var defaults.
-
-    Per-agent TTS config is resolved at synthesis time via
-    Hub.dispatch_response() → resolve_binding() → agent.config.voice.tts.
-    """
+def init_nats_tts(nc: "NATS", stt_client: object | None) -> "NatsTtsClient | None":
+    """Initialise NATS TTS client if STT is enabled and voice responses are on."""
     voice_responses = os.environ.get("LYRA_VOICE_RESPONSES", "1") != "0"
-    if stt_service is None or not voice_responses:
+    if stt_client is None or not voice_responses:
         return None
+    from lyra.nats.nats_tts_client import NatsTtsClient
 
-    tts_cfg = load_tts_config()
-    tts_service = TTSService(tts_cfg)
-    log.info(
-        "TTS voice responses enabled (global defaults): engine=%s voice=%s",
-        tts_cfg.engine or "default",
-        tts_cfg.voice or "default",
-    )
-    return tts_service
+    client = NatsTtsClient(nc=nc)
+    log.info("TTS voice responses enabled via NATS")
+    return client

--- a/src/lyra/cli.py
+++ b/src/lyra/cli.py
@@ -102,6 +102,26 @@ def _adapter_discord() -> None:
     _run_adapter("discord")
 
 
+@adapter_app.command("stt")
+def _adapter_stt() -> None:
+    """Start the standalone STT adapter connected to NATS."""
+    from lyra.bootstrap.config import _load_raw_config
+    from lyra.bootstrap.stt_adapter_standalone import _bootstrap_stt_adapter_standalone
+
+    raw_config = _load_raw_config()
+    asyncio.run(_bootstrap_stt_adapter_standalone(raw_config))
+
+
+@adapter_app.command("tts")
+def _adapter_tts() -> None:
+    """Start the standalone TTS adapter connected to NATS."""
+    from lyra.bootstrap.config import _load_raw_config
+    from lyra.bootstrap.tts_adapter_standalone import _bootstrap_tts_adapter_standalone
+
+    raw_config = _load_raw_config()
+    asyncio.run(_bootstrap_tts_adapter_standalone(raw_config))
+
+
 def _run_adapter(platform: str) -> None:
     from lyra.bootstrap.adapter_standalone import _bootstrap_adapter_standalone
     from lyra.bootstrap.config import _load_raw_config

--- a/src/lyra/config/messages.toml
+++ b/src/lyra/config/messages.toml
@@ -7,6 +7,7 @@ timeout           = "Your request timed out. Please try again."
 cancelled         = "Request cancelled."
 stt_noise         = "I couldn't make out your voice message, please try again."
 stt_unsupported   = "Voice messages are not supported — STT is not configured."
+stt_unavailable   = "Voice messages are temporarily unavailable. Please try again later or send a text message."
 stt_failed        = "Sorry, I couldn't transcribe your voice message."
 
 [adapters.telegram.en]
@@ -30,6 +31,7 @@ timeout           = "Ta requête a expiré. Réessaie."
 cancelled         = "Requête annulée."
 stt_noise         = "Je n'ai pas pu comprendre ton message vocal, réessaie."
 stt_unsupported   = "Les messages vocaux ne sont pas pris en charge — STT non configuré."
+stt_unavailable   = "Les messages vocaux sont temporairement indisponibles. Réessaie plus tard ou envoie un message texte."
 stt_failed        = "Désolé, je n'ai pas pu transcrire ton message vocal."
 
 [adapters.telegram.fr]

--- a/src/lyra/core/agent.py
+++ b/src/lyra/core/agent.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
 
-    from lyra.stt import STTService
-    from lyra.tts import TTSService
+    from lyra.stt import STTProtocol
+    from lyra.tts import TtsProtocol
 
     from .memory import MemoryManager
     from .render_events import RenderEvent
@@ -50,8 +50,8 @@ class AgentBase(ABC, SessionManager):
         plugins_dir: Path | None = None,
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
-        stt: "STTService | None" = None,
-        tts: "TTSService | None" = None,
+        stt: "STTProtocol | None" = None,
+        tts: "TtsProtocol | None" = None,
         smart_routing_decorator: Any | None = None,
         compact_context_tokens: int = MODEL_CONTEXT_TOKENS,
         instance_overrides: dict | None = None,

--- a/src/lyra/core/audio_pipeline.py
+++ b/src/lyra/core/audio_pipeline.py
@@ -207,7 +207,7 @@ class AudioPipeline:
                 _content = (
                     self._hub._msg_manager.get("stt_unavailable")
                     if self._hub._msg_manager
-                    else "Voice messages are temporarily unavailable. Please try again later."
+                    else "Voice messages are temporarily unavailable."
                 )
                 await self._dispatch_audio_reply(audio, _content)
                 log.warning("STT adapter unavailable — audio %s dropped", audio.id)
@@ -408,7 +408,7 @@ class AudioPipeline:
                 await self._hub.dispatch_response(msg, Response(content=text))
             else:
                 log.exception(
-                    "TTS synthesis failed for voice response — audio not sent (msg id=%s)",
+                    "TTS synthesis failed — audio not sent (msg id=%s)",
                     msg.id,
                 )
 

--- a/src/lyra/core/audio_pipeline.py
+++ b/src/lyra/core/audio_pipeline.py
@@ -145,7 +145,7 @@ class AudioPipeline:
             finally:
                 self._hub.inbound_audio_bus.task_done()
 
-    async def _process_audio_item(self, audio: InboundAudio) -> None:
+    async def _process_audio_item(self, audio: InboundAudio) -> None:  # noqa: C901, PLR0915
         from ..stt import is_whisper_noise
         from .hub import RoutingKey
 
@@ -313,7 +313,7 @@ class AudioPipeline:
         )
         await self._hub.dispatch_response(synthetic, Response(content=content))
 
-    async def synthesize_and_dispatch_audio(  # noqa: PLR0913
+    async def synthesize_and_dispatch_audio(  # noqa: PLR0913, C901
         self,
         msg: InboundMessage,
         text: str,

--- a/src/lyra/core/audio_pipeline.py
+++ b/src/lyra/core/audio_pipeline.py
@@ -199,7 +199,21 @@ class AudioPipeline:
         )
         try:
             result = await self._hub._stt.transcribe(tmp)
-        finally:
+        except Exception as _transcribe_exc:
+            from ..stt import STTUnavailableError
+
+            tmp.unlink(missing_ok=True)
+            if isinstance(_transcribe_exc, STTUnavailableError):
+                _content = (
+                    self._hub._msg_manager.get("stt_unavailable")
+                    if self._hub._msg_manager
+                    else "Voice messages are temporarily unavailable. Please try again later."
+                )
+                await self._dispatch_audio_reply(audio, _content)
+                log.warning("STT adapter unavailable — audio %s dropped", audio.id)
+                return
+            raise
+        else:
             tmp.unlink(missing_ok=True)
 
         if is_whisper_noise(result.text):
@@ -383,11 +397,20 @@ class AudioPipeline:
                 len(result.audio_bytes),
                 msg.id,
             )
-        except Exception:
-            log.exception(
-                "TTS synthesis failed for voice response — audio not sent (msg id=%s)",
-                msg.id,
-            )
+        except Exception as _tts_exc:
+            from ..tts import TtsUnavailableError
+
+            if isinstance(_tts_exc, TtsUnavailableError):
+                log.warning(
+                    "TTS adapter unavailable — sending text fallback for msg id=%s",
+                    msg.id,
+                )
+                await self._hub.dispatch_response(msg, Response(content=text))
+            else:
+                log.exception(
+                    "TTS synthesis failed for voice response — audio not sent (msg id=%s)",
+                    msg.id,
+                )
 
     @staticmethod
     def _write_temp_audio(data: bytes, suffix: str) -> str:

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -32,8 +32,8 @@ from .pool_manager import PoolManager
 if TYPE_CHECKING:
     from collections import deque
 
-    from ...stt import STTService
-    from ...tts import TTSService
+    from ...stt import STTProtocol
+    from ...tts import TtsProtocol
     from ..circuit_breaker import CircuitRegistry
     from ..cli_pool import CliPool
     from ..memory import MemoryManager
@@ -76,8 +76,8 @@ class Hub(HubOutboundMixin):
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
         pairing_manager: "PairingManager | None" = None,
-        stt: "STTService | None" = None,
-        tts: "TTSService | None" = None,
+        stt: "STTProtocol | None" = None,
+        tts: "TtsProtocol | None" = None,
         debounce_ms: int = 0,
         cancel_on_new_message: bool = False,
         prefs_store: "PrefsStore | None" = None,
@@ -111,8 +111,8 @@ class Hub(HubOutboundMixin):
         self._msg_manager = msg_manager
         self._pairing_manager = pairing_manager
         self._message_index: MessageIndex | None = None
-        self._stt: STTService | None = stt
-        self._tts: TTSService | None = tts
+        self._stt: STTProtocol | None = stt
+        self._tts: TtsProtocol | None = tts
         self._pool_ttl = pool_ttl
         self._debounce_ms = debounce_ms
         self._cancel_on_new_message = cancel_on_new_message

--- a/src/lyra/core/hub/hub_outbound.py
+++ b/src/lyra/core/hub/hub_outbound.py
@@ -21,7 +21,7 @@ from ..render_events import TextRenderEvent
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-    from ...tts import TTSService
+    from ...tts import TtsProtocol
     from ..agent import AgentBase
     from ..agent_config import AgentTTSConfig
     from ..audio_pipeline import AudioPipeline
@@ -53,7 +53,7 @@ class HubOutboundMixin:
         circuit_registry: CircuitRegistry | None
         cli_pool: CliPool | None
         _msg_manager: MessageManager | None
-        _tts: TTSService | None
+        _tts: TtsProtocol | None
         _audio_pipeline: AudioPipeline
         _memory_tasks: set[asyncio.Task]
         _last_processed_at: float | None

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -82,6 +82,11 @@ class NatsBus(Generic[T]):
         item_type: type[T],
         subject_prefix: str = "lyra.inbound",
     ) -> None:
+        if not re.fullmatch(r'[A-Za-z0-9_.\-]+', subject_prefix):
+            raise ValueError(
+                f"Invalid subject_prefix for NATS: {subject_prefix!r} — "
+                "must match [A-Za-z0-9_.\\-]+ (no wildcards or spaces)"
+            )
         self._nc = nc
         self._bot_id = bot_id
         self._item_type = item_type

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -70,12 +70,22 @@ class NatsBus(Generic[T]):
         bot_id: Default bot identifier used when ``register()`` is called
             without an explicit ``bot_id``.
         item_type: Concrete type used for deserialization (e.g. ``InboundMessage``).
+        subject_prefix: NATS subject prefix. Defaults to ``"lyra.inbound"``.
+            Use a different prefix (e.g. ``"lyra.inbound.audio"``) to avoid
+            subject collisions between different message types.
     """
 
-    def __init__(self, nc: NATS, bot_id: str, item_type: type[T]) -> None:
+    def __init__(
+        self,
+        nc: NATS,
+        bot_id: str,
+        item_type: type[T],
+        subject_prefix: str = "lyra.inbound",
+    ) -> None:
         self._nc = nc
         self._bot_id = bot_id
         self._item_type = item_type
+        self._subject_prefix = subject_prefix
         self._registrations: set[tuple[Platform, str]] = set()
         self._subscriptions: dict[tuple[Platform, str], Subscription] = {}
         self._staging: asyncio.Queue[T] = asyncio.Queue(maxsize=500)
@@ -120,7 +130,7 @@ class NatsBus(Generic[T]):
     async def start(self) -> None:
         """Create one NATS subscription per registered (platform, bot_id) pair.
 
-        Subject pattern: ``lyra.inbound.{platform.value}.{bot_id}``
+        Subject pattern: ``{subject_prefix}.{platform.value}.{bot_id}``
 
         No-op if zero registrations exist.
 
@@ -166,7 +176,7 @@ class NatsBus(Generic[T]):
                 f"Platform {platform!r} is not registered — call register() first."
             )
         bid = next((b for p, b in self._registrations if p == platform), self._bot_id)
-        subject = f"lyra.inbound.{platform.value}.{bid}"
+        subject = f"{self._subject_prefix}.{platform.value}.{bid}"
         payload = serialize(item)
         await self._nc.publish(subject, payload)
 
@@ -201,7 +211,7 @@ class NatsBus(Generic[T]):
     async def _make_handler(self, platform: Platform, bot_id: str) -> None:
         """Create NATS subscription for *(platform, bot_id)* and register the handler.
         """
-        subject = f"lyra.inbound.{platform.value}.{bot_id}"
+        subject = f"{self._subject_prefix}.{platform.value}.{bot_id}"
 
         async def handler(msg: Msg) -> None:
             try:

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -1,0 +1,76 @@
+"""NatsSttClient — hub-side NATS request-reply client for STT."""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from pathlib import Path
+from uuid import uuid4
+
+from nats.aio.client import Client as NATS
+
+from lyra.stt import STTUnavailableError, TranscriptionResult
+
+log = logging.getLogger(__name__)
+
+
+class NatsSttClient:
+    SUBJECT = "lyra.voice.stt.request"
+
+    def __init__(
+        self,
+        nc: NATS,
+        *,
+        timeout: float = 60.0,
+        model: str = "large-v3-turbo",
+        language_detection_threshold: float | None = None,
+        language_detection_segments: int | None = None,
+        language_fallback: str | None = None,
+    ) -> None:
+        self._nc = nc
+        self._timeout = timeout
+        self._model = model
+        self._detection_threshold = language_detection_threshold
+        self._detection_segments = language_detection_segments
+        self._detection_fallback = language_fallback
+
+    async def transcribe(self, path: Path | str) -> TranscriptionResult:
+        resolved = Path(path).resolve()
+        audio_bytes = await asyncio.to_thread(resolved.read_bytes)
+        mime = _mime_from_suffix(resolved.suffix)
+        request = {
+            "request_id": str(uuid4()),
+            "audio_b64": base64.b64encode(audio_bytes).decode("ascii"),
+            "mime_type": mime,
+            "model": self._model,
+            "language_detection_threshold": self._detection_threshold,
+            "language_detection_segments": self._detection_segments,
+            "language_fallback": self._detection_fallback,
+        }
+        payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+        try:
+            reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
+        except Exception as exc:
+            raise STTUnavailableError(f"STT adapter unreachable: {exc}") from exc
+        data = json.loads(reply.data)
+        if not data.get("ok"):
+            error_msg = data.get("error", "STT request failed")
+            raise STTUnavailableError(error_msg)
+        return TranscriptionResult(
+            text=data["text"],
+            language=data.get("language", "unknown"),
+            duration_seconds=data.get("duration_seconds", 0.0),
+        )
+
+
+def _mime_from_suffix(suffix: str) -> str:
+    return {
+        ".ogg": "audio/ogg",
+        ".mp3": "audio/mpeg",
+        ".wav": "audio/wav",
+        ".m4a": "audio/mp4",
+        ".webm": "audio/webm",
+        ".flac": "audio/flac",
+        ".opus": "audio/ogg",
+    }.get(suffix.lower(), "audio/ogg")

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -51,12 +51,11 @@ class NatsSttClient:
         payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
         try:
             reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
+            data = json.loads(reply.data)
         except Exception as exc:
             raise STTUnavailableError(f"STT adapter unreachable: {exc}") from exc
-        data = json.loads(reply.data)
         if not data.get("ok"):
-            error_msg = data.get("error", "STT request failed")
-            raise STTUnavailableError(error_msg)
+            raise STTUnavailableError("STT transcription failed")
         return TranscriptionResult(
             text=data["text"],
             language=data.get("language", "unknown"),

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -59,7 +59,8 @@ class NatsSttClient:
         except Exception as exc:
             if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
                 log.error(
-                    "STT request payload too large (%.0f KB) — check NATS max_payload config",
+                    "STT payload too large (%.0f KB)"
+                    " — check NATS max_payload",
                     payload_kb,
                 )
                 raise STTUnavailableError("STT request payload too large") from exc

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -52,8 +52,12 @@ class NatsSttClient:
         try:
             reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
             data = json.loads(reply.data)
+        except TimeoutError as exc:
+            log.warning("STT adapter timeout after %.0fs", self._timeout)
+            raise STTUnavailableError("STT adapter timeout") from exc
         except Exception as exc:
-            raise STTUnavailableError(f"STT adapter unreachable: {exc}") from exc
+            log.warning("STT adapter unreachable: %s: %s", type(exc).__name__, exc)
+            raise STTUnavailableError("STT adapter unreachable") from exc
         if not data.get("ok"):
             raise STTUnavailableError("STT transcription failed")
         return TranscriptionResult(

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class NatsSttClient:
     SUBJECT = "lyra.voice.stt.request"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         nc: NATS,
         *,

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -49,6 +49,7 @@ class NatsSttClient:
             "language_fallback": self._detection_fallback,
         }
         payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+        payload_kb = len(payload) / 1024
         try:
             reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
             data = json.loads(reply.data)
@@ -56,6 +57,12 @@ class NatsSttClient:
             log.warning("STT adapter timeout after %.0fs", self._timeout)
             raise STTUnavailableError("STT adapter timeout") from exc
         except Exception as exc:
+            if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
+                log.error(
+                    "STT request payload too large (%.0f KB) — check NATS max_payload config",
+                    payload_kb,
+                )
+                raise STTUnavailableError("STT request payload too large") from exc
             log.warning("STT adapter unreachable: %s: %s", type(exc).__name__, exc)
             raise STTUnavailableError("STT adapter unreachable") from exc
         if not data.get("ok"):

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -1,0 +1,81 @@
+"""NatsTtsClient — hub-side NATS request-reply client for TTS."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from nats.aio.client import Client as NATS
+
+from lyra.tts import SynthesisResult, TtsUnavailableError
+
+if TYPE_CHECKING:
+    from lyra.core.agent_config import AgentTTSConfig
+
+log = logging.getLogger(__name__)
+
+_TTS_CONFIG_FIELDS = (
+    "engine",
+    "accent",
+    "personality",
+    "speed",
+    "emotion",
+    "exaggeration",
+    "cfg_weight",
+    "segment_gap",
+    "crossfade",
+    "chunk_size",
+)
+
+
+class NatsTtsClient:
+    SUBJECT = "lyra.voice.tts.request"
+
+    def __init__(self, nc: NATS, *, timeout: float = 30.0) -> None:
+        self._nc = nc
+        self._timeout = timeout
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        agent_tts: "AgentTTSConfig | None" = None,
+        language: str | None = None,
+        voice: str | None = None,
+        fallback_language: str | None = None,
+    ) -> SynthesisResult:
+        request: dict = {
+            "request_id": str(uuid4()),
+            "text": text,
+            "language": language,
+            "voice": voice,
+            "fallback_language": fallback_language,
+            "chunked": True,
+        }
+        if agent_tts is not None:
+            for field in _TTS_CONFIG_FIELDS:
+                val = getattr(agent_tts, field, None)
+                if val is not None:
+                    request[field] = val
+            # Also pass language/voice from agent_tts if not overridden by caller
+            if language is None and getattr(agent_tts, "language", None) is not None:
+                request["language"] = agent_tts.language
+            if voice is None and getattr(agent_tts, "voice", None) is not None:
+                request["voice"] = agent_tts.voice
+        payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+        try:
+            reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
+        except Exception as exc:
+            raise TtsUnavailableError(f"TTS adapter unreachable: {exc}") from exc
+        data = json.loads(reply.data)
+        if not data.get("ok"):
+            raise TtsUnavailableError(data.get("error", "TTS request failed"))
+        audio_bytes = base64.b64decode(data["audio_b64"])
+        return SynthesisResult(
+            audio_bytes=audio_bytes,
+            mime_type=data.get("mime_type", "audio/ogg"),
+            duration_ms=data.get("duration_ms"),
+            waveform_b64=data.get("waveform_b64"),
+        )

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -67,11 +67,11 @@ class NatsTtsClient:
         payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
         try:
             reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
+            data = json.loads(reply.data)
         except Exception as exc:
             raise TtsUnavailableError(f"TTS adapter unreachable: {exc}") from exc
-        data = json.loads(reply.data)
         if not data.get("ok"):
-            raise TtsUnavailableError(data.get("error", "TTS request failed"))
+            raise TtsUnavailableError("TTS synthesis failed")
         audio_bytes = base64.b64decode(data["audio_b64"])
         return SynthesisResult(
             audio_bytes=audio_bytes,

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -68,8 +68,12 @@ class NatsTtsClient:
         try:
             reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
             data = json.loads(reply.data)
+        except TimeoutError as exc:
+            log.warning("TTS adapter timeout after %.0fs", self._timeout)
+            raise TtsUnavailableError("TTS adapter timeout") from exc
         except Exception as exc:
-            raise TtsUnavailableError(f"TTS adapter unreachable: {exc}") from exc
+            log.warning("TTS adapter unreachable: %s: %s", type(exc).__name__, exc)
+            raise TtsUnavailableError("TTS adapter unreachable") from exc
         if not data.get("ok"):
             raise TtsUnavailableError("TTS synthesis failed")
         audio_bytes = base64.b64decode(data["audio_b64"])

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -75,7 +75,8 @@ class NatsTtsClient:
         except Exception as exc:
             if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
                 log.error(
-                    "TTS request payload too large (%.0f KB) — check NATS max_payload config",
+                    "TTS payload too large (%.0f KB)"
+                    " — check NATS max_payload",
                     payload_kb,
                 )
                 raise TtsUnavailableError("TTS request payload too large") from exc

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -65,6 +65,7 @@ class NatsTtsClient:
             if voice is None and getattr(agent_tts, "voice", None) is not None:
                 request["voice"] = agent_tts.voice
         payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+        payload_kb = len(payload) / 1024
         try:
             reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
             data = json.loads(reply.data)
@@ -72,6 +73,12 @@ class NatsTtsClient:
             log.warning("TTS adapter timeout after %.0fs", self._timeout)
             raise TtsUnavailableError("TTS adapter timeout") from exc
         except Exception as exc:
+            if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
+                log.error(
+                    "TTS request payload too large (%.0f KB) — check NATS max_payload config",
+                    payload_kb,
+                )
+                raise TtsUnavailableError("TTS request payload too large") from exc
             log.warning("TTS adapter unreachable: %s: %s", type(exc).__name__, exc)
             raise TtsUnavailableError("TTS adapter unreachable") from exc
         if not data.get("ok"):

--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -8,10 +8,21 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class STTProtocol(Protocol):
+    async def transcribe(self, path: Path | str) -> "TranscriptionResult": ...
+
+
+class STTUnavailableError(Exception):
+    """Raised when the STT NATS adapter is unreachable (timeout or connection error)."""
+
 
 WHISPER_NOISE_TOKENS = {"[music]", "[applause]", "[laughter]", "[silence]", "[noise]"}
 _ALLOWED_AUDIO_EXTENSIONS = {".ogg", ".mp3", ".wav", ".m4a", ".webm", ".flac", ".opus"}

--- a/src/lyra/tts/__init__.py
+++ b/src/lyra/tts/__init__.py
@@ -10,13 +10,30 @@ import tempfile
 import wave
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from lyra.core.agent_config import AgentTTSConfig
     from lyra.integrations.base import AudioConverter
+
+
+@runtime_checkable
+class TtsProtocol(Protocol):
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        agent_tts: "AgentTTSConfig | None" = None,
+        language: str | None = None,
+        voice: str | None = None,
+        fallback_language: str | None = None,
+    ) -> "SynthesisResult": ...
+
+
+class TtsUnavailableError(Exception):
+    """Raised when the TTS NATS adapter is unreachable (timeout or connection error)."""
 
 log = logging.getLogger(__name__)
 

--- a/supervisor/conf.d/lyra_stt.conf
+++ b/supervisor/conf.d/lyra_stt.conf
@@ -1,0 +1,17 @@
+[program:lyra_stt]
+command=%(ENV_HOME)s/projects/lyra/supervisor/scripts/run_adapter.sh stt
+directory=%(ENV_HOME)s/projects/lyra
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s"
+autostart=false
+autorestart=true
+startsecs=5
+startretries=3
+stopwaitsecs=75
+stopasgroup=true
+killasgroup=true
+stdout_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_stt.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stderr_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_stt_error.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=3

--- a/supervisor/conf.d/lyra_tts.conf
+++ b/supervisor/conf.d/lyra_tts.conf
@@ -1,0 +1,17 @@
+[program:lyra_tts]
+command=%(ENV_HOME)s/projects/lyra/supervisor/scripts/run_adapter.sh tts
+directory=%(ENV_HOME)s/projects/lyra
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s"
+autostart=false
+autorestart=true
+startsecs=5
+startretries=3
+stopwaitsecs=75
+stopasgroup=true
+killasgroup=true
+stdout_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_tts.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stderr_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_tts_error.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=3

--- a/supervisor/scripts/run_adapter.sh
+++ b/supervisor/scripts/run_adapter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Wrapper for lyra adapter daemon — sources .env before launching.
-# Usage: run_adapter.sh telegram|discord
+# Usage: run_adapter.sh telegram|discord|stt|tts
 set -a
 [ -f "$HOME/projects/lyra/.env" ] && source "$HOME/projects/lyra/.env"
 set +a

--- a/tests/core/test_agent_config_tts_stt.py
+++ b/tests/core/test_agent_config_tts_stt.py
@@ -110,49 +110,6 @@ class TestAgentRowToConfigTTSNewFields:
 
 
 # ---------------------------------------------------------------------------
-# SC-8 -- apply_agent_stt_overlay helper
+# SC-8 -- apply_agent_stt_overlay removed in #518 (ADR-039)
+# STT config overlay is now applied per-request inside stt_adapter_standalone.py
 # ---------------------------------------------------------------------------
-
-
-class TestApplyAgentSTTOverlay:
-    """SC-8 -- apply_agent_stt_overlay merges AgentSTTConfig into STTConfig."""
-
-    def test_none_agent_stt_returns_stt_cfg_unchanged(self):
-        from lyra.bootstrap.agent_factory import apply_agent_stt_overlay
-        from lyra.stt import STTConfig
-
-        stt_cfg = STTConfig(model_size="large-v3-turbo")
-        result = apply_agent_stt_overlay(None, stt_cfg)
-        assert result is stt_cfg
-
-    def test_non_none_fields_overwrite(self):
-        from lyra.bootstrap.agent_factory import apply_agent_stt_overlay
-        from lyra.core.agent_config import AgentSTTConfig
-        from lyra.stt import STTConfig
-
-        stt_cfg = STTConfig(model_size="large-v3-turbo")
-        agent_stt = AgentSTTConfig(
-            language_detection_threshold=0.9,
-            language_fallback="en",
-        )
-        result = apply_agent_stt_overlay(agent_stt, stt_cfg)
-        assert result.language_detection_threshold == 0.9
-        assert result.language_fallback == "en"
-        assert result.language_detection_segments is None  # unchanged
-
-    def test_none_fields_leave_stt_cfg_unchanged(self):
-        from lyra.bootstrap.agent_factory import apply_agent_stt_overlay
-        from lyra.core.agent_config import AgentSTTConfig
-        from lyra.stt import STTConfig
-
-        stt_cfg = STTConfig(
-            model_size="large-v3-turbo",
-            language_detection_threshold=0.8,
-            language_detection_segments=3,
-            language_fallback="fr",
-        )
-        agent_stt = AgentSTTConfig()  # all fields None
-        result = apply_agent_stt_overlay(agent_stt, stt_cfg)
-        assert result.language_detection_threshold == 0.8
-        assert result.language_detection_segments == 3
-        assert result.language_fallback == "fr"

--- a/tests/core/test_pool_tasks.py
+++ b/tests/core/test_pool_tasks.py
@@ -7,7 +7,6 @@ Spec trace: S4-1, S4-2, S4-3, S4-4, S4-5, S4-6, S4-7
 from __future__ import annotations
 
 import asyncio
-import logging
 from unittest.mock import MagicMock
 
 import pytest


### PR DESCRIPTION
## Summary

- Decouple STT/TTS voice processing from the hub into independent NATS adapter processes (`lyra_stt`, `lyra_tts`)
- Wire `InboundAudio` over NATS so voice messages work in three-process production mode (C5)
- Hub never imports voicecli — voice processing runs in separate adapter processes communicating via NATS request-reply

Closes #518

## Changes

### Slice 1: InboundAudio over NATS (C5)
- `NatsBus` gains `subject_prefix` parameter (default: `"lyra.inbound"`)
- Adapter and hub audio buses use `NatsBus[InboundAudio]` with prefix `lyra.inbound.audio`

### Slice 2: Protocol interfaces + NATS clients
- `STTProtocol` / `TtsProtocol` — structural interfaces in `stt/` and `tts/`
- `STTUnavailableError` / `TtsUnavailableError` — domain exceptions
- `NatsSttClient` / `NatsTtsClient` — hub-side NATS request-reply wrappers

### Slice 3: Adapter processes
- `stt_adapter_standalone.py` / `tts_adapter_standalone.py` — NATS subscribe loops wrapping voicecli
- CLI: `lyra adapter stt` / `lyra adapter tts`

### Slice 4: Hub cutover + graceful degradation
- `voice_overlay.py`: `init_nats_stt()` / `init_nats_tts()` replace old init functions
- All type annotations updated: `STTService → STTProtocol`, `TTSService → TtsProtocol`
- STT down → `stt_unavailable` polite reply (distinct from `stt_unsupported`)
- TTS down → text fallback via `dispatch_response()` (not silence)

### Slice 5: Supervisor + Makefile
- `lyra_stt.conf` / `lyra_tts.conf` (reuse `run_adapter.sh stt/tts`)
- `make lyra-stt` / `make lyra-tts` targets; `register` target updated

## Design

See ADR-039: `docs/architecture/adr/039-stt-tts-nats-adapter-decoupling.mdx`

## Test plan

- [ ] Hub starts without voice adapters — text messages work, voice gets `stt_unavailable`
- [ ] Start STT/TTS adapters — voice messages transcribed and answered end-to-end
- [ ] Stop STT adapter mid-session — next voice message gets polite error, text unaffected
- [ ] Stop TTS adapter — voice response falls back to text-only delivery
- [ ] `grep -r "from voicecli\|import voicecli" src/lyra/` — only in `stt/__init__.py` and `tts/__init__.py` (lazy, inside method bodies)
- [ ] `make lyra-stt` / `make lyra-tts` / `make register` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)