### PR TITLE
feat(nats): --regen-authconf mode + stt/tts-adapter ACL hygiene (#689 unblock)

### DIFF
--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -51,11 +51,15 @@ SUB_ALLOW[telegram-adapter]='"lyra.outbound.telegram.>"'
 PUB_ALLOW[discord-adapter]='"lyra.inbound.discord.>","lyra.system.ready"'
 SUB_ALLOW[discord-adapter]='"lyra.outbound.discord.>"'
 
-PUB_ALLOW[tts-adapter]='"lyra.voice.tts.heartbeat"'
-SUB_ALLOW[tts-adapter]='"lyra.voice.tts.request"'
+# tts-adapter / stt-adapter: lyra-side voice satellites (retired in #690 cutover).
+# Readiness probe via nc.request('lyra.system.ready') needs pub on system.ready
+# + sub on _INBOX.*.* for reply. Uppercase + lowercase forms included because
+# nats-py historically emits lowercase inboxes and NATS subjects are case-sensitive.
+PUB_ALLOW[tts-adapter]='"lyra.voice.tts.heartbeat","lyra.system.ready"'
+SUB_ALLOW[tts-adapter]='"lyra.voice.tts.request","_INBOX.>","_inbox.>"'
 
-PUB_ALLOW[stt-adapter]='"lyra.voice.stt.heartbeat"'
-SUB_ALLOW[stt-adapter]='"lyra.voice.stt.request"'
+PUB_ALLOW[stt-adapter]='"lyra.voice.stt.heartbeat","lyra.system.ready"'
+SUB_ALLOW[stt-adapter]='"lyra.voice.stt.request","_INBOX.>","_inbox.>"'
 
 # voice-tts: voicecli nats-serve worker on Machine 1 (#689)
 # NB: voicecli.nats.base.AdapterBase subscribes to heartbeat_subject

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -188,6 +188,27 @@ apply_permissions() {
   info "Permissions applied for LYRA_USER=${LYRA_USER}, SEEDS_DIR=${SEEDS_DIR}"
 }
 
+# ── generate_nkey (defined early so --regen-authconf can call it) ─────────────
+# Writes a fresh user nkey seed to ${SEEDS_DIR}/${name}.seed and echoes its
+# public key. Relies on NK_BIN + LYRA_USER being set (both resolved at the
+# top of the file or by ensure_nk). Used by default mode (all seeds) and
+# --regen-authconf (only missing seeds).
+generate_nkey() {
+  local name="$1"
+  local seed_file="${SEEDS_DIR}/${name}.seed"
+  local tmp_seed
+  tmp_seed=$(mktemp)
+  trap 'rm -f "${tmp_seed}"' RETURN
+
+  "${NK_BIN}" -gen user > "${tmp_seed}"
+  local pubkey
+  pubkey=$("${NK_BIN}" -inkey "${tmp_seed}" -pubout) \
+    || error "Failed to derive public key for ${name} — is the nk binary valid?"
+
+  install -m 0600 -o "${LYRA_USER}" -g "${LYRA_USER}" "${tmp_seed}" "${seed_file}"
+  echo "${pubkey}"
+}
+
 # ── fix-perms mode ─────────────────────────────────────────────────────────────
 if [ "${FIX_PERMS}" = true ]; then
   [ -d "${SEEDS_DIR}" ] || error "${SEEDS_DIR} does not exist — run without --fix-perms first"
@@ -428,23 +449,7 @@ mkdir -p "${AUTH_DIR}"
 chown root:nats "${AUTH_DIR}"
 chmod 750 "${AUTH_DIR}"
 
-# ── generate nkey pairs (T1.5: extended to 7) ─────────────────────────────────
-
-generate_nkey() {
-  local name="$1"
-  local seed_file="${SEEDS_DIR}/${name}.seed"
-  local tmp_seed
-  tmp_seed=$(mktemp)
-  trap 'rm -f "${tmp_seed}"' RETURN
-
-  "${NK_BIN}" -gen user > "${tmp_seed}"
-  local pubkey
-  pubkey=$("${NK_BIN}" -inkey "${tmp_seed}" -pubout) \
-    || error "Failed to derive public key for ${name} — is the nk binary valid?"
-
-  install -m 0600 -o "${LYRA_USER}" -g "${LYRA_USER}" "${tmp_seed}" "${seed_file}"
-  echo "${pubkey}"
-}
+# ── generate nkey pairs (T1.5: extended to 7; generate_nkey defined earlier) ──
 
 info "Generating nkey pairs in ${SEEDS_DIR}/ ..."
 HUB_PUB=$(generate_nkey "hub")

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -210,23 +210,20 @@ if [ "${REGEN_AUTHCONF}" = true ]; then
   NK_BIN=$(command -v nk || echo "")
   [ -n "${NK_BIN}" ] || error "nk not found — run without flags first (it will install nk)"
 
-  # Verify all seeds exist; collect pubkeys
+  # Collect pubkeys — derive from existing seeds or create missing ones
   declare -A EXISTING_PUBKEYS
-  missing=()
   for name in "${IDENTITIES[@]}"; do
     seed_file="${SEEDS_DIR}/${name}.seed"
-    if [ ! -f "${seed_file}" ]; then
-      missing+=("${name}")
-      continue
+    if [ -f "${seed_file}" ]; then
+      pubkey=$("${NK_BIN}" -inkey "${seed_file}" -pubout 2>/dev/null) \
+        || error "Failed to derive pubkey from ${seed_file}"
+      info "Derived pubkey from existing seed: ${name}"
+      EXISTING_PUBKEYS[$name]="${pubkey}"
+    else
+      info "Created missing seed: ${name}"
+      EXISTING_PUBKEYS[$name]=$(generate_nkey "${name}")
     fi
-    pubkey=$("${NK_BIN}" -inkey "${seed_file}" -pubout 2>/dev/null) \
-      || error "Failed to derive pubkey from ${seed_file}"
-    EXISTING_PUBKEYS[$name]="${pubkey}"
   done
-
-  if [ ${#missing[@]} -gt 0 ]; then
-    error "Missing seeds for: ${missing[*]} — run --regenerate to create all, or generate individually with nk"
-  fi
 
   # Backup current auth.conf if present
   if [ -f "${AUTH_CONF}" ]; then

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -58,12 +58,14 @@ PUB_ALLOW[stt-adapter]='"lyra.voice.stt.heartbeat"'
 SUB_ALLOW[stt-adapter]='"lyra.voice.stt.request"'
 
 # voice-tts: voicecli nats-serve worker on Machine 1 (#689)
+# NB: voicecli.nats.base.AdapterBase subscribes to heartbeat_subject
+#     (no-op callback) in addition to publishing — ACL must allow both.
 PUB_ALLOW[voice-tts]='"lyra.voice.tts.heartbeat","_INBOX.>"'
-SUB_ALLOW[voice-tts]='"lyra.voice.tts.request"'
+SUB_ALLOW[voice-tts]='"lyra.voice.tts.request","lyra.voice.tts.heartbeat"'
 
 # voice-stt: voicecli nats-serve worker on Machine 1 (#689)
 PUB_ALLOW[voice-stt]='"lyra.voice.stt.heartbeat","_INBOX.>"'
-SUB_ALLOW[voice-stt]='"lyra.voice.stt.request"'
+SUB_ALLOW[voice-stt]='"lyra.voice.stt.request","lyra.voice.stt.heartbeat"'
 
 PUB_ALLOW[llm-worker]='"lyra.llm.health.*"'
 SUB_ALLOW[llm-worker]='"lyra.llm.request"'

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -8,11 +8,12 @@
 #                             tts-adapter, stt-adapter, llm-worker, monitor
 #
 # Usage: sudo ./deploy/nats/gen-nkeys.sh
-#        sudo ./deploy/nats/gen-nkeys.sh --fix-perms      # re-apply permissions without regenerating
-#        sudo ./deploy/nats/gen-nkeys.sh --show           # print existing public keys
-#        sudo ./deploy/nats/gen-nkeys.sh --regenerate     # atomic backup + wipe + regenerate
-#        sudo ./deploy/nats/gen-nkeys.sh --regenerate --yes  # non-interactive regenerate
-#             ./deploy/nats/gen-nkeys.sh --template-only  # write auth.conf skeleton to stdout (no root needed)
+#        sudo ./deploy/nats/gen-nkeys.sh --fix-perms        # re-apply permissions without regenerating
+#        sudo ./deploy/nats/gen-nkeys.sh --show             # print existing public keys
+#        sudo ./deploy/nats/gen-nkeys.sh --regenerate       # atomic backup + wipe + regenerate (rotates keys)
+#        sudo ./deploy/nats/gen-nkeys.sh --regenerate --yes # non-interactive regenerate
+#        sudo ./deploy/nats/gen-nkeys.sh --regen-authconf   # re-render auth.conf from EXISTING seeds (no key rotation)
+#             ./deploy/nats/gen-nkeys.sh --template-only    # write auth.conf skeleton to stdout (no root needed)
 #
 # Idempotent — skips if auth.conf already exists. Delete auth.conf + seeds dir to regenerate.
 # Override seeds location: SEEDS_DIR=/custom/path sudo ./gen-nkeys.sh
@@ -95,15 +96,17 @@ SHOW_ONLY=false
 FIX_PERMS=false
 TEMPLATE_ONLY=false
 REGENERATE=false
+REGEN_AUTHCONF=false
 AUTO_YES=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --show)          SHOW_ONLY=true;    shift ;;
-    --fix-perms)     FIX_PERMS=true;    shift ;;
-    --template-only) TEMPLATE_ONLY=true; shift ;;
-    --regenerate)    REGENERATE=true;   shift ;;
-    --yes)           AUTO_YES=true;     shift ;;
+    --show)            SHOW_ONLY=true;      shift ;;
+    --fix-perms)       FIX_PERMS=true;      shift ;;
+    --template-only)   TEMPLATE_ONLY=true;  shift ;;
+    --regenerate)      REGENERATE=true;     shift ;;
+    --regen-authconf)  REGEN_AUTHCONF=true; shift ;;
+    --yes)             AUTO_YES=true;       shift ;;
     *) error "Unknown option: $1" ;;
   esac
 done
@@ -189,6 +192,77 @@ apply_permissions() {
 if [ "${FIX_PERMS}" = true ]; then
   [ -d "${SEEDS_DIR}" ] || error "${SEEDS_DIR} does not exist — run without --fix-perms first"
   apply_permissions
+  exit 0
+fi
+
+# ── regen-authconf mode: re-render auth.conf from existing seeds ──────────────
+# Purpose: upgrade a live auth.conf to the current IDENTITIES + ACL matrix
+# without rotating keys. Used when the script's ACL model has evolved
+# (e.g. #714 added per-role ACLs, #689 added voice-{stt,tts} roles) but seeds
+# on disk are still valid.
+#
+# Differs from --regenerate: no seed wipe, no key rotation — existing services
+# keep working, only the auth.conf content changes.
+if [ "${REGEN_AUTHCONF}" = true ]; then
+  [ -d "${SEEDS_DIR}" ] || error "${SEEDS_DIR} does not exist — run without flags first to seed keys"
+
+  # Need nk to derive pubkeys from existing seeds
+  NK_BIN=$(command -v nk || echo "")
+  [ -n "${NK_BIN}" ] || error "nk not found — run without flags first (it will install nk)"
+
+  # Verify all seeds exist; collect pubkeys
+  declare -A EXISTING_PUBKEYS
+  missing=()
+  for name in "${IDENTITIES[@]}"; do
+    seed_file="${SEEDS_DIR}/${name}.seed"
+    if [ ! -f "${seed_file}" ]; then
+      missing+=("${name}")
+      continue
+    fi
+    pubkey=$("${NK_BIN}" -inkey "${seed_file}" -pubout 2>/dev/null) \
+      || error "Failed to derive pubkey from ${seed_file}"
+    EXISTING_PUBKEYS[$name]="${pubkey}"
+  done
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    error "Missing seeds for: ${missing[*]} — run --regenerate to create all, or generate individually with nk"
+  fi
+
+  # Backup current auth.conf if present
+  if [ -f "${AUTH_CONF}" ]; then
+    BACKUP_AUTH="${AUTH_CONF}.bak.$(date +%Y%m%d-%H%M%S)"
+    cp -a "${AUTH_CONF}" "${BACKUP_AUTH}"
+    chmod 0640 "${BACKUP_AUTH}"
+    info "Backed up auth.conf → ${BACKUP_AUTH}"
+  fi
+
+  # Render new auth.conf to temp, install atomically
+  TMP_AUTH=$(mktemp)
+  trap 'rm -f "${TMP_AUTH}"' EXIT
+  render_auth_conf EXISTING_PUBKEYS > "${TMP_AUTH}"
+
+  # Validate with nats-server -t if available
+  if command -v nats-server &>/dev/null && [ -f /etc/nats/nats.conf ]; then
+    # Temporarily stage: copy to AUTH_CONF location for include-path resolution,
+    # keep backup as safety net.
+    install -m 0640 -o root -g nats "${TMP_AUTH}" "${AUTH_CONF}"
+    if ! nats-server -t -c /etc/nats/nats.conf >/dev/null 2>&1; then
+      if [ -n "${BACKUP_AUTH:-}" ] && [ -f "${BACKUP_AUTH}" ]; then
+        cp -a "${BACKUP_AUTH}" "${AUTH_CONF}"
+        error "nats-server config validation failed — restored backup. Inspect ${TMP_AUTH} for issues."
+      else
+        rm -f "${AUTH_CONF}"
+        error "nats-server config validation failed — no backup to restore. Re-run --regenerate if needed."
+      fi
+    fi
+    info "nats-server config validation OK."
+  else
+    install -m 0640 -o root -g nats "${TMP_AUTH}" "${AUTH_CONF}"
+    warn "nats-server not found or /etc/nats/nats.conf missing — skipped config validation."
+  fi
+
+  info "auth.conf re-rendered from ${#IDENTITIES[@]} existing seeds."
+  info "Next: sudo systemctl reload nats.service"
   exit 0
 fi
 

--- a/deploy/supervisor/conf.d/voicecli_stt.conf
+++ b/deploy/supervisor/conf.d/voicecli_stt.conf
@@ -1,7 +1,7 @@
 [program:voicecli_stt]
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_voicecli.sh stt
 directory=%(ENV_HOME)s/projects/voiceCLI
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="nats://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/voice-stt.seed",LYRA_STT_ENGINE="whisper"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="tls://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/voice-stt.seed",NATS_CA_CERT="/etc/nats/certs/ca.crt",LYRA_STT_ENGINE="whisper"
 autostart=false
 autorestart=true
 # startsecs: supervisor marks RUNNING after this many seconds of uptime (time-based,

--- a/deploy/supervisor/conf.d/voicecli_tts.conf
+++ b/deploy/supervisor/conf.d/voicecli_tts.conf
@@ -1,7 +1,7 @@
 [program:voicecli_tts]
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_voicecli.sh tts
 directory=%(ENV_HOME)s/projects/voiceCLI
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="nats://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/voice-tts.seed",LYRA_TTS_ENGINE="chatterbox"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="tls://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/voice-tts.seed",NATS_CA_CERT="/etc/nats/certs/ca.crt",LYRA_TTS_ENGINE="chatterbox"
 autostart=false
 autorestart=true
 # startsecs: see voicecli_stt.conf for semantics. TTS Chatterbox model load may

--- a/deploy/supervisor/scripts/run_adapter.sh
+++ b/deploy/supervisor/scripts/run_adapter.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 # Wrapper for lyra adapter daemon — sources .env before launching.
 # Usage: run_adapter.sh telegram|discord|stt|tts
+#
+# IMPORTANT: .env values must NOT override per-program supervisor env.
+# We snapshot supervisor-set vars, source .env for shared defaults, then
+# restore the snapshot so supervisor conf (e.g. NATS_NKEY_SEED_PATH per
+# program) wins. Prevents the regression where a global .env pinned every
+# adapter to hub.seed (see #689 cutover investigation).
+_sv_snapshot=$(env | grep -E '^(NATS_|LYRA_)' || true)
 set -a
 [ -f "$HOME/projects/lyra/.env" ] && source "$HOME/projects/lyra/.env"
 set +a
+while IFS= read -r kv; do [ -n "$kv" ] && export "$kv"; done <<< "$_sv_snapshot"
+unset _sv_snapshot
 exec "$HOME/projects/lyra/.venv/bin/lyra" adapter "$@"

--- a/deploy/supervisor/scripts/run_hub.sh
+++ b/deploy/supervisor/scripts/run_hub.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Wrapper for lyra hub daemon — sources .env before launching.
+# Supervisor env wins over .env — see run_adapter.sh for rationale (#689).
+_sv_snapshot=$(env | grep -E '^(NATS_|LYRA_)' || true)
 set -a
 [ -f "$HOME/projects/lyra/.env" ] && source "$HOME/projects/lyra/.env"
 set +a
+while IFS= read -r kv; do [ -n "$kv" ] && export "$kv"; done <<< "$_sv_snapshot"
+unset _sv_snapshot
 exec "$HOME/projects/lyra/.venv/bin/lyra" hub

--- a/docs/architecture/adr/046-nkey-provisioning-declarative-authconf.mdx
+++ b/docs/architecture/adr/046-nkey-provisioning-declarative-authconf.mdx
@@ -1,0 +1,131 @@
+---
+title: "ADR-046: nkey provisioning is declarative — auth.conf is a pure function of IDENTITIES × seed dir"
+description: Establish that auth.conf must always be derived from a single IDENTITIES manifest and the on-disk seed directory, never constructed or patched incrementally, and that a --regen-authconf mode in gen-nkeys.sh is the correct mechanism for closing drift without seed rotation.
+---
+
+## Status
+
+Accepted
+
+## Context
+
+The #714 per-role ACL rework updated `gen-nkeys.sh` to emit per-identity `permissions` blocks (publish/subscribe matrices, `allow_responses: true`). It also documented a rollout runbook requiring `--regenerate` (full seed rotation + auth.conf rewrite).
+
+By April 2026 (7+ days post-#714 merge) Machine 1 (`roxabituwer`) had drifted into the following state:
+
+- **Live auth.conf** — old minimal format (`{ nkey: "..." }` per user, no `permissions` blocks), 5 identities: hub, llm-worker, monitor, tts-adapter, stt-adapter.
+- **Seeds on disk** — 7 seeds present: hub, llm-worker, monitor, tts-adapter, stt-adapter, voice-tts, voice-stt (voice-* were manually created during #689 work).
+- **Seeds missing** — telegram-adapter, discord-adapter (never generated; the old provisioning pre-dated these roles).
+- **Expected per spec** — 9 identities for the combined #714 + #689 state (hub, telegram-adapter, discord-adapter, tts-adapter, stt-adapter, llm-worker, monitor, voice-tts, voice-stt).
+- **Silent auth degradation** — `lyra_telegram` and `lyra_discord` supervisor envs pointed to `telegram-adapter.seed` / `discord-adapter.seed` which did not exist; Python fell back to `.env` which contained `NATS_NKEY_SEED_PATH=hub.seed`; both adapters authenticated as hub. This was invisible at runtime because auth.conf had no permissions blocks — all authenticated identities could publish and subscribe to anything.
+- **voicecli workers** — `voicecli_tts` / `voicecli_stt` ran with voice-{tts,stt}.seed whose public keys were absent from auth.conf; those processes were likely in NATS auth-retry loops and functionally disconnected despite supervisor reporting RUNNING.
+
+Root cause: the provisioning model was **additive and imperative**. Each ticket added identities by extending a shell script. auth.conf was never re-rendered after #714's ACL matrix was introduced. There was no mechanism to close the gap between the IDENTITIES manifest in gen-nkeys.sh and the live auth.conf without either full seed rotation (destructive, requiring every service credential to be reissued) or a manual sed/append (fragile, not idempotent).
+
+This drift class — manifest defines N identities, live auth.conf has M < N identities, M identities lack permissions blocks — is structural, not accidental. It will recur whenever a new identity is introduced without a matching auth.conf re-render path.
+
+## Options Considered
+
+### Option A: --regenerate only (full seed rotation)
+
+Keep the existing `--regenerate` flag as the sole remediation path. Whenever auth.conf drifts, the operator rotates all seeds, re-provisions every service with new credentials, reloads NATS, and restarts everything.
+
+- **Pros:** Simple code path — one flag does everything. No partial state possible after the run.
+- **Cons:** Destroys all existing seeds. Requires simultaneous credential update across every running service (hub, adapters, voicecli workers). On a 24/7 machine this is a coordinated maintenance window. Cannot be used to add a single identity without disrupting all others. Overkill for drift that is purely a render gap, not a seed compromise.
+
+### Option B: --regen-authconf mode (re-render without seed rotation) — recommended
+
+Add a `--regen-authconf` mode that:
+1. Reads the IDENTITIES manifest embedded in gen-nkeys.sh.
+2. For each identity, reads the existing `.seed` file from `~/.lyra/nkeys/` (if present) and extracts its public key via `nk -inkey`.
+3. For each identity with a missing seed, auto-creates a new seed + writes the pubkey.
+4. Renders auth.conf from scratch using the full IDENTITIES × permissions matrix.
+5. Never touches existing seeds.
+
+auth.conf is therefore always a **pure function** of two inputs: the IDENTITIES manifest (in-script constant) and the seed directory (on-disk state). The mode is idempotent — running it twice produces identical output.
+
+- **Pros:** Non-destructive. Running services keep their seeds and credentials. Can close drift (missing identities, missing permissions blocks) without a maintenance window. Idempotent — safe to re-run after any spec change. Makes the relationship between manifest and auth.conf explicit and mechanical.
+- **Cons:** Adds a second flag to gen-nkeys.sh (complexity). If a seed file is present but its public key no longer matches a live process (e.g., the seed was rotated manually outside the script), the re-rendered auth.conf will still be consistent with the file — the inconsistency is in the deployment, not in the render. This is the operator's responsibility to detect, not the script's.
+
+### Option C: External config management (Ansible / Terraform)
+
+Replace gen-nkeys.sh with a declarative provisioning tool that manages seeds and auth.conf as resources.
+
+- **Pros:** Full idempotency, drift detection, and remediation in a standard tool.
+- **Cons:** Disproportionate for a single-machine, single-operator setup. Introduces a new dependency (Ansible or similar) into a Python-native stack. Lyra's deployment model (supervisord + systemd, no orchestrator) does not justify this overhead at current scale.
+
+## Decision
+
+**Option B — --regen-authconf mode in gen-nkeys.sh, combined with the following invariants:**
+
+### Invariant 1 — auth.conf is a pure render
+
+auth.conf MUST always be the output of rendering the IDENTITIES manifest against the seed directory. It MUST NOT be constructed by appending, patching, or diffing against an existing auth.conf. Every render produces the complete file; partial renders are not permitted.
+
+### Invariant 2 — IDENTITIES is the single source of truth
+
+The IDENTITIES constant in gen-nkeys.sh (or its successor) is the authoritative list of nkey identities for the deployment. Adding a new process that connects to NATS requires adding it to IDENTITIES first. A process not in IDENTITIES cannot be granted a valid auth.conf entry.
+
+### Invariant 3 — Missing seeds are auto-created, never silently skipped
+
+When `--regen-authconf` encounters an identity in IDENTITIES whose seed file does not exist, it creates the seed, writes it to `~/.lyra/nkeys/<identity>.seed`, and includes the new pubkey in the rendered auth.conf. It MUST NOT skip the identity, emit a partial auth.conf, or require a separate `--create-missing` flag.
+
+### Invariant 4 — Supervisor env points to identity-specific seed, no fallback
+
+Each supervisor program's environment MUST reference its own seed file (`<identity>.seed`). The `.env` fallback to `hub.seed` is a configuration error, not a feature. The supervisor conf is the authoritative source of which NATS identity a process uses. If the seed file is absent at process start, the process MUST fail fast (exit non-zero) rather than silently degrade to a different identity.
+
+### Invariant 5 — Drift is detectable before harm
+
+A `lyra ops verify` CLI command (or equivalent script) MUST be able to: (a) parse IDENTITIES from gen-nkeys.sh, (b) check which seeds exist on disk, (c) parse the live auth.conf, and (d) report any gap between the three — missing seeds, extra auth.conf entries, entries without permissions blocks. This check runs in CI and as a pre-deploy gate.
+
+### Rollout for the current drift
+
+1. Run `gen-nkeys.sh --regen-authconf` on Machine 1. Auto-creates telegram-adapter + discord-adapter seeds; renders auth.conf with all 9 identities × full permissions matrix.
+2. `sudo systemctl reload nats.service` — applies new auth.conf in place, no connection drop.
+3. Update supervisor envs to point each adapter to its own seed (fix the hub.seed fallback).
+4. Restart adapters in order: telegram, discord, tts, stt, hub.
+5. Run `scripts/check-nats-acls.sh --since @{reload-timestamp}` — zero `Permissions Violation` lines is the pass signal.
+6. Verify voicecli workers reconnect (heartbeats appear on `lyra.voice.*.heartbeat`).
+
+### Lane sequencing
+
+The auth remediation (Invariants 1–4 + rollout above) MUST complete before Lane G (#689) continues past T6. The voice-{tts,stt} seeds and their auth.conf entries are already present after step 1; the remaining Lane G tasks (ACL verification, staged cutover, smoke tests) can proceed immediately after the reload.
+
+Lane B (containerize, #727/#728) remains independent — it does not need to land before Lane G continues on bare-metal supervisord.
+
+## Consequences
+
+### Positive
+
+- auth.conf drift is closable without a maintenance window or seed rotation.
+- The rendering is deterministic and auditable — given IDENTITIES + seed dir, the expected auth.conf is computable offline.
+- New identities added to IDENTITIES are automatically included in the next `--regen-authconf` run, including auto-created seeds.
+- The "authenticate as hub via .env fallback" silent security hole is structurally eliminated by Invariant 4 — it is a misconfiguration that the supervisor conf must not allow.
+- `lyra ops verify` (Invariant 5) closes the detection gap — the current drift would have been caught before any process was started.
+
+### Negative
+
+- gen-nkeys.sh grows a second mode. The script's cognitive surface area increases.
+- Invariant 4 (fail-fast on missing seed) will surface misconfigurations that currently pass silently. Any deployment that relied on the hub.seed fallback will break on restart — intentionally.
+- `lyra ops verify` is a new deliverable that does not exist yet; until it is implemented, drift remains manually detectable only.
+
+### Neutral
+
+- The telegram/discord "authenticate as hub" issue is closed as part of the current cutover (step 3 above), not deferred to a separate issue. Discovery attribution: found during #689 Lane G T6 execution, April 2026.
+- The `--regenerate` flag remains available for credential rotation (seed compromise, periodic rotation policy). It is not deprecated by this ADR.
+- This ADR does not address the Lane B (containerize) sequencing question — that lane's auth provisioning follows the same invariants but targets Quadlet-mounted secret volumes rather than bare-metal `~/.lyra/nkeys/`.
+
+## Relation to other ADRs
+
+- **ADR-035** — NATS subject naming convention. IDENTITIES in gen-nkeys.sh must align with the subject catalogue defined there.
+- **ADR-039** — STT/TTS NATS adapter decoupling. Establishes lyra_stt / lyra_tts as new supervisor programs; Invariant 2 requires their identities (stt-adapter, tts-adapter) to be in IDENTITIES.
+- **ADR-041** — Supervisor pattern. Invariant 4 (fail-fast on missing seed) must be implemented in the supervisor launch scripts, not in the Python process itself.
+- **ADR-044** — lyra ↔ voicecli NATS voice contract. voice-tts and voice-stt are the voicecli-side identities; they are distinct from tts-adapter / stt-adapter (lyra-side). Both sets must appear in IDENTITIES.
+- **ADR-045** — roxabi-nats SDK extraction. Plugin identities provisioned via the SDK will need their own IDENTITIES entries; this ADR's invariants apply to that provisioning as well.
+
+## References
+
+- Spec: [`artifacts/specs/706-per-role-nkeys-acls-spec.mdx`](../../../artifacts/specs/706-per-role-nkeys-acls-spec.mdx)
+- Issue: [#714](https://github.com/Roxabi/lyra/issues/714) (per-role ACLs), [#689](https://github.com/Roxabi/lyra/issues/689) (Lane G voicecli cutover)
+- Script: `deploy/nats/gen-nkeys.sh`
+- Planned: `scripts/check-nats-acls.sh`, `lyra ops verify` CLI command

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -42,6 +42,7 @@
     "040-nats-messaging-architecture-review",
     "043-roxabi-autodeploy-per-project-manifests",
     "044-lyra-voicecli-nats-contract",
-    "045-roxabi-nats-sdk-uv-workspace-extraction"
+    "045-roxabi-nats-sdk-uv-workspace-extraction",
+    "046-nkey-provisioning-declarative-authconf"
   ]
 }

--- a/tests/nats/test_gen_nkeys_acls.sh
+++ b/tests/nats/test_gen_nkeys_acls.sh
@@ -7,7 +7,7 @@
 #   (a) 7 identity blocks exist (one per user in IDENTITIES)
 #   (b) each identity's publish allow-list equals its matrix row (set equality)
 #   (c) each identity's subscribe allow-list equals its matrix row (set equality)
-#   (d) allow_responses: true present on every user (7 occurrences)
+#   (d) allow_responses: true present on every user (9 occurrences)
 #   (e) no 'plugin' reference anywhere in output
 #   (f) no over-privilege: no identity has unexpected extra subjects
 #   (g) default_permissions { deny: [">"] } present (defense-in-depth)
@@ -39,16 +39,20 @@ EXPECTED_PUB[telegram-adapter]='lyra.inbound.telegram.> lyra.system.ready'
 EXPECTED_SUB[telegram-adapter]='lyra.outbound.telegram.>'
 EXPECTED_PUB[discord-adapter]='lyra.inbound.discord.> lyra.system.ready'
 EXPECTED_SUB[discord-adapter]='lyra.outbound.discord.>'
-EXPECTED_PUB[tts-adapter]='lyra.voice.tts.heartbeat'
-EXPECTED_SUB[tts-adapter]='lyra.voice.tts.request'
-EXPECTED_PUB[stt-adapter]='lyra.voice.stt.heartbeat'
-EXPECTED_SUB[stt-adapter]='lyra.voice.stt.request'
+EXPECTED_PUB[tts-adapter]='lyra.voice.tts.heartbeat lyra.system.ready'
+EXPECTED_SUB[tts-adapter]='lyra.voice.tts.request _INBOX.> _inbox.>'
+EXPECTED_PUB[stt-adapter]='lyra.voice.stt.heartbeat lyra.system.ready'
+EXPECTED_SUB[stt-adapter]='lyra.voice.stt.request _INBOX.> _inbox.>'
+EXPECTED_PUB[voice-tts]='lyra.voice.tts.heartbeat _INBOX.>'
+EXPECTED_SUB[voice-tts]='lyra.voice.tts.request lyra.voice.tts.heartbeat'
+EXPECTED_PUB[voice-stt]='lyra.voice.stt.heartbeat _INBOX.>'
+EXPECTED_SUB[voice-stt]='lyra.voice.stt.request lyra.voice.stt.heartbeat'
 EXPECTED_PUB[llm-worker]='lyra.llm.health.*'
 EXPECTED_SUB[llm-worker]='lyra.llm.request'
 EXPECTED_PUB[monitor]='lyra.monitor.>'
 EXPECTED_SUB[monitor]='lyra.monitor.>'
 
-IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter llm-worker monitor)
+IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker monitor)
 
 # ── extract_block: print the user{} block for a given identity name ────────────
 # B9: the closing-brace condition records `entry_depth` when the identity's
@@ -106,11 +110,11 @@ assert_allow_list_equals() {
   fi
 }
 
-# ── (a) 7 identity comment labels ──────────────────────────────────────────────
-count=$(grep -cE '^[[:space:]]+#[[:space:]]+(hub|telegram-adapter|discord-adapter|tts-adapter|stt-adapter|llm-worker|monitor)$' "$OUT" || true)
-[ "$count" -eq 7 ] \
-  || { echo "FAIL (a): expected 7 identity blocks, got ${count}"; exit 1; }
-echo "PASS (a): 7 identity blocks found"
+# ── (a) 9 identity comment labels ──────────────────────────────────────────────
+count=$(grep -cE '^[[:space:]]+#[[:space:]]+(hub|telegram-adapter|discord-adapter|tts-adapter|stt-adapter|voice-tts|voice-stt|llm-worker|monitor)$' "$OUT" || true)
+[ "$count" -eq 9 ] \
+  || { echo "FAIL (a): expected 9 identity blocks, got ${count}"; exit 1; }
+echo "PASS (a): 9 identity blocks found"
 
 # ── (b) + (c) + (f) set-equality publish and subscribe for all 7 identities ───
 for name in "${IDENTITIES[@]}"; do
@@ -119,15 +123,15 @@ for name in "${IDENTITIES[@]}"; do
   assert_allow_list_equals "$block" "publish"   "${EXPECTED_PUB[$name]}" "$name"
   assert_allow_list_equals "$block" "subscribe" "${EXPECTED_SUB[$name]}" "$name"
 done
-echo "PASS (b): publish allow-lists match matrix (set equality, 7 identities)"
-echo "PASS (c): subscribe allow-lists match matrix (set equality, 7 identities)"
+echo "PASS (b): publish allow-lists match matrix (set equality, 9 identities)"
+echo "PASS (c): subscribe allow-lists match matrix (set equality, 9 identities)"
 echo "PASS (f): no over-privilege detected"
 
-# ── (d) allow_responses: true present on every user (7 occurrences) ───────────
+# ── (d) allow_responses: true present on every user (9 occurrences) ───────────
 ar_count=$(grep -c 'allow_responses: true' "$OUT" || true)
-[ "$ar_count" -eq 7 ] \
-  || { echo "FAIL (d): expected 7 allow_responses: true lines, got ${ar_count}"; exit 1; }
-echo "PASS (d): allow_responses: true appears 7 times"
+[ "$ar_count" -eq 9 ] \
+  || { echo "FAIL (d): expected 9 allow_responses: true lines, got ${ar_count}"; exit 1; }
+echo "PASS (d): allow_responses: true appears 9 times"
 
 # ── (e) the word 'plugin' must not appear anywhere in the generated conf ──────
 if grep -qi 'plugin' "$OUT"; then


### PR DESCRIPTION
## Summary

Adds an idempotent `--regen-authconf` mode to `gen-nkeys.sh` and closes the ACL drift + supervisor-env regression uncovered during the #689 voicecli Machine-1 cutover. Ships ADR-046 establishing `auth.conf = f(IDENTITIES × seeds)` as the invariant.

## Background

The #714 per-role ACL work introduced `permissions` blocks per identity but shipped only a destructive `--regenerate` path (full seed rotation). By the time #689 ran on Machine 1, live auth.conf had drifted to a 5-identity pre-#714 format while `gen-nkeys.sh` declared 9 identities. Two silent regressions compounded the drift:

1. `stt/tts-adapter` ACLs were too narrow for the `nc.request('lyra.system.ready')` readiness probe used by `roxabi_nats.readiness` — missing `lyra.system.ready` publish + `_INBOX.>` subscribe.
2. `run_adapter.sh` / `run_hub.sh` sourced `.env` with `set -a`, letting a legacy `NATS_NKEY_SEED_PATH=hub.seed` override the per-program supervisor env. All 5 lyra programs silently authenticated as `hub`. Invisible because the legacy auth.conf had no `permissions` blocks.

## Changes

- **`deploy/nats/gen-nkeys.sh`**
  - `--regen-authconf` (new) — re-renders auth.conf from existing seeds + IDENTITIES matrix. Idempotent. Auto-creates missing seeds for known identities. No rotation.
  - Moves `generate_nkey()` above flag-mode branches so the new mode can call it.
  - ACL matrix: `stt/tts-adapter` gain `lyra.system.ready` pub + `_INBOX.>` / `_inbox.>` sub (readiness probe). `voice-{stt,tts}` gain sub on own heartbeat (AdapterBase subscribes for no-op callback).
- **`deploy/supervisor/scripts/run_{adapter,hub}.sh`** — snapshot supervisor-set env before sourcing `.env`, restore after. Supervisor conf wins per program.
- **`deploy/supervisor/conf.d/voicecli_{stt,tts}.conf`** — add TLS scheme + `NATS_CA_CERT` (was plain `nats://`, failed cert verify).
- **`tests/nats/test_gen_nkeys_acls.sh`** — updated for the 9-identity roster and the expanded stt/tts-adapter allow-lists.
- **`docs/architecture/adr/046-nkey-provisioning-declarative-authconf.mdx`** — establishes 5 invariants; declares `--regen-authconf` the correct drift-closing mechanism.

## Validation

- ACL matrix test passes (9 identities, full publish/subscribe set-equality).
- Live on Machine 1: all 7 supervisor programs (`lyra_hub`, `lyra_telegram`, `lyra_discord`, `lyra_stt`, `lyra_tts`, `voicecli_stt`, `voicecli_tts`) authenticate with the correct per-role seed; `voicecli_tts` receives and processes NATS TTS requests; `roxabi_nats.readiness: Hub readiness confirmed — starting polling`.

## Test plan

- [ ] `bash tests/nats/test_gen_nkeys_acls.sh` — PASS
- [ ] Dry-run `--regen-authconf` on a fresh install (seeds present) produces valid auth.conf
- [ ] Supervisor env precedence: start a program with a conflicting `.env` value; confirm supervisor conf wins at runtime (`/proc/PID/environ`)
- [ ] voice-smoke round-trip once upstream voiceCLI output-path fix lands (separate PR)

## Follow-ups

- **voiceCLI** — nats-serve TTS adapter reads wrong output path (`{id}.wav` vs actual `{id}_001.wav`). Fix PR in flight in voiceCLI repo.
- **#690** — retire lyra_stt / lyra_tts satellites (deprecated by cutover).
- **#691** — drop `voicecli` dep from lyra; voice is a pure NATS RPC after #690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)