### PR TITLE
refactor(adapters): align outbound extraction patterns (#649)

### DIFF
--- a/src/lyra/adapters/discord.py
+++ b/src/lyra/adapters/discord.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 from lyra.adapters import discord_audio  # noqa: I001
 from lyra.adapters import discord_audio_outbound
-from lyra.adapters._shared import ATTACHMENT_EXTS_BASE, TypingTaskManager, resolve_msg
+from lyra.adapters._shared import TypingTaskManager, resolve_msg
 from lyra.adapters.discord_config import (  # noqa: F401
     DiscordConfig as DiscordConfig,
     load_discord_config as load_discord_config,
@@ -28,6 +28,7 @@ from lyra.adapters.discord_normalize import normalize as _normalize_impl
 from lyra.adapters._base_outbound import OutboundAdapterBase
 from lyra.adapters.discord_outbound import (
     _discord_typing_worker,
+    build_streaming_callbacks as _build_streaming_callbacks,
     send as _send_impl,
 )
 from lyra.adapters.discord_threads import restore_hot_threads
@@ -49,9 +50,6 @@ from lyra.core.message import (
 )
 from lyra.core.messages import MessageManager
 from lyra.core.stores.thread_store import ThreadStore
-
-# Discord: same base extensions, no platform-specific additions needed.
-_ATTACHMENT_EXTS = ATTACHMENT_EXTS_BASE
 
 log = logging.getLogger(__name__)
 
@@ -283,129 +281,24 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         """Send response back to Discord."""
         await _send_impl(self, original_msg, outbound)
 
-    def _make_streaming_callbacks(  # noqa: C901 — streaming callbacks: one closure per platform op
+    def _make_streaming_callbacks(
         self,
         original_msg: InboundMessage,
         outbound: OutboundMessage | None,
     ) -> "PlatformCallbacks":
         """Build platform-specific callbacks for StreamingSession."""
-        from lyra.adapters._shared import DISCORD_MAX_LENGTH, send_with_retry
-        from lyra.adapters._shared_streaming import PlatformCallbacks
-        from lyra.adapters.discord_formatting import render_text
-        from lyra.adapters.discord_outbound import _build_tool_embed
-
-        if original_msg.platform != "discord":
-            async def _bad_placeholder():
-                raise ValueError("not a discord message")
-            async def _noop(text=""):
-                return None
-            return PlatformCallbacks(
-                send_placeholder=_bad_placeholder,
-                edit_placeholder_text=lambda ph, text: asyncio.sleep(0),
-                edit_placeholder_tool=lambda ph, ev, h: asyncio.sleep(0),
-                send_message=_noop,
-                send_fallback=_noop,
-                chunk_text=lambda t: [t],
-                start_typing=lambda: None,
-                cancel_typing=lambda: None,
-                get_msg=lambda key, fallback: fallback,
-                placeholder_text="\u2026",
-            )
-
-        channel_id: int | None = original_msg.platform_meta.get("channel_id")
-        thread_id: int | None = original_msg.platform_meta.get("thread_id")
-        send_to_id: int = thread_id if thread_id is not None else channel_id  # type: ignore[assignment]
-        reply_msg_id: int | None = original_msg.platform_meta.get("message_id")
-        should_reply = reply_msg_id is not None and thread_id is None
-        _placeholder_text = self._msg("stream_placeholder", "\u2026")
-
-        async def _send_placeholder():
-            messageable = await self._resolve_channel(send_to_id)
-            if should_reply:
-                msg_obj = messageable.get_partial_message(reply_msg_id)  # type: ignore[attr-defined]
-                placeholder = await msg_obj.reply(_placeholder_text)
-            else:
-                placeholder = await messageable.send(_placeholder_text)
-            return placeholder, placeholder.id
-
-        async def _edit_placeholder_text(ph, text):
-            display = text[-DISCORD_MAX_LENGTH:]
-            await send_with_retry(
-                lambda d=display: ph.edit(content=d, embed=None),
-                label="Intermediate text edit",
-            )
-
-        async def _edit_placeholder_tool(ph, event, header: str = ""):
-            embed = _build_tool_embed(event)
-            await send_with_retry(
-                lambda e=embed: ph.edit(content="", embed=e),
-                label="Tool summary embed",
-            )
-
-        async def _send_message(text: str) -> int | None:
-            messageable = await self._resolve_channel(send_to_id)
-            chunks = render_text(text, DISCORD_MAX_LENGTH)
-            last_id = None
-            for i, chunk in enumerate(chunks):
-                is_last = i == len(chunks) - 1
-                if is_last:
-                    try:
-                        sent = await messageable.send(chunk)
-                        last_id = sent.id
-                    except Exception:
-                        log.exception("Failed to send final text chunk")
-                else:
-                    await send_with_retry(
-                        lambda c=chunk: messageable.send(c),
-                        label="Final text chunk",
-                    )
-            return last_id
-
-        async def _send_fallback(text: str) -> int | None:
-            fallback_outbound = (
-                OutboundMessage.from_text(text) if text
-                else OutboundMessage.from_text(_placeholder_text)
-            )
-            from lyra.adapters.discord_outbound import (
-                send as _discord_send,  # late: avoids circular import
-            )
-            await _discord_send(self, original_msg, fallback_outbound)
-            return fallback_outbound.metadata.get("reply_message_id")
-
-        return PlatformCallbacks(
-            send_placeholder=_send_placeholder,
-            edit_placeholder_text=_edit_placeholder_text,
-            edit_placeholder_tool=_edit_placeholder_tool,
-            send_message=_send_message,
-            send_fallback=_send_fallback,
-            chunk_text=lambda text: render_text(text, DISCORD_MAX_LENGTH),
-            start_typing=lambda: self._start_typing(send_to_id),
-            cancel_typing=lambda: self._cancel_typing(send_to_id),
-            get_msg=self._msg,
-            placeholder_text=_placeholder_text,
-        )
+        return _build_streaming_callbacks(self, original_msg, outbound)
 
     async def render_audio(self, msg: OutboundAudio, inbound: InboundMessage) -> None:
         """Send an OutboundAudio envelope as a Discord voice message."""
-        await discord_audio_outbound.render_audio(
-            msg,
-            inbound,
-            bot_id=self._bot_id,
-            resolve_channel=self._resolve_channel,
-            http=self.http,
-        )
+        await discord_audio_outbound.render_audio(self, msg, inbound)
         self._cancel_typing_for(inbound)
 
     async def render_attachment(
         self, msg: OutboundAttachment, inbound: InboundMessage
     ) -> None:
         """Send an OutboundAttachment envelope as a Discord file attachment."""
-        await discord_audio_outbound.render_attachment(
-            msg,
-            inbound,
-            resolve_channel=self._resolve_channel,
-            attachment_exts=_ATTACHMENT_EXTS,
-        )
+        await discord_audio_outbound.render_attachment(self, msg, inbound)
         self._cancel_typing_for(inbound)
 
     async def render_audio_stream(
@@ -414,9 +307,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         inbound: InboundMessage,
     ) -> None:
         """Buffer streamed audio chunks and send as a single Discord file attachment."""
-        await discord_audio_outbound.render_audio_stream(
-            chunks, inbound, self.render_audio
-        )
+        await discord_audio_outbound.render_audio_stream(self, chunks, inbound)
         self._cancel_typing_for(inbound)
 
     async def render_voice_stream(
@@ -425,7 +316,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         inbound: InboundMessage,
     ) -> None:
         """Route TTS stream to the active Discord voice session for this guild."""
-        await discord_audio_outbound.render_voice_stream(chunks, inbound, self._vsm)
+        await discord_audio_outbound.render_voice_stream(self, chunks, inbound)
         self._cancel_typing_for(inbound)
 
     async def _resolve_channel(self, channel_id: int) -> discord.abc.Messageable:

--- a/src/lyra/adapters/discord_audio_outbound.py
+++ b/src/lyra/adapters/discord_audio_outbound.py
@@ -173,6 +173,7 @@ async def render_audio_stream(
     inbound: InboundMessage,
 ) -> None:
     """Buffer streamed audio chunks and send as a single Discord file attachment."""
+    # Guard: short-circuit before consuming chunks (render_audio re-validates).
     meta = _validate_inbound(inbound, "render_audio_stream")
     if meta is None:
         return

--- a/src/lyra/adapters/discord_audio_outbound.py
+++ b/src/lyra/adapters/discord_audio_outbound.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +11,7 @@ import discord
 
 from lyra.adapters._shared import (
     _AUDIO_EXTS,
+    ATTACHMENT_EXTS_BASE,
     DISCORD_MAX_LENGTH,
     buffer_and_render_audio,
     mime_to_ext,
@@ -18,6 +19,7 @@ from lyra.adapters._shared import (
     sanitize_filename,
     truncate_caption,
 )
+from lyra.adapters.discord_formatting import _validate_inbound
 from lyra.core.message import (
     InboundMessage,
     OutboundAttachment,
@@ -27,7 +29,7 @@ from lyra.core.message import (
 )
 
 if TYPE_CHECKING:
-    from lyra.adapters.discord_voice import VoiceSessionManager
+    from lyra.adapters.discord import DiscordAdapter
 
 log = logging.getLogger(__name__)
 
@@ -36,12 +38,9 @@ _VOICE_MESSAGE_FLAG = 8192
 
 
 async def render_audio(
+    adapter: "DiscordAdapter",
     msg: OutboundAudio,
     inbound: InboundMessage,
-    *,
-    bot_id: str,
-    resolve_channel: Any,
-    http: Any,
 ) -> None:
     """Send an OutboundAudio envelope as a Discord voice message.
 
@@ -49,26 +48,13 @@ async def render_audio(
     renders a proper voice bubble with waveform and inline playback.
     Falls back to regular file attachment if conversion fails.
     """
-    if inbound.platform != Platform.DISCORD.value:
-        log.error(
-            "render_audio() called with non-discord message id=%s",
-            inbound.id,
-        )
+    meta = _validate_inbound(inbound, "render_audio")
+    if meta is None:
         return
-
-    channel_id: int | None = inbound.platform_meta.get("channel_id")
-    if channel_id is None:
-        log.error(
-            "render_audio: platform_meta missing 'channel_id' for msg id=%s",
-            inbound.id,
-        )
-        return
-
-    thread_id: int | None = inbound.platform_meta.get("thread_id")
+    channel_id, thread_id, message_id = meta
     send_to_id = thread_id if thread_id is not None else channel_id
 
     # Determine message to reply to
-    message_id: int | None = inbound.platform_meta.get("message_id")
     reply_to_id = parse_reply_to_id(msg.reply_to_id)
     if reply_to_id is None and thread_id is None:
         reply_to_id = message_id
@@ -109,7 +95,7 @@ async def render_audio(
         "POST", "/channels/{channel_id}/messages", channel_id=send_to_id
     )
     try:
-        await http.request(route, form=form, files=[voice_file])
+        await adapter.http.request(route, form=form, files=[voice_file])
         log.info(
             "render_audio: voice message sent (%d bytes OGG, %.1fs) for msg id=%s",
             len(msg.audio_bytes),
@@ -121,18 +107,16 @@ async def render_audio(
             "render_audio: voice message failed — falling back to file attachment",
             exc_info=True,
         )
-        messageable = await resolve_channel(send_to_id)
+        messageable = await adapter._resolve_channel(send_to_id)
         ext = mime_to_ext(msg.mime_type, _AUDIO_EXTS)
         attachment = discord.File(fp=BytesIO(msg.audio_bytes), filename=f"audio.{ext}")
         await messageable.send(content=content or None, file=attachment)
 
 
 async def render_attachment(
+    adapter: "DiscordAdapter",
     msg: OutboundAttachment,
     inbound: InboundMessage,
-    *,
-    resolve_channel: Any,
-    attachment_exts: frozenset[str],
 ) -> None:
     """Send an OutboundAttachment envelope as a Discord file attachment.
 
@@ -140,40 +124,27 @@ async def render_attachment(
     Caption (if set) is passed as message content. Reply and thread routing
     follow the same pattern as render_audio.
     """
-    if inbound.platform != Platform.DISCORD.value:
-        log.error(
-            "render_attachment() called with non-discord message id=%s",
-            inbound.id,
-        )
+    meta = _validate_inbound(inbound, "render_attachment")
+    if meta is None:
         return
-
-    channel_id: int | None = inbound.platform_meta.get("channel_id")
-    if channel_id is None:
-        log.error(
-            "render_attachment: platform_meta missing 'channel_id' for msg id=%s",
-            inbound.id,
-        )
-        return
-
-    thread_id: int | None = inbound.platform_meta.get("thread_id")
+    channel_id, thread_id, message_id = meta
     send_to_id = thread_id if thread_id is not None else channel_id
-    messageable = await resolve_channel(send_to_id)
+    messageable = await adapter._resolve_channel(send_to_id)
 
     # Derive filename: sanitize explicit name or derive from mime_type.
     if msg.filename:
         filename = sanitize_filename(
             msg.filename,
-            attachment_exts,
+            ATTACHMENT_EXTS_BASE,
         )
     else:
-        ext = mime_to_ext(msg.mime_type, attachment_exts)
+        ext = mime_to_ext(msg.mime_type, ATTACHMENT_EXTS_BASE)
         filename = f"attachment.{ext}"
 
     buf = BytesIO(msg.data)
     file_obj = discord.File(fp=buf, filename=filename)
 
     # Determine reply target
-    message_id: int | None = inbound.platform_meta.get("message_id")
     reply_to_id = parse_reply_to_id(msg.reply_to_id)
     if reply_to_id is None and thread_id is None:
         reply_to_id = message_id
@@ -197,26 +168,29 @@ async def render_attachment(
 
 
 async def render_audio_stream(
+    adapter: "DiscordAdapter",
     chunks: AsyncIterator[OutboundAudioChunk],
     inbound: InboundMessage,
-    render_audio_fn: Callable[[OutboundAudio, InboundMessage], Awaitable[None]],
 ) -> None:
     """Buffer streamed audio chunks and send as a single Discord file attachment."""
-    if inbound.platform != Platform.DISCORD.value:
-        log.error(
-            "render_audio_stream() called with non-discord message id=%s",
-            inbound.id,
-        )
+    meta = _validate_inbound(inbound, "render_audio_stream")
+    if meta is None:
         return
-    await buffer_and_render_audio(chunks, inbound, render_audio_fn)
+    await buffer_and_render_audio(
+        chunks, inbound, lambda audio, msg: render_audio(adapter, audio, msg)
+    )
 
 
 async def render_voice_stream(
+    adapter: "DiscordAdapter",
     chunks: AsyncIterator[OutboundAudioChunk],
     inbound: InboundMessage,
-    vsm: "VoiceSessionManager",
 ) -> None:
-    """Route TTS stream to the active Discord voice session for this guild."""
+    """Route TTS stream to the active Discord voice session for this guild.
+
+    Uses platform-only check (not _validate_inbound) because voice streams
+    route by guild_id, not channel_id.
+    """
     if inbound.platform != Platform.DISCORD.value:
         log.warning(
             "render_voice_stream() called with non-discord message id=%s",
@@ -230,4 +204,4 @@ async def render_voice_stream(
             inbound.id,
         )
         return
-    await vsm.stream(str(guild_id), chunks)
+    await adapter._vsm.stream(str(guild_id), chunks)

--- a/src/lyra/adapters/discord_formatting.py
+++ b/src/lyra/adapters/discord_formatting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -9,7 +10,9 @@ import discord
 from tabulate import tabulate
 
 from lyra.adapters._shared import AUDIO_MIME_TYPES, chunk_text
-from lyra.core.message import Attachment
+from lyra.core.message import Attachment, InboundMessage, Platform
+
+log = logging.getLogger("lyra.adapters.discord")
 
 _TABLE_RE = re.compile(
     r"(?m)"
@@ -98,3 +101,25 @@ def render_buttons(buttons: list[Any]) -> discord.ui.View | None:
     for b in buttons:
         view.add_item(discord.ui.Button(label=b.text, custom_id=b.callback_data))
     return view
+
+
+def _validate_inbound(
+    inbound: InboundMessage, caller: str
+) -> tuple[int, int | None, int | None] | None:
+    """Validate platform is Discord and extract (channel_id, thread_id, message_id).
+
+    Returns None on validation failure (logs error).
+    Mirrors telegram_formatting._validate_inbound().
+    """
+    if inbound.platform != Platform.DISCORD.value:
+        log.error("%s called with non-discord message id=%s", caller, inbound.id)
+        return None
+    channel_id: int | None = inbound.platform_meta.get("channel_id")
+    if channel_id is None:
+        log.error(
+            "%s: platform_meta missing 'channel_id' for msg id=%s", caller, inbound.id
+        )
+        return None
+    thread_id: int | None = inbound.platform_meta.get("thread_id")
+    message_id: int | None = inbound.platform_meta.get("message_id")
+    return channel_id, thread_id, message_id

--- a/src/lyra/adapters/discord_outbound.py
+++ b/src/lyra/adapters/discord_outbound.py
@@ -163,7 +163,8 @@ def build_streaming_callbacks(  # noqa: C901 — one closure per platform op
     from lyra.adapters._shared import send_with_retry
     from lyra.adapters._shared_streaming import PlatformCallbacks
 
-    if original_msg.platform != "discord":
+    meta = _validate_inbound(original_msg, "build_streaming_callbacks")
+    if meta is None:
 
         async def _bad_placeholder():
             raise ValueError("not a discord message")
@@ -184,10 +185,9 @@ def build_streaming_callbacks(  # noqa: C901 — one closure per platform op
             placeholder_text="\u2026",
         )
 
-    channel_id: int | None = original_msg.platform_meta.get("channel_id")
-    thread_id: int | None = original_msg.platform_meta.get("thread_id")
-    send_to_id: int = thread_id if thread_id is not None else channel_id  # type: ignore[assignment]
-    reply_msg_id: int | None = original_msg.platform_meta.get("message_id")
+    channel_id, thread_id, message_id = meta
+    send_to_id: int = thread_id if thread_id is not None else channel_id
+    reply_msg_id: int | None = message_id
     should_reply = reply_msg_id is not None and thread_id is None
     _placeholder_text = adapter._msg("stream_placeholder", "\u2026")
 

--- a/src/lyra/adapters/discord_outbound.py
+++ b/src/lyra/adapters/discord_outbound.py
@@ -13,15 +13,19 @@ from lyra.adapters._shared import (
     DISCORD_MAX_LENGTH,
     format_tool_summary_header,
 )
-from lyra.adapters.discord_formatting import render_buttons, render_text
+from lyra.adapters.discord_formatting import (
+    _validate_inbound,
+    render_buttons,
+    render_text,
+)
 from lyra.core.message import (
     InboundMessage,
     OutboundMessage,
-    Platform,
 )
 from lyra.core.render_events import ToolSummaryRenderEvent
 
 if TYPE_CHECKING:
+    from lyra.adapters._shared_streaming import PlatformCallbacks
     from lyra.adapters.discord import DiscordAdapter
 
 log = logging.getLogger("lyra.adapters.discord")
@@ -88,24 +92,16 @@ async def _discord_typing_worker(  # noqa: C901 — retry + error branches
         )
 
 
-
 async def send(  # noqa: C901 — attachment loop adds branches
     adapter: "DiscordAdapter",
     original_msg: InboundMessage,
     outbound: OutboundMessage,
 ) -> None:
     """Send response back to Discord."""
-    if original_msg.platform != Platform.DISCORD.value:
-        log.error(
-            "send() called with non-discord message id=%s",
-            original_msg.id,
-        )
+    meta = _validate_inbound(original_msg, "send")
+    if meta is None:
         return
-
-    channel_id: int | None = original_msg.platform_meta.get("channel_id")
-    if channel_id is None:
-        raise ValueError("platform_meta missing required key 'channel_id' for send()")
-    thread_id: int | None = original_msg.platform_meta.get("thread_id")
+    channel_id, thread_id, message_id = meta
     send_to_id: int = thread_id if thread_id is not None else channel_id
     messageable = await adapter._resolve_channel(send_to_id)
 
@@ -115,7 +111,7 @@ async def send(  # noqa: C901 — attachment loop adds branches
     last_idx = len(chunks) - 1
 
     # Skip reply-to in threads — thread context makes it redundant.
-    reply_msg_id: int | None = original_msg.platform_meta.get("message_id")
+    reply_msg_id: int | None = message_id
     should_reply = reply_msg_id is not None and thread_id is None
     for i, chunk in enumerate(chunks):
         chunk_view = view if (i == last_idx and view is not None) else None
@@ -151,3 +147,110 @@ def _build_tool_embed(event: ToolSummaryRenderEvent) -> "discord.Embed":
     color = discord.Color.green() if event.is_complete else discord.Color.blue()
     description = "\n".join(format_tool_lines(event)) or "\u200b"
     return discord.Embed(title=title, description=description, color=color)
+
+
+def build_streaming_callbacks(  # noqa: C901 — one closure per platform op
+    adapter: "DiscordAdapter",
+    original_msg: InboundMessage,
+    outbound: OutboundMessage | None,
+) -> "PlatformCallbacks":
+    """Build PlatformCallbacks for StreamingSession from a DiscordAdapter context.
+
+    Extracted from DiscordAdapter._make_streaming_callbacks to keep discord.py
+    under the 300-line file-length limit, matching the Telegram pattern in
+    telegram_outbound.build_streaming_callbacks().
+    """
+    from lyra.adapters._shared import send_with_retry
+    from lyra.adapters._shared_streaming import PlatformCallbacks
+
+    if original_msg.platform != "discord":
+
+        async def _bad_placeholder():
+            raise ValueError("not a discord message")
+
+        async def _noop(text=""):
+            return None
+
+        return PlatformCallbacks(
+            send_placeholder=_bad_placeholder,
+            edit_placeholder_text=lambda ph, text: asyncio.sleep(0),
+            edit_placeholder_tool=lambda ph, ev, h: asyncio.sleep(0),
+            send_message=_noop,
+            send_fallback=_noop,
+            chunk_text=lambda t: [t],
+            start_typing=lambda: None,
+            cancel_typing=lambda: None,
+            get_msg=lambda key, fallback: fallback,
+            placeholder_text="\u2026",
+        )
+
+    channel_id: int | None = original_msg.platform_meta.get("channel_id")
+    thread_id: int | None = original_msg.platform_meta.get("thread_id")
+    send_to_id: int = thread_id if thread_id is not None else channel_id  # type: ignore[assignment]
+    reply_msg_id: int | None = original_msg.platform_meta.get("message_id")
+    should_reply = reply_msg_id is not None and thread_id is None
+    _placeholder_text = adapter._msg("stream_placeholder", "\u2026")
+
+    async def _send_placeholder():
+        messageable = await adapter._resolve_channel(send_to_id)
+        if should_reply:
+            msg_obj = messageable.get_partial_message(reply_msg_id)  # type: ignore[attr-defined]
+            placeholder = await msg_obj.reply(_placeholder_text)
+        else:
+            placeholder = await messageable.send(_placeholder_text)
+        return placeholder, placeholder.id
+
+    async def _edit_placeholder_text(ph, text):
+        display = text[-DISCORD_MAX_LENGTH:]
+        await send_with_retry(
+            lambda d=display: ph.edit(content=d, embed=None),
+            label="Intermediate text edit",
+        )
+
+    async def _edit_placeholder_tool(ph, event, header: str = ""):
+        embed = _build_tool_embed(event)
+        await send_with_retry(
+            lambda e=embed: ph.edit(content="", embed=e),
+            label="Tool summary embed",
+        )
+
+    async def _send_message(text: str) -> int | None:
+        messageable = await adapter._resolve_channel(send_to_id)
+        chunks = render_text(text, DISCORD_MAX_LENGTH)
+        last_id = None
+        for i, chunk in enumerate(chunks):
+            is_last = i == len(chunks) - 1
+            if is_last:
+                try:
+                    sent = await messageable.send(chunk)
+                    last_id = sent.id
+                except Exception:
+                    log.exception("Failed to send final text chunk")
+            else:
+                await send_with_retry(
+                    lambda c=chunk: messageable.send(c),
+                    label="Final text chunk",
+                )
+        return last_id
+
+    async def _send_fallback(text: str) -> int | None:
+        fallback_outbound = (
+            OutboundMessage.from_text(text)
+            if text
+            else OutboundMessage.from_text(_placeholder_text)
+        )
+        await send(adapter, original_msg, fallback_outbound)
+        return fallback_outbound.metadata.get("reply_message_id")
+
+    return PlatformCallbacks(
+        send_placeholder=_send_placeholder,
+        edit_placeholder_text=_edit_placeholder_text,
+        edit_placeholder_tool=_edit_placeholder_tool,
+        send_message=_send_message,
+        send_fallback=_send_fallback,
+        chunk_text=lambda text: render_text(text, DISCORD_MAX_LENGTH),
+        start_typing=lambda: adapter._start_typing(send_to_id),
+        cancel_typing=lambda: adapter._cancel_typing(send_to_id),
+        get_msg=adapter._msg,
+        placeholder_text=_placeholder_text,
+    )


### PR DESCRIPTION
## Summary
- Extract `_make_streaming_callbacks` from `discord.py` to `discord_outbound.build_streaming_callbacks()`, matching Telegram's extraction pattern
- Add `_validate_inbound()` helper to `discord_formatting.py`, replacing 5 inline platform checks across Discord outbound modules
- Align `render_audio`, `render_attachment`, `render_audio_stream`, `render_voice_stream` signatures to `(adapter, msg, inbound)` matching Telegram's convention

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #649: align outbound extraction patterns | Open |
| Implementation | 1 commit on `refactor/649-align-outbound-adapters` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2660 passed) | Passed |

## Test Plan
- [x] All 415 adapter tests pass
- [x] All 43 core outbound dispatcher tests pass
- [x] Full suite: 2660 passed, 0 failures
- [x] Pyright: 0 errors on all modified files
- [x] Ruff: all checks passed
- [ ] Verify voice streaming works on Discord (render_voice_stream signature changed)
- [ ] Verify audio rendering on both Telegram and Discord

Closes #649

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`