### PR TITLE
fix(persistence): track resume_count for pending-path session resumes

### DIFF
--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -230,6 +230,8 @@ class CreatePoolMiddleware:
         if _agent is not None and hasattr(_agent, "configure_pool"):
             _agent.configure_pool(pool)
 
+        if pool._on_resume_fn is None and ctx.hub._turn_store is not None:
+            pool._on_resume_fn = ctx.hub._turn_store.increment_resume_count
         # Parse command context and rewrite bare URLs (#99).
         cmd_ctx = _command_parser.parse(msg.text)
         if cmd_ctx is not None:

--- a/src/lyra/core/hub/middleware_stages.py
+++ b/src/lyra/core/hub/middleware_stages.py
@@ -230,7 +230,7 @@ class CreatePoolMiddleware:
         if _agent is not None and hasattr(_agent, "configure_pool"):
             _agent.configure_pool(pool)
 
-        if pool._on_resume_fn is None and ctx.hub._turn_store is not None:
+        if pool._on_resume_fn is None and ctx.hub._turn_store is not None:  # #597
             pool._on_resume_fn = ctx.hub._turn_store.increment_resume_count
         # Parse command context and rewrite bare URLs (#99).
         cmd_ctx = _command_parser.parse(msg.text)

--- a/src/lyra/core/pool/pool.py
+++ b/src/lyra/core/pool/pool.py
@@ -81,7 +81,7 @@ class Pool:
         self._safe_dispatch_timeout: float = safe_dispatch_timeout
         self._session_reset_fn: Callable[[], Awaitable[None]] | None = None
         self._session_resume_fn: Callable[[str], Awaitable[bool]] | None = None
-        self._on_resume_fn: Callable[[str], Awaitable[None]] | None = None
+        self._on_resume_fn: Callable[[str], Awaitable[None]] | None = None  # set once
         self._switch_workspace_fn: Callable[[Path], Awaitable[None]] | None = None
         self._ctx = ctx
         # Ceiling clamp: use ceiling as default, clamp agent override to ceiling

--- a/src/lyra/core/pool/pool.py
+++ b/src/lyra/core/pool/pool.py
@@ -81,6 +81,7 @@ class Pool:
         self._safe_dispatch_timeout: float = safe_dispatch_timeout
         self._session_reset_fn: Callable[[], Awaitable[None]] | None = None
         self._session_resume_fn: Callable[[str], Awaitable[bool]] | None = None
+        self._on_resume_fn: Callable[[str], Awaitable[None]] | None = None
         self._switch_workspace_fn: Callable[[Path], Awaitable[None]] | None = None
         self._ctx = ctx
         # Ceiling clamp: use ceiling as default, clamp agent override to ceiling

--- a/src/lyra/core/pool/pool_processor.py
+++ b/src/lyra/core/pool/pool_processor.py
@@ -51,7 +51,9 @@ class PoolProcessor:
                     _pending = pool._pending_session_id
                     pool._pending_session_id = None
                     try:
-                        await pool.resume_session(_pending)
+                        _resume_accepted = await pool.resume_session(_pending)
+                        if _resume_accepted and pool._on_resume_fn is not None:
+                            await pool._on_resume_fn(_pending)
                     except Exception:
                         log.exception(
                             "[pool:%s] pending session resume failed for %r"

--- a/src/lyra/core/pool/pool_processor.py
+++ b/src/lyra/core/pool/pool_processor.py
@@ -52,8 +52,6 @@ class PoolProcessor:
                     pool._pending_session_id = None
                     try:
                         _resume_accepted = await pool.resume_session(_pending)
-                        if _resume_accepted and pool._on_resume_fn is not None:
-                            await pool._on_resume_fn(_pending)
                     except Exception:
                         log.exception(
                             "[pool:%s] pending session resume failed for %r"
@@ -61,6 +59,23 @@ class PoolProcessor:
                             pool.pool_id,
                             _pending,
                         )
+                        _resume_accepted = False
+                    if not _resume_accepted:
+                        log.info(
+                            "[pool:%s] pending session resume rejected for %r",
+                            pool.pool_id,
+                            _pending,
+                        )
+                    elif pool._on_resume_fn is not None:
+                        try:
+                            await pool._on_resume_fn(_pending)
+                        except Exception:
+                            log.exception(
+                                "[pool:%s] pending resume count increment"
+                                " failed for %r",
+                                pool.pool_id,
+                                _pending,
+                            )
 
                 agent = pool._ctx.get_agent(pool.agent_name)
                 if agent is None:

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -199,6 +199,62 @@ class TestCreatePool:
         next_fn.assert_awaited_once()
         assert ctx.pool is not None
 
+    async def test_on_resume_fn_wired_when_turn_store_present(self) -> None:
+        from lyra.core.hub.hub_protocol import Binding
+
+        hub = _make_hub()
+        hub._turn_store = MagicMock()
+        hub._turn_store.increment_resume_count = AsyncMock()
+        agent = hub.agent_registry["lyra"]
+        binding = Binding(agent_name="lyra", pool_id="telegram:main:chat:42")
+        mw = CreatePoolMiddleware()
+        ctx = PipelineContext(hub=hub, binding=binding, agent=agent)
+        msg = make_inbound_message()
+
+        await mw(msg, ctx, _make_next())
+
+        assert ctx.pool is not None
+        assert ctx.pool._on_resume_fn is hub._turn_store.increment_resume_count  # type: ignore[attr-defined]
+
+    async def test_on_resume_fn_not_set_when_turn_store_absent(self) -> None:
+        from lyra.core.hub.hub_protocol import Binding
+
+        hub = _make_hub()
+        hub._turn_store = None
+        agent = hub.agent_registry["lyra"]
+        binding = Binding(agent_name="lyra", pool_id="telegram:main:chat:42")
+        mw = CreatePoolMiddleware()
+        ctx = PipelineContext(hub=hub, binding=binding, agent=agent)
+        msg = make_inbound_message()
+
+        await mw(msg, ctx, _make_next())
+
+        assert ctx.pool is not None
+        assert ctx.pool._on_resume_fn is None  # type: ignore[attr-defined]
+
+    async def test_on_resume_fn_not_overwritten_when_already_set(self) -> None:
+        from lyra.core.hub.hub_protocol import Binding
+
+        hub = _make_hub()
+        hub._turn_store = MagicMock()
+        hub._turn_store.increment_resume_count = AsyncMock()
+
+        # Pre-create the pool and assign a sentinel
+        pool = hub.get_or_create_pool("telegram:main:chat:42", "lyra")
+        sentinel = MagicMock()
+        pool._on_resume_fn = sentinel
+
+        agent = hub.agent_registry["lyra"]
+        binding = Binding(agent_name="lyra", pool_id="telegram:main:chat:42")
+        mw = CreatePoolMiddleware()
+        ctx = PipelineContext(hub=hub, binding=binding, agent=agent)
+        msg = make_inbound_message()
+
+        await mw(msg, ctx, _make_next())
+
+        assert ctx.pool is not None
+        assert ctx.pool._on_resume_fn is sentinel  # type: ignore[attr-defined]
+
 
 # ──────────────────────────────────────────────────────────────────────
 # CommandMiddleware

--- a/tests/integration/test_session_reply_to.py
+++ b/tests/integration/test_session_reply_to.py
@@ -177,6 +177,10 @@ async def test_process_loop_fires_pending_session_id() -> None:
         scope_id="chat:42",
     )
 
+    # Wire an on_resume callback
+    on_resume_fn = AsyncMock()
+    pool._on_resume_fn = on_resume_fn
+
     # Submit triggers process_loop via asyncio.create_task
     pool.submit(msg)
 
@@ -184,3 +188,33 @@ async def test_process_loop_fires_pending_session_id() -> None:
     await asyncio.sleep(0.1)
 
     resume_fn.assert_awaited_once_with("target-session-id")
+    on_resume_fn.assert_awaited_once_with("target-session-id")
+
+
+async def test_process_loop_does_not_call_on_resume_fn_when_resume_rejected() -> None:
+    """process_loop must NOT call _on_resume_fn when resume_session returns False."""
+    pool = _make_pool("telegram:main:chat:42")
+
+    pool.debounce_ms = 0
+
+    resume_fn = AsyncMock(return_value=False)
+    on_resume_fn = AsyncMock()
+    pool._session_resume_fn = resume_fn
+    pool._on_resume_fn = on_resume_fn
+
+    pool._pending_session_id = "target-session-id"  # type: ignore[attr-defined]
+
+    pool._ctx.get_agent = MagicMock(side_effect=RuntimeError("stop here"))
+
+    msg = _make_msg(
+        id="msg-1",
+        platform="telegram",
+        bot_id="main",
+        scope_id="chat:42",
+    )
+
+    pool.submit(msg)
+
+    await asyncio.sleep(0.1)
+
+    on_resume_fn.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add `_on_resume_fn` callback to `Pool` so the busy-pool reply-to path can notify callers after a deferred session resume succeeds
- Wire `hub._turn_store.increment_resume_count` via `CreatePoolMiddleware` so `resume_count` is correctly incremented for both the idle-pool path (already working) and the busy-pool path (previously missed)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #597: feat(persistence): track resume_count for pending-path session resumes | Open |
| Implementation | 1 commit on `feat/597-track-resume-count-pending-path` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2578 passed) | Passed |

## Test Plan
- [ ] Send a message to a busy bot (bot is mid-response) so `_pending_session_id` is set via the reply-to path
- [ ] Confirm `resume_count` increments in `pool_sessions` for the resumed session
- [ ] Verify existing idle-pool resume path still increments (regression check)

Closes #597

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`