### PR TITLE
chore(core): extend ModelConfig — add base_url + api_key fields

### DIFF
--- a/src/lyra/core/agent_config.py
+++ b/src/lyra/core/agent_config.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 
 from .commands.command_router import CommandConfig
 
-_VALID_BACKENDS: frozenset[str] = frozenset({"claude-cli", "ollama", "anthropic-sdk"})
+_VALID_BACKENDS: frozenset[str] = frozenset({"claude-cli", "ollama", "anthropic-sdk", "litellm"})
 _MAX_PROMPT_BYTES = 64 * 1024  # 64 KB
 
 _WORKSPACE_BUILTIN_CONFLICTS = frozenset(
@@ -34,8 +34,8 @@ _WORKSPACE_BUILTIN_CONFLICTS = frozenset(
 class ModelConfig(BaseModel):
     """Per-agent model configuration.
 
-    backend: execution backend — "claude-cli" (Claude Code subscription)
-             or "ollama" (local, future).
+    backend: execution backend — "claude-cli" (Claude Code subscription),
+             "ollama" (local, future), or "litellm" (unified LLM proxy).
     model:   model identifier passed to the backend CLI.
     max_turns: max agentic turns per conversation turn.
              None (or 0 in DB) means unlimited — the backend imposes no cap.
@@ -46,6 +46,13 @@ class ModelConfig(BaseModel):
              None → defaults to the Lyra project root.
              Useful to point a dedicated agent at another project so it reads
              that project's CLAUDE.md and has access to its files.
+    base_url: override the backend API base URL.
+             e.g. "http://localhost:11434/v1" for Ollama local, None for cloud
+             defaults. Used by litellm and anthropic-sdk backends.
+    api_key: backend API key override. Resolved via secrets store at runtime;
+             None = use env var (FIREWORKS_API_KEY, ANTHROPIC_API_KEY, etc.).
+             Intentionally excluded from __eq__ and __hash__ — it is a
+             credential, not part of model identity.
 
     This will evolve into an intelligent model selection system.
     """
@@ -62,6 +69,10 @@ class ModelConfig(BaseModel):
     cwd: Path | None = None
     skip_permissions: bool = False
     streaming: bool = False
+    base_url: str | None = None
+    # e.g. "http://localhost:11434/v1" for Ollama local, None for cloud defaults
+    api_key: str | None = None
+    # resolved via secrets store at runtime; None = use env var (FIREWORKS_API_KEY etc.)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ModelConfig):
@@ -73,7 +84,9 @@ class ModelConfig(BaseModel):
             and self.tools == other.tools
             and self.skip_permissions == other.skip_permissions
             and self.streaming == other.streaming
+            and self.base_url == other.base_url
             # cwd excluded — spawn-routing config, not model identity
+            # api_key excluded — credential, not model identity
         )
 
     def __hash__(self) -> int:
@@ -85,7 +98,9 @@ class ModelConfig(BaseModel):
                 self.tools,
                 self.skip_permissions,
                 self.streaming,
+                self.base_url,
                 # cwd intentionally excluded
+                # api_key intentionally excluded — credential, not model identity
             )
         )
 

--- a/src/lyra/core/agent_config.py
+++ b/src/lyra/core/agent_config.py
@@ -50,11 +50,11 @@ class ModelConfig(BaseModel):
              that project's CLAUDE.md and has access to its files.
     base_url: override the backend API base URL.
              e.g. "http://localhost:11434/v1" for Ollama local, None for cloud
-             defaults. Used by litellm and anthropic-sdk backends.
-    api_key: backend API key override. Resolved via secrets store at runtime;
+             defaults. Used by litellm (future).
+    api_key: backend API key override. Used by litellm (future);
              None = use env var (FIREWORKS_API_KEY, ANTHROPIC_API_KEY, etc.).
-             Intentionally excluded from __eq__ and __hash__ — it is a
-             credential, not part of model identity.
+             Intentionally excluded from __eq__, __hash__, model_dump, and
+             repr — it is a credential, not part of model identity.
 
     This will evolve into an intelligent model selection system.
     """
@@ -73,6 +73,18 @@ class ModelConfig(BaseModel):
     streaming: bool = False
     base_url: str | None = None
     api_key: str | None = Field(default=None, exclude=True, repr=False)
+
+    @field_validator("base_url")
+    @classmethod
+    def _validate_base_url_scheme(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        from urllib.parse import urlparse
+
+        scheme = urlparse(v).scheme.lower()
+        if scheme not in {"http", "https"}:
+            raise ValueError(f"base_url must use http or https scheme, got {scheme!r}")
+        return v
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ModelConfig):

--- a/src/lyra/core/agent_config.py
+++ b/src/lyra/core/agent_config.py
@@ -8,7 +8,9 @@ from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 
 from .commands.command_router import CommandConfig
 
-_VALID_BACKENDS: frozenset[str] = frozenset({"claude-cli", "ollama", "anthropic-sdk", "litellm"})
+_VALID_BACKENDS: frozenset[str] = frozenset(
+    {"claude-cli", "ollama", "anthropic-sdk", "litellm"}
+)
 _MAX_PROMPT_BYTES = 64 * 1024  # 64 KB
 
 _WORKSPACE_BUILTIN_CONFLICTS = frozenset(

--- a/src/lyra/core/agent_config.py
+++ b/src/lyra/core/agent_config.py
@@ -4,7 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from .commands.command_router import CommandConfig
 
@@ -72,9 +72,7 @@ class ModelConfig(BaseModel):
     skip_permissions: bool = False
     streaming: bool = False
     base_url: str | None = None
-    # e.g. "http://localhost:11434/v1" for Ollama local, None for cloud defaults
-    api_key: str | None = None
-    # resolved via secrets store at runtime; None = use env var (FIREWORKS_API_KEY etc.)
+    api_key: str | None = Field(default=None, exclude=True, repr=False)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ModelConfig):

--- a/src/lyra/llm/CLAUDE.md
+++ b/src/lyra/llm/CLAUDE.md
@@ -82,7 +82,7 @@ Configure in agent TOML under `[agent.smart_routing]`. Default: `enabled = false
 ## ProviderRegistry (`registry.py`)
 
 A simple dict-based registry: `register(backend, driver)` and `get(backend)`.
-Backends are registered by name: `"claude-cli"`, `"anthropic-sdk"`.
+Backends are registered by name: `"claude-cli"`, `"anthropic-sdk"`, `"litellm"` (future).
 `get()` raises `KeyError` for unknown backends — callers must handle this.
 
 ## Conventions

--- a/tests/core/test_agent_config.py
+++ b/tests/core/test_agent_config.py
@@ -55,3 +55,79 @@ class TestModelConfig:
         a = ModelConfig(cwd=Path("/a"))
         b = ModelConfig(cwd=Path("/b"))
         assert hash(a) == hash(b)
+
+    # ------------------------------------------------------------------
+    # base_url field
+    # ------------------------------------------------------------------
+
+    def test_base_url_defaults_to_none(self) -> None:
+        cfg = ModelConfig()
+        assert cfg.base_url is None
+
+    def test_base_url_accepts_string(self) -> None:
+        cfg = ModelConfig(base_url="http://localhost:11434/v1")
+        assert cfg.base_url == "http://localhost:11434/v1"
+
+    def test_base_url_serializes_correctly(self) -> None:
+        cfg = ModelConfig(base_url="http://localhost:11434/v1")
+        dumped = cfg.model_dump()
+        assert dumped["base_url"] == "http://localhost:11434/v1"
+
+    def test_base_url_roundtrips_via_model_validate(self) -> None:
+        cfg = ModelConfig(base_url="http://localhost:11434/v1")
+        restored = ModelConfig.model_validate(cfg.model_dump())
+        assert restored.base_url == "http://localhost:11434/v1"
+
+    def test_eq_same_base_url_are_equal(self) -> None:
+        a = ModelConfig(base_url="http://localhost:11434/v1")
+        b = ModelConfig(base_url="http://localhost:11434/v1")
+        assert a == b
+
+    def test_eq_different_base_url_are_not_equal(self) -> None:
+        a = ModelConfig(base_url="http://localhost:11434/v1")
+        b = ModelConfig(base_url="http://remotehost:8080/v1")
+        assert a != b
+
+    def test_eq_one_base_url_none_not_equal(self) -> None:
+        a = ModelConfig(base_url=None)
+        b = ModelConfig(base_url="http://localhost:11434/v1")
+        assert a != b
+
+    def test_hash_same_base_url_same_hash(self) -> None:
+        a = ModelConfig(base_url="http://localhost:11434/v1")
+        b = ModelConfig(base_url="http://localhost:11434/v1")
+        assert hash(a) == hash(b)
+
+    def test_hash_different_base_url_different_hash(self) -> None:
+        a = ModelConfig(base_url="http://localhost:11434/v1")
+        b = ModelConfig(base_url="http://remotehost:8080/v1")
+        assert hash(a) != hash(b)
+
+    # ------------------------------------------------------------------
+    # api_key field — excluded from hash and eq
+    # ------------------------------------------------------------------
+
+    def test_api_key_defaults_to_none(self) -> None:
+        cfg = ModelConfig()
+        assert cfg.api_key is None
+
+    def test_api_key_accepts_string(self) -> None:
+        cfg = ModelConfig(api_key="sk-secret")
+        assert cfg.api_key == "sk-secret"
+
+    def test_api_key_excluded_from_eq(self) -> None:
+        """Two configs differing only in api_key must be equal."""
+        a = ModelConfig(api_key="sk-one")
+        b = ModelConfig(api_key="sk-two")
+        assert a == b
+
+    def test_api_key_excluded_from_hash(self) -> None:
+        """Two configs differing only in api_key must share the same hash."""
+        a = ModelConfig(api_key="sk-one")
+        b = ModelConfig(api_key="sk-two")
+        assert hash(a) == hash(b)
+
+    def test_api_key_none_and_set_same_hash(self) -> None:
+        a = ModelConfig(api_key=None)
+        b = ModelConfig(api_key="sk-any")
+        assert hash(a) == hash(b)

--- a/tests/core/test_agent_config.py
+++ b/tests/core/test_agent_config.py
@@ -98,11 +98,6 @@ class TestModelConfig:
         b = ModelConfig(base_url="http://localhost:11434/v1")
         assert hash(a) == hash(b)
 
-    def test_hash_different_base_url_different_hash(self) -> None:
-        a = ModelConfig(base_url="http://localhost:11434/v1")
-        b = ModelConfig(base_url="http://remotehost:8080/v1")
-        assert hash(a) != hash(b)
-
     # ------------------------------------------------------------------
     # api_key field — excluded from hash and eq
     # ------------------------------------------------------------------

--- a/tests/core/test_agent_config.py
+++ b/tests/core/test_agent_config.py
@@ -22,6 +22,27 @@ class TestModelConfig:
         assert cfg.model == "claude-opus-4-6"
         assert cfg.max_turns is None  # None = unlimited (default)
         assert cfg.tools == ()
+        assert cfg.base_url is None
+        assert cfg.api_key is None
+
+    def test_backend_litellm_accepted(self) -> None:
+        cfg = ModelConfig(backend="litellm")
+        assert cfg.backend == "litellm"
+
+    def test_valid_backends_contains_litellm(self) -> None:
+        from lyra.core.agent_config import _VALID_BACKENDS
+
+        assert "litellm" in _VALID_BACKENDS
+
+    def test_base_url_invalid_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelConfig(base_url="file:///etc/passwd")
+        with pytest.raises(ValidationError):
+            ModelConfig(base_url="gopher://example.com")
+
+    def test_base_url_http_and_https_accepted(self) -> None:
+        assert ModelConfig(base_url="http://localhost:11434/v1").base_url
+        assert ModelConfig(base_url="https://api.example.com").base_url
 
     def test_tools_field_is_tuple(self) -> None:
         cfg = ModelConfig(tools=("Read", "Grep"))
@@ -126,3 +147,20 @@ class TestModelConfig:
         a = ModelConfig(api_key=None)
         b = ModelConfig(api_key="sk-any")
         assert hash(a) == hash(b)
+
+    def test_api_key_excluded_from_model_dump(self) -> None:
+        """api_key must never leak into serialized payloads (NATS, DB, logs)."""
+        cfg = ModelConfig(api_key="sk-secret")
+        dumped = cfg.model_dump()
+        assert "api_key" not in dumped
+
+    def test_api_key_excluded_from_repr(self) -> None:
+        """repr must not leak the credential in log/debug output."""
+        cfg = ModelConfig(api_key="sk-secret")
+        assert "sk-secret" not in repr(cfg)
+
+    def test_api_key_roundtrip_does_not_restore_value(self) -> None:
+        """model_dump → model_validate does not round-trip api_key by design."""
+        cfg = ModelConfig(api_key="sk-secret")
+        restored = ModelConfig.model_validate(cfg.model_dump())
+        assert restored.api_key is None


### PR DESCRIPTION
## Summary
- Extend `ModelConfig` with `base_url` and `api_key` fields so LiteLLMDriver can configure local (Ollama) and cloud (Fireworks, Anthropic, etc.) providers as first-class config.
- Add `"litellm"` to valid backends; `api_key` excluded from `__eq__`/`__hash__` (credential, not identity).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #664: chore(core): extend ModelConfig — add base_url + api_key fields | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 2 commits on `chore/664-modelconfig-base-url-apikey` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new file) | Passed |

## Test Plan
- [ ] `uv run pytest tests/core/test_agent_config.py` — new ModelConfig fields round-trip
- [ ] Load an agent TOML with `backend = "litellm"`, `base_url`, `api_key` → `lyra agent validate <name>` passes
- [ ] Verify `api_key` absent from `ModelConfig.__eq__` (two configs differing only in api_key compare equal)

Closes #664
Part of #663

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`