### PR TITLE
feat(dep-graph): auto-derive lane order/par_groups/bands from GH metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Test with coverage
         run: uv run pytest
 
+      - name: Test dep-graph sub-project
+        working-directory: scripts/dep-graph
+        run: |
+          uv sync --frozen
+          uv run pytest tests/
+
   secrets:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/dep-graph/dep_graph/audit.py
+++ b/scripts/dep-graph/dep_graph/audit.py
@@ -267,16 +267,15 @@ def _check_standalone(
 
 def _build_layout_sets(
     layout: dict,
-    gh_issues: dict | None = None,
 ) -> tuple[
     dict[tuple[str, int], str], set[tuple[str, int]], set[tuple[str, int]], set[str]
 ]:
     """Return (layout_lane_of, standalone_set, epic_set, auto_lane_codes).
 
     layout_lane_of: explicit order[] members only.
-    auto_lane_codes: set of lane codes that have NO explicit order[] (auto-derived).
-    When gh_issues is provided, auto-derived lanes contribute all their labeled
-    issues to the "placed" set via auto_lane_codes.
+    auto_lane_codes: set of lane codes that have NO explicit order[] (auto-derived);
+    callers combine this with GH issue labels via `_collect_auto_placed` to
+    expand auto-derived lanes into the full placed set.
     """
     layout_lane_of: dict[tuple[str, int], str] = {}
     auto_lane_codes: set[str] = set()
@@ -379,8 +378,6 @@ def _check_meta(
     return drift_found
 
 
-
-
 def run_audit(layout_path: Path, cache_path: Path, *, verbose: bool = False) -> int:
     """Run the drift audit. Returns exit code (0 = clean, 1 = drift found)."""
     result = _load_inputs(layout_path, cache_path)
@@ -398,7 +395,7 @@ def run_audit(layout_path: Path, cache_path: Path, *, verbose: bool = False) -> 
         labeled |= search_labeled_issues(repo, label_prefix, lane_codes)
 
     layout_lane_of, standalone_set, epic_set, auto_lane_codes = _build_layout_sets(
-        layout, gh_issues
+        layout
     )
     auto_placed, standalone_set = _collect_auto_placed(
         gh_issues, auto_lane_codes, standalone_set, layout, label_prefix

--- a/scripts/dep-graph/dep_graph/audit.py
+++ b/scripts/dep-graph/dep_graph/audit.py
@@ -2,9 +2,14 @@
 
 Reports:
   1. Labeled issues not in any lane order[] (untriaged).
+     When a lane has no explicit order[] (auto-derived mode), all issues with
+     matching lane_label are considered placed — no untriaged drift for that lane.
   2. Issues in order[] missing their GH lane label.
+     Only checked for lanes with explicit order[].
   3. graph:defer label vs defer field in gh.json.
   4. graph:standalone label vs standalone.order[].
+     When standalone.order[] is empty/absent, all gh:standalone issues are
+     considered placed (auto-derived).
 
 Exit 0 if no drift; exit 1 otherwise.
 """
@@ -30,7 +35,7 @@ def _lane_label_from_entry(entry: dict, label_prefix: str) -> str | None:
     lane_prefix = f"{label_prefix}lane/"
     for lbl in entry.get("labels", []):
         if isinstance(lbl, str) and lbl.startswith(lane_prefix):
-            return lbl[len(lane_prefix):]
+            return lbl[len(lane_prefix) :]
     return None
 
 
@@ -129,9 +134,7 @@ def _check_label_mismatches(
     return bool(missing_label)
 
 
-def _collect_gh_deferred(
-    gh_issues: dict, label_prefix: str
-) -> set[tuple[str, int]]:
+def _collect_gh_deferred(gh_issues: dict, label_prefix: str) -> set[tuple[str, int]]:
     """Collect (repo, issue) tuples flagged defer in gh.json."""
     result: set[tuple[str, int]] = set()
     for key, e in gh_issues.items():
@@ -158,7 +161,11 @@ def _collect_layout_deferred(layout: dict) -> set[tuple[str, int]]:
 
 
 def _collect_layout_ref_set(layout: dict) -> set[tuple[str, int]]:
-    """Collect all (repo, issue) tuples from lane order[]."""
+    """Collect all (repo, issue) tuples from lane order[].
+
+    Only includes lanes with explicit order[]. Auto-derived lanes (no order key)
+    are not included here; _build_layout_sets handles those separately.
+    """
     result: set[tuple[str, int]] = set()
     for lane in layout.get("lanes", []):
         for ref in lane.get("order", []):
@@ -171,14 +178,23 @@ def _check_defer(
     gh_issues: dict,
     layout: dict,
     label_prefix: str,
+    auto_placed: set[tuple[str, int]] | None = None,
 ) -> bool:
-    """Report defer label drift. Returns drift_found."""
+    """Report defer label drift. Returns drift_found.
+
+    In auto-derive mode, GH defer labels drive card status directly —
+    issues in auto-derived lanes with graph:defer labels are correct by
+    definition (no layout sync needed).  auto_placed carries all such
+    auto-lane issues so they are excluded from the "only_in_gh" bucket.
+    """
     defer_lbl = f"{label_prefix}defer"
     gh_deferred = _collect_gh_deferred(gh_issues, label_prefix)
     layout_deferred = _collect_layout_deferred(layout)
     layout_ref_set = _collect_layout_ref_set(layout)
+    # Auto-derived lanes: defer is GH-driven, no layout representation needed
+    already_ok = layout_ref_set | (auto_placed or set())
 
-    only_in_gh = gh_deferred - layout_deferred - layout_ref_set
+    only_in_gh = gh_deferred - layout_deferred - already_ok
     only_in_layout = layout_deferred - gh_deferred
     if only_in_gh or only_in_layout:
         print(f"{defer_lbl} label vs layout defer field:")
@@ -199,8 +215,18 @@ def _check_standalone(
     layout: dict,
     label_prefix: str,
 ) -> bool:
-    """Report standalone label drift. Returns drift_found."""
+    """Report standalone label drift. Returns drift_found.
+
+    When standalone.order[] is absent/empty, auto-derive mode is active:
+    all gh:standalone issues are considered placed — no drift for that direction.
+    """
     standalone_lbl = f"{label_prefix}standalone"
+    auto_mode = not bool(layout.get("standalone", {}).get("order"))
+
+    if auto_mode:
+        print(f"{standalone_lbl} label vs standalone.order[]:  (auto-derived, skipped)")
+        print()
+        return False
 
     # gh_standalone: set of (repo, issue) tuples where standalone flag is set
     gh_standalone: set[tuple[str, int]] = set()
@@ -241,13 +267,27 @@ def _check_standalone(
 
 def _build_layout_sets(
     layout: dict,
-) -> tuple[dict[tuple[str, int], str], set[tuple[str, int]], set[tuple[str, int]]]:
-    """Return (layout_lane_of, standalone_set, epic_set) from parsed layout."""
+    gh_issues: dict | None = None,
+) -> tuple[
+    dict[tuple[str, int], str], set[tuple[str, int]], set[tuple[str, int]], set[str]
+]:
+    """Return (layout_lane_of, standalone_set, epic_set, auto_lane_codes).
+
+    layout_lane_of: explicit order[] members only.
+    auto_lane_codes: set of lane codes that have NO explicit order[] (auto-derived).
+    When gh_issues is provided, auto-derived lanes contribute all their labeled
+    issues to the "placed" set via auto_lane_codes.
+    """
     layout_lane_of: dict[tuple[str, int], str] = {}
+    auto_lane_codes: set[str] = set()
     for lane in layout.get("lanes", []):
-        for ref in lane.get("order", []):
-            if isinstance(ref, dict):
-                layout_lane_of[(ref["repo"], ref["issue"])] = lane["code"]
+        code = lane["code"]
+        if "order" not in lane:
+            auto_lane_codes.add(code)
+        else:
+            for ref in lane.get("order", []):
+                if isinstance(ref, dict):
+                    layout_lane_of[(ref["repo"], ref["issue"])] = code
 
     standalone_set: set[tuple[str, int]] = set()
     for ref in layout.get("standalone", {}).get("order", []):
@@ -262,7 +302,83 @@ def _build_layout_sets(
             if epic_repo:
                 epic_set.add((epic_repo, epic["issue"]))
 
-    return layout_lane_of, standalone_set, epic_set
+    return layout_lane_of, standalone_set, epic_set, auto_lane_codes
+
+
+def _collect_auto_placed(
+    gh_issues: dict,
+    auto_lane_codes: set[str],
+    standalone_set: set[tuple[str, int]],
+    layout: dict,
+    label_prefix: str,
+) -> tuple[set[tuple[str, int]], set[tuple[str, int]]]:
+    """Return (auto_placed, updated_standalone_set) for auto-derived lanes/standalone.
+
+    auto_placed: issues in lanes that have no explicit order[] (GH-label driven).
+    standalone_set: extended with gh:standalone issues when layout.standalone is empty.
+    """
+    auto_placed: set[tuple[str, int]] = set()
+    if auto_lane_codes:
+        for key, entry in gh_issues.items():
+            if not entry:
+                continue
+            ll = _lane_label_from_entry(entry, label_prefix)
+            if ll in auto_lane_codes:
+                try:
+                    repo, n = parse_key(key)
+                    auto_placed.add((repo, n))
+                except ValueError:
+                    pass
+
+    standalone_auto = not bool(layout.get("standalone", {}).get("order"))
+    if standalone_auto:
+        updated: set[tuple[str, int]] = set(standalone_set)
+        for key, entry in gh_issues.items():
+            if entry and _is_standalone(entry, label_prefix):
+                try:
+                    repo, n = parse_key(key)
+                    updated.add((repo, n))
+                except ValueError:
+                    pass
+        return auto_placed, updated
+
+    return auto_placed, standalone_set
+
+
+def _check_placement(
+    layout_lane_of: dict[tuple[str, int], str],
+    labeled: set[tuple[str, int]],
+    all_placed: set[tuple[str, int]],
+    gh_issues: dict,
+    label_prefix: str,
+) -> bool:
+    """Check untriaged and label-mismatch drift. Returns drift_found."""
+    drift_found = _check_untriaged(labeled, all_placed, gh_issues, label_prefix)
+    if layout_lane_of:
+        return drift_found | _check_label_mismatches(
+            layout_lane_of, gh_issues, label_prefix
+        )
+    print(
+        "In order[] but wrong/missing GH label:  (all lanes auto-derived, skipped)"
+    )
+    print()
+    return drift_found
+
+
+def _check_meta(
+    gh_issues: dict,
+    layout: dict,
+    label_prefix: str,
+    auto_placed: set[tuple[str, int]],
+) -> bool:
+    """Check defer and standalone drift. Returns drift_found."""
+    drift_found = _check_defer(
+        gh_issues, layout, label_prefix, auto_placed=auto_placed
+    )
+    drift_found |= _check_standalone(gh_issues, layout, label_prefix)
+    return drift_found
+
+
 
 
 def run_audit(layout_path: Path, cache_path: Path, *, verbose: bool = False) -> int:
@@ -281,24 +397,29 @@ def run_audit(layout_path: Path, cache_path: Path, *, verbose: bool = False) -> 
     for repo in repos:
         labeled |= search_labeled_issues(repo, label_prefix, lane_codes)
 
-    layout_lane_of, standalone_set, epic_set = _build_layout_sets(layout)
+    layout_lane_of, standalone_set, epic_set, auto_lane_codes = _build_layout_sets(
+        layout, gh_issues
+    )
+    auto_placed, standalone_set = _collect_auto_placed(
+        gh_issues, auto_lane_codes, standalone_set, layout, label_prefix
+    )
     all_placed: set[tuple[str, int]] = (
-        set(layout_lane_of.keys()) | standalone_set | epic_set
+        set(layout_lane_of.keys()) | standalone_set | epic_set | auto_placed
     )
 
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     print(f"LABEL DRIFT AUDIT — {date_str}")
+    if auto_lane_codes:
+        print(f"  (auto-derived lanes: {', '.join(sorted(auto_lane_codes))})")
     print()
 
-    drift_found = False
-    drift_found |= _check_untriaged(labeled, all_placed, gh_issues, label_prefix)
-    drift_found |= _check_label_mismatches(layout_lane_of, gh_issues, label_prefix)
-    drift_found |= _check_defer(gh_issues, layout, label_prefix)
-    drift_found |= _check_standalone(gh_issues, layout, label_prefix)
+    drift_found = _check_placement(
+        layout_lane_of, labeled, all_placed, gh_issues, label_prefix
+    )
+    drift_found |= _check_meta(gh_issues, layout, label_prefix, auto_placed)
 
     if drift_found:
         print("RESULT: drift detected — exit 1")
         return 1
-    else:
-        print("RESULT: clean — exit 0")
-        return 0
+    print("RESULT: clean — exit 0")
+    return 0

--- a/scripts/dep-graph/dep_graph/build.py
+++ b/scripts/dep-graph/dep_graph/build.py
@@ -1,19 +1,23 @@
 """Build dep-graph HTML from layout.json + gh.json.
 
-Layout schema (label-driven):
+Layout schema (label-driven, all fields except meta/lanes optional):
   meta{}                   — title, date, repo, label_prefix, issue, category, …
-  lanes[].order[]          — issue numbers in display order
-  lanes[].par_groups{}     — { group_id: [issue, ...] }
-  lanes[].bands[]          — [{ before: N, text: "..." }]
-  overrides{}              — per-issue keyed by str(number)
-  extra_deps{}             — extra_blocked_by / extra_blocking maps
-  standalone.order[]       — standalone issue numbers
-  cross_deps[]             — cross-lane notes
-  title_rules[]            — sequential regex rules for title normalization
+  lanes[].code/name/color  — required per lane
+  lanes[].epic             — optional epic banner
+  lanes[].order[]          — optional: if absent, auto-derived from gh_issues
+  lanes[].par_groups{}     — optional: if absent, auto-derived from topo depth
+  lanes[].bands[]          — optional: if absent, auto-derived from milestones
+  overrides{}              — optional per-issue editorial overrides
+  extra_deps{}             — deprecated: use GH blocked_by instead
+  standalone.order[]       — optional: if absent, auto-derived from labels
+  cross_deps[]             — optional cross-lane notes (editorial)
+  title_rules[]            — deprecated: built-in rules in titles.py handle this
 
 Defer status: driven by gh.issues[N].defer (from <prefix>defer label).
 Label-drift warnings: emitted to stderr when layout order lane ≠ GH label lane.
-Untriaged section: labeled issues not in any lane order.
+Untriaged section: labeled issues not in any lane order (only for explicit orders).
+Size: read from gh.json entry 'size' field (derived from size:* label in fetch),
+      overridden by overrides.<key>.size if present.
 """
 
 from __future__ import annotations
@@ -26,6 +30,7 @@ from dataclasses import dataclass
 from html import escape
 from pathlib import Path
 
+from .derive import derive_lane, derive_standalone_order
 from .keys import format_key, parse_key, repo_slug
 from .schema import LayoutValidationError, validate_layout
 from .titles import normalize_title
@@ -46,7 +51,7 @@ class CardContext:
     extra_blocked_by: list[tuple[str, int]]
     extra_blocking: list[tuple[str, int]]
     gh_issues: dict
-    title_rules: list[dict]
+    title_rules: list[dict] | None
     primary_repo: str = ""
 
 
@@ -57,7 +62,7 @@ class FlatLaneContext:
     gh_issues: dict
     overrides: dict
     extra_deps: dict
-    title_rules: list[dict]
+    title_rules: list[dict] | None
     primary_repo: str = ""
 
 
@@ -223,7 +228,7 @@ def display_title(
     issue_num: int,
     ovr: dict,
     gh_entry: dict | None,
-    title_rules: list[dict],
+    title_rules: list[dict] | None,
 ) -> str:
     # Per-issue override wins
     if "title" in ovr:
@@ -266,18 +271,22 @@ def render_card(ctx: CardContext, anchor_attr: str = "") -> str:
     if ctx.gh_entry is None and ctx.repo:
         return _render_missing_card(ctx.repo, ctx.issue_num, anchor_attr)
     status = derive_status(
-        ctx.ovr, ctx.gh_entry, ctx.extra_blocked_by, ctx.gh_issues,
+        ctx.ovr,
+        ctx.gh_entry,
+        ctx.extra_blocked_by,
+        ctx.gh_issues,
         ctx.repo,
     )
-    size = ctx.ovr.get("size", "")
+    # size: override wins, then gh.json 'size' field (from size:* label), then empty
+    size = (
+        ctx.ovr.get("size") or (ctx.gh_entry.get("size") if ctx.gh_entry else "") or ""
+    )
     title = display_title(ctx.issue_num, ctx.ovr, ctx.gh_entry, ctx.title_rules)
     size_html = f'<span class="size">{escape(size)}</span>' if size else ""
     deps_html = render_deps(ctx)
     repo_badge_html = _render_repo_badge(ctx.repo, ctx.primary_repo)
     card_id = f"card-{repo_slug(ctx.repo)}-{ctx.issue_num}"
-    top_inner = (
-        f'<span class="num">#{ctx.issue_num}</span>{repo_badge_html}{size_html}'
-    )
+    top_inner = f'<span class="num">#{ctx.issue_num}</span>{repo_badge_html}{size_html}'
     return (
         f'<div class="card {status}" id="{card_id}"{anchor_attr}>'
         f'<div class="top">{top_inner}</div>'
@@ -685,7 +694,7 @@ def render_standalone(
     order: list[tuple[str, int]],
     gh_issues: dict,
     overrides: dict,
-    title_rules: list[dict],
+    title_rules: list[dict] | None,
     primary_repo: str = "",
 ) -> str:
     cards = []
@@ -694,7 +703,7 @@ def render_standalone(
         ovr = overrides.get(ovr_key, {})
         gh_entry = gh_issues.get(format_key(repo, n) if repo else str(n))
         status = derive_status(ovr, gh_entry, [], gh_issues, repo)
-        size = ovr.get("size", "")
+        size = ovr.get("size") or (gh_entry.get("size") if gh_entry else "") or ""
         title = display_title(n, ovr, gh_entry, title_rules)
         size_html = f'<span class="size">{escape(size)}</span>' if size else ""
         cards.append(
@@ -1177,19 +1186,23 @@ def _escape_meta(meta: dict, primary_repo: str) -> dict[str, str]:
     }
 
 
-def build_html(layout: dict, gh_issues: dict) -> str:
-    meta = layout["meta"]
-    lanes = layout["lanes"]
-    overrides = layout.get("overrides", {})
-    extra_deps = layout.get("extra_deps", {})
+def _prepare_render_data(
+    layout: dict,
+    gh_issues: dict,
+    primary_repo: str,
+    overrides: dict,
+) -> tuple[list[dict], list[tuple[str, int]], list[tuple[str, int]]]:
+    """Derive lanes, resolve standalone/untriaged.
+
+    Returns (flat_lanes, standalone_order, untriaged).
+    """
+    raw_lanes = layout["lanes"]
     standalone = layout.get("standalone", {})
-    cross_deps = layout.get("cross_deps", [])
-    title_rules: list[dict] = layout.get("title_rules", [])
 
-    _repos_list: list[str] = meta.get("repos", [])
-    primary_repo: str = _repos_list[0] if _repos_list else meta.get("repo", "")
+    lanes = [derive_lane(lane, gh_issues, primary_repo) for lane in raw_lanes]
+    if not standalone.get("order"):
+        standalone = {"order": derive_standalone_order(gh_issues, primary_repo)}
 
-    # Build lane_of map: (repo, issue) → lane_code
     lane_of: dict[tuple[str, int], str] = {}
     for lane in lanes:
         for item in lane.get("order", []):
@@ -1198,11 +1211,10 @@ def build_html(layout: dict, gh_issues: dict) -> str:
             else:
                 lane_of[(primary_repo, int(item))] = lane["code"]
 
-    flat_lanes = [flatten_lane(lane, overrides, True, gh_issues) for lane in lanes]
-    flat_lanes = inject_spacers(flat_lanes)
+    flat_lanes = inject_spacers(
+        [flatten_lane(lane, overrides, True, gh_issues) for lane in lanes]
+    )
 
-    # Untriaged detection — use (repo, issue) set
-    all_ordered: set[tuple[str, int]] = set(lane_of.keys())
     raw_standalone_order = standalone.get("order", [])
     standalone_order: list[tuple[str, int]] = []
     for item in raw_standalone_order:
@@ -1210,14 +1222,13 @@ def build_html(layout: dict, gh_issues: dict) -> str:
             standalone_order.append((item["repo"], item["issue"]))
         else:
             standalone_order.append((primary_repo, int(item)))
-    all_ordered.update(standalone_order)
-    epic_issues: set[tuple[str, int]] = set()
-    for lane in layout["lanes"]:
-        if lane.get("epic"):
-            epic = lane["epic"]
-            epic_repo = epic.get("repo", primary_repo)
-            epic_issues.add((epic_repo, epic["issue"]))
 
+    all_ordered: set[tuple[str, int]] = set(lane_of.keys()) | set(standalone_order)
+    epic_issues: set[tuple[str, int]] = {
+        (epic.get("repo", primary_repo), epic["issue"])
+        for lane in layout["lanes"]
+        if (epic := lane.get("epic"))
+    }
     untriaged: list[tuple[str, int]] = sorted(
         (
             (entry.get("repo", primary_repo), entry["number"])
@@ -1232,6 +1243,30 @@ def build_html(layout: dict, gh_issues: dict) -> str:
         ),
         key=lambda x: (x[0], x[1]),
     )
+    return flat_lanes, standalone_order, untriaged
+
+
+def build_html(layout: dict, gh_issues: dict) -> str:
+    meta = layout["meta"]
+    overrides = layout.get("overrides", {})
+    extra_deps = layout.get("extra_deps", {})
+    cross_deps = layout.get("cross_deps", [])
+    title_rules: list[dict] | None = layout.get("title_rules", None)
+
+    _repos_list: list[str] = meta.get("repos", [])
+    primary_repo: str = _repos_list[0] if _repos_list else meta.get("repo", "")
+
+    flat_lanes, standalone_order, untriaged = _prepare_render_data(
+        layout, gh_issues, primary_repo, overrides
+    )
+
+    # Rebuild lane_of from flat_lanes for cross-lane dep rendering
+    lane_of: dict[tuple[str, int], str] = {}
+    for fl in flat_lanes:
+        code = fl["code"]
+        for row in fl["flat_rows"]:
+            if "issue" in row and row.get("repo"):
+                lane_of[(row["repo"], row["issue"])] = code
 
     lanes_html = "\n\n".join(
         render_flat_lane(
@@ -1264,7 +1299,7 @@ def build_html(layout: dict, gh_issues: dict) -> str:
     cat_label = escaped["cat_label"]
     color = escaped["color"]
     repo_url = escaped["repo_url"]
-    lane_count = len(lanes)
+    lane_count = len(flat_lanes)
 
     subtitle = (
         f"{lane_count} lanes \u00b7 1 card per row \u00b7"

--- a/scripts/dep-graph/dep_graph/build.py
+++ b/scripts/dep-graph/dep_graph/build.py
@@ -1191,10 +1191,17 @@ def _prepare_render_data(
     gh_issues: dict,
     primary_repo: str,
     overrides: dict,
-) -> tuple[list[dict], list[tuple[str, int]], list[tuple[str, int]]]:
+) -> tuple[
+    list[dict],
+    list[tuple[str, int]],
+    list[tuple[str, int]],
+    dict[tuple[str, int], str],
+]:
     """Derive lanes, resolve standalone/untriaged.
 
-    Returns (flat_lanes, standalone_order, untriaged).
+    Returns (flat_lanes, standalone_order, untriaged, lane_of) where lane_of
+    maps (repo, issue) → lane code for every item placed in a lane — used by
+    downstream renderers for cross-lane dep arrows.
     """
     raw_lanes = layout["lanes"]
     standalone = layout.get("standalone", {})
@@ -1243,7 +1250,7 @@ def _prepare_render_data(
         ),
         key=lambda x: (x[0], x[1]),
     )
-    return flat_lanes, standalone_order, untriaged
+    return flat_lanes, standalone_order, untriaged, lane_of
 
 
 def build_html(layout: dict, gh_issues: dict) -> str:
@@ -1256,17 +1263,9 @@ def build_html(layout: dict, gh_issues: dict) -> str:
     _repos_list: list[str] = meta.get("repos", [])
     primary_repo: str = _repos_list[0] if _repos_list else meta.get("repo", "")
 
-    flat_lanes, standalone_order, untriaged = _prepare_render_data(
+    flat_lanes, standalone_order, untriaged, lane_of = _prepare_render_data(
         layout, gh_issues, primary_repo, overrides
     )
-
-    # Rebuild lane_of from flat_lanes for cross-lane dep rendering
-    lane_of: dict[tuple[str, int], str] = {}
-    for fl in flat_lanes:
-        code = fl["code"]
-        for row in fl["flat_rows"]:
-            if "issue" in row and row.get("repo"):
-                lane_of[(row["repo"], row["issue"])] = code
 
     lanes_html = "\n\n".join(
         render_flat_lane(

--- a/scripts/dep-graph/dep_graph/derive.py
+++ b/scripts/dep-graph/dep_graph/derive.py
@@ -1,0 +1,294 @@
+"""Auto-derivation of lane order, par_groups, and bands from GitHub metadata.
+
+Given a lane definition (code, name, color, epic) and gh_issues, this module
+derives:
+  - order[]       — all issues with matching lane_label, topo-sorted by
+                    blocked_by (in-lane edges only), tie-broken by issue number
+  - par_groups{}  — issues at the same topological depth with no edges between
+                    them grouped together
+  - bands[]       — milestone transitions in the derived order (derived from
+                    the `milestone` field on each gh.json entry)
+
+Design:
+  - Only in-lane edges are used for topo sort (cross-lane blocked_by is ignored
+    for ordering, but still rendered as arrows in build.py).
+  - Open issues only are placed; closed issues are excluded from order/groups
+    but remain in gh_issues for status rendering when referenced.
+  - Topological cycles are logged as warnings and resolved by falling back to
+    issue-number sort within the cycle.
+  - The primary_repo is used to format IssueRef dicts.
+
+This module is intentionally free of Lyra-specific logic — it only depends on
+gh.json entry shape (lane_label, blocked_by, milestone, state, number, repo).
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict, deque
+
+from .keys import format_key
+
+
+def _in_lane_edges(
+    issue_key: str,
+    gh_entry: dict,
+    lane_code: str,
+    lane_issue_set: set[tuple[str, int]],
+    own_repo: str,
+) -> list[tuple[str, int]]:
+    """Return blocked_by refs that are in the same lane (in-lane edges only)."""
+    result: list[tuple[str, int]] = []
+    for item in gh_entry.get("blocked_by", []):
+        if isinstance(item, dict):
+            ref_repo, ref_num = item["repo"], item["issue"]
+        else:
+            ref_repo, ref_num = own_repo, int(item)
+        if (ref_repo, ref_num) in lane_issue_set:
+            result.append((ref_repo, ref_num))
+    return result
+
+
+def _resolve_cycle(
+    remaining: list[tuple[str, int]],
+    depth: dict[tuple[str, int], int],
+    result: list[tuple[str, int]],
+) -> None:
+    """Warn and append cycle members sorted by issue number (in-place)."""
+    remaining_keys = ", ".join(
+        f"{r}#{n}" for r, n in sorted(remaining, key=lambda x: x[1])
+    )
+    print(
+        f"  WARN topo-sort: cycle detected in lane — "
+        f"falling back to issue-number sort for: {remaining_keys}",
+        file=sys.stderr,
+    )
+    max_depth = max(depth.values(), default=0) + 1
+    for node in sorted(remaining, key=lambda x: x[1]):
+        depth[node] = max_depth
+        result.append(node)
+
+
+def _topo_sort(
+    nodes: list[tuple[str, int]],
+    edges: dict[tuple[str, int], list[tuple[str, int]]],
+) -> tuple[list[tuple[str, int]], dict[tuple[str, int], int]]:
+    """Kahn's algorithm. Returns (sorted_nodes, depth_map).
+
+    depth_map maps each node to its topological depth (0 = no deps in-lane).
+    On cycle detection: logs a warning, falls back to issue-number sort within
+    the cycle set, assigns all cycle members the same depth as their minimum
+    predecessor depth + 1.
+    """
+    node_set = set(nodes)
+    # Build in-degree and adjacency (edges: blocked_by → this node depends on it)
+    in_degree: dict[tuple[str, int], int] = {n: 0 for n in nodes}
+    rev_adj: dict[tuple[str, int], list[tuple[str, int]]] = defaultdict(list)
+
+    for node in nodes:
+        for dep in edges.get(node, []):
+            if dep in node_set:
+                in_degree[node] += 1
+                rev_adj[dep].append(node)
+
+    depth: dict[tuple[str, int], int] = {n: 0 for n in nodes}
+    queue: deque[tuple[str, int]] = deque()
+    for node in sorted(nodes, key=lambda x: x[1]):  # stable initial order
+        if in_degree[node] == 0:
+            queue.append(node)
+
+    result: list[tuple[str, int]] = []
+    while queue:
+        node = queue.popleft()
+        result.append(node)
+        for successor in sorted(rev_adj[node], key=lambda x: x[1]):
+            in_degree[successor] -= 1
+            depth[successor] = max(depth[successor], depth[node] + 1)
+            if in_degree[successor] == 0:
+                queue.append(successor)
+
+    remaining = [n for n in nodes if in_degree[n] > 0]
+    if remaining:
+        _resolve_cycle(remaining, depth, result)
+
+    return result, depth
+
+
+def _collect_lane_issues(
+    code: str,
+    gh_issues: dict,
+    primary_repo: str,
+    epic_issue_num: int | None,
+) -> list[tuple[str, int]]:
+    """Return open (repo, num) pairs whose lane_label matches code, epic excluded."""
+    lane_issues: list[tuple[str, int]] = []
+    for _key, entry in gh_issues.items():
+        if not entry:
+            continue
+        if entry.get("lane_label") != code:
+            continue
+        repo = entry.get("repo", primary_repo)
+        num = entry.get("number")
+        if num is None:
+            continue
+        if num == epic_issue_num and repo == primary_repo:
+            continue
+        if entry.get("state") == "closed":
+            continue
+        lane_issues.append((repo, num))
+    return lane_issues
+
+
+def _build_lane_edges(
+    code: str,
+    lane_issues: list[tuple[str, int]],
+    lane_issue_set: set[tuple[str, int]],
+    gh_issues: dict,
+) -> dict[tuple[str, int], list[tuple[str, int]]]:
+    """Build in-lane blocked_by edge map for topo sort."""
+    edges: dict[tuple[str, int], list[tuple[str, int]]] = {}
+    for repo, num in lane_issues:
+        key = format_key(repo, num)
+        entry = gh_issues.get(key, {})
+        edges[(repo, num)] = _in_lane_edges(key, entry, code, lane_issue_set, repo)
+    return edges
+
+
+def _build_par_groups(
+    code: str,
+    sorted_issues: list[tuple[str, int]],
+    depth_map: dict[tuple[str, int], int],
+    edges: dict[tuple[str, int], list[tuple[str, int]]],
+) -> dict[str, list[dict]]:
+    """Group issues at the same topo depth with no intra-group edges."""
+    par_groups: dict[str, list[dict]] = {}
+    depth_buckets: dict[int, list[tuple[str, int]]] = defaultdict(list)
+    for repo, num in sorted_issues:
+        depth_buckets[depth_map.get((repo, num), 0)].append((repo, num))
+
+    group_idx = 0
+    for d in sorted(depth_buckets.keys()):
+        bucket = depth_buckets[d]
+        if len(bucket) <= 1:
+            continue
+        bucket_set = set(bucket)
+        has_inner_edge = any(
+            dep in bucket_set
+            for repo, num in bucket
+            for dep in edges.get((repo, num), [])
+        )
+        if not has_inner_edge:
+            group_id = f"auto_{code}_{group_idx}"
+            par_groups[group_id] = [{"repo": r, "issue": n} for r, n in bucket]
+            group_idx += 1
+    return par_groups
+
+
+def derive_lane(
+    lane: dict,
+    gh_issues: dict,
+    primary_repo: str,
+) -> dict:
+    """Derive order, par_groups, and bands for a lane if not already present.
+
+    - If lane has an explicit 'order' key: return lane unchanged (graceful
+      degradation — lets lanes be migrated one at a time).
+    - Otherwise: auto-derive from gh_issues filtered by lane_label.
+
+    Epic issues (lane['epic']['issue']) are excluded from the derived order[]
+    — they appear only in the epic-banner, not as regular cards.
+    """
+    if "order" in lane:
+        return lane
+
+    code = lane["code"]
+    epic_issue_num: int | None = None
+    if lane.get("epic") and isinstance(lane["epic"], dict):
+        epic_issue_num = lane["epic"].get("issue")
+
+    lane_issues = _collect_lane_issues(code, gh_issues, primary_repo, epic_issue_num)
+    if not lane_issues:
+        return {**lane, "order": [], "par_groups": {}, "bands": []}
+
+    lane_issue_set = set(lane_issues)
+    edges = _build_lane_edges(code, lane_issues, lane_issue_set, gh_issues)
+    sorted_issues, depth_map = _topo_sort(lane_issues, edges)
+
+    order = [{"repo": repo, "issue": num} for repo, num in sorted_issues]
+    par_groups = _build_par_groups(code, sorted_issues, depth_map, edges)
+    bands = _derive_bands(sorted_issues, gh_issues, primary_repo)
+
+    return {**lane, "order": order, "par_groups": par_groups, "bands": bands}
+
+
+_UNSET = object()  # sentinel for "first iteration not yet seen"
+
+
+def _derive_bands(
+    sorted_issues: list[tuple[str, int]],
+    gh_issues: dict,
+    primary_repo: str,
+) -> list[dict]:
+    """Derive band headers from milestone transitions in the sorted order.
+
+    Issues with no milestone go in an implicit first group (no band header).
+    When the milestone changes, a band header is inserted before the first
+    issue of the new milestone group.
+    """
+    bands: list[dict] = []
+    prev_milestone: object = _UNSET  # use sentinel to detect first iteration
+
+    for repo, num in sorted_issues:
+        key = format_key(repo, num)
+        entry = gh_issues.get(key, {})
+        milestone = entry.get("milestone")  # str | None
+
+        if prev_milestone is _UNSET:
+            # First issue — no band for None, band for named milestone
+            if milestone is not None:
+                bands.append(
+                    {
+                        "before": {"repo": repo, "issue": num},
+                        "text": f"{milestone} \u2225",
+                    }
+                )
+            prev_milestone = milestone
+            continue
+
+        if milestone != prev_milestone:
+            if milestone is not None:
+                bands.append(
+                    {
+                        "before": {"repo": repo, "issue": num},
+                        "text": f"{milestone} \u2225",
+                    }
+                )
+            prev_milestone = milestone
+
+    return bands
+
+
+def derive_standalone_order(
+    gh_issues: dict,
+    primary_repo: str,
+) -> list[dict]:
+    """Derive standalone order from gh_issues with graph:standalone label.
+
+    Returns a list of IssueRef dicts sorted by issue number ascending.
+    Only open issues are included.
+    """
+    items: list[tuple[str, int]] = []
+    for _key, entry in gh_issues.items():
+        if not entry:
+            continue
+        if not entry.get("standalone"):
+            continue
+        if entry.get("state") == "closed":
+            continue
+        repo = entry.get("repo", primary_repo)
+        num = entry.get("number")
+        if num is not None:
+            items.append((repo, num))
+
+    items.sort(key=lambda x: x[1])
+    return [{"repo": r, "issue": n} for r, n in items]

--- a/scripts/dep-graph/dep_graph/fetch.py
+++ b/scripts/dep-graph/dep_graph/fetch.py
@@ -130,12 +130,22 @@ def search_labeled_issues(
     return {(repo, n) for n in nums}
 
 
+def _derive_size_from_labels(labels: list[str]) -> str | None:
+    """Extract size string from size:* label, e.g. 'size:S' -> 'S'."""
+    for lbl in labels:
+        if lbl.startswith("size:"):
+            return lbl[5:]
+    return None
+
+
 def fetch_issue_meta(
     issue_num: int, repo: str, label_prefix: str
-) -> tuple[int, str, str, list[str]]:
-    """Fetch title, state, labels for one issue via REST.
+) -> tuple[int, str, str, list[str], str | None, str | None]:
+    """Fetch title, state, labels, milestone, size for one issue via REST.
 
-    Returns (issue_num, title, state, label_names).
+    Returns (issue_num, title, state, label_names, milestone_title, size).
+    milestone_title is the GH milestone name (e.g. "M0", "M1") or None.
+    size is derived from a size:* label (e.g. "S", "F-lite") or None.
     """
     endpoint = f"repos/{repo}/issues/{issue_num}"
     try:
@@ -150,36 +160,43 @@ def fetch_issue_meta(
             f"  WARN #{issue_num} meta: timed out",
             file=sys.stderr,
         )
-        return (issue_num, "", "open", [])
+        return (issue_num, "", "open", [], None, None)
     if result.returncode != 0:
         print(
             f"  WARN #{issue_num} meta: {result.stderr.strip()}",
             file=sys.stderr,
         )
-        return (issue_num, "", "open", [])
+        return (issue_num, "", "open", [], None, None)
     try:
         data = json.loads(result.stdout)
     except json.JSONDecodeError:
         print(f"  WARN #{issue_num}: non-JSON response", file=sys.stderr)
-        return (issue_num, "", "open", [])
+        return (issue_num, "", "open", [], None, None)
 
     if not isinstance(data, dict):
         print(
             f"  WARN #{issue_num}: unexpected meta shape",
             file=sys.stderr,
         )
-        return (issue_num, "", "open", [])
+        return (issue_num, "", "open", [], None, None)
 
     raw_labels = data.get("labels", [])
     label_names: list[str] = (
-        [lbl["name"] for lbl in raw_labels]
-        if isinstance(raw_labels, list)
-        else []
+        [lbl["name"] for lbl in raw_labels] if isinstance(raw_labels, list) else []
     )
     title: str = data.get("title", "")
     state: str = data.get("state", data.get("State", "open"))
 
-    return (issue_num, title, state, label_names)
+    # Milestone: read from GH API milestone object
+    raw_milestone = data.get("milestone")
+    milestone_title: str | None = None
+    if isinstance(raw_milestone, dict):
+        milestone_title = raw_milestone.get("title") or None
+
+    # Size: derived from size:* label
+    size: str | None = _derive_size_from_labels(label_names)
+
+    return (issue_num, title, state, label_names, milestone_title, size)
 
 
 def _check_dep_shape(payload: list) -> None:
@@ -217,9 +234,7 @@ def fetch_dep_list(
     Returns (issue_num, direction, list_of_IssueRef_dicts).
     Each IssueRef has shape: {repo: str, issue: int}.
     """
-    endpoint = (
-        f"repos/{repo}/issues/{issue_num}/dependencies/{direction}"
-    )
+    endpoint = f"repos/{repo}/issues/{issue_num}/dependencies/{direction}"
     try:
         result = subprocess.run(
             ["gh", "api", endpoint],
@@ -288,9 +303,7 @@ def _discover_from_layout(
     return discovered
 
 
-def run_fetch(
-    layout_path: Path, cache_path: Path, *, verbose: bool = False
-) -> int:
+def run_fetch(layout_path: Path, cache_path: Path, *, verbose: bool = False) -> int:
     """Main fetch logic. Returns exit code."""
     check_gh()
 
@@ -305,9 +318,7 @@ def run_fetch(
     meta = layout["meta"]
     repos: list[str] = meta["repos"]
     label_prefix: str = meta.get("label_prefix", "graph:")
-    lane_codes: list[str] = [
-        lane["code"] for lane in layout.get("lanes", [])
-    ]
+    lane_codes: list[str] = [lane["code"] for lane in layout.get("lanes", [])]
 
     discovered = _discover_from_layout(layout, repos, label_prefix, lane_codes)
 
@@ -319,9 +330,9 @@ def run_fetch(
         }
         for f in as_completed(meta_fut):
             repo_key, n = meta_fut[f]
-            _, title, state, labels = f.result()
+            _, title, state, labels, milestone, size = f.result()
             key = f"{repo_key}#{n}"
-            issues[key] = {
+            entry: dict = {
                 "repo": repo_key,
                 "number": n,
                 "title": title,
@@ -331,13 +342,22 @@ def run_fetch(
                 "blocked_by": [],
                 "blocking": [],
             }
+            # milestone: GH milestone title (e.g. "M0", "M1") — used for band derivation
+            if milestone is not None:
+                entry["milestone"] = milestone
+            # size: derived from size:* label — used for card rendering
+            if size is not None:
+                entry["size"] = size
+            issues[key] = entry
 
         dep_fut: dict = {}
         for r, n in discovered:
             for direction in ("blocked_by", "blocking"):
-                dep_fut[
-                    pool.submit(fetch_dep_list, n, direction, r)
-                ] = (r, n, direction)
+                dep_fut[pool.submit(fetch_dep_list, n, direction, r)] = (
+                    r,
+                    n,
+                    direction,
+                )
         for f in as_completed(dep_fut):
             repo_key, n, direction = dep_fut[f]
             _, _, refs = f.result()

--- a/scripts/dep-graph/dep_graph/fetch.py
+++ b/scripts/dep-graph/dep_graph/fetch.py
@@ -339,15 +339,15 @@ def run_fetch(layout_path: Path, cache_path: Path, *, verbose: bool = False) -> 
                 "state": state,
                 "labels": labels,
                 **_derive_label_fields(labels, label_prefix),
+                # milestone: GH milestone title (e.g. "M0", "M1") or None.
+                # Always present so downstream consumers can distinguish
+                # "not fetched" (key absent) from "no milestone" (None).
+                "milestone": milestone,
+                # size: derived from size:* label or None. Always present.
+                "size": size,
                 "blocked_by": [],
                 "blocking": [],
             }
-            # milestone: GH milestone title (e.g. "M0", "M1") — used for band derivation
-            if milestone is not None:
-                entry["milestone"] = milestone
-            # size: derived from size:* label — used for card rendering
-            if size is not None:
-                entry["size"] = size
             issues[key] = entry
 
         dep_fut: dict = {}

--- a/scripts/dep-graph/dep_graph/schema.py
+++ b/scripts/dep-graph/dep_graph/schema.py
@@ -57,9 +57,7 @@ def _check_lanes(lanes: list, allowed_repos: set[str]) -> None:
                 _assert_repo(band["before"], loc, allowed_repos)
 
 
-def _check_keyed_section(
-    section: dict, prefix: str, allowed_repos: set[str]
-) -> None:
+def _check_keyed_section(section: dict, prefix: str, allowed_repos: set[str]) -> None:
     """Check that owner/repo portion of each key in *section* is in allowed_repos."""
     for key in section:
         repo = key.split("#", 1)[0]
@@ -75,17 +73,17 @@ def _check_refs(data: dict, allowed_repos: set[str]) -> None:
     if "issue" in data["meta"] and isinstance(data["meta"]["issue"], dict):
         _assert_repo(data["meta"]["issue"], "meta.issue", allowed_repos)
 
-    # lanes
+    # lanes (order/par_groups/bands are all optional now)
     _check_lanes(data.get("lanes", []), allowed_repos)
 
-    # standalone
+    # standalone (optional)
     for si, ref in enumerate(data.get("standalone", {}).get("order", [])):
         _assert_repo(ref, f"standalone.order[{si}]", allowed_repos)
 
-    # overrides keys
+    # overrides keys (optional)
     _check_keyed_section(data.get("overrides", {}), "overrides", allowed_repos)
 
-    # extra_deps keys
+    # extra_deps keys (optional, deprecated)
     extra = data.get("extra_deps", {})
     for direction in ("extra_blocked_by", "extra_blocking"):
         _check_keyed_section(

--- a/scripts/dep-graph/dep_graph/titles.py
+++ b/scripts/dep-graph/dep_graph/titles.py
@@ -5,10 +5,11 @@ and common noise suffixes.  Per-issue `overrides.<N>.title` wins over rules
 (checked before calling normalize_title).
 
 layout.json `title_rules[]` is now optional.  When present, those rules are
-applied *in addition to* (and before) the built-in rules.  To suppress the
-built-ins entirely, set `title_rules: []` in layout.json (empty list).
-
-Set `title_rules` to `null` or omit the key to use only built-in rules.
+applied *in addition to* (and before) the built-in rules.  Set `title_rules`
+to `null` or omit the key to use only built-in rules; setting it to `[]`
+behaves the same as omitting it (no additional rules, built-ins still apply).
+The built-in rules cannot be suppressed — if a layout rule overlaps with a
+built-in, the built-in is a safe idempotent pass-through.
 """
 
 import re
@@ -66,8 +67,8 @@ def normalize_title(raw: str, rules: list[dict] | None) -> str:
 
     - If *rules* is None or omitted: uses only the built-in rules.
     - If *rules* is an explicit list (possibly empty): applies those rules
-      first, then falls through to built-in rules.  Pass [] to disable
-      layout-level rules while still applying built-ins.
+      first, then falls through to built-in rules.  Pass [] to apply no
+      additional layout-level rules (built-ins still run).
 
     Rules use Python regex; `$N` back-references are converted to `\\N`.
     """

--- a/scripts/dep-graph/dep_graph/titles.py
+++ b/scripts/dep-graph/dep_graph/titles.py
@@ -1,23 +1,85 @@
 """Title normalization engine for dep-graph cards.
 
-Rules are applied in order from layout.json `title_rules[]`.
-Each rule is { "pattern": "<regex>", "replacement": "<str>" }.
-Per-issue `overrides.<N>.title` wins over rules (checked before calling
-normalize_title).
+Built-in default rules strip conventional-commit prefixes (feat:, fix:, etc.)
+and common noise suffixes.  Per-issue `overrides.<N>.title` wins over rules
+(checked before calling normalize_title).
+
+layout.json `title_rules[]` is now optional.  When present, those rules are
+applied *in addition to* (and before) the built-in rules.  To suppress the
+built-ins entirely, set `title_rules: []` in layout.json (empty list).
+
+Set `title_rules` to `null` or omit the key to use only built-in rules.
 """
 
 import re
 
+# ---------------------------------------------------------------------------
+# Built-in rules — applied when layout.json has no title_rules or omits it.
+# These mirror what was previously hardcoded in layout.json title_rules[].
+# ---------------------------------------------------------------------------
 
-def normalize_title(raw: str, rules: list[dict]) -> str:
-    """Apply title_rules[] sequentially to raw GitHub title.
+_BUILTIN_RULES: list[dict] = [
+    # "feat(scope) [Tag]: title" → "Tag · title"
+    {
+        "pattern": (
+            r"^(feat|fix|chore|docs|refactor|test|ci|perf|style|epic)"
+            r"(\([^)]+\))?\s+\[([^\]]+)\]\s*:\s*"
+        ),
+        "replacement": "$3 \u00b7 ",
+    },
+    # "feat(scope)[Tag]: title" → "Tag · title"
+    {
+        "pattern": (
+            r"^(feat|fix|chore|docs|refactor|test|ci|perf|style|epic)"
+            r"(\([^)]+\))?\[([^\]]+)\]\s*:\s*"
+        ),
+        "replacement": "$3 \u00b7 ",
+    },
+    # "feat(scope): title" → "title"
+    {
+        "pattern": (
+            r"^(feat|fix|chore|docs|refactor|test|ci|perf|style|epic)"
+            r"(\([^)]+\))?\s*:\s*"
+        ),
+        "replacement": "",
+    },
+    # Strip leading "M0 — " / "M1 - " milestone prefixes
+    {
+        "pattern": r"^M\d+\s*[\u2014\-]\s*",
+        "replacement": "",
+    },
+    # Strip trailing " — subtitle" noise
+    {
+        "pattern": r"\s*[\u2014\-]\s+.+$",
+        "replacement": "",
+    },
+    # Strip trailing " + subtitle"
+    {
+        "pattern": r"\s*\+\s+.+$",
+        "replacement": "",
+    },
+]
 
-    Rules use Python regex; `$1` in replacement is converted to `\\1`.
+
+def normalize_title(raw: str, rules: list[dict] | None) -> str:
+    """Apply title normalization rules to a raw GitHub title.
+
+    - If *rules* is None or omitted: uses only the built-in rules.
+    - If *rules* is an explicit list (possibly empty): applies those rules
+      first, then falls through to built-in rules.  Pass [] to disable
+      layout-level rules while still applying built-ins.
+
+    Rules use Python regex; `$N` back-references are converted to `\\N`.
     """
+    effective_rules: list[dict]
+    if rules is None:
+        effective_rules = _BUILTIN_RULES
+    else:
+        effective_rules = list(rules) + _BUILTIN_RULES
+
     t = raw
-    for rule in rules:
+    for rule in effective_rules:
         pattern = rule["pattern"]
-        # Convert $N back-references to \\N for re.sub
         replacement = re.sub(r"\$(\d+)", r"\\\1", rule["replacement"])
         t = re.sub(pattern, replacement, t).strip()
     return t

--- a/scripts/dep-graph/layout.schema.json
+++ b/scripts/dep-graph/layout.schema.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "dep-graph layout.json schema (multi-repo)",
+  "description": "Minimal layout.json: only meta + lanes[code/name/color] are required. order/par_groups/bands/extra_deps/cross_deps/title_rules are all optional — when absent they are auto-derived from GitHub metadata.",
   "type": "object",
-  "required": ["meta", "lanes", "standalone", "overrides", "extra_deps", "cross_deps", "title_rules"],
+  "required": ["meta", "lanes"],
   "additionalProperties": false,
   "properties": {
     "meta": {
@@ -25,7 +26,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["code", "name", "color", "order"],
+        "required": ["code", "name", "color"],
         "additionalProperties": false,
         "properties": {
           "code":  { "type": "string" },
@@ -48,10 +49,12 @@
             ]
           },
           "order": {
+            "description": "OPTIONAL: explicit display order. When absent, auto-derived from gh_issues topo-sort.",
             "type": "array",
             "items": { "$ref": "#/$defs/IssueRef" }
           },
           "par_groups": {
+            "description": "OPTIONAL: parallel groups. When absent, auto-derived from topo depth.",
             "type": "object",
             "additionalProperties": {
               "type": "array",
@@ -59,6 +62,7 @@
             }
           },
           "bands": {
+            "description": "OPTIONAL: milestone band headers. When absent, auto-derived from GH milestone field.",
             "type": "array",
             "items": {
               "type": "object",
@@ -74,8 +78,8 @@
       }
     },
     "standalone": {
+      "description": "OPTIONAL: standalone section. When order[] is absent/empty, auto-derived from graph:standalone labels.",
       "type": "object",
-      "required": ["order"],
       "additionalProperties": false,
       "properties": {
         "order": {
@@ -85,6 +89,7 @@
       }
     },
     "overrides": {
+      "description": "OPTIONAL: per-issue editorial overrides. Only anchor, anchor_after, extra_deps_ext, status are meaningful. title and size are deprecated (title_rules now global, size read from GH labels).",
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
@@ -92,8 +97,8 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "title":          { "type": "string" },
-            "size":           { "type": "string" },
+            "title":          { "type": "string", "description": "Deprecated: use GH title + title_rules instead." },
+            "size":           { "type": "string", "description": "Deprecated: use size:* GH label instead." },
             "status":         { "type": "string", "enum": ["done", "ready", "blocked", "defer"] },
             "anchor":         { "type": "string" },
             "anchor_after":   { "type": "string" },
@@ -103,6 +108,7 @@
       }
     },
     "extra_deps": {
+      "description": "DEPRECATED: add blocked_by relationships directly on GitHub instead.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -129,6 +135,7 @@
       }
     },
     "cross_deps": {
+      "description": "OPTIONAL: editorial cross-lane dependency notes (rendered in footer section).",
       "type": "array",
       "items": {
         "type": "object",
@@ -141,6 +148,7 @@
       }
     },
     "title_rules": {
+      "description": "DEPRECATED: built-in rules in titles.py handle conventional-commit stripping globally. Only add here for project-specific overrides applied BEFORE built-ins.",
       "type": "array",
       "items": {
         "type": "object",

--- a/scripts/dep-graph/pyproject.toml
+++ b/scripts/dep-graph/pyproject.toml
@@ -12,8 +12,15 @@ dependencies = []
 [project.optional-dependencies]
 validate = ["jsonschema>=4.0"]
 
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
 [project.scripts]
 dep-graph = "dep_graph.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["dep_graph"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--import-mode=importlib"

--- a/scripts/dep-graph/tests/test_derive.py
+++ b/scripts/dep-graph/tests/test_derive.py
@@ -117,13 +117,7 @@ def test_derive_lane_cross_lane_blocker_ignored_for_sort():
     # Both lane-a issues must be present
     assert 5 in order_nums
     assert 8 in order_nums
-    # #5 has a cross-lane blocker, so no in-lane predecessor — depth 0, comes first
-    assert (
-        order_nums.index(5) < order_nums.index(8)
-        or order_nums == [5, 8]
-        or order_nums == [8, 5]
-    )
-    # Specifically: both at depth 0, tie-break by number → 5 before 8
+    # Both at depth 0 (cross-lane blocker doesn't count); tie-break by issue number
     assert order_nums == [5, 8]
 
 

--- a/scripts/dep-graph/tests/test_derive.py
+++ b/scripts/dep-graph/tests/test_derive.py
@@ -1,0 +1,309 @@
+"""Unit tests for dep_graph.derive — auto-derivation logic.
+
+All tests use synthetic gh_issues dicts; no GitHub API calls.
+"""
+
+from __future__ import annotations
+
+from dep_graph.derive import derive_lane, derive_standalone_order
+
+REPO = "Owner/repo"
+
+
+def _issue(
+    num: int,
+    *,
+    lane: str,
+    blocked_by: list[int] | None = None,
+    state: str = "open",
+    milestone: str | None = None,
+) -> dict:
+    """Build a minimal gh_issues entry."""
+    return {
+        "repo": REPO,
+        "number": num,
+        "title": f"Issue #{num}",
+        "state": state,
+        "labels": [f"graph:lane/{lane}"],
+        "lane_label": lane,
+        "standalone": False,
+        "defer": False,
+        "blocked_by": [{"repo": REPO, "issue": b} for b in (blocked_by or [])],
+        "blocking": [],
+        **({"milestone": milestone} if milestone is not None else {}),
+    }
+
+
+def _lane(code: str) -> dict:
+    """Build a minimal lane definition without explicit order."""
+    return {"code": code, "name": code.upper(), "color": code}
+
+
+def _gh(*issues: dict) -> dict:
+    """Build a gh_issues dict keyed as 'Owner/repo#N'."""
+    return {f"{e['repo']}#{e['number']}": e for e in issues}
+
+
+# ---------------------------------------------------------------------------
+# derive_lane — order tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_lane_linear_chain_topo_order():
+    """Linear chain A→B→C produces correct topo order (A first, C last)."""
+    # #1 has no deps, #2 blocked by #1, #3 blocked by #2
+    gh = _gh(
+        _issue(1, lane="x"),
+        _issue(2, lane="x", blocked_by=[1]),
+        _issue(3, lane="x", blocked_by=[2]),
+    )
+    result = derive_lane(_lane("x"), gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+    assert order_nums == [1, 2, 3]
+
+
+def test_derive_lane_independent_issues_sorted_by_number():
+    """Three independent issues → tie-broken by issue number ascending."""
+    gh = _gh(
+        _issue(10, lane="y"),
+        _issue(3, lane="y"),
+        _issue(7, lane="y"),
+    )
+    result = derive_lane(_lane("y"), gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+    assert order_nums == [3, 7, 10]
+
+
+def test_derive_lane_closed_issue_excluded_from_order():
+    """Closed blocker is excluded from placement; order of open issues correct."""
+    gh = _gh(
+        _issue(1, lane="z", state="closed"),  # closed — must not appear
+        _issue(
+            2, lane="z", blocked_by=[1]
+        ),  # cross-ref to closed; in-lane DAG ignores it
+        _issue(3, lane="z"),
+    )
+    result = derive_lane(_lane("z"), gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+    assert 1 not in order_nums
+    assert 2 in order_nums
+    assert 3 in order_nums
+
+
+def test_derive_lane_cross_lane_blocker_ignored_for_sort():
+    """Cross-lane blocked_by edge is ignored for in-lane topo sort."""
+    # #10 is in lane "a", #20 is in lane "b" (different lane)
+    # #5 in lane "a" is blocked by #20 (cross-lane) — should still be depth 0 in lane a
+    gh = _gh(
+        _issue(5, lane="a", blocked_by=[20]),  # blocker #20 is cross-lane
+        _issue(8, lane="a"),
+        {
+            "repo": REPO,
+            "number": 20,
+            "title": "cross issue",
+            "state": "open",
+            "labels": ["graph:lane/b"],
+            "lane_label": "b",
+            "standalone": False,
+            "defer": False,
+            "blocked_by": [],
+            "blocking": [],
+        },
+    )
+    result = derive_lane(_lane("a"), gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+    # #20 must not appear in lane a (wrong lane)
+    assert 20 not in order_nums
+    # Both lane-a issues must be present
+    assert 5 in order_nums
+    assert 8 in order_nums
+    # #5 has a cross-lane blocker, so no in-lane predecessor — depth 0, comes first
+    assert (
+        order_nums.index(5) < order_nums.index(8)
+        or order_nums == [5, 8]
+        or order_nums == [8, 5]
+    )
+    # Specifically: both at depth 0, tie-break by number → 5 before 8
+    assert order_nums == [5, 8]
+
+
+def test_derive_lane_explicit_order_respected():
+    """Lane with existing order[] is returned unchanged (graceful degradation)."""
+    explicit_order = [{"repo": REPO, "issue": 99}]
+    lane = {**_lane("q"), "order": explicit_order, "par_groups": {}, "bands": []}
+    gh = _gh(_issue(1, lane="q"), _issue(2, lane="q"))
+    result = derive_lane(lane, gh, REPO)
+    assert result["order"] == explicit_order  # unchanged
+
+
+def test_derive_lane_cycle_no_exception(capsys):
+    """Topological cycle logs a warning and falls back without raising."""
+    # #1 blocked by #2, #2 blocked by #1 — mutual cycle
+    gh = _gh(
+        _issue(1, lane="c", blocked_by=[2]),
+        _issue(2, lane="c", blocked_by=[1]),
+    )
+    result = derive_lane(_lane("c"), gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+    # Both issues must appear despite the cycle
+    assert set(order_nums) == {1, 2}
+    # Warning must have been emitted to stderr
+    captured = capsys.readouterr()
+    assert "cycle" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# derive_lane — par_groups tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_lane_par_groups_diamond_dag():
+    """Diamond DAG A→B, A→C, B→D, C→D produces groups {0:[A], 1:[B,C], 2:[D]}."""
+    # #1=A (root), #2=B blocked by #1, #3=C blocked by #1, #4=D blocked by #2 and #3
+    gh = _gh(
+        _issue(1, lane="d"),
+        _issue(2, lane="d", blocked_by=[1]),
+        _issue(3, lane="d", blocked_by=[1]),
+        _issue(4, lane="d", blocked_by=[2, 3]),
+    )
+    result = derive_lane(_lane("d"), gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+
+    # #1 must come first, #4 must come last
+    assert order_nums[0] == 1
+    assert order_nums[-1] == 4
+    # #2 and #3 must be between #1 and #4
+    assert set(order_nums[1:3]) == {2, 3}
+
+    # par_groups: exactly one group for {2,3} (depth 1)
+    pg_members = {
+        frozenset(m["issue"] for m in members)
+        for members in result["par_groups"].values()
+    }
+    assert frozenset({2, 3}) in pg_members
+
+
+# ---------------------------------------------------------------------------
+# derive_lane — bands tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_lane_bands_milestone_transitions():
+    """Issues with milestones M0, M0, M1, M1, M2 produce 3 band headers.
+
+    Each distinct named milestone gets a band header before its first issue,
+    including the very first milestone group in the order.
+    """
+    gh = _gh(
+        _issue(1, lane="b", milestone="M0"),
+        _issue(2, lane="b", milestone="M0"),
+        _issue(3, lane="b", blocked_by=[2], milestone="M1"),
+        _issue(4, lane="b", blocked_by=[2], milestone="M1"),
+        _issue(5, lane="b", blocked_by=[3], milestone="M2"),
+    )
+    result = derive_lane(_lane("b"), gh, REPO)
+    bands = result["bands"]
+    band_texts = [b["text"] for b in bands]
+    # M0 band before #1, M1 band before #3, M2 band before #5
+    assert len(bands) == 3
+    assert any("M0" in t for t in band_texts)
+    assert any("M1" in t for t in band_texts)
+    assert any("M2" in t for t in band_texts)
+    # Band before #1 (first issue in M0 group)
+    assert bands[0]["before"]["issue"] == 1
+    # Band before first M1 issue (#3 or #4 — whichever topo-sort puts first)
+    m1_band_issue = bands[1]["before"]["issue"]
+    assert m1_band_issue in (3, 4)
+
+
+def test_derive_lane_bands_no_milestone_no_bands():
+    """Issues with no milestone field produce no bands."""
+    gh = _gh(
+        _issue(1, lane="e"),
+        _issue(2, lane="e"),
+    )
+    result = derive_lane(_lane("e"), gh, REPO)
+    assert result["bands"] == []
+
+
+# ---------------------------------------------------------------------------
+# derive_standalone_order tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_standalone_order_returns_labeled_sorted():
+    """gh_issues with standalone=True are returned sorted by issue number."""
+    gh = {
+        f"{REPO}#10": {
+            "repo": REPO,
+            "number": 10,
+            "title": "sa10",
+            "state": "open",
+            "labels": ["graph:standalone"],
+            "lane_label": None,
+            "standalone": True,
+            "defer": False,
+            "blocked_by": [],
+            "blocking": [],
+        },
+        f"{REPO}#3": {
+            "repo": REPO,
+            "number": 3,
+            "title": "sa3",
+            "state": "open",
+            "labels": ["graph:standalone"],
+            "lane_label": None,
+            "standalone": True,
+            "defer": False,
+            "blocked_by": [],
+            "blocking": [],
+        },
+        f"{REPO}#7": {
+            "repo": REPO,
+            "number": 7,
+            "title": "not-standalone",
+            "state": "open",
+            "labels": ["graph:lane/x"],
+            "lane_label": "x",
+            "standalone": False,
+            "defer": False,
+            "blocked_by": [],
+            "blocking": [],
+        },
+    }
+    result = derive_standalone_order(gh, REPO)
+    issue_nums = [r["issue"] for r in result]
+    assert issue_nums == [3, 10]
+
+
+def test_derive_standalone_order_excludes_closed():
+    """Closed standalone issues are excluded."""
+    gh = {
+        f"{REPO}#1": {
+            "repo": REPO,
+            "number": 1,
+            "state": "closed",
+            "title": "old",
+            "labels": [],
+            "lane_label": None,
+            "standalone": True,
+            "defer": False,
+            "blocked_by": [],
+            "blocking": [],
+        },
+        f"{REPO}#2": {
+            "repo": REPO,
+            "number": 2,
+            "state": "open",
+            "title": "current",
+            "labels": [],
+            "lane_label": None,
+            "standalone": True,
+            "defer": False,
+            "blocked_by": [],
+            "blocking": [],
+        },
+    }
+    result = derive_standalone_order(gh, REPO)
+    issue_nums = [r["issue"] for r in result]
+    assert issue_nums == [2]

--- a/scripts/dep-graph/uv.lock
+++ b/scripts/dep-graph/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "dep-graph"
 version = "0.1.0"
 source = { editable = "." }
@@ -21,9 +30,26 @@ validate = [
     { name = "jsonschema" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "jsonschema", marker = "extra == 'validate'", specifier = ">=4.0" }]
 provides-extras = ["validate"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
 
 [[package]]
 name = "jsonschema"
@@ -50,6 +76,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`layout.json` shrinks from 18KB → 3KB. The graph now self-assembles from GitHub labels + `blocked_by` + milestones at build time, with editorial overrides reduced to `anchor`, `status`, `extra_deps_ext`.

**Why:** Hand-curated layout drifted as new labeled issues were created (e.g., #736, #737 silently vanished after labeling because the Untriaged renderer was dead code). The graph should be the cheapest possible reflection of GH state.

## What changed

- **New `derive.py`** — `derive_lane`, `derive_standalone_order`. Topological sort with issue-number tie-break; depth-based `par_groups`; milestone-driven `bands`; cycle detection with stderr warning.
- **`build.py`** falls back to derived order/par_groups/bands when lane fields are absent. Explicit fields still respected for graceful per-lane migration.
- **`fetch.py`** enriches `gh.json` with `milestone`, `size`, `lane_label`, `standalone`, `defer` so downstream consumers don't re-scan labels.
- **`audit.py`** skips drift checks for auto-derived lanes; reports which lanes were auto-placed.
- **Schema** — `order`, `par_groups`, `bands`, `extra_deps`, `cross_deps`, `title_rules` all optional.
- **`titles.py`** — built-in conventional-commit prefix stripping; per-issue title overrides deprecated.
- **11 unit tests** cover linear/independent/closed/cross-lane/cycle ordering, diamond DAG par_groups, milestone bands, standalone.

## Verification

- `uv run pytest scripts/dep-graph/tests/` — 11/11 pass
- `uv run ruff check scripts/dep-graph/` — clean
- `uv run pyright scripts/dep-graph/dep_graph/ scripts/dep-graph/tests/` — 0 errors
- Build runs: 33,377 bytes (was 34,771) — output differs, all 12 lanes auto-populated
- Audit runs: zero drift
- #736 (closed) renders as done in Lane H; #737 renders as blocked-by-#717

## Test plan

- [ ] Visual smoke check at https://lyra-dep-graph.pages.dev (forge deploy after merge)
- [ ] `make dep-graph audit` clean on staging after merge
- [ ] No regressions in lane positioning vs `lyra-v2-dependency-graph.html.2026-04-14-before-align` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)