### PR TITLE
fix(nats): harden NATS_CA_CERT load with O_NOFOLLOW + fstat

### DIFF
--- a/src/lyra/nats/connect.py
+++ b/src/lyra/nats/connect.py
@@ -6,7 +6,6 @@ import logging
 import os
 import ssl
 import sys
-from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -71,14 +70,43 @@ def _build_tls_context() -> ssl.SSLContext | None:
     """Build a TLS context from NATS_CA_CERT env var.
 
     Returns None if env var is unset (plain TCP / dev mode).
+    Exits with clear error if path is not a regular file, unreadable, or empty.
+
+    Security (TOCTOU): the path is opened once with ``O_NOFOLLOW`` (symlinks
+    rejected) and ``os.fstat`` inspects the live file descriptor so the
+    is-file check and the read operate on the same inode. Cert data is
+    loaded via ``cadata=`` so ssl never re-opens the path. CA certs are not
+    secret, so no file-mode restriction is imposed.
     """
+    import errno
+    import stat as _stat
+
     ca_path_str = os.environ.get("NATS_CA_CERT")
     if not ca_path_str:
         return None
-    ca_path = Path(ca_path_str)
-    if not ca_path.is_file():
-        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a file")
-    ctx = ssl.create_default_context(cafile=str(ca_path))
+    fd = -1
+    try:
+        fd = os.open(ca_path_str, os.O_RDONLY | os.O_NOFOLLOW)
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode):
+            sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a file")
+        with os.fdopen(fd, "r") as fh:
+            fd = -1  # fdopen takes ownership; prevent double-close below
+            ca_data = fh.read()
+    except OSError as exc:
+        if fd != -1:
+            os.close(fd)
+        if exc.errno in (errno.ENOENT, errno.ELOOP):
+            # Missing path, or a symlink rejected by O_NOFOLLOW.
+            sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a file")
+        strerror = exc.strerror or str(exc)
+        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is unreadable: {strerror}")
+    if not ca_data.strip():
+        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is empty")
+    try:
+        ctx = ssl.create_default_context(cadata=ca_data)
+    except ssl.SSLError as exc:
+        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a valid PEM bundle: {exc}")
     return ctx
 
 

--- a/src/lyra/nats/connect.py
+++ b/src/lyra/nats/connect.py
@@ -92,7 +92,7 @@ def _build_tls_context() -> ssl.SSLContext | None:
             sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a file")
         with os.fdopen(fd, "r") as fh:
             fd = -1  # fdopen takes ownership; prevent double-close below
-            ca_data = fh.read()
+            ca_data = fh.read().strip()
     except OSError as exc:
         if fd != -1:
             os.close(fd)
@@ -101,12 +101,15 @@ def _build_tls_context() -> ssl.SSLContext | None:
             sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a file")
         strerror = exc.strerror or str(exc)
         sys.exit(f"NATS_CA_CERT={ca_path_str!r} is unreadable: {strerror}")
-    if not ca_data.strip():
+    if not ca_data:
         sys.exit(f"NATS_CA_CERT={ca_path_str!r} is empty")
     try:
         ctx = ssl.create_default_context(cadata=ca_data)
     except ssl.SSLError as exc:
-        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a valid PEM bundle: {exc}")
+        # Use exc.reason only — avoid leaking OpenSSL internals (file paths,
+        # library build details) that would surface via the default str(exc).
+        reason = exc.reason or "invalid PEM"
+        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a valid PEM bundle: {reason}")
     return ctx
 
 

--- a/tests/nats/test_nats_connect.py
+++ b/tests/nats/test_nats_connect.py
@@ -223,15 +223,14 @@ class TestBuildTlsContext:
             _build_tls_context()
 
     def test_dangling_symlink_rejected(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        valid_ca_pem: str,
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SystemExit when NATS_CA_CERT is a symlink whose target is gone
         (O_NOFOLLOW guard, ENOENT branch)."""
+        # Target content is irrelevant — os.open never reads it because
+        # ENOENT fires on symlink resolution.
         target = tmp_path / "ca.pem"
-        target.write_text(valid_ca_pem)
+        target.write_text("placeholder")
         link = tmp_path / "ca-link.pem"
         link.symlink_to(target)
         target.unlink()  # leave the symlink dangling

--- a/tests/nats/test_nats_connect.py
+++ b/tests/nats/test_nats_connect.py
@@ -210,11 +210,31 @@ class TestBuildTlsContext:
         monkeypatch: pytest.MonkeyPatch,
         valid_ca_pem: str,
     ) -> None:
-        """SystemExit when NATS_CA_CERT is a symlink (O_NOFOLLOW guard)."""
+        """SystemExit when NATS_CA_CERT is a symlink (O_NOFOLLOW, ELOOP branch)."""
         target = tmp_path / "ca.pem"
         target.write_text(valid_ca_pem)
         link = tmp_path / "ca-link.pem"
         link.symlink_to(target)
+        monkeypatch.setenv("NATS_CA_CERT", str(link))
+
+        # O_NOFOLLOW raises OSError(ELOOP) on a non-dangling symlink →
+        # mapped to "is not a file".
+        with pytest.raises(SystemExit, match="is not a file"):
+            _build_tls_context()
+
+    def test_dangling_symlink_rejected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valid_ca_pem: str,
+    ) -> None:
+        """SystemExit when NATS_CA_CERT is a symlink whose target is gone
+        (O_NOFOLLOW guard, ENOENT branch)."""
+        target = tmp_path / "ca.pem"
+        target.write_text(valid_ca_pem)
+        link = tmp_path / "ca-link.pem"
+        link.symlink_to(target)
+        target.unlink()  # leave the symlink dangling
         monkeypatch.setenv("NATS_CA_CERT", str(link))
 
         with pytest.raises(SystemExit, match="is not a file"):

--- a/tests/nats/test_nats_connect.py
+++ b/tests/nats/test_nats_connect.py
@@ -1,16 +1,46 @@
-"""Unit tests for lyra.nats.connect — nats_connect() and _read_nkey_seed().
+"""Unit tests for lyra.nats.connect — nats_connect(), _read_nkey_seed(),
+and _build_tls_context().
 
 Mocks nats.connect so no real NATS server is required.
 """
 
 from __future__ import annotations
 
+import datetime
+import ssl
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
-from lyra.nats.connect import nats_connect
+from lyra.nats.connect import _build_tls_context, nats_connect
+
+
+@pytest.fixture(scope="session")
+def valid_ca_pem() -> str:
+    """Generate a self-signed CA PEM once per test session."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "lyra-test-ca")]
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)
+        )
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
 
 
 class TestNatsConnect:
@@ -122,3 +152,103 @@ class TestNatsConnect:
         # Act / Assert
         with pytest.raises(SystemExit, match="unsafe permissions"):
             await nats_connect("nats://localhost:4222")
+
+
+class TestBuildTlsContext:
+    def test_returns_none_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """None when NATS_CA_CERT is absent (plain TCP / dev mode)."""
+        monkeypatch.delenv("NATS_CA_CERT", raising=False)
+        assert _build_tls_context() is None
+
+    def test_returns_context_for_valid_pem(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valid_ca_pem: str,
+    ) -> None:
+        """Returns an SSLContext when NATS_CA_CERT points to a valid PEM file."""
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text(valid_ca_pem)
+        monkeypatch.setenv("NATS_CA_CERT", str(ca_file))
+
+        ctx = _build_tls_context()
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_world_readable_ca_accepted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valid_ca_pem: str,
+    ) -> None:
+        """CA certs are not secret — 0o644 must be accepted (no unsafe-perm check)."""
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text(valid_ca_pem)
+        ca_file.chmod(0o644)
+        monkeypatch.setenv("NATS_CA_CERT", str(ca_file))
+
+        assert isinstance(_build_tls_context(), ssl.SSLContext)
+
+    def test_missing_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SystemExit when NATS_CA_CERT points to a missing path."""
+        monkeypatch.setenv("NATS_CA_CERT", str(tmp_path / "nope.pem"))
+        with pytest.raises(SystemExit, match="is not a file"):
+            _build_tls_context()
+
+    def test_directory_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SystemExit when NATS_CA_CERT points to a directory."""
+        monkeypatch.setenv("NATS_CA_CERT", str(tmp_path))
+        with pytest.raises(SystemExit, match="is not a file"):
+            _build_tls_context()
+
+    def test_symlink_rejected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valid_ca_pem: str,
+    ) -> None:
+        """SystemExit when NATS_CA_CERT is a symlink (O_NOFOLLOW guard)."""
+        target = tmp_path / "ca.pem"
+        target.write_text(valid_ca_pem)
+        link = tmp_path / "ca-link.pem"
+        link.symlink_to(target)
+        monkeypatch.setenv("NATS_CA_CERT", str(link))
+
+        with pytest.raises(SystemExit, match="is not a file"):
+            _build_tls_context()
+
+    def test_empty_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SystemExit when NATS_CA_CERT points to an empty / whitespace file."""
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("   \n  ")
+        monkeypatch.setenv("NATS_CA_CERT", str(ca_file))
+
+        with pytest.raises(SystemExit, match="is empty"):
+            _build_tls_context()
+
+    def test_invalid_pem(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SystemExit when NATS_CA_CERT is not valid PEM."""
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("not a real certificate")
+        monkeypatch.setenv("NATS_CA_CERT", str(ca_file))
+
+        with pytest.raises(SystemExit, match="not a valid PEM bundle"):
+            _build_tls_context()
+
+    def test_unreadable_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SystemExit when NATS_CA_CERT is mode 0o000."""
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("irrelevant")
+        ca_file.chmod(0o000)
+        monkeypatch.setenv("NATS_CA_CERT", str(ca_file))
+
+        try:
+            with pytest.raises(SystemExit, match="unreadable"):
+                _build_tls_context()
+        finally:
+            ca_file.chmod(0o600)  # let tmp_path cleanup succeed


### PR DESCRIPTION
## Summary
- Mirror the TOCTOU-safe pattern from `_read_nkey_seed()` in `_build_tls_context()`: `O_NOFOLLOW` rejects symlinks, `fstat` on the live fd ties the is-file check to the read, and cert bytes are passed via `cadata=` so `ssl` never re-opens the path.
- No file-mode restriction imposed — CA certs are not secret (per issue). Invalid PEM now exits with a clear error instead of failing later at connect time.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #708: fix(nats): apply O_NOFOLLOW + perm check to NATS_CA_CERT path | OPEN |
| Implementation | 1 commit on `feat/708-nats-ca-cert-harden` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (9 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats/test_nats_connect.py -v` — all 16 tests pass
- [ ] Symlink rejected: `ln -s ca.pem link.pem && NATS_CA_CERT=link.pem lyra hub` exits with "is not a file"
- [ ] World-readable CA still accepted: `chmod 644 ca.pem` → connects normally
- [ ] Invalid PEM fails fast at startup instead of at TLS handshake time

Closes #708

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`