### PR TITLE
feat(nats): SDK heartbeat in NatsAdapterBase + voice adapter opt-in

### DIFF
--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -268,7 +268,11 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
 
         # STT / TTS via NATS clients (hub talks to voicecli adapters over NATS)
         stt_service = init_nats_stt(nc)
+        if stt_service is not None:
+            await stt_service._setup_heartbeat_subscription()
         tts_service = init_nats_tts(nc)
+        if tts_service is not None:
+            await tts_service._setup_heartbeat_subscription()
 
         cli_pool_cfg = _load_cli_pool_config(raw_config)
         hub_cfg = _load_hub_config(raw_config)

--- a/src/lyra/bootstrap/hub_standalone.py
+++ b/src/lyra/bootstrap/hub_standalone.py
@@ -269,10 +269,10 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
         # STT / TTS via NATS clients (hub talks to voicecli adapters over NATS)
         stt_service = init_nats_stt(nc)
         if stt_service is not None:
-            await stt_service._setup_heartbeat_subscription()
+            await stt_service.start()
         tts_service = init_nats_tts(nc)
         if tts_service is not None:
-            await tts_service._setup_heartbeat_subscription()
+            await tts_service.start()
 
         cli_pool_cfg = _load_cli_pool_config(raw_config)
         hub_cfg = _load_hub_config(raw_config)

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -26,64 +26,105 @@ SUBJECT = "lyra.voice.stt.request"
 
 class SttAdapterStandalone(NatsAdapterBase):
     def __init__(self, raw_config: dict) -> None:
-        super().__init__(SUBJECT, STT_WORKERS, "SttRequest", 1)
+        super().__init__(
+            SUBJECT, STT_WORKERS, "SttRequest", 1,
+            heartbeat_subject="lyra.voice.stt.heartbeat",
+            heartbeat_interval=5.0,
+        )
+        self._active_count: int = 0
         self._base_stt_cfg = load_stt_config()
         self._stt_service = STTService(self._base_stt_cfg)
         log.info(
             "stt_adapter: STTService ready (model=%s)", self._base_stt_cfg.model_size
         )
 
+    def _get_vram_used(self) -> int:
+        try:
+            import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            return int(info.used // (1024 * 1024))
+        except Exception:
+            return 0
+
+    def _get_vram_total(self) -> int:
+        try:
+            import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            return int(info.total // (1024 * 1024))
+        except Exception:
+            return 0
+
+    def heartbeat_payload(self) -> dict:
+        base = super().heartbeat_payload()
+        base.update({
+            "model_loaded": self._base_stt_cfg.model_size,
+            "vram_used_mb": self._get_vram_used(),
+            "vram_total_mb": self._get_vram_total(),
+            "active_requests": self._active_count,
+        })
+        return base
+
     async def handle(self, msg, payload: dict) -> None:
         data: dict = payload
         response: dict
+        self._active_count += 1
         try:
-            request_id = data.get("request_id", "unknown")
-            audio_b64 = data["audio_b64"]
-            audio_bytes = base64.b64decode(audio_b64)
-            mime_type = data.get("mime_type", "audio/ogg")
-
-            svc = self._stt_service
-            overrides: dict = {}
-            for key in (
-                "language_detection_threshold",
-                "language_detection_segments",
-                "language_fallback",
-            ):
-                if data.get(key) is not None:
-                    overrides[key] = data[key]
-            if overrides:
-                cfg = self._base_stt_cfg.model_copy(update=overrides)
-                svc = STTService(cfg)
-
-            suffix = _mime_to_ext(mime_type)
-            fd, tmp_path_str = tempfile.mkstemp(suffix=suffix)
             try:
-                os.write(fd, audio_bytes)
-                os.close(fd)
-                tmp_path = Path(tmp_path_str)
-                result: TranscriptionResult = await svc.transcribe(tmp_path)
+                request_id = data.get("request_id", "unknown")
+                audio_b64 = data["audio_b64"]
+                audio_bytes = base64.b64decode(audio_b64)
+                mime_type = data.get("mime_type", "audio/ogg")
+
+                svc = self._stt_service
+                overrides: dict = {}
+                for key in (
+                    "language_detection_threshold",
+                    "language_detection_segments",
+                    "language_fallback",
+                ):
+                    if data.get(key) is not None:
+                        overrides[key] = data[key]
+                if overrides:
+                    cfg = self._base_stt_cfg.model_copy(update=overrides)
+                    svc = STTService(cfg)
+
+                suffix = _mime_to_ext(mime_type)
+                fd, tmp_path_str = tempfile.mkstemp(suffix=suffix)
+                try:
+                    os.write(fd, audio_bytes)
+                    os.close(fd)
+                    tmp_path = Path(tmp_path_str)
+                    result: TranscriptionResult = await svc.transcribe(tmp_path)
+                    response = {
+                        "request_id": request_id,
+                        "ok": True,
+                        "text": result.text,
+                        "language": result.language,
+                        "duration_seconds": result.duration_seconds,
+                    }
+                finally:
+                    Path(tmp_path_str).unlink(missing_ok=True)
+
+            except Exception:
+                log.exception(
+                    "stt_adapter: transcription failed (request_id=%s)",
+                    data.get("request_id", "?"),
+                )
                 response = {
-                    "request_id": request_id,
-                    "ok": True,
-                    "text": result.text,
-                    "language": result.language,
-                    "duration_seconds": result.duration_seconds,
+                    "request_id": data.get("request_id", "unknown"),
+                    "ok": False,
+                    "error": "transcription_failed",
                 }
-            finally:
-                Path(tmp_path_str).unlink(missing_ok=True)
 
-        except Exception:
-            log.exception(
-                "stt_adapter: transcription failed (request_id=%s)",
-                data.get("request_id", "?"),
+            await self.reply(
+                msg, json.dumps(response, ensure_ascii=False).encode("utf-8")
             )
-            response = {
-                "request_id": data.get("request_id", "unknown"),
-                "ok": False,
-                "error": "transcription_failed",
-            }
-
-        await self.reply(msg, json.dumps(response, ensure_ascii=False).encode("utf-8"))
+        finally:
+            self._active_count -= 1
 
 
 async def _bootstrap_stt_adapter_standalone(

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -38,32 +38,24 @@ class SttAdapterStandalone(NatsAdapterBase):
             "stt_adapter: STTService ready (model=%s)", self._base_stt_cfg.model_size
         )
 
-    def _get_vram_used(self) -> int:
+    def _get_vram_info(self) -> tuple[int, int]:
+        """Return (used_mb, total_mb). Both 0 if pynvml is unavailable."""
         try:
             import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
             pynvml.nvmlInit()
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            return int(info.used // (1024 * 1024))
+            return int(info.used // (1024 * 1024)), int(info.total // (1024 * 1024))
         except Exception:
-            return 0
-
-    def _get_vram_total(self) -> int:
-        try:
-            import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
-            pynvml.nvmlInit()
-            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            return int(info.total // (1024 * 1024))
-        except Exception:
-            return 0
+            return 0, 0
 
     def heartbeat_payload(self) -> dict:
         base = super().heartbeat_payload()
+        vram_used, vram_total = self._get_vram_info()
         base.update({
             "model_loaded": self._base_stt_cfg.model_size,
-            "vram_used_mb": self._get_vram_used(),
-            "vram_total_mb": self._get_vram_total(),
+            "vram_used_mb": vram_used,
+            "vram_total_mb": vram_total,
             "active_requests": self._active_count,
         })
         return base

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -49,61 +49,103 @@ class _NatsTtsConfig:
 
 class TtsAdapterStandalone(NatsAdapterBase):
     def __init__(self, raw_config: dict) -> None:
-        super().__init__(SUBJECT, TTS_WORKERS, "TtsRequest", 1)
+        super().__init__(
+            SUBJECT, TTS_WORKERS, "TtsRequest", 1,
+            heartbeat_subject="lyra.voice.tts.heartbeat",
+            heartbeat_interval=5.0,
+        )
+        self._active_count: int = 0
         tts_cfg = load_tts_config()
+        self._tts_cfg = tts_cfg
         self._tts_service = TTSService(tts_cfg)
         log.info(
             "tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default"
         )
 
+    def _get_vram_used(self) -> int:
+        try:
+            import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            return int(info.used // (1024 * 1024))
+        except Exception:
+            return 0
+
+    def _get_vram_total(self) -> int:
+        try:
+            import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            return int(info.total // (1024 * 1024))
+        except Exception:
+            return 0
+
+    def heartbeat_payload(self) -> dict:
+        base = super().heartbeat_payload()
+        base.update({
+            "model_loaded": self._tts_cfg.engine or "default",
+            "vram_used_mb": self._get_vram_used(),
+            "vram_total_mb": self._get_vram_total(),
+            "active_requests": self._active_count,
+        })
+        return base
+
     async def handle(self, msg, payload: dict) -> None:
         data: dict = payload
         response: dict
+        self._active_count += 1
         try:
-            request_id = data.get("request_id", "unknown")
-            text = data["text"]
+            try:
+                request_id = data.get("request_id", "unknown")
+                text = data["text"]
 
-            # Build a lightweight TTS config from the flat NATS request fields.
-            # This mirrors AgentTTSConfig without importing the hub-layer type.
-            tts_config_kwargs = {
-                k: data[k] for k in _AGENT_TTS_FIELDS if data.get(k) is not None
-            }
-            agent_tts = (
-                _NatsTtsConfig(**tts_config_kwargs) if tts_config_kwargs else None
+                # Build a lightweight TTS config from the flat NATS request fields.
+                # This mirrors AgentTTSConfig without importing the hub-layer type.
+                tts_config_kwargs = {
+                    k: data[k] for k in _AGENT_TTS_FIELDS if data.get(k) is not None
+                }
+                agent_tts = (
+                    _NatsTtsConfig(**tts_config_kwargs) if tts_config_kwargs else None
+                )
+
+                synth_kwargs: dict = {}
+                for key in ("language", "voice", "fallback_language"):
+                    if data.get(key) is not None:
+                        synth_kwargs[key] = data[key]
+
+                result: SynthesisResult = await self._tts_service.synthesize(
+                    text,
+                    agent_tts=agent_tts,  # type: ignore[arg-type]  # duck-typed stand-in
+                    **synth_kwargs,
+                )
+
+                response = {
+                    "request_id": request_id,
+                    "ok": True,
+                    "audio_b64": base64.b64encode(result.audio_bytes).decode("ascii"),
+                    "mime_type": result.mime_type,
+                    "duration_ms": result.duration_ms,
+                    "waveform_b64": result.waveform_b64,
+                }
+
+            except Exception:
+                log.exception(
+                    "tts_adapter: synthesis failed (request_id=%s)",
+                    data.get("request_id", "?"),
+                )
+                response = {
+                    "request_id": data.get("request_id", "unknown"),
+                    "ok": False,
+                    "error": "synthesis_failed",
+                }
+
+            await self.reply(
+                msg, json.dumps(response, ensure_ascii=False).encode("utf-8")
             )
-
-            synth_kwargs: dict = {}
-            for key in ("language", "voice", "fallback_language"):
-                if data.get(key) is not None:
-                    synth_kwargs[key] = data[key]
-
-            result: SynthesisResult = await self._tts_service.synthesize(
-                text,
-                agent_tts=agent_tts,  # type: ignore[arg-type]  # duck-typed stand-in
-                **synth_kwargs,
-            )
-
-            response = {
-                "request_id": request_id,
-                "ok": True,
-                "audio_b64": base64.b64encode(result.audio_bytes).decode("ascii"),
-                "mime_type": result.mime_type,
-                "duration_ms": result.duration_ms,
-                "waveform_b64": result.waveform_b64,
-            }
-
-        except Exception:
-            log.exception(
-                "tts_adapter: synthesis failed (request_id=%s)",
-                data.get("request_id", "?"),
-            )
-            response = {
-                "request_id": data.get("request_id", "unknown"),
-                "ok": False,
-                "error": "synthesis_failed",
-            }
-
-        await self.reply(msg, json.dumps(response, ensure_ascii=False).encode("utf-8"))
+        finally:
+            self._active_count -= 1
 
 
 async def _bootstrap_tts_adapter_standalone(

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -62,32 +62,24 @@ class TtsAdapterStandalone(NatsAdapterBase):
             "tts_adapter: TTSService ready (engine=%s)", tts_cfg.engine or "default"
         )
 
-    def _get_vram_used(self) -> int:
+    def _get_vram_info(self) -> tuple[int, int]:
+        """Return (used_mb, total_mb). Both 0 if pynvml is unavailable."""
         try:
             import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
             pynvml.nvmlInit()
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            return int(info.used // (1024 * 1024))
+            return int(info.used // (1024 * 1024)), int(info.total // (1024 * 1024))
         except Exception:
-            return 0
-
-    def _get_vram_total(self) -> int:
-        try:
-            import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
-            pynvml.nvmlInit()
-            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            return int(info.total // (1024 * 1024))
-        except Exception:
-            return 0
+            return 0, 0
 
     def heartbeat_payload(self) -> dict:
         base = super().heartbeat_payload()
+        vram_used, vram_total = self._get_vram_info()
         base.update({
             "model_loaded": self._tts_cfg.engine or "default",
-            "vram_used_mb": self._get_vram_used(),
-            "vram_total_mb": self._get_vram_total(),
+            "vram_used_mb": vram_used,
+            "vram_total_mb": vram_total,
             "active_requests": self._active_count,
         })
         return base

--- a/src/lyra/bootstrap/unified.py
+++ b/src/lyra/bootstrap/unified.py
@@ -172,10 +172,10 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
 
             stt_service = init_nats_stt(nc)
             if stt_service is not None:
-                await stt_service._setup_heartbeat_subscription()
+                await stt_service.start()
             tts_service = init_nats_tts(nc)
             if tts_service is not None:
-                await tts_service._setup_heartbeat_subscription()
+                await tts_service.start()
             cli_pool_cfg = _load_cli_pool_config(raw_config)
             hub_cfg = _load_hub_config(raw_config)
             pool_cfg = _load_pool_config(raw_config)

--- a/src/lyra/bootstrap/unified.py
+++ b/src/lyra/bootstrap/unified.py
@@ -171,7 +171,11 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
             from lyra.bootstrap.voice_overlay import init_nats_stt, init_nats_tts
 
             stt_service = init_nats_stt(nc)
+            if stt_service is not None:
+                await stt_service._setup_heartbeat_subscription()
             tts_service = init_nats_tts(nc)
+            if tts_service is not None:
+                await tts_service._setup_heartbeat_subscription()
             cli_pool_cfg = _load_cli_pool_config(raw_config)
             hub_cfg = _load_hub_config(raw_config)
             pool_cfg = _load_pool_config(raw_config)

--- a/src/lyra/nats/adapter_base.py
+++ b/src/lyra/nats/adapter_base.py
@@ -105,7 +105,10 @@ class NatsAdapterBase(ABC):
         }
 
     async def _heartbeat_loop(self) -> None:
-        while self._nc and self._nc.is_connected:
+        while self._nc and not self._nc.is_closed:
+            if not self._nc.is_connected:
+                await asyncio.sleep(1.0)
+                continue
             try:
                 payload = self.heartbeat_payload()
                 await self._nc.publish(

--- a/src/lyra/nats/adapter_base.py
+++ b/src/lyra/nats/adapter_base.py
@@ -7,9 +7,12 @@ drain/close shutdown, and a ``health()`` introspection method.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+import os
 import signal
+import socket
 import time
 from abc import ABC, abstractmethod
 
@@ -27,6 +30,7 @@ class NatsAdapterBase(ABC):
     def __init__(  # noqa: PLR0913
         self, subject, queue_group, envelope_name, schema_version,
         timeout=30.0, drain_timeout=30.0,
+        *, heartbeat_subject: str | None = None, heartbeat_interval: float = 5.0,
     ):
         validate_nats_token(subject, kind="subject")
         validate_nats_token(queue_group, kind="queue_group")
@@ -39,12 +43,18 @@ class NatsAdapterBase(ABC):
         self._nc: NATS | None = None
         self._drop_count: dict[str, int] = {}
         self._started_at: float | None = None
+        self._heartbeat_subject = heartbeat_subject
+        self._heartbeat_interval = heartbeat_interval
+        self._worker_id = f"{queue_group}-{socket.gethostname()}-{os.getpid()}"
+        self._heartbeat_task: asyncio.Task | None = None
 
     async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
         nc = await nats_connect(nats_url)
         self._nc = nc
         await self._wait_ready()
         await nc.subscribe(self.subject, queue=self.queue_group, cb=self._dispatch)
+        if self._heartbeat_subject:
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         if stop is None:
             stop = asyncio.Event()
             loop = asyncio.get_running_loop()
@@ -80,7 +90,37 @@ class NatsAdapterBase(ABC):
             counter=self._drop_count,
         )
 
+    def heartbeat_payload(self) -> dict:
+        """Base heartbeat payload. Subclasses override to add service fields."""
+        uptime = time.monotonic() - self._started_at if self._started_at else 0.0
+        return {
+            "worker_id": self._worker_id,
+            "service": self.queue_group,
+            "host": socket.gethostname(),
+            "subject": self.subject,
+            "queue_group": self.queue_group,
+            "connected": self._nc.is_connected if self._nc else False,
+            "uptime_s": uptime,
+            "ts": time.time(),
+        }
+
+    async def _heartbeat_loop(self) -> None:
+        while self._nc and self._nc.is_connected:
+            try:
+                payload = self.heartbeat_payload()
+                await self._nc.publish(
+                    self._heartbeat_subject,  # type: ignore[arg-type]
+                    json.dumps(payload).encode(),
+                )
+            except Exception:
+                log.warning("adapter_base: heartbeat publish failed", exc_info=True)
+            await asyncio.sleep(self._heartbeat_interval)
+
     async def _shutdown(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._heartbeat_task
         if self._nc:
             await asyncio.wait_for(self._nc.drain(), timeout=self.drain_timeout)
             await self._nc.close()

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -82,9 +82,9 @@ class NatsSttClient:
         self._detection_fallback = language_fallback
         self._cb = NatsCircuitBreaker()
         self._worker_freshness: dict[str, float] = {}
-        self._hb_sub = None  # set by _setup_heartbeat_subscription
+        self._hb_sub = None  # set by start
 
-    async def _setup_heartbeat_subscription(self) -> None:
+    async def start(self) -> None:
         """Subscribe to heartbeat subject. Called once after nc is connected."""
         if self._hb_sub is None:
             self._hb_sub = await self._nc.subscribe(
@@ -100,6 +100,9 @@ class NatsSttClient:
 
     def _any_worker_alive(self) -> bool:
         now = time.monotonic()
+        self._worker_freshness = {
+            k: v for k, v in self._worker_freshness.items() if now - v <= _HB_TTL * 2
+        }
         return any(now - ts <= _HB_TTL for ts in self._worker_freshness.values())
 
     async def transcribe(self, path: Path | str) -> TranscriptionResult:

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -96,7 +96,7 @@ class NatsSttClient:
             data = json.loads(msg.data)
             self._worker_freshness[data["worker_id"]] = time.monotonic()
         except Exception:
-            pass
+            log.debug("stt_client: heartbeat parse error", exc_info=True)
 
     def _any_worker_alive(self) -> bool:
         now = time.monotonic()

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -94,7 +94,11 @@ class NatsSttClient:
     async def _on_heartbeat(self, msg) -> None:
         try:
             data = json.loads(msg.data)
-            self._worker_freshness[data["worker_id"]] = time.monotonic()
+            worker_id = data.get("worker_id")
+            if not worker_id:
+                log.warning("stt_client: heartbeat missing worker_id, ignoring")
+                return
+            self._worker_freshness[worker_id] = time.monotonic()
         except Exception:
             log.debug("stt_client: heartbeat parse error", exc_info=True)
 

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from uuid import uuid4
 
@@ -25,6 +26,9 @@ log = logging.getLogger(__name__)
 _STT_TIMEOUT_DEFAULT = 15.0
 _STT_TIMEOUT_MIN = 1.0
 _STT_TIMEOUT_MAX = 300.0
+
+_HB_SUBJECT = "lyra.voice.stt.heartbeat"
+_HB_TTL = 15.0
 
 
 def _parse_stt_timeout(timeout: float | None) -> float:
@@ -77,8 +81,32 @@ class NatsSttClient:
         self._detection_segments = language_detection_segments
         self._detection_fallback = language_fallback
         self._cb = NatsCircuitBreaker()
+        self._worker_freshness: dict[str, float] = {}
+        self._hb_sub = None  # set by _setup_heartbeat_subscription
+
+    async def _setup_heartbeat_subscription(self) -> None:
+        """Subscribe to heartbeat subject. Called once after nc is connected."""
+        if self._hb_sub is None:
+            self._hb_sub = await self._nc.subscribe(
+                _HB_SUBJECT, cb=self._on_heartbeat
+            )
+
+    async def _on_heartbeat(self, msg) -> None:
+        try:
+            data = json.loads(msg.data)
+            self._worker_freshness[data["worker_id"]] = time.monotonic()
+        except Exception:
+            pass
+
+    def _any_worker_alive(self) -> bool:
+        now = time.monotonic()
+        return any(now - ts <= _HB_TTL for ts in self._worker_freshness.values())
 
     async def transcribe(self, path: Path | str) -> TranscriptionResult:
+        if not self._any_worker_alive():
+            raise STTUnavailableError(
+                "STT: no live worker (heartbeat stale >15s)"
+            )
         if self._cb.is_open():
             raise STTUnavailableError(
                 "STT circuit open — adapter temporarily unavailable"

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -31,9 +31,9 @@ class NatsTtsClient:
         self._timeout = timeout
         self._cb = NatsCircuitBreaker()
         self._worker_freshness: dict[str, float] = {}
-        self._hb_sub = None  # set by _setup_heartbeat_subscription
+        self._hb_sub = None  # set by start
 
-    async def _setup_heartbeat_subscription(self) -> None:
+    async def start(self) -> None:
         """Subscribe to heartbeat subject. Called once after nc is connected."""
         if self._hb_sub is None:
             self._hb_sub = await self._nc.subscribe(
@@ -49,6 +49,9 @@ class NatsTtsClient:
 
     def _any_worker_alive(self) -> bool:
         now = time.monotonic()
+        self._worker_freshness = {
+            k: v for k, v in self._worker_freshness.items() if now - v <= _HB_TTL * 2
+        }
         return any(now - ts <= _HB_TTL for ts in self._worker_freshness.values())
 
     async def _send(self, payload: bytes, payload_kb: float) -> dict:

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -45,7 +45,7 @@ class NatsTtsClient:
             data = json.loads(msg.data)
             self._worker_freshness[data["worker_id"]] = time.monotonic()
         except Exception:
-            pass
+            log.debug("tts_client: heartbeat parse error", exc_info=True)
 
     def _any_worker_alive(self) -> bool:
         now = time.monotonic()

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -43,7 +43,11 @@ class NatsTtsClient:
     async def _on_heartbeat(self, msg) -> None:
         try:
             data = json.loads(msg.data)
-            self._worker_freshness[data["worker_id"]] = time.monotonic()
+            worker_id = data.get("worker_id")
+            if not worker_id:
+                log.warning("tts_client: heartbeat missing worker_id, ignoring")
+                return
+            self._worker_freshness[worker_id] = time.monotonic()
         except Exception:
             log.debug("tts_client: heartbeat parse error", exc_info=True)
 

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import time
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+_HB_SUBJECT = "lyra.voice.tts.heartbeat"
+_HB_TTL = 15.0
+
 
 class NatsTtsClient:
     SUBJECT = "lyra.voice.tts.request"
@@ -26,6 +30,26 @@ class NatsTtsClient:
         self._nc = nc
         self._timeout = timeout
         self._cb = NatsCircuitBreaker()
+        self._worker_freshness: dict[str, float] = {}
+        self._hb_sub = None  # set by _setup_heartbeat_subscription
+
+    async def _setup_heartbeat_subscription(self) -> None:
+        """Subscribe to heartbeat subject. Called once after nc is connected."""
+        if self._hb_sub is None:
+            self._hb_sub = await self._nc.subscribe(
+                _HB_SUBJECT, cb=self._on_heartbeat
+            )
+
+    async def _on_heartbeat(self, msg) -> None:
+        try:
+            data = json.loads(msg.data)
+            self._worker_freshness[data["worker_id"]] = time.monotonic()
+        except Exception:
+            pass
+
+    def _any_worker_alive(self) -> bool:
+        now = time.monotonic()
+        return any(now - ts <= _HB_TTL for ts in self._worker_freshness.values())
 
     async def _send(self, payload: bytes, payload_kb: float) -> dict:
         """Send payload to TTS subject and return parsed response dict."""
@@ -62,6 +86,10 @@ class NatsTtsClient:
         voice: str | None = None,
         fallback_language: str | None = None,
     ) -> SynthesisResult:
+        if not self._any_worker_alive():
+            raise TtsUnavailableError(
+                "TTS: no live worker (heartbeat stale >15s)"
+            )
         if self._cb.is_open():
             raise TtsUnavailableError(
                 "TTS circuit open — adapter temporarily unavailable"

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -201,3 +201,27 @@ class TestSttHeartbeatPayload:
             assert field in payload, (
                 f"heartbeat_payload() must include base field '{field}'"
             )
+
+    def test_vram_fallback_is_zero_when_pynvml_unavailable(self) -> None:
+        """_get_vram_info() returns (0, 0) when pynvml is unavailable."""
+        adapter = self._make_adapter()
+        with patch(
+            "lyra.bootstrap.stt_adapter_standalone.SttAdapterStandalone"
+            "._get_vram_info",
+            return_value=(0, 0),
+        ):
+            payload = adapter.heartbeat_payload()
+        assert payload["vram_used_mb"] == 0
+        assert payload["vram_total_mb"] == 0
+
+    def test_vram_values_from_pynvml_when_available(self) -> None:
+        """_get_vram_info() returns real MB values when pynvml succeeds."""
+        adapter = self._make_adapter()
+        with patch(
+            "lyra.bootstrap.stt_adapter_standalone.SttAdapterStandalone"
+            "._get_vram_info",
+            return_value=(4096, 10240),
+        ):
+            payload = adapter.heartbeat_payload()
+        assert payload["vram_used_mb"] == 4096
+        assert payload["vram_total_mb"] == 10240

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -115,3 +116,88 @@ def test_mime_to_ext_still_accessible() -> None:
     assert _mime_to_ext("audio/unknown") == ".ogg", (
         "_mime_to_ext with unknown MIME must fall back to '.ogg'"
     )
+
+
+class TestSttHeartbeatPayload:
+    """Behavioural tests for SttAdapterStandalone heartbeat opt-in (T9/T11)."""
+
+    def _make_adapter(self):
+        """Build SttAdapterStandalone with mocked STTService."""
+        from lyra.bootstrap.stt_adapter_standalone import SttAdapterStandalone
+        from lyra.stt import STTConfig
+
+        mock_cfg = STTConfig(model_size="large-v3-turbo")
+        mock_stt_service = MagicMock()
+
+        with (
+            patch(
+                "lyra.bootstrap.stt_adapter_standalone.load_stt_config",
+                return_value=mock_cfg,
+            ),
+            patch(
+                "lyra.bootstrap.stt_adapter_standalone.STTService",
+                return_value=mock_stt_service,
+            ),
+        ):
+            adapter = SttAdapterStandalone(raw_config={})
+
+        return adapter
+
+    def test_heartbeat_subject_is_stt_subject(self) -> None:
+        """SttAdapterStandalone passes heartbeat_subject='lyra.voice.stt.heartbeat'."""
+        adapter = self._make_adapter()
+        assert adapter._heartbeat_subject == "lyra.voice.stt.heartbeat", (
+            f"Expected heartbeat_subject='lyra.voice.stt.heartbeat', "
+            f"got {adapter._heartbeat_subject!r}"
+        )
+
+    def test_heartbeat_payload_includes_model_loaded(self) -> None:
+        """heartbeat_payload() includes 'model_loaded' key matching the model size."""
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert "model_loaded" in payload, (
+            "heartbeat_payload() must include 'model_loaded'"
+        )
+        assert payload["model_loaded"] == "large-v3-turbo", (
+            f"Expected model_loaded='large-v3-turbo', got {payload['model_loaded']!r}"
+        )
+
+    def test_heartbeat_payload_includes_vram_fields(self) -> None:
+        """heartbeat_payload() includes 'vram_used_mb' and 'vram_total_mb' as int."""
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert "vram_used_mb" in payload, (
+            "heartbeat_payload() must include 'vram_used_mb'"
+        )
+        assert "vram_total_mb" in payload, (
+            "heartbeat_payload() must include 'vram_total_mb'"
+        )
+        assert isinstance(payload["vram_used_mb"], int), (
+            f"vram_used_mb must be int, got {type(payload['vram_used_mb'])}"
+        )
+        assert isinstance(payload["vram_total_mb"], int), (
+            f"vram_total_mb must be int, got {type(payload['vram_total_mb'])}"
+        )
+
+    def test_heartbeat_payload_includes_active_requests(self) -> None:
+        """heartbeat_payload() includes 'active_requests' as int."""
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert "active_requests" in payload, (
+            "heartbeat_payload() must include 'active_requests'"
+        )
+        assert isinstance(payload["active_requests"], int), (
+            f"active_requests must be int, got {type(payload['active_requests'])}"
+        )
+        assert payload["active_requests"] == 0, (
+            f"active_requests must start at 0, got {payload['active_requests']}"
+        )
+
+    def test_heartbeat_payload_includes_base_fields(self) -> None:
+        """heartbeat_payload() includes base fields: worker_id, service, ts, etc."""
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        for field in ("worker_id", "service", "ts", "host", "subject", "queue_group"):
+            assert field in payload, (
+                f"heartbeat_payload() must include base field '{field}'"
+            )

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -148,3 +149,27 @@ class TestTtsHeartbeatPayload:
         payload = adapter.heartbeat_payload()
         for field in ("worker_id", "service", "host", "subject", "queue_group", "ts"):
             assert field in payload, f"Missing base field: {field}"
+
+    def test_vram_fallback_is_zero_when_pynvml_unavailable(self) -> None:
+        """_get_vram_info() returns (0, 0) when pynvml is unavailable."""
+        adapter = self._make_adapter()
+        with patch(
+            "lyra.bootstrap.tts_adapter_standalone.TtsAdapterStandalone"
+            "._get_vram_info",
+            return_value=(0, 0),
+        ):
+            payload = adapter.heartbeat_payload()
+        assert payload["vram_used_mb"] == 0
+        assert payload["vram_total_mb"] == 0
+
+    def test_vram_values_from_pynvml_when_available(self) -> None:
+        """_get_vram_info() returns real MB values when pynvml succeeds."""
+        adapter = self._make_adapter()
+        with patch(
+            "lyra.bootstrap.tts_adapter_standalone.TtsAdapterStandalone"
+            "._get_vram_info",
+            return_value=(4096, 10240),
+        ):
+            payload = adapter.heartbeat_payload()
+        assert payload["vram_used_mb"] == 4096
+        assert payload["vram_total_mb"] == 10240

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -93,3 +93,58 @@ def test_tts_adapter_standalone_class_exists() -> None:
     assert issubclass(TtsAdapterStandalone, NatsAdapterBase), (
         "TtsAdapterStandalone must subclass NatsAdapterBase"
     )
+
+
+class TestTtsHeartbeatPayload:
+    def _make_adapter(self):
+        """Build TtsAdapterStandalone with mocked TTSService to avoid loading engine."""
+        from unittest.mock import MagicMock, patch
+
+        from lyra.tts import TTSConfig
+
+        mock_tts_service = MagicMock()
+        mock_tts_service.engine_name = "chatterbox"
+
+        with (
+            patch(
+                "lyra.bootstrap.tts_adapter_standalone.load_tts_config",
+                return_value=TTSConfig(engine="chatterbox"),
+            ),
+            patch(
+                "lyra.bootstrap.tts_adapter_standalone.TTSService",
+                return_value=mock_tts_service,
+            ),
+        ):
+            from lyra.bootstrap.tts_adapter_standalone import TtsAdapterStandalone
+            adapter = TtsAdapterStandalone({})
+
+        return adapter
+
+    def test_heartbeat_subject_is_tts_subject(self):
+        adapter = self._make_adapter()
+        assert adapter._heartbeat_subject == "lyra.voice.tts.heartbeat"
+
+    def test_heartbeat_payload_includes_model_loaded(self):
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert "model_loaded" in payload
+
+    def test_heartbeat_payload_includes_vram_fields(self):
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert "vram_used_mb" in payload
+        assert "vram_total_mb" in payload
+        assert isinstance(payload["vram_used_mb"], int)
+        assert isinstance(payload["vram_total_mb"], int)
+
+    def test_heartbeat_payload_includes_active_requests(self):
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert "active_requests" in payload
+        assert payload["active_requests"] == 0
+
+    def test_heartbeat_payload_includes_base_fields(self):
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        for field in ("worker_id", "service", "host", "subject", "queue_group", "ts"):
+            assert field in payload, f"Missing base field: {field}"

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -831,6 +831,7 @@ class TestHeartbeatLoop:
         adapter = self._make_adapter(heartbeat_interval=0.01)
         mock_nc = AsyncMock()
         mock_nc.is_connected = True
+        mock_nc.is_closed = False
         adapter._nc = mock_nc
         adapter._started_at = time.monotonic()
 
@@ -838,8 +839,8 @@ class TestHeartbeatLoop:
 
         async def _fake_publish(subject: str, data: bytes) -> None:
             publish_calls.append((subject, data))
-            # Disconnect after first publish to stop the loop
-            mock_nc.is_connected = False
+            # Close after first publish to stop the loop
+            mock_nc.is_closed = True
 
         mock_nc.publish = AsyncMock(side_effect=_fake_publish)
 
@@ -862,6 +863,7 @@ class TestHeartbeatLoop:
         adapter = self._make_adapter(heartbeat_interval=0.01)
         mock_nc = AsyncMock()
         mock_nc.is_connected = True
+        mock_nc.is_closed = False
         adapter._nc = mock_nc
         adapter._started_at = time.monotonic()
 
@@ -872,8 +874,8 @@ class TestHeartbeatLoop:
             call_count += 1
             if call_count == 1:
                 raise RuntimeError("publish failed")
-            # Disconnect after second call so loop exits
-            mock_nc.is_connected = False
+            # Close after second call so loop exits
+            mock_nc.is_closed = True
 
         mock_nc.publish = AsyncMock(side_effect=_failing_publish)
 
@@ -898,12 +900,13 @@ class TestHeartbeatLoop:
         # Assert — we just check it returned (no infinite loop / no error)
 
     @pytest.mark.asyncio
-    async def test_loop_exits_when_nc_disconnected(self) -> None:
-        """_heartbeat_loop exits when _nc.is_connected is False."""
+    async def test_loop_exits_when_nc_closed(self) -> None:
+        """_heartbeat_loop exits when _nc.is_closed is True."""
         # Arrange
         adapter = self._make_adapter()
         mock_nc = AsyncMock()
-        mock_nc.is_connected = False  # already disconnected
+        mock_nc.is_connected = False
+        mock_nc.is_closed = True  # closed connection terminates the loop
         adapter._nc = mock_nc
 
         # Act — must return immediately without publishing

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -915,6 +915,35 @@ class TestHeartbeatLoop:
         # Assert
         mock_nc.publish.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_loop_sleeps_on_disconnect_then_resumes(self) -> None:
+        """Loop skips publish while disconnected; resumes when reconnected."""
+        # Arrange
+        adapter = self._make_adapter(heartbeat_interval=0.01)
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = False  # start disconnected
+        mock_nc.is_closed = False
+        adapter._nc = mock_nc
+        adapter._started_at = time.monotonic()
+
+        publish_calls: list = []
+
+        async def _fake_publish(subject: str, data: bytes) -> None:
+            publish_calls.append(subject)
+            mock_nc.is_closed = True  # close after first publish to stop the loop
+
+        mock_nc.publish = AsyncMock(side_effect=_fake_publish)
+
+        async def _reconnect_after_sleep() -> None:
+            await asyncio.sleep(0.05)
+            mock_nc.is_connected = True
+
+        # Act — reconnect happens after one sleep cycle
+        await asyncio.gather(adapter._heartbeat_loop(), _reconnect_after_sleep())
+
+        # Assert — loop published once after reconnect, not while disconnected
+        assert len(publish_calls) == 1
+
 
 # ---------------------------------------------------------------------------
 # TestHeartbeatShutdown

--- a/tests/nats/test_adapter_base.py
+++ b/tests/nats/test_adapter_base.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import json
 import signal
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -732,3 +733,339 @@ class TestDispatch:
 
         # Assert
         adapter.handle.assert_awaited_once_with(msg, raw_payload)
+
+
+# ---------------------------------------------------------------------------
+# TestHeartbeatConstruction
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatConstruction:
+    """Heartbeat kwargs are stored; _worker_id is formatted correctly."""
+
+    def _make_adapter(self, **kwargs) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+            **kwargs,
+        )
+
+    def test_heartbeat_subject_stored(self) -> None:
+        """heartbeat_subject kwarg is stored on the adapter."""
+        # Arrange / Act
+        adapter = self._make_adapter(heartbeat_subject="lyra.voice.stt.heartbeat")
+
+        # Assert
+        assert adapter._heartbeat_subject == "lyra.voice.stt.heartbeat"
+
+    def test_heartbeat_interval_stored(self) -> None:
+        """heartbeat_interval kwarg is stored (default 5.0)."""
+        # Arrange / Act
+        adapter_default = self._make_adapter()
+        adapter_custom = self._make_adapter(heartbeat_interval=10.0)
+
+        # Assert
+        assert adapter_default._heartbeat_interval == 5.0
+        assert adapter_custom._heartbeat_interval == 10.0
+
+    def test_worker_id_format(self) -> None:
+        """_worker_id is formatted as '{queue_group}-{hostname}-{pid}'."""
+        import os
+        import socket
+
+        # Arrange / Act
+        adapter = self._make_adapter()
+
+        # Assert
+        expected = f"telegram_workers-{socket.gethostname()}-{os.getpid()}"
+        assert adapter._worker_id == expected
+
+    def test_no_heartbeat_subject_stores_none(self) -> None:
+        """heartbeat_subject=None (default) stores None, no task attr."""
+        # Arrange / Act
+        adapter = self._make_adapter()
+
+        # Assert
+        assert adapter._heartbeat_subject is None
+        assert adapter._heartbeat_task is None
+
+    def test_existing_callers_unaffected(self) -> None:
+        """NatsAdapterBase subclass with no heartbeat kwargs still works."""
+        # Arrange / Act — no heartbeat kwargs, must not raise
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+
+        # Assert — basic fields are still intact
+        assert adapter.subject == "lyra.inbound.telegram.main"
+        assert adapter._heartbeat_subject is None
+
+
+# ---------------------------------------------------------------------------
+# TestHeartbeatLoop
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatLoop:
+    """_heartbeat_loop publishes, handles errors, and exits on disconnected state."""
+
+    def _make_adapter(self, **kwargs) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+            heartbeat_subject="lyra.voice.stt.heartbeat",
+            **kwargs,
+        )
+
+    @pytest.mark.asyncio
+    async def test_publishes_payload_at_interval(self) -> None:
+        """_heartbeat_loop publishes heartbeat_payload() JSON to heartbeat_subject."""
+        # Arrange
+        adapter = self._make_adapter(heartbeat_interval=0.01)
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        adapter._nc = mock_nc
+        adapter._started_at = time.monotonic()
+
+        publish_calls: list[tuple] = []
+
+        async def _fake_publish(subject: str, data: bytes) -> None:
+            publish_calls.append((subject, data))
+            # Disconnect after first publish to stop the loop
+            mock_nc.is_connected = False
+
+        mock_nc.publish = AsyncMock(side_effect=_fake_publish)
+
+        # Act
+        await adapter._heartbeat_loop()
+
+        # Assert
+        assert len(publish_calls) == 1
+        subject, data = publish_calls[0]
+        assert subject == "lyra.voice.stt.heartbeat"
+        payload = json.loads(data)
+        assert "worker_id" in payload
+        assert "service" in payload
+        assert "ts" in payload
+
+    @pytest.mark.asyncio
+    async def test_publish_error_logs_warning_and_continues(self) -> None:
+        """Publish error logs a warning and loop continues (no crash)."""
+        # Arrange
+        adapter = self._make_adapter(heartbeat_interval=0.01)
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        adapter._nc = mock_nc
+        adapter._started_at = time.monotonic()
+
+        call_count = 0
+
+        async def _failing_publish(subject: str, data: bytes) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("publish failed")
+            # Disconnect after second call so loop exits
+            mock_nc.is_connected = False
+
+        mock_nc.publish = AsyncMock(side_effect=_failing_publish)
+
+        # Act — must not raise despite publish error on first call
+        with patch("lyra.nats.adapter_base.log") as mock_log:
+            await adapter._heartbeat_loop()
+
+        # Assert — warning logged, loop continued to second call
+        mock_log.warning.assert_called()
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_loop_exits_when_nc_none(self) -> None:
+        """_heartbeat_loop exits immediately when _nc is None."""
+        # Arrange
+        adapter = self._make_adapter()
+        adapter._nc = None  # no connection
+
+        # Act — must return immediately without error
+        await adapter._heartbeat_loop()
+
+        # Assert — we just check it returned (no infinite loop / no error)
+
+    @pytest.mark.asyncio
+    async def test_loop_exits_when_nc_disconnected(self) -> None:
+        """_heartbeat_loop exits when _nc.is_connected is False."""
+        # Arrange
+        adapter = self._make_adapter()
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = False  # already disconnected
+        adapter._nc = mock_nc
+
+        # Act — must return immediately without publishing
+        await adapter._heartbeat_loop()
+
+        # Assert
+        mock_nc.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestHeartbeatShutdown
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatShutdown:
+    """_shutdown() properly cancels the heartbeat task before draining."""
+
+    def _make_adapter(self, **kwargs) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+            heartbeat_subject="lyra.voice.stt.heartbeat",
+            **kwargs,
+        )
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_task_cancelled_before_drain(self) -> None:
+        """_shutdown() cancels _heartbeat_task before calling nc.drain()."""
+        # Arrange
+        adapter = self._make_adapter()
+        mock_nc = AsyncMock()
+        drain_called_after_cancel = []
+
+        async def _tracking_drain() -> None:
+            drain_called_after_cancel.append(task_cancelled)
+
+        mock_nc.drain = AsyncMock(side_effect=_tracking_drain)
+        mock_nc.close = AsyncMock()
+        adapter._nc = mock_nc
+
+        # Create a real task that sleeps forever (will be cancelled by _shutdown)
+        async def _forever() -> None:
+            await asyncio.sleep(9999)
+
+        task = asyncio.create_task(_forever())
+        adapter._heartbeat_task = task
+
+        task_cancelled = False
+
+        # Patch task.cancel to track cancellation order
+        original_cancel = task.cancel
+
+        def _tracking_cancel(*args, **kwargs):
+            nonlocal task_cancelled
+            task_cancelled = True
+            return original_cancel(*args, **kwargs)
+
+        task.cancel = _tracking_cancel  # type: ignore[method-assign]
+
+        # Act
+        await adapter._shutdown()
+
+        # Assert — drain was called after task was cancelled
+        assert drain_called_after_cancel == [True]
+
+    @pytest.mark.asyncio
+    async def test_no_crash_when_no_heartbeat_task(self) -> None:
+        """_shutdown() works normally when no heartbeat task was created."""
+        # Arrange
+        adapter = _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+        )
+        mock_nc = AsyncMock()
+        adapter._nc = mock_nc
+
+        # Act / Assert — no error raised
+        await adapter._shutdown()
+        mock_nc.drain.assert_awaited_once()
+        mock_nc.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# TestHeartbeatRun
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatRun:
+    """run() creates / skips the heartbeat task based on heartbeat_subject."""
+
+    def _make_adapter(self, **kwargs) -> _ConcreteAdapter:
+        return _ConcreteAdapter(
+            subject="lyra.inbound.telegram.main",
+            queue_group="telegram_workers",
+            envelope_name="InboundMessage",
+            schema_version=1,
+            **kwargs,
+        )
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_task_created_when_subject_set(self) -> None:
+        """run() creates _heartbeat_task when heartbeat_subject is set."""
+        # Arrange
+        adapter = self._make_adapter(heartbeat_subject="lyra.voice.stt.heartbeat")
+        stop = asyncio.Event()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        # Set stop immediately after heartbeat task would be created
+        async def _set_stop_soon() -> None:
+            await asyncio.sleep(0.01)
+            stop.set()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            asyncio.create_task(_set_stop_soon())
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert
+        assert adapter._heartbeat_task is not None
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_task_when_subject_none(self) -> None:
+        """run() does NOT create _heartbeat_task when heartbeat_subject is None."""
+        # Arrange
+        adapter = self._make_adapter()  # no heartbeat_subject
+        stop = asyncio.Event()
+        stop.set()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.subscribe = AsyncMock()
+        mock_nc.drain = AsyncMock()
+        mock_nc.close = AsyncMock()
+
+        with (
+            patch(
+                "lyra.nats.adapter_base.nats_connect",
+                new=AsyncMock(return_value=mock_nc),
+            ),
+            patch(
+                "lyra.nats.adapter_base.wait_for_hub",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            await adapter.run("nats://localhost:4222", stop=stop)
+
+        # Assert
+        assert adapter._heartbeat_task is None

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -174,6 +174,29 @@ class TestCircuitBreaker:
         assert client._cb._failures == 0
 
 
+class TestSttClientStart:
+    """Tests for NatsSttClient.start() lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_start_subscribes_to_heartbeat_subject(self) -> None:
+        """start() subscribes to the STT heartbeat subject."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        await client.start()
+        mock_nc.subscribe.assert_awaited_once()
+        call_args = mock_nc.subscribe.call_args
+        assert call_args[0][0] == "lyra.voice.stt.heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self) -> None:
+        """start() called twice only subscribes once."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        await client.start()
+        await client.start()
+        assert mock_nc.subscribe.await_count == 1
+
+
 class TestSttClientFreshness:
     """Tests for freshness tracking gate in NatsSttClient."""
 

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -82,12 +82,18 @@ class TestTimeoutResolution:
         assert client._timeout == 15.0
 
 
+def _inject_fresh_worker(client: NatsSttClient) -> None:
+    """Seed _worker_freshness with a fresh timestamp so freshness gate passes."""
+    client._worker_freshness["test-worker"] = time.monotonic()
+
+
 class TestCircuitBreaker:
     @pytest.mark.asyncio
     async def test_cb_open_blocks_call(self, tmp_path: Path) -> None:
         # Arrange — circuit manually forced open
         mock_nc = AsyncMock()
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         client._cb._open_until = time.monotonic() + 100.0
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"")
@@ -102,6 +108,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=TimeoutError())
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"\x00" * 64)
         # Act
@@ -116,6 +123,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=Exception("NATS error"))
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"\x00" * 64)
         # Act
@@ -132,6 +140,7 @@ class TestCircuitBreaker:
             side_effect=Exception("NATS: max_payload exceeded")
         )
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"\x00" * 64)
         # Act
@@ -154,6 +163,7 @@ class TestCircuitBreaker:
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         client._cb._failures = 2
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"\x00" * 64)
@@ -162,6 +172,105 @@ class TestCircuitBreaker:
         # Assert
         assert result.text == "hello"
         assert client._cb._failures == 0
+
+
+class TestSttClientFreshness:
+    """Tests for freshness tracking gate in NatsSttClient."""
+
+    @pytest.mark.asyncio
+    async def test_no_workers_ever_raises_unavailable(self, tmp_path: Path) -> None:
+        """transcribe() raises STTUnavailableError when _worker_freshness is empty."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        with pytest.raises(STTUnavailableError, match="no live worker"):
+            await client.transcribe(wav_file)
+        mock_nc.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_worker_raises_unavailable(self, tmp_path: Path) -> None:
+        """transcribe() raises STTUnavailableError when last heartbeat was >15s ago."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 20.0
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        with pytest.raises(STTUnavailableError, match="no live worker"):
+            await client.transcribe(wav_file)
+        mock_nc.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fresh_worker_proceeds_to_request(self, tmp_path: Path) -> None:
+        """transcribe() proceeds past freshness gate when a worker is fresh (<15s)."""
+        mock_nc = AsyncMock()
+        success_payload = json.dumps({
+            "ok": True,
+            "text": "hello world",
+            "language": "en",
+            "duration_seconds": 1.0,
+        }).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = success_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 5.0
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        result = await client.transcribe(wav_file)
+        assert result.text == "hello world"
+        mock_nc.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_freshness_gate_before_circuit_breaker(self, tmp_path: Path) -> None:
+        """STTUnavailableError from freshness gate does NOT trip circuit breaker."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        # _worker_freshness is empty — freshness gate fires first
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        with pytest.raises(STTUnavailableError, match="no live worker"):
+            await client.transcribe(wav_file)
+        assert client._cb._failures == 0
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_resumes_reenables_worker(self, tmp_path: Path) -> None:
+        """After stale, a new heartbeat re-enables the worker immediately."""
+        mock_nc = AsyncMock()
+        success_payload = json.dumps({
+            "ok": True,
+            "text": "resumed",
+            "language": "en",
+            "duration_seconds": 1.0,
+        }).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = success_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        # First: stale
+        client._worker_freshness["worker-1"] = time.monotonic() - 20.0
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+        with pytest.raises(STTUnavailableError, match="no live worker"):
+            await client.transcribe(wav_file)
+        # Simulate fresh heartbeat arrives
+        client._worker_freshness["worker-1"] = time.monotonic()
+        result = await client.transcribe(wav_file)
+        assert result.text == "resumed"
+
+    def test_any_worker_alive_true_within_ttl(self) -> None:
+        """_any_worker_alive() returns True when a worker has a recent timestamp."""
+        mock_nc = MagicMock()
+        client = NatsSttClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 5.0
+        assert client._any_worker_alive() is True
+
+    def test_any_worker_alive_false_when_stale(self) -> None:
+        """_any_worker_alive() returns False when all workers are >15s stale."""
+        mock_nc = MagicMock()
+        client = NatsSttClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 20.0
+        assert client._any_worker_alive() is False
 
 
 class TestTranscribeResponseParsing:
@@ -181,6 +290,7 @@ class TestTranscribeResponseParsing:
         fake_reply.data = error_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"\x00" * 64)
         # Act / Assert
@@ -202,6 +312,7 @@ class TestTranscribeResponseParsing:
         fake_reply.data = noise_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         wav_file = tmp_path / "test.wav"
         wav_file.write_bytes(b"\x00" * 64)
         # Act / Assert

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -272,6 +272,24 @@ class TestSttClientFreshness:
         client._worker_freshness["worker-1"] = time.monotonic() - 20.0
         assert client._any_worker_alive() is False
 
+    def test_any_worker_alive_true_with_mixed_freshness(self) -> None:
+        """_any_worker_alive() returns True when at least one worker is fresh."""
+        mock_nc = MagicMock()
+        client = NatsSttClient(nc=mock_nc)
+        client._worker_freshness["stale-worker"] = time.monotonic() - 20.0
+        client._worker_freshness["fresh-worker"] = time.monotonic() - 5.0
+        assert client._any_worker_alive() is True
+
+    def test_stale_entries_pruned_in_any_worker_alive(self) -> None:
+        """_any_worker_alive() evicts entries older than TTL*2."""
+        mock_nc = MagicMock()
+        client = NatsSttClient(nc=mock_nc)
+        client._worker_freshness["ancient"] = time.monotonic() - 35.0  # > 15*2
+        client._worker_freshness["fresh"] = time.monotonic() - 5.0
+        client._any_worker_alive()
+        assert "ancient" not in client._worker_freshness
+        assert "fresh" in client._worker_freshness
+
 
 class TestTranscribeResponseParsing:
     """Tests for NATS response parsing in NatsSttClient.transcribe().

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -139,6 +139,29 @@ class TestCircuitBreaker:
         assert client._cb._failures == 0
 
 
+class TestTtsClientStart:
+    """Tests for NatsTtsClient.start() lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_start_subscribes_to_heartbeat_subject(self) -> None:
+        """start() subscribes to the TTS heartbeat subject."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        await client.start()
+        mock_nc.subscribe.assert_awaited_once()
+        call_args = mock_nc.subscribe.call_args
+        assert call_args[0][0] == "lyra.voice.tts.heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self) -> None:
+        """start() called twice only subscribes once."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        await client.start()
+        await client.start()
+        assert mock_nc.subscribe.await_count == 1
+
+
 class TestTtsClientFreshness:
     """Tests for freshness tracking gate in NatsTtsClient."""
 

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -222,3 +222,21 @@ class TestTtsClientFreshness:
         client = NatsTtsClient(nc=mock_nc)
         client._worker_freshness["worker-1"] = time.monotonic() - 20.0
         assert client._any_worker_alive() is False
+
+    def test_any_worker_alive_true_with_mixed_freshness(self) -> None:
+        """_any_worker_alive() returns True when at least one worker is fresh."""
+        mock_nc = MagicMock()
+        client = NatsTtsClient(nc=mock_nc)
+        client._worker_freshness["stale-worker"] = time.monotonic() - 20.0
+        client._worker_freshness["fresh-worker"] = time.monotonic() - 5.0
+        assert client._any_worker_alive() is True
+
+    def test_stale_entries_pruned_in_any_worker_alive(self) -> None:
+        """_any_worker_alive() evicts entries older than TTL*2."""
+        mock_nc = MagicMock()
+        client = NatsTtsClient(nc=mock_nc)
+        client._worker_freshness["ancient"] = time.monotonic() - 35.0  # > 15*2
+        client._worker_freshness["fresh"] = time.monotonic() - 5.0
+        client._any_worker_alive()
+        assert "ancient" not in client._worker_freshness
+        assert "fresh" in client._worker_freshness

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -14,12 +14,18 @@ from lyra.nats.nats_tts_client import _TTS_CONFIG_FIELDS, NatsTtsClient
 from lyra.tts import TtsUnavailableError
 
 
+def _inject_fresh_worker(client: NatsTtsClient) -> None:
+    """Seed _worker_freshness with a fresh timestamp so freshness gate passes."""
+    client._worker_freshness["test-worker"] = time.monotonic()
+
+
 class TestCircuitBreaker:
     @pytest.mark.asyncio
     async def test_cb_open_blocks_synthesize(self) -> None:
         # Arrange — circuit manually forced open
         mock_nc = AsyncMock()
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         client._cb._open_until = time.monotonic() + 100.0
         # Act / Assert
         with pytest.raises(TtsUnavailableError, match="circuit open"):
@@ -32,6 +38,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=TimeoutError())
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         # Act
         with pytest.raises(TtsUnavailableError):
             await client.synthesize("hello")
@@ -44,6 +51,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=Exception("NATS error"))
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         # Act
         with pytest.raises(TtsUnavailableError):
             await client.synthesize("hello")
@@ -58,6 +66,7 @@ class TestCircuitBreaker:
             side_effect=Exception("NATS: max_payload exceeded")
         )
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         # Act
         with pytest.raises(TtsUnavailableError, match="payload too large"):
             await client.synthesize("hello")
@@ -73,6 +82,7 @@ class TestCircuitBreaker:
         fake_reply.data = error_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         # Act / Assert
         with pytest.raises(TtsUnavailableError, match="synthesis failed"):
             await client.synthesize("hello")
@@ -91,6 +101,7 @@ class TestCircuitBreaker:
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
 
         agent_tts = AgentTTSConfig(engine="chatterbox", speed="1.2")
         # Act
@@ -119,9 +130,95 @@ class TestCircuitBreaker:
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
         client._cb._failures = 2
         # Act
         result = await client.synthesize("hello")
         # Assert
         assert result.audio_bytes == b"fake"
         assert client._cb._failures == 0
+
+
+class TestTtsClientFreshness:
+    """Tests for freshness tracking gate in NatsTtsClient."""
+
+    @pytest.mark.asyncio
+    async def test_no_workers_ever_raises_unavailable(self) -> None:
+        """synthesize() raises TtsUnavailableError when _worker_freshness is empty."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        with pytest.raises(TtsUnavailableError, match="no live worker"):
+            await client.synthesize("hello")
+        mock_nc.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_worker_raises_unavailable(self) -> None:
+        """synthesize() raises TtsUnavailableError when last heartbeat was >15s ago."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 20.0
+        with pytest.raises(TtsUnavailableError, match="no live worker"):
+            await client.synthesize("hello")
+        mock_nc.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fresh_worker_proceeds_to_request(self) -> None:
+        """synthesize() proceeds past freshness gate when a worker is fresh (<15s)."""
+        mock_nc = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.data = json.dumps({
+            "ok": True,
+            "audio_b64": base64.b64encode(b"audio").decode(),
+            "mime_type": "audio/ogg",
+        }).encode()
+        mock_nc.request = AsyncMock(return_value=mock_response)
+        client = NatsTtsClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 5.0
+        result = await client.synthesize("hello")
+        assert result.audio_bytes == b"audio"
+        mock_nc.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_freshness_gate_before_circuit_breaker(self) -> None:
+        """TtsUnavailableError from freshness gate does NOT trip circuit breaker."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        # _worker_freshness is empty — freshness gate fires first
+        with pytest.raises(TtsUnavailableError, match="no live worker"):
+            await client.synthesize("hello")
+        assert client._cb._failures == 0
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_resumes_reenables_worker(self) -> None:
+        """After stale, a new heartbeat re-enables the worker immediately."""
+        mock_nc = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.data = json.dumps({
+            "ok": True,
+            "audio_b64": base64.b64encode(b"audio").decode(),
+            "mime_type": "audio/ogg",
+        }).encode()
+        mock_nc.request = AsyncMock(return_value=mock_response)
+        client = NatsTtsClient(nc=mock_nc)
+        # First: stale
+        client._worker_freshness["worker-1"] = time.monotonic() - 20.0
+        with pytest.raises(TtsUnavailableError, match="no live worker"):
+            await client.synthesize("hello")
+        # Simulate fresh heartbeat arrives
+        client._worker_freshness["worker-1"] = time.monotonic()
+        result = await client.synthesize("hello")
+        assert result.audio_bytes == b"audio"
+
+    def test_any_worker_alive_true_within_ttl(self) -> None:
+        """_any_worker_alive() returns True when a worker has a recent timestamp."""
+        mock_nc = MagicMock()
+        client = NatsTtsClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 5.0
+        assert client._any_worker_alive() is True
+
+    def test_any_worker_alive_false_when_stale(self) -> None:
+        """_any_worker_alive() returns False when all workers are >15s stale."""
+        mock_nc = MagicMock()
+        client = NatsTtsClient(nc=mock_nc)
+        client._worker_freshness["worker-1"] = time.monotonic() - 20.0
+        assert client._any_worker_alive() is False


### PR DESCRIPTION
## Summary

- Add opt-in heartbeat loop to `NatsAdapterBase` — adapters pass `heartbeat_subject` to broadcast liveness every 5s; base class handles task lifecycle (create after subscribe, cancel before drain)
- Wire `SttAdapterStandalone` and `TtsAdapterStandalone` to opt in with GPU-enriched payloads (`model_loaded`, `vram_used_mb`, `vram_total_mb`, `active_requests`)
- Add freshness tracking to `NatsSttClient` / `NatsTtsClient` — subscribe to heartbeat subjects, maintain `_worker_freshness` dict, gate `transcribe()` / `synthesize()` before the circuit breaker (no live worker in 15s → immediate `Unavailable`, no CB state change)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #602: feat(nats): SDK heartbeat in NatsAdapterBase + voice adapter opt-in | Open |
| Analysis | — | Absent (F-lite, skipped) |
| Spec | [602-nats-sdk-heartbeat-spec.mdx](artifacts/specs/602-nats-sdk-heartbeat-spec.mdx) | Present |
| Plan | [602-nats-sdk-heartbeat-plan.mdx](artifacts/plans/602-nats-sdk-heartbeat-plan.mdx) | Present |
| Implementation | 1 commit on `feat/602-nats-sdk-heartbeat` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (104 new / 2655 total) | Passed |

## Test Plan

- [ ] `uv run pytest tests/nats/test_adapter_base.py -k heartbeat -v` — S1 heartbeat SDK tests
- [ ] `uv run pytest tests/bootstrap/test_stt_adapter_standalone.py tests/bootstrap/test_tts_adapter_standalone.py -k heartbeat -v` — S2 voice adapter payload tests
- [ ] `uv run pytest tests/nats/test_nats_stt_client.py tests/nats/test_nats_tts_client.py -k freshness -v` — S3 hub client freshness tests
- [ ] Verify `NatsAdapterBase` subclass with no `heartbeat_subject` still works (backward compat)
- [ ] On production: confirm `lyra.voice.stt.heartbeat` / `lyra.voice.tts.heartbeat` messages appear in NATS after adapter start

Closes #602

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`