### PR TITLE
feat(voice): freeze NATS contract as ADR-044 + contract_version field

### DIFF
--- a/docs/architecture/adr/044-lyra-voicecli-nats-contract.mdx
+++ b/docs/architecture/adr/044-lyra-voicecli-nats-contract.mdx
@@ -1,0 +1,229 @@
+---
+title: "ADR-044: lyra ↔ voicecli NATS voice contract (STT + TTS)"
+description: Freeze the request/reply and heartbeat payloads exchanged between lyra (hub) and voicecli (satellite) over NATS, including the contract_version additive field for forward compatibility.
+---
+
+## Status
+
+Accepted
+
+## Context
+
+Lyra currently invokes voiceCLI for STT and TTS via two parallel code paths:
+
+1. **In-process** — `STTService` / `TTSService` import `voicecli` directly inside the hub venv.
+2. **NATS request-reply** — `NatsSttClient` / `NatsTtsClient` send JSON payloads to `lyra.voice.{stt,tts}.request`; `stt_adapter_standalone.py` / `tts_adapter_standalone.py` consume them inside a satellite process that owns the voicecli import.
+
+The NATS path lets voiceCLI run on a different host, with its own venv, GPU and lifecycle — a hard requirement on `roxabituwer`, where the hub and the voice workers will live in separate containers/processes (see #658). The in-process path must eventually be removed (slice S4 of #658), but slices S1–S3 run both side-by-side so that the production cutover is reversible.
+
+For the two sides to diverge safely, the wire contract has to be explicit — what fields land on each subject, which are required, which are optional, and how each side evolves without breaking the other. So far it has lived only in the hub source code. This ADR freezes it.
+
+It also introduces a single additive field — `contract_version: "1"` — carried on every producer-emitted payload. This field exists to make future field additions or deprecations detectable on the wire, without dragging version handshakes or schema negotiation into the current code paths.
+
+## Decision
+
+### Subjects
+
+| Subject | Direction | Producer | Consumer | Purpose |
+|---|---|---|---|---|
+| `lyra.voice.stt.request` | request-reply | `NatsSttClient.transcribe` (hub) | `SttAdapterStandalone.handle` (satellite) | Transcribe audio to text |
+| `lyra.voice.tts.request` | request-reply | `NatsTtsClient.synthesize` (hub) | `TtsAdapterStandalone.handle` (satellite) | Synthesize speech from text |
+| `lyra.voice.stt.heartbeat` | fire-and-forget | `SttAdapterStandalone` (satellite) | `NatsSttClient._on_heartbeat` (hub) | Liveness + capacity |
+| `lyra.voice.tts.heartbeat` | fire-and-forget | `TtsAdapterStandalone` (satellite) | `NatsTtsClient._on_heartbeat` (hub) | Liveness + capacity |
+
+Queue groups (load balancing across satellite replicas): `STT_WORKERS` for STT, `TTS_WORKERS` for TTS. Replies use the NATS request-reply inbox; no dedicated reply subject.
+
+### Payload encoding
+
+UTF-8 JSON. Binary audio is base64-encoded in-payload (no sidecar stream). NATS `max_payload` is the hard ceiling; requests that exceed it fail fast with `STTUnavailableError("STT request payload too large")` / `TtsUnavailableError("TTS request payload too large")` on the hub side.
+
+### `contract_version` — additive, one-way
+
+Every payload listed below carries `contract_version: "1"` as a top-level string field.
+
+- **Producers (hub or satellite) MUST emit it** on every outgoing request, reply, and heartbeat.
+- **Consumers MUST ignore unknown values.** A consumer reading a payload uses `.get("contract_version")` (or simply does not read it at all); it MUST NOT reject or error on any value. `"1"`, `"2"`, `"whatever"`, or missing — all are accepted.
+- The field is **additive**, not a handshake. A `"2"` sender and a `"1"` reader continue to work as long as no other field has been removed or reinterpreted between versions. When an incompatible change is needed, it ships as a new subject (or a new ADR), not a bumped version.
+- The goal is **observability** — logs and metrics on both sides can filter by version, and operators can diagnose mismatches on the wire without guessing.
+
+### Request — `lyra.voice.stt.request`
+
+```json
+{
+  "contract_version": "1",
+  "request_id": "b6d5a3a0-7e70-4e3a-ae93-3a9f1c2b7c5e",
+  "audio_b64": "T2dnUwACAAAA...",
+  "mime_type": "audio/ogg",
+  "model": "large-v3-turbo",
+  "language_detection_threshold": 0.5,
+  "language_detection_segments": 3,
+  "language_fallback": "en"
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` for this ADR |
+| `request_id` | string (uuid4) | ✓ | Echoed back in the reply |
+| `audio_b64` | string (base64) | ✓ | Raw audio bytes |
+| `mime_type` | string | ✓ | `audio/ogg`, `audio/mpeg`, `audio/wav`, `audio/mp4`, `audio/webm`, `audio/flac`; unknown → treated as `audio/ogg` |
+| `model` | string | ✓ | Whisper model name (e.g. `large-v3-turbo`) |
+| `language_detection_threshold` | number \| null | — | Overrides STT config if non-null |
+| `language_detection_segments` | integer \| null | — | Overrides STT config if non-null |
+| `language_fallback` | string \| null | — | ISO-639-1 code; fallback when detection confidence is below threshold |
+
+### Reply — `lyra.voice.stt.request` (success)
+
+```json
+{
+  "contract_version": "1",
+  "request_id": "b6d5a3a0-7e70-4e3a-ae93-3a9f1c2b7c5e",
+  "ok": true,
+  "text": "bonjour tout le monde",
+  "language": "fr",
+  "duration_seconds": 1.42
+}
+```
+
+### Reply — `lyra.voice.stt.request` (error)
+
+```json
+{
+  "contract_version": "1",
+  "request_id": "b6d5a3a0-7e70-4e3a-ae93-3a9f1c2b7c5e",
+  "ok": false,
+  "error": "transcription_failed"
+}
+```
+
+Error codes are short snake_case tokens. The hub raises `STTUnavailableError` on `ok: false` regardless of the specific `error` value — the token is for logs, not for control flow.
+
+### Request — `lyra.voice.tts.request`
+
+```json
+{
+  "contract_version": "1",
+  "request_id": "2f77f4fa-58c2-4d35-8c9e-2e7c3f9c8f1e",
+  "text": "hello world",
+  "language": "en",
+  "voice": "alice",
+  "fallback_language": "en",
+  "chunked": true,
+  "engine": "chatterbox",
+  "speed": 1.0
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` |
+| `request_id` | string (uuid4) | ✓ | Echoed back |
+| `text` | string | ✓ | UTF-8 text to synthesize |
+| `language` | string \| null | — | ISO-639-1 code; caller override |
+| `voice` | string \| null | — | Engine-specific voice id; caller override |
+| `fallback_language` | string \| null | — | Used when `language` is ambiguous |
+| `chunked` | boolean | — | Enables multi-segment synthesis; default `true` |
+| _agent TTS fields_ | various \| null | — | `engine`, `accent`, `personality`, `speed`, `emotion`, `exaggeration`, `cfg_weight`, `segment_gap`, `crossfade`, `chunk_size`, `default_language`, `languages` — forwarded verbatim when set; omitted when null. See `_TTS_CONFIG_FIELDS` / `_AGENT_TTS_FIELDS` for the authoritative list. |
+
+### Reply — `lyra.voice.tts.request` (success)
+
+```json
+{
+  "contract_version": "1",
+  "request_id": "2f77f4fa-58c2-4d35-8c9e-2e7c3f9c8f1e",
+  "ok": true,
+  "audio_b64": "T2dnUwACAAAA...",
+  "mime_type": "audio/ogg",
+  "duration_ms": 1420,
+  "waveform_b64": null
+}
+```
+
+`mime_type` defaults to `audio/ogg` on the hub side if absent. `duration_ms` and `waveform_b64` are both optional/nullable; renderers must handle nulls.
+
+### Reply — `lyra.voice.tts.request` (error)
+
+```json
+{
+  "contract_version": "1",
+  "request_id": "2f77f4fa-58c2-4d35-8c9e-2e7c3f9c8f1e",
+  "ok": false,
+  "error": "synthesis_failed"
+}
+```
+
+### Heartbeats — `lyra.voice.{stt,tts}.heartbeat`
+
+```json
+{
+  "contract_version": "1",
+  "worker_id": "stt-roxabituwer-1712934123",
+  "service": "stt_workers",
+  "host": "roxabituwer",
+  "subject": "lyra.voice.stt.request",
+  "queue_group": "stt_workers",
+  "ts": 1712934198.123,
+  "model_loaded": "large-v3-turbo",
+  "vram_used_mb": 4128,
+  "vram_total_mb": 10240,
+  "active_requests": 0
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` |
+| `worker_id` | string | ✓ | Unique per process; hub indexes freshness by this key |
+| `service`, `queue_group`, `subject`, `host`, `ts` | string/number | ✓ | Populated by `NatsAdapterBase.heartbeat_payload` |
+| `model_loaded` | string | — | Active model/engine name |
+| `vram_used_mb`, `vram_total_mb` | integer | — | `0` when pynvml is unavailable |
+| `active_requests` | integer | — | In-flight count for capacity signalling |
+
+**Cadence.** Satellites emit a heartbeat every **5 s**. The hub marks a worker alive if a heartbeat landed within the last **15 s** (`_HB_TTL`); older entries are pruned after `2 × _HB_TTL`. No worker alive → `STTUnavailableError("STT: no live worker (heartbeat stale >15s)")` / `TtsUnavailableError` before any request is dispatched.
+
+A heartbeat with a missing `worker_id` is dropped with a warning log and does not update freshness.
+
+## Rationale
+
+**Why NATS at all.** Voice workloads are GPU-bound and need a different venv than the hub. Making them a request-reply service over NATS lets them run on a different host (or even a different OS) without the hub importing their dependencies. It also gives us load balancing (queue groups), liveness tracking (heartbeats), and zero-downtime worker replacement — all for free on the messaging layer.
+
+**Why these subjects.** `lyra.voice.<service>.<verb>` follows the project-wide NATS naming convention (ADR-035): subjects encode the namespace (`lyra`), the capability (`voice`), the service (`stt`/`tts`), and the verb (`request`/`heartbeat`). Flat, predictable, greppable.
+
+**Why one `contract_version` field and not a handshake.** A handshake would require the hub and the satellite to negotiate on connect, which is exactly the kind of implicit coupling the NATS migration is trying to remove. An additive string makes the contract self-describing on the wire without any state on either side. When we need a breaking change, we ship a new ADR (and likely a new subject); we don't re-negotiate versions over the wire.
+
+**Why "1" as a string, not 1 as an integer.** String comparison works in every language we might bind to later, and `"1.1"` / `"1.2"` remain trivially orderable. Mixing numeric and string values in the same field name after a bump is not a road we want to leave open.
+
+## Consequences
+
+### Positive
+
+- The lyra↔voicecli contract is frozen and greppable. Any payload change is visible as an ADR change.
+- `contract_version` gives operators and log aggregators a cheap way to filter by wire version without reading each payload.
+- Adding a field on either side no longer requires a coordinated release — producers simply add it; consumers ignore it until they care.
+
+### Negative
+
+- Every producer path has to remember to stamp `contract_version`. A missing field is only caught by tests or by a downstream grep; there is no runtime enforcement.
+- The hub still carries the in-process `STTService` / `TTSService` path through S3. Until S4 deletes them, the contract has two implementations (NATS and direct) that must stay behavioural-equivalent.
+
+### Neutral
+
+- `contract_version` is one string on every voice payload. The wire overhead is negligible.
+- Schema enforcement remains in tests and in the adapter base's `check_schema_version`; this ADR does not introduce a runtime validator.
+
+## Relation to other ADRs
+
+- **ADR-035** — NATS subject naming convention. `lyra.voice.*` follows the `<namespace>.<capability>.<service>.<verb>` shape.
+- **ADR-039** — STT/TTS NATS adapter decoupling. Establishes the satellite-bootstrap pattern; ADR-044 freezes its on-the-wire payload.
+- **ADR-040** — NATS messaging architecture review. Baseline for subjects, queue groups, and replies.
+
+## References
+
+- Spec: [`artifacts/specs/658-voicecli-nats-decouple-spec.mdx`](../../../artifacts/specs/658-voicecli-nats-decouple-spec.mdx) — parent decoupling work (S1–S5)
+- Issue: [#658](https://github.com/Roxabi/lyra/issues/658), slice S1 [#688](https://github.com/Roxabi/lyra/issues/688)
+- Code:
+  - `src/lyra/nats/nats_stt_client.py` — hub STT client
+  - `src/lyra/nats/nats_tts_client.py` — hub TTS client
+  - `src/lyra/bootstrap/stt_adapter_standalone.py` — STT satellite
+  - `src/lyra/bootstrap/tts_adapter_standalone.py` — TTS satellite
+  - `src/lyra/nats/adapter_base.py` — `NatsAdapterBase.heartbeat_payload` base fields

--- a/docs/architecture/adr/044-lyra-voicecli-nats-contract.mdx
+++ b/docs/architecture/adr/044-lyra-voicecli-nats-contract.mdx
@@ -191,7 +191,7 @@ A heartbeat with a missing `worker_id` is dropped with a warning log and does no
 
 **Why one `contract_version` field and not a handshake.** A handshake would require the hub and the satellite to negotiate on connect, which is exactly the kind of implicit coupling the NATS migration is trying to remove. An additive string makes the contract self-describing on the wire without any state on either side. When we need a breaking change, we ship a new ADR (and likely a new subject); we don't re-negotiate versions over the wire.
 
-**Why "1" as a string, not 1 as an integer.** String comparison works in every language we might bind to later, and `"1.1"` / `"1.2"` remain trivially orderable. Mixing numeric and string values in the same field name after a bump is not a road we want to leave open.
+**Why "1" as a string, not 1 as an integer.** String comparison works in every language we might bind to later, and mixing numeric and string values in the same field name after a bump is not a road we want to leave open. Future major bumps (`"2"`, `"3"`) ship with a new ADR; intermediate minor bumps (`"1.1"`, `"1.2"`) are not defined.
 
 ## Consequences
 

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -40,6 +40,7 @@
     "038-health-monitoring-layer-boundaries",
     "039-stt-tts-nats-adapter-decoupling",
     "040-nats-messaging-architecture-review",
-    "043-roxabi-autodeploy-per-project-manifests"
+    "043-roxabi-autodeploy-per-project-manifests",
+    "044-lyra-voicecli-nats-contract"
   ]
 }

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -17,6 +17,7 @@ import tempfile
 from pathlib import Path
 
 from lyra.nats import NatsAdapterBase
+from lyra.nats.adapter_base import CONTRACT_VERSION
 from lyra.nats.queue_groups import STT_WORKERS
 from lyra.stt import STTService, TranscriptionResult, load_stt_config
 
@@ -59,7 +60,6 @@ class SttAdapterStandalone(NatsAdapterBase):
         vram_used, vram_total = self._get_vram_info()
         base.update(
             {
-                "contract_version": "1",
                 "model_loaded": self._base_stt_cfg.model_size,
                 "vram_used_mb": vram_used,
                 "vram_total_mb": vram_total,
@@ -100,7 +100,7 @@ class SttAdapterStandalone(NatsAdapterBase):
                     tmp_path = Path(tmp_path_str)
                     result: TranscriptionResult = await svc.transcribe(tmp_path)
                     response = {
-                        "contract_version": "1",
+                        "contract_version": CONTRACT_VERSION,
                         "request_id": request_id,
                         "ok": True,
                         "text": result.text,
@@ -116,7 +116,7 @@ class SttAdapterStandalone(NatsAdapterBase):
                     data.get("request_id", "?"),
                 )
                 response = {
-                    "contract_version": "1",
+                    "contract_version": CONTRACT_VERSION,
                     "request_id": data.get("request_id", "unknown"),
                     "ok": False,
                     "error": "transcription_failed",

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -4,6 +4,7 @@ Runs as a separate supervisor process (lyra_stt). Subscribes to
 lyra.voice.stt.request, transcribes audio via voicecli, responds to
 the reply-to inbox. The hub never imports voicecli — this process does.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -27,7 +28,10 @@ SUBJECT = "lyra.voice.stt.request"
 class SttAdapterStandalone(NatsAdapterBase):
     def __init__(self, raw_config: dict) -> None:
         super().__init__(
-            SUBJECT, STT_WORKERS, "SttRequest", 1,
+            SUBJECT,
+            STT_WORKERS,
+            "SttRequest",
+            1,
             heartbeat_subject="lyra.voice.stt.heartbeat",
             heartbeat_interval=5.0,
         )
@@ -42,6 +46,7 @@ class SttAdapterStandalone(NatsAdapterBase):
         """Return (used_mb, total_mb). Both 0 if pynvml is unavailable."""
         try:
             import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
+
             pynvml.nvmlInit()
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             info = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -52,12 +57,15 @@ class SttAdapterStandalone(NatsAdapterBase):
     def heartbeat_payload(self) -> dict:
         base = super().heartbeat_payload()
         vram_used, vram_total = self._get_vram_info()
-        base.update({
-            "model_loaded": self._base_stt_cfg.model_size,
-            "vram_used_mb": vram_used,
-            "vram_total_mb": vram_total,
-            "active_requests": self._active_count,
-        })
+        base.update(
+            {
+                "contract_version": "1",
+                "model_loaded": self._base_stt_cfg.model_size,
+                "vram_used_mb": vram_used,
+                "vram_total_mb": vram_total,
+                "active_requests": self._active_count,
+            }
+        )
         return base
 
     async def handle(self, msg, payload: dict) -> None:
@@ -92,6 +100,7 @@ class SttAdapterStandalone(NatsAdapterBase):
                     tmp_path = Path(tmp_path_str)
                     result: TranscriptionResult = await svc.transcribe(tmp_path)
                     response = {
+                        "contract_version": "1",
                         "request_id": request_id,
                         "ok": True,
                         "text": result.text,
@@ -107,6 +116,7 @@ class SttAdapterStandalone(NatsAdapterBase):
                     data.get("request_id", "?"),
                 )
                 response = {
+                    "contract_version": "1",
                     "request_id": data.get("request_id", "unknown"),
                     "ok": False,
                     "error": "transcription_failed",

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -4,6 +4,7 @@ Runs as a separate supervisor process (lyra_tts). Subscribes to
 lyra.voice.tts.request, synthesizes speech via voicecli, responds to
 the reply-to inbox. The hub never imports voicecli — this process does.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -31,6 +32,7 @@ class _NatsTtsConfig:
     TTSService._build_generate_kwargs uses getattr(agent_tts, field, None) so any
     object with matching attributes works. This avoids importing the hub-layer type.
     """
+
     engine: str | None = None
     voice: str | None = None
     language: str | None = None
@@ -50,7 +52,10 @@ class _NatsTtsConfig:
 class TtsAdapterStandalone(NatsAdapterBase):
     def __init__(self, raw_config: dict) -> None:
         super().__init__(
-            SUBJECT, TTS_WORKERS, "TtsRequest", 1,
+            SUBJECT,
+            TTS_WORKERS,
+            "TtsRequest",
+            1,
             heartbeat_subject="lyra.voice.tts.heartbeat",
             heartbeat_interval=5.0,
         )
@@ -66,6 +71,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
         """Return (used_mb, total_mb). Both 0 if pynvml is unavailable."""
         try:
             import pynvml  # noqa: PLC0415  # type: ignore[import-untyped]
+
             pynvml.nvmlInit()
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             info = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -76,12 +82,15 @@ class TtsAdapterStandalone(NatsAdapterBase):
     def heartbeat_payload(self) -> dict:
         base = super().heartbeat_payload()
         vram_used, vram_total = self._get_vram_info()
-        base.update({
-            "model_loaded": self._tts_cfg.engine or "default",
-            "vram_used_mb": vram_used,
-            "vram_total_mb": vram_total,
-            "active_requests": self._active_count,
-        })
+        base.update(
+            {
+                "contract_version": "1",
+                "model_loaded": self._tts_cfg.engine or "default",
+                "vram_used_mb": vram_used,
+                "vram_total_mb": vram_total,
+                "active_requests": self._active_count,
+            }
+        )
         return base
 
     async def handle(self, msg, payload: dict) -> None:
@@ -114,6 +123,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
                 )
 
                 response = {
+                    "contract_version": "1",
                     "request_id": request_id,
                     "ok": True,
                     "audio_b64": base64.b64encode(result.audio_bytes).decode("ascii"),
@@ -128,6 +138,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
                     data.get("request_id", "?"),
                 )
                 response = {
+                    "contract_version": "1",
                     "request_id": data.get("request_id", "unknown"),
                     "ok": False,
                     "error": "synthesis_failed",

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 from lyra.nats import NatsAdapterBase
 from lyra.nats._tts_constants import _AGENT_TTS_FIELDS
+from lyra.nats.adapter_base import CONTRACT_VERSION
 from lyra.nats.queue_groups import TTS_WORKERS
 from lyra.tts import SynthesisResult, TTSService, load_tts_config
 
@@ -84,7 +85,6 @@ class TtsAdapterStandalone(NatsAdapterBase):
         vram_used, vram_total = self._get_vram_info()
         base.update(
             {
-                "contract_version": "1",
                 "model_loaded": self._tts_cfg.engine or "default",
                 "vram_used_mb": vram_used,
                 "vram_total_mb": vram_total,
@@ -123,7 +123,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
                 )
 
                 response = {
-                    "contract_version": "1",
+                    "contract_version": CONTRACT_VERSION,
                     "request_id": request_id,
                     "ok": True,
                     "audio_b64": base64.b64encode(result.audio_bytes).decode("ascii"),
@@ -138,7 +138,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
                     data.get("request_id", "?"),
                 )
                 response = {
-                    "contract_version": "1",
+                    "contract_version": CONTRACT_VERSION,
                     "request_id": data.get("request_id", "unknown"),
                     "ok": False,
                     "error": "synthesis_failed",

--- a/src/lyra/nats/adapter_base.py
+++ b/src/lyra/nats/adapter_base.py
@@ -4,6 +4,7 @@ Subclass this and implement ``handle(msg)`` to build a NATS queue-subscriber
 adapter with built-in envelope validation, hub readiness waiting, graceful
 drain/close shutdown, and a ``health()`` introspection method.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -25,12 +26,24 @@ from lyra.nats.readiness import wait_for_hub
 
 log = logging.getLogger(__name__)
 
+# ADR-044 — single source of truth for the voice NATS contract version. All
+# producer sites (hub clients + satellite adapters) stamp this on outgoing
+# payloads. Consumers ignore unknown values. Bumping requires a new ADR.
+CONTRACT_VERSION = "1"
+
 
 class NatsAdapterBase(ABC):
     def __init__(  # noqa: PLR0913
-        self, subject, queue_group, envelope_name, schema_version,
-        timeout=30.0, drain_timeout=30.0,
-        *, heartbeat_subject: str | None = None, heartbeat_interval: float = 5.0,
+        self,
+        subject,
+        queue_group,
+        envelope_name,
+        schema_version,
+        timeout=30.0,
+        drain_timeout=30.0,
+        *,
+        heartbeat_subject: str | None = None,
+        heartbeat_interval: float = 5.0,
     ):
         validate_nats_token(subject, kind="subject")
         validate_nats_token(queue_group, kind="queue_group")
@@ -94,6 +107,7 @@ class NatsAdapterBase(ABC):
         """Base heartbeat payload. Subclasses override to add service fields."""
         uptime = time.monotonic() - self._started_at if self._started_at else 0.0
         return {
+            "contract_version": CONTRACT_VERSION,
             "worker_id": self._worker_id,
             "service": self.queue_group,
             "host": socket.gethostname(),

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from nats.aio.client import Client as NATS
 
+from lyra.nats.adapter_base import CONTRACT_VERSION
 from lyra.nats.circuit_breaker import NatsCircuitBreaker
 from lyra.stt import (
     STTNoiseError,
@@ -118,7 +119,7 @@ class NatsSttClient:
         audio_bytes = await asyncio.to_thread(resolved.read_bytes)
         mime = _mime_from_suffix(resolved.suffix)
         request = {
-            "contract_version": "1",
+            "contract_version": CONTRACT_VERSION,
             "request_id": str(uuid4()),
             "audio_b64": base64.b64encode(audio_bytes).decode("ascii"),
             "mime_type": mime,

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -87,9 +87,7 @@ class NatsSttClient:
     async def start(self) -> None:
         """Subscribe to heartbeat subject. Called once after nc is connected."""
         if self._hb_sub is None:
-            self._hb_sub = await self._nc.subscribe(
-                _HB_SUBJECT, cb=self._on_heartbeat
-            )
+            self._hb_sub = await self._nc.subscribe(_HB_SUBJECT, cb=self._on_heartbeat)
 
     async def _on_heartbeat(self, msg) -> None:
         try:
@@ -111,9 +109,7 @@ class NatsSttClient:
 
     async def transcribe(self, path: Path | str) -> TranscriptionResult:
         if not self._any_worker_alive():
-            raise STTUnavailableError(
-                "STT: no live worker (heartbeat stale >15s)"
-            )
+            raise STTUnavailableError("STT: no live worker (heartbeat stale >15s)")
         if self._cb.is_open():
             raise STTUnavailableError(
                 "STT circuit open — adapter temporarily unavailable"
@@ -122,6 +118,7 @@ class NatsSttClient:
         audio_bytes = await asyncio.to_thread(resolved.read_bytes)
         mime = _mime_from_suffix(resolved.suffix)
         request = {
+            "contract_version": "1",
             "request_id": str(uuid4()),
             "audio_b64": base64.b64encode(audio_bytes).decode("ascii"),
             "mime_type": mime,

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from nats.aio.client import Client as NATS
 
 from lyra.nats._tts_constants import _TTS_CONFIG_FIELDS
+from lyra.nats.adapter_base import CONTRACT_VERSION
 from lyra.nats.circuit_breaker import NatsCircuitBreaker
 from lyra.tts import SynthesisResult, TtsUnavailableError
 
@@ -98,7 +99,7 @@ class NatsTtsClient:
                 "TTS circuit open — adapter temporarily unavailable"
             )
         request: dict = {
-            "contract_version": "1",
+            "contract_version": CONTRACT_VERSION,
             "request_id": str(uuid4()),
             "text": text,
             "language": language,

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -1,4 +1,5 @@
 """NatsTtsClient — hub-side NATS request-reply client for TTS."""
+
 from __future__ import annotations
 
 import base64
@@ -36,9 +37,7 @@ class NatsTtsClient:
     async def start(self) -> None:
         """Subscribe to heartbeat subject. Called once after nc is connected."""
         if self._hb_sub is None:
-            self._hb_sub = await self._nc.subscribe(
-                _HB_SUBJECT, cb=self._on_heartbeat
-            )
+            self._hb_sub = await self._nc.subscribe(_HB_SUBJECT, cb=self._on_heartbeat)
 
     async def _on_heartbeat(self, msg) -> None:
         try:
@@ -70,8 +69,7 @@ class NatsTtsClient:
         except Exception as exc:
             if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
                 log.error(
-                    "TTS payload too large (%.0f KB)"
-                    " — check NATS max_payload",
+                    "TTS payload too large (%.0f KB) — check NATS max_payload",
                     payload_kb,
                 )
                 self._cb.record_failure()
@@ -94,14 +92,13 @@ class NatsTtsClient:
         fallback_language: str | None = None,
     ) -> SynthesisResult:
         if not self._any_worker_alive():
-            raise TtsUnavailableError(
-                "TTS: no live worker (heartbeat stale >15s)"
-            )
+            raise TtsUnavailableError("TTS: no live worker (heartbeat stale >15s)")
         if self._cb.is_open():
             raise TtsUnavailableError(
                 "TTS circuit open — adapter temporarily unavailable"
             )
         request: dict = {
+            "contract_version": "1",
             "request_id": str(uuid4()),
             "text": text,
             "language": language,

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -10,6 +10,7 @@ These tests verify the post-migration shape of stt_adapter_standalone.py:
 Tests 1, 2, and 4 are RED before migration (they fail against current source).
 Tests 3 and 5 pass both before and after migration (signature and helper unchanged).
 """
+
 from __future__ import annotations
 
 import inspect
@@ -95,6 +96,23 @@ def test_stt_adapter_standalone_class_exists() -> None:
     assert issubclass(SttAdapterStandalone, NatsAdapterBase), (
         "SttAdapterStandalone must subclass NatsAdapterBase"
     )
+
+
+def test_stt_adapter_replies_carry_contract_version() -> None:
+    """Success and error reply dicts must emit contract_version='1' (ADR-044).
+
+    Verified at the source level: every `response = {` literal in
+    stt_adapter_standalone.py must set `"contract_version": "1"`.
+    """
+    import re
+
+    source = _SOURCE.read_text()
+    response_blocks = re.findall(r"response = \{[^}]*\}", source, flags=re.DOTALL)
+    assert response_blocks, "expected at least one `response = { ... }` block"
+    for block in response_blocks:
+        assert '"contract_version": "1"' in block, (
+            f"response block missing contract_version='1': {block!r}"
+        )
 
 
 def test_mime_to_ext_still_accessible() -> None:
@@ -193,6 +211,14 @@ class TestSttHeartbeatPayload:
             f"active_requests must start at 0, got {payload['active_requests']}"
         )
 
+    def test_heartbeat_payload_includes_contract_version(self) -> None:
+        """heartbeat_payload() includes 'contract_version' per ADR-044."""
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert payload.get("contract_version") == "1", (
+            "heartbeat_payload() must include contract_version='1' (ADR-044)"
+        )
+
     def test_heartbeat_payload_includes_base_fields(self) -> None:
         """heartbeat_payload() includes base fields: worker_id, service, ts, etc."""
         adapter = self._make_adapter()
@@ -206,8 +232,7 @@ class TestSttHeartbeatPayload:
         """_get_vram_info() returns (0, 0) when pynvml is unavailable."""
         adapter = self._make_adapter()
         with patch(
-            "lyra.bootstrap.stt_adapter_standalone.SttAdapterStandalone"
-            "._get_vram_info",
+            "lyra.bootstrap.stt_adapter_standalone.SttAdapterStandalone._get_vram_info",
             return_value=(0, 0),
         ):
             payload = adapter.heartbeat_payload()
@@ -218,8 +243,7 @@ class TestSttHeartbeatPayload:
         """_get_vram_info() returns real MB values when pynvml succeeds."""
         adapter = self._make_adapter()
         with patch(
-            "lyra.bootstrap.stt_adapter_standalone.SttAdapterStandalone"
-            "._get_vram_info",
+            "lyra.bootstrap.stt_adapter_standalone.SttAdapterStandalone._get_vram_info",
             return_value=(4096, 10240),
         ):
             payload = adapter.heartbeat_payload()

--- a/tests/bootstrap/test_stt_adapter_standalone.py
+++ b/tests/bootstrap/test_stt_adapter_standalone.py
@@ -13,9 +13,11 @@ Tests 3 and 5 pass both before and after migration (signature and helper unchang
 
 from __future__ import annotations
 
+import base64
 import inspect
+import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -98,21 +100,82 @@ def test_stt_adapter_standalone_class_exists() -> None:
     )
 
 
-def test_stt_adapter_replies_carry_contract_version() -> None:
-    """Success and error reply dicts must emit contract_version='1' (ADR-044).
+class TestSttAdapterReplyContractVersion:
+    """Behavioural: handle() replies emit contract_version (ADR-044)."""
 
-    Verified at the source level: every `response = {` literal in
-    stt_adapter_standalone.py must set `"contract_version": "1"`.
-    """
-    import re
+    def _make_adapter(self, transcribe_result=None, transcribe_raises=None):
+        """Build SttAdapterStandalone with a stubbed STTService.transcribe."""
+        from lyra.bootstrap.stt_adapter_standalone import SttAdapterStandalone
+        from lyra.stt import STTConfig
 
-    source = _SOURCE.read_text()
-    response_blocks = re.findall(r"response = \{[^}]*\}", source, flags=re.DOTALL)
-    assert response_blocks, "expected at least one `response = { ... }` block"
-    for block in response_blocks:
-        assert '"contract_version": "1"' in block, (
-            f"response block missing contract_version='1': {block!r}"
+        mock_cfg = STTConfig(model_size="large-v3-turbo")
+        mock_stt_service = MagicMock()
+        if transcribe_raises is not None:
+            mock_stt_service.transcribe = AsyncMock(side_effect=transcribe_raises)
+        else:
+            mock_stt_service.transcribe = AsyncMock(return_value=transcribe_result)
+
+        with (
+            patch(
+                "lyra.bootstrap.stt_adapter_standalone.load_stt_config",
+                return_value=mock_cfg,
+            ),
+            patch(
+                "lyra.bootstrap.stt_adapter_standalone.STTService",
+                return_value=mock_stt_service,
+            ),
+        ):
+            adapter = SttAdapterStandalone(raw_config={})
+        return adapter
+
+    async def _call_handle(self, adapter, payload: dict) -> dict:
+        """Run adapter.handle(); capture and return the decoded reply payload."""
+        captured = {}
+
+        async def capture_reply(msg, data: bytes) -> None:
+            captured["payload"] = json.loads(data)
+
+        adapter.reply = capture_reply  # type: ignore[method-assign]
+        mock_msg = MagicMock()
+        mock_msg.reply = "_INBOX.test"
+        await adapter.handle(mock_msg, payload)
+        return captured["payload"]
+
+    @pytest.mark.asyncio
+    async def test_success_reply_emits_contract_version(self) -> None:
+        """A successful transcription reply stamps contract_version='1'."""
+        from lyra.stt import TranscriptionResult
+
+        adapter = self._make_adapter(
+            transcribe_result=TranscriptionResult(
+                text="hello", language="en", duration_seconds=1.0
+            )
         )
+        reply = await self._call_handle(
+            adapter,
+            {
+                "request_id": "rid-1",
+                "audio_b64": base64.b64encode(b"\x00" * 8).decode(),
+                "mime_type": "audio/ogg",
+            },
+        )
+        assert reply["ok"] is True
+        assert reply["contract_version"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_error_reply_emits_contract_version(self) -> None:
+        """An error reply (transcription failed) also stamps contract_version='1'."""
+        adapter = self._make_adapter(transcribe_raises=RuntimeError("engine down"))
+        reply = await self._call_handle(
+            adapter,
+            {
+                "request_id": "rid-2",
+                "audio_b64": base64.b64encode(b"\x00" * 8).decode(),
+                "mime_type": "audio/ogg",
+            },
+        )
+        assert reply["ok"] is False
+        assert reply["contract_version"] == "1"
 
 
 def test_mime_to_ext_still_accessible() -> None:

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -13,8 +13,9 @@ Test 3 passes both before and after migration (signature is unchanged).
 from __future__ import annotations
 
 import inspect
+import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -97,21 +98,74 @@ def test_tts_adapter_standalone_class_exists() -> None:
     )
 
 
-def test_tts_adapter_replies_carry_contract_version() -> None:
-    """Success and error reply dicts must emit contract_version='1' (ADR-044).
+class TestTtsAdapterReplyContractVersion:
+    """Behavioural: handle() replies emit contract_version (ADR-044)."""
 
-    Verified at the source level: every `response = {` literal in
-    tts_adapter_standalone.py must set `"contract_version": "1"`.
-    """
-    import re
+    def _make_adapter(self, synth_result=None, synth_raises=None):
+        """Build TtsAdapterStandalone with a stubbed TTSService.synthesize."""
+        from lyra.bootstrap.tts_adapter_standalone import TtsAdapterStandalone
+        from lyra.tts import TTSConfig
 
-    source = _SOURCE.read_text()
-    response_blocks = re.findall(r"response = \{[^}]*\}", source, flags=re.DOTALL)
-    assert response_blocks, "expected at least one `response = { ... }` block"
-    for block in response_blocks:
-        assert '"contract_version": "1"' in block, (
-            f"response block missing contract_version='1': {block!r}"
+        mock_tts_service = MagicMock()
+        if synth_raises is not None:
+            mock_tts_service.synthesize = AsyncMock(side_effect=synth_raises)
+        else:
+            mock_tts_service.synthesize = AsyncMock(return_value=synth_result)
+
+        with (
+            patch(
+                "lyra.bootstrap.tts_adapter_standalone.load_tts_config",
+                return_value=TTSConfig(engine="chatterbox"),
+            ),
+            patch(
+                "lyra.bootstrap.tts_adapter_standalone.TTSService",
+                return_value=mock_tts_service,
+            ),
+        ):
+            adapter = TtsAdapterStandalone({})
+        return adapter
+
+    async def _call_handle(self, adapter, payload: dict) -> dict:
+        """Run adapter.handle(); capture and return the decoded reply payload."""
+        captured = {}
+
+        async def capture_reply(msg, data: bytes) -> None:
+            captured["payload"] = json.loads(data)
+
+        adapter.reply = capture_reply  # type: ignore[method-assign]
+        mock_msg = MagicMock()
+        mock_msg.reply = "_INBOX.test"
+        await adapter.handle(mock_msg, payload)
+        return captured["payload"]
+
+    @pytest.mark.asyncio
+    async def test_success_reply_emits_contract_version(self) -> None:
+        """A successful synthesis reply stamps contract_version='1'."""
+        from lyra.tts import SynthesisResult
+
+        adapter = self._make_adapter(
+            synth_result=SynthesisResult(
+                audio_bytes=b"audio",
+                mime_type="audio/ogg",
+                duration_ms=420,
+                waveform_b64=None,
+            )
         )
+        reply = await self._call_handle(
+            adapter, {"request_id": "rid-1", "text": "hello"}
+        )
+        assert reply["ok"] is True
+        assert reply["contract_version"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_error_reply_emits_contract_version(self) -> None:
+        """An error reply (synthesis failed) also stamps contract_version='1'."""
+        adapter = self._make_adapter(synth_raises=RuntimeError("engine down"))
+        reply = await self._call_handle(
+            adapter, {"request_id": "rid-2", "text": "hello"}
+        )
+        assert reply["ok"] is False
+        assert reply["contract_version"] == "1"
 
 
 class TestTtsHeartbeatPayload:

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -171,8 +171,6 @@ class TestTtsAdapterReplyContractVersion:
 class TestTtsHeartbeatPayload:
     def _make_adapter(self):
         """Build TtsAdapterStandalone with mocked TTSService to avoid loading engine."""
-        from unittest.mock import MagicMock, patch
-
         from lyra.tts import TTSConfig
 
         mock_tts_service = MagicMock()
@@ -194,16 +192,19 @@ class TestTtsHeartbeatPayload:
 
         return adapter
 
-    def test_heartbeat_subject_is_tts_subject(self):
+    def test_heartbeat_subject_is_tts_subject(self) -> None:
+        """TtsAdapterStandalone passes heartbeat_subject='lyra.voice.tts.heartbeat'."""
         adapter = self._make_adapter()
         assert adapter._heartbeat_subject == "lyra.voice.tts.heartbeat"
 
-    def test_heartbeat_payload_includes_model_loaded(self):
+    def test_heartbeat_payload_includes_model_loaded(self) -> None:
+        """heartbeat_payload() includes 'model_loaded' key."""
         adapter = self._make_adapter()
         payload = adapter.heartbeat_payload()
         assert "model_loaded" in payload
 
-    def test_heartbeat_payload_includes_vram_fields(self):
+    def test_heartbeat_payload_includes_vram_fields(self) -> None:
+        """heartbeat_payload() includes 'vram_used_mb' and 'vram_total_mb' as int."""
         adapter = self._make_adapter()
         payload = adapter.heartbeat_payload()
         assert "vram_used_mb" in payload
@@ -211,7 +212,8 @@ class TestTtsHeartbeatPayload:
         assert isinstance(payload["vram_used_mb"], int)
         assert isinstance(payload["vram_total_mb"], int)
 
-    def test_heartbeat_payload_includes_active_requests(self):
+    def test_heartbeat_payload_includes_active_requests(self) -> None:
+        """heartbeat_payload() includes 'active_requests' starting at 0."""
         adapter = self._make_adapter()
         payload = adapter.heartbeat_payload()
         assert "active_requests" in payload
@@ -225,7 +227,8 @@ class TestTtsHeartbeatPayload:
             "heartbeat_payload() must include contract_version='1' (ADR-044)"
         )
 
-    def test_heartbeat_payload_includes_base_fields(self):
+    def test_heartbeat_payload_includes_base_fields(self) -> None:
+        """heartbeat_payload() includes base fields: worker_id, service, ts, etc."""
         adapter = self._make_adapter()
         payload = adapter.heartbeat_payload()
         for field in ("worker_id", "service", "host", "subject", "queue_group", "ts"):

--- a/tests/bootstrap/test_tts_adapter_standalone.py
+++ b/tests/bootstrap/test_tts_adapter_standalone.py
@@ -9,6 +9,7 @@ These tests verify the post-migration shape of tts_adapter_standalone.py:
 Tests 1, 2, and 4 are RED before migration (they fail against current source).
 Test 3 passes both before and after migration (signature is unchanged).
 """
+
 from __future__ import annotations
 
 import inspect
@@ -96,6 +97,23 @@ def test_tts_adapter_standalone_class_exists() -> None:
     )
 
 
+def test_tts_adapter_replies_carry_contract_version() -> None:
+    """Success and error reply dicts must emit contract_version='1' (ADR-044).
+
+    Verified at the source level: every `response = {` literal in
+    tts_adapter_standalone.py must set `"contract_version": "1"`.
+    """
+    import re
+
+    source = _SOURCE.read_text()
+    response_blocks = re.findall(r"response = \{[^}]*\}", source, flags=re.DOTALL)
+    assert response_blocks, "expected at least one `response = { ... }` block"
+    for block in response_blocks:
+        assert '"contract_version": "1"' in block, (
+            f"response block missing contract_version='1': {block!r}"
+        )
+
+
 class TestTtsHeartbeatPayload:
     def _make_adapter(self):
         """Build TtsAdapterStandalone with mocked TTSService to avoid loading engine."""
@@ -117,6 +135,7 @@ class TestTtsHeartbeatPayload:
             ),
         ):
             from lyra.bootstrap.tts_adapter_standalone import TtsAdapterStandalone
+
             adapter = TtsAdapterStandalone({})
 
         return adapter
@@ -144,6 +163,14 @@ class TestTtsHeartbeatPayload:
         assert "active_requests" in payload
         assert payload["active_requests"] == 0
 
+    def test_heartbeat_payload_includes_contract_version(self):
+        """heartbeat_payload() includes 'contract_version' per ADR-044."""
+        adapter = self._make_adapter()
+        payload = adapter.heartbeat_payload()
+        assert payload.get("contract_version") == "1", (
+            "heartbeat_payload() must include contract_version='1' (ADR-044)"
+        )
+
     def test_heartbeat_payload_includes_base_fields(self):
         adapter = self._make_adapter()
         payload = adapter.heartbeat_payload()
@@ -154,8 +181,7 @@ class TestTtsHeartbeatPayload:
         """_get_vram_info() returns (0, 0) when pynvml is unavailable."""
         adapter = self._make_adapter()
         with patch(
-            "lyra.bootstrap.tts_adapter_standalone.TtsAdapterStandalone"
-            "._get_vram_info",
+            "lyra.bootstrap.tts_adapter_standalone.TtsAdapterStandalone._get_vram_info",
             return_value=(0, 0),
         ):
             payload = adapter.heartbeat_payload()
@@ -166,8 +192,7 @@ class TestTtsHeartbeatPayload:
         """_get_vram_info() returns real MB values when pynvml succeeds."""
         adapter = self._make_adapter()
         with patch(
-            "lyra.bootstrap.tts_adapter_standalone.TtsAdapterStandalone"
-            "._get_vram_info",
+            "lyra.bootstrap.tts_adapter_standalone.TtsAdapterStandalone._get_vram_info",
             return_value=(4096, 10240),
         ):
             payload = adapter.heartbeat_payload()

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -153,6 +153,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "text": "hello",
                 "language": "en",
@@ -183,6 +184,7 @@ class TestContractVersion:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "text": "hi",
                 "language": "en",
@@ -289,6 +291,7 @@ class TestSttClientFreshness:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "text": "hello world",
                 "language": "en",
@@ -324,6 +327,7 @@ class TestSttClientFreshness:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "text": "resumed",
                 "language": "en",
@@ -390,7 +394,7 @@ class TestTranscribeResponseParsing:
     async def test_ok_false_raises_unavailable(self, tmp_path: Path) -> None:
         # Arrange
         mock_nc = AsyncMock()
-        error_payload = json.dumps({"ok": False}).encode()
+        error_payload = json.dumps({"contract_version": "1", "ok": False}).encode()
         fake_reply = MagicMock()
         fake_reply.data = error_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -409,6 +413,7 @@ class TestTranscribeResponseParsing:
         mock_nc = AsyncMock()
         noise_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "text": "[music]",
                 "language": "en",

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -136,9 +136,7 @@ class TestCircuitBreaker:
     async def test_failure_records_on_max_payload(self, tmp_path: Path) -> None:
         # Arrange
         mock_nc = AsyncMock()
-        mock_nc.request = AsyncMock(
-            side_effect=Exception("NATS: max_payload exceeded")
-        )
+        mock_nc.request = AsyncMock(side_effect=Exception("NATS: max_payload exceeded"))
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
         wav_file = tmp_path / "test.wav"
@@ -153,12 +151,14 @@ class TestCircuitBreaker:
     async def test_success_clears_failures(self, tmp_path: Path) -> None:
         # Arrange — pre-inject 2 failures
         mock_nc = AsyncMock()
-        success_payload = json.dumps({
-            "ok": True,
-            "text": "hello",
-            "language": "en",
-            "duration_seconds": 1.0,
-        }).encode()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "text": "hello",
+                "language": "en",
+                "duration_seconds": 1.0,
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -171,6 +171,66 @@ class TestCircuitBreaker:
         result = await client.transcribe(wav_file)
         # Assert
         assert result.text == "hello"
+        assert client._cb._failures == 0
+
+
+class TestContractVersion:
+    """Tests for the `contract_version` additive field (ADR-044)."""
+
+    @pytest.mark.asyncio
+    async def test_request_payload_emits_contract_version(self, tmp_path: Path) -> None:
+        """NatsSttClient.transcribe() stamps contract_version='1' on the request."""
+        mock_nc = AsyncMock()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "text": "hi",
+                "language": "en",
+                "duration_seconds": 1.0,
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = success_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+
+        await client.transcribe(wav_file)
+
+        payload_bytes = mock_nc.request.call_args.args[1]
+        request_dict = json.loads(payload_bytes)
+        assert request_dict["contract_version"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_reply_with_unknown_contract_version_is_tolerated(
+        self, tmp_path: Path
+    ) -> None:
+        """Hub ignores unknown contract_version values on reply (defensive read)."""
+        mock_nc = AsyncMock()
+        # Reply carries a version the hub has never seen — must be silently accepted.
+        reply_payload = json.dumps(
+            {
+                "contract_version": "999",
+                "ok": True,
+                "text": "future",
+                "language": "en",
+                "duration_seconds": 0.5,
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = reply_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+
+        result = await client.transcribe(wav_file)
+
+        assert result.text == "future"
+        assert result.language == "en"
         assert client._cb._failures == 0
 
 
@@ -227,12 +287,14 @@ class TestSttClientFreshness:
     async def test_fresh_worker_proceeds_to_request(self, tmp_path: Path) -> None:
         """transcribe() proceeds past freshness gate when a worker is fresh (<15s)."""
         mock_nc = AsyncMock()
-        success_payload = json.dumps({
-            "ok": True,
-            "text": "hello world",
-            "language": "en",
-            "duration_seconds": 1.0,
-        }).encode()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "text": "hello world",
+                "language": "en",
+                "duration_seconds": 1.0,
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -260,12 +322,14 @@ class TestSttClientFreshness:
     async def test_heartbeat_resumes_reenables_worker(self, tmp_path: Path) -> None:
         """After stale, a new heartbeat re-enables the worker immediately."""
         mock_nc = AsyncMock()
-        success_payload = json.dumps({
-            "ok": True,
-            "text": "resumed",
-            "language": "en",
-            "duration_seconds": 1.0,
-        }).encode()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "text": "resumed",
+                "language": "en",
+                "duration_seconds": 1.0,
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -343,12 +407,14 @@ class TestTranscribeResponseParsing:
     async def test_noise_transcript_raises_noise_error(self, tmp_path: Path) -> None:
         # Arrange — Whisper returns a known noise token
         mock_nc = AsyncMock()
-        noise_payload = json.dumps({
-            "ok": True,
-            "text": "[music]",
-            "language": "en",
-            "duration_seconds": 0.5,
-        }).encode()
+        noise_payload = json.dumps(
+            {
+                "ok": True,
+                "text": "[music]",
+                "language": "en",
+                "duration_seconds": 0.5,
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = noise_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -143,6 +143,58 @@ class TestCircuitBreaker:
         assert client._cb._failures == 0
 
 
+class TestContractVersion:
+    """Tests for the `contract_version` additive field (ADR-044)."""
+
+    @pytest.mark.asyncio
+    async def test_request_payload_emits_contract_version(self) -> None:
+        """NatsTtsClient.synthesize() stamps contract_version='1' on the request."""
+        mock_nc = AsyncMock()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "audio_b64": base64.b64encode(b"hi").decode(),
+                "mime_type": "audio/ogg",
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = success_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+
+        await client.synthesize("hello")
+
+        payload_bytes = mock_nc.request.call_args.args[1]
+        request_dict = json.loads(payload_bytes)
+        assert request_dict["contract_version"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_reply_with_unknown_contract_version_is_tolerated(self) -> None:
+        """Hub ignores unknown contract_version values on reply (defensive read)."""
+        mock_nc = AsyncMock()
+        # Reply carries a version the hub has never seen — must be silently accepted.
+        reply_payload = json.dumps(
+            {
+                "contract_version": "999",
+                "ok": True,
+                "audio_b64": base64.b64encode(b"future").decode(),
+                "mime_type": "audio/ogg",
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = reply_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+
+        result = await client.synthesize("hello")
+
+        assert result.audio_bytes == b"future"
+        assert result.mime_type == "audio/ogg"
+        assert client._cb._failures == 0
+
+
 class TestTtsClientStart:
     """Tests for NatsTtsClient.start() lifecycle."""
 

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -62,9 +62,7 @@ class TestCircuitBreaker:
     async def test_failure_records_on_max_payload(self) -> None:
         # Arrange
         mock_nc = AsyncMock()
-        mock_nc.request = AsyncMock(
-            side_effect=Exception("NATS: max_payload exceeded")
-        )
+        mock_nc.request = AsyncMock(side_effect=Exception("NATS: max_payload exceeded"))
         client = NatsTtsClient(nc=mock_nc)
         _inject_fresh_worker(client)
         # Act
@@ -92,11 +90,13 @@ class TestCircuitBreaker:
     async def test_agent_tts_fields_forwarded_in_request(self) -> None:
         # Arrange — agent_tts with engine + speed set
         mock_nc = AsyncMock()
-        success_payload = json.dumps({
-            "ok": True,
-            "audio_b64": base64.b64encode(b"fake").decode(),
-            "mime_type": "audio/ogg",
-        }).encode()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "audio_b64": base64.b64encode(b"fake").decode(),
+                "mime_type": "audio/ogg",
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -113,6 +113,8 @@ class TestCircuitBreaker:
         request_dict = json.loads(payload_bytes)
         assert request_dict["engine"] == "chatterbox"
         assert request_dict["speed"] == "1.2"
+        # contract_version is always stamped (ADR-044)
+        assert request_dict["contract_version"] == "1"
         # All unset fields (None) must be absent from the NATS payload
         none_fields = [f for f in _TTS_CONFIG_FIELDS if f not in ("engine", "speed")]
         assert all(f not in request_dict for f in none_fields)
@@ -121,11 +123,13 @@ class TestCircuitBreaker:
     async def test_success_clears_failures(self) -> None:
         # Arrange — pre-inject 2 failures
         mock_nc = AsyncMock()
-        success_payload = json.dumps({
-            "ok": True,
-            "audio_b64": base64.b64encode(b"fake").decode(),
-            "mime_type": "audio/ogg",
-        }).encode()
+        success_payload = json.dumps(
+            {
+                "ok": True,
+                "audio_b64": base64.b64encode(b"fake").decode(),
+                "mime_type": "audio/ogg",
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = success_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -189,11 +193,13 @@ class TestTtsClientFreshness:
         """synthesize() proceeds past freshness gate when a worker is fresh (<15s)."""
         mock_nc = AsyncMock()
         mock_response = MagicMock()
-        mock_response.data = json.dumps({
-            "ok": True,
-            "audio_b64": base64.b64encode(b"audio").decode(),
-            "mime_type": "audio/ogg",
-        }).encode()
+        mock_response.data = json.dumps(
+            {
+                "ok": True,
+                "audio_b64": base64.b64encode(b"audio").decode(),
+                "mime_type": "audio/ogg",
+            }
+        ).encode()
         mock_nc.request = AsyncMock(return_value=mock_response)
         client = NatsTtsClient(nc=mock_nc)
         client._worker_freshness["worker-1"] = time.monotonic() - 5.0
@@ -216,11 +222,13 @@ class TestTtsClientFreshness:
         """After stale, a new heartbeat re-enables the worker immediately."""
         mock_nc = AsyncMock()
         mock_response = MagicMock()
-        mock_response.data = json.dumps({
-            "ok": True,
-            "audio_b64": base64.b64encode(b"audio").decode(),
-            "mime_type": "audio/ogg",
-        }).encode()
+        mock_response.data = json.dumps(
+            {
+                "ok": True,
+                "audio_b64": base64.b64encode(b"audio").decode(),
+                "mime_type": "audio/ogg",
+            }
+        ).encode()
         mock_nc.request = AsyncMock(return_value=mock_response)
         client = NatsTtsClient(nc=mock_nc)
         # First: stale

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -75,7 +75,7 @@ class TestCircuitBreaker:
     async def test_ok_false_raises_unavailable(self) -> None:
         # Arrange
         mock_nc = AsyncMock()
-        error_payload = json.dumps({"ok": False}).encode()
+        error_payload = json.dumps({"contract_version": "1", "ok": False}).encode()
         fake_reply = MagicMock()
         fake_reply.data = error_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -92,6 +92,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "audio_b64": base64.b64encode(b"fake").decode(),
                 "mime_type": "audio/ogg",
@@ -125,6 +126,7 @@ class TestCircuitBreaker:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "audio_b64": base64.b64encode(b"fake").decode(),
                 "mime_type": "audio/ogg",
@@ -152,6 +154,7 @@ class TestContractVersion:
         mock_nc = AsyncMock()
         success_payload = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "audio_b64": base64.b64encode(b"hi").decode(),
                 "mime_type": "audio/ogg",
@@ -247,6 +250,7 @@ class TestTtsClientFreshness:
         mock_response = MagicMock()
         mock_response.data = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "audio_b64": base64.b64encode(b"audio").decode(),
                 "mime_type": "audio/ogg",
@@ -276,6 +280,7 @@ class TestTtsClientFreshness:
         mock_response = MagicMock()
         mock_response.data = json.dumps(
             {
+                "contract_version": "1",
                 "ok": True,
                 "audio_b64": base64.b64encode(b"audio").decode(),
                 "mime_type": "audio/ogg",


### PR DESCRIPTION
## Summary
- Freeze the lyra ↔ voicecli NATS voice contract as ADR-044 (requests, replies, heartbeat payloads + cadence).
- Add `contract_version: "1"` to every producer-emitted voice payload — additive on the wire, ignored on read by consumers.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #688 — refactor(voice)[S1]: freeze NATS voice contract as ADR-044 + add contract_version field | Open |
| Plan | [688-voicecli-contract-adr-plan.mdx](artifacts/plans/688-voicecli-contract-adr-plan.mdx) | Present |
| Parent spec | [658-voicecli-nats-decouple-spec.mdx](artifacts/specs/658-voicecli-nats-decouple-spec.mdx) | Present |
| Implementation | 1 commit on `feat/688-voicecli-contract-adr` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2754 passed, 42 skipped, 6 new) | Passed |

## What changed
- `docs/architecture/adr/044-lyra-voicecli-nats-contract.mdx` (new) — frozen contract with JSON schemas for STT/TTS request, success/error replies, heartbeat; rationale + consequences; cadence (5s emit, 15s TTL); version semantics (producers must emit, consumers must ignore unknown values).
- `docs/architecture/adr/meta.json` — register ADR-044.
- `src/lyra/nats/nats_stt_client.py`, `src/lyra/nats/nats_tts_client.py` — emit `contract_version` on outgoing requests.
- `src/lyra/bootstrap/stt_adapter_standalone.py`, `src/lyra/bootstrap/tts_adapter_standalone.py` — emit on success reply, error reply, and heartbeat.
- Tests: assert emission on every path; new defensive-read test confirms the hub tolerates an unknown `contract_version` on the reply.

## Test Plan
- [ ] `uv run pytest tests/nats/test_nats_stt_client.py tests/nats/test_nats_tts_client.py tests/bootstrap/test_stt_adapter_standalone.py tests/bootstrap/test_tts_adapter_standalone.py` green (76 tests)
- [ ] `uv run pytest` full suite green (2754 passed locally)
- [ ] `rg 'contract_version' src/lyra/nats src/lyra/bootstrap` returns 8 hits (1+1 client requests, 3+3 adapter reply/heartbeat)
- [ ] `jq '.pages[-1]' docs/architecture/adr/meta.json` returns `"044-lyra-voicecli-nats-contract"`

## Scope boundaries
- **In:** ADR-044, `contract_version` plumbing in 4 Python files, related test updates.
- **Out:** deletion of `STTService`/`TTSService` (S4, #690), pyproject changes (S5, #691), supervisor conf changes (S3, #689), voicecli-side NATS subscriber (voiceCLI#42).

Closes #688

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`