### PR TITLE
refactor(nats): NatsAdapterBase — enforced nkey, schema validation, queue group, lifecycle (#582)

### DIFF
--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -86,11 +86,17 @@ class SttAdapterStandalone(NatsAdapterBase):
         await self.reply(msg, json.dumps(response, ensure_ascii=False).encode("utf-8"))
 
 
-async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
+async def _bootstrap_stt_adapter_standalone(
     raw_config: dict,
     *,
     _stop: asyncio.Event | None = None,
 ) -> None:
+    """Bootstrap a standalone STT adapter process connected to NATS.
+
+    Args:
+        raw_config: Parsed config dict (lyra config.toml content).
+        _stop: Optional event for graceful shutdown (tests inject this).
+    """
     nats_url = os.environ.get("NATS_URL")
     if not nats_url:
         sys.exit("NATS_URL required for standalone STT adapter")

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -11,44 +11,29 @@ import base64
 import json
 import logging
 import os
-import signal
 import sys
 import tempfile
 from pathlib import Path
 
-import nats
-
+from lyra.nats import NatsAdapterBase
+from lyra.nats.queue_groups import STT_WORKERS
 from lyra.stt import STTService, TranscriptionResult, load_stt_config
 
 log = logging.getLogger(__name__)
 
 SUBJECT = "lyra.voice.stt.request"
-QUEUE_GROUP = "stt-workers"
 
 
-async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
-    raw_config: dict,
-    *,
-    _stop: asyncio.Event | None = None,
-) -> None:
-    """Bootstrap a standalone STT adapter process connected to NATS.
+class SttAdapterStandalone(NatsAdapterBase):
+    def __init__(self, raw_config: dict) -> None:
+        super().__init__(SUBJECT, STT_WORKERS, "SttRequest", 1)
+        self._base_stt_cfg = load_stt_config()
+        self._stt_service = STTService(self._base_stt_cfg)
+        log.info(
+            "stt_adapter: STTService ready (model=%s)", self._base_stt_cfg.model_size
+        )
 
-    Args:
-        raw_config: Parsed config dict (lyra config.toml content).
-        _stop: Optional event for graceful shutdown (tests inject this).
-    """
-    nats_url = os.environ.get("NATS_URL")
-    if not nats_url:
-        sys.exit("NATS_URL required for standalone STT adapter")
-
-    nc = await nats.connect(nats_url)
-    log.info("stt_adapter: connected to NATS at %s", nats_url)
-
-    base_stt_cfg = load_stt_config()
-    stt_service = STTService(base_stt_cfg)
-    log.info("stt_adapter: STTService ready (model=%s)", base_stt_cfg.model_size)
-
-    async def handler(msg) -> None:  # nats.aio.msg.Msg
+    async def handle(self, msg) -> None:
         data: dict = {}
         response: dict
         try:
@@ -58,8 +43,7 @@ async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
             audio_bytes = base64.b64decode(audio_b64)
             mime_type = data.get("mime_type", "audio/ogg")
 
-            # Apply per-request STT config overrides from hub (detection params)
-            svc = stt_service
+            svc = self._stt_service
             overrides: dict = {}
             for key in (
                 "language_detection_threshold",
@@ -69,7 +53,7 @@ async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
                 if data.get(key) is not None:
                     overrides[key] = data[key]
             if overrides:
-                cfg = base_stt_cfg.model_copy(update=overrides)
+                cfg = self._base_stt_cfg.model_copy(update=overrides)
                 svc = STTService(cfg)
 
             suffix = _mime_to_ext(mime_type)
@@ -78,9 +62,7 @@ async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
                 os.write(fd, audio_bytes)
                 os.close(fd)
                 tmp_path = Path(tmp_path_str)
-
                 result: TranscriptionResult = await svc.transcribe(tmp_path)
-
                 response = {
                     "request_id": request_id,
                     "ok": True,
@@ -102,27 +84,23 @@ async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
                 "error": "transcription_failed",
             }
 
-        if msg.reply:
-            await nc.publish(
+        if msg.reply and self._nc:
+            await self._nc.publish(
                 msg.reply,
                 json.dumps(response, ensure_ascii=False).encode("utf-8"),
             )
 
-    sub = await nc.subscribe(SUBJECT, queue=QUEUE_GROUP, cb=handler)
-    log.info("stt_adapter: subscribed to %s (queue=%s)", SUBJECT, QUEUE_GROUP)
 
-    stop = _stop if _stop is not None else asyncio.Event()
-    if _stop is None:
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, stop.set)
-
-    await stop.wait()
-    log.info("stt_adapter: shutdown signal received")
-
-    await sub.unsubscribe()
-    await nc.close()
-    log.info("stt_adapter: stopped")
+async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring
+    raw_config: dict,
+    *,
+    _stop: asyncio.Event | None = None,
+) -> None:
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit("NATS_URL required for standalone STT adapter")
+    log.info("stt_adapter: connecting to NATS at %s", nats_url)
+    await SttAdapterStandalone(raw_config).run(nats_url, _stop)
 
 
 def _mime_to_ext(mime_type: str) -> str:

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -33,11 +33,10 @@ class SttAdapterStandalone(NatsAdapterBase):
             "stt_adapter: STTService ready (model=%s)", self._base_stt_cfg.model_size
         )
 
-    async def handle(self, msg) -> None:
-        data: dict = {}
+    async def handle(self, msg, payload: dict) -> None:
+        data: dict = payload
         response: dict
         try:
-            data = json.loads(msg.data)
             request_id = data.get("request_id", "unknown")
             audio_b64 = data["audio_b64"]
             audio_bytes = base64.b64decode(audio_b64)
@@ -84,11 +83,7 @@ class SttAdapterStandalone(NatsAdapterBase):
                 "error": "transcription_failed",
             }
 
-        if msg.reply and self._nc:
-            await self._nc.publish(
-                msg.reply,
-                json.dumps(response, ensure_ascii=False).encode("utf-8"),
-            )
+        await self.reply(msg, json.dumps(response, ensure_ascii=False).encode("utf-8"))
 
 
 async def _bootstrap_stt_adapter_standalone(  # noqa: PLR0915 — startup wiring

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -11,18 +11,16 @@ import base64
 import json
 import logging
 import os
-import signal
 import sys
 from dataclasses import dataclass
 
-import nats
-
+from lyra.nats import NatsAdapterBase
+from lyra.nats.queue_groups import TTS_WORKERS
 from lyra.tts import SynthesisResult, TTSService, load_tts_config
 
 log = logging.getLogger(__name__)
 
 SUBJECT = "lyra.voice.tts.request"
-QUEUE_GROUP = "tts-workers"
 
 # Fields the hub serializes from AgentTTSConfig into the NATS request.
 _AGENT_TTS_FIELDS = (
@@ -55,29 +53,16 @@ class _NatsTtsConfig:
     languages: list[str] | None = None
 
 
-async def _bootstrap_tts_adapter_standalone(
-    raw_config: dict,
-    *,
-    _stop: asyncio.Event | None = None,
-) -> None:
-    """Bootstrap a standalone TTS adapter process connected to NATS.
+class TtsAdapterStandalone(NatsAdapterBase):
+    def __init__(self, raw_config: dict) -> None:
+        super().__init__(SUBJECT, TTS_WORKERS, "TtsRequest", 1)
+        tts_cfg = load_tts_config()
+        self._tts_service = TTSService(tts_cfg)
+        log.info(
+            "tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default"
+        )
 
-    Args:
-        raw_config: Parsed config dict (lyra config.toml content).
-        _stop: Optional event for graceful shutdown (tests inject this).
-    """
-    nats_url = os.environ.get("NATS_URL")
-    if not nats_url:
-        sys.exit("NATS_URL required for standalone TTS adapter")
-
-    nc = await nats.connect(nats_url)
-    log.info("tts_adapter: connected to NATS at %s", nats_url)
-
-    tts_cfg = load_tts_config()
-    tts_service = TTSService(tts_cfg)
-    log.info("tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default")
-
-    async def handler(msg) -> None:  # nats.aio.msg.Msg
+    async def handle(self, msg) -> None:
         data: dict = {}
         response: dict
         try:
@@ -99,7 +84,7 @@ async def _bootstrap_tts_adapter_standalone(
                 if data.get(key) is not None:
                     synth_kwargs[key] = data[key]
 
-            result: SynthesisResult = await tts_service.synthesize(
+            result: SynthesisResult = await self._tts_service.synthesize(
                 text,
                 agent_tts=agent_tts,  # type: ignore[arg-type]  # duck-typed stand-in
                 **synth_kwargs,
@@ -125,24 +110,26 @@ async def _bootstrap_tts_adapter_standalone(
                 "error": "synthesis_failed",
             }
 
-        if msg.reply:
-            await nc.publish(
+        if msg.reply and self._nc:
+            await self._nc.publish(
                 msg.reply,
                 json.dumps(response, ensure_ascii=False).encode("utf-8"),
             )
 
-    sub = await nc.subscribe(SUBJECT, queue=QUEUE_GROUP, cb=handler)
-    log.info("tts_adapter: subscribed to %s (queue=%s)", SUBJECT, QUEUE_GROUP)
 
-    stop = _stop if _stop is not None else asyncio.Event()
-    if _stop is None:
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, stop.set)
+async def _bootstrap_tts_adapter_standalone(
+    raw_config: dict,
+    *,
+    _stop: asyncio.Event | None = None,
+) -> None:
+    """Bootstrap a standalone TTS adapter process connected to NATS.
 
-    await stop.wait()
-    log.info("tts_adapter: shutdown signal received")
-
-    await sub.unsubscribe()
-    await nc.close()
-    log.info("tts_adapter: stopped")
+    Args:
+        raw_config: Parsed config dict (lyra config.toml content).
+        _stop: Optional event for graceful shutdown (tests inject this).
+    """
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit("NATS_URL required for standalone TTS adapter")
+    log.info("tts_adapter: connecting to NATS at %s", nats_url)
+    await TtsAdapterStandalone(raw_config).run(nats_url, _stop)

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -62,11 +62,10 @@ class TtsAdapterStandalone(NatsAdapterBase):
             "tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default"
         )
 
-    async def handle(self, msg) -> None:
-        data: dict = {}
+    async def handle(self, msg, payload: dict) -> None:
+        data: dict = payload
         response: dict
         try:
-            data = json.loads(msg.data)
             request_id = data.get("request_id", "unknown")
             text = data["text"]
 
@@ -110,11 +109,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
                 "error": "synthesis_failed",
             }
 
-        if msg.reply and self._nc:
-            await self._nc.publish(
-                msg.reply,
-                json.dumps(response, ensure_ascii=False).encode("utf-8"),
-            )
+        await self.reply(msg, json.dumps(response, ensure_ascii=False).encode("utf-8"))
 
 
 async def _bootstrap_tts_adapter_standalone(

--- a/src/lyra/nats/__init__.py
+++ b/src/lyra/nats/__init__.py
@@ -19,9 +19,10 @@ Usage::
     ...
     await bus.stop()
 """
+from .adapter_base import NatsAdapterBase
 from .connect import nats_connect
 from .nats_bus import NatsBus
 from .nats_channel_proxy import NatsChannelProxy
 from .render_event_codec import NatsRenderEventCodec
 
-__all__ = ["NatsBus", "NatsChannelProxy", "NatsRenderEventCodec", "nats_connect"]
+__all__ = ["NatsAdapterBase", "NatsBus", "NatsChannelProxy", "NatsRenderEventCodec", "nats_connect"]

--- a/src/lyra/nats/__init__.py
+++ b/src/lyra/nats/__init__.py
@@ -25,4 +25,10 @@ from .nats_bus import NatsBus
 from .nats_channel_proxy import NatsChannelProxy
 from .render_event_codec import NatsRenderEventCodec
 
-__all__ = ["NatsAdapterBase", "NatsBus", "NatsChannelProxy", "NatsRenderEventCodec", "nats_connect"]
+__all__ = [
+    "NatsAdapterBase",
+    "NatsBus",
+    "NatsChannelProxy",
+    "NatsRenderEventCodec",
+    "nats_connect",
+]

--- a/src/lyra/nats/adapter_base.py
+++ b/src/lyra/nats/adapter_base.py
@@ -1,0 +1,98 @@
+"""NatsAdapterBase — ABC lifecycle host for NATS request-reply adapters.
+
+Subclass this and implement ``handle(msg)`` to build a NATS queue-subscriber
+adapter with built-in envelope validation, hub readiness waiting, graceful
+drain/close shutdown, and a ``health()`` introspection method.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import signal
+import time
+from abc import ABC, abstractmethod
+
+from nats.aio.client import Client as NATS
+
+from lyra.nats._validate import validate_nats_token
+from lyra.nats._version_check import check_schema_version
+from lyra.nats.connect import nats_connect
+from lyra.nats.readiness import wait_for_hub
+
+log = logging.getLogger(__name__)
+
+
+class NatsAdapterBase(ABC):
+    def __init__(  # noqa: PLR0913
+        self, subject, queue_group, envelope_name, schema_version,
+        timeout=30.0, drain_timeout=30.0,
+    ):
+        validate_nats_token(subject, kind="subject")
+        validate_nats_token(queue_group, kind="queue_group")
+        self.subject = subject
+        self.queue_group = queue_group
+        self.envelope_name = envelope_name
+        self.schema_version = schema_version
+        self.timeout = timeout
+        self.drain_timeout = drain_timeout
+        self._nc: NATS | None = None
+        self._drop_count: dict[str, int] = {}
+        self._started_at: float | None = None
+
+    async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
+        nc = await nats_connect(nats_url)
+        self._nc = nc
+        await self._wait_ready()
+        await nc.subscribe(self.subject, queue=self.queue_group, cb=self._dispatch)
+        if stop is None:
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(sig, stop.set)
+        self._started_at = time.monotonic()
+        await stop.wait()
+        await self._shutdown()
+
+    @abstractmethod
+    async def handle(self, msg) -> None: ...
+
+    async def _dispatch(self, msg) -> None:
+        try:
+            payload = json.loads(msg.data)
+        except Exception:
+            log.error("adapter_base: malformed JSON on %s", self.subject)
+            return
+        if self._validate_envelope(payload):
+            await self.handle(msg)
+
+    def _validate_envelope(self, payload: dict) -> bool:
+        return check_schema_version(
+            payload,
+            envelope_name=self.envelope_name,
+            expected=self.schema_version,
+            subject=self.subject,
+            counter=self._drop_count,
+        )
+
+    async def _shutdown(self) -> None:
+        if self._nc:
+            await self._nc.drain()
+            await self._nc.close()
+
+    async def _wait_ready(self) -> None:
+        assert self._nc is not None
+        ok = await wait_for_hub(self._nc, timeout=self.timeout)
+        if not ok:
+            log.warning("adapter_base: hub readiness timed out — starting anyway")
+
+    def health(self) -> dict:
+        uptime = time.monotonic() - self._started_at if self._started_at else 0.0
+        return {
+            "status": "ok",
+            "subject": self.subject,
+            "queue_group": self.queue_group,
+            "schema_version": self.schema_version,
+            "connected": self._nc.is_connected if self._nc else False,
+            "uptime_s": round(uptime, 3),
+        }

--- a/src/lyra/nats/adapter_base.py
+++ b/src/lyra/nats/adapter_base.py
@@ -55,7 +55,12 @@ class NatsAdapterBase(ABC):
         await self._shutdown()
 
     @abstractmethod
-    async def handle(self, msg) -> None: ...
+    async def handle(self, msg, payload: dict) -> None: ...
+
+    async def reply(self, msg, data: bytes) -> None:
+        """Publish a response to msg.reply if a reply subject exists."""
+        if msg.reply and self._nc:
+            await self._nc.publish(msg.reply, data)
 
     async def _dispatch(self, msg) -> None:
         try:
@@ -64,7 +69,7 @@ class NatsAdapterBase(ABC):
             log.error("adapter_base: malformed JSON on %s", self.subject)
             return
         if self._validate_envelope(payload):
-            await self.handle(msg)
+            await self.handle(msg, payload)
 
     def _validate_envelope(self, payload: dict) -> bool:
         return check_schema_version(
@@ -77,11 +82,14 @@ class NatsAdapterBase(ABC):
 
     async def _shutdown(self) -> None:
         if self._nc:
-            await self._nc.drain()
+            await asyncio.wait_for(self._nc.drain(), timeout=self.drain_timeout)
             await self._nc.close()
 
     async def _wait_ready(self) -> None:
-        assert self._nc is not None
+        if self._nc is None:
+            raise RuntimeError(  # noqa: TRY003
+                "_wait_ready called before NATS connection was established"
+            )
         ok = await wait_for_hub(self._nc, timeout=self.timeout)
         if not ok:
             log.warning("adapter_base: hub readiness timed out — starting anyway")

--- a/src/lyra/nats/queue_groups.py
+++ b/src/lyra/nats/queue_groups.py
@@ -11,6 +11,12 @@ from lyra.core.message import Platform
 #: Hub-side inbound text message subscription (``NatsBus``).
 HUB_INBOUND = "hub-inbound"
 
+#: Queue group for TTS worker processes consuming synthesis requests.
+TTS_WORKERS = "tts-workers"
+
+#: Queue group for STT worker processes consuming transcription requests.
+STT_WORKERS = "stt-workers"
+
 
 def adapter_outbound(platform: Platform, bot_id: str) -> str:
     """Return the NATS queue group for an adapter's outbound subscription.

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -21,22 +21,22 @@ _SOURCE = Path("src/lyra/bootstrap/stt_adapter_standalone.py")
 
 
 def test_stt_adapter_source_uses_no_bare_nats_connect() -> None:
-    """Source must not contain bare nats.connect() or bare 'import nats' after migration.
+    """Source must not contain bare nats.connect() or 'import nats' after migration.
 
     RED gate: current source has `nats.connect(` and `import nats\\n` — this fails
     until the migration to NatsAdapterBase removes them.
     """
     source = _SOURCE.read_text()
     assert "nats.connect(" not in source, (
-        "stt_adapter_standalone still uses bare nats.connect() — migrate to NatsAdapterBase"
+        "stt_adapter_standalone still uses bare nats.connect()"
     )
     assert "import nats\n" not in source, (
-        "stt_adapter_standalone still has bare 'import nats' — migrate to NatsAdapterBase"
+        "stt_adapter_standalone still has bare 'import nats'"
     )
 
 
 def test_stt_adapter_uses_stt_workers_constant() -> None:
-    """Source must reference the STT_WORKERS constant, not a hardcoded QUEUE_GROUP string.
+    """Source must reference STT_WORKERS, not a hardcoded QUEUE_GROUP string.
 
     RED gate: current source uses a bare QUEUE_GROUP string; STT_WORKERS is not
     imported or defined until migration.
@@ -49,7 +49,7 @@ def test_stt_adapter_uses_stt_workers_constant() -> None:
 
 
 def test_bootstrap_stt_adapter_standalone_signature() -> None:
-    """_bootstrap_stt_adapter_standalone must be an async function with the expected params.
+    """_bootstrap_stt_adapter_standalone must be async with the expected params.
 
     This test passes before and after migration — the public signature is unchanged.
     """

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import pytest
 
-_SOURCE = Path("src/lyra/bootstrap/stt_adapter_standalone.py")
+_SOURCE = (
+    Path(__file__).parent.parent.parent / "src/lyra/bootstrap/stt_adapter_standalone.py"
+)
 
 
 def test_stt_adapter_source_uses_no_bare_nats_connect() -> None:

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -1,0 +1,115 @@
+"""Tests for stt_adapter_standalone — RED-phase tests for NatsAdapterBase migration.
+
+These tests verify the post-migration shape of stt_adapter_standalone.py:
+  - No bare nats.connect() / import nats usage
+  - STT_WORKERS constant is used (not a hardcoded QUEUE_GROUP string)
+  - _bootstrap_stt_adapter_standalone retains its async signature
+  - SttAdapterStandalone class exists and inherits from NatsAdapterBase
+  - _mime_to_ext helper remains accessible at module level
+
+Tests 1, 2, and 4 are RED before migration (they fail against current source).
+Tests 3 and 5 pass both before and after migration (signature and helper unchanged).
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+_SOURCE = Path("src/lyra/bootstrap/stt_adapter_standalone.py")
+
+
+def test_stt_adapter_source_uses_no_bare_nats_connect() -> None:
+    """Source must not contain bare nats.connect() or bare 'import nats' after migration.
+
+    RED gate: current source has `nats.connect(` and `import nats\\n` — this fails
+    until the migration to NatsAdapterBase removes them.
+    """
+    source = _SOURCE.read_text()
+    assert "nats.connect(" not in source, (
+        "stt_adapter_standalone still uses bare nats.connect() — migrate to NatsAdapterBase"
+    )
+    assert "import nats\n" not in source, (
+        "stt_adapter_standalone still has bare 'import nats' — migrate to NatsAdapterBase"
+    )
+
+
+def test_stt_adapter_uses_stt_workers_constant() -> None:
+    """Source must reference the STT_WORKERS constant, not a hardcoded QUEUE_GROUP string.
+
+    RED gate: current source uses a bare QUEUE_GROUP string; STT_WORKERS is not
+    imported or defined until migration.
+    """
+    source = _SOURCE.read_text()
+    assert "STT_WORKERS" in source, (
+        "stt_adapter_standalone does not reference STT_WORKERS — "
+        "migration must import and pass this constant to NatsAdapterBase"
+    )
+
+
+def test_bootstrap_stt_adapter_standalone_signature() -> None:
+    """_bootstrap_stt_adapter_standalone must be an async function with the expected params.
+
+    This test passes before and after migration — the public signature is unchanged.
+    """
+    from lyra.bootstrap.stt_adapter_standalone import _bootstrap_stt_adapter_standalone
+
+    assert inspect.iscoroutinefunction(_bootstrap_stt_adapter_standalone), (
+        "_bootstrap_stt_adapter_standalone must be a coroutine function"
+    )
+
+    sig = inspect.signature(_bootstrap_stt_adapter_standalone)
+    params = list(sig.parameters)
+
+    assert params[0] == "raw_config", (
+        f"First parameter must be 'raw_config', got '{params[0]}'"
+    )
+
+    stop_param = sig.parameters.get("_stop")
+    assert stop_param is not None, "Keyword-only parameter '_stop' must exist"
+    assert stop_param.kind == inspect.Parameter.KEYWORD_ONLY, (
+        "'_stop' must be a keyword-only parameter"
+    )
+
+
+def test_stt_adapter_standalone_class_exists() -> None:
+    """SttAdapterStandalone must exist and subclass NatsAdapterBase after migration.
+
+    RED gate: the class does not exist in current source — ImportError expected
+    before migration.
+    """
+    from lyra.nats import NatsAdapterBase
+
+    try:
+        from lyra.bootstrap.stt_adapter_standalone import SttAdapterStandalone
+    except ImportError as exc:
+        pytest.fail(
+            f"SttAdapterStandalone not found in stt_adapter_standalone — "
+            f"migration has not been applied yet: {exc}"
+        )
+
+    assert issubclass(SttAdapterStandalone, NatsAdapterBase), (
+        "SttAdapterStandalone must subclass NatsAdapterBase"
+    )
+
+
+def test_mime_to_ext_still_accessible() -> None:
+    """_mime_to_ext must remain a module-level helper after migration.
+
+    This test passes before and after migration — the helper is kept at module level.
+    """
+    from lyra.bootstrap.stt_adapter_standalone import _mime_to_ext
+
+    assert _mime_to_ext("audio/ogg") == ".ogg", (
+        "_mime_to_ext('audio/ogg') must return '.ogg'"
+    )
+    assert _mime_to_ext("audio/mpeg") == ".mp3", (
+        "_mime_to_ext('audio/mpeg') must return '.mp3'"
+    )
+    assert _mime_to_ext("audio/wav") == ".wav", (
+        "_mime_to_ext('audio/wav') must return '.wav'"
+    )
+    assert _mime_to_ext("audio/unknown") == ".ogg", (
+        "_mime_to_ext with unknown MIME must fall back to '.ogg'"
+    )

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 import pytest
 
-_SOURCE = Path("src/lyra/bootstrap/tts_adapter_standalone.py")
+_SOURCE = (
+    Path(__file__).parent.parent.parent / "src/lyra/bootstrap/tts_adapter_standalone.py"
+)
 
 
 def test_tts_adapter_source_uses_no_bare_nats_connect() -> None:

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -1,0 +1,93 @@
+"""Tests for tts_adapter_standalone — RED-phase tests for NatsAdapterBase migration.
+
+These tests verify the post-migration shape of tts_adapter_standalone.py:
+  - No bare nats.connect() / import nats usage
+  - TTS_WORKERS constant is used (not a hardcoded string)
+  - _bootstrap_tts_adapter_standalone retains its async signature
+  - TtsAdapterStandalone class exists and inherits from NatsAdapterBase
+
+Tests 1, 2, and 4 are RED before migration (they fail against current source).
+Test 3 passes both before and after migration (signature is unchanged).
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+_SOURCE = Path("src/lyra/bootstrap/tts_adapter_standalone.py")
+
+
+def test_tts_adapter_source_uses_no_bare_nats_connect() -> None:
+    """Source must not contain bare nats.connect() or bare 'import nats' after migration.
+
+    RED gate: current source has `nats.connect(` and `import nats\\n` — this fails
+    until the migration to NatsAdapterBase removes them.
+    """
+    source = _SOURCE.read_text()
+    assert "nats.connect(" not in source, (
+        "tts_adapter_standalone still uses bare nats.connect() — migrate to NatsAdapterBase"
+    )
+    assert "import nats\n" not in source, (
+        "tts_adapter_standalone still has bare 'import nats' — migrate to NatsAdapterBase"
+    )
+
+
+def test_tts_adapter_uses_tts_workers_constant() -> None:
+    """Source must reference the TTS_WORKERS constant, not a hardcoded string.
+
+    RED gate: current source uses a bare QUEUE_GROUP string; TTS_WORKERS is not
+    imported or defined until migration.
+    """
+    source = _SOURCE.read_text()
+    assert "TTS_WORKERS" in source, (
+        "tts_adapter_standalone does not reference TTS_WORKERS — "
+        "migration must import and pass this constant to NatsAdapterBase"
+    )
+
+
+def test_bootstrap_tts_adapter_standalone_signature() -> None:
+    """_bootstrap_tts_adapter_standalone must be an async function with the expected params.
+
+    This test passes before and after migration — the public signature is unchanged.
+    """
+    from lyra.bootstrap.tts_adapter_standalone import _bootstrap_tts_adapter_standalone
+
+    assert inspect.iscoroutinefunction(_bootstrap_tts_adapter_standalone), (
+        "_bootstrap_tts_adapter_standalone must be a coroutine function"
+    )
+
+    sig = inspect.signature(_bootstrap_tts_adapter_standalone)
+    params = list(sig.parameters)
+
+    assert params[0] == "raw_config", (
+        f"First parameter must be 'raw_config', got '{params[0]}'"
+    )
+
+    stop_param = sig.parameters.get("_stop")
+    assert stop_param is not None, "Keyword-only parameter '_stop' must exist"
+    assert stop_param.kind == inspect.Parameter.KEYWORD_ONLY, (
+        "'_stop' must be a keyword-only parameter"
+    )
+
+
+def test_tts_adapter_standalone_class_exists() -> None:
+    """TtsAdapterStandalone must exist and subclass NatsAdapterBase after migration.
+
+    RED gate: the class does not exist in current source — ImportError expected
+    before migration.
+    """
+    from lyra.nats import NatsAdapterBase
+
+    try:
+        from lyra.bootstrap.tts_adapter_standalone import TtsAdapterStandalone
+    except ImportError as exc:
+        pytest.fail(
+            f"TtsAdapterStandalone not found in tts_adapter_standalone — "
+            f"migration has not been applied yet: {exc}"
+        )
+
+    assert issubclass(TtsAdapterStandalone, NatsAdapterBase), (
+        "TtsAdapterStandalone must subclass NatsAdapterBase"
+    )

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -20,17 +20,17 @@ _SOURCE = Path("src/lyra/bootstrap/tts_adapter_standalone.py")
 
 
 def test_tts_adapter_source_uses_no_bare_nats_connect() -> None:
-    """Source must not contain bare nats.connect() or bare 'import nats' after migration.
+    """Source must not contain bare nats.connect() or 'import nats' after migration.
 
     RED gate: current source has `nats.connect(` and `import nats\\n` — this fails
     until the migration to NatsAdapterBase removes them.
     """
     source = _SOURCE.read_text()
     assert "nats.connect(" not in source, (
-        "tts_adapter_standalone still uses bare nats.connect() — migrate to NatsAdapterBase"
+        "tts_adapter_standalone still uses bare nats.connect()"
     )
     assert "import nats\n" not in source, (
-        "tts_adapter_standalone still has bare 'import nats' — migrate to NatsAdapterBase"
+        "tts_adapter_standalone still has bare 'import nats'"
     )
 
 
@@ -48,7 +48,7 @@ def test_tts_adapter_uses_tts_workers_constant() -> None:
 
 
 def test_bootstrap_tts_adapter_standalone_signature() -> None:
-    """_bootstrap_tts_adapter_standalone must be an async function with the expected params.
+    """_bootstrap_tts_adapter_standalone must be async with the expected params.
 
     This test passes before and after migration — the public signature is unchanged.
     """

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -28,7 +28,7 @@ from lyra.nats.adapter_base import NatsAdapterBase  # ImportError expected (RED)
 
 
 class _ConcreteAdapter(NatsAdapterBase):
-    async def handle(self, msg: object) -> None:  # noqa: D102
+    async def handle(self, msg: object, payload: dict) -> None:  # noqa: D102
         pass
 
 
@@ -669,3 +669,66 @@ class TestRun:
         # Assert — drain and close both called (shutdown path)
         mock_nc.drain.assert_awaited_once()
         mock_nc.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# T7 — _dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    """T7 — _dispatch routes messages correctly: JSON error, bad envelope, valid."""
+
+    def _make_adapter(self) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_does_not_call_handle(self) -> None:
+        """Non-JSON bytes → handle() is never called."""
+        # Arrange
+        adapter = self._make_adapter()
+        adapter.handle = AsyncMock()  # type: ignore[method-assign]
+        msg = MagicMock()
+        msg.data = b"not json at all"
+
+        # Act
+        await adapter._dispatch(msg)
+
+        # Assert
+        adapter.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_envelope_does_not_call_handle(self) -> None:
+        """Valid JSON but wrong schema_version → handle() is never called."""
+        # Arrange
+        adapter = self._make_adapter()
+        adapter.handle = AsyncMock()  # type: ignore[method-assign]
+        msg = MagicMock()
+        msg.data = b'{"schema_version": 99, "text": "hello"}'
+
+        # Act
+        await adapter._dispatch(msg)
+
+        # Assert
+        adapter.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_message_calls_handle_with_msg_and_payload(self) -> None:
+        """Valid JSON + valid envelope → handle called with msg and parsed payload."""
+        # Arrange
+        adapter = self._make_adapter()
+        adapter.handle = AsyncMock()  # type: ignore[method-assign]
+        msg = MagicMock()
+        raw_payload = {"schema_version": 1, "text": "hello"}
+        msg.data = b'{"schema_version": 1, "text": "hello"}'
+
+        # Act
+        await adapter._dispatch(msg)
+
+        # Assert
+        adapter.handle.assert_awaited_once_with(msg, raw_payload)

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -16,12 +16,11 @@ from __future__ import annotations
 import asyncio
 import signal
 import time
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lyra.nats.adapter_base import NatsAdapterBase  # ImportError expected (RED)
-
 
 # ---------------------------------------------------------------------------
 # Concrete subclass used across all test classes
@@ -67,7 +66,7 @@ class TestNatsAdapterBaseConstruction:
             )
 
     def test_bad_queue_group_raises_value_error(self) -> None:
-        """Queue group containing a space triggers ValueError from validate_nats_token."""
+        """Queue group with a space triggers ValueError from validate_nats_token."""
         # Arrange
         bad_group = "bad group"
 
@@ -602,7 +601,8 @@ class TestRun:
 
         # Assert — add_signal_handler called twice: once for SIGTERM, once for SIGINT
         assert mock_loop.add_signal_handler.call_count == 2
-        registered_sigs = {args[0] for args, _ in mock_loop.add_signal_handler.call_args_list}
+        calls = mock_loop.add_signal_handler.call_args_list
+        registered_sigs = {args[0] for args, _ in calls}
         assert signal.SIGTERM in registered_sigs
         assert signal.SIGINT in registered_sigs
 

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -571,7 +571,8 @@ class TestRun:
         # We need to control the stop event so run() exits cleanly.
         # Capture the event that run() creates internally by intercepting
         # add_signal_handler — on the second call, set the event so run() exits.
-        captured_setters: list[object] = []
+        from typing import Any
+        captured_setters: list[Any] = []
 
         mock_loop = MagicMock()
 
@@ -601,8 +602,9 @@ class TestRun:
 
         # Assert — add_signal_handler called twice: once for SIGTERM, once for SIGINT
         assert mock_loop.add_signal_handler.call_count == 2
-        calls = mock_loop.add_signal_handler.call_args_list
-        registered_sigs = {args[0] for args, _ in calls}
+        registered_sigs = {
+            c.args[0] for c in mock_loop.add_signal_handler.call_args_list
+        }
         assert signal.SIGTERM in registered_sigs
         assert signal.SIGINT in registered_sigs
 

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -1,0 +1,669 @@
+"""RED-phase tests for NatsAdapterBase (issue #582).
+
+NatsAdapterBase does not exist yet — all tests are expected to fail with
+ImportError until the implementation is in place.
+
+Covers:
+- T2: Construction validation (valid args, bad subject, bad queue_group, field storage)
+- T3: _validate_envelope (v1 accepted, version mismatch dropped, missing field,
+      counter keyed by envelope_name)
+- T4: _shutdown (drain before close, no unsubscribe call)
+- T5: health() return shape, connected flag, uptime_s before/after _started_at
+- T6: run() signal handler wiring and _wait_ready invocation
+"""
+from __future__ import annotations
+
+import asyncio
+import signal
+import time
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from lyra.nats.adapter_base import NatsAdapterBase  # ImportError expected (RED)
+
+
+# ---------------------------------------------------------------------------
+# Concrete subclass used across all test classes
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteAdapter(NatsAdapterBase):
+    async def handle(self, msg: object) -> None:  # noqa: D102
+        pass
+
+
+# ---------------------------------------------------------------------------
+# T2 — Construction
+# ---------------------------------------------------------------------------
+
+
+class TestNatsAdapterBaseConstruction:
+    """T2 — __init__ validates tokens and stores all fields."""
+
+    def test_valid_args_no_error(self) -> None:
+        """Constructing with valid tokens raises no exception."""
+        # Arrange / Act / Assert — no exception raised
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+        assert adapter is not None
+
+    def test_bad_subject_raises_value_error(self) -> None:
+        """Subject containing a space triggers ValueError from validate_nats_token."""
+        # Arrange
+        bad_subject = "bad subject"
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="subject"):
+            _ConcreteAdapter(
+                subject=bad_subject,
+                queue_group="telegram_workers",
+                envelope_name="InboundMessage",
+                schema_version=1,
+            )
+
+    def test_bad_queue_group_raises_value_error(self) -> None:
+        """Queue group containing a space triggers ValueError from validate_nats_token."""
+        # Arrange
+        bad_group = "bad group"
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="queue_group"):
+            _ConcreteAdapter(
+                subject="lyra.inbound.telegram.main",
+                queue_group=bad_group,
+                envelope_name="InboundMessage",
+                schema_version=1,
+            )
+
+    def test_all_fields_stored_correctly(self) -> None:
+        """All constructor arguments are stored as instance attributes."""
+        # Arrange
+        subject = "lyra.inbound.telegram.main"
+        queue_group = "telegram_workers"
+        envelope_name = "InboundMessage"
+        schema_version = 2
+        timeout = 15.0
+        drain_timeout = 10.0
+
+        # Act
+        adapter = _ConcreteAdapter(
+            subject=subject,
+            queue_group=queue_group,
+            envelope_name=envelope_name,
+            schema_version=schema_version,
+            timeout=timeout,
+            drain_timeout=drain_timeout,
+        )
+
+        # Assert
+        assert adapter.subject == subject
+        assert adapter.queue_group == queue_group
+        assert adapter.envelope_name == envelope_name
+        assert adapter.schema_version == schema_version
+        assert adapter.timeout == timeout
+        assert adapter.drain_timeout == drain_timeout
+        assert adapter._nc is None
+        assert adapter._drop_count == {}
+        assert adapter._started_at is None
+
+    def test_default_timeout_values(self) -> None:
+        """Default timeout and drain_timeout are 30.0 when not supplied."""
+        # Arrange / Act
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.discord.main",
+            queue_group="discord_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+
+        # Assert
+        assert adapter.timeout == 30.0
+        assert adapter.drain_timeout == 30.0
+
+
+# ---------------------------------------------------------------------------
+# T3 — _validate_envelope
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEnvelope:
+    """T3 — _validate_envelope delegates to check_schema_version correctly."""
+
+    def _make_adapter(self, *, schema_version: int = 1) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=schema_version,
+        )
+
+    def test_v1_payload_accepted(self) -> None:
+        """Payload with schema_version == expected is accepted (returns True)."""
+        # Arrange
+        adapter = self._make_adapter(schema_version=1)
+        payload = {"schema_version": 1, "data": "hello"}
+
+        # Act
+        result = adapter._validate_envelope(payload)
+
+        # Assert
+        assert result is True
+        assert adapter._drop_count == {}
+
+    def test_higher_version_payload_dropped(self) -> None:
+        """Payload with schema_version > expected is dropped (returns False)."""
+        # Arrange
+        adapter = self._make_adapter(schema_version=1)
+        payload = {"schema_version": 2, "data": "hello"}
+
+        # Act
+        result = adapter._validate_envelope(payload)
+
+        # Assert
+        assert result is False
+
+    def test_drop_increments_drop_count(self) -> None:
+        """A dropped envelope increments _drop_count keyed by envelope_name."""
+        # Arrange
+        adapter = self._make_adapter(schema_version=1)
+        payload = {"schema_version": 2, "data": "hello"}
+
+        # Act
+        adapter._validate_envelope(payload)
+
+        # Assert — counter key matches the adapter's envelope_name
+        assert adapter._drop_count.get("InboundMessage", 0) == 1
+
+    def test_multiple_drops_accumulate_count(self) -> None:
+        """Repeated drops accumulate the counter for the same envelope_name."""
+        # Arrange
+        adapter = self._make_adapter(schema_version=1)
+        payload = {"schema_version": 2}
+
+        # Act
+        adapter._validate_envelope(payload)
+        adapter._validate_envelope(payload)
+        adapter._validate_envelope(payload)
+
+        # Assert
+        assert adapter._drop_count["InboundMessage"] == 3
+
+    def test_missing_schema_version_treated_as_v1(self) -> None:
+        """Payload without schema_version key is accepted as legacy v1."""
+        # Arrange
+        adapter = self._make_adapter(schema_version=1)
+        payload = {"data": "legacy message"}
+
+        # Act
+        result = adapter._validate_envelope(payload)
+
+        # Assert — treated as v1, no drop
+        assert result is True
+        assert adapter._drop_count == {}
+
+    def test_envelope_name_used_as_counter_key(self) -> None:
+        """_drop_count is keyed by envelope_name, not by subject."""
+        # Arrange
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="CustomEnvelope",
+            schema_version=1,
+        )
+        payload = {"schema_version": 3}
+
+        # Act
+        adapter._validate_envelope(payload)
+
+        # Assert — key is "CustomEnvelope", not the subject
+        assert "CustomEnvelope" in adapter._drop_count
+        assert adapter._drop_count["CustomEnvelope"] == 1
+
+
+# ---------------------------------------------------------------------------
+# T4 — _shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestShutdown:
+    """T4 — _shutdown drains then closes; does not call unsubscribe."""
+
+    @pytest.mark.asyncio
+    async def test_drain_called_before_close(self) -> None:
+        """nc.drain() is awaited before nc.close()."""
+        # Arrange
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+        mock_nc = AsyncMock()
+        call_order: list[str] = []
+        mock_nc.drain = AsyncMock(side_effect=lambda: call_order.append("drain"))
+        mock_nc.close = AsyncMock(side_effect=lambda: call_order.append("close"))
+        adapter._nc = mock_nc
+
+        # Act
+        await adapter._shutdown()
+
+        # Assert
+        assert call_order == ["drain", "close"], (
+            f"Expected drain then close, got: {call_order}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_drain_and_close_each_called_once(self) -> None:
+        """nc.drain() and nc.close() are each called exactly once."""
+        # Arrange
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+        mock_nc = AsyncMock()
+        adapter._nc = mock_nc
+
+        # Act
+        await adapter._shutdown()
+
+        # Assert
+        mock_nc.drain.assert_awaited_once()
+        mock_nc.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_not_called(self) -> None:
+        """nc.unsubscribe() is NOT called — drain subsumes subscription teardown."""
+        # Arrange
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+        mock_nc = AsyncMock()
+        adapter._nc = mock_nc
+
+        # Act
+        await adapter._shutdown()
+
+        # Assert — unsubscribe must never have been called
+        mock_nc.unsubscribe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_skips_when_nc_is_none(self) -> None:
+        """_shutdown is a no-op when _nc has not been set (pre-run state)."""
+        # Arrange
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+        # _nc is None by default
+
+        # Act / Assert — no AttributeError raised
+        await adapter._shutdown()
+
+
+# ---------------------------------------------------------------------------
+# T5 — health()
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    """T5 — health() returns the correct shape and reflects live state."""
+
+    def _make_adapter(self) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=2,
+        )
+
+    def test_health_returns_all_required_keys(self) -> None:
+        """health() returns a dict with all documented keys."""
+        # Arrange
+        adapter = self._make_adapter()
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        required_keys = {
+            "status",
+            "connected",
+            "uptime_s",
+            "subject",
+            "queue_group",
+            "schema_version",
+        }
+        assert required_keys.issubset(result.keys())
+
+    def test_status_is_ok(self) -> None:
+        """health() always reports status == 'ok'."""
+        # Arrange
+        adapter = self._make_adapter()
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["status"] == "ok"
+
+    def test_connected_reflects_nc_is_connected_true(self) -> None:
+        """connected key mirrors nc.is_connected when nc is set."""
+        # Arrange
+        adapter = self._make_adapter()
+        mock_nc = MagicMock()
+        mock_nc.is_connected = True
+        adapter._nc = mock_nc
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["connected"] is True
+
+    def test_connected_reflects_nc_is_connected_false(self) -> None:
+        """connected is False when nc.is_connected is False."""
+        # Arrange
+        adapter = self._make_adapter()
+        mock_nc = MagicMock()
+        mock_nc.is_connected = False
+        adapter._nc = mock_nc
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["connected"] is False
+
+    def test_connected_is_false_when_nc_is_none(self) -> None:
+        """connected is False when _nc has not been set (pre-run)."""
+        # Arrange
+        adapter = self._make_adapter()
+        # _nc is None
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["connected"] is False
+
+    def test_uptime_zero_before_run(self) -> None:
+        """uptime_s is 0.0 before run() sets _started_at."""
+        # Arrange
+        adapter = self._make_adapter()
+        # _started_at is None
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["uptime_s"] == 0.0
+
+    def test_uptime_positive_after_started_at_set(self) -> None:
+        """uptime_s is positive when _started_at was set in the past."""
+        # Arrange
+        adapter = self._make_adapter()
+        adapter._started_at = time.monotonic() - 5.0  # 5 seconds ago
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["uptime_s"] > 0.0
+
+    def test_subject_and_queue_group_in_health(self) -> None:
+        """health() includes the adapter's subject and queue_group values."""
+        # Arrange
+        adapter = self._make_adapter()
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["subject"] == "lyra.inbound.telegram.main"
+        assert result["queue_group"] == "telegram_workers"
+
+    def test_schema_version_in_health(self) -> None:
+        """health() includes the schema_version the adapter was built with."""
+        # Arrange
+        adapter = self._make_adapter()
+
+        # Act
+        result = adapter.health()
+
+        # Assert
+        assert result["schema_version"] == 2
+
+
+# ---------------------------------------------------------------------------
+# T6 — run()
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    """T6 — run() wires NATS, readiness check, subscription, and signal handlers."""
+
+    def _make_adapter(self) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_wait_ready_always_called(self) -> None:
+        """_wait_ready() is called on every run() invocation."""
+        # Arrange
+        adapter = self._make_adapter()
+        stop = asyncio.Event()
+        stop.set()  # immediate exit
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ) as mock_wait,
+        ):
+            # Act
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert
+        mock_wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_subscribe_called_with_subject_and_queue(self) -> None:
+        """nc.subscribe is called with the adapter's subject and queue_group."""
+        # Arrange
+        adapter = self._make_adapter()
+        stop = asyncio.Event()
+        stop.set()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            # Act
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert
+        mock_nc.subscribe.assert_awaited_once_with(
+            "lyra.inbound.telegram.main",
+            queue="telegram_workers",
+            cb=adapter._dispatch,
+        )
+
+    @pytest.mark.asyncio
+    async def test_signal_handlers_not_registered_when_stop_injected(self) -> None:
+        """When stop event is pre-injected, loop.add_signal_handler is NOT called."""
+        # Arrange
+        adapter = self._make_adapter()
+        stop = asyncio.Event()
+        stop.set()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+            patch("asyncio.get_running_loop") as mock_get_loop,
+        ):
+            # Act
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert — get_running_loop was never called (signal setup skipped)
+        mock_get_loop.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_signal_handlers_registered_when_stop_is_none(self) -> None:
+        """When stop=None, loop.add_signal_handler is called for SIGTERM and SIGINT."""
+        # Arrange
+        adapter = self._make_adapter()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        # We need to control the stop event so run() exits cleanly.
+        # Capture the event that run() creates internally by intercepting
+        # add_signal_handler — on the second call, set the event so run() exits.
+        captured_setters: list[object] = []
+
+        mock_loop = MagicMock()
+
+        def _capture_handler(sig: signal.Signals, setter: object) -> None:
+            captured_setters.append((sig, setter))
+            # Trigger stop after both handlers are registered
+            if len(captured_setters) == 2:
+                # The setter is stop.set — call it so run() can exit
+                for _, fn in captured_setters:
+                    fn()
+
+        mock_loop.add_signal_handler = MagicMock(side_effect=_capture_handler)
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+            patch("asyncio.get_running_loop", return_value=mock_loop),
+        ):
+            # Act
+            await adapter.run("nats://localhost:4222", stop=None)
+
+        # Assert — add_signal_handler called twice: once for SIGTERM, once for SIGINT
+        assert mock_loop.add_signal_handler.call_count == 2
+        registered_sigs = {args[0] for args, _ in mock_loop.add_signal_handler.call_args_list}
+        assert signal.SIGTERM in registered_sigs
+        assert signal.SIGINT in registered_sigs
+
+    @pytest.mark.asyncio
+    async def test_started_at_set_during_run(self) -> None:
+        """_started_at is set to a float after run() initialises."""
+        # Arrange
+        adapter = self._make_adapter()
+        stop = asyncio.Event()
+        stop.set()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            # Act
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert
+        assert adapter._started_at is not None
+        assert isinstance(adapter._started_at, float)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_called_on_stop(self) -> None:
+        """_shutdown (drain+close) is invoked when the stop event fires."""
+        # Arrange
+        adapter = self._make_adapter()
+        stop = asyncio.Event()
+        stop.set()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            # Act
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert — drain and close both called (shutdown path)
+        mock_nc.drain.assert_awaited_once()
+        mock_nc.close.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Introduce `NatsAdapterBase` ABC (`src/lyra/nats/adapter_base.py`): enforces `nats_connect` (nkey auth), schema envelope validation via `check_schema_version`, hub readiness wait, drain/close lifecycle, and `health()` introspection — establishing the shared pattern for all future NATS request-reply adapters (#451, epic #581)
- Add `TTS_WORKERS`/`STT_WORKERS` constants to `queue_groups.py`, eliminating hardcoded `"tts-workers"`/`"stt-workers"` literals
- Migrate `TtsAdapterStandalone` and `SttAdapterStandalone` to inherit `NatsAdapterBase`, removing the bare `nats.connect()` calls that bypassed nkey auth (#563)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #582: refactor(nats): NatsAdapterBase — enforced nkey, schema validation, queue group, lifecycle | Open |
| Analysis | — | Absent (F-lite) |
| Spec | [582-nats-adapter-base-spec.mdx](artifacts/specs/582-nats-adapter-base-spec.mdx) | Present |
| Implementation | 1 commit on `feat/582-nats-adapter-base` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (39 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats/test_adapter_base.py` — 30 tests: construction, envelope validation, shutdown, health, run lifecycle
- [ ] `uv run pytest tests/bootstrap/test_tts_adapter_standalone.py` — 4 tests: no bare `nats.connect`, `TTS_WORKERS` used, class exists, signature intact
- [ ] `uv run pytest tests/bootstrap/test_stt_adapter_standalone.py` — 5 tests: no bare `nats.connect`, `STT_WORKERS` used, class exists, `_mime_to_ext` accessible, signature intact
- [ ] Verify `from lyra.nats import NatsAdapterBase` works in a subclass

Closes #582

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`