### PR TITLE
fix(hub): call hub.shutdown() after cli_pool.stop() on both shutdown paths

### DIFF
--- a/src/lyra/bootstrap/bootstrap_lifecycle.py
+++ b/src/lyra/bootstrap/bootstrap_lifecycle.py
@@ -112,4 +112,5 @@ async def run_lifecycle(  # noqa: PLR0913, C901 — lifecycle orchestration
         if active_ids:
             await hub.notify_shutdown_inflight(active_ids)
         await cli_pool.stop()
+    await hub.shutdown()
     log.info("Lyra stopped.")

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -485,6 +485,7 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
             if active_ids:
                 await hub.notify_shutdown_inflight(active_ids)
             await cli_pool.stop()
+        await hub.shutdown()
 
     # Close NATS connection after stores context exits
     try:

--- a/src/lyra/core/stores/sqlite_base.py
+++ b/src/lyra/core/stores/sqlite_base.py
@@ -85,7 +85,7 @@ class SqliteStore:
         try:
             async with db.execute("PRAGMA wal_checkpoint(TRUNCATE)") as cur:
                 row = await cur.fetchone()
-        except sqlite3.OperationalError as exc:
+        except (sqlite3.OperationalError, sqlite3.ProgrammingError) as exc:
             log.debug("WAL checkpoint skipped (db=%s): %s", self._db_path, exc)
             return
         if row is not None:

--- a/src/lyra/core/stores/sqlite_base.py
+++ b/src/lyra/core/stores/sqlite_base.py
@@ -75,9 +75,10 @@ class SqliteStore:
     async def _checkpoint(self) -> None:
         """Run ``PRAGMA wal_checkpoint(TRUNCATE)`` and log the result.
 
-        Best-effort — logs and returns silently on ``OperationalError`` (e.g.
-        active transaction on the connection, or concurrent readers blocking
-        the truncation).  The WAL will be checkpointed on the next opportunity.
+        Best-effort — logs and returns silently on ``OperationalError`` or
+        ``ProgrammingError`` (e.g. active transaction, concurrent readers, or
+        connection closed during shutdown).  The WAL will be checkpointed on
+        the next opportunity.
         """
         db = self._db
         if db is None:

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -211,10 +211,16 @@ class TestHubEvictFlushTask:
         assert len(hub._memory_tasks) >= 1
 
     @pytest.mark.asyncio
-    async def test_shutdown_has_shutdown_method(self) -> None:
-        """Hub must expose a shutdown() coroutine method (S4)."""
+    async def test_shutdown_closes_injected_stores(self) -> None:
+        """hub.shutdown() must close turn_store and message_index when injected."""
         hub = Hub()
-        assert hasattr(hub, "shutdown")  # FAILS until shutdown() is added
+        mock_turn = AsyncMock()
+        mock_index = AsyncMock()
+        hub.set_turn_store(mock_turn)
+        hub.set_message_index(mock_index)
+        await hub.shutdown()
+        mock_turn.close.assert_awaited_once()
+        mock_index.close.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_sqlite_base_wal.py
+++ b/tests/core/test_sqlite_base_wal.py
@@ -74,6 +74,26 @@ class TestWalCheckpointOnClose:
         finally:
             await store.close()
 
+    async def test_checkpoint_suppresses_programming_error(
+        self, tmp_path: Path
+    ) -> None:
+        """_checkpoint() must not propagate sqlite3.ProgrammingError."""
+
+        class _ClosedCM:
+            async def __aenter__(self) -> None:
+                raise sqlite3.ProgrammingError("Cannot operate on a closed database")
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+        store = _SimpleStore(tmp_path / "test.db")
+        await store.connect()
+        try:
+            with patch.object(store._db, "execute", return_value=_ClosedCM()):
+                await store._checkpoint()  # must not raise
+        finally:
+            await store.close()
+
     async def test_checkpoint_task_cancelled_on_close(self, tmp_path: Path) -> None:
         store = _SimpleStore(tmp_path / "test.db")
         await store.connect()


### PR DESCRIPTION
## Summary
- Add `await hub.shutdown()` after `cli_pool.stop()` in both shutdown paths (`hub_standalone.py` and `bootstrap_lifecycle.py`) so TTS fire-and-forget tasks in `hub._memory_tasks` are always awaited before stores are torn down
- Catch `sqlite3.ProgrammingError` in `sqlite_base._checkpoint()` alongside the existing `OperationalError` — prevents an uncaught exception if the connection is closed mid-checkpoint

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #586: fix(hub): hub.shutdown() never called | Open |
| Implementation | 1 commit on `feat/586-fix-hub-shutdown-ordering` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2482 passed) | Passed |

## Root cause
```
Signal received
→ tasks cancelled + gathered
→ cli_pool.drain(60s) + cli_pool.stop()
→ run_lifecycle / hub_standalone returns   ← hub.shutdown() never called
→ open_stores() finally block closes ALL stores
→ prefs_store._db = None
  ↕ RACE
→ TTS task still running (fire-and-forget)
→ synthesize_and_dispatch_audio()
→ get_prefs() → _require_db() → None → CRASH
```

## Test Plan
- [ ] Deploy to production and observe clean shutdown (no `sqlite3.ProgrammingError` / `RuntimeError: call connect() first` in logs)
- [ ] Send a TTS-triggering message, immediately restart hub — confirm no crash on next startup

Closes #586

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`