### PR TITLE
fix(nats): extract shared _TTS_CONFIG_FIELDS constant to _tts_constants.py

### DIFF
--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -15,19 +15,13 @@ import sys
 from dataclasses import dataclass
 
 from lyra.nats import NatsAdapterBase
+from lyra.nats._tts_constants import _AGENT_TTS_FIELDS
 from lyra.nats.queue_groups import TTS_WORKERS
 from lyra.tts import SynthesisResult, TTSService, load_tts_config
 
 log = logging.getLogger(__name__)
 
 SUBJECT = "lyra.voice.tts.request"
-
-# Fields the hub serializes from AgentTTSConfig into the NATS request.
-_AGENT_TTS_FIELDS = (
-    "engine", "voice", "language", "accent", "personality", "speed",
-    "emotion", "exaggeration", "cfg_weight", "segment_gap", "crossfade",
-    "chunk_size", "default_language", "languages",
-)
 
 
 @dataclass

--- a/src/lyra/nats/_tts_constants.py
+++ b/src/lyra/nats/_tts_constants.py
@@ -1,0 +1,33 @@
+"""Shared TTS field constants for the NATS request/response boundary.
+
+Two separate tuples because each side of the boundary has different needs:
+- ``_TTS_CONFIG_FIELDS`` — fields NatsTtsClient serializes from AgentTTSConfig
+  into the outgoing request. voice/language are passed as explicit keyword
+  arguments to synthesize(); default_language/languages are not forwarded.
+- ``_AGENT_TTS_FIELDS`` — fields TtsAdapterStandalone reads back from the
+  request payload into a lightweight _NatsTtsConfig stand-in.
+
+Both are defined here so that additions to AgentTTSConfig only require a
+single-file update.
+"""
+
+# Hub side — serialised by NatsTtsClient.synthesize()
+_TTS_CONFIG_FIELDS: tuple[str, ...] = (
+    "engine",
+    "accent",
+    "personality",
+    "speed",
+    "emotion",
+    "exaggeration",
+    "cfg_weight",
+    "segment_gap",
+    "crossfade",
+    "chunk_size",
+)
+
+# Adapter side — deserialised by TtsAdapterStandalone.handle()
+_AGENT_TTS_FIELDS: tuple[str, ...] = (
+    "engine", "voice", "language", "accent", "personality", "speed",
+    "emotion", "exaggeration", "cfg_weight", "segment_gap", "crossfade",
+    "chunk_size", "default_language", "languages",
+)

--- a/src/lyra/nats/_tts_constants.py
+++ b/src/lyra/nats/_tts_constants.py
@@ -27,7 +27,18 @@ _TTS_CONFIG_FIELDS: tuple[str, ...] = (
 
 # Adapter side — deserialised by TtsAdapterStandalone.handle()
 _AGENT_TTS_FIELDS: tuple[str, ...] = (
-    "engine", "voice", "language", "accent", "personality", "speed",
-    "emotion", "exaggeration", "cfg_weight", "segment_gap", "crossfade",
-    "chunk_size", "default_language", "languages",
+    "engine",
+    "voice",
+    "language",
+    "accent",
+    "personality",
+    "speed",
+    "emotion",
+    "exaggeration",
+    "cfg_weight",
+    "segment_gap",
+    "crossfade",
+    "chunk_size",
+    "default_language",
+    "languages",
 )

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -75,6 +75,7 @@ class NatsTtsClient:
             "chunked": True,
         }
         if agent_tts is not None:
+            # voice/language use caller-override semantics (see below); excluded here
             for field in _TTS_CONFIG_FIELDS:
                 val = getattr(agent_tts, field, None)
                 if val is not None:

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from nats.aio.client import Client as NATS
 
+from lyra.nats._tts_constants import _TTS_CONFIG_FIELDS
 from lyra.nats.circuit_breaker import NatsCircuitBreaker
 from lyra.tts import SynthesisResult, TtsUnavailableError
 
@@ -16,19 +17,6 @@ if TYPE_CHECKING:
     from lyra.core.agent_config import AgentTTSConfig
 
 log = logging.getLogger(__name__)
-
-_TTS_CONFIG_FIELDS = (
-    "engine",
-    "accent",
-    "personality",
-    "speed",
-    "emotion",
-    "exaggeration",
-    "cfg_weight",
-    "segment_gap",
-    "crossfade",
-    "chunk_size",
-)
 
 
 class NatsTtsClient:


### PR DESCRIPTION
## Summary
- Extract `_TTS_CONFIG_FIELDS` and `_AGENT_TTS_FIELDS` from their respective modules into `src/lyra/nats/_tts_constants.py`
- Both modules now import from the shared location — any `AgentTTSConfig` field addition requires a single-file update

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #574: fix(nats): extract shared _TTS_CONFIG_FIELDS constant (duplicated) | Open |
| Implementation | 1 commit on `fix/574-extract-tts-config-fields` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2612 passed) | Passed |

## Test Plan
- [ ] `make test` — all existing tests pass (no behavioural change)
- [ ] Verify `nats_tts_client.py` and `tts_adapter_standalone.py` import from `_tts_constants.py`

Closes #574

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`