### PR TITLE
chore(devops): harden Quadlet units with defense-in-depth directives

### DIFF
--- a/deploy/quadlet/.env.hub.example
+++ b/deploy/quadlet/.env.hub.example
@@ -9,6 +9,7 @@ ANTHROPIC_API_KEY=
 LYRA_HEALTH_SECRET=
 LYRA_HEALTH_PORT=8443
 
-# Optional overrides
+# Optional overrides — LYRA_LOG_DIR is set in hub.container to the logs
+# volume mount point. Override here only if you've remapped the volume.
 # LYRA_LOG_DIR=
 # ROXABI_VAULT_DIR=

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -25,6 +25,8 @@ Environment=NATS_URL=nats://lyra-nats:4222
 Volume=lyra-nkey-hub.volume:/run/secrets/hub.seed:ro,z
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/hub.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:z
+Volume=lyra-logs.volume:/home/lyra/.local/state/lyra/logs:z
+Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 Volume=lyra-config.volume:/app/config.toml:ro,z
 # Health endpoint — probed by lyra-monitor via host loopback (localhost:8443).
 PublishPort=127.0.0.1:8443:8443

--- a/deploy/quadlet/hub.container
+++ b/deploy/quadlet/hub.container
@@ -6,9 +6,16 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Container]
+# Image digest pinning for localhost/lyra:latest tracks on a follow-up issue
+# (CI tag-by-SHA strategy). Upstream registry images (e.g. nats.container)
+# are pinned by digest directly.
 Image=localhost/lyra:latest
 ContainerName=lyra-hub
 Network=lyra.network
+# Hardening — defense in depth (see issue #652).
+NoNewPrivileges=true
+ReadOnly=true
+DropCapability=all
 EnvironmentFile=%h/projects/lyra/.env.hub
 # .env.hub contains only hub-scoped vars (ANTHROPIC_API_KEY, LYRA_HEALTH_SECRET,
 # LYRA_LOG_DIR, ROXABI_VAULT_DIR). Adapter tokens (Telegram, Discord, TTS/STT)
@@ -26,6 +33,8 @@ Exec=lyra hub
 [Service]
 Restart=on-failure
 RestartSec=5
+# Cap at 2 full cores — prevents a runaway worker from starving hub + NATS.
+CPUQuota=200%
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/lyra-adapter@.container
+++ b/deploy/quadlet/lyra-adapter@.container
@@ -22,6 +22,8 @@ Environment=NATS_URL=nats://lyra-nats:4222
 Volume=lyra-nkey-%i-adapter.volume:/run/secrets/%i-adapter.seed:ro,z
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/%i-adapter.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:ro,z
+Volume=lyra-logs.volume:/home/lyra/.local/state/lyra/logs:z
+Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 Volume=lyra-config.volume:/app/config.toml:ro,z
 Exec=lyra adapter %i
 

--- a/deploy/quadlet/lyra-adapter@.container
+++ b/deploy/quadlet/lyra-adapter@.container
@@ -6,9 +6,15 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Container]
+# Image digest pinning for localhost/lyra:latest tracks on a follow-up issue
+# (CI tag-by-SHA strategy).
 Image=localhost/lyra:latest
 ContainerName=lyra-%i
 Network=lyra.network
+# Hardening — defense in depth (see issue #652).
+NoNewPrivileges=true
+ReadOnly=true
+DropCapability=all
 # Scoped env file — copy from .env.%i.example, fill in bot token only.
 # NATS_URL and NATS_NKEY_SEED_PATH are set inline below.
 EnvironmentFile=%h/projects/lyra/.env.%i
@@ -22,6 +28,8 @@ Exec=lyra adapter %i
 [Service]
 Restart=on-failure
 RestartSec=5
+# Cap at 2 full cores — prevents a runaway worker from starving hub + NATS.
+CPUQuota=200%
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/lyra-logs.volume
+++ b/deploy/quadlet/lyra-logs.volume
@@ -1,0 +1,5 @@
+[Unit]
+Description=Lyra logs volume (rotating file handlers, rw for hub + adapters)
+
+[Volume]
+Label=app=lyra

--- a/deploy/quadlet/nats.container
+++ b/deploy/quadlet/nats.container
@@ -2,9 +2,15 @@
 Description=Lyra NATS server
 
 [Container]
-Image=nats:2.10.29-alpine
+# Pinned by digest (immutable) — bump on upstream NATS releases.
+# Tag 2.10.29-alpine resolved via Docker Hub registry API (see issue #652).
+Image=docker.io/library/nats:2.10.29-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
 ContainerName=lyra-nats
 Network=lyra.network
+# Hardening — defense in depth (see issue #652).
+NoNewPrivileges=true
+ReadOnly=true
+DropCapability=all
 # Host 4223 → container 4222: runs alongside supervisord NATS (4222) during
 # parallel testing. Switch to 4222:4222 once supervisord NATS is retired.
 PublishPort=127.0.0.1:4223:4222
@@ -15,6 +21,8 @@ Exec=nats-server -js -c /etc/nats/nats.conf
 [Service]
 Restart=always
 RestartSec=5
+# Cap at 2 full cores — keeps NATS from starving hub/adapters under load.
+CPUQuota=200%
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

Harden all three Podman Quadlet `.container` units against container-escape and noisy-neighbour vectors (finding M6 from the 2026-04-12 from-scratch rebuild review).

- **`[Container]` per unit:** `NoNewPrivileges=true`, `ReadOnly=true`, `DropCapability=all`
- **`[Service]` per unit:** `CPUQuota=200%` (cap at 2 cores)
- **NATS image:** pinned by sha256 digest — `docker.io/library/nats:2.10.29-alpine@sha256:b83efa…6bb927`
- **`localhost/lyra:latest`:** left on the mutable tag with a comment pointing to a follow-up issue — digest pinning for a locally-built image needs a CI tag-by-SHA strategy, out of scope for this S-tier

### Deviations from the issue body

The issue listed `ReadOnlyRootFilesystem=true` (Kubernetes terminology) and `CPUQuota=200%` under `[Container]`. Neither is a valid Quadlet directive in those forms:

| Issue wording | Actual directive used |
|---|---|
| `ReadOnlyRootFilesystem=true` | `ReadOnly=true` (Quadlet) — `/tmp`, `/run`, `/var/tmp` auto-mounted as tmpfs via `--read-only-tmpfs` default |
| `CPUQuota=200%` in `[Container]` | `CPUQuota=200%` in `[Service]` (systemd unit directive, not Quadlet `[Container]`) |

Everything else lands as the issue intended.

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | #652: chore(devops): harden Quadlet container units | OPEN |
| Implementation | 1 commit on `feat/652-harden-quadlet` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (2638 passed, 83% cov, 0 new tests) | Passed |

## Test Plan

- [ ] Deploy to Machine 1: `systemctl --user daemon-reload && systemctl --user restart lyra.service`
- [ ] `systemctl --user status lyra-hub lyra-nats 'lyra-*.service'` — all active
- [ ] Hub + NATS pass `HealthCmd` probes (monitor endpoint `127.0.0.1:8443`)
- [ ] `make ps` clean — no regression vs pre-deploy
- [ ] Verify `ReadOnly=true` doesn't surprise-break writes: tail journal for `EROFS` / permission errors for 5 min post-restart
- [ ] Verify NATS JetStream still works with default `/tmp` tmpfs (ephemeral state acceptable)

## Follow-ups

- Separate issue: CI tag-by-SHA strategy so `localhost/lyra:latest` can be digest-pinned with traceability back to git SHA
- Separate issue: decouple voicecli from lyra (NATS-only, remove direct `import voicecli.*` paths) — surfaced while debugging the pre-commit typecheck hook

Closes #652

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`