### PR TITLE
fix(stores): add periodic WAL checkpoint and checkpoint on close

### DIFF
--- a/src/lyra/core/stores/sqlite_base.py
+++ b/src/lyra/core/stores/sqlite_base.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import sqlite3
 from pathlib import Path
 
 import aiosqlite
@@ -22,11 +24,29 @@ class SqliteStore:
             # any extra setup (cache warming, etc.)
 
     ``_open_db`` is idempotent — calling it when already connected is a no-op.
+
+    WAL management
+    --------------
+    SQLite WAL mode is enabled on every connection.  Without periodic
+    checkpointing the WAL file grows unbounded when long-lived readers prevent
+    SQLite's automatic checkpoint from running.
+
+    This class handles checkpointing in two ways:
+
+    * **On close** — ``close()`` runs ``PRAGMA wal_checkpoint(TRUNCATE)`` before
+      closing the connection so the WAL is flushed on every clean shutdown.
+    * **Periodic** — a background ``asyncio.Task`` runs the same pragma every
+      ``_wal_checkpoint_interval`` seconds (default 30 min) while the store is
+      open.  This keeps the WAL bounded during long-running processes.
     """
+
+    #: Seconds between periodic WAL checkpoints.  Override in subclass to tune.
+    _wal_checkpoint_interval: int = 1800
 
     def __init__(self, db_path: str | Path) -> None:
         self._db_path = str(db_path)
         self._db: aiosqlite.Connection | None = None
+        self._checkpoint_task: asyncio.Task[None] | None = None
 
     def _require_db(self) -> aiosqlite.Connection:
         """Return the open connection or raise RuntimeError."""
@@ -47,9 +67,56 @@ class SqliteStore:
         for stmt in ddl or []:
             await self._db.execute(stmt)
         await self._db.commit()
+        self._checkpoint_task = asyncio.get_event_loop().create_task(
+            self._run_periodic_checkpoint(),
+            name=f"wal-checkpoint:{self._db_path}",
+        )
+
+    async def _checkpoint(self) -> None:
+        """Run ``PRAGMA wal_checkpoint(TRUNCATE)`` and log the result.
+
+        Best-effort — logs and returns silently on ``OperationalError`` (e.g.
+        active transaction on the connection, or concurrent readers blocking
+        the truncation).  The WAL will be checkpointed on the next opportunity.
+        """
+        db = self._db
+        if db is None:
+            return
+        try:
+            async with db.execute("PRAGMA wal_checkpoint(TRUNCATE)") as cur:
+                row = await cur.fetchone()
+        except sqlite3.OperationalError as exc:
+            log.debug("WAL checkpoint skipped (db=%s): %s", self._db_path, exc)
+            return
+        if row is not None:
+            busy, log_pages, checkpointed = row
+            log.debug(
+                "WAL checkpoint: db=%s busy=%s log=%s checkpointed=%s",
+                self._db_path,
+                busy,
+                log_pages,
+                checkpointed,
+            )
+
+    async def _run_periodic_checkpoint(self) -> None:
+        """Background task: checkpoint WAL every ``_wal_checkpoint_interval`` s."""
+        try:
+            while True:
+                await asyncio.sleep(self._wal_checkpoint_interval)
+                await self._checkpoint()
+        except asyncio.CancelledError:
+            pass
 
     async def close(self) -> None:
-        """Close the database connection."""
+        """Checkpoint WAL and close the database connection."""
+        if self._checkpoint_task is not None:
+            self._checkpoint_task.cancel()
+            try:
+                await self._checkpoint_task
+            except asyncio.CancelledError:
+                pass
+            self._checkpoint_task = None
         if self._db is not None:
+            await self._checkpoint()
             await self._db.close()
             self._db = None

--- a/src/lyra/core/stores/sqlite_base.py
+++ b/src/lyra/core/stores/sqlite_base.py
@@ -67,7 +67,7 @@ class SqliteStore:
         for stmt in ddl or []:
             await self._db.execute(stmt)
         await self._db.commit()
-        self._checkpoint_task = asyncio.get_event_loop().create_task(
+        self._checkpoint_task = asyncio.get_running_loop().create_task(
             self._run_periodic_checkpoint(),
             name=f"wal-checkpoint:{self._db_path}",
         )

--- a/tests/core/test_sqlite_base_wal.py
+++ b/tests/core/test_sqlite_base_wal.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 from lyra.core.stores.sqlite_base import (
     SqliteStore,
@@ -31,6 +33,12 @@ class _SimpleStore(SqliteStore):
 class TestWalCheckpointOnClose:
     """close() must checkpoint WAL before closing the connection."""
 
+    async def test_close_without_connect_is_safe(self, tmp_path: Path) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.close()  # must not raise — _db and _checkpoint_task are None
+        assert store._db is None
+        assert store._checkpoint_task is None
+
     async def test_checkpoint_on_close_runs_without_error(self, tmp_path: Path) -> None:
         store = _SimpleStore(tmp_path / "test.db")
         await store.connect()
@@ -45,6 +53,26 @@ class TestWalCheckpointOnClose:
         # Second close must not raise
         await store.close()
         assert store._db is None
+
+    async def test_checkpoint_suppresses_operational_error(
+        self, tmp_path: Path
+    ) -> None:
+        """_checkpoint() must not propagate sqlite3.OperationalError."""
+
+        class _LockedCM:
+            async def __aenter__(self) -> None:
+                raise sqlite3.OperationalError("database is locked")
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        try:
+            with patch.object(store._db, "execute", return_value=_LockedCM()):
+                await store._checkpoint()  # must not raise
+        finally:
+            await store.close()
 
     async def test_checkpoint_task_cancelled_on_close(self, tmp_path: Path) -> None:
         store = _SimpleStore(tmp_path / "test.db")
@@ -125,7 +153,7 @@ class TestPeriodicCheckpointTask:
             await store.close()
 
     async def test_short_interval_checkpoint_fires(self, tmp_path: Path) -> None:
-        """With a 0-second interval the checkpoint runs immediately on next tick."""
+        """With a 0-second interval _checkpoint() is called on the next tick."""
 
         class _FastStore(_SimpleStore):
             _wal_checkpoint_interval = 0
@@ -133,10 +161,12 @@ class TestPeriodicCheckpointTask:
         store = _FastStore(tmp_path / "fast.db")
         await store.connect()
         try:
-            # Let the event loop tick so the task can run
+            spy = AsyncMock(wraps=store._checkpoint)
+            store._checkpoint = spy  # type: ignore[method-assign]
             await asyncio.sleep(0.05)
-            # If checkpoint raised, the task would be in an exception state
-            assert store._checkpoint_task is not None
-            assert not store._checkpoint_task.done()
+            assert spy.call_count >= 1, (
+                f"Expected _checkpoint() to be called at least once, "
+                f"got {spy.call_count}"
+            )
         finally:
             await store.close()

--- a/tests/core/test_sqlite_base_wal.py
+++ b/tests/core/test_sqlite_base_wal.py
@@ -1,0 +1,142 @@
+"""SqliteStore WAL checkpoint — periodic task and checkpoint-on-close."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from lyra.core.stores.sqlite_base import (
+    SqliteStore,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass for testing
+# ---------------------------------------------------------------------------
+
+
+class _SimpleStore(SqliteStore):
+    """Concrete subclass with a trivial schema."""
+
+    async def connect(self) -> None:
+        await self._open_db(
+            ["CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY)"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestWalCheckpointOnClose
+# ---------------------------------------------------------------------------
+
+
+class TestWalCheckpointOnClose:
+    """close() must checkpoint WAL before closing the connection."""
+
+    async def test_checkpoint_on_close_runs_without_error(self, tmp_path: Path) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        # Should not raise — even on an empty WAL
+        await store.close()
+        assert store._db is None
+
+    async def test_close_is_idempotent(self, tmp_path: Path) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        await store.close()
+        # Second close must not raise
+        await store.close()
+        assert store._db is None
+
+    async def test_checkpoint_task_cancelled_on_close(self, tmp_path: Path) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        task = store._checkpoint_task
+        assert task is not None
+        assert not task.done()
+        await store.close()
+        assert task.done()
+        assert store._checkpoint_task is None
+
+    async def test_wal_file_truncated_after_close(self, tmp_path: Path) -> None:
+        """WAL file should be at zero or minimal size after TRUNCATE checkpoint."""
+        db_path = tmp_path / "test.db"
+        wal_path = tmp_path / "test.db-wal"
+
+        store = _SimpleStore(db_path)
+        await store.connect()
+        # Write enough rows to produce WAL pages
+        db = store._require_db()
+        for i in range(50):
+            await db.execute("INSERT INTO items VALUES (?)", (i,))
+        await db.commit()
+
+        # WAL should exist with some content now
+        assert wal_path.exists()
+
+        await store.close()
+
+        # After TRUNCATE checkpoint the WAL should be absent or empty
+        wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+        assert wal_size == 0, f"WAL not truncated after close: {wal_size} bytes"
+
+
+# ---------------------------------------------------------------------------
+# TestPeriodicCheckpointTask
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodicCheckpointTask:
+    """Background checkpoint task lifecycle."""
+
+    async def test_checkpoint_task_started_on_open_db(self, tmp_path: Path) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        try:
+            assert store._checkpoint_task is not None
+            assert not store._checkpoint_task.done()
+        finally:
+            await store.close()
+
+    async def test_checkpoint_task_not_started_before_connect(
+        self, tmp_path: Path
+    ) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        assert store._checkpoint_task is None
+
+    async def test_open_db_idempotent_does_not_spawn_second_task(
+        self, tmp_path: Path
+    ) -> None:
+        """Calling _open_db() twice must not create a second background task."""
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        try:
+            task_after_first = store._checkpoint_task
+            # Simulate accidental second call
+            await store._open_db()
+            assert store._checkpoint_task is task_after_first
+        finally:
+            await store.close()
+
+    async def test_manual_checkpoint_runs_without_error(self, tmp_path: Path) -> None:
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        try:
+            await store._checkpoint()
+        finally:
+            await store.close()
+
+    async def test_short_interval_checkpoint_fires(self, tmp_path: Path) -> None:
+        """With a 0-second interval the checkpoint runs immediately on next tick."""
+
+        class _FastStore(_SimpleStore):
+            _wal_checkpoint_interval = 0
+
+        store = _FastStore(tmp_path / "fast.db")
+        await store.connect()
+        try:
+            # Let the event loop tick so the task can run
+            await asyncio.sleep(0.05)
+            # If checkpoint raised, the task would be in an exception state
+            assert store._checkpoint_task is not None
+            assert not store._checkpoint_task.done()
+        finally:
+            await store.close()


### PR DESCRIPTION
## Summary
- Add periodic WAL checkpoint background task (every 30 min) to `SqliteStore` base class — prevents WAL from growing unbounded across long-lived hub/adapter processes
- Add checkpoint-on-close so every clean shutdown flushes the WAL to the main DB file

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #502: fix(stores): add periodic WAL checkpoint and checkpoint on close | Open |
| Implementation | 1 commit on `feat/502-fix-stores-wal-checkpoint` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (9 new) | Passed |

## Test Plan
- [ ] All 9 new WAL tests pass (`tests/core/test_sqlite_base_wal.py`)
- [ ] Existing store tests pass without regression (64 total)
- [ ] On production: verify WAL files truncate to 0 bytes after restart

Closes #502

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`