### PR TITLE
fix(nats): add check_schema_version to OutboundMessage receive paths

### DIFF
--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -84,8 +84,8 @@ class NatsOutboundListener:
         """Cumulative drops for *envelope_name* (schema version mismatches)."""
         return self._version_mismatch_drops.get(envelope_name, 0)
 
-    def _check_outbound_version(self, payload: dict) -> bool:
-        return check_schema_version(payload, envelope_name="OutboundMessage",
+    def _check_outbound_version(self, payload: dict, envelope_name: str) -> bool:
+        return check_schema_version(payload, envelope_name=envelope_name,
             expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
             subject=self._subject, counter=self._version_mismatch_drops)
 
@@ -145,7 +145,7 @@ class NatsOutboundListener:
         if outbound_data is None:
             log.warning("NatsOutboundListener: missing 'outbound' key in send envelope")
             return
-        if not self._check_outbound_version(outbound_data):
+        if not self._check_outbound_version(outbound_data, "OutboundMessage"):
             return
         try:
             outbound = _deserialize_dict(outbound_data, OutboundMessage)
@@ -168,7 +168,7 @@ class NatsOutboundListener:
         if attachment_data is None:
             log.warning("NatsOutboundListener: missing 'attachment' key in envelope")
             return
-        if not self._check_outbound_version(attachment_data):
+        if not self._check_outbound_version(attachment_data, "OutboundAttachment"):
             return
         try:
             attachment = _deserialize_dict(attachment_data, OutboundAttachment)
@@ -187,7 +187,7 @@ class NatsOutboundListener:
         outbound_data = data.get("outbound")
         if stream_id is None or outbound_data is None:
             return
-        if not self._check_outbound_version(outbound_data):
+        if not self._check_outbound_version(outbound_data, "OutboundMessage"):
             return
         if len(self._stream_outbound) >= _MAX_STREAMS:
             log.warning("NatsOutboundListener: _stream_outbound full"

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -18,6 +18,7 @@ from lyra.adapters.nats_stream_decoder import (
     handle_stream_error as _handle_stream_error_impl,
 )
 from lyra.core.message import (
+    SCHEMA_VERSION_OUTBOUND_MESSAGE,
     InboundMessage,
     OutboundAttachment,
     OutboundMessage,
@@ -25,6 +26,7 @@ from lyra.core.message import (
 )
 from lyra.nats._serialize import deserialize_dict as _deserialize_dict
 from lyra.nats._validate import validate_nats_token
+from lyra.nats._version_check import check_schema_version
 
 if TYPE_CHECKING:
     from lyra.core.hub.hub_protocol import ChannelAdapter
@@ -56,6 +58,7 @@ class NatsOutboundListener:
         self._bot_id = bot_id
         self._adapter = adapter
         self._queue_group = queue_group
+        self._subject = f"lyra.outbound.{platform.value}.{bot_id}"
         self._cache: dict[str, InboundMessage] = {}
         self._cache_ts: dict[str, float] = {}
         self._stream_queues: dict[str, asyncio.Queue[dict]] = {}
@@ -139,6 +142,14 @@ class NatsOutboundListener:
         if outbound_data is None:
             log.warning("NatsOutboundListener: missing 'outbound' key in send envelope")
             return
+        if not check_schema_version(
+            outbound_data,
+            envelope_name="OutboundMessage",
+            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
+            subject=self._subject,
+            counter=self._version_mismatch_drops,
+        ):
+            return
         try:
             outbound = _deserialize_dict(outbound_data, OutboundMessage)
         except Exception:
@@ -160,6 +171,14 @@ class NatsOutboundListener:
         if attachment_data is None:
             log.warning("NatsOutboundListener: missing 'attachment' key in envelope")
             return
+        if not check_schema_version(
+            attachment_data,
+            envelope_name="OutboundMessage",
+            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
+            subject=self._subject,
+            counter=self._version_mismatch_drops,
+        ):
+            return
         try:
             attachment = _deserialize_dict(attachment_data, OutboundAttachment)
         except Exception:
@@ -176,6 +195,14 @@ class NatsOutboundListener:
         stream_id = data.get("stream_id")
         outbound_data = data.get("outbound")
         if stream_id is None or outbound_data is None:
+            return
+        if not check_schema_version(
+            outbound_data,
+            envelope_name="OutboundMessage",
+            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
+            subject=self._subject,
+            counter=self._version_mismatch_drops,
+        ):
             return
         if len(self._stream_outbound) >= _MAX_STREAMS:
             log.warning(

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -75,16 +75,19 @@ class NatsOutboundListener:
             oldest = next(iter(self._cache))
             self._cache.pop(oldest)
             self._cache_ts.pop(oldest, None)
-            log.warning(
-                "NatsOutboundListener: _cache full (%d), evicted %r",
-                _MAX_CACHE_SIZE, oldest,
-            )
+            log.warning("NatsOutboundListener: _cache full (%d), evicted %r",
+                _MAX_CACHE_SIZE, oldest)
         self._cache[msg.id] = msg
         self._cache_ts[msg.id] = time.monotonic()
 
     def version_mismatch_count(self, envelope_name: str) -> int:
         """Cumulative drops for *envelope_name* (schema version mismatches)."""
         return self._version_mismatch_drops.get(envelope_name, 0)
+
+    def _check_outbound_version(self, payload: dict) -> bool:
+        return check_schema_version(payload, envelope_name="OutboundMessage",
+            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
+            subject=self._subject, counter=self._version_mismatch_drops)
 
     async def start(self) -> None:
         """Subscribe to the outbound NATS subject."""
@@ -142,13 +145,7 @@ class NatsOutboundListener:
         if outbound_data is None:
             log.warning("NatsOutboundListener: missing 'outbound' key in send envelope")
             return
-        if not check_schema_version(
-            outbound_data,
-            envelope_name="OutboundMessage",
-            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
-            subject=self._subject,
-            counter=self._version_mismatch_drops,
-        ):
+        if not self._check_outbound_version(outbound_data):
             return
         try:
             outbound = _deserialize_dict(outbound_data, OutboundMessage)
@@ -171,13 +168,7 @@ class NatsOutboundListener:
         if attachment_data is None:
             log.warning("NatsOutboundListener: missing 'attachment' key in envelope")
             return
-        if not check_schema_version(
-            attachment_data,
-            envelope_name="OutboundMessage",
-            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
-            subject=self._subject,
-            counter=self._version_mismatch_drops,
-        ):
+        if not self._check_outbound_version(attachment_data):
             return
         try:
             attachment = _deserialize_dict(attachment_data, OutboundAttachment)
@@ -196,21 +187,11 @@ class NatsOutboundListener:
         outbound_data = data.get("outbound")
         if stream_id is None or outbound_data is None:
             return
-        if not check_schema_version(
-            outbound_data,
-            envelope_name="OutboundMessage",
-            expected=SCHEMA_VERSION_OUTBOUND_MESSAGE,
-            subject=self._subject,
-            counter=self._version_mismatch_drops,
-        ):
+        if not self._check_outbound_version(outbound_data):
             return
         if len(self._stream_outbound) >= _MAX_STREAMS:
-            log.warning(
-                "NatsOutboundListener: _stream_outbound full"
-                " (%d entries), dropping stream_id=%r",
-                _MAX_STREAMS,
-                stream_id,
-            )
+            log.warning("NatsOutboundListener: _stream_outbound full"
+                " (%d entries), dropping stream_id=%r", _MAX_STREAMS, stream_id)
             return
         try:
             self._stream_outbound[stream_id] = _deserialize_dict(
@@ -237,12 +218,8 @@ class NatsOutboundListener:
             return
         at_limit = len(self._stream_tasks) >= _MAX_STREAMS
         if stream_id not in self._stream_tasks and at_limit:
-            log.warning(
-                "NatsOutboundListener: _stream_tasks full"
-                " (%d streams), dropping stream_id=%r",
-                _MAX_STREAMS,
-                stream_id,
-            )
+            log.warning("NatsOutboundListener: _stream_tasks full"
+                " (%d streams), dropping stream_id=%r", _MAX_STREAMS, stream_id)
             return
         q = self._stream_queues.setdefault(
             stream_id, asyncio.Queue(maxsize=_MAX_QUEUE_SIZE),
@@ -252,11 +229,8 @@ class NatsOutboundListener:
         try:
             q.put_nowait(data)
         except asyncio.QueueFull:
-            log.warning(
-                "NatsOutboundListener: stream queue full"
-                " for stream_id=%r, dropping chunk",
-                stream_id,
-            )
+            log.warning("NatsOutboundListener: stream queue full"
+                " for stream_id=%r, dropping chunk", stream_id)
             return
         if stream_id not in self._stream_tasks:
             self._stream_tasks[stream_id] = asyncio.create_task(

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -603,9 +603,7 @@ async def test_stream_error_unknown_stream_id_is_noop() -> None:
 async def test_send_version_mismatch_drops_and_increments_counter() -> None:
     """send envelope with schema_version > expected is dropped; counter incremented."""
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
-    from lyra.nats._version_check import _reset_log_state
 
-    _reset_log_state()
     nc = AsyncMock()
     adapter = AsyncMock()
     listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
@@ -633,9 +631,7 @@ async def test_send_version_mismatch_drops_and_increments_counter() -> None:
 async def test_stream_start_version_mismatch_drops_and_increments_counter() -> None:
     """stream_start envelope with schema_version > expected is dropped; counter incremented."""  # noqa: E501
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
-    from lyra.nats._version_check import _reset_log_state
 
-    _reset_log_state()
     nc = AsyncMock()
     adapter = AsyncMock()
     listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
@@ -665,9 +661,7 @@ async def test_attachment_version_mismatch_drops_and_increments_counter() -> Non
     import base64
 
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
-    from lyra.nats._version_check import _reset_log_state
 
-    _reset_log_state()
     nc = AsyncMock()
     adapter = AsyncMock()
     listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
@@ -689,7 +683,8 @@ async def test_attachment_version_mismatch_drops_and_increments_counter() -> Non
     await listener._handle(_make_nats_msg(envelope))
 
     adapter.render_attachment.assert_not_called()
-    assert listener.version_mismatch_count("OutboundMessage") == 1
+    assert listener.version_mismatch_count("OutboundAttachment") == 1
+    assert listener.version_mismatch_count("OutboundMessage") == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -603,6 +603,7 @@ async def test_stream_error_unknown_stream_id_is_noop() -> None:
 async def test_send_version_mismatch_drops_and_increments_counter() -> None:
     """send envelope with schema_version > expected is dropped; counter incremented."""
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.core.message import SCHEMA_VERSION_OUTBOUND_MESSAGE
 
     nc = AsyncMock()
     adapter = AsyncMock()
@@ -615,7 +616,7 @@ async def test_send_version_mismatch_drops_and_increments_counter() -> None:
         "type": "send",
         "stream_id": msg.id,
         "outbound": {
-            "schema_version": 99,
+            "schema_version": SCHEMA_VERSION_OUTBOUND_MESSAGE + 1,
             "content": ["hello"],
             "buttons": [],
             "metadata": {},
@@ -624,13 +625,14 @@ async def test_send_version_mismatch_drops_and_increments_counter() -> None:
     await listener._handle(_make_nats_msg(envelope))
 
     adapter.send.assert_not_called()
-    assert listener.version_mismatch_count("OutboundMessage") == 1
+    assert listener._version_mismatch_drops == {"OutboundMessage": 1}
 
 
 @pytest.mark.asyncio
 async def test_stream_start_version_mismatch_drops_and_increments_counter() -> None:
     """stream_start envelope with schema_version > expected is dropped; counter incremented."""  # noqa: E501
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.core.message import SCHEMA_VERSION_OUTBOUND_MESSAGE
 
     nc = AsyncMock()
     adapter = AsyncMock()
@@ -643,7 +645,7 @@ async def test_stream_start_version_mismatch_drops_and_increments_counter() -> N
         "type": "stream_start",
         "stream_id": msg.id,
         "outbound": {
-            "schema_version": 99,
+            "schema_version": SCHEMA_VERSION_OUTBOUND_MESSAGE + 1,
             "content": [],
             "buttons": [],
             "metadata": {},
@@ -652,7 +654,7 @@ async def test_stream_start_version_mismatch_drops_and_increments_counter() -> N
     await listener._handle(_make_nats_msg(envelope))
 
     assert msg.id not in listener._stream_outbound
-    assert listener.version_mismatch_count("OutboundMessage") == 1
+    assert listener._version_mismatch_drops == {"OutboundMessage": 1}
 
 
 @pytest.mark.asyncio
@@ -661,6 +663,7 @@ async def test_attachment_version_mismatch_drops_and_increments_counter() -> Non
     import base64
 
     from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.core.message import SCHEMA_VERSION_OUTBOUND_MESSAGE
 
     nc = AsyncMock()
     adapter = AsyncMock()
@@ -674,7 +677,7 @@ async def test_attachment_version_mismatch_drops_and_increments_counter() -> Non
         "type": "attachment",
         "stream_id": msg.id,
         "attachment": {
-            "schema_version": 99,
+            "schema_version": SCHEMA_VERSION_OUTBOUND_MESSAGE + 1,
             "data": b64_data,
             "type": "image",
             "mime_type": "image/png",
@@ -683,8 +686,30 @@ async def test_attachment_version_mismatch_drops_and_increments_counter() -> Non
     await listener._handle(_make_nats_msg(envelope))
 
     adapter.render_attachment.assert_not_called()
-    assert listener.version_mismatch_count("OutboundAttachment") == 1
-    assert listener.version_mismatch_count("OutboundMessage") == 0
+    assert listener._version_mismatch_drops == {"OutboundAttachment": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema_version", [None, 1])
+async def test_send_valid_version_is_accepted(schema_version) -> None:
+    """send envelope with valid schema_version (absent or == 1) is accepted."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-send-valid")
+    listener.cache_inbound(msg)
+
+    outbound: dict = {"content": ["hello"], "buttons": [], "metadata": {}}
+    if schema_version is not None:
+        outbound["schema_version"] = schema_version
+    envelope = {"type": "send", "stream_id": msg.id, "outbound": outbound}
+    await listener._handle(_make_nats_msg(envelope))
+
+    adapter.send.assert_called_once()
+    assert listener._version_mismatch_drops == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -595,6 +595,104 @@ async def test_stream_error_unknown_stream_id_is_noop() -> None:
 
 
 # ---------------------------------------------------------------------------
+# #566: check_schema_version on OutboundMessage receive paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_version_mismatch_drops_and_increments_counter() -> None:
+    """send envelope with schema_version > expected is dropped; counter incremented."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.nats._version_check import _reset_log_state
+
+    _reset_log_state()
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-send-version")
+    listener.cache_inbound(msg)
+
+    envelope = {
+        "type": "send",
+        "stream_id": msg.id,
+        "outbound": {
+            "schema_version": 99,
+            "content": ["hello"],
+            "buttons": [],
+            "metadata": {},
+        },
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    adapter.send.assert_not_called()
+    assert listener.version_mismatch_count("OutboundMessage") == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_start_version_mismatch_drops_and_increments_counter() -> None:
+    """stream_start envelope with schema_version > expected is dropped; counter incremented."""  # noqa: E501
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.nats._version_check import _reset_log_state
+
+    _reset_log_state()
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-stream-start-version")
+    listener.cache_inbound(msg)
+
+    envelope = {
+        "type": "stream_start",
+        "stream_id": msg.id,
+        "outbound": {
+            "schema_version": 99,
+            "content": [],
+            "buttons": [],
+            "metadata": {},
+        },
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    assert msg.id not in listener._stream_outbound
+    assert listener.version_mismatch_count("OutboundMessage") == 1
+
+
+@pytest.mark.asyncio
+async def test_attachment_version_mismatch_drops_and_increments_counter() -> None:
+    """attachment envelope with schema_version > expected is dropped; counter incremented."""  # noqa: E501
+    import base64
+
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+    from lyra.nats._version_check import _reset_log_state
+
+    _reset_log_state()
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-attach-version")
+    listener.cache_inbound(msg)
+
+    b64_data = "b64:" + base64.b64encode(b"PNG").decode("ascii")
+    envelope = {
+        "type": "attachment",
+        "stream_id": msg.id,
+        "attachment": {
+            "schema_version": 99,
+            "data": b64_data,
+            "type": "image",
+            "mime_type": "image/png",
+        },
+    }
+    await listener._handle(_make_nats_msg(envelope))
+
+    adapter.render_attachment.assert_not_called()
+    assert listener.version_mismatch_count("OutboundMessage") == 1
+
+
+# ---------------------------------------------------------------------------
 # MT-14: Listener-level version mismatch counter integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `check_schema_version` guard to `_handle_send`, `_handle_stream_start`, and `_handle_attachment` in `NatsOutboundListener` — mirrors the existing pattern used for `InboundMessage` and render events
- Import `SCHEMA_VERSION_OUTBOUND_MESSAGE` which was defined in `message.py` but consumed nowhere; on a future version bump, adapters would have silently misinterpreted v2 messages from the hub

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #566: fix(nats): add check_schema_version to OutboundMessage receive paths | Open |
| Implementation | 1 commit on `feat/566-check-schema-outbound` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/adapters/test_nats_outbound_listener.py` — all 21 tests pass
- [ ] Version mismatch on `send` envelope → drops message, increments `version_mismatch_count("OutboundMessage")`
- [ ] Version mismatch on `stream_start` envelope → drops, outbound not stored in `_stream_outbound`
- [ ] Version mismatch on `attachment` envelope → drops, `render_attachment` not called

Closes #566

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`