### PR TITLE
fix(nats): 8 quick-win hardening fixes from cross-review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,8 @@ DEPLOY_DIR=~/projects/lyra             # project path on the production host
 # LYRA_VAULT_DIR=                       # credential vault dir (default: ~/.lyra)
 # ROXABI_VAULT_DIR=                     # roxabi-vault dir (default: ~/.roxabi-vault)
 
+# --- NATS (standalone hub/adapter mode) ---
+# NATS_URL=nats://localhost:4222          # NATS server URL (required for standalone mode)
+
 # --- NATS authentication (production only) ---
 # NATS_NKEY_SEED_PATH=/etc/nats/nkeys/hub.seed   # path to nkey seed file (unset = no auth, for local dev)

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -32,17 +32,7 @@ _REAPER_INTERVAL_SECONDS = 30
 
 
 class NatsOutboundListener:
-    """Subscribes to NATS outbound subject and dispatches to the platform adapter.
-
-    Three envelope types:
-    - send:       {"type": "send", "stream_id": ..., "outbound": {...}}
-    - attachment: {"type": "attachment", "stream_id": ..., "attachment": {...}}
-    - chunk:      {"stream_id": ..., "seq": N, "event_type": ..., "payload": {...},
-                   "done": bool}
-
-    Inbound message cache: populated by cache_inbound() before push_to_hub_guarded.
-    Used to correlate stream_id → original InboundMessage for reply routing.
-    """
+    """NATS outbound subscriber → adapter dispatch (send/attachment/stream)."""
 
     def __init__(
         self,
@@ -70,10 +60,8 @@ class NatsOutboundListener:
             self._cache.pop(oldest)
             self._cache_ts.pop(oldest, None)
             log.warning(
-                "NatsOutboundListener: _cache full"
-                " (%d), evicted stream_id=%r",
-                _MAX_CACHE_SIZE,
-                oldest,
+                "NatsOutboundListener: _cache full (%d), evicted %r",
+                _MAX_CACHE_SIZE, oldest,
             )
         self._cache[msg.id] = msg
         self._cache_ts[msg.id] = time.monotonic()

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -17,7 +17,7 @@ from lyra.core.message import (
     OutboundMessage,
     Platform,
 )
-from lyra.nats._serialize import deserialize as _deserialize
+from lyra.nats._serialize import deserialize_dict as _deserialize_dict
 
 if TYPE_CHECKING:
     from lyra.core.hub.hub_protocol import ChannelAdapter
@@ -134,9 +134,7 @@ class NatsOutboundListener:
             log.warning("NatsOutboundListener: missing 'outbound' key in send envelope")
             return
         try:
-            outbound = _deserialize(
-                json.dumps(outbound_data).encode("utf-8"), OutboundMessage
-            )
+            outbound = _deserialize_dict(outbound_data, OutboundMessage)
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize outbound message")
             return
@@ -157,9 +155,7 @@ class NatsOutboundListener:
             log.warning("NatsOutboundListener: missing 'attachment' key in envelope")
             return
         try:
-            attachment = _deserialize(
-                json.dumps(attachment_data).encode("utf-8"), OutboundAttachment
-            )
+            attachment = _deserialize_dict(attachment_data, OutboundAttachment)
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize attachment")
             return
@@ -184,8 +180,8 @@ class NatsOutboundListener:
             )
             return
         try:
-            self._stream_outbound[stream_id] = _deserialize(
-                json.dumps(outbound_data).encode("utf-8"), OutboundMessage
+            self._stream_outbound[stream_id] = _deserialize_dict(
+                outbound_data, OutboundMessage
             )
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize stream outbound")

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -17,6 +17,7 @@ from lyra.core.message import (
     OutboundMessage,
     Platform,
 )
+from lyra.nats._serialize import deserialize as _deserialize
 
 if TYPE_CHECKING:
     from lyra.core.hub.hub_protocol import ChannelAdapter
@@ -133,7 +134,9 @@ class NatsOutboundListener:
             log.warning("NatsOutboundListener: missing 'outbound' key in send envelope")
             return
         try:
-            outbound = OutboundMessage(**outbound_data)
+            outbound = _deserialize(
+                json.dumps(outbound_data).encode("utf-8"), OutboundMessage
+            )
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize outbound message")
             return
@@ -154,7 +157,9 @@ class NatsOutboundListener:
             log.warning("NatsOutboundListener: missing 'attachment' key in envelope")
             return
         try:
-            attachment = OutboundAttachment(**attachment_data)
+            attachment = _deserialize(
+                json.dumps(attachment_data).encode("utf-8"), OutboundAttachment
+            )
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize attachment")
             return
@@ -179,7 +184,9 @@ class NatsOutboundListener:
             )
             return
         try:
-            self._stream_outbound[stream_id] = OutboundMessage(**outbound_data)
+            self._stream_outbound[stream_id] = _deserialize(
+                json.dumps(outbound_data).encode("utf-8"), OutboundMessage
+            )
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize stream outbound")
 
@@ -240,7 +247,15 @@ class NatsOutboundListener:
         async def _events():
             expected_seq = 0
             while True:
-                chunk = await q.get()
+                try:
+                    chunk = await asyncio.wait_for(q.get(), timeout=120.0)
+                except TimeoutError:
+                    log.warning(
+                        "NatsOutboundListener: stream timed out waiting for chunk"
+                        " stream_id=%r (120s)",
+                        stream_id,
+                    )
+                    break
                 seq = chunk.get("seq")
                 if seq is not None and seq != expected_seq:
                     log.warning(

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -40,11 +40,25 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
     if not nats_url:
         sys.exit("NATS_URL required for standalone adapter mode")
 
+    async def _nats_error_cb(exc: Exception) -> None:
+        log.error("NATS error: %s", exc)
+
+    async def _nats_disconnected_cb() -> None:
+        log.warning("NATS disconnected — messages will be lost until reconnect")
+
+    async def _nats_reconnected_cb() -> None:
+        log.info("NATS reconnected")
+
     try:
-        nc = await nats_connect(nats_url)
-        log.info("adapter_standalone: connected to NATS at %s", nats_url)
+        nc = await nats_connect(
+            nats_url,
+            error_cb=_nats_error_cb,
+            disconnected_cb=_nats_disconnected_cb,
+            reconnected_cb=_nats_reconnected_cb,
+        )
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
+    log.info("adapter_standalone: connected to NATS at %s", nats_url)
 
     platform_enum = Platform(platform)
 

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -1,11 +1,4 @@
-"""Standalone adapter bootstrap — runs TelegramAdapter or DiscordAdapter as a
-pure NATS client, without a local Hub instance.
-
-Entry point: _bootstrap_adapter_standalone(raw_config, platform)
-
-Used by lyra_telegram and lyra_discord supervisor programs in NATS mode.
-Tokens are read from the encrypted credential store then closed immediately.
-"""
+"""Standalone adapter bootstrap — NATS-connected adapter without local Hub."""
 from __future__ import annotations
 
 import asyncio

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -19,6 +19,7 @@ from lyra.core.bus import Bus
 from lyra.core.message import InboundAudio, InboundMessage, Platform
 from lyra.core.stores.credential_store import CredentialStore, LyraKeyring
 from lyra.nats import nats_connect
+from lyra.nats.connect import scrub_nats_url
 
 log = logging.getLogger(__name__)
 
@@ -40,23 +41,9 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
     if not nats_url:
         sys.exit("NATS_URL required for standalone adapter mode")
 
-    async def _nats_error_cb(exc: Exception) -> None:
-        log.error("NATS error: %s", exc)
-
-    async def _nats_disconnected_cb() -> None:
-        log.warning("NATS disconnected — messages will be lost until reconnect")
-
-    async def _nats_reconnected_cb() -> None:
-        log.info("NATS reconnected")
-
     try:
-        nc = await nats_connect(
-            nats_url,
-            error_cb=_nats_error_cb,
-            disconnected_cb=_nats_disconnected_cb,
-            reconnected_cb=_nats_reconnected_cb,
-        )
-        log.info("adapter_standalone: connected to NATS at %s", nats_url)
+        nc = await nats_connect(nats_url)
+        log.info("adapter_standalone: connected to NATS at %s", scrub_nats_url(nats_url))
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
 

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -56,9 +56,9 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             disconnected_cb=_nats_disconnected_cb,
             reconnected_cb=_nats_reconnected_cb,
         )
+        log.info("adapter_standalone: connected to NATS at %s", nats_url)
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
-    log.info("adapter_standalone: connected to NATS at %s", nats_url)
 
     platform_enum = Platform(platform)
 

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -43,7 +43,10 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
 
     try:
         nc = await nats_connect(nats_url)
-        log.info("adapter_standalone: connected to NATS at %s", scrub_nats_url(nats_url))
+        log.info(
+            "adapter_standalone: connected to NATS at %s",
+            scrub_nats_url(nats_url),
+        )
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
 

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -168,12 +168,12 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
 
-    _early_inbound_bus_cfg = _load_inbound_bus_config(raw_config)
+    inbound_bus_cfg = _load_inbound_bus_config(raw_config)
     inbound_bus: NatsBus[InboundMessage] = NatsBus(
         nc=nc,
         bot_id="hub",
         item_type=InboundMessage,
-        staging_maxsize=_early_inbound_bus_cfg.staging_maxsize,
+        staging_maxsize=inbound_bus_cfg.staging_maxsize,
     )
     inbound_audio_bus: NatsBus[InboundAudio] = NatsBus(
         nc=nc, bot_id="hub", item_type=InboundAudio, subject_prefix="lyra.inbound.audio"
@@ -279,7 +279,6 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
         hub_cfg = _load_hub_config(raw_config)
         pool_cfg = _load_pool_config(raw_config)
         llm_cfg = _load_llm_config(raw_config)
-        inbound_bus_cfg = _load_inbound_bus_config(raw_config)
         debouncer_cfg = _load_debouncer_config(raw_config)
         event_bus_cfg = _load_event_bus_config(raw_config)
         event_bus = PipelineEventBus(maxsize=event_bus_cfg.queue_maxsize)

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -148,14 +148,32 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
 
     _acquire_lockfile()
 
+    async def _nats_error_cb(exc: Exception) -> None:
+        log.error("NATS error: %s", exc)
+
+    async def _nats_disconnected_cb() -> None:
+        log.warning("NATS disconnected — messages will be lost until reconnect")
+
+    async def _nats_reconnected_cb() -> None:
+        log.info("NATS reconnected")
+
     try:
-        nc = await nats_connect(nats_url)
+        nc = await nats_connect(
+            nats_url,
+            error_cb=_nats_error_cb,
+            disconnected_cb=_nats_disconnected_cb,
+            reconnected_cb=_nats_reconnected_cb,
+        )
         log.info("Connected to NATS at %s", nats_url)
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
 
+    _early_inbound_bus_cfg = _load_inbound_bus_config(raw_config)
     inbound_bus: NatsBus[InboundMessage] = NatsBus(
-        nc=nc, bot_id="hub", item_type=InboundMessage
+        nc=nc,
+        bot_id="hub",
+        item_type=InboundMessage,
+        staging_maxsize=_early_inbound_bus_cfg.staging_maxsize,
     )
     inbound_audio_bus: NatsBus[InboundAudio] = NatsBus(
         nc=nc, bot_id="hub", item_type=InboundAudio, subject_prefix="lyra.inbound.audio"

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -43,6 +43,7 @@ from lyra.core.hub.outbound_dispatcher import OutboundDispatcher
 from lyra.core.message import InboundAudio, InboundMessage, Platform
 from lyra.core.stores.pairing import PairingManager, set_pairing_manager
 from lyra.nats import nats_connect
+from lyra.nats.connect import scrub_nats_url
 from lyra.nats.nats_bus import NatsBus
 from lyra.nats.nats_channel_proxy import NatsChannelProxy
 
@@ -148,23 +149,9 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
 
     _acquire_lockfile()
 
-    async def _nats_error_cb(exc: Exception) -> None:
-        log.error("NATS error: %s", exc)
-
-    async def _nats_disconnected_cb() -> None:
-        log.warning("NATS disconnected — messages will be lost until reconnect")
-
-    async def _nats_reconnected_cb() -> None:
-        log.info("NATS reconnected")
-
     try:
-        nc = await nats_connect(
-            nats_url,
-            error_cb=_nats_error_cb,
-            disconnected_cb=_nats_disconnected_cb,
-            reconnected_cb=_nats_reconnected_cb,
-        )
-        log.info("Connected to NATS at %s", nats_url)
+        nc = await nats_connect(nats_url)
+        log.info("Connected to NATS at %s", scrub_nats_url(nats_url))
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {nats_url!r}: {exc}")
 

--- a/src/lyra/nats/_serialize.py
+++ b/src/lyra/nats/_serialize.py
@@ -51,6 +51,15 @@ def deserialize(data: bytes, item_type: type[T]) -> T:
     return _decode(raw, item_type)  # type: ignore[return-value]
 
 
+def deserialize_dict(d: dict[str, Any], item_type: type[T]) -> T:
+    """Reconstruct a dataclass from a pre-parsed dict.
+
+    Same as :func:`deserialize` but skips the JSON parse step — use when
+    the caller already has a ``dict`` (e.g. from a prior ``json.loads``).
+    """
+    return _decode(d, item_type)  # type: ignore[return-value]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -106,8 +115,10 @@ def _get_hints(dc_type: type) -> dict[str, Any]:
     try:
         result = get_type_hints(dc_type, globalns=globalns, localns=localns)
     except Exception:
-        # Final fallback: no type coercion — raw JSON values returned as-is
-        result = {}
+        # Final fallback: no type coercion — raw JSON values returned as-is.
+        # Do NOT cache the empty fallback: a transient resolution failure
+        # should not permanently disable type coercion for this type.
+        return {}
     _hints_cache[dc_type] = result
     return result
 

--- a/src/lyra/nats/_serialize.py
+++ b/src/lyra/nats/_serialize.py
@@ -23,6 +23,7 @@ from typing import Any, TypeVar, get_type_hints
 T = TypeVar("T")
 
 _B64_PREFIX = "b64:"
+_hints_cache: dict[type, dict[str, Any]] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -69,9 +70,17 @@ def _get_hints(dc_type: type) -> dict[str, Any]:
 
     Falls back to explicitly importing known TYPE_CHECKING-only types when
     NameError is raised (e.g. ``CommandContext`` imported under TYPE_CHECKING).
+
+    Results are cached per type to avoid repeated ``get_type_hints`` calls.
     """
+    cached = _hints_cache.get(dc_type)
+    if cached is not None:
+        return cached
+
     try:
-        return get_type_hints(dc_type)
+        result = get_type_hints(dc_type)
+        _hints_cache[dc_type] = result
+        return result
     except NameError:
         pass
 
@@ -95,10 +104,12 @@ def _get_hints(dc_type: type) -> dict[str, Any]:
                 pass
 
     try:
-        return get_type_hints(dc_type, globalns=globalns, localns=localns)
+        result = get_type_hints(dc_type, globalns=globalns, localns=localns)
     except Exception:
         # Final fallback: no type coercion — raw JSON values returned as-is
-        return {}
+        result = {}
+    _hints_cache[dc_type] = result
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +212,9 @@ def _decode_concrete(value: Any, target_type: Any) -> Any:
             return base64.b64decode(value[len(_B64_PREFIX):])
         if isinstance(value, bytes):
             return value
-        return value
+        raise ValueError(
+            f"Expected b64:-prefixed string for bytes field, got {type(value).__name__}"
+        )
 
     # ── Scalar / dict / unknown ───────────────────────────────────────────────
     return value

--- a/src/lyra/nats/connect.py
+++ b/src/lyra/nats/connect.py
@@ -40,13 +40,16 @@ def _read_nkey_seed() -> str | None:
     return seed
 
 
-async def nats_connect(url: str) -> NATS:
+async def nats_connect(url: str, **extra: Any) -> NATS:
     """Connect to NATS, optionally authenticating with an nkey seed.
 
     If NATS_NKEY_SEED_PATH is set, reads the seed file and passes it
     via nkeys_seed_str. If unset, connects without authentication (dev mode).
+
+    Extra keyword arguments (e.g. ``error_cb``, ``disconnected_cb``,
+    ``reconnected_cb``) are forwarded to ``nats.connect()``.
     """
-    kwargs: dict[str, Any] = {}
+    kwargs: dict[str, Any] = dict(extra)
     seed = _read_nkey_seed()
     if seed:
         kwargs["nkeys_seed_str"] = seed

--- a/src/lyra/nats/connect.py
+++ b/src/lyra/nats/connect.py
@@ -40,6 +40,9 @@ def _read_nkey_seed() -> str | None:
     return seed
 
 
+_RESERVED_AUTH_KEYS = frozenset({"nkeys_seed_str", "token", "user", "password", "tls"})
+
+
 async def nats_connect(url: str, **extra: Any) -> NATS:
     """Connect to NATS, optionally authenticating with an nkey seed.
 
@@ -48,7 +51,14 @@ async def nats_connect(url: str, **extra: Any) -> NATS:
 
     Extra keyword arguments (e.g. ``error_cb``, ``disconnected_cb``,
     ``reconnected_cb``) are forwarded to ``nats.connect()``.
+    Auth-related keys (``nkeys_seed_str``, ``token``, ``user``, ``password``,
+    ``tls``) are rejected — authentication is owned exclusively by this helper.
     """
+    bad = _RESERVED_AUTH_KEYS & extra.keys()
+    if bad:
+        raise ValueError(
+            f"nats_connect: auth keys must not be passed via **extra: {bad}"
+        )
     kwargs: dict[str, Any] = dict(extra)
     seed = _read_nkey_seed()
     if seed:

--- a/src/lyra/nats/connect.py
+++ b/src/lyra/nats/connect.py
@@ -7,6 +7,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import nats
 from nats.aio.client import Client as NATS
@@ -43,6 +44,32 @@ def _read_nkey_seed() -> str | None:
 _RESERVED_AUTH_KEYS = frozenset({"nkeys_seed_str", "token", "user", "password", "tls"})
 
 
+def scrub_nats_url(url: str) -> str:
+    """Return *url* with any embedded credentials removed.
+
+    ``nats://user:pass@host:4222`` → ``nats://host:4222``
+    """
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return url
+    clean_netloc = parsed.hostname
+    if parsed.port:
+        clean_netloc += f":{parsed.port}"
+    return urlunparse(parsed._replace(netloc=clean_netloc))
+
+
+async def _default_error_cb(exc: Exception) -> None:
+    log.error("NATS error: %s", exc)
+
+
+async def _default_disconnected_cb() -> None:
+    log.warning("NATS disconnected")
+
+
+async def _default_reconnected_cb() -> None:
+    log.info("NATS reconnected")
+
+
 async def nats_connect(url: str, **extra: Any) -> NATS:
     """Connect to NATS, optionally authenticating with an nkey seed.
 
@@ -59,7 +86,12 @@ async def nats_connect(url: str, **extra: Any) -> NATS:
         raise ValueError(
             f"nats_connect: auth keys must not be passed via **extra: {bad}"
         )
-    kwargs: dict[str, Any] = dict(extra)
+    kwargs: dict[str, Any] = {
+        "error_cb": _default_error_cb,
+        "disconnected_cb": _default_disconnected_cb,
+        "reconnected_cb": _default_reconnected_cb,
+        **extra,
+    }
     seed = _read_nkey_seed()
     if seed:
         kwargs["nkeys_seed_str"] = seed

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -83,6 +83,8 @@ class NatsBus(Generic[T]):
         bot_id: str,
         item_type: type[T],
         subject_prefix: str = "lyra.inbound",
+        *,
+        staging_maxsize: int = 500,
     ) -> None:
         if not re.fullmatch(r'[A-Za-z0-9_.\-]+', subject_prefix):
             raise ValueError(
@@ -95,7 +97,7 @@ class NatsBus(Generic[T]):
         self._subject_prefix = subject_prefix
         self._registrations: set[tuple[Platform, str]] = set()
         self._subscriptions: dict[tuple[Platform, str], Subscription] = {}
-        self._staging: asyncio.Queue[T] = asyncio.Queue(maxsize=500)
+        self._staging: asyncio.Queue[T] = asyncio.Queue(maxsize=staging_maxsize)
 
     # ------------------------------------------------------------------
     # Registration

--- a/tests/core/test_pool_tasks.py
+++ b/tests/core/test_pool_tasks.py
@@ -7,6 +7,7 @@ Spec trace: S4-1, S4-2, S4-3, S4-4, S4-5, S4-6, S4-7
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -205,8 +206,6 @@ class TestPoolTimeout:
         self, fast_pool: Pool, ctx_mock: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Timeout with dead backend logs ERROR distinguishing from normal timeout."""
-        import logging
-
         agent = SlowAgent()
         object.__setattr__(agent, "is_backend_alive", lambda pool_id: False)
         ctx_mock._agents["test_agent"] = agent
@@ -223,8 +222,6 @@ class TestPoolTimeout:
         self, fast_pool: Pool, ctx_mock: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Normal timeout (live backend) does NOT log the dead-backend ERROR."""
-        import logging
-
         agent = SlowAgent()  # is_backend_alive returns True by default
         ctx_mock._agents["test_agent"] = agent
         msg = make_msg()

--- a/tests/nats/test_nats_connect.py
+++ b/tests/nats/test_nats_connect.py
@@ -32,10 +32,12 @@ class TestNatsConnect:
             result = await nats_connect("nats://localhost:4222")
 
             # Assert
-            mock_connect.assert_called_once_with(
-                "nats://localhost:4222",
-                nkeys_seed_str=seed_content,
-            )
+            mock_connect.assert_called_once()
+            call_kwargs = mock_connect.call_args.kwargs
+            assert call_kwargs["nkeys_seed_str"] == seed_content
+            assert "error_cb" in call_kwargs
+            assert "disconnected_cb" in call_kwargs
+            assert "reconnected_cb" in call_kwargs
             assert result is mock_nc
 
     async def test_connect_without_seed(
@@ -54,8 +56,10 @@ class TestNatsConnect:
             result = await nats_connect("nats://localhost:4222")
 
             # Assert — nkeys_seed_str must NOT be present in the call
-            mock_connect.assert_called_once_with("nats://localhost:4222")
-            assert "nkeys_seed_str" not in mock_connect.call_args.kwargs
+            mock_connect.assert_called_once()
+            call_kwargs = mock_connect.call_args.kwargs
+            assert "nkeys_seed_str" not in call_kwargs
+            assert "error_cb" in call_kwargs
             assert result is mock_nc
 
     async def test_connect_missing_file(


### PR DESCRIPTION
## Summary

Applies 8 small, well-scoped fixes to the NATS messaging layer, identified by a cross-review (security, devops, architect).

- **Add NATS client callbacks** (error/disconnect/reconnect logging) to hub + adapter bootstrap
- **Wrap adapter `nats.connect()`** in try/except for clean error on startup failure
- **Add `NATS_URL` to `.env.example`** so fresh deployers don't miss it
- **Make NatsBus staging queue size configurable** — was hardcoded to 500, now accepts `staging_maxsize` param
- **Raise `ValueError` on non-`b64:` bytes** in deserializer — was silent passthrough that corrupted downstream types
- **Cache type hints** in serializer `_get_hints()` — avoids repeated `get_type_hints()` calls under streaming chunk rates
- **Add 120s timeout to `_drain_stream`** — prevents permanent task leaks when hub crashes mid-stream
- **Deserialize `OutboundMessage` via typed codec** — was bare `**dict` unpacking that bypassed type coercion

## Test plan

- [ ] Verify hub starts cleanly with NATS callbacks (check logs for "Connected to NATS")
- [ ] Verify adapter starts cleanly with try/except (kill NATS, start adapter → clean exit message)
- [ ] Verify `_drain_stream` timeout fires after 120s of no chunks (unit test or manual)
- [ ] Verify `OutboundMessage` deserialization handles nested types (content parts, enums)
- [ ] Run full test suite (`pytest`)

Closes #522 (partial — quick wins only)
Refs: #523, #524, #525, #526, #527, #528, #529, #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)