### PR TITLE
feat(infra): nats.container + hub.container — Quadlet units

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ See `docs/ARCHITECTURE.md` for full context.
 | `docs/GETTING-STARTED.md` | Machine 1 setup guide |
 | `artifacts/` | Frames, specs, plans, analyses, explorations (dev-core) |
 | `deploy/provision.sh` | Machine 1 post-install provisioning script |
-| `deploy/quadlet/` | Podman Quadlet units (`.container`, `.volume`, `.network`) — systemd-integrated containers |
+| `deploy/quadlet/` | Podman Quadlet units (`.container`, `.volume`, `.network`) — systemd-integrated containers; `lyra-nats-auth.volume` for NATS public auth.conf |
 | `deploy/nats/nats-container.conf` | NATS config for container deployment (no TLS, 0.0.0.0 bind) |
 
 ## Local infrastructure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ See `docs/ARCHITECTURE.md` for full context.
 | `docs/GETTING-STARTED.md` | Machine 1 setup guide |
 | `artifacts/` | Frames, specs, plans, analyses, explorations (dev-core) |
 | `deploy/provision.sh` | Machine 1 post-install provisioning script |
+| `deploy/quadlet/` | Podman Quadlet units (`.container`, `.volume`, `.network`) — systemd-integrated containers |
+| `deploy/nats/nats-container.conf` | NATS config for container deployment (no TLS, 0.0.0.0 bind) |
 
 ## Local infrastructure
 

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ quadlet-install:  ## install Quadlet units to ~/.config/containers/systemd/ + re
 	@cp deploy/quadlet/lyra-nkey-monitor.volume    "$(QUADLET_DIR)/lyra-nkey-monitor.volume"
 	@cp deploy/quadlet/lyra-nkey-tts-adapter.volume "$(QUADLET_DIR)/lyra-nkey-tts-adapter.volume"
 	@cp deploy/quadlet/lyra-nkey-stt-adapter.volume "$(QUADLET_DIR)/lyra-nkey-stt-adapter.volume"
+	@cp deploy/quadlet/lyra-nats-auth.volume       "$(QUADLET_DIR)/lyra-nats-auth.volume"
+	@cp deploy/quadlet/nats.container              "$(QUADLET_DIR)/nats.container"
+	@cp deploy/quadlet/hub.container               "$(QUADLET_DIR)/hub.container"
 	@systemctl --user daemon-reload
 	@echo "Quadlet units installed."
 

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -20,7 +20,6 @@ max_connections: 20       # hub + adapters + headroom
 max_payload:     52428800 # 50 MB — supports audio, images, video over NATS
 
 # ── Monitoring ─────────────────────────────────────────────────────────────
-# Exposed on host port 8223 (see nats.container PublishPort).
-http_port: 8222
+# Disabled until Slice A3 (lyra-monitor health probe) — consistent with nats.conf policy.
 
 logtime: true

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -1,0 +1,26 @@
+# NATS Server — Lyra by Roxabi (container)
+# Used by: deploy/quadlet/nats.container
+# Differences from nats.conf:
+#   - Listens on 0.0.0.0 — hub container connects via lyra.network
+#   - No TLS — internal container network, no external exposure
+#   - Monitoring enabled on 8222 (mapped to host 8223 by Quadlet)
+#   - No pid_file — not applicable inside a container
+
+# Bind to all interfaces so hub/adapter containers can reach NATS via
+# the lyra bridge network (nats://lyra-nats:4222).
+port: 4222
+
+# ── nkey auth ──────────────────────────────────────────────────────────────
+# Public keys mounted at /etc/nats/nkeys via Quadlet Volume.
+# Regenerate with deploy/nats/gen-nkeys.sh, then copy seeds to ~/.lyra/nkeys/.
+include "nkeys/auth.conf"
+
+# ── Resource limits ────────────────────────────────────────────────────────
+max_connections: 20       # hub + adapters + headroom
+max_payload:     52428800 # 50 MB — supports audio, images, video over NATS
+
+# ── Monitoring ─────────────────────────────────────────────────────────────
+# Exposed on host port 8223 (see nats.container PublishPort).
+http_port: 8222
+
+logtime: true

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -3,7 +3,7 @@
 # Differences from nats.conf:
 #   - Listens on 0.0.0.0 — hub container connects via lyra.network
 #   - No TLS — internal container network, no external exposure
-#   - Monitoring enabled on 8222 (mapped to host 8223 by Quadlet)
+#   - Monitoring: disabled (same as nats.conf — re-enable in Slice A3)
 #   - No pid_file — not applicable inside a container
 
 # Bind to all interfaces so hub/adapter containers can reach NATS via

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -11,9 +11,9 @@
 port: 4222
 
 # ── nkey auth ──────────────────────────────────────────────────────────────
-# Public keys mounted at /etc/nats/nkeys via Quadlet Volume.
-# Regenerate with deploy/nats/gen-nkeys.sh, then copy seeds to ~/.lyra/nkeys/.
-include "nkeys/auth.conf"
+# Only auth.conf (public keys) is mounted — seeds stay on the host.
+# Regenerate with deploy/nats/gen-nkeys.sh, then copy auth.conf to ~/.lyra/nkeys/.
+include "/etc/nats/nkeys/auth.conf"
 
 # ── Resource limits ────────────────────────────────────────────────────────
 max_connections: 20       # hub + adapters + headroom

--- a/deploy/quadlet/.env.hub.example
+++ b/deploy/quadlet/.env.hub.example
@@ -1,0 +1,14 @@
+# .env.hub — hub container environment (hub-scoped vars only)
+# Copy to ~/.env.hub (or %h/projects/lyra/.env.hub) and fill in values.
+# Adapter tokens (Telegram, Discord, TTS/STT) do NOT belong here.
+#
+# NATS_URL and LYRA_VAULT_DIR are set directly in hub.container — no need here.
+
+ANTHROPIC_API_KEY=
+
+LYRA_HEALTH_SECRET=
+LYRA_HEALTH_PORT=8443
+
+# Optional overrides
+# LYRA_LOG_DIR=
+# ROXABI_VAULT_DIR=

--- a/deploy/quadlet/.env.hub.example
+++ b/deploy/quadlet/.env.hub.example
@@ -2,7 +2,7 @@
 # Copy to ~/.env.hub (or %h/projects/lyra/.env.hub) and fill in values.
 # Adapter tokens (Telegram, Discord, TTS/STT) do NOT belong here.
 #
-# NATS_URL and LYRA_VAULT_DIR are set directly in hub.container — no need here.
+# NATS_URL and NATS_NKEY_SEED_PATH are set directly in hub.container — no need here.
 
 ANTHROPIC_API_KEY=
 

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -1,0 +1,22 @@
+[Unit]
+Description=Lyra Hub
+After=lyra-nats.service
+
+[Container]
+Image=localhost/lyra:latest
+ContainerName=lyra-hub
+Network=lyra.network
+EnvironmentFile=%h/projects/lyra/.env
+# Override NATS_URL to use container network — takes precedence over .env.
+# Update .env directly when supervisord NATS is retired (cutover step).
+Environment=NATS_URL=nats://lyra-nats:4222
+Volume=lyra-data.volume:/root/.lyra:z
+Volume=%h/projects/lyra/config.toml:/app/config.toml:ro,z
+Exec=lyra hub
+
+[Service]
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -2,6 +2,8 @@
 Description=Lyra Hub
 After=nats.service
 Requires=nats.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Container]
 Image=localhost/lyra:latest
@@ -16,11 +18,13 @@ Environment=NATS_URL=nats://lyra-nats:4222
 Volume=lyra-nkey-hub.volume:/run/secrets/hub.seed:ro,z
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/hub.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:z
-Volume=%h/projects/lyra/config.toml:/app/config.toml:ro,z
+Volume=lyra-config.volume:/app/config.toml:ro,z
+# Health endpoint — probed by lyra-monitor via host loopback (localhost:8443).
+PublishPort=127.0.0.1:8443:8443
 Exec=lyra hub
 
 [Service]
-Restart=always
+Restart=on-failure
 RestartSec=5
 
 [Install]

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Lyra Hub
-After=lyra-nats.service
-Requires=lyra-nats.service
+After=nats.service
+Requires=nats.service
 
 [Container]
 Image=localhost/lyra:latest
@@ -13,8 +13,9 @@ EnvironmentFile=%h/projects/lyra/.env.hub
 # are excluded — hub does not need them. See deploy/quadlet/.env.hub.example.
 # NATS_URL is overridden inline below; cutover = update .env.hub directly.
 Environment=NATS_URL=nats://lyra-nats:4222
+Volume=lyra-nkey-hub.volume:/run/secrets/hub.seed:ro,z
+Environment=NATS_NKEY_SEED_PATH=/run/secrets/hub.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:z
-Environment=LYRA_VAULT_DIR=/home/lyra/.lyra
 Volume=%h/projects/lyra/config.toml:/app/config.toml:ro,z
 Exec=lyra hub
 

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -1,6 +1,7 @@
 [Unit]
 Description=Lyra Hub
 After=lyra-nats.service
+Requires=lyra-nats.service
 
 [Container]
 Image=localhost/lyra:latest
@@ -10,7 +11,8 @@ EnvironmentFile=%h/projects/lyra/.env
 # Override NATS_URL to use container network — takes precedence over .env.
 # Update .env directly when supervisord NATS is retired (cutover step).
 Environment=NATS_URL=nats://lyra-nats:4222
-Volume=lyra-data.volume:/root/.lyra:z
+Volume=lyra-data.volume:/home/lyra/.lyra:z
+Environment=LYRA_VAULT_DIR=/home/lyra/.lyra
 Volume=%h/projects/lyra/config.toml:/app/config.toml:ro,z
 Exec=lyra hub
 

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -7,9 +7,11 @@ Requires=lyra-nats.service
 Image=localhost/lyra:latest
 ContainerName=lyra-hub
 Network=lyra.network
-EnvironmentFile=%h/projects/lyra/.env
-# Override NATS_URL to use container network — takes precedence over .env.
-# Update .env directly when supervisord NATS is retired (cutover step).
+EnvironmentFile=%h/projects/lyra/.env.hub
+# .env.hub contains only hub-scoped vars (ANTHROPIC_API_KEY, LYRA_HEALTH_SECRET,
+# LYRA_LOG_DIR, ROXABI_VAULT_DIR). Adapter tokens (Telegram, Discord, TTS/STT)
+# are excluded — hub does not need them. See deploy/quadlet/.env.hub.example.
+# NATS_URL is overridden inline below; cutover = update .env.hub directly.
 Environment=NATS_URL=nats://lyra-nats:4222
 Volume=lyra-data.volume:/home/lyra/.lyra:z
 Environment=LYRA_VAULT_DIR=/home/lyra/.lyra

--- a/deploy/quadlet/lyra-nats-auth.volume
+++ b/deploy/quadlet/lyra-nats-auth.volume
@@ -1,0 +1,9 @@
+[Unit]
+Description=Lyra NATS auth.conf (public nkeys — read-only)
+ConditionPathExists=%h/.lyra/nkeys/auth.conf
+
+[Volume]
+Device=%h/.lyra/nkeys/auth.conf
+Type=bind
+Options=bind,ro
+Label=app=lyra

--- a/deploy/quadlet/lyra.network
+++ b/deploy/quadlet/lyra.network
@@ -3,4 +3,6 @@ Description=Lyra container bridge network
 
 [Network]
 Driver=bridge
+# Internal=true: container-to-container traffic only; no outbound internet routing.
+Internal=true
 Label=app=lyra

--- a/deploy/quadlet/lyra.network
+++ b/deploy/quadlet/lyra.network
@@ -3,6 +3,7 @@ Description=Lyra container bridge network
 
 [Network]
 Driver=bridge
-# Internal=true: container-to-container traffic only; no outbound internet routing.
-Internal=true
+# No Internal=true — the hub needs outbound internet (Anthropic API, Telegram).
+# Isolation is achieved via: nkey auth (NATS rejects unauthenticated clients) +
+# PublishPort=127.0.0.1:4223:4222 (NATS port is localhost-only, no LAN exposure).
 Label=app=lyra

--- a/deploy/quadlet/nats.container
+++ b/deploy/quadlet/nats.container
@@ -9,9 +9,8 @@ Network=lyra.network
 # Host 4223 → container 4222: runs alongside supervisord NATS (4222) during
 # parallel testing. Switch to 4222:4222 once supervisord NATS is retired.
 PublishPort=127.0.0.1:4223:4222
-PublishPort=127.0.0.1:8223:8222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
-Volume=%h/.lyra/nkeys/auth.conf:/etc/nats/nkeys/auth.conf:ro,z
+Volume=/etc/nats/nkeys/auth.conf:/etc/nats/nkeys/auth.conf:ro,z
 Exec=nats-server -js -c /etc/nats/nats.conf
 
 [Service]

--- a/deploy/quadlet/nats.container
+++ b/deploy/quadlet/nats.container
@@ -11,8 +11,8 @@ Network=lyra.network
 PublishPort=127.0.0.1:4223:4222
 PublishPort=127.0.0.1:8223:8222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
-Volume=%h/.lyra/nkeys:/etc/nats/nkeys:ro,z
-Exec=-js -c /etc/nats/nats.conf
+Volume=%h/.lyra/nkeys/auth.conf:/etc/nats/nkeys/auth.conf:ro,z
+Exec=nats-server -js -c /etc/nats/nats.conf
 
 [Service]
 Restart=always

--- a/deploy/quadlet/nats.container
+++ b/deploy/quadlet/nats.container
@@ -1,6 +1,5 @@
 [Unit]
 Description=Lyra NATS server
-After=network-online.target
 
 [Container]
 Image=nats:2.10.29-alpine
@@ -10,7 +9,7 @@ Network=lyra.network
 # parallel testing. Switch to 4222:4222 once supervisord NATS is retired.
 PublishPort=127.0.0.1:4223:4222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
-Volume=/etc/nats/nkeys/auth.conf:/etc/nats/nkeys/auth.conf:ro,z
+Volume=lyra-nats-auth.volume:/etc/nats/nkeys/auth.conf:ro,z
 Exec=nats-server -js -c /etc/nats/nats.conf
 
 [Service]

--- a/deploy/quadlet/nats.container
+++ b/deploy/quadlet/nats.container
@@ -1,0 +1,22 @@
+[Unit]
+Description=Lyra NATS server
+After=network-online.target
+
+[Container]
+Image=nats:2.10-alpine
+ContainerName=lyra-nats
+Network=lyra.network
+# Host 4223 → container 4222: runs alongside supervisord NATS (4222) during
+# parallel testing. Switch to 4222:4222 once supervisord NATS is retired.
+PublishPort=4223:4222
+PublishPort=8223:8222
+Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
+Volume=%h/.lyra/nkeys:/etc/nats/nkeys:ro,z
+Exec=-js -c /etc/nats/nats.conf
+
+[Service]
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/nats.container
+++ b/deploy/quadlet/nats.container
@@ -3,13 +3,13 @@ Description=Lyra NATS server
 After=network-online.target
 
 [Container]
-Image=nats:2.10-alpine
+Image=nats:2.10.29-alpine
 ContainerName=lyra-nats
 Network=lyra.network
 # Host 4223 → container 4222: runs alongside supervisord NATS (4222) during
 # parallel testing. Switch to 4222:4222 once supervisord NATS is retired.
-PublishPort=4223:4222
-PublishPort=8223:8222
+PublishPort=127.0.0.1:4223:4222
+PublishPort=127.0.0.1:8223:8222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
 Volume=%h/.lyra/nkeys:/etc/nats/nkeys:ro,z
 Exec=-js -c /etc/nats/nats.conf


### PR DESCRIPTION
## Summary
- Add `nats.container` and `hub.container` Podman Quadlet units for systemd-integrated container management
- Add `nats-container.conf` — container-appropriate NATS config (0.0.0.0 bind, no TLS, monitoring on 8222) since `nats.conf` binds to 127.0.0.1 and uses TLS, neither of which work cross-container
- Host ports 4223/8223 for NATS during parallel-with-supervisord testing (avoids port 4222 conflict); hub overrides `NATS_URL=nats://lyra-nats:4222` inline

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #607: feat(infra): nats.container + hub.container — Quadlet units | Open |
| Implementation | 1 commit on `feat/607-nats-container-hub-container-quadlet-units` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new — config files only) | Passed |

## Test Plan
- [ ] `systemctl --user start lyra-nats` — NATS container starts, `podman ps` shows `lyra-nats`
- [ ] `journalctl --user -u lyra-nats` — NATS logs visible, listening on 4222
- [ ] `systemctl --user start lyra-hub` — Hub container starts after lyra-nats.service
- [ ] `journalctl --user -u lyra-hub` — Hub logs visible, connects to `nats://lyra-nats:4222`
- [ ] Both services survive `systemctl --user restart` with no data loss
- [ ] Supervisord NATS still runs on 4222 (no port conflict — Podman NATS on 4223)

Closes #607

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`