### PR TITLE
feat(nats): add schema_version to wire format (#530)

### DIFF
--- a/artifacts/frames/530-nats-message-versioning-frame.mdx
+++ b/artifacts/frames/530-nats-message-versioning-frame.mdx
@@ -1,0 +1,133 @@
+---
+title: Add message versioning to NATS wire format
+issue: 530
+status: approved
+tier: F-lite
+date: 2026-04-05
+---
+
+## Problem
+
+Lyra runs as three separate processes (`lyra_hub`, `lyra_telegram`,
+`lyra_discord`) that communicate exclusively over NATS using JSON-encoded
+dataclasses (`InboundMessage`, `InboundAudio`, `OutboundMessage`, and the
+render-event stream). The wire format has **no version field**.
+
+Today, the serializer in `src/lyra/nats/_serialize.py` is lenient on missing
+fields (`_decode_dataclass` falls through to dataclass defaults at line 272),
+so **additive** schema changes degrade gracefully — a v2 receiver reading a v1
+payload just sees the new field at its default.
+
+**Breaking** schema changes (renaming a field, changing a type, removing a
+field, semantic shifts) are a different story: they require the hub and both
+adapter processes to be redeployed **simultaneously**, because a mismatched
+producer/consumer pair will silently misinterpret the payload with zero signal
+in logs or metrics. The existing `handler` error path in `nats_bus.py:242`
+only catches `deserialize` exceptions — it doesn't notice when JSON decodes
+cleanly but the fields mean something different than the receiver expects.
+
+The immediate goal is not to *enable* rolling deploys across breaking changes
+(that still requires coordination), but to make the failure mode **explicit
+and loud** when someone forgets to coordinate: the receiver should detect the
+mismatch, drop the message, log an ERROR, and emit a metric — not silently
+proceed with corrupt data.
+
+## Who
+
+- **Primary:** Lyra maintainers deploying schema changes across the
+  hub + adapter boundary. Today this means anyone touching `core/message.py`,
+  `core/render_events.py`, or the NATS serializer.
+- **Secondary:** Future contributors evolving the wire format who need a
+  ratchet to signal "this change is breaking — bump the version."
+- **Secondary:** On-call — a clear `schema_version mismatch` log line points
+  directly at a botched deploy instead of a vague "messages disappeared."
+
+## Constraints
+
+- **Backwards compatible on the wire.** Legacy (unversioned) payloads must
+  still decode — `schema_version` defaults to `1` when absent, and existing
+  NATS messages in flight during the rollout must not be dropped.
+- **One field, per envelope.** Each top-level NATS envelope dataclass carries
+  its own `schema_version: int = 1`. No shared wrapper envelope (preserves the
+  current `_serialize.py` contract; minimizes diff surface).
+- **Field name: `schema_version`.** Not `version` — avoids ambiguity with
+  potential domain fields and is self-documenting at the JSON-dump level.
+- **Localized version constants.** Each envelope module exposes a
+  module-level `SCHEMA_VERSION_<ENVELOPE>` constant (e.g.
+  `SCHEMA_VERSION_INBOUND_MESSAGE = 1` in `core/message.py`). Bumping a
+  version is a single-line edit.
+- **Forward-compat rule: `payload.schema_version <= receiver.known`.**
+  A receiver accepts any version ≤ its own known version (old → new is fine,
+  since additive fields already degrade). It **drops strictly greater**
+  versions with an ERROR log and a metric increment.
+- **Reuse existing error path.** Mismatch handling lives inside the
+  `deserialize` → `handler` path in `nats_bus.py` and `render_event_codec.py`
+  — same drop-and-log pattern already used for decode failures. No new
+  top-level error plumbing.
+- **Scope: Lyra hub↔adapter envelopes only.** `InboundMessage`,
+  `InboundAudio`, `OutboundMessage`, and the render-event payloads
+  (`TextRenderEvent`, `ToolSummaryRenderEvent`). TTS/STT client messages
+  (`nats_tts_client.py`, `nats_stt_client.py`) live across the voiceCLI
+  boundary and are versioned separately by that repo.
+- **Observability.** Each drop emits a log line with
+  `(platform, bot_id, envelope_type, payload_version, receiver_version)` and
+  increments a counter metric (via whatever metrics plumbing already exists
+  in the adapter/hub process).
+
+## Out of Scope
+
+- **Rolling deploys across breaking changes.** Coordinated deploy is still
+  required; versioning only surfaces failures faster. A future issue may
+  introduce dual-reader support, but not this frame.
+- **Chunk-envelope versioning.** The hand-rolled wrapper in
+  `render_event_codec.py` (`{stream_id, seq, event_type, payload, done}`) is
+  itself an implicit schema. This frame versions the inner payload only.
+  Chunk-wrapper evolution is a separate concern.
+- **NATS subject-pattern versioning.** The subject layout
+  (`lyra.inbound.<platform>.<bot_id>`) is also schema; this frame does not
+  touch it.
+- **TTS/STT wire format.** Owned by voiceCLI; out of scope.
+- **Schema registry / migration tooling.** No central registry, no migration
+  scripts. Bumping is a manual integer increment tied to a code change.
+- **Version negotiation / downgrade.** No handshake, no "fall back to v1"
+  logic — fail fast is the policy.
+- **Shared wrapper envelope migration.** Not a refactor of the serializer to
+  introduce `{v, type, payload}` wrapping. If we ever want that, this
+  frame's `schema_version` field is the ratchet that makes the migration
+  safe.
+
+## Complexity
+
+**Tier: F-lite** — Clear scope, single domain (NATS wire format), no new
+architectural patterns, no unknowns. Touches ~6–8 files across `core/` and
+`nats/`, all in one layer. Benefits from a spec gate so the forward-compat
+rule, field naming, and the `ToolSummaryRenderEvent` manual-decode landmine
+are reviewed before implementation.
+
+Signals observed:
+- Single domain (NATS wire serialization)
+- ~6–8 files in one layer: `core/message.py`, `core/render_events.py`,
+  `nats/_serialize.py` (minor), `nats/nats_bus.py` (version-check helper),
+  `nats/render_event_codec.py` (manual decode path), plus tests
+- No new runtime paths beyond a single version-check branch in the decode
+  helper
+- No architectural unknowns — dataclass defaults already provide the
+  backward-read story; only the forward-read (v1 reads v2) needs a new
+  check
+- Issue complexity label = 3; P3-low urgency
+- One known landmine (`ToolSummaryRenderEvent` manual decoder) needs
+  explicit handling in the spec
+
+## Notes for Spec
+
+- Confirm whether `schema_version` should be `int` or `str` (recommend `int`
+  — cheaper to compare, no parsing).
+- Decide whether the check runs inside `_serialize.deserialize()` (centralized)
+  or in each consumer (`nats_bus.py` handler + `render_event_codec.decode`).
+  Recommend a helper `check_schema_version(payload_dict, expected: int)` used
+  by both paths so the drop/log semantics are identical.
+- Enumerate the metric name and tag set for version-mismatch drops so the
+  hub's existing metrics surface (if any) can pick it up.
+- Test plan should include: legacy payload (no `schema_version`) → decodes as
+  v1; matching version → decodes; higher version → dropped + logged + metric
+  incremented; lower version (future case) → decodes (forward-compat rule).

--- a/artifacts/plans/530-nats-message-versioning-plan.mdx
+++ b/artifacts/plans/530-nats-message-versioning-plan.mdx
@@ -1,0 +1,433 @@
+---
+title: "Plan: feat(nats): add message versioning to wire format"
+issue: 530
+spec: artifacts/specs/530-nats-message-versioning-spec.mdx
+frame: artifacts/frames/530-nats-message-versioning-frame.mdx
+complexity: 4
+tier: F-lite
+generated: "2026-04-05T00:00:00Z"
+status: approved
+---
+
+## Summary
+
+Add a `schema_version: int = 1` field to all 5 hub↔adapter envelope dataclasses, implement a caller-owned `check_schema_version` helper, and wire it into `NatsBus` (inbound) and `NatsRenderEventCodec` via `decode_stream_events` (outbound) so a receiver reading a payload with a higher version than it was compiled against **drops the message with a loud ERROR log + in-process counter increment** instead of silently misinterpreting fields.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph Constants["src/lyra/core/ (constants + fields)"]
+        MSG["message.py<br/>InboundMessage / InboundAudio / OutboundMessage<br/>+ schema_version: int = 1<br/>+ SCHEMA_VERSION_INBOUND_MESSAGE<br/>+ SCHEMA_VERSION_INBOUND_AUDIO<br/>+ SCHEMA_VERSION_OUTBOUND_MESSAGE"]
+        RE["render_events.py<br/>TextRenderEvent / ToolSummaryRenderEvent<br/>+ schema_version: int = 1<br/>+ SCHEMA_VERSION_TEXT_RENDER_EVENT<br/>+ SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT"]
+    end
+
+    subgraph Helper["src/lyra/nats/_version_check.py (NEW)"]
+        CHK["check_schema_version(payload, *,<br/>envelope_name, expected,<br/>subject=None, counter=None) -> bool"]
+    end
+
+    subgraph InboundPath["Inbound: adapter → hub"]
+        NB["nats_bus.py<br/>_make_handler.handler()<br/>1. json.loads(msg.data)<br/>2. check_schema_version(...)<br/>3. if False: drop + return<br/>4. deserialize_dict(dict, T)"]
+        NBC["NatsBus._version_mismatch_drops<br/>(instance dict[str, int])"]
+        NBA["NatsBus.version_mismatch_count(name)<br/>(public accessor)"]
+    end
+
+    subgraph OutboundPath["Outbound: hub → adapter (render events)"]
+        SD["nats_stream_decoder.py<br/>decode_stream_events(stream_id, q,<br/>*, counter)"]
+        REC["render_event_codec.py<br/>NatsRenderEventCodec.decode(<br/>event_type, payload, *, counter)<br/>1. check_schema_version(...)<br/>2. if False: return None<br/>3. deserialize / manual extract"]
+        NOL["nats_outbound_listener.py<br/>NatsOutboundListener<br/>._version_mismatch_drops<br/>(instance dict[str, int])"]
+    end
+
+    Constants --> Helper
+    Helper --> NB
+    Helper --> REC
+
+    NB --> NBC
+    NBC --> NBA
+
+    NOL -->|passes counter| SD
+    SD -->|passes counter| REC
+
+    style Helper fill:#fde,stroke:#a0a
+    style NB fill:#dfd
+    style REC fill:#dfd
+    style NBC fill:#fdd
+    style NOL fill:#fdd
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+    subgraph M["core/message.py"]
+        IM["InboundMessage<br/>+ schema_version"]
+        IA["InboundAudio<br/>+ schema_version"]
+        OM["OutboundMessage<br/>+ schema_version"]
+        C1["SCHEMA_VERSION_*<br/>constants"]
+    end
+
+    subgraph R["core/render_events.py"]
+        TRE["TextRenderEvent<br/>+ schema_version"]
+        TSRE["ToolSummaryRenderEvent<br/>+ schema_version"]
+        C2["SCHEMA_VERSION_*<br/>constants"]
+    end
+
+    subgraph VC["nats/_version_check.py (NEW)"]
+        FN["check_schema_version()"]
+    end
+
+    subgraph NB["nats/nats_bus.py"]
+        H["_make_handler.handler()"]
+        CNT["_version_mismatch_drops"]
+        ACC["version_mismatch_count()"]
+    end
+
+    subgraph REC["nats/render_event_codec.py"]
+        DEC["decode(event_type,<br/>payload, *, counter)"]
+    end
+
+    subgraph SD["adapters/nats_stream_decoder.py"]
+        DSE["decode_stream_events(<br/>stream_id, q, *, counter)"]
+    end
+
+    subgraph NOL["adapters/nats_outbound_listener.py"]
+        LNB["NatsOutboundListener"]
+        LCNT["_version_mismatch_drops"]
+    end
+
+    subgraph T["tests/nats/ + tests/adapters/"]
+        TVC["test_version_check.py (NEW)"]
+        TNB["test_nats_bus.py (add)"]
+        TNP["test_nats_channel_proxy.py (add)"]
+        TOL["test_nats_outbound_listener.py (add)"]
+        TSR["test_serialize.py (add)"]
+    end
+
+    FN --> H
+    FN --> DEC
+    H --> CNT
+    CNT --> ACC
+    DEC --> DSE
+    DSE --> LNB
+    LNB --> LCNT
+
+    TVC -.tests.-> FN
+    TSR -.tests.-> IM
+    TNB -.tests.-> H
+    TNP -.tests.-> DEC
+    TOL -.tests.-> LNB
+
+    C1 -.used by.-> H
+    C2 -.used by.-> DEC
+```
+
+## Agents
+
+| Agent | Files owned | Task count |
+|---|---|---|
+| `backend-dev` | `src/lyra/core/message.py`, `src/lyra/core/render_events.py`, `src/lyra/nats/_version_check.py`, `src/lyra/nats/nats_bus.py`, `src/lyra/nats/render_event_codec.py`, `src/lyra/adapters/nats_stream_decoder.py`, `src/lyra/adapters/nats_outbound_listener.py` | 10 |
+| `tester` | `tests/nats/test_version_check.py`, `tests/nats/test_serialize.py` (or nearest existing), `tests/nats/test_nats_bus.py`, `tests/nats/test_nats_channel_proxy.py`, `tests/adapters/test_nats_outbound_listener.py` | 8 |
+| `doc-writer` | `docs/ARCHITECTURE.md` | 2 |
+
+Single agent per domain (F-lite default). No intra-domain parallelism.
+
+## Reference Patterns
+
+| Topic | Reference |
+|---|---|
+| Dataclass field + module constant | `src/lyra/core/message.py` existing `GENERIC_ERROR_REPLY`, `Platform` enum — shows top-of-module constant placement |
+| Helper module in `nats/` with tests | `src/lyra/nats/_sanitize.py` ↔ `tests/nats/test_sanitize.py` — lean module + focused unit tests |
+| Pre-parse JSON before deserialize | `src/lyra/nats/render_event_codec.py:47` — already does `json.loads(serialize(...).decode(...))` round-trip pattern |
+| Handler drop-and-log in nats_bus | `src/lyra/nats/nats_bus.py:225-247` — existing `handler()` with `try/except Exception` + `log.exception` |
+| Caller-owned counter propagation | `src/lyra/adapters/nats_stream_decoder.py:28` — already takes `q: asyncio.Queue` as parameter, easy to add `counter` kwarg |
+| Round-trip serialization test | `tests/nats/test_serialize_outbound.py` — round-trip pattern for OutboundMessage |
+| NATS publish/subscribe test | `tests/nats/test_nats_bus.py` — integration test setup with nats-server fixture |
+
+## Consistency Report
+
+| Spec trace | Plan coverage |
+|---|---|
+| SC-1: 5 envelopes get `schema_version: int = 1` | MT-1, MT-2 |
+| SC-2: Module-level `SCHEMA_VERSION_*` constants | MT-1, MT-2 |
+| SC-3: `_version_check.py` exports `check_schema_version(...)` | MT-3 |
+| SC-4: Legacy payload round-trips cleanly | MT-6 |
+| SC-5: `NatsBus` handler drops v2 against v1 | MT-8, MT-12 |
+| SC-6: `NatsBus` handler accepts matching version | MT-8, MT-12 |
+| SC-7: `NatsBus` handler accepts legacy (no field) | MT-8, MT-12 |
+| SC-8: `RenderEventCodec.decode()` drops v2 text branch | MT-9, MT-13 |
+| SC-9: `RenderEventCodec.decode()` drops v2 tool_summary branch | MT-9, MT-13 |
+| SC-10: Version-mismatch drop does not raise/stall | MT-12 (mixed-batch test) |
+| SC-11: `NatsBus.version_mismatch_count(name)` public method | MT-8, MT-12 |
+| SC-11b: Codec counter is caller-owned (no static state) | MT-9, MT-13, MT-14 |
+| SC-12: ARCHITECTURE.md schema-versioning subsection | MT-15 |
+| SC-13: ARCHITECTURE.md numbered bump procedure | MT-15 |
+
+**Coverage:** 13/13 success criteria · **Untraced tasks:** 0 · **Exemptions:** 0
+
+## Micro-Tasks
+
+### Slice 1 — Version field + helper (foundation, no call sites)
+
+**MT-1 · Add `schema_version` field + constants to `core/message.py`** [backend-dev] [SC-1, SC-2] [V1] [GREEN] [diff: 2]
+- File: `src/lyra/core/message.py`
+- Add at top (after existing `GENERIC_ERROR_REPLY`):
+  ```python
+  SCHEMA_VERSION_INBOUND_MESSAGE = 1
+  SCHEMA_VERSION_INBOUND_AUDIO = 1
+  SCHEMA_VERSION_OUTBOUND_MESSAGE = 1
+  ```
+- Add `schema_version: int = 1` as the **first** field of each dataclass (after docstring, before existing fields) on: `InboundMessage`, `InboundAudio`, `OutboundMessage`.
+- Verify: `python -c "from lyra.core.message import InboundMessage, SCHEMA_VERSION_INBOUND_MESSAGE; m = InboundMessage(id='x', platform='telegram', bot_id='main', scope_id='s', user_id='u', user_name='n', is_mention=False, text='', text_raw='', trust_level=__import__('lyra.core.trust', fromlist=['TrustLevel']).TrustLevel.PUBLIC); assert m.schema_version == 1 == SCHEMA_VERSION_INBOUND_MESSAGE"`
+- Est: 5 min
+
+**MT-2 · Add `schema_version` field + constants to `core/render_events.py`** [backend-dev] [SC-1, SC-2] [V1] [GREEN] [diff: 2]
+- File: `src/lyra/core/render_events.py`
+- Add at top:
+  ```python
+  SCHEMA_VERSION_TEXT_RENDER_EVENT = 1
+  SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT = 1
+  ```
+- Add `schema_version: int = 1` as the **first** field on `TextRenderEvent` and `ToolSummaryRenderEvent` (both frozen dataclasses — field must come before defaults with factories; since `schema_version` itself has a default, all current fields already have defaults or can stay where they are — verify field ordering).
+- Extend `__all__` to include both new constants.
+- Verify: `python -c "from lyra.core.render_events import TextRenderEvent, SCHEMA_VERSION_TEXT_RENDER_EVENT; e = TextRenderEvent(text='hi', is_final=True); assert e.schema_version == 1"`
+- Est: 5 min
+
+**MT-3 · Create `src/lyra/nats/_version_check.py`** [backend-dev] [SC-3] [V1] [GREEN] [diff: 3]
+- File: `src/lyra/nats/_version_check.py` (NEW)
+- Exports a single function:
+  ```python
+  def check_schema_version(
+      payload: dict,
+      *,
+      envelope_name: str,
+      expected: int,
+      subject: str | None = None,
+      counter: dict[str, int] | None = None,
+  ) -> bool:
+      """Return True if payload is acceptable for this receiver; drop + log + count otherwise.
+
+      Rules:
+      - Missing field → treated as version 1 (legacy backwards compat).
+      - Non-int value (string, null, float) → dropped.
+      - Integer <= 0 → dropped.
+      - Integer > expected → dropped (forward-compat violation).
+      - Integer in [1, expected] → accepted.
+      """
+  ```
+- Log line format on drop:
+  ```
+  log.error(
+      "NATS schema version mismatch — dropping message: envelope=%s "
+      "payload_version=%r expected=%d subject=%s",
+      envelope_name, raw_version, expected, subject or "<unknown>",
+  )
+  ```
+- On drop, if `counter is not None`: `counter[envelope_name] = counter.get(envelope_name, 0) + 1`.
+- Verify: `python -c "from lyra.nats._version_check import check_schema_version; c={}; assert check_schema_version({'schema_version': 1}, envelope_name='X', expected=1, counter=c) is True; assert c == {}; assert check_schema_version({'schema_version': 2}, envelope_name='X', expected=1, counter=c) is False; assert c == {'X': 1}"`
+- Est: 10 min
+
+**MT-4 · Unit tests for `check_schema_version` helper** [tester] [SC-3] [V1] [RED] [diff: 2] [P]
+- File: `tests/nats/test_version_check.py` (NEW)
+- Test cases (8 total):
+  1. `check({}, envelope_name="A", expected=1)` → True (legacy absent → v1)
+  2. `check({"schema_version": 1}, ..., expected=1)` → True (exact match)
+  3. `check({"schema_version": 1}, ..., expected=2)` → True (receiver newer)
+  4. `check({"schema_version": 2}, ..., expected=1)` → False (receiver older)
+  5. `check({"schema_version": "1"}, ..., expected=1)` → False (string → malformed)
+  6. `check({"schema_version": None}, ..., expected=1)` → False (null → malformed)
+  7. `check({"schema_version": 0}, ..., expected=1)` → False (invalid range)
+  8. Counter isolation: two separate dicts passed to two calls each get exactly their own counts.
+- Verify log emission with `caplog` on drop cases (assert `log.error` fired once with expected substring).
+- Verify: `uv run pytest tests/nats/test_version_check.py -xvs`
+- Est: 10 min
+- `[P]` with MT-5, MT-6 after MT-3 lands.
+
+**MT-5 · Legacy round-trip serialization test** [tester] [SC-4] [V1] [RED] [diff: 1] [P]
+- File: `tests/nats/test_serialize.py` if present, otherwise `tests/nats/test_serialize_outbound.py`. Pick whichever test file already exercises `serialize` / `deserialize` round-trips for an envelope type.
+- Test: construct an `InboundMessage` **without** setting `schema_version` (rely on default), `serialize()` it, `deserialize()` it back → assert reconstructed `.schema_version == 1`. Repeat for `OutboundMessage`, `TextRenderEvent`, `ToolSummaryRenderEvent`, `InboundAudio`.
+- Parametrize over all 5 envelope types.
+- Verify: `uv run pytest tests/nats/test_serialize*.py -k schema_version -xvs`
+- Est: 5 min
+- `[P]` with MT-4, MT-6.
+
+**MT-6 · RED-GATE 1 — All Slice 1 tests green** [backend-dev] [V1] [RED-GATE] [diff: 1]
+- Verify: `uv run pytest tests/nats/test_version_check.py tests/nats/test_serialize*.py -x 2>&1 | tail -20`
+- Expected: all tests pass. No call sites touched yet — `NatsBus` and `NatsRenderEventCodec` still behave identically to before. In-flight NATS messages are still decoded cleanly.
+- Blocks: Slice 2, Slice 3, Slice 4.
+
+### Slice 2 — NatsBus handler wiring
+
+**MT-7 · Wire version check into `nats_bus.py`** [backend-dev] [SC-5, SC-6, SC-7, SC-11] [V2] [GREEN] [diff: 3]
+- File: `src/lyra/nats/nats_bus.py`
+- Changes:
+  1. Import helper + constants at top: `from lyra.nats._version_check import check_schema_version`, `from lyra.nats._serialize import deserialize_dict` (replacing bare `deserialize`), and the 2 inbound constants from `lyra.core.message`.
+  2. In `NatsBus.__init__`, add: `self._version_mismatch_drops: dict[str, int] = {}`.
+  3. Add a mapping (module-level or `_item_type_version` helper) from `item_type` → `(envelope_name, expected_version)`:
+     ```python
+     _VERSIONS = {
+         InboundMessage: ("InboundMessage", SCHEMA_VERSION_INBOUND_MESSAGE),
+         InboundAudio:   ("InboundAudio",   SCHEMA_VERSION_INBOUND_AUDIO),
+     }
+     ```
+     (`OutboundMessage` is never consumed by `NatsBus` — it's outbound; but include it if `NatsBus` is ever parameterized for it in tests. Verify by reading `bootstrap/` for `NatsBus` instantiations first.)
+  4. Rewrite `_make_handler.handler()`:
+     ```python
+     async def handler(msg: Msg) -> None:
+         try:
+             payload = json.loads(msg.data.decode("utf-8"))
+         except Exception:
+             log.exception("NatsBus: failed to parse JSON on ...")
+             return
+         name, expected = _VERSIONS[self._item_type]
+         if not check_schema_version(
+             payload,
+             envelope_name=name,
+             expected=expected,
+             subject=subject,
+             counter=self._version_mismatch_drops,
+         ):
+             return
+         try:
+             item = deserialize_dict(payload, self._item_type)
+             ... (rest unchanged: sanitize + staging.put_nowait)
+         except asyncio.QueueFull:
+             ...
+         except Exception:
+             log.exception(...)
+     ```
+  5. Add public accessor:
+     ```python
+     def version_mismatch_count(self, envelope_name: str) -> int:
+         """Return cumulative count of dropped messages for the given envelope type."""
+         return self._version_mismatch_drops.get(envelope_name, 0)
+     ```
+- Verify: `uv run ruff check src/lyra/nats/nats_bus.py && uv run mypy src/lyra/nats/nats_bus.py`
+- Est: 15 min
+
+**MT-8 · Integration tests for `NatsBus` version mismatch** [tester] [SC-5, SC-6, SC-7, SC-10, SC-11] [V2] [RED] [diff: 3] [P]
+- File: `tests/nats/test_nats_bus.py` (add new test class or block)
+- Test cases:
+  1. `test_version_match_accepts`: publish a v1 `InboundMessage` → assert it reaches staging, counter unchanged.
+  2. `test_legacy_payload_accepts`: publish a dict without `schema_version` (manually crafted JSON, not a dataclass) → assert it reaches staging, counter unchanged.
+  3. `test_version_mismatch_drops`: publish a dict with `schema_version=2` → assert staging queue receives nothing, `bus.version_mismatch_count("InboundMessage") == 1`, `log.error` fired once (use `caplog`).
+  4. `test_mixed_batch_survives`: publish `[v1, v2_bad, v1]` in sequence → assert staging receives exactly 2 messages (both v1s), counter is `{"InboundMessage": 1}`, subscription still alive for a subsequent v1 publish.
+  5. `test_subscription_does_not_close`: after mismatch drop, publish another v1 and assert it still arrives (no leaked `await sub.unsubscribe()`).
+- Reuse existing nats-server fixture from `tests/nats/conftest.py`.
+- Verify: `uv run pytest tests/nats/test_nats_bus.py -k "version or mismatch" -xvs`
+- Est: 20 min
+- `[P]` with MT-7 on a separate branch; merge-order: MT-7 before MT-8 runs green.
+
+**MT-9 · RED-GATE 2 — Slice 2 green + Slice 1 still green** [backend-dev] [V2] [RED-GATE] [diff: 1]
+- Verify: `uv run pytest tests/nats/test_nats_bus.py tests/nats/test_version_check.py tests/nats/test_serialize*.py -x 2>&1 | tail -20`
+- Expected: all pass, all pre-existing `test_nats_bus.py` tests still green (no regression).
+- Blocks: Slice 3.
+
+### Slice 3 — RenderEventCodec + stream decoder + listener wiring
+
+**MT-10 · Add counter kwarg + version check to `render_event_codec.py`** [backend-dev] [SC-8, SC-9, SC-11b] [V3] [GREEN] [diff: 3]
+- File: `src/lyra/nats/render_event_codec.py`
+- Changes:
+  1. Import `check_schema_version` + both render-event constants.
+  2. Change signature: `def decode(event_type: str, payload: dict, *, counter: dict[str, int] | None = None) -> RenderEvent | None:`
+  3. In the `text` branch: before `return deserialize(...)`, call `check_schema_version(payload, envelope_name="TextRenderEvent", expected=SCHEMA_VERSION_TEXT_RENDER_EVENT, counter=counter)`. Return `None` on False.
+  4. In the `tool_summary` branch: same check (using `SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT`) **before** the manual `files_raw = payload.get("files", {})` line. Return `None` on False.
+  5. `encode()` and `is_terminal()` are unchanged.
+- Verify: `uv run ruff check src/lyra/nats/render_event_codec.py && uv run mypy src/lyra/nats/render_event_codec.py`
+- Est: 8 min
+
+**MT-11 · Add counter kwarg to `decode_stream_events`** [backend-dev] [SC-8, SC-9, SC-11b] [V3] [GREEN] [diff: 2]
+- File: `src/lyra/adapters/nats_stream_decoder.py`
+- Change signature: `async def decode_stream_events(stream_id: str, q: asyncio.Queue[dict], *, counter: dict[str, int] | None = None) -> AsyncIterator["RenderEvent"]:`
+- Pass through on line 75: `event = NatsRenderEventCodec.decode(event_type, payload, counter=counter)`
+- Verify: `uv run ruff check src/lyra/adapters/nats_stream_decoder.py`
+- Est: 3 min
+
+**MT-12 · Wire counter into `NatsOutboundListener`** [backend-dev] [SC-11b] [V3] [GREEN] [diff: 3]
+- File: `src/lyra/adapters/nats_outbound_listener.py`
+- Changes:
+  1. In `__init__`, add: `self._version_mismatch_drops: dict[str, int] = {}`.
+  2. Find the call site of `decode_stream_events(stream_id, q)` (around line 262) → change to `decode_stream_events(stream_id, q, counter=self._version_mismatch_drops)`.
+  3. Add a public accessor `version_mismatch_count(envelope_name: str) -> int` mirroring `NatsBus`.
+- Verify: `uv run ruff check src/lyra/adapters/nats_outbound_listener.py && uv run pytest tests/adapters/test_nats_outbound_listener.py -x 2>&1 | tail -10`
+- Est: 10 min
+
+**MT-13 · Codec-level version mismatch tests (text + tool_summary)** [tester] [SC-8, SC-9, SC-11b] [V3] [RED] [diff: 3] [P]
+- File: `tests/nats/test_nats_channel_proxy.py` (add new test class) OR if cleaner, a new `tests/nats/test_render_event_codec.py`.
+- Test cases (6 total):
+  1. `test_text_match_decodes`: `decode("text", {"schema_version": 1, "text": "hi", "is_final": True}, counter={})` → returns `TextRenderEvent(...)`.
+  2. `test_text_legacy_decodes`: `decode("text", {"text": "hi", "is_final": True}, counter={})` → returns `TextRenderEvent` (no schema_version → v1).
+  3. `test_text_mismatch_drops`: `decode("text", {"schema_version": 2, ...}, counter=c)` → returns `None`, `c == {"TextRenderEvent": 1}`, `log.error` fired.
+  4. `test_tool_summary_match_decodes`: v1 tool_summary → returns `ToolSummaryRenderEvent`.
+  5. `test_tool_summary_mismatch_drops`: v2 tool_summary → returns `None`, counter incremented, **manual `payload.get("files", ...)` block is NOT executed** (verify by passing a malformed `files` value that would otherwise raise — a passing test proves the check short-circuits before extraction).
+  6. `test_counter_isolation`: two separate counter dicts → no cross-talk.
+- Verify: `uv run pytest tests/nats/test_nats_channel_proxy.py -k "version or mismatch or schema" -xvs`
+- Est: 15 min
+- `[P]` with MT-14.
+
+**MT-14 · Listener-level counter integration test** [tester] [SC-11b] [V3] [RED] [diff: 2] [P]
+- File: `tests/adapters/test_nats_outbound_listener.py` (add test)
+- Test case: build a `NatsOutboundListener` with a stubbed hub. Feed it a stream where one chunk carries a v2 `text` payload. Assert `listener._version_mismatch_drops == {"TextRenderEvent": 1}` after the drain loop completes, and that subsequent v1 chunks still decode normally.
+- Reuse existing listener fixtures.
+- Verify: `uv run pytest tests/adapters/test_nats_outbound_listener.py -k version -xvs`
+- Est: 10 min
+- `[P]` with MT-13.
+
+**MT-15 · RED-GATE 3 — Full test suite green** [backend-dev] [V3] [RED-GATE] [diff: 1]
+- Verify: `uv run pytest tests/nats tests/adapters -x 2>&1 | tail -30`
+- Expected: all pass, no regressions anywhere in `tests/nats/` or `tests/adapters/`.
+- Blocks: Slice 4 (docs can also parallelize with Slice 2/3; here it's sequenced after to avoid doc drift).
+
+### Slice 4 — Documentation
+
+**MT-16 · Add schema versioning section to `docs/ARCHITECTURE.md`** [doc-writer] [SC-12, SC-13] [V4] [GREEN] [diff: 2]
+- File: `docs/ARCHITECTURE.md`
+- Locate the existing NATS wire format section (or closest equivalent — verify first). Add a new `### Schema versioning` subsection containing:
+  1. **What it is:** "Every hub↔adapter envelope (`InboundMessage`, `InboundAudio`, `OutboundMessage`, `TextRenderEvent`, `ToolSummaryRenderEvent`) carries a `schema_version: int = 1` field. Current version for each envelope lives in a `SCHEMA_VERSION_*` module-level constant in `core/message.py` and `core/render_events.py`."
+  2. **Forward-compat rule:** "A receiver accepts any `payload.schema_version <= expected`. Strictly-greater versions are dropped with an ERROR log and an in-process counter increment via `check_schema_version` in `nats/_version_check.py`. Legacy payloads (no field) default to version 1."
+  3. **Why (design intent):** "Versioning does not enable rolling deploys across breaking changes — coordinated deploy of all 3 processes is still required. It exists to make failures **loud** instead of silent."
+  4. **Numbered bump procedure:**
+     ```
+     1. Bump the SCHEMA_VERSION_<ENVELOPE> constant in core/message.py or core/render_events.py by 1.
+     2. Update the dataclass field default on the corresponding envelope to match.
+     3. Coordinate a simultaneous deploy of lyra_hub + lyra_telegram + lyra_discord. Rolling deploys across a version bump will produce loud ERROR logs on the still-v1 receivers until they are upgraded.
+     4. Verify the bump with: `grep SCHEMA_VERSION_ src/lyra/core/*.py`.
+     ```
+- Verify: `grep -c "schema_version" docs/ARCHITECTURE.md` should return ≥4; `grep -A2 "^1\. Bump" docs/ARCHITECTURE.md` should show the numbered procedure.
+- Est: 15 min
+
+**MT-17 · RED-GATE 4 — Final verification** [backend-dev] [V4] [RED-GATE] [diff: 1]
+- Verify:
+  1. `uv run pytest tests/nats tests/adapters -x`
+  2. `uv run ruff check src/lyra tests`
+  3. `uv run mypy src/lyra/nats src/lyra/core/message.py src/lyra/core/render_events.py src/lyra/adapters/nats_outbound_listener.py src/lyra/adapters/nats_stream_decoder.py`
+  4. `grep -n "schema_version" docs/ARCHITECTURE.md`
+- Expected: all lint/type checks pass, all 13 SC covered, docs contains the section.
+
+## Parallelization Hints
+
+- **Within Slice 1:** MT-4 [P], MT-5 [P], MT-6 [P] — all read-only tests runnable in parallel once MT-3 lands.
+- **Slice 2 and Slice 3** both depend only on Slice 1. After MT-6 passes, they could theoretically run on parallel branches and merge separately. For this F-lite we ship them in a single PR sequentially to minimize review overhead.
+- **Slice 4 (docs)** is fully parallel with Slice 2 and Slice 3 after Slice 1 — no code dependency.
+
+## Risks + Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `NatsBus` uses `deserialize(raw_bytes, T)` today; switching to `deserialize_dict(dict, T)` after `json.loads` changes the error surface (e.g. bytes decode errors bubble differently) | Wrap `json.loads` in its own `try/except` (see MT-7 code); existing `log.exception` still catches downstream failures. Covered by MT-8 regression case. |
+| `_item_type` → `(name, expected)` mapping forgets an envelope used by `NatsBus` | MT-7 step 3 requires reading `bootstrap/` to enumerate every `NatsBus(... item_type=X)` call before writing the mapping. Make the mapping a `dict` not a tuple so missing keys raise `KeyError` loudly in tests. |
+| `frozen=True` dataclass field ordering — adding `schema_version` as first field breaks positional constructors in existing test code | Use keyword-only construction everywhere new; existing call sites use kwargs (verified in `tests/nats/conftest.py` — no positional construction). Add `schema_version` AFTER all non-default fields if positional use is found. |
+| `ToolSummaryRenderEvent` manual-decode path silently misses the check | Explicit check-before-extraction in MT-10 step 4; MT-13 test case 5 proves short-circuit works (malformed `files` raises iff check skipped). |
+| Counter dicts accumulate across long-running process lifetimes → memory leak | Keyed by envelope name (bounded set of ~5 keys). Not a leak. |
+| JSON null / non-int `schema_version` sneaks through | MT-3 helper treats non-int as drop; MT-4 tests 5, 6, 7 cover null, string, negative. |
+
+## Definition of Done
+
+All checkboxes from the spec's Success Criteria section green:
+- [ ] SC-1 through SC-13 from spec verified by tests or presence check (see Consistency Report above).
+- [ ] All RED-GATEs passed (MT-6, MT-9, MT-15, MT-17).
+- [ ] `uv run pytest tests/nats tests/adapters` green.
+- [ ] `uv run ruff check src/lyra tests` clean.
+- [ ] `uv run mypy` on touched modules clean.
+- [ ] PR opened, linked to #530, CI green, code review complete.

--- a/artifacts/specs/530-nats-message-versioning-spec.mdx
+++ b/artifacts/specs/530-nats-message-versioning-spec.mdx
@@ -1,0 +1,179 @@
+---
+title: Add message versioning to NATS wire format
+issue: 530
+status: approved
+tier: F-lite
+date: 2026-04-05
+source_frame: artifacts/frames/530-nats-message-versioning-frame.mdx
+---
+
+## Context
+
+Promoted from [`artifacts/frames/530-nats-message-versioning-frame.mdx`](../frames/530-nats-message-versioning-frame.mdx). Analysis was skipped per F-lite flow — the frame captured enough detail to move directly to spec.
+
+**Current state (verified):**
+- NATS wire format = UTF-8 JSON produced by `_serialize.py`, which recursively encodes dataclasses.
+- Envelope dataclasses: `InboundMessage`, `InboundAudio`, `OutboundMessage` (`src/lyra/core/message.py`); `TextRenderEvent`, `ToolSummaryRenderEvent` (`src/lyra/core/render_events.py`).
+- `_decode_dataclass` (`_serialize.py:266`) silently falls back to dataclass defaults for missing fields → additive changes already degrade gracefully.
+- Decode failures are already drop-and-log in `nats_bus.py:242` (`log.exception`, queue never stalls).
+- `render_event_codec.py:66-79` has a **manual** decode path for `ToolSummaryRenderEvent` using `payload.get(...)` — this bypasses `deserialize()` and must be handled explicitly.
+- **No metrics infrastructure exists** in Lyra — only logging. (`pipeline_events.py:5` notes metrics as "future".) This spec introduces an in-process counter only.
+
+## Goal
+
+When a NATS receiver gets a payload with a `schema_version` **higher** than what it was compiled against, it drops the message, logs an ERROR identifying the mismatch, and increments an in-process counter — instead of silently misinterpreting fields.
+
+## Users
+
+- **Primary:** Lyra maintainers evolving the wire format. A breaking schema change becomes a single-line bump + a coordinated deploy, with observable failure if the deploy is mis-sequenced.
+- **Secondary:** On-call / operators reading logs — a version mismatch surfaces as an explicit ERROR with `(platform, bot_id, envelope_type, payload_version, receiver_version)` instead of "messages disappeared".
+- **Secondary:** Future contributors — the `SCHEMA_VERSION_*` constants become the authoritative "current wire contract" per envelope type.
+
+## Expected Behavior
+
+### Happy path (same version)
+Producer serializes `InboundMessage(schema_version=1, ...)` → JSON includes `"schema_version": 1`. Receiver decodes, sees 1 ≤ its own `SCHEMA_VERSION_INBOUND_MESSAGE = 1`, accepts the message, forwards to the staging queue. No change in throughput.
+
+### Backwards read (legacy payload, no version field at all)
+A payload from before this change has **no** `schema_version` field. The helper defaults it to `1` via `payload.get("schema_version", 1)`. The version check sees 1 ≤ 1, accepts. Legacy NATS messages in flight during the rollout are never dropped.
+
+### Forward read — receiver newer, producer older (receiver was upgraded first)
+Producer at v1, receiver at v2. Receiver sees 1 ≤ 2, accepts — additive schema changes already degrade, so v2 fields just take their defaults. This is the "rolling deploy where the newest process reads old traffic" case and it continues to work.
+
+### Mismatch — receiver older, producer newer (producer was upgraded first, or a stray v2 message reaches a rolled-back v1 receiver)
+Producer at v2, receiver at v1. Receiver sees 2 > 1:
+1. Message **dropped** (never reaches staging queue / never dispatched).
+2. `log.error("NATS schema version mismatch — dropping message: envelope=%s payload_version=%d receiver_version=%d subject=%s", ...)` emitted exactly once per message.
+3. In-process counter `bus._version_mismatch_drops` (or codec equivalent) incremented.
+4. No exception propagates — the NATS subscription keeps running.
+
+### ToolSummaryRenderEvent landmine
+The manual decode path in `render_event_codec.py:66-79` does NOT go through `_decode_dataclass`. The version check must run **before** the manual reconstruction, using the same helper as the `deserialize()` path. If the check fails, `decode()` returns `None` (already the "unknown/skip" sentinel for callers) and logs + counts the drop.
+
+## Data Model & Consumers
+
+### Envelopes getting a `schema_version` field (plus their module-level constant)
+
+| Envelope | Module | Constant |
+|---|---|---|
+| `InboundMessage` (frozen) | `core/message.py` | `SCHEMA_VERSION_INBOUND_MESSAGE = 1` |
+| `InboundAudio` (frozen) | `core/message.py` | `SCHEMA_VERSION_INBOUND_AUDIO = 1` |
+| `OutboundMessage` (mutable) | `core/message.py` | `SCHEMA_VERSION_OUTBOUND_MESSAGE = 1` |
+| `TextRenderEvent` (frozen) | `core/render_events.py` | `SCHEMA_VERSION_TEXT_RENDER_EVENT = 1` |
+| `ToolSummaryRenderEvent` (frozen) | `core/render_events.py` | `SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT = 1` |
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    Producer[Producer process] -->|serialize with schema_version| NATS[(NATS subject)]
+    NATS -->|raw JSON bytes| Handler[nats_bus handler<br/>or render_event_codec.decode]
+    Handler -->|pre-decode check| Check{check_schema_version}
+    Check -->|pass: payload_v <= known_v| Decode[deserialize / manual reconstruct]
+    Check -->|fail: payload_v > known_v| Drop[log.error + counter++]
+    Decode --> Staging[staging queue / stream decoder]
+    Drop -.-> Metrics[in-process counter]
+
+    style Drop fill:#fdd
+    style Staging fill:#dfd
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When |
+|---|---|---|
+| `NatsBus._make_handler` inner `handler()` | `InboundMessage` / `InboundAudio` | on every received NATS message |
+| `NatsRenderEventCodec.decode()` — text branch | `TextRenderEvent` | per render-event chunk |
+| `NatsRenderEventCodec.decode()` — tool_summary branch | `ToolSummaryRenderEvent` (manual extraction) | per render-event chunk |
+| `nats_tts_client` / `nats_stt_client` | voiceCLI-owned payloads | **out of scope** — voiceCLI boundary |
+
+All three in-scope consumers get the pre-decode version check in this issue. Serialized payloads at rest (dumps, replays) also benefit: `schema_version` is visible inline in the JSON.
+
+## Breadboard
+
+### Affordances → Handlers → Data
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `schema_version: int = 1` field on each envelope dataclass | — (dataclass field) | Serialized into JSON via existing `_encode` path |
+| N2 | `SCHEMA_VERSION_*` module-level constants | — (module consts) | `core/message.py`, `core/render_events.py` |
+| N3 | `check_schema_version(payload, *, envelope_name, expected, subject, counter) -> bool` helper — **counter is caller-owned** (dict passed in, mutated on drop) | `nats/_version_check.py` (new) | Returns True on accept, False on drop; logs and increments `counter[envelope_name]` on drop |
+| N4 | Pre-decode check in `NatsBus` handler | `nats_bus.py:_make_handler.handler()` | Call `check_schema_version` with `json.loads(msg.data)` + `self._version_mismatch_drops` before `deserialize_dict` |
+| N5 | Pre-decode check in `NatsRenderEventCodec.decode` | `render_event_codec.py` | Same helper, both text and tool_summary branches. **Counter dict passed in by the caller** (e.g. `NatsOutboundListener` / `NatsChannelProxy`) — not a class attribute on the codec (avoids test-isolation bugs from static state). |
+| N6 | In-process mismatch counter | `NatsBus._version_mismatch_drops: dict[str, int]` (instance attr). For the codec path, the counter lives on the **caller** that invokes `decode()` (listener/proxy), passed into each call. | Key = envelope_name; value = count |
+| N7 | Introspection accessor | `NatsBus.version_mismatch_count(envelope_name: str) -> int`. Codec callers expose their own if needed. | Reads from N6 |
+| N8 | Legacy-compatibility decode | existing `_decode_dataclass` defaults path | No change — defaults handle absent field transparently |
+
+### Wiring notes
+
+- **Single helper, two call sites.** `check_schema_version` lives in a new lean module `src/lyra/nats/_version_check.py` so both `nats_bus.py` and `render_event_codec.py` import it. Logs and counter-increments are the helper's responsibility — callers just branch on the bool.
+- **Counter storage — always caller-owned.** Simple `dict[str, int]` held by whoever calls the helper. `NatsBus` stores it as `self._version_mismatch_drops`. For render events, since `NatsRenderEventCodec` is a stateless static-method class (see `render_event_codec.py:21`), the caller of `decode()` (e.g. `NatsOutboundListener`, `NatsChannelProxy`) owns the counter and passes it in. This keeps the codec stateless, avoids process-global test-isolation bugs, and makes the counter accessible where it's relevant (per-bus, per-stream-consumer).
+- **JSON parse happens once.** The `NatsBus` handler currently calls `deserialize(msg.data, T)` which does `json.loads` internally. To check version before `_decode_dataclass` runs, the handler pre-parses with `json.loads(msg.data)`, calls the check, and then hands the dict to `deserialize_dict(d, T)` (existing function at `_serialize.py:54`) to avoid a double-parse. This also lets `render_event_codec.decode` stay on its existing parsed-dict path.
+- **Helper signature.**
+  ```python
+  def check_schema_version(
+      payload: dict,
+      *,
+      envelope_name: str,
+      expected: int,
+      subject: str | None = None,
+      counter: dict[str, int] | None = None,
+  ) -> bool:
+      """Return True if payload.schema_version <= expected; else drop (log + count) and return False."""
+  ```
+- **Default for absent field.** `payload.get("schema_version", 1)` → legacy payloads are treated as v1.
+- **Starting version.** Every envelope ships with version `1`. No migration needed.
+
+## Slices
+
+| # | Slice | Deliverable | Demo |
+|---|---|---|---|
+| 1 | **Version field + helper** — add `schema_version: int = 1` to all 5 envelopes, add `SCHEMA_VERSION_*` constants, add `_version_check.py` helper with tests. No call sites yet. | Envelopes serialize with the field; helper returns correct bool for all 4 cases (equal / less / greater / absent); helper increments counter and logs on drop | Unit test: `serialize(InboundMessage(...))` round-trips the field. Unit test: helper drops v2 when expected=1, accepts v1/absent. |
+| 2 | **Wire up NatsBus** — `_make_handler.handler()` pre-parses JSON, calls helper with `SCHEMA_VERSION_INBOUND_MESSAGE` / `_INBOUND_AUDIO`, drops on mismatch, otherwise forwards to `deserialize_dict`. | Integration test: produce a v2 payload against a v1-expected bus → message dropped, counter == 1, log line emitted, subscription still alive; produce a v1 payload → message reaches staging queue. | `pytest tests/nats/test_nats_bus.py -k version_mismatch` |
+| 3 | **Wire up RenderEventCodec + caller counter** — extend `NatsRenderEventCodec.decode()` to accept an optional `counter: dict[str, int]` kwarg and call the helper in both branches (text + tool_summary). Update callers (`NatsOutboundListener`, `NatsChannelProxy`) to own a counter dict and pass it in. Check runs before manual reconstruction in the tool_summary branch. | Decode a v2 text render event against v1-expected codec → returns `None`, caller counter == 1; v1 decodes normally. Same for tool_summary branch — manual `payload.get(...)` reconstruction is skipped on mismatch. | `pytest tests/nats/test_nats_channel_proxy.py -k version_mismatch` + new codec-level unit test |
+
+## Success Criteria
+
+- [ ] `InboundMessage`, `InboundAudio`, `OutboundMessage`, `TextRenderEvent`, `ToolSummaryRenderEvent` each declare `schema_version: int = 1` as a dataclass field.
+- [ ] Module-level `SCHEMA_VERSION_*` constants exist in `core/message.py` and `core/render_events.py`, one per envelope, all equal to `1`.
+- [ ] `src/lyra/nats/_version_check.py` exports `check_schema_version(payload, *, envelope_name, expected, subject=None, counter=None) -> bool`.
+- [ ] Legacy JSON payload (no `schema_version` field) round-trips cleanly: `deserialize(serialize(dc))` where `dc` was constructed without setting the field, equals the original with `schema_version=1`.
+- [ ] `NatsBus` handler drops a payload with `schema_version=2` when its known version is `1`: message does not reach the staging queue, `log.error` is emitted exactly once with `(envelope_name, payload_version, expected, subject)`, and the mismatch counter increments by 1.
+- [ ] `NatsBus` handler accepts a payload with `schema_version=1` (matching) and forwards it unchanged.
+- [ ] `NatsBus` handler accepts a payload with **no** `schema_version` field (legacy) — treated as `1`.
+- [ ] `NatsRenderEventCodec.decode()` accepts an optional `counter: dict[str, int]` kwarg and returns `None` (logs + increments counter) for a v2 payload in the `text` branch when expected is v1.
+- [ ] `NatsRenderEventCodec.decode()` returns `None` (logs + increments counter) for a v2 payload in the `tool_summary` branch when expected is v1 — the manual `payload.get(...)` reconstruction is **not** executed when version is mismatched.
+- [ ] A version-mismatch drop does NOT raise an exception, does NOT close the NATS subscription, and does NOT stall the staging queue — verified by a test that publishes `[v1, v2_bad, v1]` and asserts the two v1 messages reach staging.
+- [ ] `NatsBus.version_mismatch_count(envelope_name)` public method returns the cumulative count for the given envelope and is used in the tests above.
+- [ ] The codec counter is caller-owned (passed in as a kwarg), verified by a unit test that asserts two independent dicts passed into two separate `decode()` calls get independent counts (no cross-talk from any static class state).
+- [ ] `docs/ARCHITECTURE.md` (or the closest existing NATS doc) gains a new "Schema versioning" subsection that mentions (a) the `schema_version` field exists on every hub↔adapter envelope and (b) the forward-compat rule `payload_v <= expected`.
+- [ ] That same doc includes a numbered "How to bump `schema_version`" procedure (e.g. 1. bump the `SCHEMA_VERSION_*` constant, 2. update the default on the dataclass field, 3. coordinate the deploy) — checkable by presence of the numbered list.
+- [ ] `pytest tests/nats/` passes with all existing tests green (backwards compatibility with in-flight serialized payloads).
+
+## Edge Cases
+
+| Edge | Handling |
+|---|---|
+| Payload has `schema_version` as a string (malformed producer) | `check_schema_version` treats non-int as a drop (log + count). `payload.get("schema_version", 1)` coerced via `isinstance(..., int)` check. |
+| Payload has `schema_version` as JSON `null` | `payload.get("schema_version", 1)` returns `None` for an explicit null; `isinstance(None, int)` is False → drop + log + count. |
+| Payload `schema_version` is negative or zero | Treat as malformed → drop + log + count. Valid range is `>= 1`. |
+| Payload dict doesn't have any fields (empty `{}`) | `json.loads` succeeds, `payload.get("schema_version", 1)` → 1, check passes, `deserialize_dict` will then fail on missing required fields → existing `log.exception` path catches it. No double-logging. |
+| `json.loads` raises (invalid JSON) | Existing `try/except Exception` in `nats_bus.py:242` catches — no change. |
+| Legacy v1 producer sending to a v1 receiver during rollout | Same version → accepted, no behavior change. |
+| v1 receiver rolled back after v2 deploy → v2 messages still in subject buffer | Each one triggers one drop log. Rate-limit is **out of scope** — if this becomes noisy in practice, a follow-up can add log deduplication. |
+
+## Open Questions
+
+_None — reviewer feedback resolved both prior χ items:_
+- Helper is a **pure function**, counter is caller-owned (`dict[str, int]`).
+- `NatsBus.version_mismatch_count` is a **public method** (for future metrics export).
+
+## Out of Scope (from frame, re-affirmed)
+
+- Rolling deploys across breaking changes (coordinated deploy still required)
+- Chunk-envelope versioning (the `{stream_id, seq, event_type, payload, done}` wrapper)
+- NATS subject-pattern versioning
+- TTS/STT wire format (voiceCLI owned)
+- Schema registry / migration tooling
+- Version negotiation / downgrade
+- Prometheus / external metrics export — in-process counter only

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -288,6 +288,21 @@ class InboundMessage:
     platform_meta: dict         # platform-specific routing data (chat_id, guild_id, …)
 ```
 
+### Schema versioning
+
+Every hub↔adapter envelope (`InboundMessage`, `InboundAudio`, `OutboundMessage`, `TextRenderEvent`, `ToolSummaryRenderEvent`) carries a `schema_version: int = 1` field. The current version for each envelope lives in a `SCHEMA_VERSION_*` module-level constant in `src/lyra/core/message.py` and `src/lyra/core/render_events.py`.
+
+A receiver accepts any payload where `schema_version <= expected`. Strictly-greater versions are **dropped** with an ERROR log and an in-process counter increment via `check_schema_version` in `src/lyra/nats/_version_check.py`. Legacy payloads without a `schema_version` key default to version 1, so existing wire traffic is never dropped.
+
+Versioning does **not** enable rolling deploys across breaking schema changes — coordinated deploy of `lyra_hub`, `lyra_telegram`, and `lyra_discord` is still required. It exists to make failures **loud** (ERROR log + counter) instead of silent (mis-interpreted fields).
+
+**How to bump `schema_version`:**
+
+1. Bump the `SCHEMA_VERSION_<ENVELOPE>` constant in `src/lyra/core/message.py` or `src/lyra/core/render_events.py` by 1.
+2. Update the `schema_version` field default on the corresponding envelope to match.
+3. Coordinate a simultaneous deploy of `lyra_hub` + `lyra_telegram` + `lyra_discord`. Rolling deploys across a version bump will produce loud ERROR logs on the still-old receivers until they are upgraded.
+4. Verify the bump with: `grep SCHEMA_VERSION_ src/lyra/core/*.py`.
+
 ### Bindings (routing table)
 
 Rule: `(platform, bot_id, scope_id)` → `(agent, pool_id)`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -296,6 +296,8 @@ A receiver accepts any payload where `schema_version <= expected`. Strictly-grea
 
 Versioning does **not** enable rolling deploys across breaking schema changes — coordinated deploy of `lyra_hub`, `lyra_telegram`, and `lyra_discord` is still required. It exists to make failures **loud** (ERROR log + counter) instead of silent (mis-interpreted fields).
 
+Note: the outer render-event chunk envelope (`{stream_id, seq, event_type, payload, done}` in `render_event_codec.py`) is itself an implicit, unversioned contract. The `schema_version` field only guards the inner payload — a future rename of the outer wrapper's fields would not be caught by this mechanism.
+
 **How to bump `schema_version`:**
 
 1. Bump the `SCHEMA_VERSION_<ENVELOPE>` constant in `src/lyra/core/message.py` or `src/lyra/core/render_events.py` by 1.

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -67,6 +67,8 @@ class NatsOutboundListener:
         # late-arriving chunks after a stream has been terminated. Bounded to
         # _MAX_TERMINATED_STREAMS; an arbitrary entry is evicted when full.
         self._terminated_streams: set[str] = set()
+        # Per-envelope drop counts from schema version mismatches.
+        self._version_mismatch_drops: dict[str, int] = {}
 
     def cache_inbound(self, msg: InboundMessage | InboundAudio) -> None:
         """Store msg so it can be retrieved later by stream_id."""
@@ -80,6 +82,14 @@ class NatsOutboundListener:
             )
         self._cache[msg.id] = msg
         self._cache_ts[msg.id] = time.monotonic()
+
+    def version_mismatch_count(self, envelope_name: str) -> int:
+        """Return the cumulative count of dropped render events for *envelope_name*.
+
+        Counts are per-listener and accumulate across the listener lifetime. Used
+        by tests and future metrics surfaces to detect botched rolling deploys.
+        """
+        return self._version_mismatch_drops.get(envelope_name, 0)
 
     async def start(self) -> None:
         """Subscribe to the outbound NATS subject."""
@@ -259,7 +269,9 @@ class NatsOutboundListener:
         try:
             await self._adapter.send_streaming(
                 cast(InboundMessage, original_msg),
-                decode_stream_events(stream_id, q),
+                decode_stream_events(
+                    stream_id, q, counter=self._version_mismatch_drops
+                ),
                 outbound,
             )
         except Exception:

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -63,11 +63,9 @@ class NatsOutboundListener:
         self._stream_outbound: dict[str, OutboundMessage] = {}
         self._sub: Any = None  # nats.aio.subscription.Subscription | None
         self._reaper_task: asyncio.Task[None] | None = None
-        # Tombstone set: stream_ids that received stream_error, used to reject
-        # late-arriving chunks after a stream has been terminated. Bounded to
-        # _MAX_TERMINATED_STREAMS; an arbitrary entry is evicted when full.
+        # Tombstone set: stream_ids that received stream_error — rejects late
+        # chunks after termination. Bounded; arbitrary entry evicted when full.
         self._terminated_streams: set[str] = set()
-        # Per-envelope drop counts from schema version mismatches.
         self._version_mismatch_drops: dict[str, int] = {}
 
     def cache_inbound(self, msg: InboundMessage | InboundAudio) -> None:
@@ -84,11 +82,7 @@ class NatsOutboundListener:
         self._cache_ts[msg.id] = time.monotonic()
 
     def version_mismatch_count(self, envelope_name: str) -> int:
-        """Return the cumulative count of dropped render events for *envelope_name*.
-
-        Counts are per-listener and accumulate across the listener lifetime. Used
-        by tests and future metrics surfaces to detect botched rolling deploys.
-        """
+        """Cumulative drops for *envelope_name* (schema version mismatches)."""
         return self._version_mismatch_drops.get(envelope_name, 0)
 
     async def start(self) -> None:

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -63,8 +64,6 @@ class NatsOutboundListener:
         self._stream_outbound: dict[str, OutboundMessage] = {}
         self._sub: Any = None  # nats.aio.subscription.Subscription | None
         self._reaper_task: asyncio.Task[None] | None = None
-        # Tombstone set: stream_ids that received stream_error — rejects late
-        # chunks after termination. Bounded; arbitrary entry evicted when full.
         self._terminated_streams: set[str] = set()
         self._version_mismatch_drops: dict[str, int] = {}
 
@@ -97,15 +96,12 @@ class NatsOutboundListener:
         """Unsubscribe from NATS."""
         if self._reaper_task is not None:
             self._reaper_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await self._reaper_task
-            except asyncio.CancelledError:
-                pass
             self._reaper_task = None
         if self._sub is not None:
             await self._sub.unsubscribe()
             self._sub = None
-        # cancel pending stream tasks
         for task in list(self._stream_tasks.values()):
             task.cancel()
         self._stream_tasks.clear()
@@ -236,7 +232,6 @@ class NatsOutboundListener:
                 stream_id,
             )
             return
-        # Launch a drain task on first chunk; subsequent chunks just enqueue
         if stream_id not in self._stream_tasks:
             self._stream_tasks[stream_id] = asyncio.create_task(
                 self._drain_stream(stream_id, q)
@@ -278,7 +273,6 @@ class NatsOutboundListener:
             self._cache_ts.pop(stream_id, None)
             self._stream_tasks.pop(stream_id, None)
             self._stream_queues.pop(stream_id, None)
-            # Clean up tombstone for completed streams; bounded set handles the rest
             self._terminated_streams.discard(stream_id)
 
     async def _reap_stale(self) -> None:

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -256,6 +256,7 @@ class NatsOutboundListener:
 
         outbound = self._stream_outbound.pop(stream_id, None)
         try:
+            # counter= wires drop tracking; read via version_mismatch_count().
             await self._adapter.send_streaming(
                 cast(InboundMessage, original_msg),
                 decode_stream_events(

--- a/src/lyra/adapters/nats_stream_decoder.py
+++ b/src/lyra/adapters/nats_stream_decoder.py
@@ -26,7 +26,10 @@ _MAX_TERMINATED_STREAMS = 500
 
 
 async def decode_stream_events(
-    stream_id: str, q: asyncio.Queue[dict],
+    stream_id: str,
+    q: asyncio.Queue[dict],
+    *,
+    counter: dict[str, int] | None = None,
 ) -> AsyncIterator["RenderEvent"]:
     """Drain chunks from *q* and yield decoded :class:`RenderEvent` objects.
 
@@ -36,7 +39,10 @@ async def decode_stream_events(
 
     Args:
         stream_id: Logical stream identifier (used only for log correlation).
-        q: Queue populated by :meth:`NatsOutboundListener._handle_chunk`.
+        q:         Queue populated by :meth:`NatsOutboundListener._handle_chunk`.
+        counter:   Caller-owned mutable dict passed through to
+                   :meth:`NatsRenderEventCodec.decode` for version-mismatch
+                   drop counting.  ``None`` skips counting.
 
     Yields:
         Decoded render events until a terminal chunk arrives or the timeout
@@ -72,7 +78,7 @@ async def decode_stream_events(
             break
         payload = chunk.get("payload", {})
         is_done = chunk.get("done", False)
-        event = NatsRenderEventCodec.decode(event_type, payload)
+        event = NatsRenderEventCodec.decode(event_type, payload, counter=counter)
         if event is not None:
             yield event
         if NatsRenderEventCodec.is_terminal(event_type, is_done):

--- a/src/lyra/core/message.py
+++ b/src/lyra/core/message.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 # Shared user-facing fallback for unhandled agent or dispatch errors.
 GENERIC_ERROR_REPLY = "Something went wrong. Please try again."
 
+SCHEMA_VERSION_INBOUND_MESSAGE = 1
+SCHEMA_VERSION_INBOUND_AUDIO = 1
+SCHEMA_VERSION_OUTBOUND_MESSAGE = 1
+
 
 class Platform(str, Enum):
     TELEGRAM = "telegram"
@@ -79,6 +83,7 @@ class InboundMessage:
     text: str  # normalized plain text (markup stripped)
     text_raw: str  # original text with platform markup
     trust_level: TrustLevel
+    schema_version: int = 1
     is_admin: bool = False
     roles: tuple[str, ...] = ()
     attachments: list[Attachment] = field(default_factory=list)
@@ -121,6 +126,7 @@ class InboundAudio:
     file_id: str | None
     timestamp: datetime
     trust_level: TrustLevel
+    schema_version: int = 1
     # Deprecated: use trust_level (TrustLevel) for authorization.
     # Removal tracked separately.
     trust: Literal["user", "system"] = "user"
@@ -258,6 +264,7 @@ class OutboundMessage:
     intermediate: bool = False  # True → typing continues after send
     metadata: dict[str, Any] = field(default_factory=dict)
     routing: RoutingContext | None = None
+    schema_version: int = 1
 
     @classmethod
     def from_text(cls, text: str) -> "OutboundMessage":

--- a/src/lyra/core/render_events.py
+++ b/src/lyra/core/render_events.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+SCHEMA_VERSION_TEXT_RENDER_EVENT = 1
+SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT = 1
+
 
 @dataclass(frozen=True)
 class SilentCounts:
@@ -74,6 +77,7 @@ class TextRenderEvent:
 
     text: str
     is_final: bool
+    schema_version: int = 1
     is_error: bool = False
 
 
@@ -95,6 +99,7 @@ class ToolSummaryRenderEvent:
     agent_calls: list[str] = field(default_factory=list)
     silent_counts: SilentCounts = field(default_factory=SilentCounts)
     is_complete: bool = False
+    schema_version: int = 1
 
 
 # Union type exported for type annotations and ``isinstance`` checks.
@@ -103,6 +108,8 @@ RenderEvent = TextRenderEvent | ToolSummaryRenderEvent
 __all__ = [
     "FileEditSummary",
     "RenderEvent",
+    "SCHEMA_VERSION_TEXT_RENDER_EVENT",
+    "SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT",
     "SilentCounts",
     "TextRenderEvent",
     "ToolSummaryRenderEvent",

--- a/src/lyra/nats/_version_check.py
+++ b/src/lyra/nats/_version_check.py
@@ -1,0 +1,90 @@
+"""Forward-compatibility version check for NATS envelope payloads.
+
+A receiver accepts any payload whose ``schema_version`` is less than or equal
+to the receiver's own compiled-in ``SCHEMA_VERSION_*`` constant (forward-compat
+rule).  Strictly-greater versions are dropped with a single ERROR log line and
+an optional in-process counter increment — instead of silently misinterpreting
+unknown or removed fields.
+
+Missing field: treated as version 1 (legacy backwards-compat).
+Non-int / null / negative / zero: treated as malformed → drop.
+"""
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def check_schema_version(
+    payload: dict,
+    *,
+    envelope_name: str,
+    expected: int,
+    subject: str | None = None,
+    counter: dict[str, int] | None = None,
+) -> bool:
+    """Return True if payload is acceptable for this receiver; else drop + log + count.
+
+    Rules
+    -----
+    - Missing field → treated as version 1 (legacy backwards compat).
+    - Non-int value (string, null, float) → dropped.
+    - Integer <= 0 → dropped (invalid range).
+    - Integer > expected → dropped (forward-compat violation).
+    - Integer in [1, expected] → accepted.
+
+    Parameters
+    ----------
+    payload:
+        The decoded JSON dict received from NATS.
+    envelope_name:
+        Human-readable name of the envelope type (e.g. ``"InboundMessage"``).
+        Used as the counter key and in the log line.
+    expected:
+        The ``SCHEMA_VERSION_*`` constant this receiver was compiled against.
+    subject:
+        The NATS subject the message arrived on — included in the log line for
+        easier triage.  ``None`` renders as ``"<unknown>"``.
+    counter:
+        Caller-owned mutable dict; incremented at ``counter[envelope_name]`` on
+        every drop.  Pass ``None`` to skip counting.
+    """
+    raw = payload.get("schema_version", 1)
+
+    # Non-int (including None, str, float) → drop.
+    if not isinstance(raw, int):
+        _drop(envelope_name, raw, expected, subject, counter)
+        return False
+
+    # Out-of-range integer → drop.
+    if raw <= 0:
+        _drop(envelope_name, raw, expected, subject, counter)
+        return False
+
+    # Forward-compat violation → drop.
+    if raw > expected:
+        _drop(envelope_name, raw, expected, subject, counter)
+        return False
+
+    # 1 <= raw <= expected → accept.
+    return True
+
+
+def _drop(
+    envelope_name: str,
+    raw_version: object,
+    expected: int,
+    subject: str | None,
+    counter: dict[str, int] | None,
+) -> None:
+    log.error(
+        "NATS schema version mismatch — dropping message: envelope=%s "
+        "payload_version=%r expected=%d subject=%s",
+        envelope_name,
+        raw_version,
+        expected,
+        subject or "<unknown>",
+    )
+    if counter is not None:
+        counter[envelope_name] = counter.get(envelope_name, 0) + 1

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -228,11 +228,7 @@ class NatsBus(Generic[T]):
         return len(self._subscriptions)
 
     def version_mismatch_count(self, envelope_name: str) -> int:
-        """Return the cumulative count of dropped messages for *envelope_name*.
-
-        Counts are per-instance and accumulate across the bus lifetime. Used by
-        tests and future metrics surfaces to detect botched rolling deploys.
-        """
+        """Cumulative drops for *envelope_name* (schema version mismatches)."""
         return self._version_mismatch_drops.get(envelope_name, 0)
 
     # ------------------------------------------------------------------

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -252,9 +252,7 @@ class NatsBus(Generic[T]):
                 )
                 return
 
-            envelope_name, expected = _ENVELOPE_VERSIONS.get(
-                self._item_type, (self._item_type.__name__, 1)
-            )
+            envelope_name, expected = _ENVELOPE_VERSIONS[self._item_type]
             if not check_schema_version(
                 payload,
                 envelope_name=envelope_name,

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
 import logging
 from typing import Any, Generic, TypeVar
 
@@ -40,14 +41,26 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 
-from lyra.core.message import Platform
+from lyra.core.message import (
+    SCHEMA_VERSION_INBOUND_AUDIO,
+    SCHEMA_VERSION_INBOUND_MESSAGE,
+    InboundAudio,
+    InboundMessage,
+    Platform,
+)
 from lyra.nats._sanitize import sanitize_platform_meta
-from lyra.nats._serialize import deserialize, serialize
+from lyra.nats._serialize import deserialize_dict, serialize
 from lyra.nats._validate import validate_nats_token
+from lyra.nats._version_check import check_schema_version
 
 log = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+_ENVELOPE_VERSIONS: dict[type, tuple[str, int]] = {
+    InboundMessage: ("InboundMessage", SCHEMA_VERSION_INBOUND_MESSAGE),
+    InboundAudio: ("InboundAudio", SCHEMA_VERSION_INBOUND_AUDIO),
+}
 
 
 class NatsBus(Generic[T]):
@@ -97,6 +110,7 @@ class NatsBus(Generic[T]):
         self._registrations: set[tuple[Platform, str]] = set()
         self._subscriptions: dict[tuple[Platform, str], Subscription] = {}
         self._staging: asyncio.Queue[T] = asyncio.Queue(maxsize=staging_maxsize)
+        self._version_mismatch_drops: dict[str, int] = {}
 
     # ------------------------------------------------------------------
     # Registration
@@ -213,6 +227,14 @@ class NatsBus(Generic[T]):
         """Return the number of active NATS subscriptions."""
         return len(self._subscriptions)
 
+    def version_mismatch_count(self, envelope_name: str) -> int:
+        """Return the cumulative count of dropped messages for *envelope_name*.
+
+        Counts are per-instance and accumulate across the bus lifetime. Used by
+        tests and future metrics surfaces to detect botched rolling deploys.
+        """
+        return self._version_mismatch_drops.get(envelope_name, 0)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -223,8 +245,31 @@ class NatsBus(Generic[T]):
         subject = f"{self._subject_prefix}.{platform.value}.{bot_id}"
 
         async def handler(msg: Msg) -> None:
+            # Pre-parse JSON so we can inspect schema_version before full deserialize.
             try:
-                item = deserialize(msg.data, self._item_type)
+                payload = json.loads(msg.data.decode("utf-8"))
+            except Exception:
+                log.exception(
+                    "NatsBus: failed to parse JSON on platform=%s bot_id=%s",
+                    platform.value,
+                    bot_id,
+                )
+                return
+
+            envelope_name, expected = _ENVELOPE_VERSIONS.get(
+                self._item_type, (self._item_type.__name__, 1)
+            )
+            if not check_schema_version(
+                payload,
+                envelope_name=envelope_name,
+                expected=expected,
+                subject=subject,
+                counter=self._version_mismatch_drops,
+            ):
+                return  # helper already logged + incremented counter
+
+            try:
+                item = deserialize_dict(payload, self._item_type)
                 if hasattr(item, "platform_meta"):
                     _item: Any = item
                     item = dataclasses.replace(

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 
 from lyra.core.render_events import (
+    SCHEMA_VERSION_TEXT_RENDER_EVENT,
+    SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT,
     FileEditSummary,
     RenderEvent,
     SilentCounts,
@@ -16,6 +18,7 @@ from lyra.core.render_events import (
     ToolSummaryRenderEvent,
 )
 from lyra.nats._serialize import deserialize, serialize
+from lyra.nats._version_check import check_schema_version
 
 
 class NatsRenderEventCodec:
@@ -51,18 +54,45 @@ class NatsRenderEventCodec:
         return "tool_summary", payload, event.is_complete
 
     @staticmethod
-    def decode(event_type: str, payload: dict) -> RenderEvent | None:
+    def decode(
+        event_type: str,
+        payload: dict,
+        *,
+        counter: dict[str, int] | None = None,
+    ) -> RenderEvent | None:
         """Reconstruct a ``RenderEvent`` from *(event_type, payload_dict)*.
 
-        Returns ``None`` for synthetic types (``"stream_end"``) or unknown
-        event types — callers should skip yielding ``None`` values.
+        Returns ``None`` for synthetic types (``"stream_end"``), unknown event
+        types, or payloads that fail the schema version check.  Callers should
+        skip yielding ``None`` values.
+
+        Args:
+            event_type: The ``"event_type"`` field from the wire chunk.
+            payload:    The ``"payload"`` dict from the wire chunk.
+            counter:    Caller-owned mutable dict; incremented at
+                        ``counter[envelope_name]`` on every version-check drop.
+                        Pass ``None`` to skip counting.
         """
         if event_type == "text":
+            if not check_schema_version(
+                payload,
+                envelope_name="TextRenderEvent",
+                expected=SCHEMA_VERSION_TEXT_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
             return deserialize(
                 json.dumps(payload, ensure_ascii=False).encode("utf-8"),
                 TextRenderEvent,
             )
         if event_type == "tool_summary":
+            if not check_schema_version(
+                payload,
+                envelope_name="ToolSummaryRenderEvent",
+                expected=SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
             files_raw = payload.get("files", {})
             silent_raw = payload.get("silent_counts", {})
             return ToolSummaryRenderEvent(

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -592,3 +592,75 @@ async def test_stream_error_unknown_stream_id_is_noop() -> None:
 
     # The legitimate cache entry is untouched.
     assert cached.id in listener._cache
+
+
+# ---------------------------------------------------------------------------
+# MT-14: Listener-level version mismatch counter integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_version_mismatch_counter_flows_from_listener() -> None:
+    """version_mismatch_count() reflects drops that occurred inside _drain_stream.
+
+    Strategy: construct a listener and manually call decode_stream_events with
+    listener._version_mismatch_drops as the counter, feeding a queue that contains
+    one v2 text chunk (should be dropped) followed by a terminal v1 chunk.
+    After draining the generator we assert:
+    - listener.version_mismatch_count("TextRenderEvent") == 1
+    - the terminal v1 chunk was decoded and yielded
+
+    This is a direct integration test: real NatsRenderEventCodec.decode() +
+    real decode_stream_events() + real listener counter dict — no mocks on
+    the tested path.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.adapters.nats_stream_decoder import decode_stream_events
+    from lyra.core.message import Platform
+    from lyra.core.render_events import TextRenderEvent
+
+    # Arrange
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    # Initial state: counter is empty
+    assert listener.version_mismatch_count("TextRenderEvent") == 0
+
+    stream_id = "test-stream-mt14"
+    q: asyncio.Queue[dict] = asyncio.Queue()
+
+    # Chunk 1: v2 payload → should be dropped, counter incremented
+    await q.put({
+        "stream_id": stream_id,
+        "seq": 0,
+        "event_type": "text",
+        "payload": {"schema_version": 2, "text": "bad", "is_final": False},
+        "done": False,
+    })
+    # Chunk 2: v1 payload → should decode and be yielded; is_final=True → terminal
+    await q.put({
+        "stream_id": stream_id,
+        "seq": 1,
+        "event_type": "text",
+        "payload": {"schema_version": 1, "text": "good", "is_final": True},
+        "done": True,
+    })
+
+    # Act — drain the generator using the listener's own counter dict
+    yielded: list[object] = []
+    async for event in decode_stream_events(
+        stream_id, q, counter=listener._version_mismatch_drops
+    ):
+        yielded.append(event)
+
+    # Assert — v2 chunk was dropped, counter reflects it
+    assert listener.version_mismatch_count("TextRenderEvent") == 1
+
+    # Assert — v1 chunk was decoded and yielded
+    assert len(yielded) == 1
+    assert isinstance(yielded[0], TextRenderEvent)
+    assert yielded[0].text == "good"  # type: ignore[union-attr]

--- a/tests/core/test_message.py
+++ b/tests/core/test_message.py
@@ -131,3 +131,15 @@ def test_outbound_importable_from_core() -> None:
     assert CodeBlock is not None
     assert ContentPart is not None
     assert OutboundMessage is not None
+
+
+def test_schema_version_constants_exist_and_equal_one() -> None:
+    """All SCHEMA_VERSION_* constants for core/message.py exist and equal 1."""
+    from lyra.core.message import (
+        SCHEMA_VERSION_INBOUND_AUDIO,
+        SCHEMA_VERSION_INBOUND_MESSAGE,
+        SCHEMA_VERSION_OUTBOUND_MESSAGE,
+    )
+    assert SCHEMA_VERSION_INBOUND_MESSAGE == 1
+    assert SCHEMA_VERSION_INBOUND_AUDIO == 1
+    assert SCHEMA_VERSION_OUTBOUND_MESSAGE == 1

--- a/tests/core/test_render_events.py
+++ b/tests/core/test_render_events.py
@@ -225,6 +225,8 @@ class TestRenderEventUnion:
         assert set(_mod.__all__) == {
             "FileEditSummary",
             "RenderEvent",
+            "SCHEMA_VERSION_TEXT_RENDER_EVENT",
+            "SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT",
             "SilentCounts",
             "TextRenderEvent",
             "ToolSummaryRenderEvent",

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -612,19 +612,17 @@ class TestNatsBusVersionMismatch:
             # Act — publish a future-version payload that this receiver cannot handle
             with caplog.at_level(logging.ERROR):
                 await nc.publish(subject, _make_inbound_bytes_version(2))
-                # Give the NATS delivery + handler a moment to run
-                await asyncio.sleep(0.15)
 
-            # Assert — staging queue stays empty (message was dropped)
-            with pytest.raises((asyncio.TimeoutError, TimeoutError)):
-                await asyncio.wait_for(bus.get(), timeout=0.3)
+            # Assert — staging queue stays empty (handler dropped the message)
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(bus.get(), timeout=0.5)
 
             # Counter must have incremented exactly once
             assert bus.version_mismatch_count("InboundMessage") == 1
 
             # ERROR log must mention the mismatch
             assert any(
-                "NATS schema version mismatch" in r.message
+                "NATS schema version mismatch" in r.getMessage()
                 for r in caplog.records
                 if r.levelno >= logging.ERROR
             )
@@ -641,27 +639,31 @@ class TestNatsBusVersionMismatch:
         subject = "lyra.inbound.telegram.main"
 
         try:
-            # Act — publish three messages; only the two v1s should arrive
+            # Act — publish four messages; only the two v1s should arrive
             await nc.publish(subject, _make_inbound_bytes_v1())
             await nc.publish(subject, _make_inbound_bytes_version(2))
             await nc.publish(subject, _make_inbound_bytes_v1())
+            await nc.publish(subject, _make_inbound_bytes_version(2))
 
-            # Wait for all deliveries to propagate through the NATS handler
-            await asyncio.sleep(0.2)
+            # Drain two v1s via event-driven wait
+            first = await asyncio.wait_for(bus.get(), timeout=1.0)
+            second = await asyncio.wait_for(bus.get(), timeout=1.0)
 
-            # Drain the staging queue
-            received: list = []
-            while bus.staging_qsize() > 0:
-                received.append(await bus.get())
+            # Assert — both are valid InboundMessage instances
+            assert first is not None
+            assert second is not None
 
-            # Assert — exactly 2 valid messages arrived
-            assert len(received) == 2
-            assert bus.version_mismatch_count("InboundMessage") == 1
+            # Assert — no v2 bled through (next get must time out)
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(bus.get(), timeout=0.5)
 
-            # Assert — subscription is still alive: a 4th v1 must arrive
+            # Assert — counter accumulated both drops
+            assert bus.version_mismatch_count("InboundMessage") == 2
+
+            # Assert — subscription is still alive: a final v1 must arrive
             await nc.publish(subject, _make_inbound_bytes_v1())
-            fourth = await asyncio.wait_for(bus.get(), timeout=2.0)
-            assert fourth is not None
+            fifth = await asyncio.wait_for(bus.get(), timeout=2.0)
+            assert fifth is not None
         finally:
             await bus.stop()
 
@@ -677,11 +679,10 @@ class TestNatsBusVersionMismatch:
         try:
             # Act — publish JSON with schema_version: "1" (string, not int)
             await nc.publish(subject, _make_inbound_bytes_string_version())
-            await asyncio.sleep(0.15)
 
-            # Assert — staging queue stays empty
-            with pytest.raises((asyncio.TimeoutError, TimeoutError)):
-                await asyncio.wait_for(bus.get(), timeout=0.3)
+            # Assert — staging queue stays empty (handler dropped the message)
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(bus.get(), timeout=0.5)
 
             # Counter must have incremented
             assert bus.version_mismatch_count("InboundMessage") == 1

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -511,3 +511,179 @@ def test_nats_bus_default_queue_group_is_empty() -> None:
 
     # Assert
     assert bus._queue_group == ""
+
+
+# ---------------------------------------------------------------------------
+# TestNatsBusVersionMismatch — MT-8: schema_version filtering in NatsBus handler
+# ---------------------------------------------------------------------------
+
+
+import json as _json  # noqa: E402 — module-level import placed here to avoid reordering existing imports
+
+
+def _make_inbound_bytes_v1() -> bytes:
+    """Return serialized bytes for a valid v1 InboundMessage."""
+    return serialize(_make_msg(Platform.TELEGRAM))
+
+
+def _make_inbound_bytes_no_version() -> bytes:
+    """Return JSON bytes for an InboundMessage with schema_version removed (legacy)."""
+    d = _json.loads(serialize(_make_msg(Platform.TELEGRAM)).decode("utf-8"))
+    del d["schema_version"]
+    return _json.dumps(d).encode("utf-8")
+
+
+def _make_inbound_bytes_version(version: int) -> bytes:
+    """Return JSON bytes for an InboundMessage with an explicit schema_version value."""
+    d = _json.loads(serialize(_make_msg(Platform.TELEGRAM)).decode("utf-8"))
+    d["schema_version"] = version
+    return _json.dumps(d).encode("utf-8")
+
+
+def _make_inbound_bytes_string_version() -> bytes:
+    """Return JSON bytes for an InboundMessage with schema_version as string."""
+    d = _json.loads(serialize(_make_msg(Platform.TELEGRAM)).decode("utf-8"))
+    d["schema_version"] = "1"
+    return _json.dumps(d).encode("utf-8")
+
+
+@requires_nats_server
+class TestNatsBusVersionMismatch:
+    """Integration tests for schema_version filtering wired into NatsBus._make_handler.
+
+    Covers SC-5 (drops v2), SC-6 (accepts matching v1), SC-7 (accepts legacy/no-field),
+    SC-10 (mixed batch survives subscription), SC-11 (version_mismatch_count accessor).
+    """
+
+    async def test_version_match_accepts(self, nc: NATS) -> None:
+        """Publish a v1 InboundMessage — it reaches staging and counter stays 0."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        subject = "lyra.inbound.telegram.main"
+
+        try:
+            # Act — publish a properly serialized v1 message
+            await nc.publish(subject, _make_inbound_bytes_v1())
+            received = await asyncio.wait_for(bus.get(), timeout=2.0)
+
+            # Assert — message arrived and mismatch counter untouched
+            assert received is not None
+            assert bus.version_mismatch_count("InboundMessage") == 0
+        finally:
+            await bus.stop()
+
+    async def test_legacy_payload_without_field_accepts(self, nc: NATS) -> None:
+        """Publish a payload without schema_version (pre-versioning producer) — ok."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        subject = "lyra.inbound.telegram.main"
+
+        try:
+            # Act — publish JSON without the schema_version key
+            await nc.publish(subject, _make_inbound_bytes_no_version())
+            received = await asyncio.wait_for(bus.get(), timeout=2.0)
+
+            # Assert — message arrives; no mismatch counted (missing field → v1)
+            assert received is not None
+            assert bus.version_mismatch_count("InboundMessage") == 0
+        finally:
+            await bus.stop()
+
+    async def test_version_mismatch_drops(
+        self, nc: NATS, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Publish schema_version=2 payload — dropped, counter=1, ERROR logged."""
+        import logging
+
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        subject = "lyra.inbound.telegram.main"
+
+        try:
+            # Act — publish a future-version payload that this receiver cannot handle
+            with caplog.at_level(logging.ERROR):
+                await nc.publish(subject, _make_inbound_bytes_version(2))
+                # Give the NATS delivery + handler a moment to run
+                await asyncio.sleep(0.15)
+
+            # Assert — staging queue stays empty (message was dropped)
+            with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+                await asyncio.wait_for(bus.get(), timeout=0.3)
+
+            # Counter must have incremented exactly once
+            assert bus.version_mismatch_count("InboundMessage") == 1
+
+            # ERROR log must mention the mismatch
+            assert any(
+                "NATS schema version mismatch" in r.message
+                for r in caplog.records
+                if r.levelno >= logging.ERROR
+            )
+        finally:
+            await bus.stop()
+
+    async def test_mixed_batch_survives_subscription(self, nc: NATS) -> None:
+        """Publish [v1, v2_bad, v1] — 2 accepted, 1 dropped, bus stays alive."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        subject = "lyra.inbound.telegram.main"
+
+        try:
+            # Act — publish three messages; only the two v1s should arrive
+            await nc.publish(subject, _make_inbound_bytes_v1())
+            await nc.publish(subject, _make_inbound_bytes_version(2))
+            await nc.publish(subject, _make_inbound_bytes_v1())
+
+            # Wait for all deliveries to propagate through the NATS handler
+            await asyncio.sleep(0.2)
+
+            # Drain the staging queue
+            received: list = []
+            while bus.staging_qsize() > 0:
+                received.append(await bus.get())
+
+            # Assert — exactly 2 valid messages arrived
+            assert len(received) == 2
+            assert bus.version_mismatch_count("InboundMessage") == 1
+
+            # Assert — subscription is still alive: a 4th v1 must arrive
+            await nc.publish(subject, _make_inbound_bytes_v1())
+            fourth = await asyncio.wait_for(bus.get(), timeout=2.0)
+            assert fourth is not None
+        finally:
+            await bus.stop()
+
+    async def test_non_int_schema_version_drops(self, nc: NATS) -> None:
+        """Publish a payload with schema_version as a string — dropped, counter=1."""
+        # Arrange
+        bus = _make_bus(nc)
+        bus.register(Platform.TELEGRAM)
+        await bus.start()
+
+        subject = "lyra.inbound.telegram.main"
+
+        try:
+            # Act — publish JSON with schema_version: "1" (string, not int)
+            await nc.publish(subject, _make_inbound_bytes_string_version())
+            await asyncio.sleep(0.15)
+
+            # Assert — staging queue stays empty
+            with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+                await asyncio.wait_for(bus.get(), timeout=0.3)
+
+            # Counter must have incremented
+            assert bus.version_mismatch_count("InboundMessage") == 1
+        finally:
+            await bus.stop()

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -1,0 +1,184 @@
+"""Unit tests for NatsRenderEventCodec.decode() — schema version checks (issue #530).
+
+These tests are purely in-process: they call NatsRenderEventCodec.decode() directly
+with hand-crafted dicts and assert on the returned value + side effects.  No NATS
+server is required.
+
+MT-13 covers:
+- text branch: match, legacy (no field), mismatch
+- tool_summary branch: match, landmine mismatch (malformed files), counter isolation
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lyra.core.render_events import TextRenderEvent, ToolSummaryRenderEvent
+from lyra.nats.render_event_codec import NatsRenderEventCodec
+
+
+class TestRenderEventCodecVersionCheck:
+    """NatsRenderEventCodec.decode() — schema version gate for text + tool_summary."""
+
+    # -----------------------------------------------------------------------
+    # text branch — acceptance cases
+    # -----------------------------------------------------------------------
+
+    def test_text_match_decodes(self) -> None:
+        """v1 text payload decodes to TextRenderEvent; counter stays empty."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        result = NatsRenderEventCodec.decode(
+            "text",
+            {"schema_version": 1, "text": "hi", "is_final": True},
+            counter=counter,
+        )
+
+        # Assert
+        assert isinstance(result, TextRenderEvent)
+        assert result.text == "hi"
+        assert result.is_final is True
+        assert counter == {}
+
+    def test_text_legacy_decodes(self) -> None:
+        """text payload without schema_version defaults to v1 and decodes normally."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        result = NatsRenderEventCodec.decode(
+            "text",
+            {"text": "hi", "is_final": True},
+            counter=counter,
+        )
+
+        # Assert — missing field → legacy v1 path → accepted
+        assert isinstance(result, TextRenderEvent)
+        assert result.text == "hi"
+        assert result.is_final is True
+        assert counter == {}
+
+    # -----------------------------------------------------------------------
+    # text branch — mismatch
+    # -----------------------------------------------------------------------
+
+    def test_text_mismatch_drops(self, caplog: pytest.LogCaptureFixture) -> None:
+        """v2 text payload returns None, increments counter, emits log.error."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = NatsRenderEventCodec.decode(
+                "text",
+                {"schema_version": 2, "text": "hi", "is_final": True},
+                counter=counter,
+            )
+
+        # Assert — dropped
+        assert result is None
+        # Assert — counter incremented for this envelope
+        assert counter == {"TextRenderEvent": 1}
+        # Assert — exactly one ERROR log with expected substring
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "NATS schema version mismatch" in error_records[0].getMessage()
+
+    # -----------------------------------------------------------------------
+    # tool_summary branch — acceptance
+    # -----------------------------------------------------------------------
+
+    def test_tool_summary_match_decodes(self) -> None:
+        """v1 tool_summary payload decodes to ToolSummaryRenderEvent; counter empty."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        result = NatsRenderEventCodec.decode(
+            "tool_summary",
+            {
+                "schema_version": 1,
+                "files": {},
+                "bash_commands": [],
+                "web_fetches": [],
+                "agent_calls": [],
+                "silent_counts": {},
+                "is_complete": False,
+            },
+            counter=counter,
+        )
+
+        # Assert
+        assert isinstance(result, ToolSummaryRenderEvent)
+        assert counter == {}
+
+    # -----------------------------------------------------------------------
+    # tool_summary branch — landmine mismatch
+    # -----------------------------------------------------------------------
+
+    def test_tool_summary_mismatch_short_circuits_manual_extraction(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Version check fires BEFORE manual payload extraction in tool_summary branch.
+
+        The 'files' value is a string, not a dict.  If execution ever reached
+        the `payload.get("files", {}).items()` line it would raise AttributeError.
+        A passing test proves the version gate short-circuits before the landmine.
+        """
+        # Arrange — payload that would blow up if extracted
+        counter: dict[str, int] = {}
+        landmine_payload = {
+            "schema_version": 2,
+            "files": "not-a-dict",  # AttributeError on .items() if reached
+        }
+
+        # Act — must NOT raise
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = NatsRenderEventCodec.decode(
+                "tool_summary",
+                landmine_payload,
+                counter=counter,
+            )
+
+        # Assert — dropped without raising
+        assert result is None
+        assert counter == {"ToolSummaryRenderEvent": 1}
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "NATS schema version mismatch" in error_records[0].getMessage()
+
+    # -----------------------------------------------------------------------
+    # Counter isolation
+    # -----------------------------------------------------------------------
+
+    def test_counter_isolation_between_decodes(self) -> None:
+        """Two independent counter dicts accumulate only their own drops."""
+        # Arrange
+        c1: dict[str, int] = {}
+        c2: dict[str, int] = {}
+
+        # Act — two drops into c1
+        NatsRenderEventCodec.decode(
+            "text",
+            {"schema_version": 2, "text": "x", "is_final": True},
+            counter=c1,
+        )
+        NatsRenderEventCodec.decode(
+            "text",
+            {"schema_version": 2, "text": "x", "is_final": True},
+            counter=c1,
+        )
+        # One drop into c2
+        NatsRenderEventCodec.decode(
+            "text",
+            {"schema_version": 2, "text": "y", "is_final": True},
+            counter=c2,
+        )
+
+        # Assert — counts are independent
+        assert c1 == {"TextRenderEvent": 2}
+        assert c2 == {"TextRenderEvent": 1}

--- a/tests/nats/test_serialize_outbound.py
+++ b/tests/nats/test_serialize_outbound.py
@@ -5,13 +5,24 @@ objects for all types published by NatsChannelProxy over NATS.
 """
 from __future__ import annotations
 
-from lyra.core.message import OutboundAttachment, OutboundMessage
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from lyra.core.message import (
+    InboundAudio,
+    InboundMessage,
+    OutboundAttachment,
+    OutboundMessage,
+)
 from lyra.core.render_events import (
     FileEditSummary,
     SilentCounts,
     TextRenderEvent,
     ToolSummaryRenderEvent,
 )
+from lyra.core.trust import TrustLevel
 from lyra.nats._serialize import deserialize, serialize
 
 # ---------------------------------------------------------------------------
@@ -213,3 +224,99 @@ def test_outbound_attachment_file_no_optional_fields_roundtrip() -> None:
     assert recovered.type == "file"
     assert recovered.filename is None
     assert recovered.caption is None
+
+
+# ---------------------------------------------------------------------------
+# Legacy round-trip: schema_version defaults to 1 (MT-5, SC-4)
+# ---------------------------------------------------------------------------
+
+# Factories for the 5 envelope types — all constructed WITHOUT setting schema_version,
+# relying entirely on the dataclass default.
+
+
+def _make_inbound_message() -> InboundMessage:
+    return InboundMessage(
+        id="msg-legacy",
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:42",
+        user_id="user:1",
+        user_name="Alice",
+        is_mention=False,
+        text="hello",
+        text_raw="hello",
+        trust_level=TrustLevel.PUBLIC,
+    )
+
+
+def _make_inbound_audio() -> InboundAudio:
+    return InboundAudio(
+        id="audio-legacy",
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:42",
+        user_id="user:1",
+        audio_bytes=b"fake-audio",
+        mime_type="audio/ogg",
+        duration_ms=1000,
+        file_id=None,
+        timestamp=datetime.now(timezone.utc),
+        trust_level=TrustLevel.PUBLIC,
+    )
+
+
+def _make_outbound_message() -> OutboundMessage:
+    return OutboundMessage.from_text("hello from hub")
+
+
+def _make_text_render_event() -> TextRenderEvent:
+    return TextRenderEvent(text="Final answer", is_final=True)
+
+
+def _make_tool_summary_render_event() -> ToolSummaryRenderEvent:
+    return ToolSummaryRenderEvent()
+
+
+_ENVELOPE_FACTORIES = [
+    pytest.param(_make_inbound_message, InboundMessage, id="InboundMessage"),
+    pytest.param(_make_inbound_audio, InboundAudio, id="InboundAudio"),
+    pytest.param(_make_outbound_message, OutboundMessage, id="OutboundMessage"),
+    pytest.param(_make_text_render_event, TextRenderEvent, id="TextRenderEvent"),
+    pytest.param(
+        _make_tool_summary_render_event,
+        ToolSummaryRenderEvent,
+        id="ToolSummaryRenderEvent",
+    ),
+]
+
+
+@pytest.mark.parametrize("factory,envelope_type", _ENVELOPE_FACTORIES)
+def test_legacy_payload_round_trip_defaults_to_v1(factory, envelope_type) -> None:
+    """All 5 envelopes round-trip with schema_version==1 when default is used.
+
+    Covers SC-4: legacy payload round-trips cleanly with default schema_version=1.
+    Also verifies that a payload with no schema_version key at all (simulating a
+    pre-versioning producer) deserializes correctly — the absent field path in
+    _decode_dataclass yields the dataclass default of 1.
+    """
+    # Arrange — construct without setting schema_version (rely on dataclass default)
+    original = factory()
+    assert original.schema_version == 1
+
+    # Act — full round-trip: serialize → deserialize
+    data = serialize(original)
+    recovered = deserialize(data, envelope_type)
+
+    # Assert — schema_version is preserved as 1 through the wire format
+    assert recovered.schema_version == 1
+
+    # --- Simulate a pre-versioning producer (no schema_version key in JSON) ---
+    # Strip schema_version from the serialized JSON to mimic an old producer
+    raw_dict = json.loads(data.decode("utf-8"))
+    assert "schema_version" in raw_dict, "serialize() must include schema_version"
+    del raw_dict["schema_version"]
+    legacy_bytes = json.dumps(raw_dict).encode("utf-8")
+
+    # Deserialize the stripped payload → should fall back to dataclass default = 1
+    legacy_recovered = deserialize(legacy_bytes, envelope_type)
+    assert legacy_recovered.schema_version == 1

--- a/tests/nats/test_version_check.py
+++ b/tests/nats/test_version_check.py
@@ -1,0 +1,199 @@
+"""Unit tests for the check_schema_version helper (issue #530).
+
+Covers all rules described in _version_check.py:
+- Missing field → v1 (legacy backwards compat)
+- Exact match → accepted
+- Receiver newer than payload → accepted (forward-compat)
+- Receiver older than payload → dropped (mismatch)
+- Non-int values (string, None, zero, negative) → dropped
+- Counter isolation between independent callers
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lyra.nats._version_check import check_schema_version
+
+# ---------------------------------------------------------------------------
+# TestCheckSchemaVersion
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSchemaVersion:
+    """Unit tests for check_schema_version()."""
+
+    # --- acceptance cases ---------------------------------------------------
+
+    def test_absent_field_treated_as_v1(self) -> None:
+        """Missing schema_version key is treated as version 1 (legacy compat)."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        result = check_schema_version(
+            {}, envelope_name="A", expected=1, counter=counter
+        )
+
+        # Assert
+        assert result is True
+        assert counter == {}
+
+    def test_exact_match_accepts(self) -> None:
+        """Payload version == expected version → accepted."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        result = check_schema_version(
+            {"schema_version": 1},
+            envelope_name="A",
+            expected=1,
+            counter=counter,
+        )
+
+        # Assert
+        assert result is True
+        assert counter == {}
+
+    def test_receiver_newer_accepts(self) -> None:
+        """Payload version < expected → accepted (receiver upgraded first)."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        result = check_schema_version(
+            {"schema_version": 1},
+            envelope_name="A",
+            expected=2,
+            counter=counter,
+        )
+
+        # Assert
+        assert result is True
+        assert counter == {}
+
+    # --- drop cases ---------------------------------------------------------
+
+    def test_receiver_older_drops(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Payload version > expected → dropped, counter++, log.error emitted."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = check_schema_version(
+                {"schema_version": 2},
+                envelope_name="InboundMessage",
+                expected=1,
+                counter=counter,
+            )
+
+        # Assert — return value
+        assert result is False
+        # Assert — counter incremented
+        assert counter == {"InboundMessage": 1}
+        # Assert — exactly one ERROR log with the expected substring
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "NATS schema version mismatch" in error_records[0].getMessage()
+
+    def test_string_value_drops(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """String schema_version (malformed) → dropped, counter++, log.error."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = check_schema_version(
+                {"schema_version": "1"},
+                envelope_name="InboundMessage",
+                expected=1,
+                counter=counter,
+            )
+
+        # Assert
+        assert result is False
+        assert counter == {"InboundMessage": 1}
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "NATS schema version mismatch" in error_records[0].getMessage()
+
+    def test_null_value_drops(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Explicit null schema_version → dropped, counter++, log.error."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = check_schema_version(
+                {"schema_version": None},
+                envelope_name="InboundMessage",
+                expected=1,
+                counter=counter,
+            )
+
+        # Assert
+        assert result is False
+        assert counter == {"InboundMessage": 1}
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+
+    @pytest.mark.parametrize("bad_version", [0, -1])
+    def test_zero_or_negative_drops(
+        self, bad_version: int, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Integer <= 0 → dropped (invalid range), counter++, log.error."""
+        # Arrange
+        counter: dict[str, int] = {}
+
+        # Act
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = check_schema_version(
+                {"schema_version": bad_version},
+                envelope_name="InboundMessage",
+                expected=1,
+                counter=counter,
+            )
+
+        # Assert
+        assert result is False
+        assert counter == {"InboundMessage": 1}
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "NATS schema version mismatch" in error_records[0].getMessage()
+
+    # --- isolation -----------------------------------------------------------
+
+    def test_counter_isolation(self) -> None:
+        """Two separate counter dicts accumulate only their own drops."""
+        # Arrange
+        counter_a: dict[str, int] = {}
+        counter_b: dict[str, int] = {}
+
+        # Act — both calls are mismatch drops (payload v2, expected v1)
+        check_schema_version(
+            {"schema_version": 2},
+            envelope_name="EnvelopeA",
+            expected=1,
+            counter=counter_a,
+        )
+        check_schema_version(
+            {"schema_version": 2},
+            envelope_name="EnvelopeB",
+            expected=1,
+            counter=counter_b,
+        )
+
+        # Assert — each dict holds only its own key, not the other's
+        assert counter_a == {"EnvelopeA": 1}
+        assert counter_b == {"EnvelopeB": 1}
+        assert "EnvelopeB" not in counter_a
+        assert "EnvelopeA" not in counter_b

--- a/tests/nats/test_version_check.py
+++ b/tests/nats/test_version_check.py
@@ -146,11 +146,11 @@ class TestCheckSchemaVersion:
         error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert len(error_records) == 1
 
-    @pytest.mark.parametrize("bad_version", [0, -1])
-    def test_zero_or_negative_drops(
-        self, bad_version: int, caplog: pytest.LogCaptureFixture
+    @pytest.mark.parametrize("bad_version", [0, -1, 1.0, 2.0])
+    def test_malformed_numeric_values_drop(
+        self, bad_version: int | float, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Integer <= 0 → dropped (invalid range), counter++, log.error."""
+        """Integer <= 0 or float → dropped (invalid), counter++, log.error."""
         # Arrange
         counter: dict[str, int] = {}
 


### PR DESCRIPTION
## Summary

Closes #530

Adds a `schema_version: int = 1` field to all 5 hub↔adapter NATS envelopes so mismatched producer/consumer pairs fail **loudly** (drop + `log.error` + in-process counter) instead of silently misinterpreting fields.

The issue is not about enabling rolling deploys across breaking schema changes — coordinated deploy of `lyra_hub` + `lyra_telegram` + `lyra_discord` is still required. Versioning exists to make failures **explicit** when someone forgets to coordinate.

## What changed

- **New envelope field.** `schema_version: int = 1` on `InboundMessage`, `InboundAudio`, `OutboundMessage`, `TextRenderEvent`, `ToolSummaryRenderEvent`. Colocated `SCHEMA_VERSION_*` module-level constants are the single source of truth for bumping.
- **New helper.** `src/lyra/nats/_version_check.py` exports `check_schema_version(payload, *, envelope_name, expected, subject, counter)` — pure function with a **caller-owned** counter (no static class state, no test-isolation bugs).
- **Inbound path.** `NatsBus._make_handler.handler()` now `json.loads` → `check_schema_version` → `deserialize_dict` (no double-parse; uses the existing `_serialize.py:54` helper). Instance counter `self._version_mismatch_drops` + public `version_mismatch_count(envelope_name)` accessor.
- **Outbound path.** `NatsRenderEventCodec.decode()` gains a `counter` kwarg. The check runs **before** the manual `payload.get()` extraction in the `tool_summary` branch — this was a flagged landmine in the spec and is tested explicitly.
- **Counter propagation.** `NatsOutboundListener` owns `self._version_mismatch_drops` and passes it through `decode_stream_events(..., counter=...)` to `NatsRenderEventCodec.decode(..., counter=...)`.
- **Docs.** `docs/ARCHITECTURE.md` gains a "Schema versioning" subsection under the NATS wire format section, with the forward-compat rule and a numbered bump procedure.

## Forward-compat rule

A receiver accepts any payload where `schema_version <= expected`. Strictly-greater versions are dropped. Legacy payloads (no field) default to version 1 — so existing wire traffic is never dropped.

| Case | Behavior |
|---|---|
| `schema_version` absent (legacy) | Decoded as v1 |
| `schema_version == expected` | Decoded normally |
| `schema_version < expected` (receiver newer) | Decoded normally (additive fields already degrade) |
| `schema_version > expected` (receiver older) | Dropped + `log.error` + counter++ |
| Non-int / null / ≤0 | Dropped + `log.error` + counter++ |

## Test plan

- [x] Helper unit tests cover 8 cases: absent, match, receiver-newer, receiver-older, string, null, 0/-1, counter isolation
- [x] Legacy round-trip test parametrized over all 5 envelope types (serialize → strip `schema_version` → deserialize → default == 1)
- [x] `NatsBus` integration tests (real nats-server): match, legacy, mismatch, mixed batch `[v1, v2_bad, v1]` survives subscription, non-int drops
- [x] `NatsRenderEventCodec.decode()` unit tests for text + tool_summary branches, including the landmine test that passes a malformed `files` value (would raise if the check ran after extraction)
- [x] `NatsOutboundListener` integration test: counter flows through `decode_stream_events` → codec → listener accessor
- [x] Full `tests/nats/` + `tests/adapters/` sweep: 490 passed, 35 skipped (nats-server tests skip cleanly when binary absent), 0 failures, 0 regressions
- [x] `ruff check` and `pyright` clean on all touched files
- [x] `docs/ARCHITECTURE.md` gains the subsection + numbered bump procedure

## Out of scope

Chunk-envelope wrapper versioning (hand-rolled `{stream_id, seq, event_type, payload, done}` in `render_event_codec.py`), NATS subject-pattern versioning, TTS/STT wire format (voiceCLI boundary), schema registry, version negotiation, prometheus export.

## Artifacts

- Frame: `artifacts/frames/530-nats-message-versioning-frame.mdx`
- Spec:  `artifacts/specs/530-nats-message-versioning-spec.mdx`
- Plan:  `artifacts/plans/530-nats-message-versioning-plan.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)