### PR TITLE
fix(nats): sanitize platform_meta at NATS trust boundary

### DIFF
--- a/src/lyra/core/hub/message_pipeline.py
+++ b/src/lyra/core/hub/message_pipeline.py
@@ -322,6 +322,27 @@ class MessagePipeline:
         # Path 2: thread-session-resume.
         thread_session_id: str | None = msg.platform_meta.get("thread_session_id")
         if thread_session_id is not None:
+            # Scope-validate: session must belong to this pool (#525).
+            if self._hub._turn_store is not None:
+                session_pool = await self._hub._turn_store.get_session_pool_id(
+                    thread_session_id
+                )
+                if session_pool is None or session_pool != pool_id:
+                    log.warning(
+                        "thread-session-resume: scope mismatch for %r — "
+                        "expected pool %r, got %r — skipping",
+                        thread_session_id,
+                        pool_id,
+                        session_pool,
+                    )
+                    return ResumeStatus.SKIPPED
+            else:
+                # No TurnStore → cannot validate scope → safe default: skip.
+                log.debug(
+                    "thread-session-resume: no TurnStore — skipping %r",
+                    thread_session_id,
+                )
+                return ResumeStatus.SKIPPED
             if not pool.is_idle:
                 log.info(
                     "thread-session-resume: pool %r busy — skipping %r",
@@ -337,10 +358,7 @@ class MessagePipeline:
             path2_attempted = True
             accepted = await pool.resume_session(thread_session_id)
             if accepted:
-                if self._hub._turn_store is not None:
-                    await self._hub._turn_store.increment_resume_count(
-                        thread_session_id
-                    )
+                await self._hub._turn_store.increment_resume_count(thread_session_id)
                 return ResumeStatus.RESUMED
             log.info(
                 "thread-session-resume: session %r not accepted"

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -163,6 +163,27 @@ class SubmitToPoolMiddleware:
         # Path 2: thread-session-resume.
         thread_session_id: str | None = msg.platform_meta.get("thread_session_id")
         if thread_session_id is not None:
+            # Scope-validate: session must belong to this pool (#525).
+            if hub._turn_store is not None:
+                session_pool = await hub._turn_store.get_session_pool_id(
+                    thread_session_id
+                )
+                if session_pool is None or session_pool != pool_id:
+                    log.warning(
+                        "thread-session-resume: scope mismatch for %r — "
+                        "expected pool %r, got %r — skipping",
+                        thread_session_id,
+                        pool_id,
+                        session_pool,
+                    )
+                    return ResumeStatus.SKIPPED
+            else:
+                # No TurnStore → cannot validate scope → safe default: skip.
+                log.debug(
+                    "thread-session-resume: no TurnStore — skipping %r",
+                    thread_session_id,
+                )
+                return ResumeStatus.SKIPPED
             if not pool.is_idle:
                 log.info(
                     "thread-session-resume: pool %r busy — skipping %r",
@@ -178,8 +199,7 @@ class SubmitToPoolMiddleware:
             path2_attempted = True
             accepted = await pool.resume_session(thread_session_id)
             if accepted:
-                if hub._turn_store is not None:
-                    await hub._turn_store.increment_resume_count(thread_session_id)
+                await hub._turn_store.increment_resume_count(thread_session_id)
                 return ResumeStatus.RESUMED
             log.info(
                 "thread-session-resume: session %r not accepted"

--- a/src/lyra/core/stores/turn_store.py
+++ b/src/lyra/core/stores/turn_store.py
@@ -241,6 +241,25 @@ class TurnStore(SqliteStore):
             log.exception("TurnStore.get_last_session failed (pool=%s)", pool_id)
             return None
 
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        """Return the pool_id for a session, or None if not found.
+
+        Used for scope validation at the NATS trust boundary (#525).
+        """
+        db = self._db_or_raise()
+        try:
+            async with db.execute(
+                "SELECT pool_id FROM pool_sessions WHERE session_id = ?",
+                (session_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else None
+        except Exception:
+            log.exception(
+                "TurnStore.get_session_pool_id failed (session=%s)", session_id
+            )
+            return None
+
     async def _backfill_sessions(self, db) -> None:
         """One-time backfill: derive pool_sessions from conversation_turns.
 

--- a/src/lyra/nats/_sanitize.py
+++ b/src/lyra/nats/_sanitize.py
@@ -1,0 +1,44 @@
+"""Allowlist-based sanitization for platform_meta at the NATS trust boundary.
+
+Strips unknown and underscore-prefixed keys from platform_meta dicts after
+NATS deserialization, preventing session hijacking via crafted messages.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+PLATFORM_META_ALLOWLIST: frozenset[str] = frozenset({
+    "guild_id",
+    "channel_id",
+    "message_id",
+    "thread_id",
+    "channel_type",
+    "chat_id",
+    "topic_id",
+    "is_group",
+    "thread_session_id",
+})
+
+
+def sanitize_platform_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """Filter platform_meta to allowlisted keys only.
+
+    Strips:
+    - Keys not in PLATFORM_META_ALLOWLIST
+    - Keys with leading underscore (internal-only, e.g. _session_update_fn)
+
+    Stripped keys are logged at DEBUG level (key names only, not values).
+    """
+    stripped = [
+        k for k in meta if k not in PLATFORM_META_ALLOWLIST or k.startswith("_")
+    ]
+    if stripped:
+        log.debug("platform_meta: stripped keys %s", stripped)
+    return {
+        k: v
+        for k, v in meta.items()
+        if k in PLATFORM_META_ALLOWLIST and not k.startswith("_")
+    }

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -32,15 +32,17 @@ Multi-bot usage::
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import re
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 
 from lyra.core.message import Platform
+from lyra.nats._sanitize import sanitize_platform_meta
 from lyra.nats._serialize import deserialize, serialize
 
 log = logging.getLogger(__name__)
@@ -221,6 +223,12 @@ class NatsBus(Generic[T]):
         async def handler(msg: Msg) -> None:
             try:
                 item = deserialize(msg.data, self._item_type)
+                if hasattr(item, "platform_meta"):
+                    _item: Any = item
+                    item = dataclasses.replace(
+                        _item,
+                        platform_meta=sanitize_platform_meta(_item.platform_meta),
+                    )
                 self._staging.put_nowait(item)
             except asyncio.QueueFull:
                 log.warning(

--- a/tests/core/test_message_pipeline_context.py
+++ b/tests/core/test_message_pipeline_context.py
@@ -16,8 +16,30 @@ if TYPE_CHECKING:
     from lyra.core.stores.turn_store import TurnStore
 
 # -------------------------------------------------------------------
-# Stub
+# Stubs
 # -------------------------------------------------------------------
+
+
+class _FakeTurnStoreScope:
+    """Minimal TurnStore stub that satisfies scope validation (#525).
+
+    Returns *pool_id* from get_session_pool_id so Path 2 scope-check passes.
+    """
+
+    def __init__(self, pool_id: str) -> None:
+        self._pool_id = pool_id
+
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        return self._pool_id
+
+    async def get_last_session(self, pid: str) -> str | None:
+        return None
+
+    async def increment_resume_count(self, sid: str) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
 
 
 class _StubMessageIndex:
@@ -310,9 +332,14 @@ class TestResolveContextResumeStatus:
         assert status == ResumeStatus.RESUMED
 
     async def test_path2_accepted_returns_resumed(self) -> None:
-        """Path 2 accepted → RESUMED."""
+        """Path 2 accepted → RESUMED.
+
+        TurnStore is required for scope validation (#525): get_session_pool_id
+        must return the pool_id so the check passes before resume is attempted.
+        """
         pool_id = "telegram:main:chat:42"
         hub = _make_hub()
+        hub._turn_store = cast("TurnStore", _FakeTurnStoreScope(pool_id))
         pool = hub.get_or_create_pool(pool_id, "lyra")
 
         async def _fake_resume(sid: str) -> bool:
@@ -330,9 +357,15 @@ class TestResolveContextResumeStatus:
         assert status == ResumeStatus.RESUMED
 
     async def test_path2_rejected_no_path3_returns_fresh(self) -> None:
-        """Path 2 rejected, no TurnStore → FRESH (user must be notified)."""
+        """Path 2 rejected, no further TurnStore path → FRESH (user must be notified).
+
+        Scope validation passes (TurnStore present, pool_id matches), but
+        resume_session returns False — so the result is FRESH with no Path 3
+        rescue possible (get_last_session returns None).
+        """
         pool_id = "telegram:main:chat:42"
         hub = _make_hub()
+        hub._turn_store = cast("TurnStore", _FakeTurnStoreScope(pool_id))
         pool = hub.get_or_create_pool(pool_id, "lyra")
 
         async def _fake_resume(sid: str) -> bool:
@@ -365,6 +398,9 @@ class TestResolveContextResumeStatus:
         pool._session_resume_fn = _fake_resume
 
         class _FakeTurnStore:
+            async def get_session_pool_id(self, session_id: str) -> str | None:
+                return pool_id  # scope validation passes (#525)
+
             async def get_last_session(self, pid: str) -> str | None:
                 return "last-sess"
 
@@ -427,7 +463,7 @@ class TestResolveContextResumeStatus:
         """Path 2 rejected in a group chat → FRESH (no is_group guard since #356).
 
         With user-scoped pool_ids, group chats no longer need is_group guards.
-        Path 2 rejection falls through to Path 3, and without a TurnStore
+        Path 2 rejection falls through to Path 3, and without a last session
         this returns FRESH (user should be notified of fresh start).
         """
         pool_id = "telegram:main:chat:42:user:tg:user:alice"
@@ -438,6 +474,19 @@ class TestResolveContextResumeStatus:
             return False
 
         pool._session_resume_fn = _rejected_resume
+
+        # Wire fake TurnStore so scope validation passes (#525).
+        class _FakeTurnStore:
+            async def get_session_pool_id(self, session_id: str) -> str | None:
+                return pool_id  # scope validation passes
+
+            async def get_last_session(self, pid: str) -> str | None:
+                return None  # no last session → FRESH
+
+            async def increment_resume_count(self, sid: str) -> None:
+                pass
+
+        hub._turn_store = cast("TurnStore", _FakeTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
         # is_group in platform_meta no longer affects the pipeline path since #356
@@ -525,8 +574,14 @@ class TestPath3DeadBackendGuard:
         object.__setattr__(agent, "is_backend_alive", lambda _pool_id: False)
 
         class _FakeTurnStore:
+            async def get_session_pool_id(self, session_id: str) -> str | None:
+                return pool_id  # scope validation passes (#525)
+
             async def get_last_session(self, pid: str) -> str | None:
                 return pool.session_id  # matches pool.session_id exactly
+
+            async def increment_resume_count(self, sid: str) -> None:
+                pass
 
             async def close(self) -> None:
                 pass
@@ -597,6 +652,9 @@ class TestNotifySessionFallthrough:
             return False
 
         pool._session_resume_fn = _rejected_resume
+
+        # Wire fake TurnStore so scope validation passes (#525).
+        hub._turn_store = cast("TurnStore", _FakeTurnStoreScope(pool_id))
 
         _base = make_inbound_message(scope_id="chat:42")
         _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -521,12 +521,23 @@ class TestResolveContextMiddleware:
     async def test_thread_session_accepted_returns_resumed(self) -> None:
         """thread_session_id + accepted → RESUMED."""
         hub = _make_hub()
-        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        pool_id = "telegram:main:chat:42"
+        pool = hub.get_or_create_pool(pool_id, "lyra")
 
         async def _fake_resume(sid: str) -> bool:
             return True
 
         pool._session_resume_fn = _fake_resume  # type: ignore[attr-defined]
+
+        # Wire fake TurnStore so scope validation passes (#525).
+        class _FakeTurnStore:
+            async def get_session_pool_id(self, session_id: str) -> str | None:
+                return pool_id
+
+            async def increment_resume_count(self, sid: str) -> None:
+                pass
+
+        hub._turn_store = _FakeTurnStore()  # type: ignore[assignment]
 
         ctx = PipelineContext(hub=hub)
         mw = SubmitToPoolMiddleware()
@@ -539,14 +550,28 @@ class TestResolveContextMiddleware:
         assert status == ResumeStatus.RESUMED
 
     async def test_thread_session_rejected_returns_fresh(self) -> None:
-        """thread_session_id rejected, no TurnStore → FRESH."""
+        """thread_session_id rejected → FRESH."""
         hub = _make_hub()
-        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        pool_id = "telegram:main:chat:42"
+        pool = hub.get_or_create_pool(pool_id, "lyra")
 
         async def _fake_resume(sid: str) -> bool:
             return False
 
         pool._session_resume_fn = _fake_resume  # type: ignore[attr-defined]
+
+        # Wire fake TurnStore so scope validation passes (#525).
+        class _FakeTurnStore:
+            async def get_session_pool_id(self, session_id: str) -> str | None:
+                return pool_id
+
+            async def get_last_session(self, pid: str) -> str | None:
+                return None
+
+            async def increment_resume_count(self, sid: str) -> None:
+                pass
+
+        hub._turn_store = _FakeTurnStore()  # type: ignore[assignment]
 
         ctx = PipelineContext(hub=hub)
         mw = SubmitToPoolMiddleware()
@@ -634,12 +659,26 @@ class TestNotifySessionFallthroughMiddleware:
         from lyra.core.hub.hub_protocol import RoutingKey
 
         hub = _make_hub()
-        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        pool_id = "telegram:main:chat:42"
+        pool = hub.get_or_create_pool(pool_id, "lyra")
 
         async def _rejected_resume(sid: str) -> bool:
             return False
 
         pool._session_resume_fn = _rejected_resume  # type: ignore[attr-defined]
+
+        # Wire fake TurnStore so scope validation passes (#525).
+        class _FakeTurnStore:
+            async def get_session_pool_id(self, session_id: str) -> str | None:
+                return pool_id
+
+            async def get_last_session(self, pid: str) -> str | None:
+                return None
+
+            async def increment_resume_count(self, sid: str) -> None:
+                pass
+
+        hub._turn_store = _FakeTurnStore()  # type: ignore[assignment]
 
         _base = make_inbound_message(scope_id="chat:42")
         _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -3,7 +3,7 @@
 Covers:
 - sanitize_platform_meta() pure-function behaviour (allowlist, underscore strip,
   debug logging)
-- Path 2 (thread-session-resume) scope validation in SubmitToPoolMiddleware._resolve_context()
+- Path 2 scope validation in SubmitToPoolMiddleware
 """
 
 from __future__ import annotations

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import cast
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from lyra.core.stores.turn_store import TurnStore
 
 import pytest
 
@@ -167,7 +170,7 @@ class TestScopeValidation:
         hub = _make_hub()
         # TurnStore says this session belongs to a *different* pool
         hub._turn_store = cast(
-            "object",
+            "TurnStore",
             _FakeTurnStore({"sess-1": "telegram:main:chat:OTHER"}),
         )
         pool = hub.get_or_create_pool(pool_id, "lyra")
@@ -195,7 +198,7 @@ class TestScopeValidation:
         hub = _make_hub()
         # TurnStore says this session belongs to the *same* pool
         hub._turn_store = cast(
-            "object",
+            "TurnStore",
             _FakeTurnStore({"sess-live": pool_id}),
         )
         pool = hub.get_or_create_pool(pool_id, "lyra")
@@ -229,7 +232,7 @@ class TestScopeValidation:
         hub = _make_hub()
         # TurnStore has no record of this session
         hub._turn_store = cast(
-            "object",
+            "TurnStore",
             _FakeTurnStore({}),  # empty map → None for all session_ids
         )
         pool = hub.get_or_create_pool(pool_id, "lyra")
@@ -285,7 +288,7 @@ class TestScopeValidation:
         hub = _make_hub()
         # Even with a TurnStore wired, Path 2 must not fire
         hub._turn_store = cast(
-            "object",
+            "TurnStore",
             _FakeTurnStore({}),
         )
         pool = hub.get_or_create_pool(pool_id, "lyra")
@@ -307,7 +310,7 @@ class TestScopeValidation:
         pool_id = "telegram:main:chat:42"
         hub = _make_hub()
         hub._turn_store = cast(
-            "object",
+            "TurnStore",
             _FakeTurnStore({"sess-cross": "telegram:main:chat:DIFFERENT"}),
         )
         pool = hub.get_or_create_pool(pool_id, "lyra")

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 import dataclasses
 import logging
 from typing import cast
-from unittest.mock import patch
 
 import pytest
 
-from lyra.core.hub.message_pipeline import Action, ResumeStatus
+from lyra.core.hub.message_pipeline import ResumeStatus
 from lyra.core.hub.middleware import PipelineContext
 from lyra.core.hub.middleware_submit import SubmitToPoolMiddleware
 from lyra.nats._sanitize import PLATFORM_META_ALLOWLIST, sanitize_platform_meta
@@ -101,7 +100,9 @@ class TestSanitizePlatformMeta:
         # Assert
         assert result == {}
 
-    def test_stripped_keys_logged_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_stripped_keys_logged_at_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Stripped key names appear in a DEBUG log record."""
         # Arrange
         meta = {"chat_id": 1, "evil_key": "x", "_internal": "y"}
@@ -115,7 +116,9 @@ class TestSanitizePlatformMeta:
         assert "evil_key" in debug_messages
         assert "_internal" in debug_messages
 
-    def test_no_log_when_nothing_stripped(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_no_log_when_nothing_stripped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """No log is emitted when all keys are allowlisted (no stripping needed)."""
         # Arrange
         meta = {"chat_id": 1, "is_group": False}
@@ -158,7 +161,7 @@ class TestScopeValidation:
     async def test_cross_scope_thread_session_id_rejected(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """session registered to pool_A but message arrives at pool_B → SKIPPED + warning."""
+        """Cross-scope session → SKIPPED + warning."""
         # Arrange
         pool_id = "telegram:main:chat:99"
         hub = _make_hub()

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -84,7 +84,7 @@ class TestSanitizePlatformMeta:
         """All 9 keys in PLATFORM_META_ALLOWLIST survive sanitization."""
         # Arrange — build a meta dict with every allowlisted key
         meta = {k: f"val_{k}" for k in PLATFORM_META_ALLOWLIST}
-        assert len(meta) == 9, "allowlist must have exactly 9 keys"
+        assert len(meta) == len(PLATFORM_META_ALLOWLIST)
 
         # Act
         result = sanitize_platform_meta(meta)
@@ -151,6 +151,83 @@ class TestSanitizePlatformMeta:
         assert result["is_group"] is True
         assert result["thread_session_id"] == "sess-abc"
         assert "unknown_field" not in result
+
+
+# ---------------------------------------------------------------------------
+# TestNatsBusSanitization — handler-level integration
+# ---------------------------------------------------------------------------
+
+
+class TestNatsBusSanitization:
+    """Verify sanitization fires inside the NatsBus handler closure."""
+
+    def test_inbound_audio_sanitized(self) -> None:
+        """InboundAudio platform_meta is sanitized like InboundMessage."""
+        from datetime import datetime, timezone
+
+        from lyra.core.message import InboundAudio, Platform
+        from lyra.core.trust import TrustLevel
+
+        audio = InboundAudio(
+            id="audio-1",
+            platform=Platform.DISCORD.value,
+            bot_id="main",
+            scope_id="channel:1",
+            user_id="user:1",
+            audio_bytes=b"fake",
+            mime_type="audio/ogg",
+            duration_ms=1000,
+            file_id=None,
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.PUBLIC,
+            platform_meta={
+                "guild_id": 1,
+                "channel_id": 2,
+                "message_id": 3,
+                "_evil": "x",
+                "injected": "y",
+            },
+        )
+        result = sanitize_platform_meta(audio.platform_meta)
+        assert "guild_id" in result
+        assert "channel_id" in result
+        assert "message_id" in result
+        assert "_evil" not in result
+        assert "injected" not in result
+
+    def test_handler_sanitizes_platform_meta(self) -> None:
+        """NatsBus handler strips unknown keys via dataclasses.replace."""
+        from lyra.core.message import InboundMessage, Platform
+        from lyra.core.trust import TrustLevel
+        from lyra.nats._serialize import deserialize, serialize
+
+        msg = InboundMessage(
+            id="msg-1",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="chat:42",
+            user_id="user:1",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            trust_level=TrustLevel.PUBLIC,
+            platform_meta={
+                "chat_id": 123,
+                "is_group": False,
+                "evil_key": "should_vanish",
+            },
+        )
+        # Simulate the handler: serialize → deserialize → sanitize
+        raw = serialize(msg)
+        item = deserialize(raw, InboundMessage)
+        assert "evil_key" in item.platform_meta
+        cleaned = dataclasses.replace(
+            item,
+            platform_meta=sanitize_platform_meta(item.platform_meta),
+        )
+        assert "evil_key" not in cleaned.platform_meta
+        assert cleaned.platform_meta["chat_id"] == 123
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -1,0 +1,334 @@
+"""Tests for platform_meta sanitization and scope validation (issue #525).
+
+Covers:
+- sanitize_platform_meta() pure-function behaviour (allowlist, underscore strip,
+  debug logging)
+- Path 2 (thread-session-resume) scope validation in SubmitToPoolMiddleware._resolve_context()
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from lyra.core.hub.message_pipeline import Action, ResumeStatus
+from lyra.core.hub.middleware import PipelineContext
+from lyra.core.hub.middleware_submit import SubmitToPoolMiddleware
+from lyra.nats._sanitize import PLATFORM_META_ALLOWLIST, sanitize_platform_meta
+from tests.core.conftest import _make_hub, make_inbound_message
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTurnStore:
+    """Minimal TurnStore stub for scope-validation tests.
+
+    Callers configure *session_map* to control what get_session_pool_id returns.
+    """
+
+    def __init__(self, session_map: dict[str, str | None] | None = None) -> None:
+        self._session_map: dict[str, str | None] = session_map or {}
+
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        return self._session_map.get(session_id)
+
+    async def get_last_session(self, pid: str) -> str | None:
+        return None
+
+    async def increment_resume_count(self, sid: str) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# TestSanitizePlatformMeta — pure-function tests (no async needed)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizePlatformMeta:
+    def test_unknown_keys_stripped(self) -> None:
+        """Unknown keys are stripped; allowlisted keys are preserved."""
+        # Arrange
+        meta = {"chat_id": 1, "evil_key": "x"}
+
+        # Act
+        result = sanitize_platform_meta(meta)
+
+        # Assert
+        assert "evil_key" not in result
+        assert result["chat_id"] == 1
+
+    def test_underscore_keys_stripped(self) -> None:
+        """Keys with a leading underscore are stripped unconditionally."""
+        # Arrange
+        meta = {"chat_id": 1, "_internal": "secret"}
+
+        # Act
+        result = sanitize_platform_meta(meta)
+
+        # Assert
+        assert "_internal" not in result
+        assert result["chat_id"] == 1
+
+    def test_all_9_allowlisted_keys_preserved(self) -> None:
+        """All 9 keys in PLATFORM_META_ALLOWLIST survive sanitization."""
+        # Arrange — build a meta dict with every allowlisted key
+        meta = {k: f"val_{k}" for k in PLATFORM_META_ALLOWLIST}
+        assert len(meta) == 9, "allowlist must have exactly 9 keys"
+
+        # Act
+        result = sanitize_platform_meta(meta)
+
+        # Assert — all 9 keys present, no extras
+        assert set(result.keys()) == PLATFORM_META_ALLOWLIST
+
+    def test_empty_dict_unchanged(self) -> None:
+        """An empty dict passes through as an empty dict."""
+        # Arrange
+        meta: dict = {}
+
+        # Act
+        result = sanitize_platform_meta(meta)
+
+        # Assert
+        assert result == {}
+
+    def test_stripped_keys_logged_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Stripped key names appear in a DEBUG log record."""
+        # Arrange
+        meta = {"chat_id": 1, "evil_key": "x", "_internal": "y"}
+
+        # Act
+        with caplog.at_level(logging.DEBUG, logger="lyra.nats._sanitize"):
+            sanitize_platform_meta(meta)
+
+        # Assert — at least one debug record mentions the stripped keys
+        debug_messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "evil_key" in debug_messages
+        assert "_internal" in debug_messages
+
+    def test_no_log_when_nothing_stripped(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No log is emitted when all keys are allowlisted (no stripping needed)."""
+        # Arrange
+        meta = {"chat_id": 1, "is_group": False}
+
+        # Act
+        with caplog.at_level(logging.DEBUG, logger="lyra.nats._sanitize"):
+            sanitize_platform_meta(meta)
+
+        # Assert — no debug records emitted
+        assert caplog.records == []
+
+    def test_allowlist_values_preserved_exactly(self) -> None:
+        """Values of allowlisted keys are returned verbatim."""
+        # Arrange
+        meta = {
+            "chat_id": 42,
+            "is_group": True,
+            "thread_session_id": "sess-abc",
+            "unknown_field": "should_vanish",
+        }
+
+        # Act
+        result = sanitize_platform_meta(meta)
+
+        # Assert
+        assert result["chat_id"] == 42
+        assert result["is_group"] is True
+        assert result["thread_session_id"] == "sess-abc"
+        assert "unknown_field" not in result
+
+
+# ---------------------------------------------------------------------------
+# TestScopeValidation — Path 2 scope-check in SubmitToPoolMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestScopeValidation:
+    """_resolve_context Path 2 rejects thread_session_id from wrong pool."""
+
+    async def test_cross_scope_thread_session_id_rejected(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """session registered to pool_A but message arrives at pool_B → SKIPPED + warning."""
+        # Arrange
+        pool_id = "telegram:main:chat:99"
+        hub = _make_hub()
+        # TurnStore says this session belongs to a *different* pool
+        hub._turn_store = cast(
+            "object",
+            _FakeTurnStore({"sess-1": "telegram:main:chat:OTHER"}),
+        )
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(hub=hub)
+
+        _base = make_inbound_message(scope_id="chat:99")
+        msg = dataclasses.replace(
+            _base, platform_meta={**_base.platform_meta, "thread_session_id": "sess-1"}
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="lyra.core.hub.middleware_submit"):
+            status = await mw._resolve_context(msg, pool, pool_id, ctx)
+
+        # Assert
+        assert status == ResumeStatus.SKIPPED
+        warning_text = " ".join(r.getMessage() for r in caplog.records)
+        assert "scope mismatch" in warning_text
+
+    async def test_same_scope_thread_session_id_accepted(self) -> None:
+        """session registered to the same pool → resume is attempted and RESUMED."""
+        # Arrange
+        pool_id = "telegram:main:chat:42"
+        hub = _make_hub()
+        # TurnStore says this session belongs to the *same* pool
+        hub._turn_store = cast(
+            "object",
+            _FakeTurnStore({"sess-live": pool_id}),
+        )
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+
+        async def _accepted_resume(sid: str) -> bool:
+            return True
+
+        pool._session_resume_fn = _accepted_resume  # type: ignore[attr-defined]
+
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(hub=hub)
+
+        _base = make_inbound_message(scope_id="chat:42")
+        msg = dataclasses.replace(
+            _base,
+            platform_meta={**_base.platform_meta, "thread_session_id": "sess-live"},
+        )
+
+        # Act
+        status = await mw._resolve_context(msg, pool, pool_id, ctx)
+
+        # Assert
+        assert status == ResumeStatus.RESUMED
+
+    async def test_unknown_session_id_rejected(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """get_session_pool_id returns None (unknown session) → SKIPPED + warning."""
+        # Arrange
+        pool_id = "telegram:main:chat:42"
+        hub = _make_hub()
+        # TurnStore has no record of this session
+        hub._turn_store = cast(
+            "object",
+            _FakeTurnStore({}),  # empty map → None for all session_ids
+        )
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(hub=hub)
+
+        _base = make_inbound_message(scope_id="chat:42")
+        msg = dataclasses.replace(
+            _base,
+            platform_meta={**_base.platform_meta, "thread_session_id": "sess-ghost"},
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="lyra.core.hub.middleware_submit"):
+            status = await mw._resolve_context(msg, pool, pool_id, ctx)
+
+        # Assert
+        assert status == ResumeStatus.SKIPPED
+        warning_text = " ".join(r.getMessage() for r in caplog.records)
+        assert "scope mismatch" in warning_text
+
+    async def test_no_turn_store_skips_path2(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No TurnStore → cannot validate scope → SKIPPED (safe default)."""
+        # Arrange
+        pool_id = "telegram:main:chat:42"
+        hub = _make_hub()
+        assert hub._turn_store is None
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(hub=hub)
+
+        _base = make_inbound_message(scope_id="chat:42")
+        msg = dataclasses.replace(
+            _base,
+            platform_meta={**_base.platform_meta, "thread_session_id": "sess-any"},
+        )
+
+        # Act
+        with caplog.at_level(logging.DEBUG, logger="lyra.core.hub.middleware_submit"):
+            status = await mw._resolve_context(msg, pool, pool_id, ctx)
+
+        # Assert
+        assert status == ResumeStatus.SKIPPED
+        debug_text = " ".join(r.getMessage() for r in caplog.records)
+        assert "no TurnStore" in debug_text
+
+    async def test_path2_not_triggered_without_thread_session_id(self) -> None:
+        """When thread_session_id is absent, scope validation is never consulted."""
+        # Arrange
+        pool_id = "telegram:main:chat:42"
+        hub = _make_hub()
+        # Even with a TurnStore wired, Path 2 must not fire
+        hub._turn_store = cast(
+            "object",
+            _FakeTurnStore({}),
+        )
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(hub=hub)
+
+        msg = make_inbound_message(scope_id="chat:42")
+        assert msg.platform_meta.get("thread_session_id") is None
+
+        # Act
+        status = await mw._resolve_context(msg, pool, pool_id, ctx)
+
+        # Assert — no thread_session_id means Path 2 is skipped entirely
+        assert status == ResumeStatus.SKIPPED
+
+    async def test_cross_scope_does_not_resume_session(self) -> None:
+        """A cross-scope session must never call pool.resume_session."""
+        # Arrange
+        pool_id = "telegram:main:chat:42"
+        hub = _make_hub()
+        hub._turn_store = cast(
+            "object",
+            _FakeTurnStore({"sess-cross": "telegram:main:chat:DIFFERENT"}),
+        )
+        pool = hub.get_or_create_pool(pool_id, "lyra")
+
+        resume_called: list[str] = []
+
+        async def _track_resume(sid: str) -> bool:
+            resume_called.append(sid)
+            return True
+
+        pool._session_resume_fn = _track_resume  # type: ignore[attr-defined]
+
+        mw = SubmitToPoolMiddleware()
+        ctx = PipelineContext(hub=hub)
+
+        _base = make_inbound_message(scope_id="chat:42")
+        msg = dataclasses.replace(
+            _base,
+            platform_meta={**_base.platform_meta, "thread_session_id": "sess-cross"},
+        )
+
+        # Act
+        status = await mw._resolve_context(msg, pool, pool_id, ctx)
+
+        # Assert — SKIPPED and resume was never called
+        assert status == ResumeStatus.SKIPPED
+        assert resume_called == []


### PR DESCRIPTION
## Summary

Closes #525.

- **Allowlist sanitization** at NATS ingress boundary (`nats_bus.py` handler): only 9 known adapter keys pass through `platform_meta`; unknown and underscore-prefixed keys are stripped
- **Scope validation** for `thread_session_id`: before Path 2 session resume, look up the session's `pool_id` from `TurnStore.pool_sessions` and compare with the inbound message's `pool_id` — mismatch or unknown session skips Path 2 with a warning
- New `sanitize_platform_meta()` in `nats/_sanitize.py` with `PLATFORM_META_ALLOWLIST` (9 keys)
- New `TurnStore.get_session_pool_id()` method for session→pool lookup
- Scope validation applied in both `middleware_submit.py` and `message_pipeline.py` Path 2 blocks
- 13 new tests covering sanitization and scope validation
- Updated 4 existing tests to wire `FakeTurnStore` stubs for scope validation

## Test plan

- [ ] `python -m pytest tests/nats/test_sanitize.py -v` — 13 tests pass
- [ ] `python -m pytest tests/core/test_middleware.py -v` — all pass
- [ ] `python -m pytest tests/core/test_message_pipeline_context.py -v` — all pass
- [ ] `python -m pytest tests/nats/test_nats_bus.py -v` — existing round-trip tests unchanged
- [ ] Verify crafted NATS message with unknown `platform_meta` keys → keys stripped
- [ ] Verify cross-scope `thread_session_id` injection → Path 2 skipped with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)