### PR TITLE
fix(security): wire nkey auth for TTS/STT adapter processes (#563)

### DIFF
--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -119,6 +119,12 @@ info "Generating nkey pairs..."
 HUB_PUB=$(generate_nkey "hub")
 WORKER_PUB=$(generate_nkey "llm-worker")
 MONITOR_PUB=$(generate_nkey "monitor")
+TTS_PUB=$(generate_nkey "tts-adapter")
+STT_PUB=$(generate_nkey "stt-adapter")
+chmod 0640 "${NKEYS_DIR}/tts-adapter.seed"
+chgrp mickael "${NKEYS_DIR}/tts-adapter.seed"
+chmod 0640 "${NKEYS_DIR}/stt-adapter.seed"
+chgrp mickael "${NKEYS_DIR}/stt-adapter.seed"
 
 # ── write auth.conf ────────────────────────────────────────────────────────
 
@@ -132,6 +138,8 @@ authorization {
     { nkey: "${HUB_PUB}",    name: "hub" }
     { nkey: "${WORKER_PUB}", name: "llm-worker" }
     { nkey: "${MONITOR_PUB}", name: "monitor" }
+    { nkey: "${TTS_PUB}", name: "tts-adapter" }
+    { nkey: "${STT_PUB}", name: "stt-adapter" }
   ]
 }
 EOF
@@ -139,9 +147,9 @@ chmod 640 "${NKEYS_DIR}/auth.conf"
 chown root:nats "${NKEYS_DIR}/auth.conf"
 
 info "nkeys generated at ${NKEYS_DIR}/"
-info "  hub.seed        — seed for Lyra hub process       (NATS_HUB_NKEY_SEED)"
-info "  llm-worker.seed — seed for Machine 2 LLM worker   (NATS_LLM_WORKER_NKEY_SEED)"
-info "  monitor.seed    — seed for lyra-monitor health check (NATS_MONITOR_NKEY_SEED)"
-info "  auth.conf       — public keys included by nats.conf"
-warn "Set env vars in each service's run script to point at the seed files:"
-warn "  export NATS_NKEY_SEED_PATH=/etc/nats/nkeys/hub.seed"
+info "  hub.seed          — Lyra hub process         NATS_NKEY_SEED_PATH=/etc/nats/nkeys/hub.seed"
+info "  llm-worker.seed   — Machine 2 LLM worker     NATS_NKEY_SEED_PATH=/etc/nats/nkeys/llm-worker.seed"
+info "  monitor.seed      — lyra-monitor health check NATS_NKEY_SEED_PATH=/etc/nats/nkeys/monitor.seed"
+info "  tts-adapter.seed  — lyra_tts adapter process  NATS_NKEY_SEED_PATH=/etc/nats/nkeys/tts-adapter.seed"
+info "  stt-adapter.seed  — lyra_stt adapter process  NATS_NKEY_SEED_PATH=/etc/nats/nkeys/stt-adapter.seed"
+warn "Set NATS_NKEY_SEED_PATH in each service's supervisor conf.d to the seed path above."

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Generate nkey seeds for NATS authentication
 #
-# Creates 3 user nkey seeds: hub, llm-worker, monitor
-# Seeds: /etc/nats/nkeys/{hub,llm-worker,monitor}.seed  (mode 0600, root:root)
+# Creates 5 user nkey seeds: hub, llm-worker, monitor, tts-adapter, stt-adapter
+# Seeds: /etc/nats/nkeys/{hub,llm-worker,monitor}.seed (0600 root:root), {tts-adapter,stt-adapter}.seed (0640 root:LYRA_USER)
 # Auth config: /etc/nats/nkeys/auth.conf  (included by /etc/nats/nats.conf)
 #
 # Usage: sudo ./deploy/nats/gen-nkeys.sh
@@ -21,6 +21,7 @@ warn()  { echo -e "${YELLOW}[!]${NC} $1" >&2; }
 error() { echo -e "${RED}[x]${NC} $1" >&2; exit 1; }
 
 SHOW_ONLY=false
+LYRA_USER="${SUDO_USER:-mickael}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --show) SHOW_ONLY=true; shift ;;
@@ -92,8 +93,9 @@ NK_BIN=$(ensure_nk)
 # ── create directories ─────────────────────────────────────────────────────
 
 mkdir -p "${NKEYS_DIR}"
-chmod 700 "${NKEYS_DIR}"
 chown root:root "${NKEYS_DIR}"
+chmod 0750 "${NKEYS_DIR}"
+chgrp "${LYRA_USER}" "${NKEYS_DIR}"
 
 # ── generate nkey pairs ────────────────────────────────────────────────────
 
@@ -121,10 +123,10 @@ WORKER_PUB=$(generate_nkey "llm-worker")
 MONITOR_PUB=$(generate_nkey "monitor")
 TTS_PUB=$(generate_nkey "tts-adapter")
 STT_PUB=$(generate_nkey "stt-adapter")
+chgrp "${LYRA_USER}" "${NKEYS_DIR}/tts-adapter.seed"
 chmod 0640 "${NKEYS_DIR}/tts-adapter.seed"
-chgrp mickael "${NKEYS_DIR}/tts-adapter.seed"
+chgrp "${LYRA_USER}" "${NKEYS_DIR}/stt-adapter.seed"
 chmod 0640 "${NKEYS_DIR}/stt-adapter.seed"
-chgrp mickael "${NKEYS_DIR}/stt-adapter.seed"
 
 # ── write auth.conf ────────────────────────────────────────────────────────
 

--- a/deploy/supervisor/conf.d/lyra_stt.conf
+++ b/deploy/supervisor/conf.d/lyra_stt.conf
@@ -1,7 +1,7 @@
 [program:lyra_stt]
 command=%(ENV_HOME)s/projects/lyra/supervisor/scripts/run_adapter.sh stt
 directory=%(ENV_HOME)s/projects/lyra
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="/etc/nats/nkeys/stt-adapter.seed"
 autostart=false
 autorestart=true
 startsecs=5

--- a/deploy/supervisor/conf.d/lyra_tts.conf
+++ b/deploy/supervisor/conf.d/lyra_tts.conf
@@ -1,7 +1,7 @@
 [program:lyra_tts]
 command=%(ENV_HOME)s/projects/lyra/supervisor/scripts/run_adapter.sh tts
 directory=%(ENV_HOME)s/projects/lyra
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="/etc/nats/nkeys/tts-adapter.seed"
 autostart=false
 autorestart=true
 startsecs=5


### PR DESCRIPTION
## Summary
- Add `tts-adapter` and `stt-adapter` nkey seed generation to `gen-nkeys.sh` (5 users total in `auth.conf`), with `0640 root:mickael` permissions so the supervisord user can read them
- Set `NATS_NKEY_SEED_PATH` in `lyra_tts.conf` and `lyra_stt.conf` so `nats_connect()` authenticates instead of falling through to unauthenticated dev mode
- Update `gen-nkeys.sh` trailing info block to list all 5 seeds with correct `NATS_NKEY_SEED_PATH` env var name (replaces legacy `NATS_*_NKEY_SEED` names)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #563: fix(security): TTS/STT adapters bypass nkey auth | Open |
| Analysis | Absent (F-lite — frame sufficient) | — |
| Spec | [563-tts-stt-nkey-auth-spec.mdx](artifacts/specs/563-tts-stt-nkey-auth-spec.mdx) | Present |
| Implementation | 1 commit on `feat/563-tts-stt-nkey-auth` | Complete |
| Verification | Lint ✅ Typecheck N/A (no Python changes) Tests ✅ (2500 passed, 81% coverage) | Passed |

## Test Plan
- [ ] On Machine 1: `sudo rm -rf /etc/nats/nkeys/ && sudo ./deploy/nats/gen-nkeys.sh` — verify 5 seed files created, `tts-adapter.seed` and `stt-adapter.seed` are `0640 root:mickael`
- [ ] Verify `auth.conf` has 5 `nkey:` entries including `tts-adapter` and `stt-adapter`
- [ ] Reload NATS: `nats-server --signal reload=/run/nats-server/nats-server.pid`
- [ ] `supervisorctl restart lyra_tts lyra_stt` — check logs show `nats_connect: auth keys enabled`, no auth errors
- [ ] If `NATS_NKEY_SEED_PATH` set but seed missing → process exits with descriptive error (fail-closed)

Closes #563

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`