### PR TITLE
feat(persistence): session resume, /clear rotation, reply-to queue

### DIFF
--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from lyra.adapters._shared_streaming import PlatformCallbacks
     from lyra.adapters.outbound_listener import OutboundListener
     from lyra.core.bus import Bus
+    from lyra.core.stores.turn_store import TurnStore
 
 from lyra.adapters import discord_audio  # noqa: I001
 from lyra.adapters import discord_audio_outbound
@@ -83,6 +84,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         auth: Authenticator = _DENY_ALL,
         thread_store: ThreadStore | None = None,
         watch_channels: frozenset[int] = frozenset(),
+        turn_store: "TurnStore | None" = None,
     ) -> None:
         if intents is None:
             intents = discord.Intents.default()
@@ -115,6 +117,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         self._mention_re: re.Pattern[str] | None = None  # compiled on on_ready
         self._owned_threads: set[int] = set()  # populated from ThreadStore on on_ready
         self._thread_store: ThreadStore | None = thread_store
+        self._turn_store: "TurnStore | None" = turn_store
         self._watch_channels: frozenset[int] = watch_channels
         self._thread_sessions: dict[str, tuple[str, str]] = {}
         self._vsm: VoiceSessionManager = VoiceSessionManager()

--- a/src/lyra/adapters/discord_inbound.py
+++ b/src/lyra/adapters/discord_inbound.py
@@ -195,6 +195,33 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
     _meta_updates: dict[str, Any] = {}
     if _stored_session_id is not None:
         _meta_updates["thread_session_id"] = _stored_session_id
+
+    # DM session wiring: inject prior session_id + persist callback for DMs.
+    _dm_session_id: str | None = None
+    if _is_dm and adapter._turn_store is not None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+        from lyra.core.message import Platform
+        _pool_id = RoutingKey(
+            Platform.DISCORD, adapter._bot_id, f"channel:{message.channel.id}"
+        ).to_pool_id()
+        try:
+            _dm_session_id = await adapter._turn_store.get_last_session(_pool_id)
+        except Exception:
+            log.exception(  # noqa: TRY401
+                "TurnStore.get_last_session failed for DM pool_id=%s", _pool_id
+            )
+    if _dm_session_id is not None:
+        _meta_updates["thread_session_id"] = _dm_session_id
+    if _is_dm and adapter._turn_store is not None:
+        _dm_ts = adapter._turn_store
+
+        async def _dm_session_update_fn(
+            _msg: InboundMessage, session_id: str, pool_id: str
+        ) -> None:
+            await _dm_ts.start_session(session_id, pool_id)
+
+        _meta_updates["_session_update_fn"] = _dm_session_update_fn
+
     _has_thread_id = hub_msg.platform_meta.get("thread_id") is not None
     if _has_thread_id and adapter._thread_store is not None:
         _ts = adapter._thread_store

--- a/src/lyra/adapters/discord_inbound.py
+++ b/src/lyra/adapters/discord_inbound.py
@@ -212,7 +212,9 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
             )
     if _dm_session_id is not None:
         _meta_updates["thread_session_id"] = _dm_session_id
+    _has_thread_id = hub_msg.platform_meta.get("thread_id") is not None
     if _is_dm and adapter._turn_store is not None:
+        # DM path takes priority over thread-session persistence
         _dm_ts = adapter._turn_store
 
         async def _dm_session_update_fn(
@@ -221,9 +223,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
             await _dm_ts.start_session(session_id, pool_id)
 
         _meta_updates["_session_update_fn"] = _dm_session_update_fn
-
-    _has_thread_id = hub_msg.platform_meta.get("thread_id") is not None
-    if _has_thread_id and adapter._thread_store is not None:
+    elif _has_thread_id and adapter._thread_store is not None:
         _ts = adapter._thread_store
         _bid, _cache = adapter._bot_id, adapter._thread_sessions
 

--- a/src/lyra/adapters/discord_normalize.py
+++ b/src/lyra/adapters/discord_normalize.py
@@ -14,7 +14,6 @@ from lyra.core.message import (
     Platform,
     RoutingContext,
 )
-from lyra.core.scope import user_scoped
 from lyra.core.trust import TrustLevel
 
 if TYPE_CHECKING:
@@ -59,12 +58,7 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
         else f"channel:{resolved_channel_id}"
     )
 
-    # User-scope guild channels so each user gets their own pool (#356).
-    # Threads and DMs are left as-is (single-user or thread-session-resume).
     user_id = f"dc:user:{raw.author.id}"
-    is_guild_channel = raw.guild is not None and not resolved_thread_id
-    if is_guild_channel:
-        scope_id = user_scoped(scope_id, user_id)
 
     # Detect channel type
     channel_type: str = "text"

--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from lyra.adapters._shared_streaming import PlatformCallbacks
     from lyra.adapters.outbound_listener import OutboundListener
     from lyra.core.bus import Bus
+    from lyra.core.stores.turn_store import TurnStore
 
 from lyra.adapters import telegram_audio  # noqa: I001
 from lyra.adapters._base_outbound import OutboundAdapterBase
@@ -98,6 +99,7 @@ class TelegramAdapter(OutboundAdapterBase):
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
         auth: Authenticator = _DENY_ALL,
+        turn_store: "TurnStore | None" = None,
     ) -> None:
         super().__init__()  # no-op today, future-proofs cooperative chain
         if auth is not _DENY_ALL:
@@ -122,6 +124,7 @@ class TelegramAdapter(OutboundAdapterBase):
         self._msg_manager = msg_manager
         self._auth: Authenticator = auth
         self._guard_chain: GuardChain = GuardChain([BlockedGuard()])
+        self._turn_store: "TurnStore | None" = turn_store
         _raw_tmp = os.environ.get("LYRA_AUDIO_TMP") or None
         if _raw_tmp is not None:
             _tmp_path = Path(_raw_tmp)

--- a/src/lyra/adapters/telegram_inbound.py
+++ b/src/lyra/adapters/telegram_inbound.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -68,6 +69,35 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
     # In private chats, always respond.
     if hub_msg.platform_meta.get("is_group") and not hub_msg.is_mention:
         return
+
+    # Session wiring: inject prior session_id + persist callback.
+    _meta_updates: dict[str, Any] = {}
+    if adapter._turn_store is not None:
+        from lyra.core.hub.hub_protocol import RoutingKey
+        from lyra.core.message import Platform
+        _pool_id = RoutingKey(
+            Platform.TELEGRAM, adapter._bot_id, hub_msg.scope_id
+        ).to_pool_id()
+        try:
+            _last_sid = await adapter._turn_store.get_last_session(_pool_id)
+        except Exception:
+            log.exception("TurnStore.get_last_session failed for pool_id=%s", _pool_id)
+            _last_sid = None
+        if _last_sid is not None:
+            _meta_updates["thread_session_id"] = _last_sid
+        _ts = adapter._turn_store
+
+        async def _tg_session_update_fn(
+            msg: InboundMessage, session_id: str, pool_id: str
+        ) -> None:
+            await _ts.start_session(session_id, pool_id)
+
+        _meta_updates["_session_update_fn"] = _tg_session_update_fn
+    if _meta_updates:
+        hub_msg = dataclasses.replace(
+            hub_msg,
+            platform_meta={**hub_msg.platform_meta, **_meta_updates},
+        )
 
     log.info(
         "message_received",

--- a/src/lyra/adapters/telegram_normalize.py
+++ b/src/lyra/adapters/telegram_normalize.py
@@ -13,7 +13,6 @@ from lyra.core.message import (
     Platform,
     RoutingContext,
 )
-from lyra.core.scope import user_scoped
 from lyra.core.trust import TrustLevel
 
 if TYPE_CHECKING:
@@ -96,7 +95,7 @@ def _make_scope_id(
         base = f"chat:{chat_id}:topic:{topic_id}"
     else:
         base = f"chat:{chat_id}"
-    return user_scoped(base, user_id) if is_group else base
+    return base
 
 
 def _build_routing(  # noqa: PLR0913 — groups related metadata fields

--- a/src/lyra/bootstrap/adapter_standalone.py
+++ b/src/lyra/bootstrap/adapter_standalone.py
@@ -84,6 +84,11 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             finally:
                 await cred_store.close()
 
+            from lyra.core.stores.turn_store import TurnStore as TurnStore
+
+            tg_turn_store = TurnStore(db_path=vault_dir / "turns.db")
+            await tg_turn_store.connect()
+
             wired: list[tuple] = []  # (TelegramAdapter, Bus)
 
             for bot_cfg in tg_multi_cfg.bots:
@@ -103,6 +108,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                     token=token,
                     inbound_bus=inbound_bus,
                     webhook_secret=webhook_secret or "",
+                    turn_store=tg_turn_store,
                 )
                 await adapter.resolve_identity()
 
@@ -145,6 +151,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                 for a, ibus in wired:
                     await a.close()
                     await ibus.stop()
+                await tg_turn_store.close()
 
         elif platform == "discord":
             from lyra.adapters.discord import DiscordAdapter
@@ -209,6 +216,11 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             dc_thread_store = ThreadStore(db_path=vault_dir / "discord.db")
             await dc_thread_store.connect()
 
+            from lyra.core.stores.turn_store import TurnStore
+
+            dc_turn_store = TurnStore(db_path=vault_dir / "turns.db")
+            await dc_turn_store.connect()
+
             wired_dc: list[tuple] = []  # (DiscordAdapter, str, Bus)
 
             for bot_cfg in dc_multi_cfg.bots:
@@ -230,6 +242,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
                     thread_hot_hours=bot_cfg.thread_hot_hours,
                     thread_store=dc_thread_store,
                     watch_channels=dc_bot_watch_channels.get(bot_id, frozenset()),
+                    turn_store=dc_turn_store,
                 )
 
                 listener_dc = NatsOutboundListener(
@@ -270,6 +283,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
             finally:
                 for _, _, ibus in wired_dc:
                     await ibus.stop()
+                await dc_turn_store.close()
 
         else:
             sys.exit(f"Unknown platform: {platform!r}")

--- a/src/lyra/bootstrap/bootstrap_wiring.py
+++ b/src/lyra/bootstrap/bootstrap_wiring.py
@@ -71,6 +71,7 @@ async def wire_telegram_adapters(  # noqa: PLR0913 — wiring requires all deps
             webhook_secret=tg_webhook_secret or "",
             circuit_registry=circuit_registry,
             msg_manager=msg_manager,
+            turn_store=hub._turn_store,
         )
         await adapter.resolve_identity()
         # C3: Hub is the trust authority — register authenticator here, not on adapter.
@@ -182,6 +183,7 @@ async def wire_discord_adapters(  # noqa: PLR0913, C901 — wiring requires all 
                 thread_hot_hours=bot_cfg.thread_hot_hours,
                 thread_store=thread_store,
                 watch_channels=watch_channels,
+                turn_store=hub._turn_store,
             )
             # Wire identity resolver for slash command trust (voice commands).
             adapter._resolve_identity_fn = hub.resolve_identity

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -144,8 +144,9 @@ class SubmitToPoolMiddleware:
             session_id = await hub._message_index.resolve(pool_id, str(msg.reply_to_id))
             if session_id is not None:
                 if not pool.is_idle:
+                    pool._pending_session_id = session_id  # was: log + skip
                     log.info(
-                        "reply-to-resume: pool %r busy — skipping resume of session %r",
+                        "reply-to-resume: pool %r busy — queued session %r",
                         pool_id,
                         session_id,
                     )

--- a/src/lyra/core/hub/middleware_submit.py
+++ b/src/lyra/core/hub/middleware_submit.py
@@ -150,6 +150,7 @@ class SubmitToPoolMiddleware:
                         pool_id,
                         session_id,
                     )
+                    return ResumeStatus.SKIPPED
                 else:
                     log.info(
                         "reply-to-resume: resuming session %r for pool %r",

--- a/src/lyra/core/pool/pool.py
+++ b/src/lyra/core/pool/pool.py
@@ -125,7 +125,6 @@ class Pool:
         self._processor = PoolProcessor(self)
 
     # Backward-compat shims — delegate to observer so callers keep working.
-
     @property
     def _turn_store(self) -> TurnStore | None:
         return self._observer._turn_store
@@ -221,12 +220,9 @@ class Pool:
             self._current_task.cancel()
 
     async def resume_session(self, session_id: str) -> bool:
-        """Resume a specific Claude session (CLI backend).
-
-        Returns True if the resume was accepted, False if skipped (pruned file,
-        invalid id, SDK pool, or misconfigured agent).
-        Resets _session_persisted only when resume is accepted so the resumed
-        session_id is re-persisted on the next turn (#341).
+        """Resume a specific Claude session (CLI backend). Returns True if accepted.
+        Resets _session_persisted only when accepted so the resumed session_id is
+        re-persisted on the next turn (#341).
         """
         if self._session_resume_fn is not None:
             accepted = await self._session_resume_fn(session_id)
@@ -253,9 +249,12 @@ class Pool:
         await self._observer.end_session_async(old_sid)
         self.session_id = str(uuid.uuid4())
         if self._observer._turn_store is not None:
-            await self._observer._turn_store.start_session(
-                self.session_id, self.pool_id
-            )
+            try:
+                await self._observer._turn_store.start_session(
+                    self.session_id, self.pool_id
+                )
+            except Exception:
+                log.exception("[pool:%s] start_session failed", self.pool_id)
         self._observer.reset_session_persisted()
         if self._session_reset_fn is not None:
             await self._session_reset_fn()

--- a/src/lyra/core/pool/pool.py
+++ b/src/lyra/core/pool/pool.py
@@ -60,7 +60,6 @@ class Pool:
     _session_reset_fn: Callable[[], Awaitable[None]] | None
     _session_resume_fn: Callable[[str], Awaitable[bool]] | None
     _switch_workspace_fn: Callable[[Path], Awaitable[None]] | None
-
     def __init__(  # noqa: PLR0913
         self,
         pool_id: str,
@@ -117,16 +116,15 @@ class Pool:
         self.last_detected_language: str | None = None
         self._last_turn_had_backend_error: bool = False
         self._last_msg: InboundMessage | None = None
+        # set by pipeline when pool busy on reply-to
+        self._pending_session_id: str | None = None
         self._observer = PoolObserver(
             pool_id=pool_id,
             session_id_fn=lambda: self.session_id,
         )
         self._processor = PoolProcessor(self)
 
-    # ------------------------------------------------------------------
-    # Backward-compat shims — delegate to observer so existing callers
-    # (tests, hub.py) that read/write these attributes keep working.
-    # ------------------------------------------------------------------
+    # Backward-compat shims — delegate to observer so callers keep working.
 
     @property
     def _turn_store(self) -> TurnStore | None:
@@ -250,7 +248,14 @@ class Pool:
         return result if result is not None else fallback
 
     async def reset_session(self) -> None:
-        """Reset session state; called by /clear. Delegates to reset callback if set."""
+        """Reset session state; called by /clear. Rotates UUID, notifies TurnStore."""
+        old_sid = self.session_id
+        await self._observer.end_session_async(old_sid)
+        self.session_id = str(uuid.uuid4())
+        if self._observer._turn_store is not None:
+            await self._observer._turn_store.start_session(
+                self.session_id, self.pool_id
+            )
         self._observer.reset_session_persisted()
         if self._session_reset_fn is not None:
             await self._session_reset_fn()

--- a/src/lyra/core/pool/pool_processor.py
+++ b/src/lyra/core/pool/pool_processor.py
@@ -46,6 +46,12 @@ class PoolProcessor:
                     break
                 buffer = await pool._debouncer.collect(pool._inbox)
 
+                # Fire any pending reply-to session resume before processing
+                if pool._pending_session_id is not None:
+                    _pending = pool._pending_session_id
+                    pool._pending_session_id = None
+                    await pool.resume_session(_pending)
+
                 agent = pool._ctx.get_agent(pool.agent_name)
                 if agent is None:
                     log.error(

--- a/src/lyra/core/pool/pool_processor.py
+++ b/src/lyra/core/pool/pool_processor.py
@@ -50,7 +50,15 @@ class PoolProcessor:
                 if pool._pending_session_id is not None:
                     _pending = pool._pending_session_id
                     pool._pending_session_id = None
-                    await pool.resume_session(_pending)
+                    try:
+                        await pool.resume_session(_pending)
+                    except Exception:
+                        log.exception(
+                            "[pool:%s] pending session resume failed for %r"
+                            " — continuing",
+                            pool.pool_id,
+                            _pending,
+                        )
 
                 agent = pool._ctx.get_agent(pool.agent_name)
                 if agent is None:

--- a/tests/adapters/test_discord_normalize.py
+++ b/tests/adapters/test_discord_normalize.py
@@ -43,7 +43,7 @@ def test_normalize_builds_correct_discord_context() -> None:
 
     assert isinstance(msg, InboundMessage)
     assert msg.platform == "discord"
-    assert msg.scope_id == "channel:333:user:dc:user:42"
+    assert msg.scope_id == "channel:333"  # guild channels share one pool (#592)
     assert msg.platform_meta["guild_id"] == 111
     assert msg.platform_meta["channel_id"] == 333
     assert msg.platform_meta["message_id"] == 555
@@ -381,7 +381,7 @@ def test_normalize_guild_channel_user_scoped_scope_id() -> None:
     msg = adapter.normalize(discord_msg)
 
     assert isinstance(msg, InboundMessage)
-    assert msg.scope_id == "channel:333:user:dc:user:42"
+    assert msg.scope_id == "channel:333"  # guild channels share one pool (#592)
     assert msg.user_id == "dc:user:42"
 
 
@@ -441,8 +441,11 @@ def test_normalize_thread_scope_id_unchanged() -> None:
     assert msg.scope_id == "thread:888"
 
 
-def test_two_users_same_guild_channel_get_distinct_pool_ids() -> None:
-    """Two users in the same guild channel → distinct scope_ids → distinct pool_ids."""
+def test_two_users_same_guild_channel_share_pool_id() -> None:
+    """Two users in the same guild channel → same scope_id → same pool_id (#592).
+
+    Guild channels are no longer user-scoped: all users in a channel share one pool.
+    """
     from lyra.adapters.discord import DiscordAdapter
     from lyra.core.hub.hub_protocol import RoutingKey
     from lyra.core.message import Platform
@@ -471,8 +474,8 @@ def test_two_users_same_guild_channel_get_distinct_pool_ids() -> None:
     msg_alice = adapter.normalize(_make_guild_msg(1, "Alice"))
     msg_bob = adapter.normalize(_make_guild_msg(2, "Bob"))
 
-    assert msg_alice.scope_id != msg_bob.scope_id
+    assert msg_alice.scope_id == msg_bob.scope_id
 
     key_alice = RoutingKey(Platform.DISCORD, "main", msg_alice.scope_id)
     key_bob = RoutingKey(Platform.DISCORD, "main", msg_bob.scope_id)
-    assert key_alice.to_pool_id() != key_bob.to_pool_id()
+    assert key_alice.to_pool_id() == key_bob.to_pool_id()

--- a/tests/adapters/test_scope_id.py
+++ b/tests/adapters/test_scope_id.py
@@ -1,0 +1,218 @@
+"""Unit tests — scope_id must NOT be user-scoped in shared spaces.
+
+Issue #592: Groups / guild channels must produce the same scope_id for all
+users so everyone shares one pool.  Currently both adapters add per-user
+suffixes, causing each user to get their own pool.
+
+RED phase:
+- Discord: normalize() calls user_scoped() for guild channels → different users
+  get different scope_ids → the equality assertion fails.
+- Telegram: _make_scope_id() returns user_scoped(base, user_id) for groups →
+  same failure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from lyra.adapters.discord import _ALLOW_ALL, DiscordAdapter
+from lyra.adapters.telegram_normalize import _make_scope_id
+
+# ---------------------------------------------------------------------------
+# Discord — two users in same guild channel
+# ---------------------------------------------------------------------------
+
+
+def _make_discord_adapter() -> DiscordAdapter:
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+    return adapter
+
+
+def _make_guild_message(
+    guild_id: int, channel_id: int, user_id: int
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        guild=SimpleNamespace(id=guild_id),
+        channel=SimpleNamespace(id=channel_id, send=AsyncMock()),
+        author=SimpleNamespace(
+            id=user_id,
+            name=f"User{user_id}",
+            display_name=f"User{user_id}",
+            bot=False,
+        ),
+        content="hello",
+        created_at=datetime.now(timezone.utc),
+        id=1000 + user_id,
+        mentions=[],
+        thread=None,
+    )
+
+
+def test_discord_two_users_same_guild_channel_same_scope_id() -> None:
+    """Two users in the same guild channel must share the same scope_id.
+
+    RED: currently discord_normalize calls user_scoped() for guild channels →
+    user A: scope_id='channel:200:user:dc:user:1'
+    user B: scope_id='channel:200:user:dc:user:2'
+    → assertion fails.
+    """
+    adapter = _make_discord_adapter()
+
+    msg_a = _make_guild_message(guild_id=100, channel_id=200, user_id=1)
+    msg_b = _make_guild_message(guild_id=100, channel_id=200, user_id=2)
+
+    normalized_a = adapter.normalize(msg_a)
+    normalized_b = adapter.normalize(msg_b)
+
+    sid_a = normalized_a.scope_id
+    sid_b = normalized_b.scope_id
+
+    # RED: fails because user_scoped() appends different user ids
+    assert sid_a == sid_b, (
+        f"Guild channel scope_ids must be identical for all users.\n"
+        f"  user 1: {sid_a!r}\n"
+        f"  user 2: {sid_b!r}"
+    )
+
+
+def test_discord_two_users_same_guild_channel_same_pool_id() -> None:
+    """Two users in the same guild channel must map to the same pool_id.
+
+    RED: scope_ids differ → pool_ids differ.
+    """
+    from lyra.core.hub.hub_protocol import RoutingKey
+    from lyra.core.message import Platform
+
+    adapter = _make_discord_adapter()
+
+    msg_a = _make_guild_message(guild_id=100, channel_id=200, user_id=1)
+    msg_b = _make_guild_message(guild_id=100, channel_id=200, user_id=2)
+
+    norm_a = adapter.normalize(msg_a)
+    norm_b = adapter.normalize(msg_b)
+
+    key_a = RoutingKey(Platform.DISCORD, "main", norm_a.scope_id)
+    key_b = RoutingKey(Platform.DISCORD, "main", norm_b.scope_id)
+
+    # RED: pool_ids will differ because scope_ids differ
+    assert key_a.to_pool_id() == key_b.to_pool_id(), (
+        f"Both users must resolve to the same pool.\n"
+        f"  pool A: {key_a.to_pool_id()!r}\n"
+        f"  pool B: {key_b.to_pool_id()!r}"
+    )
+
+
+def test_discord_dm_scope_id_is_channel_only() -> None:
+    """Discord DM (guild=None) → scope_id is just 'channel:<id>' (no user suffix).
+
+    This should already pass; included as a regression guard.
+    """
+    adapter = _make_discord_adapter()
+
+    dm_msg = SimpleNamespace(
+        guild=None,
+        channel=SimpleNamespace(id=777, send=AsyncMock()),
+        author=SimpleNamespace(id=42, name="Alice", display_name="Alice", bot=False),
+        content="hello",
+        created_at=datetime.now(timezone.utc),
+        id=555,
+        mentions=[],
+        thread=None,
+    )
+
+    normalized = adapter.normalize(dm_msg)
+
+    assert normalized.scope_id == "channel:777", (
+        f"DM scope_id should be 'channel:777', got {normalized.scope_id!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Telegram — two users in same group
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_two_users_same_group_same_scope_id() -> None:
+    """Two users in the same Telegram group must share the same scope_id.
+
+    RED: _make_scope_id returns user_scoped(base, user_id) for groups →
+    user u1: scope_id='chat:300:user:tg:user:u1'
+    user u2: scope_id='chat:300:user:tg:user:u2'
+    → assertion fails.
+    """
+    sid_a = _make_scope_id(
+        chat_id=300, topic_id=None, user_id="tg:user:u1", is_group=True
+    )
+    sid_b = _make_scope_id(
+        chat_id=300, topic_id=None, user_id="tg:user:u2", is_group=True
+    )
+
+    # RED: fails because user_scoped() appends different user ids
+    assert sid_a == sid_b, (
+        f"Group scope_ids must be identical for all users.\n"
+        f"  user u1: {sid_a!r}\n"
+        f"  user u2: {sid_b!r}"
+    )
+
+
+def test_telegram_two_users_same_topic_same_scope_id() -> None:
+    """Two users in the same topic must share the same scope_id.
+
+    RED: topic scoping also calls user_scoped → different scope_ids per user.
+    """
+    sid_a = _make_scope_id(
+        chat_id=300, topic_id=5, user_id="tg:user:u1", is_group=True
+    )
+    sid_b = _make_scope_id(
+        chat_id=300, topic_id=5, user_id="tg:user:u2", is_group=True
+    )
+
+    # RED: fails because user_scoped() appends different user ids
+    assert sid_a == sid_b, (
+        f"Topic scope_ids must be identical for all users.\n"
+        f"  user u1: {sid_a!r}\n"
+        f"  user u2: {sid_b!r}"
+    )
+
+
+def test_telegram_private_scope_id_is_chat_only() -> None:
+    """Telegram private chat → scope_id is 'chat:<id>' (no user suffix).
+
+    This should already pass; included as regression guard.
+    """
+    sid = _make_scope_id(
+        chat_id=100, topic_id=None, user_id="tg:user:42", is_group=False
+    )
+
+    assert sid == "chat:100", (
+        f"Private chat scope_id should be 'chat:100', got {sid!r}"
+    )
+
+
+def test_telegram_different_groups_different_scope_id() -> None:
+    """Users in different groups must NOT share a scope_id.
+
+    This is a sanity check — different group chats must remain isolated.
+    Expected to pass in both RED and GREEN.
+    """
+    sid_a = _make_scope_id(
+        chat_id=300, topic_id=None, user_id="tg:user:u1", is_group=True
+    )
+    sid_b = _make_scope_id(
+        chat_id=400, topic_id=None, user_id="tg:user:u1", is_group=True
+    )
+
+    # Even after fix, different chat_ids must produce different scope_ids
+    assert sid_a != sid_b, (
+        f"Different groups must have different scope_ids: {sid_a!r} vs {sid_b!r}"
+    )

--- a/tests/adapters/test_telegram_normalize_fields.py
+++ b/tests/adapters/test_telegram_normalize_fields.py
@@ -245,7 +245,7 @@ def test_normalize_captures_topic_and_message_id_for_forum() -> None:
     assert msg.platform_meta["topic_id"] == 99
     assert msg.platform_meta["message_id"] == 777
     assert msg.platform_meta["is_group"] is True
-    assert msg.scope_id == "chat:456:topic:99:user:tg:user:42"
+    assert msg.scope_id == "chat:456:topic:99"  # groups/topics share pool (#592)
 
 
 def test_normalize_empty_text() -> None:
@@ -361,12 +361,12 @@ def test_normalize_group_chat_user_scoped_scope_id() -> None:
 
     msg = adapter.normalize(aiogram_msg)
 
-    assert msg.scope_id == "chat:456:user:tg:user:42"
+    assert msg.scope_id == "chat:456"  # groups share pool (#592)
     assert msg.user_id == "tg:user:42"
 
 
-def test_normalize_group_chat_no_mention_still_user_scoped() -> None:
-    """Group chat without @mention → scope_id still includes user_id suffix."""
+def test_normalize_group_chat_no_mention_shared_scope() -> None:
+    """Group chat without @mention → scope_id is shared (no user suffix, #592)."""
     from lyra.adapters.telegram import TelegramAdapter
 
     adapter = TelegramAdapter(
@@ -388,12 +388,12 @@ def test_normalize_group_chat_no_mention_still_user_scoped() -> None:
 
     msg = adapter.normalize(aiogram_msg)
 
-    assert msg.scope_id == "chat:456:user:tg:user:42"
+    assert msg.scope_id == "chat:456"  # groups share pool (#592)
     assert msg.is_mention is False
 
 
-def test_normalize_forum_topic_user_scoped_scope_id() -> None:
-    """Forum topic in supergroup → scope_id includes topic AND user_id suffix."""
+def test_normalize_forum_topic_shared_scope_id() -> None:
+    """Forum topic in supergroup → scope_id is shared (no user suffix, #592)."""
     from lyra.adapters.telegram import TelegramAdapter
 
     adapter = TelegramAdapter(
@@ -417,7 +417,7 @@ def test_normalize_forum_topic_user_scoped_scope_id() -> None:
 
     msg = adapter.normalize(aiogram_msg)
 
-    assert msg.scope_id == "chat:456:topic:7:user:tg:user:42"
+    assert msg.scope_id == "chat:456:topic:7"  # topics share pool (#592)
 
 
 def test_normalize_private_chat_scope_id_unchanged() -> None:
@@ -446,8 +446,8 @@ def test_normalize_private_chat_scope_id_unchanged() -> None:
     assert msg.scope_id == "chat:123"
 
 
-def test_two_users_same_group_get_distinct_pool_ids() -> None:
-    """Two users in the same group → distinct scope_ids → distinct pool_ids."""
+def test_two_users_same_group_share_pool_id() -> None:
+    """Two users in the same group → same scope_id → same pool_id (#592)."""
     from lyra.adapters.telegram import TelegramAdapter
     from lyra.core.hub.hub_protocol import RoutingKey
     from lyra.core.message import Platform
@@ -475,8 +475,8 @@ def test_two_users_same_group_get_distinct_pool_ids() -> None:
     msg_alice = adapter.normalize(_make_group_msg(1, "Alice"))
     msg_bob = adapter.normalize(_make_group_msg(2, "Bob"))
 
-    assert msg_alice.scope_id != msg_bob.scope_id
+    assert msg_alice.scope_id == msg_bob.scope_id
 
     key_alice = RoutingKey(Platform.TELEGRAM, "main", msg_alice.scope_id)
     key_bob = RoutingKey(Platform.TELEGRAM, "main", msg_bob.scope_id)
-    assert key_alice.to_pool_id() != key_bob.to_pool_id()
+    assert key_alice.to_pool_id() == key_bob.to_pool_id()

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -269,8 +269,8 @@ def test_normalize_audio_private_chat_scope_id() -> None:
     assert result.scope_id == "chat:42"
 
 
-def test_normalize_audio_group_chat_user_scoped_scope_id() -> None:
-    """Group chat (no topic) → scope_id includes user suffix (#356)."""
+def test_normalize_audio_group_chat_shared_scope_id() -> None:
+    """Group chat (no topic) → scope_id shared (no user suffix, #592)."""
     from lyra.core.message import InboundMessage
     from lyra.core.trust import TrustLevel
 
@@ -280,11 +280,11 @@ def test_normalize_audio_group_chat_user_scoped_scope_id() -> None:
         msg, b"x", "audio/ogg", trust_level=TrustLevel.TRUSTED
     )
     assert isinstance(result, InboundMessage)
-    assert result.scope_id == "chat:42:user:tg:user:7"
+    assert result.scope_id == "chat:42"  # groups share pool (#592)
 
 
 def test_normalize_audio_topic_chat_scope_id() -> None:
-    """Topic chat → scope_id includes topic AND user suffix (#356)."""
+    """Topic chat → scope_id includes topic (no user suffix, #592)."""
     from lyra.core.message import InboundMessage
     from lyra.core.trust import TrustLevel
 
@@ -294,7 +294,7 @@ def test_normalize_audio_topic_chat_scope_id() -> None:
         msg, b"x", "audio/ogg", trust_level=TrustLevel.TRUSTED
     )
     assert isinstance(result, InboundMessage)
-    assert result.scope_id == "chat:42:topic:7:user:tg:user:99"
+    assert result.scope_id == "chat:42:topic:7"  # topics share pool (#592)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -93,7 +93,7 @@ class TestTelegramNormalizeRouting:
 
         msg = adapter.normalize(raw)
         assert msg.routing is not None
-        assert msg.routing.scope_id == "chat:123:topic:456:user:tg:user:42"
+        assert msg.routing.scope_id == "chat:123:topic:456"  # topics share pool (#592)
         assert msg.routing.thread_id == "456"
 
     def test_routing_platform_meta_is_copy(self) -> None:
@@ -164,7 +164,7 @@ class TestDiscordNormalizeRouting:
         assert msg.routing is not None
         assert msg.routing.platform == "discord"
         assert msg.routing.bot_id == "main"
-        assert msg.routing.scope_id == "channel:789:user:dc:user:42"
+        assert msg.routing.scope_id == "channel:789"  # guild channels share pool (#592)
         assert msg.routing.thread_id is None
         assert msg.routing.reply_to_message_id == "999"
 

--- a/tests/integration/test_session_clear.py
+++ b/tests/integration/test_session_clear.py
@@ -1,0 +1,152 @@
+"""Integration test — /clear rotates Pool session UUID and notifies TurnStore.
+
+RED phase: Pool.reset_session() does NOT rotate UUID yet (T2 pending).
+The assertion `before_sid != after_sid` will fail until T2 is implemented.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pool(pool_id: str = "telegram:main:chat:42"):
+    from lyra.core.pool import Pool
+
+    ctx = MagicMock()
+    ctx.get_agent = MagicMock(return_value=None)
+    ctx.get_message = MagicMock(return_value=None)
+    ctx.dispatch_response = AsyncMock()
+    ctx.dispatch_streaming = AsyncMock()
+    ctx.record_circuit_success = MagicMock()
+    ctx.record_circuit_failure = MagicMock()
+    return Pool(pool_id, "lyra", ctx)
+
+
+class _FakeTurnStore:
+    """Inline fake that records end_session / start_session calls."""
+
+    def __init__(self) -> None:
+        self.ended: list[str] = []
+        self.started: list[tuple[str, str]] = []
+
+    async def end_session(self, session_id: str) -> None:
+        self.ended.append(session_id)
+
+    async def start_session(self, session_id: str, pool_id: str) -> None:
+        self.started.append((session_id, pool_id))
+
+    # Stubs for other TurnStore methods the observer may call
+    async def log_turn(self, **_kwargs) -> None:  # noqa: ANN003
+        pass
+
+    async def get_last_session(self, pool_id: str) -> str | None:
+        return None
+
+    async def increment_resume_count(self, session_id: str) -> None:
+        pass
+
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_reset_session_rotates_uuid() -> None:
+    """pool.reset_session() must produce a new session_id (UUID rotation).
+
+    RED: currently reset_session() only calls observer.reset_session_persisted()
+    and the optional _session_reset_fn — it does NOT rotate the UUID.
+    """
+    pool = _make_pool("telegram:main:chat:42")
+
+    before_sid = pool.session_id
+
+    await pool.reset_session()
+
+    after_sid = pool.session_id
+
+    # RED: this assertion will fail until T2 adds UUID rotation
+    assert before_sid != after_sid, (
+        "reset_session() must rotate session_id — UUID was not changed"
+    )
+
+
+async def test_reset_session_calls_end_session_on_turn_store() -> None:
+    """pool.reset_session() must call TurnStore.end_session(before_sid).
+
+    RED: no end_session call is made today.
+    """
+    pool = _make_pool("telegram:main:chat:42")
+    fake_store = _FakeTurnStore()
+    pool._observer._turn_store = fake_store  # type: ignore[assignment]
+
+    before_sid = pool.session_id
+
+    await pool.reset_session()
+
+    # RED: end_session is never called in the current implementation
+    assert before_sid in fake_store.ended, (
+        f"end_session({before_sid!r}) was not called on TurnStore"
+    )
+
+
+async def test_reset_session_calls_start_session_on_turn_store() -> None:
+    """pool.reset_session() must call TurnStore.start_session(new_sid, pool_id).
+
+    RED: no start_session call is made today.
+    """
+    pool = _make_pool("telegram:main:chat:42")
+    fake_store = _FakeTurnStore()
+    pool._observer._turn_store = fake_store  # type: ignore[assignment]
+
+    await pool.reset_session()
+
+    # RED: start_session is never called in the current implementation
+    assert len(fake_store.started) >= 1, (
+        "start_session() was not called on TurnStore after reset_session()"
+    )
+    new_sid, recorded_pool_id = fake_store.started[0]
+    assert recorded_pool_id == "telegram:main:chat:42"
+    assert new_sid == pool.session_id
+
+
+async def test_reset_session_end_before_start() -> None:
+    """end_session must be called with the OLD id before start_session is called.
+
+    RED: neither call exists today.
+    """
+    pool = _make_pool("telegram:main:chat:42")
+    call_order: list[str] = []
+
+    class _OrderedStore(_FakeTurnStore):
+        async def end_session(self, session_id: str) -> None:
+            call_order.append(f"end:{session_id}")
+            await super().end_session(session_id)
+
+        async def start_session(self, session_id: str, pool_id: str) -> None:
+            call_order.append(f"start:{session_id}")
+            await super().start_session(session_id, pool_id)
+
+    pool._observer._turn_store = _OrderedStore()  # type: ignore
+    before_sid = pool.session_id
+
+    await pool.reset_session()
+
+    assert call_order[0] == f"end:{before_sid}", (
+        "end_session must be called before start_session"
+    )
+    assert call_order[1].startswith("start:"), (
+        "start_session must be called after end_session"
+    )

--- a/tests/integration/test_session_clear.py
+++ b/tests/integration/test_session_clear.py
@@ -1,8 +1,4 @@
-"""Integration test — /clear rotates Pool session UUID and notifies TurnStore.
-
-RED phase: Pool.reset_session() does NOT rotate UUID yet (T2 pending).
-The assertion `before_sid != after_sid` will fail until T2 is implemented.
-"""
+"""Integration test — /clear rotates Pool session UUID and notifies TurnStore."""
 
 from __future__ import annotations
 
@@ -64,11 +60,7 @@ class _FakeTurnStore:
 
 
 async def test_reset_session_rotates_uuid() -> None:
-    """pool.reset_session() must produce a new session_id (UUID rotation).
-
-    RED: currently reset_session() only calls observer.reset_session_persisted()
-    and the optional _session_reset_fn — it does NOT rotate the UUID.
-    """
+    """pool.reset_session() must produce a new session_id (UUID rotation)."""
     pool = _make_pool("telegram:main:chat:42")
 
     before_sid = pool.session_id
@@ -77,17 +69,13 @@ async def test_reset_session_rotates_uuid() -> None:
 
     after_sid = pool.session_id
 
-    # RED: this assertion will fail until T2 adds UUID rotation
     assert before_sid != after_sid, (
         "reset_session() must rotate session_id — UUID was not changed"
     )
 
 
 async def test_reset_session_calls_end_session_on_turn_store() -> None:
-    """pool.reset_session() must call TurnStore.end_session(before_sid).
-
-    RED: no end_session call is made today.
-    """
+    """pool.reset_session() must call TurnStore.end_session(before_sid)."""
     pool = _make_pool("telegram:main:chat:42")
     fake_store = _FakeTurnStore()
     pool._observer._turn_store = fake_store  # type: ignore[assignment]
@@ -96,24 +84,19 @@ async def test_reset_session_calls_end_session_on_turn_store() -> None:
 
     await pool.reset_session()
 
-    # RED: end_session is never called in the current implementation
     assert before_sid in fake_store.ended, (
         f"end_session({before_sid!r}) was not called on TurnStore"
     )
 
 
 async def test_reset_session_calls_start_session_on_turn_store() -> None:
-    """pool.reset_session() must call TurnStore.start_session(new_sid, pool_id).
-
-    RED: no start_session call is made today.
-    """
+    """pool.reset_session() must call TurnStore.start_session(new_sid, pool_id)."""
     pool = _make_pool("telegram:main:chat:42")
     fake_store = _FakeTurnStore()
     pool._observer._turn_store = fake_store  # type: ignore[assignment]
 
     await pool.reset_session()
 
-    # RED: start_session is never called in the current implementation
     assert len(fake_store.started) >= 1, (
         "start_session() was not called on TurnStore after reset_session()"
     )
@@ -123,10 +106,7 @@ async def test_reset_session_calls_start_session_on_turn_store() -> None:
 
 
 async def test_reset_session_end_before_start() -> None:
-    """end_session must be called with the OLD id before start_session is called.
-
-    RED: neither call exists today.
-    """
+    """end_session must be called with the OLD id before start_session is called."""
     pool = _make_pool("telegram:main:chat:42")
     call_order: list[str] = []
 

--- a/tests/integration/test_session_dm_discord.py
+++ b/tests/integration/test_session_dm_discord.py
@@ -1,0 +1,173 @@
+"""Integration test — Discord DM handler injects thread_session_id into inbound message.
+
+RED phase: DiscordAdapter.__init__ does not accept turn_store param yet (T8 pending).
+Constructing DiscordAdapter(turn_store=...) will raise TypeError.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from lyra.adapters.discord import _ALLOW_ALL
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTurnStore:
+    """Returns a fixed prior session id for any pool_id."""
+
+    def __init__(self, session_id: str = "prior-session-id") -> None:
+        self._session_id = session_id
+
+    async def get_last_session(self, pool_id: str) -> str | None:
+        return self._session_id
+
+    async def increment_resume_count(self, session_id: str) -> None:
+        pass
+
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        return None
+
+    async def log_turn(self, **_kwargs) -> None:
+        pass
+
+
+def _make_dm_message(channel_id: int = 555, user_id: int = 42) -> SimpleNamespace:
+    return SimpleNamespace(
+        guild=None,  # DM — no guild
+        channel=SimpleNamespace(id=channel_id, send=AsyncMock()),
+        author=SimpleNamespace(
+            id=user_id,
+            name="Alice",
+            display_name="Alice",
+            bot=False,
+        ),
+        content="hello",
+        created_at=datetime.now(timezone.utc),
+        id=1000 + user_id,
+        mentions=[],
+        thread=None,
+        attachments=[],
+        message_thread_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_discord_dm_injects_thread_session_id() -> None:
+    """DiscordAdapter with turn_store injects thread_session_id for DMs.
+
+    RED: DiscordAdapter.__init__ does not accept turn_store — TypeError.
+    """
+    from lyra.adapters.discord import DiscordAdapter
+    from lyra.adapters.discord_inbound import handle_message as discord_handle_message
+
+    mock_bus = MagicMock()
+    mock_bus.put_nowait = MagicMock()
+    mock_bus.put = AsyncMock()
+    fake_turn_store = _FakeTurnStore("prior-session-id")
+
+    # RED: turn_store param does not exist on DiscordAdapter yet
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=mock_bus,
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
+        turn_store=fake_turn_store,  # type: ignore[arg-type]
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+    fake_dm = _make_dm_message(channel_id=555, user_id=42)
+
+    await discord_handle_message(adapter, fake_dm)
+
+    # Verify something was posted to the bus
+    assert mock_bus.put_nowait.called or mock_bus.put.called, (
+        "No message was posted to the inbound bus"
+    )
+
+    # Extract the posted InboundMessage — put(platform, msg), msg is arg[1]
+    if mock_bus.put_nowait.called:
+        posted = mock_bus.put_nowait.call_args[0][1]
+    else:
+        posted = mock_bus.put.call_args[0][1]
+
+    assert posted.platform_meta.get("thread_session_id") == "prior-session-id", (
+        f"Expected thread_session_id='prior-session-id', "
+        f"got platform_meta={posted.platform_meta!r}"
+    )
+
+
+async def test_discord_dm_no_turn_store_does_not_inject() -> None:
+    """Without turn_store, thread_session_id should not be present in platform_meta.
+
+    This test verifies backward compatibility — adapters without turn_store should
+    still work and simply not inject thread_session_id.
+
+    RED: turn_store param does not exist — TypeError if passed (tested in other test).
+    This test only constructs without turn_store, so it should pass once the
+    constructor is updated. For now it also fails because handle_message currently
+    does not inject thread_session_id at all, so testing the absence is trivially
+    true but does not distinguish from the feature not existing.
+    """
+    from lyra.adapters.discord import DiscordAdapter
+    from lyra.adapters.discord_inbound import handle_message as discord_handle_message
+
+    mock_bus = MagicMock()
+    mock_bus.put_nowait = MagicMock()
+    mock_bus.put = AsyncMock()
+
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=mock_bus,
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
+        # No turn_store
+    )
+    adapter._bot_user = SimpleNamespace(id=999, bot=True)
+
+    fake_dm = _make_dm_message(channel_id=555, user_id=42)
+
+    await discord_handle_message(adapter, fake_dm)
+
+    if mock_bus.put_nowait.called:
+        posted = mock_bus.put_nowait.call_args[0][0]
+        assert "thread_session_id" not in posted.platform_meta, (
+            "thread_session_id must not appear in platform_meta without a turn_store"
+        )
+
+
+async def test_discord_dm_turn_store_attribute_stored() -> None:
+    """DiscordAdapter must expose _turn_store after construction.
+
+    RED: constructor does not accept turn_store → TypeError.
+    """
+    from lyra.adapters.discord import DiscordAdapter
+
+    mock_bus = MagicMock()
+    fake_turn_store = _FakeTurnStore("session-xyz")
+
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=mock_bus,
+        intents=discord.Intents.none(),
+        auth=_ALLOW_ALL,
+        turn_store=fake_turn_store,  # type: ignore[arg-type]
+    )
+
+    assert adapter._turn_store is fake_turn_store, (
+        "DiscordAdapter must store turn_store as _turn_store attribute"
+    )

--- a/tests/integration/test_session_dm_discord.py
+++ b/tests/integration/test_session_dm_discord.py
@@ -1,7 +1,4 @@
 """Integration test — Discord DM handler injects thread_session_id into inbound message.
-
-RED phase: DiscordAdapter.__init__ does not accept turn_store param yet (T8 pending).
-Constructing DiscordAdapter(turn_store=...) will raise TypeError.
 """
 
 from __future__ import annotations
@@ -68,10 +65,7 @@ def _make_dm_message(channel_id: int = 555, user_id: int = 42) -> SimpleNamespac
 
 
 async def test_discord_dm_injects_thread_session_id() -> None:
-    """DiscordAdapter with turn_store injects thread_session_id for DMs.
-
-    RED: DiscordAdapter.__init__ does not accept turn_store — TypeError.
-    """
+    """DiscordAdapter with turn_store injects thread_session_id for DMs."""
     from lyra.adapters.discord import DiscordAdapter
     from lyra.adapters.discord_inbound import handle_message as discord_handle_message
 
@@ -80,7 +74,6 @@ async def test_discord_dm_injects_thread_session_id() -> None:
     mock_bus.put = AsyncMock()
     fake_turn_store = _FakeTurnStore("prior-session-id")
 
-    # RED: turn_store param does not exist on DiscordAdapter yet
     adapter = DiscordAdapter(
         bot_id="main",
         inbound_bus=mock_bus,
@@ -114,14 +107,8 @@ async def test_discord_dm_injects_thread_session_id() -> None:
 async def test_discord_dm_no_turn_store_does_not_inject() -> None:
     """Without turn_store, thread_session_id should not be present in platform_meta.
 
-    This test verifies backward compatibility — adapters without turn_store should
-    still work and simply not inject thread_session_id.
-
-    RED: turn_store param does not exist — TypeError if passed (tested in other test).
-    This test only constructs without turn_store, so it should pass once the
-    constructor is updated. For now it also fails because handle_message currently
-    does not inject thread_session_id at all, so testing the absence is trivially
-    true but does not distinguish from the feature not existing.
+    Verifies backward compatibility — adapters without turn_store still work and
+    simply do not inject thread_session_id.
     """
     from lyra.adapters.discord import DiscordAdapter
     from lyra.adapters.discord_inbound import handle_message as discord_handle_message
@@ -144,17 +131,14 @@ async def test_discord_dm_no_turn_store_does_not_inject() -> None:
     await discord_handle_message(adapter, fake_dm)
 
     if mock_bus.put_nowait.called:
-        posted = mock_bus.put_nowait.call_args[0][0]
+        posted = mock_bus.put_nowait.call_args[0][1]
         assert "thread_session_id" not in posted.platform_meta, (
             "thread_session_id must not appear in platform_meta without a turn_store"
         )
 
 
 async def test_discord_dm_turn_store_attribute_stored() -> None:
-    """DiscordAdapter must expose _turn_store after construction.
-
-    RED: constructor does not accept turn_store → TypeError.
-    """
+    """DiscordAdapter must expose _turn_store after construction."""
     from lyra.adapters.discord import DiscordAdapter
 
     mock_bus = MagicMock()

--- a/tests/integration/test_session_reply_to.py
+++ b/tests/integration/test_session_reply_to.py
@@ -121,7 +121,7 @@ async def test_pending_session_id_set_when_pool_busy() -> None:
         ctx = MagicMock(hub=fake_hub)
         await middleware._resolve_context(msg, pool, pool.pool_id, ctx)
 
-        assert pool._pending_session_id == "session-abc", (
+        assert pool._pending_session_id == "session-abc", (  # type: ignore[attr-defined]
             "pool._pending_session_id must be set when pool busy and reply-to resolves"
         )
     finally:
@@ -139,7 +139,7 @@ async def test_pending_session_id_not_set_when_pool_idle() -> None:
     # Pool is idle by default (no current task)
     assert pool.is_idle
 
-    assert pool._pending_session_id is None, (
+    assert pool._pending_session_id is None, (  # type: ignore[attr-defined]
         "idle pool must start with _pending_session_id=None"
     )
 
@@ -148,6 +148,39 @@ async def test_pending_session_id_none_when_no_reply_to() -> None:
     """Without reply_to_id, _pending_session_id should remain None."""
     pool = _make_pool("telegram:main:chat:42")
 
-    assert pool._pending_session_id is None, (
+    assert pool._pending_session_id is None, (  # type: ignore[attr-defined]
         "_pending_session_id must be None when no reply-to was received"
     )
+
+
+async def test_process_loop_fires_pending_session_id() -> None:
+    """process_loop must consume _pending_session_id and call resume_session."""
+    pool = _make_pool("telegram:main:chat:42")
+
+    # Disable debounce so collect() returns immediately without a 300 ms wait
+    pool.debounce_ms = 0
+
+    # Wire a resume callback
+    resume_fn = AsyncMock(return_value=True)
+    pool._session_resume_fn = resume_fn
+
+    # Set a pending session before the loop runs
+    pool._pending_session_id = "target-session-id"  # type: ignore[attr-defined]
+
+    # Make get_agent() raise so process_loop exits quickly after the resume step
+    pool._ctx.get_agent = MagicMock(side_effect=RuntimeError("stop here"))
+
+    msg = _make_msg(
+        id="msg-1",
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:42",
+    )
+
+    # Submit triggers process_loop via asyncio.create_task
+    pool.submit(msg)
+
+    # Give the event loop enough time to run through the resume step
+    await asyncio.sleep(0.1)
+
+    resume_fn.assert_awaited_once_with("target-session-id")

--- a/tests/integration/test_session_reply_to.py
+++ b/tests/integration/test_session_reply_to.py
@@ -1,8 +1,4 @@
-"""Integration test — reply-to while pool busy sets _pending_session_id.
-
-RED phase: Pool does NOT have _pending_session_id yet (T4 pending).
-Accessing pool._pending_session_id will raise AttributeError.
-"""
+"""Integration test — reply-to while pool busy sets _pending_session_id."""
 
 from __future__ import annotations
 
@@ -99,16 +95,13 @@ class _FakeHub:
 
 
 async def test_pending_session_id_set_when_pool_busy() -> None:
-    """When pool is busy and reply-to arrives, _pending_session_id is set.
-
-    RED: Pool has no _pending_session_id attribute — AttributeError will fire.
-    """
+    """When pool is busy and reply-to arrives, _pending_session_id is set."""
     from lyra.core.hub.middleware_submit import SubmitToPoolMiddleware
 
     pool = _make_pool("telegram:main:chat:42")
 
     # Make pool appear busy
-    pool._current_task = asyncio.get_event_loop().create_task(asyncio.sleep(100))
+    pool._current_task = asyncio.create_task(asyncio.sleep(100))
 
     try:
         message_index = _FakeMessageIndex({"msg-old": "session-abc"})
@@ -128,8 +121,7 @@ async def test_pending_session_id_set_when_pool_busy() -> None:
         ctx = MagicMock(hub=fake_hub)
         await middleware._resolve_context(msg, pool, pool.pool_id, ctx)
 
-        # RED: _pending_session_id does not exist on Pool today
-        assert pool._pending_session_id == "session-abc", (  # type: ignore[attr-defined]
+        assert pool._pending_session_id == "session-abc", (
             "pool._pending_session_id must be set when pool busy and reply-to resolves"
         )
     finally:
@@ -141,29 +133,21 @@ async def test_pending_session_id_set_when_pool_busy() -> None:
 
 
 async def test_pending_session_id_not_set_when_pool_idle() -> None:
-    """When pool is idle, reply-to should attempt resume directly (not queue).
-
-    RED: no _pending_session_id attribute — AttributeError.
-    """
+    """When pool is idle, reply-to should attempt resume directly (not queue)."""
     pool = _make_pool("telegram:main:chat:42")
 
     # Pool is idle by default (no current task)
     assert pool.is_idle
 
-    # RED: _pending_session_id does not exist on Pool today
-    assert pool._pending_session_id is None, (  # type: ignore[attr-defined]
+    assert pool._pending_session_id is None, (
         "idle pool must start with _pending_session_id=None"
     )
 
 
 async def test_pending_session_id_none_when_no_reply_to() -> None:
-    """Without reply_to_id, _pending_session_id should remain None.
-
-    RED: attribute does not exist → AttributeError.
-    """
+    """Without reply_to_id, _pending_session_id should remain None."""
     pool = _make_pool("telegram:main:chat:42")
 
-    # RED: attribute does not exist
-    assert pool._pending_session_id is None, (  # type: ignore[attr-defined]
+    assert pool._pending_session_id is None, (
         "_pending_session_id must be None when no reply-to was received"
     )

--- a/tests/integration/test_session_reply_to.py
+++ b/tests/integration/test_session_reply_to.py
@@ -1,0 +1,169 @@
+"""Integration test — reply-to while pool busy sets _pending_session_id.
+
+RED phase: Pool does NOT have _pending_session_id yet (T4 pending).
+Accessing pool._pending_session_id will raise AttributeError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lyra.core.message import InboundMessage
+from lyra.core.trust import TrustLevel
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pool(pool_id: str = "telegram:main:chat:42"):
+    from lyra.core.pool import Pool
+
+    ctx = MagicMock()
+    ctx.get_agent = MagicMock(return_value=None)
+    ctx.get_message = MagicMock(return_value=None)
+    ctx.dispatch_response = AsyncMock()
+    ctx.dispatch_streaming = AsyncMock()
+    ctx.record_circuit_success = MagicMock()
+    ctx.record_circuit_failure = MagicMock()
+    return Pool(pool_id, "lyra", ctx)
+
+
+def _make_msg(**kwargs) -> InboundMessage:
+    defaults = dict(
+        id="msg-1",
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:42",
+        user_id="tg:user:42",
+        user_name="Alice",
+        is_mention=False,
+        text="hello",
+        text_raw="hello",
+        timestamp=datetime.now(timezone.utc),
+        trust_level=TrustLevel.PUBLIC,
+        reply_to_id=None,
+    )
+    defaults.update(kwargs)
+    return InboundMessage(**defaults)  # type: ignore[arg-type]
+
+
+class _FakeMessageIndex:
+    """Returns a fixed session_id for a given message id."""
+
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._mapping = mapping
+
+    async def resolve(self, pool_id: str, msg_id: str) -> str | None:
+        return self._mapping.get(msg_id)
+
+
+class _FakeTurnStore:
+    async def get_last_session(self, pool_id: str) -> str | None:
+        return None
+
+    async def increment_resume_count(self, session_id: str) -> None:
+        pass
+
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        return None
+
+    async def log_turn(self, **_kwargs) -> None:
+        pass
+
+
+class _FakeHub:
+    """Minimal hub stub for SubmitToPoolMiddleware."""
+
+    def __init__(self, pool, message_index=None, turn_store=None) -> None:
+        self._message_index = message_index
+        self._turn_store = turn_store
+        self.adapter_registry = {("telegram", "main"): MagicMock()}
+        self.agent_registry: dict = {}
+        self.circuit_registry = None
+
+    async def circuit_breaker_drop(self, msg) -> bool:  # noqa: ANN001
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_pending_session_id_set_when_pool_busy() -> None:
+    """When pool is busy and reply-to arrives, _pending_session_id is set.
+
+    RED: Pool has no _pending_session_id attribute — AttributeError will fire.
+    """
+    from lyra.core.hub.middleware_submit import SubmitToPoolMiddleware
+
+    pool = _make_pool("telegram:main:chat:42")
+
+    # Make pool appear busy
+    pool._current_task = asyncio.get_event_loop().create_task(asyncio.sleep(100))
+
+    try:
+        message_index = _FakeMessageIndex({"msg-old": "session-abc"})
+        turn_store = _FakeTurnStore()
+
+        fake_hub = _FakeHub(pool, message_index=message_index, turn_store=turn_store)
+
+        msg = _make_msg(
+            id="msg-new",
+            reply_to_id="msg-old",
+            platform="telegram",
+            bot_id="main",
+            scope_id="chat:42",
+        )
+
+        middleware = SubmitToPoolMiddleware()
+        ctx = MagicMock(hub=fake_hub)
+        await middleware._resolve_context(msg, pool, pool.pool_id, ctx)
+
+        # RED: _pending_session_id does not exist on Pool today
+        assert pool._pending_session_id == "session-abc", (  # type: ignore[attr-defined]
+            "pool._pending_session_id must be set when pool busy and reply-to resolves"
+        )
+    finally:
+        pool._current_task.cancel()
+        try:
+            await pool._current_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def test_pending_session_id_not_set_when_pool_idle() -> None:
+    """When pool is idle, reply-to should attempt resume directly (not queue).
+
+    RED: no _pending_session_id attribute — AttributeError.
+    """
+    pool = _make_pool("telegram:main:chat:42")
+
+    # Pool is idle by default (no current task)
+    assert pool.is_idle
+
+    # RED: _pending_session_id does not exist on Pool today
+    assert pool._pending_session_id is None, (  # type: ignore[attr-defined]
+        "idle pool must start with _pending_session_id=None"
+    )
+
+
+async def test_pending_session_id_none_when_no_reply_to() -> None:
+    """Without reply_to_id, _pending_session_id should remain None.
+
+    RED: attribute does not exist → AttributeError.
+    """
+    pool = _make_pool("telegram:main:chat:42")
+
+    # RED: attribute does not exist
+    assert pool._pending_session_id is None, (  # type: ignore[attr-defined]
+        "_pending_session_id must be None when no reply-to was received"
+    )

--- a/tests/integration/test_session_telegram.py
+++ b/tests/integration/test_session_telegram.py
@@ -1,0 +1,208 @@
+"""Integration test — Telegram adapter injects thread_session_id into inbound message.
+
+RED phase: TelegramAdapter.__init__ does not accept turn_store param yet (T12 pending).
+Constructing TelegramAdapter(turn_store=...) will raise TypeError.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lyra.adapters.telegram import _ALLOW_ALL
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTurnStore:
+    """Returns a fixed prior session id for any pool_id."""
+
+    def __init__(self, session_id: str = "prior-session-id") -> None:
+        self._session_id = session_id
+
+    async def get_last_session(self, pool_id: str) -> str | None:
+        return self._session_id
+
+    async def increment_resume_count(self, session_id: str) -> None:
+        pass
+
+    async def get_session_pool_id(self, session_id: str) -> str | None:
+        return None
+
+    async def log_turn(self, **_kwargs) -> None:
+        pass
+
+
+def _make_private_tg_message(
+    chat_id: int = 100,
+    user_id: int = 42,
+    text: str = "hello",
+) -> SimpleNamespace:
+    """Build a minimal aiogram-style private message SimpleNamespace."""
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id, type="private"),
+        from_user=SimpleNamespace(
+            id=user_id,
+            full_name="Alice",
+            is_bot=False,
+        ),
+        text=text,
+        date=datetime.now(timezone.utc),
+        message_thread_id=None,
+        entities=None,
+        message_id=1000 + user_id,
+        photo=None,
+        document=None,
+        video=None,
+        animation=None,
+        sticker=None,
+        voice=None,
+        audio=None,
+        video_note=None,
+    )
+
+
+def _make_telegram_adapter(fake_turn_store=None, mock_bus=None):
+    """Build a TelegramAdapter with optional turn_store injection."""
+    from lyra.adapters.telegram import TelegramAdapter
+
+    if mock_bus is None:
+        mock_bus = MagicMock()
+        mock_bus.put_nowait = MagicMock()
+
+    kwargs = dict(
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=mock_bus,
+        auth=_ALLOW_ALL,
+    )
+    if fake_turn_store is not None:
+        # RED: this param does not exist yet — TypeError
+        kwargs["turn_store"] = fake_turn_store
+
+    return TelegramAdapter(**kwargs), mock_bus  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_telegram_private_injects_thread_session_id() -> None:
+    """TelegramAdapter with turn_store injects thread_session_id for private chats.
+
+    RED: TelegramAdapter.__init__ does not accept turn_store — TypeError.
+    """
+    from lyra.adapters.telegram_inbound import handle_message as telegram_handle_message
+
+    mock_bus = MagicMock()
+    mock_bus.put_nowait = MagicMock()
+    # Also mock the async put path used by backpressure
+    mock_bus.put = AsyncMock()
+
+    fake_turn_store = _FakeTurnStore("prior-session-id")
+
+    # RED: TypeError — turn_store param does not exist
+    adapter, mock_bus = _make_telegram_adapter(
+        fake_turn_store=fake_turn_store, mock_bus=mock_bus
+    )
+
+    # Wire a fake bot so _on_message can call bot.send_message if needed
+    adapter.bot = AsyncMock()
+    adapter.bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
+    adapter._bot_username = "lyra_bot"
+
+    fake_msg = _make_private_tg_message(chat_id=100, user_id=42)
+
+    # Patch _start_typing / _cancel_typing to no-ops (no real asyncio needed)
+    adapter._start_typing = MagicMock()
+    adapter._cancel_typing = MagicMock()
+
+    await telegram_handle_message(adapter, fake_msg)
+
+    # Verify the bus received a message
+    assert mock_bus.put_nowait.called or mock_bus.put.called, (
+        "No message was posted to the inbound bus"
+    )
+
+    # Extract the posted InboundMessage — put(platform, msg), msg is arg[1]
+    if mock_bus.put_nowait.called:
+        posted = mock_bus.put_nowait.call_args[0][1]
+    else:
+        posted = mock_bus.put.call_args[0][1]
+
+    assert posted.platform_meta.get("thread_session_id") == "prior-session-id", (
+        f"Expected thread_session_id='prior-session-id', "
+        f"got platform_meta={posted.platform_meta!r}"
+    )
+
+
+async def test_telegram_no_turn_store_no_injection() -> None:
+    """Without turn_store, thread_session_id must not appear in platform_meta.
+
+    This verifies backward compatibility: adapters without turn_store still work.
+    Currently this trivially passes (no injection exists). It becomes a meaningful
+    regression guard once injection is added.
+    """
+    from lyra.adapters.telegram_inbound import handle_message as telegram_handle_message
+
+    mock_bus = MagicMock()
+    mock_bus.put_nowait = MagicMock()
+    mock_bus.put = AsyncMock()
+
+    # No turn_store — should construct fine (no RED here for this specific test)
+    from lyra.adapters.telegram import TelegramAdapter
+
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=mock_bus,
+        auth=_ALLOW_ALL,
+    )
+    adapter.bot = AsyncMock()
+    adapter.bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
+    adapter._bot_username = "lyra_bot"
+    adapter._start_typing = MagicMock()
+    adapter._cancel_typing = MagicMock()
+
+    fake_msg = _make_private_tg_message(chat_id=100, user_id=42)
+
+    await telegram_handle_message(adapter, fake_msg)
+
+    if mock_bus.put_nowait.called:
+        posted = mock_bus.put_nowait.call_args[0][0]
+        assert "thread_session_id" not in posted.platform_meta, (
+            "thread_session_id must not appear in platform_meta without turn_store"
+        )
+
+
+async def test_telegram_turn_store_attribute_stored() -> None:
+    """TelegramAdapter must expose _turn_store after construction.
+
+    RED: constructor does not accept turn_store → TypeError.
+    """
+    from lyra.adapters.telegram import TelegramAdapter
+
+    mock_bus = MagicMock()
+    fake_turn_store = _FakeTurnStore("session-xyz")
+
+    # RED: TypeError — turn_store not accepted
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="test-token-secret",
+        inbound_bus=mock_bus,
+        auth=_ALLOW_ALL,
+        turn_store=fake_turn_store,  # type: ignore[arg-type]
+    )
+
+    assert adapter._turn_store is fake_turn_store, (
+        "TelegramAdapter must store turn_store as _turn_store attribute"
+    )

--- a/tests/integration/test_session_telegram.py
+++ b/tests/integration/test_session_telegram.py
@@ -1,7 +1,4 @@
 """Integration test — Telegram adapter injects thread_session_id into inbound message.
-
-RED phase: TelegramAdapter.__init__ does not accept turn_store param yet (T12 pending).
-Constructing TelegramAdapter(turn_store=...) will raise TypeError.
 """
 
 from __future__ import annotations
@@ -85,7 +82,6 @@ def _make_telegram_adapter(fake_turn_store=None, mock_bus=None):
         auth=_ALLOW_ALL,
     )
     if fake_turn_store is not None:
-        # RED: this param does not exist yet — TypeError
         kwargs["turn_store"] = fake_turn_store
 
     return TelegramAdapter(**kwargs), mock_bus  # type: ignore[arg-type]
@@ -97,10 +93,7 @@ def _make_telegram_adapter(fake_turn_store=None, mock_bus=None):
 
 
 async def test_telegram_private_injects_thread_session_id() -> None:
-    """TelegramAdapter with turn_store injects thread_session_id for private chats.
-
-    RED: TelegramAdapter.__init__ does not accept turn_store — TypeError.
-    """
+    """TelegramAdapter with turn_store injects thread_session_id for private chats."""
     from lyra.adapters.telegram_inbound import handle_message as telegram_handle_message
 
     mock_bus = MagicMock()
@@ -110,7 +103,6 @@ async def test_telegram_private_injects_thread_session_id() -> None:
 
     fake_turn_store = _FakeTurnStore("prior-session-id")
 
-    # RED: TypeError — turn_store param does not exist
     adapter, mock_bus = _make_telegram_adapter(
         fake_turn_store=fake_turn_store, mock_bus=mock_bus
     )
@@ -158,7 +150,7 @@ async def test_telegram_no_turn_store_no_injection() -> None:
     mock_bus.put_nowait = MagicMock()
     mock_bus.put = AsyncMock()
 
-    # No turn_store — should construct fine (no RED here for this specific test)
+    # No turn_store — backward compatibility: should construct fine
     from lyra.adapters.telegram import TelegramAdapter
 
     adapter = TelegramAdapter(
@@ -178,23 +170,19 @@ async def test_telegram_no_turn_store_no_injection() -> None:
     await telegram_handle_message(adapter, fake_msg)
 
     if mock_bus.put_nowait.called:
-        posted = mock_bus.put_nowait.call_args[0][0]
+        posted = mock_bus.put_nowait.call_args[0][1]
         assert "thread_session_id" not in posted.platform_meta, (
             "thread_session_id must not appear in platform_meta without turn_store"
         )
 
 
 async def test_telegram_turn_store_attribute_stored() -> None:
-    """TelegramAdapter must expose _turn_store after construction.
-
-    RED: constructor does not accept turn_store → TypeError.
-    """
+    """TelegramAdapter must expose _turn_store after construction."""
     from lyra.adapters.telegram import TelegramAdapter
 
     mock_bus = MagicMock()
     fake_turn_store = _FakeTurnStore("session-xyz")
 
-    # RED: TypeError — turn_store not accepted
     adapter = TelegramAdapter(
         bot_id="main",
         token="test-token-secret",


### PR DESCRIPTION
## Summary
- Fixes conversations not resuming after Lyra restart: adapters now inject `thread_session_id` from TurnStore into inbound messages, so the pool resumes the last Claude session on first message
- Fixes `/clear` not rotating the session: `Pool.reset_session()` now calls `end_session_async` + rotates UUID + calls `start_session` on TurnStore, producing two distinct session IDs
- Fixes reply-to ignoring session: when a pool is busy, `_pending_session_id` is queued and fired after `collect()` drains instead of being silently dropped
- Removes per-user pool scoping from Discord guild channels and Telegram group/topic chats — all users in a shared space now use one pool (prerequisite for multi-user session continuity)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #592: bug(persistence): conversation not resumed after restart, /clear broken, reply-to ignores session | Open |
| Analysis | — | Absent (F-lite) |
| Spec | [592-persistence-session-resume-spec.mdx](artifacts/specs/592-persistence-session-resume-spec.mdx) | Present |
| Implementation | 1 commit on `feat/592-persistence-session-resume` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (20 new) | Passed |

## Test Plan
- [ ] `/clear` in Telegram DM → new conversation, no history bleed
- [ ] Restart Lyra → next message resumes prior Claude session (check logs for `resume_session`)
- [ ] Reply to a bot message while it's responding → session resume fires after response completes
- [ ] Two users in the same Telegram group → both routed to the same pool
- [ ] Two users in the same Discord guild channel → both routed to the same pool
- [ ] Telegram private chat and Discord DM still get per-user pools (no regression)

Closes #592

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`