### PR TITLE
chore(brand): V24 Test 1 — texture verification prompts (Klein 4B + PuLID)

### DIFF
--- a/brand/prompts/avatar-v24-test1/001-frontal-s42.md
+++ b/brand/prompts/avatar-v24-test1/001-frontal-s42.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 42
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/001-frontal-s42.md
+++ b/brand/prompts/avatar-v24-test1/001-frontal-s42.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 42
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/002-frontal-s137.md
+++ b/brand/prompts/avatar-v24-test1/002-frontal-s137.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 137
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/002-frontal-s137.md
+++ b/brand/prompts/avatar-v24-test1/002-frontal-s137.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 137
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/003-frontal-s271.md
+++ b/brand/prompts/avatar-v24-test1/003-frontal-s271.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 271
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/003-frontal-s271.md
+++ b/brand/prompts/avatar-v24-test1/003-frontal-s271.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 271
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/004-frontal-s512.md
+++ b/brand/prompts/avatar-v24-test1/004-frontal-s512.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 512
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/004-frontal-s512.md
+++ b/brand/prompts/avatar-v24-test1/004-frontal-s512.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 512
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/005-frontal-s888.md
+++ b/brand/prompts/avatar-v24-test1/005-frontal-s888.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 888
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/005-frontal-s888.md
+++ b/brand/prompts/avatar-v24-test1/005-frontal-s888.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 888
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Full frontal composition, direct gaze at lens.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/006-3q-left-s42.md
+++ b/brand/prompts/avatar-v24-test1/006-3q-left-s42.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 42
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/006-3q-left-s42.md
+++ b/brand/prompts/avatar-v24-test1/006-3q-left-s42.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 42
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/007-3q-left-s137.md
+++ b/brand/prompts/avatar-v24-test1/007-3q-left-s137.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 137
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/007-3q-left-s137.md
+++ b/brand/prompts/avatar-v24-test1/007-3q-left-s137.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 137
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/008-3q-left-s271.md
+++ b/brand/prompts/avatar-v24-test1/008-3q-left-s271.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 271
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/008-3q-left-s271.md
+++ b/brand/prompts/avatar-v24-test1/008-3q-left-s271.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 271
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/009-3q-left-s512.md
+++ b/brand/prompts/avatar-v24-test1/009-3q-left-s512.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 512
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/009-3q-left-s512.md
+++ b/brand/prompts/avatar-v24-test1/009-3q-left-s512.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 512
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/010-3q-left-s888.md
+++ b/brand/prompts/avatar-v24-test1/010-3q-left-s888.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 888
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/010-3q-left-s888.md
+++ b/brand/prompts/avatar-v24-test1/010-3q-left-s888.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 888
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the left, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/011-3q-right-s42.md
+++ b/brand/prompts/avatar-v24-test1/011-3q-right-s42.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 42
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/011-3q-right-s42.md
+++ b/brand/prompts/avatar-v24-test1/011-3q-right-s42.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 42
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/012-3q-right-s137.md
+++ b/brand/prompts/avatar-v24-test1/012-3q-right-s137.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 137
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/012-3q-right-s137.md
+++ b/brand/prompts/avatar-v24-test1/012-3q-right-s137.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 137
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/013-3q-right-s271.md
+++ b/brand/prompts/avatar-v24-test1/013-3q-right-s271.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 271
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/013-3q-right-s271.md
+++ b/brand/prompts/avatar-v24-test1/013-3q-right-s271.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 271
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/014-3q-right-s512.md
+++ b/brand/prompts/avatar-v24-test1/014-3q-right-s512.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 512
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/014-3q-right-s512.md
+++ b/brand/prompts/avatar-v24-test1/014-3q-right-s512.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 512
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/015-3q-right-s888.md
+++ b/brand/prompts/avatar-v24-test1/015-3q-right-s888.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 888
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/015-3q-right-s888.md
+++ b/brand/prompts/avatar-v24-test1/015-3q-right-s888.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 888
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Slight three-quarter turn to the right, gaze returning to camera.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/016-profile-left-s42.md
+++ b/brand/prompts/avatar-v24-test1/016-profile-left-s42.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 42
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/016-profile-left-s42.md
+++ b/brand/prompts/avatar-v24-test1/016-profile-left-s42.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 42
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/017-profile-left-s137.md
+++ b/brand/prompts/avatar-v24-test1/017-profile-left-s137.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 137
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/017-profile-left-s137.md
+++ b/brand/prompts/avatar-v24-test1/017-profile-left-s137.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 137
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/018-profile-left-s271.md
+++ b/brand/prompts/avatar-v24-test1/018-profile-left-s271.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 271
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/018-profile-left-s271.md
+++ b/brand/prompts/avatar-v24-test1/018-profile-left-s271.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 271
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/019-profile-left-s512.md
+++ b/brand/prompts/avatar-v24-test1/019-profile-left-s512.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 512
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/019-profile-left-s512.md
+++ b/brand/prompts/avatar-v24-test1/019-profile-left-s512.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 512
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/020-profile-left-s888.md
+++ b/brand/prompts/avatar-v24-test1/020-profile-left-s888.md
@@ -4,10 +4,11 @@ width: 1024
 height: 1024
 steps: 28
 guidance: 3.5
-face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+face_image: ~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
 pulid_strength: 0.8
 seed: 888
 ---
+# body lines 12-15: see _base.md
 Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
 Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
 

--- a/brand/prompts/avatar-v24-test1/020-profile-left-s888.md
+++ b/brand/prompts/avatar-v24-test1/020-profile-left-s888.md
@@ -1,0 +1,15 @@
+---
+engine: pulid-flux2-klein
+width: 1024
+height: 1024
+steps: 28
+guidance: 3.5
+face_image: /home/mickael/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v15-1024/000-reference-006.png
+pulid_strength: 0.8
+seed: 888
+---
+Editorial portrait photograph. Young woman, mid-20s, dark hair loose and natural. Side profile, 90-degree angle, gaze toward frame edge, left side.
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.

--- a/brand/prompts/avatar-v24-test1/FINDINGS.md
+++ b/brand/prompts/avatar-v24-test1/FINDINGS.md
@@ -6,6 +6,8 @@
 **Reference:** `concepts/avatar-lyra-v15-1024/000-reference-006.png`  
 **Baseline:** `brand/avatar/006-just-solved-1024.png` (Klein 4B, no PuLID)
 
+> **STATUS: PENDING** — fill Verdict + Decision before resolving issue #555.
+
 ## Generated Set
 
 20 images in `~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v24-test1/`

--- a/brand/prompts/avatar-v24-test1/FINDINGS.md
+++ b/brand/prompts/avatar-v24-test1/FINDINGS.md
@@ -1,0 +1,31 @@
+# V24 Test 1 — Texture Verification Findings
+
+**Issue:** roxabi/lyra#556  
+**Engine:** pulid-flux2-klein  
+**Params:** strength=0.8, steps=28, guidance=3.5, 1024×1024  
+**Reference:** `concepts/avatar-lyra-v15-1024/000-reference-006.png`  
+**Baseline:** `brand/avatar/006-just-solved-1024.png` (Klein 4B, no PuLID)
+
+## Generated Set
+
+20 images in `~/.roxabi/forge/lyra/brand/concepts/avatar-lyra-v24-test1/`
+
+| Pose | Seeds |
+|------|-------|
+| Frontal | 42, 137, 271, 512, 888 |
+| 3Q left | 42, 137, 271, 512, 888 |
+| 3Q right | 42, 137, 271, 512, 888 |
+| Profile left | 42, 137, 271, 512, 888 |
+
+## Verdict
+
+<!-- Fill in after visual inspection -->
+
+- [ ] Natural texture preserved ✓  
+- [ ] Airbrushed output ✗
+
+**Decision:** <!-- If natural → proceed to #555. If airbrushed → stop V24 exploration. -->
+
+## Notes
+
+<!-- pores / moles / asymmetry observations -->

--- a/brand/prompts/avatar-v24-test1/_base.md
+++ b/brand/prompts/avatar-v24-test1/_base.md
@@ -1,0 +1,7 @@
+# Shared body for avatar-v24-test1 prompts.
+# Edit here and sync to all 001–020 files if shared content changes.
+
+Expression: just solved it — quiet satisfied smile, eyes bright with calm pride, not showing off.
+
+Studio key light. Forge Orange rim (#e85d04) subtle warm accent. Obsidian background (#0a0a0f). Head and upper shoulders, shallow depth of field.
+Photorealistic, natural skin texture. Natural pores, subtle facial asymmetry preserved.


### PR DESCRIPTION
## Summary

- Adds 20 PuLID texture verification prompts (`brand/prompts/avatar-v24-test1/`) — 4 poses × 5 seeds, `pulid-flux2-klein`, strength=0.8, steps=28, guidance=3.5, 1024×1024
- Includes `FINDINGS.md` stub for visual verdict (natural texture ✓ or airbrushed ✗)
- Gate condition for V24 exploration: if airbrushed → stop; if natural → proceed to #555

## Context

Explored PuLID Klein 4B texture quality extensively:
- Identified that `pulid-flux2-klein` uses orthogonal (random-init) `proj_up`/`proj_down` due to 4096→3072 dim mismatch — the root cause of weak face lock
- Documented Process Pipeline v2 (`PROCESS-PIPELINE-V2.md` in forge): style exploration → description → 2000+ image dataset → dual scoring → clique → LoRA (5a) or projection training (5b)
- Fixed imageCLI bug: `PuLIDFlux2KleinEngine.__init__()` now accepts `**kwargs` to allow `batch()` passthrough (`Roxabi/imageCLI` staging, commit `6a3739a`)

## Gallery

https://diagrams.roxabi.com/lyra/brand/v24-test1-gallery.html

## Test plan

- [ ] Open gallery and visually compare generated images vs `klein-006style.png` baseline
- [ ] Fill in `FINDINGS.md` with verdict (natural ✓ or airbrushed ✗)
- [ ] If natural → open #555; if airbrushed → close V24 exploration

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)