### PR TITLE
fix(hub): remove dispatch_response from TTS error handler (#621)

### DIFF
--- a/src/lyra/config/messages.toml
+++ b/src/lyra/config/messages.toml
@@ -9,8 +9,6 @@ stt_noise         = "I couldn't make out your voice message, please try again."
 stt_unsupported   = "Voice messages are not supported — STT is not configured."
 stt_unavailable   = "Voice messages are temporarily unavailable. Please try again later or send a text message."
 stt_failed        = "Sorry, I couldn't transcribe your voice message."
-tts_unavailable   = "Voice output is temporarily unavailable."
-
 [adapters.telegram.en]
 backpressure_ack    = "Processing your request\u2026"
 circuit_open_ack    = "I'm temporarily overloaded, please try again in a moment."
@@ -34,8 +32,6 @@ stt_noise         = "Je n'ai pas pu comprendre ton message vocal, réessaie."
 stt_unsupported   = "Les messages vocaux ne sont pas pris en charge — STT non configuré."
 stt_unavailable   = "Les messages vocaux sont temporairement indisponibles. Réessaie plus tard ou envoie un message texte."
 stt_failed        = "Désolé, je n'ai pas pu transcrire ton message vocal."
-tts_unavailable   = "La synthèse vocale est temporairement indisponible."
-
 [adapters.telegram.fr]
 backpressure_ack    = "Traitement de ta requête\u2026"
 circuit_open_ack    = "Je suis temporairement surchargé, réessaie dans un instant."

--- a/src/lyra/core/tts_dispatch.py
+++ b/src/lyra/core/tts_dispatch.py
@@ -14,6 +14,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from ..tts import TtsUnavailableError
 from .message import (
     InboundMessage,
     OutboundAudio,
@@ -136,6 +137,9 @@ class AudioPipeline:
         ``agent_tts`` carries the per-agent TTS config (engine, voice, etc.).
         ``fallback_language`` is the agent-level language default (#343).
         Errors are logged and swallowed — audio failure must not crash the hub.
+        Callers always dispatch text before invoking this method; the error
+        handler therefore logs and returns only — never calls dispatch_response —
+        to avoid the reentrancy loop documented in #621.
         """
         assert self._hub._tts is not None  # caller guarantees this
         try:
@@ -204,8 +208,6 @@ class AudioPipeline:
                 msg.id,
             )
         except Exception as _tts_exc:
-            from ..tts import TtsUnavailableError
-
             # Text response was already dispatched by the caller before TTS was
             # attempted — the user has the content.  Do not call dispatch_response
             # here: doing so creates a reentrancy path that causes an infinite

--- a/src/lyra/core/tts_dispatch.py
+++ b/src/lyra/core/tts_dispatch.py
@@ -10,7 +10,6 @@ Slice 1 and replaced by ``MessagePipeline._run_stt_stage``.
 
 from __future__ import annotations
 
-import dataclasses
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -18,7 +17,6 @@ from typing import TYPE_CHECKING
 from .message import (
     InboundMessage,
     OutboundAudio,
-    Response,
 )
 
 if TYPE_CHECKING:
@@ -209,14 +207,9 @@ class AudioPipeline:
             from ..tts import TtsUnavailableError
 
             # Text response was already dispatched by the caller before TTS was
-            # attempted — only send a brief notification so the user knows voice
-            # output failed.  Override modality to "text" to avoid an infinite
-            # loop if dispatch_response itself triggers TTS.
-            _notif = (
-                self._hub.get_message("tts_unavailable")
-                or "Voice output is temporarily unavailable."
-            )
-            _notify_msg = dataclasses.replace(msg, modality="text")
+            # attempted — the user has the content.  Do not call dispatch_response
+            # here: doing so creates a reentrancy path that causes an infinite
+            # retry loop in production (#621).  Log and return.
             if isinstance(_tts_exc, TtsUnavailableError):
                 log.warning(
                     "TTS adapter unavailable for msg id=%s",
@@ -227,4 +220,3 @@ class AudioPipeline:
                     "TTS synthesis failed (msg id=%s)",
                     msg.id,
                 )
-            await self._hub.dispatch_response(_notify_msg, Response(content=_notif))

--- a/tests/core/test_audio_pipeline_tts.py
+++ b/tests/core/test_audio_pipeline_tts.py
@@ -310,15 +310,19 @@ class TestDispatchResponseAgentTTSE2E:
 
 
 class TestTtsUnavailableFallback:
-    """When TTS fails, a tts_unavailable notification is dispatched."""
+    """When TTS fails, only a log is emitted — no secondary dispatch_response call.
+
+    The text response is already delivered by the caller before TTS is attempted,
+    so calling dispatch_response again creates a reentrancy path and causes
+    the infinite loop observed in production (#621).
+    """
 
     @pytest.mark.asyncio
-    async def test_tts_unavailable_sends_notification(self) -> None:
-        """synthesize_and_dispatch_audio: TtsUnavailableError → notification.
+    async def test_tts_unavailable_no_dispatch_response(self) -> None:
+        """TtsUnavailableError → log only, dispatch_response NOT called.
 
-        The text response was already sent by the caller before TTS was
-        attempted, so only a brief notification is sent.  Modality is
-        overridden to 'text' to prevent re-triggering TTS.
+        Text was already sent by the caller. Sending a secondary notification
+        creates the infinite retry loop (#621). Fix: log and return.
         """
         from lyra.tts import TtsUnavailableError
 
@@ -346,19 +350,41 @@ class TestTtsUnavailableFallback:
 
         await hub._audio_pipeline.synthesize_and_dispatch_audio(msg, "Hello from Lyra")
 
-        # Audio must NOT be dispatched
+        # Audio must NOT be dispatched (synthesis failed)
         hub.dispatch_audio.assert_not_awaited()
+        # dispatch_response must NOT be called (#621 — text already sent before TTS)
+        hub.dispatch_response.assert_not_awaited()
 
-        # Notification MUST be dispatched
-        hub.dispatch_response.assert_awaited_once()
-        call_args = hub.dispatch_response.call_args
-        dispatched_msg = call_args.args[0]
-        dispatched_response = call_args.args[1]
-        # modality overridden to 'text' to break the TTS re-entry loop
-        assert dispatched_msg.modality == "text"
-        # routing identity must be preserved (dataclasses.replace, not a fresh message)
-        assert dispatched_msg.platform == msg.platform
-        assert dispatched_msg.scope_id == msg.scope_id
-        assert dispatched_msg.bot_id == msg.bot_id
-        # notification text (no msg_manager configured → English fallback)
-        assert "unavailable" in dispatched_response.content.lower()
+    @pytest.mark.asyncio
+    async def test_tts_generic_exception_no_dispatch_response(self) -> None:
+        """Generic TTS exception → log only, dispatch_response NOT called.
+
+        Same contract as TtsUnavailableError: text was already delivered,
+        no secondary dispatch should occur regardless of exception type.
+        """
+        mock_tts = MagicMock()
+        mock_tts.synthesize = AsyncMock(side_effect=RuntimeError("synthesis crash"))
+
+        hub = Hub(tts=mock_tts)
+        hub.dispatch_audio = AsyncMock()
+        hub.dispatch_response = AsyncMock()
+
+        msg = InboundMessage(
+            id="msg-fallback-2",
+            platform="telegram",
+            bot_id="main",
+            scope_id="chat:99",
+            user_id="alice",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.TRUSTED,
+            modality="voice",
+        )
+
+        await hub._audio_pipeline.synthesize_and_dispatch_audio(msg, "Hello from Lyra")
+
+        hub.dispatch_audio.assert_not_awaited()
+        hub.dispatch_response.assert_not_awaited()

--- a/tests/core/test_audio_pipeline_tts.py
+++ b/tests/core/test_audio_pipeline_tts.py
@@ -20,7 +20,7 @@ from lyra.core.message import InboundMessage, Platform, Response
 from lyra.core.pool import Pool
 from lyra.core.render_events import RenderEvent
 from lyra.core.trust import TrustLevel
-from tests.core.conftest import FakeSTT
+from tests.core.conftest import FakeSTT, MockAdapter
 
 if TYPE_CHECKING:
     from lyra.stt import STTService
@@ -318,14 +318,19 @@ class TestTtsUnavailableFallback:
     """
 
     @pytest.mark.asyncio
-    async def test_tts_unavailable_no_dispatch_response(self) -> None:
-        """TtsUnavailableError → log only, dispatch_response NOT called.
+    async def test_tts_unavailable_no_dispatch_response(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """TtsUnavailableError → log.warning only, dispatch_response NOT called.
 
         Text was already sent by the caller. Sending a secondary notification
         creates the infinite retry loop (#621). Fix: log and return.
         """
+        import logging
+
         from lyra.tts import TtsUnavailableError
 
+        # Arrange
         mock_tts = MagicMock()
         mock_tts.synthesize = AsyncMock(side_effect=TtsUnavailableError("adapter down"))
 
@@ -348,20 +353,32 @@ class TestTtsUnavailableFallback:
             modality="voice",
         )
 
-        await hub._audio_pipeline.synthesize_and_dispatch_audio(msg, "Hello from Lyra")
+        # Act
+        with caplog.at_level(logging.WARNING, logger="lyra.core.tts_dispatch"):
+            await hub._audio_pipeline.synthesize_and_dispatch_audio(
+                msg, "Hello from Lyra"
+            )
 
-        # Audio must NOT be dispatched (synthesis failed)
+        # Assert
         hub.dispatch_audio.assert_not_awaited()
         # dispatch_response must NOT be called (#621 — text already sent before TTS)
         hub.dispatch_response.assert_not_awaited()
+        # Log warning must be emitted (sole observable side effect of the error path)
+        assert "msg-fallback-1" in caplog.text
+        assert caplog.records[0].levelno == logging.WARNING
 
     @pytest.mark.asyncio
-    async def test_tts_generic_exception_no_dispatch_response(self) -> None:
-        """Generic TTS exception → log only, dispatch_response NOT called.
+    async def test_tts_generic_exception_no_dispatch_response(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Generic TTS exception → log.exception only, dispatch_response NOT called.
 
         Same contract as TtsUnavailableError: text was already delivered,
         no secondary dispatch should occur regardless of exception type.
         """
+        import logging
+
+        # Arrange
         mock_tts = MagicMock()
         mock_tts.synthesize = AsyncMock(side_effect=RuntimeError("synthesis crash"))
 
@@ -384,7 +401,73 @@ class TestTtsUnavailableFallback:
             modality="voice",
         )
 
-        await hub._audio_pipeline.synthesize_and_dispatch_audio(msg, "Hello from Lyra")
+        # Act
+        with caplog.at_level(logging.ERROR, logger="lyra.core.tts_dispatch"):
+            await hub._audio_pipeline.synthesize_and_dispatch_audio(
+                msg, "Hello from Lyra"
+            )
 
+        # Assert
         hub.dispatch_audio.assert_not_awaited()
+        hub.dispatch_response.assert_not_awaited()
+        # log.exception must be emitted (ERROR level with traceback)
+        assert "msg-fallback-2" in caplog.text
+        assert caplog.records[0].levelno == logging.ERROR
+
+
+# ---------------------------------------------------------------------------
+# dispatch_streaming TTS fallback — no dispatch_response on TTS failure (#621)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchStreamingTTSFallback:
+    """TTS failure during dispatch_streaming must not call dispatch_response.
+
+    dispatch_streaming fires synthesize_and_dispatch_audio as a background
+    task (_deferred_tts) after the stream completes.  If TTS fails there, the
+    same contract applies: log and return only — no secondary dispatch_response.
+    """
+
+    @pytest.mark.asyncio
+    async def test_streaming_tts_failure_no_dispatch_response(self) -> None:
+        """Voice dispatch_streaming: TTS failure → dispatch_response NOT called."""
+        from datetime import datetime, timezone
+
+        from lyra.core.render_events import TextRenderEvent
+        from lyra.tts import TtsUnavailableError
+
+        # Arrange
+        mock_tts = MagicMock()
+        mock_tts.synthesize = AsyncMock(side_effect=TtsUnavailableError("down"))
+
+        hub = Hub(tts=mock_tts)
+        hub.dispatch_response = AsyncMock()
+
+        adapter = MockAdapter()
+        hub.adapter_registry[(Platform.TELEGRAM, "main")] = adapter  # type: ignore[assignment]
+
+        msg = InboundMessage(
+            id="msg-streaming-1",
+            platform="telegram",
+            bot_id="main",
+            scope_id="chat:99",
+            user_id="alice",
+            user_name="Alice",
+            is_mention=False,
+            text="hello",
+            text_raw="hello",
+            timestamp=datetime.now(timezone.utc),
+            trust_level=TrustLevel.TRUSTED,
+            modality="voice",
+        )
+
+        async def _fake_chunks() -> AsyncIterator[RenderEvent]:
+            yield TextRenderEvent(text="Hello from Lyra", is_final=True)
+
+        # Act
+        await hub.dispatch_streaming(msg, _fake_chunks())
+        # Allow background TTS task to complete
+        await asyncio.sleep(0.05)
+
+        # Assert
         hub.dispatch_response.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Remove `dispatch_response` + `_notify_msg` from `synthesize_and_dispatch_audio` error handler — log and return only
- Text response is already dispatched before TTS is attempted; the secondary notification call creates a reentrancy path that causes an infinite retry loop in production (same `msg.id` logged ×hundreds until manual restart)
- Clean up now-unused `dataclasses` and `Response` imports from `tts_dispatch.py`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #621: bug(hub): TTS retry infinite loop causes duplicate replies attached to old messages | Open |
| Frame | [621-tts-retry-loop-duplicate-replies-frame.mdx](artifacts/frames/621-tts-retry-loop-duplicate-replies-frame.mdx) | Approved |
| Spec | [621-tts-retry-loop-duplicate-replies-spec.mdx](artifacts/specs/621-tts-retry-loop-duplicate-replies-spec.mdx) | Approved |
| Plan | [621-tts-retry-loop-duplicate-replies-plan.mdx](artifacts/plans/621-tts-retry-loop-duplicate-replies-plan.mdx) | Approved |
| Implementation | 1 commit on `feat/621-tts-retry-loop-duplicate-replies` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new) | Passed |

## Test Plan

- [ ] `uv run pytest tests/core/test_audio_pipeline_tts.py -q --no-cov` — all pass, including `TestTtsUnavailableFallback`
- [ ] Confirm `test_tts_unavailable_no_dispatch_response` asserts `dispatch_response` NOT called
- [ ] Confirm `test_tts_generic_exception_no_dispatch_response` covers non-`TtsUnavailableError` path
- [ ] Normal TTS happy path: `test_agent_tts_forwarded_to_synthesize` and `test_dispatch_response_voice_calls_synthesize_with_agent_tts` still pass
- [ ] Deploy to production and confirm hub no longer needs restart after TTS adapter downtime

Closes #621

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`