### PR TITLE
fix(agents): route CLI lifecycle ops through direct CliPool ref

### DIFF
--- a/src/lyra/agents/simple_agent.py
+++ b/src/lyra/agents/simple_agent.py
@@ -101,9 +101,8 @@ class SimpleAgent(AgentBase):
 
     async def reset_backend(self, pool_id: str) -> None:
         """Kill the backend process so the next turn gets a fresh one."""
-        reset_fn = getattr(self._provider, "reset", None)
-        if reset_fn is not None:
-            await reset_fn(pool_id)
+        if self._cli_pool is not None:
+            await self._cli_pool.reset(pool_id)
 
     def _build_router_kwargs(self) -> dict[str, object]:
         return {

--- a/src/lyra/agents/simple_agent.py
+++ b/src/lyra/agents/simple_agent.py
@@ -34,6 +34,7 @@ _AGENTS_DIR = Path(__file__).resolve().parent
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
 
+    from lyra.core.cli_pool import CliPool
     from lyra.core.render_events import RenderEvent
     from lyra.core.stores.agent_store import AgentStore
     from lyra.stt import STTProtocol
@@ -63,6 +64,7 @@ class SimpleAgent(AgentBase):
         self,
         config: Agent,
         provider: LlmProvider,
+        cli_pool: CliPool | None = None,
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
         stt: "STTProtocol | None" = None,
@@ -82,6 +84,7 @@ class SimpleAgent(AgentBase):
         self._runtime_config_holder = RuntimeConfigHolder(rc)
         self._runtime_config_path = resolved_agents_dir / "lyra_runtime.toml"
         self._provider = provider
+        self._cli_pool = cli_pool
         super().__init__(
             config,
             agents_dir=agents_dir,
@@ -148,33 +151,31 @@ class SimpleAgent(AgentBase):
         )
 
     def _maybe_register_reset(self, pool: Pool) -> None:
-        """Register a session reset callback on the pool the first time we process.
-
-        /clear calls pool.reset_session(), which delegates here → CliPool.reset().
-        """
-        if pool._session_reset_fn is None:
-            reset_fn = getattr(self._provider, "reset", None)
-            if reset_fn is not None:
+        """Register session reset/switch callbacks on the pool."""
+        _cli_pool = self._cli_pool  # narrow once; stable capture for lambdas
+        if _cli_pool is not None:
+            if pool._session_reset_fn is None:
                 _pool_id = pool.pool_id
-                pool._session_reset_fn = lambda: reset_fn(_pool_id)
-
-        switch_fn = getattr(self._provider, "switch_cwd", None)
-        if switch_fn is not None and pool._switch_workspace_fn is None:
-            _pool_id = pool.pool_id
-            pool._switch_workspace_fn = lambda cwd: switch_fn(_pool_id, cwd)
+                pool._session_reset_fn = lambda: _cli_pool.reset(_pool_id)
+            if pool._switch_workspace_fn is None:
+                _pool_id = pool.pool_id
+                pool._switch_workspace_fn = (
+                    lambda cwd: _cli_pool.switch_cwd(_pool_id, cwd)
+                )
 
     def _maybe_register_resume(self, pool: Pool) -> None:
-        """Register session resume callback on the pool the first time we process.
+        """Register session resume callback on the pool.
 
         Hub calls pool.resume_session(session_id) → delegates here →
         CliPool.resume_and_reset(). Follows the same lazy-wiring pattern as
         _maybe_register_reset.
         """
-        if pool._session_resume_fn is None:
-            resume_fn = getattr(self._provider, "resume_and_reset", None)
-            if resume_fn is not None:
-                _pool_id = pool.pool_id
-                pool._session_resume_fn = lambda sid: resume_fn(_pool_id, sid)
+        _cli_pool = self._cli_pool  # narrow once; stable capture for lambda
+        if _cli_pool is not None and pool._session_resume_fn is None:
+            _pool_id = pool.pool_id
+            pool._session_resume_fn = (
+                lambda sid: _cli_pool.resume_and_reset(_pool_id, sid)
+            )
 
     def configure_pool(self, pool: Pool) -> None:
         """Wire provider callbacks onto *pool* before first message is processed.
@@ -244,9 +245,8 @@ class SimpleAgent(AgentBase):
         model_cfg = self.config.llm_config
 
         # Link Lyra session → CLI session so reply-to-resume works.
-        _link = getattr(self._provider, "link_lyra_session", None)
-        if _link is not None:
-            _link(pool.pool_id, pool.session_id)
+        if self._cli_pool is not None:
+            self._cli_pool.link_lyra_session(pool.pool_id, pool.session_id)
 
         log.debug(
             "[agent:%s][pool:%s] processing message (%d chars)",

--- a/src/lyra/bootstrap/agent_factory.py
+++ b/src/lyra/bootstrap/agent_factory.py
@@ -197,6 +197,7 @@ def _create_agent(  # noqa: PLR0913 — factory with optional overrides for each
         return SimpleAgent(
             config,
             provider,
+            cli_pool=cli_pool,
             circuit_registry=circuit_registry,
             msg_manager=msg_manager,
             stt=stt,

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -460,6 +460,20 @@ class TestSimpleAgentCliLifecycle:
         # Assert — cli_pool.switch_cwd called with pool_id and cwd
         cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/new/cwd"))
 
+    async def test_t9a_integration_switch_workspace_full_chain(self) -> None:
+        """T9a-integration: pool.switch_workspace() routes to cli_pool.switch_cwd."""
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        cli_pool = MagicMock()
+        cli_pool.switch_cwd = AsyncMock()
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+        agent.configure_pool(pool)
+
+        await pool.switch_workspace(Path("/new/cwd"))
+
+        cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/new/cwd"))
+
     # ------------------------------------------------------------------
     # T9b — CB-wrapped resume_and_reset: resume fn → cli_pool.resume_and_reset
     # ------------------------------------------------------------------
@@ -551,7 +565,9 @@ class TestSimpleAgentCliLifecycle:
         cli_pool.reset.assert_called_once_with(pool.pool_id)
         cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/some/cwd"))
         cli_pool.resume_and_reset.assert_called_once_with(pool.pool_id, "sess-42")
-        cli_pool.link_lyra_session.assert_called()
+        cli_pool.link_lyra_session.assert_called_once_with(
+            pool.pool_id, pool.session_id
+        )
 
     # ------------------------------------------------------------------
     # T12 — idempotency: configure_pool twice → callbacks registered once

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 if TYPE_CHECKING:
+    from lyra.core.cli_pool import CliPool
     from lyra.llm.base import LlmProvider
 
 from lyra.agents.simple_agent import SimpleAgent
@@ -381,3 +383,224 @@ class TestSimpleAgentStreaming:
         # Assert — agent.config.system_prompt used
         args = provider.stream.call_args[0]
         assert args[3] == "You are Lyra."
+
+
+# ---------------------------------------------------------------------------
+# Helpers for CLI lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+def make_agent_with_cli_pool(provider: object, cli_pool: object) -> SimpleAgent:
+    """Return a SimpleAgent wired with an explicit cli_pool (T7)."""
+    config = Agent(
+        name="lyra",
+        system_prompt="You are Lyra.",
+        memory_namespace="lyra",
+        llm_config=ModelConfig(),
+    )
+    return SimpleAgent(
+        config, cast("LlmProvider", provider), cli_pool=cast("CliPool", cli_pool)
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestSimpleAgentCliLifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSimpleAgentCliLifecycle:
+    """Regression tests for issue #620: all four CLI lifecycle ops route through
+    self._cli_pool, not through getattr(self._provider, ...).
+
+    Tests T8–T13 will be RED until the backend fix lands.
+    """
+
+    # ------------------------------------------------------------------
+    # T8 — CB-wrapped reset: pool.reset_session() calls cli_pool.reset
+    # ------------------------------------------------------------------
+
+    async def test_t8_reset_routes_through_cli_pool(self) -> None:
+        """T8: pool.reset_session() → cli_pool.reset(pool_id), not provider.reset."""
+        # Arrange — provider has NO reset method
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        cli_pool = MagicMock()
+        cli_pool.reset = AsyncMock()
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+        agent.configure_pool(pool)
+
+        # Act
+        await pool.reset_session()
+
+        # Assert — cli_pool.reset called with pool_id, not provider.reset
+        cli_pool.reset.assert_called_once_with(pool.pool_id)
+
+    # ------------------------------------------------------------------
+    # T9a — CB-wrapped switch_cwd: workspace switch → cli_pool.switch_cwd
+    # ------------------------------------------------------------------
+
+    async def test_t9a_switch_cwd_routes_through_cli_pool(self) -> None:
+        """T9a: _switch_workspace_fn routes to cli_pool.switch_cwd."""
+        # Arrange — provider has NO switch_cwd method
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        cli_pool = MagicMock()
+        cli_pool.switch_cwd = AsyncMock()
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+        agent.configure_pool(pool)
+
+        # Assert — _switch_workspace_fn was registered
+        assert pool._switch_workspace_fn is not None
+
+        # Act — invoke the registered callback directly
+        await pool._switch_workspace_fn(Path("/new/cwd"))
+
+        # Assert — cli_pool.switch_cwd called with pool_id and cwd
+        cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/new/cwd"))
+
+    # ------------------------------------------------------------------
+    # T9b — CB-wrapped resume_and_reset: resume fn → cli_pool.resume_and_reset
+    # ------------------------------------------------------------------
+
+    async def test_t9b_resume_and_reset_routes_through_cli_pool(self) -> None:
+        """T9b: _session_resume_fn routes to cli_pool.resume_and_reset."""
+        # Arrange — provider has NO resume_and_reset method
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        cli_pool = MagicMock()
+        cli_pool.resume_and_reset = AsyncMock(return_value=True)
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+        agent.configure_pool(pool)
+
+        # Assert — _session_resume_fn was registered (fix: route through cli_pool)
+        assert pool._session_resume_fn is not None
+
+        # Act
+        await pool._session_resume_fn("sess-1")
+
+        # Assert — cli_pool.resume_and_reset called with pool_id and session id
+        cli_pool.resume_and_reset.assert_called_once_with(pool.pool_id, "sess-1")
+
+    # ------------------------------------------------------------------
+    # T10 — CB-wrapped link_lyra_session: process() → cli_pool.link_lyra_session
+    # ------------------------------------------------------------------
+
+    async def test_t10_link_lyra_session_routes_through_cli_pool(self) -> None:
+        """T10: process() calls cli_pool.link_lyra_session(pool_id, session_id)."""
+        # Arrange — provider has NO link_lyra_session but can complete
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        provider.complete = AsyncMock(
+            return_value=LlmResult(result="hi", session_id="s1")
+        )
+        provider.is_alive = MagicMock(return_value=True)
+
+        cli_pool = MagicMock()
+        cli_pool.link_lyra_session = MagicMock()
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+        agent.configure_pool(pool)
+
+        # Act
+        await agent.process(make_inbound_message("hi"), pool)
+
+        # Assert — link_lyra_session called via cli_pool, not provider
+        cli_pool.link_lyra_session.assert_called_once_with(
+            pool.pool_id, pool.session_id
+        )
+
+    # ------------------------------------------------------------------
+    # T11 — bare driver: all four ops still route through cli_pool
+    # ------------------------------------------------------------------
+
+    async def test_t11_bare_driver_all_four_ops_route_through_cli_pool(self) -> None:
+        """T11: even when provider has all four methods, fix routes through cli_pool."""
+        # Arrange — provider has ALL four methods
+        provider = MagicMock()
+        provider.reset = AsyncMock()
+        provider.switch_cwd = AsyncMock()
+        provider.resume_and_reset = AsyncMock(return_value=True)
+        provider.link_lyra_session = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=LlmResult(result="ok", session_id="s1")
+        )
+        provider.is_alive = MagicMock(return_value=True)
+
+        cli_pool = MagicMock()
+        cli_pool.reset = AsyncMock()
+        cli_pool.switch_cwd = AsyncMock()
+        cli_pool.resume_and_reset = AsyncMock(return_value=True)
+        cli_pool.link_lyra_session = MagicMock()
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+        agent.configure_pool(pool)
+
+        # Act — trigger each operation
+        await pool.reset_session()
+        if pool._switch_workspace_fn is not None:
+            await pool._switch_workspace_fn(Path("/some/cwd"))
+        if pool._session_resume_fn is not None:
+            await pool._session_resume_fn("sess-42")
+        await agent.process(make_inbound_message("hi"), pool)
+
+        # Assert — all four went through cli_pool
+        cli_pool.reset.assert_called_once_with(pool.pool_id)
+        cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/some/cwd"))
+        cli_pool.resume_and_reset.assert_called_once_with(pool.pool_id, "sess-42")
+        cli_pool.link_lyra_session.assert_called()
+
+    # ------------------------------------------------------------------
+    # T12 — idempotency: configure_pool twice → callbacks registered once
+    # ------------------------------------------------------------------
+
+    async def test_t12_configure_pool_idempotent(self) -> None:
+        """T12: calling configure_pool twice does not double-register callbacks."""
+        # Arrange
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        cli_pool = MagicMock()
+        cli_pool.reset = AsyncMock()
+
+        agent = make_agent_with_cli_pool(provider, cli_pool)
+        pool = make_pool()
+
+        # Act — configure twice
+        agent.configure_pool(pool)
+        fn_after_first = pool._session_reset_fn
+        agent.configure_pool(pool)
+        fn_after_second = pool._session_reset_fn
+
+        # Assert — same fn object registered (guard: if _session_reset_fn is None)
+        assert fn_after_first is not None
+        assert fn_after_second is fn_after_first
+
+        # Calling reset_session must invoke cli_pool.reset exactly once
+        await pool.reset_session()
+        cli_pool.reset.assert_called_once_with(pool.pool_id)
+
+    # ------------------------------------------------------------------
+    # T13 — cli_pool=None: no errors, reset fn stays None
+    # ------------------------------------------------------------------
+
+    async def test_t13_no_cli_pool_no_errors(self) -> None:
+        """T13: cli_pool=None → no AttributeError, _session_reset_fn stays None."""
+        # Arrange — standard agent without cli_pool
+        provider = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=LlmResult(result="ok", session_id="s1")
+        )
+        provider.is_alive = MagicMock(return_value=True)
+
+        agent = make_agent(provider)
+        pool = make_pool()
+
+        # Act — configure_pool and process must not raise
+        agent.configure_pool(pool)
+        response = await agent.process(make_inbound_message("hi"), pool)
+
+        # Assert — reset fn not registered, response returned cleanly
+        assert pool._session_reset_fn is None
+        assert isinstance(response, Response)


### PR DESCRIPTION
## Summary

- Add \`cli_pool: CliPool | None = None\` to \`SimpleAgent.__init__\` and wire all four CLI lifecycle operations (\`reset\`, \`switch_cwd\`, \`resume_and_reset\`, \`link_lyra_session\`) through \`self._cli_pool\` directly, bypassing the \`LlmProvider\` decorator chain
- Pass \`cli_pool\` through \`agent_factory._create_agent\` to the \`SimpleAgent\` constructor
- Add 7 regression tests covering CB-wrapped provider, bare driver, idempotency, and \`cli_pool=None\` paths

**Root cause:** \`_maybe_register_reset\` / \`_maybe_register_resume\` / \`process()\` used \`getattr(self._provider, "method", None)\` to discover lifecycle methods. When \`CircuitBreakerDecorator\` wraps \`ClaudeCliDriver\`, those methods are absent on the decorator — \`getattr\` returns \`None\` — so \`/clear\`, \`/workspace\`, reply-to-resume, and session linking silently no-op.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #620: fix(/clear): CLI subprocess not killed when CircuitBreakerDecorator wraps ClaudeCliDriver | Open |
| Analysis | [620-cli-lifecycle-decorator-gap.mdx](artifacts/analyses/620-cli-lifecycle-decorator-gap.mdx) | Present |
| Spec | [620-cli-lifecycle-decorator-gap-spec.mdx](artifacts/specs/620-cli-lifecycle-decorator-gap-spec.mdx) | Present |
| Implementation | 1 commit on `feat/620-cli-lifecycle-decorator-gap` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (7 new) | Passed |

## Test Plan

- [ ] `/clear` with CB-wrapped `ClaudeCliDriver`: assert subprocess is killed (`CliPool.reset` called)
- [ ] `/workspace` with CB-wrapped driver: assert `CliPool.switch_cwd` called
- [ ] Reply-to-resume with CB-wrapped driver: assert `CliPool.resume_and_reset` called
- [ ] Per-turn `link_lyra_session` with CB-wrapped driver: assert `CliPool.link_lyra_session` called
- [ ] `cli_pool=None` (SDK backend): no errors, `pool._session_reset_fn` stays `None`
- [ ] Bare `ClaudeCliDriver` (no CB): all four ops still fire — no regression
- [ ] `configure_pool` called twice: callbacks registered exactly once (idempotency)

Closes #620

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`