### PR TITLE
fix(nats): streaming response fallback on cache miss (#622)

### DIFF
--- a/src/lyra/adapters/_inbound_cache.py
+++ b/src/lyra/adapters/_inbound_cache.py
@@ -18,7 +18,7 @@ from lyra.nats._serialize import deserialize_dict
 log = logging.getLogger(__name__)
 
 MAX_SIZE = 500
-TTL_SECONDS = 120
+TTL_SECONDS = 600
 REAPER_INTERVAL_SECONDS = 30
 
 

--- a/src/lyra/adapters/_inbound_cache.py
+++ b/src/lyra/adapters/_inbound_cache.py
@@ -18,6 +18,7 @@ from lyra.nats._serialize import deserialize_dict
 log = logging.getLogger(__name__)
 
 MAX_SIZE = 500
+# 10 min — covers LLM response latency + NATS reconnect window; see #622
 TTL_SECONDS = 600
 REAPER_INTERVAL_SECONDS = 30
 

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -61,6 +61,7 @@ class NatsOutboundListener:
         self._stream_queues: dict[str, asyncio.Queue[dict]] = {}
         self._stream_tasks: dict[str, asyncio.Task[None]] = {}
         self._stream_outbound: dict[str, OutboundMessage] = {}
+        self._stream_original_msgs: dict[str, dict] = {}
         self._sub: Any = None  # nats.aio.subscription.Subscription | None
         self._reaper_task: asyncio.Task[None] | None = None
         self._terminated_streams: set[str] = set()
@@ -102,6 +103,8 @@ class NatsOutboundListener:
             task.cancel()
         self._stream_tasks.clear()
         self._stream_queues.clear()
+        self._stream_original_msgs.clear()
+        self._stream_outbound.clear()
 
     async def _handle(self, msg: Msg) -> None:
         try:
@@ -200,6 +203,9 @@ class NatsOutboundListener:
             )
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize stream outbound")
+        raw_orig = data.get("original_msg")
+        if raw_orig is not None:
+            self._stream_original_msgs[stream_id] = raw_orig
 
     def _handle_stream_error(self, data: dict) -> None:
         """Dispatch to the stream_error handler in _nats_outbound_stream."""
@@ -242,6 +248,16 @@ class NatsOutboundListener:
         """Drain a stream queue and call adapter.send_streaming()."""
         original_msg = self._cache.get(stream_id)
         if original_msg is None:
+            raw = self._stream_original_msgs.pop(stream_id, None)
+            if raw is not None:
+                try:
+                    original_msg = _deserialize_dict(raw, InboundMessage)
+                except Exception:
+                    log.warning(
+                        "NatsOutboundListener: bad embedded original_msg"
+                        " for stream_id=%r", stream_id,
+                    )
+        if original_msg is None:
             drained = 0
             while not q.empty():
                 await q.get()
@@ -275,3 +291,4 @@ class NatsOutboundListener:
             self._stream_tasks.pop(stream_id, None)
             self._stream_queues.pop(stream_id, None)
             self._terminated_streams.discard(stream_id)
+            self._stream_original_msgs.pop(stream_id, None)

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -201,11 +201,11 @@ class NatsOutboundListener:
             self._stream_outbound[stream_id] = _deserialize_dict(
                 outbound_data, OutboundMessage
             )
+            raw_orig = data.get("original_msg")
+            if raw_orig is not None:
+                self._stream_original_msgs[stream_id] = raw_orig
         except Exception:
             log.warning("NatsOutboundListener: failed to deserialize stream outbound")
-        raw_orig = data.get("original_msg")
-        if raw_orig is not None:
-            self._stream_original_msgs[stream_id] = raw_orig
 
     def _handle_stream_error(self, data: dict) -> None:
         """Dispatch to the stream_error handler in _nats_outbound_stream."""
@@ -255,6 +255,12 @@ class NatsOutboundListener:
                 except Exception:
                     log.warning(
                         "NatsOutboundListener: bad embedded original_msg"
+                        " for stream_id=%r", stream_id,
+                    )
+                else:
+                    log.debug(
+                        "NatsOutboundListener: cache miss, recovered"
+                        " original_msg from embedded payload"
                         " for stream_id=%r", stream_id,
                     )
         if original_msg is None:

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -201,7 +201,7 @@ class NatsOutboundListener:
             self._stream_outbound[stream_id] = _deserialize_dict(
                 outbound_data, OutboundMessage
             )
-            raw_orig = data.get("original_msg")
+            raw_orig = data.get("original_msg")  # bounded by _MAX_STREAMS guard above
             if raw_orig is not None:
                 self._stream_original_msgs[stream_id] = raw_orig
         except Exception:

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -114,6 +114,7 @@ class NatsChannelProxy:
                 "type": "stream_start",
                 "stream_id": original_msg.id,
                 "outbound": json.loads(serialize(outbound).decode("utf-8")),
+                "original_msg": json.loads(serialize(original_msg).decode("utf-8")),
             }
             await self._nc.publish(
                 subject,

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -796,6 +796,9 @@ async def test_stream_cache_miss_with_embedded_original_msg_delivers() -> None:
     msg = _make_tg_msg("msg-cache-miss-embed")
     # Do NOT call cache_inbound — simulate cache miss / TTL eviction
 
+    # Confirm cache truly has no entry before dispatch
+    assert msg.id not in listener._cache
+
     serialized_orig = json.loads(serialize(msg).decode("utf-8"))
 
     stream_start = {
@@ -817,11 +820,54 @@ async def test_stream_cache_miss_with_embedded_original_msg_delivers() -> None:
 
     # Act — await the drain task
     task = listener._stream_tasks.get(msg.id)
-    if task:
-        await task
+    assert task is not None, "drain task was not created"
+    await task
 
     # Assert — message was delivered via embedded fallback
     adapter.send_streaming.assert_called_once()
+    assert listener._stream_original_msgs == {}  # proves fallback dict was consumed
+
+
+@pytest.mark.asyncio
+async def test_stream_cache_miss_bad_embedded_original_msg_warns_and_drains(
+    caplog,
+) -> None:
+    """SC-7b: cache miss + malformed embedded original_msg -> warn + drain."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    adapter.send_streaming = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    stream_id = "msg-bad-embed"
+    # Malformed: id=None fails InboundMessage deserialization
+    listener._stream_original_msgs[stream_id] = {"id": None, "platform": "telegram"}
+
+    done_chunk = {
+        "stream_id": stream_id,
+        "seq": 0,
+        "event_type": "text",
+        "payload": {"text": "hi", "is_final": True},
+        "done": True,
+    }
+
+    _logger = "lyra.adapters.nats_outbound_listener"
+    with caplog.at_level(logging.WARNING, logger=_logger):
+        await listener._handle(_make_nats_msg(done_chunk))
+        task = listener._stream_tasks.get(stream_id)
+        assert task is not None, "drain task was not created"
+        await task
+
+    adapter.send_streaming.assert_not_called()
+    assert any(
+        "bad embedded" in r.message and r.levelno == logging.WARNING
+        for r in caplog.records
+    )
+    assert any(
+        "drained" in r.message and r.levelno == logging.WARNING
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio
@@ -859,8 +905,8 @@ async def test_stream_cache_hit_does_not_use_stream_original_msgs() -> None:
 
     # Act
     task = listener._stream_tasks.get(msg.id)
-    if task:
-        await task
+    assert task is not None, "drain task was not created"
+    await task
 
     # Assert — delivered via cache (not fallback)
     adapter.send_streaming.assert_called_once()
@@ -899,7 +945,10 @@ async def test_stream_both_missing_warns_and_drains(caplog) -> None:
 
     # Assert — send_streaming never called; warning fired
     adapter.send_streaming.assert_not_called()
-    assert "drained" in caplog.text
+    assert any(
+        "drained" in r.message and r.levelno == logging.WARNING
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,6 +10,7 @@ import pytest
 
 from lyra.core.message import InboundMessage, Platform
 from lyra.core.trust import TrustLevel
+from lyra.nats._serialize import serialize
 
 
 def _make_tg_msg(msg_id: str = "msg-1") -> InboundMessage:
@@ -773,3 +775,153 @@ async def test_version_mismatch_counter_flows_from_listener() -> None:
     assert len(yielded) == 1
     assert isinstance(yielded[0], TextRenderEvent)
     assert yielded[0].text == "good"  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# #622: streaming cache miss — embedded original_msg fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_cache_miss_with_embedded_original_msg_delivers() -> None:
+    """SC-7: cache miss + embedded original_msg -> send_streaming called."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    # Arrange
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    adapter.send_streaming = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-cache-miss-embed")
+    # Do NOT call cache_inbound — simulate cache miss / TTL eviction
+
+    serialized_orig = json.loads(serialize(msg).decode("utf-8"))
+
+    stream_start = {
+        "type": "stream_start",
+        "stream_id": msg.id,
+        "outbound": {"content": [], "buttons": [], "metadata": {}},
+        "original_msg": serialized_orig,
+    }
+    await listener._handle(_make_nats_msg(stream_start))
+
+    done_chunk = {
+        "stream_id": msg.id,
+        "seq": 0,
+        "event_type": "text",
+        "payload": {"text": "hi", "is_final": True},
+        "done": True,
+    }
+    await listener._handle(_make_nats_msg(done_chunk))
+
+    # Act — await the drain task
+    task = listener._stream_tasks.get(msg.id)
+    if task:
+        await task
+
+    # Assert — message was delivered via embedded fallback
+    adapter.send_streaming.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_cache_hit_does_not_use_stream_original_msgs() -> None:
+    """SC-8: cache hit -> _stream_original_msgs unused and cleaned up after drain."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    # Arrange
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    adapter.send_streaming = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    msg = _make_tg_msg("msg-cache-hit-orig")
+    listener.cache_inbound(msg)  # normal cache path
+
+    serialized_orig = json.loads(serialize(msg).decode("utf-8"))
+
+    stream_start = {
+        "type": "stream_start",
+        "stream_id": msg.id,
+        "outbound": {"content": [], "buttons": [], "metadata": {}},
+        "original_msg": serialized_orig,
+    }
+    await listener._handle(_make_nats_msg(stream_start))
+
+    done_chunk = {
+        "stream_id": msg.id,
+        "seq": 0,
+        "event_type": "text",
+        "payload": {"text": "hi", "is_final": True},
+        "done": True,
+    }
+    await listener._handle(_make_nats_msg(done_chunk))
+
+    # Act
+    task = listener._stream_tasks.get(msg.id)
+    if task:
+        await task
+
+    # Assert — delivered via cache (not fallback)
+    adapter.send_streaming.assert_called_once()
+    # _stream_original_msgs cleaned up in finally block
+    assert listener._stream_original_msgs == {}
+
+
+@pytest.mark.asyncio
+async def test_stream_both_missing_warns_and_drains(caplog) -> None:
+    """SC-9: no cache entry and no _stream_original_msgs -> warn + drain."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    # Arrange — no cache_inbound, no stream_start (so _stream_original_msgs is empty)
+    nc = AsyncMock()
+    adapter = AsyncMock()
+    adapter.send_streaming = AsyncMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    stream_id = "msg-both-missing"
+
+    done_chunk = {
+        "stream_id": stream_id,
+        "seq": 0,
+        "event_type": "text",
+        "payload": {"text": "hi", "is_final": True},
+        "done": True,
+    }
+
+    _logger = "lyra.adapters.nats_outbound_listener"
+    with caplog.at_level(logging.WARNING, logger=_logger):
+        await listener._handle(_make_nats_msg(done_chunk))
+
+        task = listener._stream_tasks.get(stream_id)
+        if task:
+            await task
+
+    # Assert — send_streaming never called; warning fired
+    adapter.send_streaming.assert_not_called()
+    assert "drained" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_stream_original_msgs() -> None:
+    """SC-11: stop() clears _stream_original_msgs dict."""
+    from lyra.adapters.nats_outbound_listener import NatsOutboundListener
+
+    # Arrange
+    mock_sub = AsyncMock()
+    nc = AsyncMock()
+    nc.subscribe = AsyncMock(return_value=mock_sub)
+
+    adapter = MagicMock()
+    listener = NatsOutboundListener(nc, Platform.TELEGRAM, "main", adapter)
+
+    # Manually populate _stream_original_msgs
+    listener._stream_original_msgs["test-id"] = {"some": "data"}
+
+    await listener.start()
+
+    # Act
+    await listener.stop()
+
+    # Assert
+    assert listener._stream_original_msgs == {}

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -940,8 +940,8 @@ async def test_stream_both_missing_warns_and_drains(caplog) -> None:
         await listener._handle(_make_nats_msg(done_chunk))
 
         task = listener._stream_tasks.get(stream_id)
-        if task:
-            await task
+        assert task is not None
+        await task
 
     # Assert — send_streaming never called; warning fired
     adapter.send_streaming.assert_not_called()


### PR DESCRIPTION
## Summary

- Raise `InboundCache.TTL_SECONDS` 120 → 600 s to cover slow LLM+TTS turns (Fix 1)
- Embed `original_msg` in `stream_start` envelope + add `_stream_original_msgs` fallback dict in `NatsOutboundListener` — mirrors the proven `send`-type resilience pattern (Fix 2)
- On cache miss in `_drain_stream`, reconstruct `InboundMessage` from embedded raw dict before falling back to drain+warn; stream is delivered instead of silently dropped
- Also clear `_stream_outbound` in `stop()` (pre-existing gap, fixed in same pass)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #622: bug(nats): streaming responses silently dropped | Open |
| Frame | [622-nats-streaming-cache-miss-frame.mdx](artifacts/frames/622-nats-streaming-cache-miss-frame.mdx) | Approved |
| Spec | [622-nats-streaming-cache-miss-spec.mdx](artifacts/specs/622-nats-streaming-cache-miss-spec.mdx) | Approved |
| Plan | [622-nats-streaming-cache-miss-plan.mdx](artifacts/plans/622-nats-streaming-cache-miss-plan.mdx) | Approved |
| Implementation | 1 commit on `feat/622-nats-streaming-cache-miss` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new) | Passed |

## Test Plan

- [ ] `test_stream_cache_miss_with_embedded_original_msg_delivers` — cache miss + embedded `original_msg` → `send_streaming` called, not drain-warn
- [ ] `test_stream_cache_hit_does_not_use_stream_original_msgs` — cache hit path unchanged, `_stream_original_msgs` empty after completion
- [ ] `test_stream_both_missing_warns_and_drains` — both cache and embedded msg absent → warn log fires, no crash, `send_streaming` not called
- [ ] `test_stop_clears_stream_original_msgs` — `stop()` leaves `_stream_original_msgs` empty

Closes #622

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`