### PR TITLE
test(nats): unit tests for NatsSttClient, NatsTtsClient, TTS fallback

### DIFF
--- a/tests/core/test_audio_pipeline_tts.py
+++ b/tests/core/test_audio_pipeline_tts.py
@@ -302,3 +302,59 @@ class TestDispatchResponseAgentTTSE2E:
         mock_tts.synthesize.assert_awaited()
         call_kwargs = mock_tts.synthesize.call_args
         assert call_kwargs.kwargs.get("agent_tts") is agent_tts
+
+
+# ---------------------------------------------------------------------------
+# TTS unavailable fallback — dispatch_response with text (#575)
+# ---------------------------------------------------------------------------
+
+
+class TestTtsUnavailableFallback:
+    """When TtsUnavailableError is raised, text is dispatched instead of audio."""
+
+    @pytest.mark.asyncio
+    async def test_tts_unavailable_sends_text_fallback(self) -> None:
+        """synthesize_and_dispatch_audio: TtsUnavailableError → dispatch_response(text).
+
+        The fallback must dispatch the original text as a text response
+        (not silence, not an error message) with modality='text' to prevent
+        re-triggering TTS.
+        """
+        from lyra.tts import TtsUnavailableError
+
+        mock_tts = MagicMock()
+        mock_tts.synthesize = AsyncMock(side_effect=TtsUnavailableError("adapter down"))
+
+        hub = Hub(tts=mock_tts)
+        hub.dispatch_audio = AsyncMock()
+        hub.dispatch_response = AsyncMock()
+
+        msg = InboundMessage(
+            id="msg-fallback-1",
+            platform="telegram",
+            bot_id="main",
+            scope_id="chat:99",
+            user_id="alice",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.TRUSTED,
+            modality="voice",
+        )
+
+        await hub._audio_pipeline.synthesize_and_dispatch_audio(msg, "Hello from Lyra")
+
+        # Audio must NOT be dispatched
+        hub.dispatch_audio.assert_not_awaited()
+
+        # Text fallback MUST be dispatched
+        hub.dispatch_response.assert_awaited_once()
+        call_args = hub.dispatch_response.call_args
+        dispatched_msg = call_args.args[0]
+        dispatched_response = call_args.args[1]
+        # modality overridden to 'text' to break the TTS re-entry loop
+        assert dispatched_msg.modality == "text"
+        # content is the original synthesis text, not an error string
+        assert dispatched_response.content == "Hello from Lyra"

--- a/tests/core/test_audio_pipeline_tts.py
+++ b/tests/core/test_audio_pipeline_tts.py
@@ -356,5 +356,9 @@ class TestTtsUnavailableFallback:
         dispatched_response = call_args.args[1]
         # modality overridden to 'text' to break the TTS re-entry loop
         assert dispatched_msg.modality == "text"
+        # routing identity must be preserved (dataclasses.replace, not a fresh message)
+        assert dispatched_msg.platform == msg.platform
+        assert dispatched_msg.scope_id == msg.scope_id
+        assert dispatched_msg.bot_id == msg.bot_id
         # content is the original synthesis text, not an error string
         assert dispatched_response.content == "Hello from Lyra"

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -141,6 +141,38 @@ class TestCircuitBreaker:
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
+    async def test_success_clears_failures(self, tmp_path: Path) -> None:
+        # Arrange — pre-inject 2 failures
+        mock_nc = AsyncMock()
+        success_payload = json.dumps({
+            "ok": True,
+            "text": "hello",
+            "language": "en",
+            "duration_seconds": 1.0,
+        }).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = success_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        client._cb._failures = 2
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        # Act
+        result = await client.transcribe(wav_file)
+        # Assert
+        assert result.text == "hello"
+        assert client._cb._failures == 0
+
+
+class TestTranscribeResponseParsing:
+    """Tests for NATS response parsing in NatsSttClient.transcribe().
+
+    Distinct from TestCircuitBreaker — these tests verify how the client
+    interprets specific response payloads (ok=false, noise tokens), not
+    circuit-breaker state transitions.
+    """
+
+    @pytest.mark.asyncio
     async def test_ok_false_raises_unavailable(self, tmp_path: Path) -> None:
         # Arrange
         mock_nc = AsyncMock()
@@ -175,26 +207,5 @@ class TestCircuitBreaker:
         # Act / Assert
         with pytest.raises(STTNoiseError):
             await client.transcribe(wav_file)
-
-    @pytest.mark.asyncio
-    async def test_success_clears_failures(self, tmp_path: Path) -> None:
-        # Arrange — pre-inject 2 failures
-        mock_nc = AsyncMock()
-        success_payload = json.dumps({
-            "ok": True,
-            "text": "hello",
-            "language": "en",
-            "duration_seconds": 1.0,
-        }).encode()
-        fake_reply = MagicMock()
-        fake_reply.data = success_payload
-        mock_nc.request = AsyncMock(return_value=fake_reply)
-        client = NatsSttClient(nc=mock_nc)
-        client._cb._failures = 2
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
-        # Act
-        result = await client.transcribe(wav_file)
-        # Assert
-        assert result.text == "hello"
+        # Noise is NOT a CB failure — record_success() runs before the noise check
         assert client._cb._failures == 0

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.nats.nats_stt_client import NatsSttClient
-from lyra.stt import STTUnavailableError
+from lyra.stt import STTNoiseError, STTUnavailableError
 
 
 @pytest.fixture()
@@ -123,6 +123,58 @@ class TestCircuitBreaker:
             await client.transcribe(wav_file)
         # Assert
         assert client._cb._failures == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_records_on_max_payload(self, tmp_path: Path) -> None:
+        # Arrange
+        mock_nc = AsyncMock()
+        mock_nc.request = AsyncMock(
+            side_effect=Exception("NATS: max_payload exceeded")
+        )
+        client = NatsSttClient(nc=mock_nc)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        # Act
+        with pytest.raises(STTUnavailableError, match="payload too large"):
+            await client.transcribe(wav_file)
+        # Assert
+        assert client._cb._failures == 1
+
+    @pytest.mark.asyncio
+    async def test_ok_false_raises_unavailable(self, tmp_path: Path) -> None:
+        # Arrange
+        mock_nc = AsyncMock()
+        error_payload = json.dumps({"ok": False}).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = error_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        # Act / Assert
+        with pytest.raises(STTUnavailableError, match="transcription failed"):
+            await client.transcribe(wav_file)
+        assert client._cb._failures == 1
+
+    @pytest.mark.asyncio
+    async def test_noise_transcript_raises_noise_error(self, tmp_path: Path) -> None:
+        # Arrange — Whisper returns a known noise token
+        mock_nc = AsyncMock()
+        noise_payload = json.dumps({
+            "ok": True,
+            "text": "[music]",
+            "language": "en",
+            "duration_seconds": 0.5,
+        }).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = noise_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        # Act / Assert
+        with pytest.raises(STTNoiseError):
+            await client.transcribe(wav_file)
 
     @pytest.mark.asyncio
     async def test_success_clears_failures(self, tmp_path: Path) -> None:

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -64,6 +64,58 @@ class TestCircuitBreaker:
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
+    async def test_ok_false_raises_unavailable(self) -> None:
+        # Arrange
+        mock_nc = AsyncMock()
+        error_payload = json.dumps({"ok": False}).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = error_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsTtsClient(nc=mock_nc)
+        # Act / Assert
+        with pytest.raises(TtsUnavailableError, match="synthesis failed"):
+            await client.synthesize("hello")
+        assert client._cb._failures == 1
+
+    @pytest.mark.asyncio
+    async def test_agent_tts_fields_forwarded_in_request(self) -> None:
+        # Arrange — agent_tts with engine + speed set
+        mock_nc = AsyncMock()
+        success_payload = json.dumps({
+            "ok": True,
+            "audio_b64": base64.b64encode(b"fake").decode(),
+            "mime_type": "audio/ogg",
+        }).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = success_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsTtsClient(nc=mock_nc)
+
+        agent_tts = MagicMock()
+        agent_tts.engine = "chatterbox"
+        agent_tts.speed = 1.2
+        agent_tts.accent = None
+        agent_tts.personality = None
+        agent_tts.emotion = None
+        agent_tts.exaggeration = None
+        agent_tts.cfg_weight = None
+        agent_tts.segment_gap = None
+        agent_tts.crossfade = None
+        agent_tts.chunk_size = None
+        agent_tts.language = None
+        agent_tts.voice = None
+        # Act
+        await client.synthesize("hello", agent_tts=agent_tts)
+        # Assert — the payload passed to nc.request contains the agent fields
+        assert mock_nc.request.await_count == 1
+        call_args = mock_nc.request.call_args
+        payload_bytes = call_args.args[1]
+        request_dict = json.loads(payload_bytes)
+        assert request_dict["engine"] == "chatterbox"
+        assert request_dict["speed"] == 1.2
+        assert "accent" not in request_dict  # None values not included
+
+    @pytest.mark.asyncio
     async def test_success_clears_failures(self) -> None:
         # Arrange — pre-inject 2 failures
         mock_nc = AsyncMock()

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -9,7 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.nats.nats_tts_client import NatsTtsClient
+from lyra.core.agent_config import AgentTTSConfig
+from lyra.nats.nats_tts_client import _TTS_CONFIG_FIELDS, NatsTtsClient
 from lyra.tts import TtsUnavailableError
 
 
@@ -91,19 +92,7 @@ class TestCircuitBreaker:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsTtsClient(nc=mock_nc)
 
-        agent_tts = MagicMock()
-        agent_tts.engine = "chatterbox"
-        agent_tts.speed = 1.2
-        agent_tts.accent = None
-        agent_tts.personality = None
-        agent_tts.emotion = None
-        agent_tts.exaggeration = None
-        agent_tts.cfg_weight = None
-        agent_tts.segment_gap = None
-        agent_tts.crossfade = None
-        agent_tts.chunk_size = None
-        agent_tts.language = None
-        agent_tts.voice = None
+        agent_tts = AgentTTSConfig(engine="chatterbox", speed="1.2")
         # Act
         await client.synthesize("hello", agent_tts=agent_tts)
         # Assert — the payload passed to nc.request contains the agent fields
@@ -112,8 +101,10 @@ class TestCircuitBreaker:
         payload_bytes = call_args.args[1]
         request_dict = json.loads(payload_bytes)
         assert request_dict["engine"] == "chatterbox"
-        assert request_dict["speed"] == 1.2
-        assert "accent" not in request_dict  # None values not included
+        assert request_dict["speed"] == "1.2"
+        # All unset fields (None) must be absent from the NATS payload
+        none_fields = [f for f in _TTS_CONFIG_FIELDS if f not in ("engine", "speed")]
+        assert all(f not in request_dict for f in none_fields)
 
     @pytest.mark.asyncio
     async def test_success_clears_failures(self) -> None:


### PR DESCRIPTION
## Summary
- Add missing unit tests for `NatsSttClient`: `ok=false` → `STTUnavailableError`, noise token → `STTNoiseError`, max_payload → `STTUnavailableError`
- Add missing unit tests for `NatsTtsClient`: `ok=false` → `TtsUnavailableError`, agent_tts field forwarding into request payload
- Add `AudioPipeline` TTS fallback test: when `TtsUnavailableError` is raised, `dispatch_response` is called with the original text (not silence, not error), with `modality='text'` to prevent re-entry loop

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #575: test(nats): unit tests for NatsSttClient, NatsTtsClient, TTS unavailable fallback | Open |
| Implementation | 1 commit on `feat/575-nats-stt-tts-tests` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (161 lines added, 2520 passed) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats/test_nats_stt_client.py tests/nats/test_nats_tts_client.py tests/core/test_audio_pipeline_tts.py -v` — all 31 pass
- [ ] `uv run pytest tests/ --no-cov` — 2520 passed, 0 failures

Closes #575

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`