### PR TITLE
test(dep-graph): fill coverage gaps from PR #739 review

### DIFF
--- a/scripts/dep-graph/pyproject.toml
+++ b/scripts/dep-graph/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = []
 validate = ["jsonschema>=4.0"]
 
 [dependency-groups]
-dev = ["pytest>=8.0"]
+dev = ["pytest>=8.0", "jsonschema>=4.0"]
 
 [project.scripts]
 dep-graph = "dep_graph.cli:main"

--- a/scripts/dep-graph/pyproject.toml
+++ b/scripts/dep-graph/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = []
 validate = ["jsonschema>=4.0"]
 
 [dependency-groups]
-dev = ["pytest>=8.0", "jsonschema>=4.0"]
+dev = ["pytest>=8.0", "jsonschema>=4.26.0"]
 
 [project.scripts]
 dep-graph = "dep_graph.cli:main"

--- a/scripts/dep-graph/tests/test_audit.py
+++ b/scripts/dep-graph/tests/test_audit.py
@@ -1,0 +1,327 @@
+"""Unit tests for dep_graph.audit — auto-derive helpers.
+
+All tests use synthetic dicts; no filesystem, no network.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dep_graph.audit import (
+    _build_layout_sets,
+    _check_defer,
+    _check_meta,
+    _check_placement,
+    _check_standalone,
+    _collect_auto_placed,
+)
+
+REPO = "Owner/repo"
+PREFIX = "graph:"
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    num: int,
+    *,
+    lane: str | None = None,
+    standalone: bool = False,
+    defer: bool = False,
+    state: str = "open",
+) -> dict:
+    """Build a minimal gh_issues entry."""
+    labels: list[str] = []
+    if lane is not None:
+        labels.append(f"{PREFIX}lane/{lane}")
+    if standalone:
+        labels.append(f"{PREFIX}standalone")
+    if defer:
+        labels.append(f"{PREFIX}defer")
+    return {
+        "repo": REPO,
+        "number": num,
+        "title": f"Issue #{num}",
+        "state": state,
+        "labels": labels,
+        "lane_label": lane,
+        "standalone": standalone,
+        "defer": defer,
+        "blocked_by": [],
+        "blocking": [],
+    }
+
+
+def _gh(*issues: tuple[int, dict]) -> dict:
+    """Build a gh_issues dict keyed as '{REPO}#{num}'."""
+    return {f"{REPO}#{num}": entry for num, entry in issues}
+
+
+def _gh_from_list(*entries: dict) -> dict:
+    """Build a gh_issues dict from _issue() dicts, keyed as '{repo}#{number}'."""
+    return {f"{e['repo']}#{e['number']}": e for e in entries}
+
+
+# ---------------------------------------------------------------------------
+# T8 — G2a _build_layout_sets
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLayoutSets:
+    def test_build_layout_sets_lane_with_explicit_order(self) -> None:
+        """Explicit order[] → layout_lane_of populated, auto_lane_codes empty."""
+        # Arrange
+        layout = {
+            "lanes": [
+                {
+                    "code": "a",
+                    "order": [{"repo": REPO, "issue": 1}],
+                }
+            ]
+        }
+        # Act
+        layout_lane_of, standalone_set, epic_set, auto_lane_codes = _build_layout_sets(
+            layout
+        )
+        # Assert
+        assert layout_lane_of == {(REPO, 1): "a"}
+        assert auto_lane_codes == set()
+
+    def test_build_layout_sets_lane_without_order_added_to_auto_codes(self) -> None:
+        """Lane without order key → added to auto_lane_codes, layout_lane_of empty."""
+        # Arrange
+        layout = {
+            "lanes": [
+                {"code": "b"}
+                # no "order" key
+            ]
+        }
+        # Act
+        layout_lane_of, standalone_set, epic_set, auto_lane_codes = _build_layout_sets(
+            layout
+        )
+        # Assert
+        assert auto_lane_codes == {"b"}
+        assert layout_lane_of == {}
+
+    def test_build_layout_sets_epic_missing_repo_excluded(self) -> None:
+        """Epic with no 'repo' field → not added to epic_set (audit.py:301 branch)."""
+        # Arrange
+        layout = {
+            "lanes": [
+                {
+                    "code": "c",
+                    "order": [],
+                    "epic": {"issue": 99},  # NO 'repo' field
+                }
+            ]
+        }
+        # Act
+        layout_lane_of, standalone_set, epic_set, auto_lane_codes = _build_layout_sets(
+            layout
+        )
+        # Assert
+        assert epic_set == set()
+
+
+# ---------------------------------------------------------------------------
+# T9 — G2b _collect_auto_placed
+# ---------------------------------------------------------------------------
+
+
+class TestCollectAutoPlaced:
+    def test_collect_auto_placed_empty_lane_codes(self) -> None:
+        """auto_lane_codes=empty → auto_placed is empty, standalone_set unchanged."""
+        # Arrange
+        gh = _gh_from_list(_issue(1, lane="x"), _issue(2, lane="y"))
+        layout = {"standalone": {"order": [{"repo": REPO, "issue": 10}]}}
+        standalone_set = {(REPO, 10)}
+        # Act
+        auto_placed, updated_standalone = _collect_auto_placed(
+            gh, set(), standalone_set, layout, PREFIX
+        )
+        # Assert
+        assert auto_placed == set()
+        assert updated_standalone == standalone_set
+
+    def test_collect_auto_placed_populated_match(self) -> None:
+        """auto_lane_codes={'x'} → only the 2 x-labeled issues in auto_placed."""
+        # Arrange
+        gh = _gh_from_list(
+            _issue(1, lane="x"),
+            _issue(2, lane="x"),
+            _issue(3, lane="y"),
+        )
+        layout = {"standalone": {"order": [{"repo": REPO, "issue": 99}]}}
+        standalone_set: set[tuple[str, int]] = set()
+        # Act
+        auto_placed, _ = _collect_auto_placed(gh, {"x"}, standalone_set, layout, PREFIX)
+        # Assert
+        assert auto_placed == {(REPO, 1), (REPO, 2)}
+        assert (REPO, 3) not in auto_placed
+
+    def test_collect_auto_placed_standalone_absent_extends_set(self) -> None:
+        """No standalone.order[] → gh standalone issues extend standalone_set."""
+        # Arrange
+        gh = _gh_from_list(
+            _issue(1, standalone=True),
+            _issue(2, standalone=True),
+            _issue(3, lane="x"),
+        )
+        layout = {"standalone": {}}  # no order key → standalone_auto=True
+        standalone_set: set[tuple[str, int]] = set()
+        # Act
+        auto_placed, updated_standalone = _collect_auto_placed(
+            gh, set(), standalone_set, layout, PREFIX
+        )
+        # Assert
+        assert (REPO, 1) in updated_standalone
+        assert (REPO, 2) in updated_standalone
+        assert (REPO, 3) not in updated_standalone
+
+
+# ---------------------------------------------------------------------------
+# T10 — G2c _check_placement
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPlacement:
+    def test_check_placement_empty_layout_lane_of_prints_skipped(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Empty layout_lane_of → prints 'skipped' message, returns False (no drift)."""
+        # Arrange
+        gh = _gh_from_list(_issue(1, lane="a"))
+        # All issues are in all_placed so no untriaged drift
+        labeled: set[tuple[str, int]] = {(REPO, 1)}
+        all_placed: set[tuple[str, int]] = {(REPO, 1)}
+        # Act
+        result = _check_placement({}, labeled, all_placed, gh, PREFIX)
+        # Assert
+        captured = capsys.readouterr()
+        assert "skipped" in captured.out
+        assert result is False
+
+    def test_check_placement_populated_no_drift(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """All labeled issues are placed → no drift reported."""
+        # Arrange
+        gh = _gh_from_list(_issue(1, lane="a"), _issue(2, lane="a"))
+        layout_lane_of = {(REPO, 1): "a", (REPO, 2): "a"}
+        labeled: set[tuple[str, int]] = {(REPO, 1), (REPO, 2)}
+        all_placed: set[tuple[str, int]] = {(REPO, 1), (REPO, 2)}
+        # Act
+        result = _check_placement(layout_lane_of, labeled, all_placed, gh, PREFIX)
+        # Assert
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# T11 — G2d _check_meta forwards auto_placed to _check_defer only
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMetaForwards:
+    def test_check_meta_forwards_auto_placed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_check_meta forwards auto_placed to _check_defer, not _check_standalone."""
+        # Arrange
+        captured: dict = {}
+
+        def stub_defer(
+            gh_issues: dict,
+            layout: dict,
+            label_prefix: str,
+            auto_placed: set | None = None,
+        ) -> bool:
+            captured["defer_auto_placed"] = auto_placed
+            return False
+
+        def stub_standalone(
+            gh_issues: dict,
+            layout: dict,
+            label_prefix: str,
+        ) -> bool:
+            captured["standalone_args_len"] = (
+                3  # verifies called with 3 positional args
+            )
+            return False
+
+        monkeypatch.setattr("dep_graph.audit._check_defer", stub_defer)
+        monkeypatch.setattr("dep_graph.audit._check_standalone", stub_standalone)
+
+        test_auto_placed = {("r", 1)}
+
+        # Act
+        _check_meta({}, {}, PREFIX, auto_placed=test_auto_placed)
+
+        # Assert
+        assert captured["defer_auto_placed"] == test_auto_placed
+        assert captured["standalone_args_len"] == 3
+
+
+# ---------------------------------------------------------------------------
+# T12 — G2e _check_standalone auto-mode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStandalone:
+    def test_check_standalone_auto_mode_empty_order(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No standalone.order[] → auto-mode; prints 'auto-derived', returns False."""
+        # Arrange
+        layout = {"standalone": {}}  # empty/absent order → auto_mode=True
+        gh = _gh_from_list(_issue(1, standalone=True))
+        # Act
+        result = _check_standalone(gh, layout, PREFIX)
+        # Assert
+        captured = capsys.readouterr()
+        assert "auto-derived" in captured.out
+        assert result is False
+
+    def test_check_standalone_explicit_order_detects_drift(self) -> None:
+        """Issue #2 standalone in GH but not in layout.standalone.order → drift=True."""
+        # Arrange
+        layout = {"standalone": {"order": [{"repo": REPO, "issue": 1}]}}
+        gh = _gh_from_list(
+            _issue(1, standalone=True),
+            _issue(2, standalone=True),  # NOT in layout → drift
+        )
+        # Act
+        result = _check_standalone(gh, layout, PREFIX)
+        # Assert
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# T13 — G2f _check_defer auto_placed arg
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDefer:
+    def test_check_defer_auto_placed_none_includes_drift(self) -> None:
+        """Defer-labeled issue missing from layout → drift when auto_placed=None."""
+        # Arrange
+        layout: dict = {"lanes": []}  # no layout deferred entries
+        gh = _gh_from_list(_issue(5, defer=True))
+        # Act
+        result = _check_defer(gh, layout, PREFIX)  # no auto_placed
+        # Assert
+        assert result is True
+
+    def test_check_defer_auto_placed_populated_excludes_item(self) -> None:
+        """Same gh but defer issue key in auto_placed → excluded from drift."""
+        # Arrange
+        layout: dict = {"lanes": []}
+        gh = _gh_from_list(_issue(5, defer=True))
+        # The issue is auto-placed, so it should NOT count as drift
+        auto_placed = {(REPO, 5)}
+        # Act
+        result = _check_defer(gh, layout, PREFIX, auto_placed=auto_placed)
+        # Assert
+        assert result is False

--- a/scripts/dep-graph/tests/test_audit.py
+++ b/scripts/dep-graph/tests/test_audit.py
@@ -201,7 +201,11 @@ class TestCheckPlacement:
         result = _check_placement({}, labeled, all_placed, gh, PREFIX)
         # Assert
         captured = capsys.readouterr()
-        assert "skipped" in captured.out
+        # Exact skip-branch marker — "skipped" alone would also match if the
+        # message drifted elsewhere, so pin the full auto-derive sentinel.
+        assert "all lanes auto-derived, skipped" in captured.out
+        # Sanity: _check_untriaged ran (proves parse_key path exercised)
+        assert "Labeled but not in any lane order" in captured.out
         assert result is False
 
     def test_check_placement_populated_no_drift(
@@ -241,14 +245,9 @@ class TestCheckMetaForwards:
             captured["defer_auto_placed"] = auto_placed
             return False
 
-        def stub_standalone(
-            gh_issues: dict,
-            layout: dict,
-            label_prefix: str,
-        ) -> bool:
-            captured["standalone_args_len"] = (
-                3  # verifies called with 3 positional args
-            )
+        def stub_standalone(*args: object, **kwargs: object) -> bool:
+            captured["standalone_args"] = args
+            captured["standalone_kwargs"] = kwargs
             return False
 
         monkeypatch.setattr("dep_graph.audit._check_defer", stub_defer)
@@ -259,9 +258,13 @@ class TestCheckMetaForwards:
         # Act
         _check_meta({}, {}, PREFIX, auto_placed=test_auto_placed)
 
-        # Assert
+        # Assert — _check_defer received auto_placed
         assert captured["defer_auto_placed"] == test_auto_placed
-        assert captured["standalone_args_len"] == 3
+        # _check_standalone called with exactly 3 positional args (gh, layout, prefix)
+        # and NO auto_placed anywhere — would regress if caller plumbed it through
+        assert len(captured["standalone_args"]) == 3
+        assert "auto_placed" not in captured["standalone_kwargs"]
+        assert test_auto_placed not in captured["standalone_args"]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/dep-graph/tests/test_build.py
+++ b/scripts/dep-graph/tests/test_build.py
@@ -1,0 +1,70 @@
+"""Unit tests for dep_graph.build — _prepare_render_data standalone fallback.
+
+Uses monkeypatch on dep_graph.build.derive_standalone_order (the imported name)
+to observe call-site behavior without re-running derive logic.
+"""
+
+from __future__ import annotations
+
+from dep_graph.build import _prepare_render_data
+
+REPO = "Owner/repo"
+
+
+def _minimal_layout(standalone: dict | None = None) -> dict:
+    """Minimal layout dict with 1 stubbed lane and optional standalone block."""
+    return {
+        "lanes": [{"code": "a", "name": "A", "color": "red"}],
+        "standalone": standalone if standalone is not None else {},
+    }
+
+
+def test_prepare_render_data_standalone_fallback_called(monkeypatch):
+    """derive_standalone_order is called once when standalone has no order."""
+    call_count = {"n": 0}
+
+    def stub_derive_standalone_order(gh_issues, primary_repo):
+        call_count["n"] += 1
+        return []
+
+    def stub_derive_lane(lane, gh_issues, primary_repo):
+        return {**lane, "order": [], "par_groups": {}, "bands": []}
+
+    monkeypatch.setattr(
+        "dep_graph.build.derive_standalone_order", stub_derive_standalone_order
+    )
+    monkeypatch.setattr("dep_graph.build.derive_lane", stub_derive_lane)
+    monkeypatch.setattr("dep_graph.build.inject_spacers", lambda x: x)
+    monkeypatch.setattr(
+        "dep_graph.build.flatten_lane", lambda lane, overrides, flag, gh_issues: {}
+    )
+
+    _prepare_render_data(_minimal_layout(), {}, REPO, {})
+
+    assert call_count["n"] == 1
+
+
+def test_prepare_render_data_standalone_fallback_skipped(monkeypatch):
+    """derive_standalone_order is NOT called when standalone already has an order."""
+    call_count = {"n": 0}
+
+    def stub_derive_standalone_order(gh_issues, primary_repo):
+        call_count["n"] += 1
+        return []
+
+    def stub_derive_lane(lane, gh_issues, primary_repo):
+        return {**lane, "order": [], "par_groups": {}, "bands": []}
+
+    monkeypatch.setattr(
+        "dep_graph.build.derive_standalone_order", stub_derive_standalone_order
+    )
+    monkeypatch.setattr("dep_graph.build.derive_lane", stub_derive_lane)
+    monkeypatch.setattr("dep_graph.build.inject_spacers", lambda x: x)
+    monkeypatch.setattr(
+        "dep_graph.build.flatten_lane", lambda lane, overrides, flag, gh_issues: {}
+    )
+
+    layout = _minimal_layout(standalone={"order": [{"repo": REPO, "issue": 1}]})
+    _prepare_render_data(layout, {}, REPO, {})
+
+    assert call_count["n"] == 0

--- a/scripts/dep-graph/tests/test_derive.py
+++ b/scripts/dep-graph/tests/test_derive.py
@@ -75,18 +75,22 @@ def test_derive_lane_independent_issues_sorted_by_number():
     assert order_nums == [3, 7, 10]
 
 
-def test_derive_lane_closed_issue_excluded_from_order():
-    """Closed blocker is excluded from placement; order of open issues correct."""
+def test_derive_lane_closed_issue_included_in_order():
+    """Closed lane-labeled issues are included in order[] for done-styling.
+
+    Since b188e69 ("fix(dep-graph): include closed issues in lane order[]
+    for done-styling"), `_collect_lane_issues` no longer filters by state —
+    closed issues land in-lane and render as `.card done` in the template.
+    """
     gh = _gh(
-        _issue(1, lane="z", state="closed"),  # closed — must not appear
-        _issue(
-            2, lane="z", blocked_by=[1]
-        ),  # cross-ref to closed; in-lane DAG ignores it
+        _issue(1, lane="z", state="closed"),
+        _issue(2, lane="z", blocked_by=[1]),
         _issue(3, lane="z"),
     )
     result = derive_lane(_lane("z"), gh, REPO)
     order_nums = [r["issue"] for r in result["order"]]
-    assert 1 not in order_nums
+    # All three issues placed in-lane, including the closed one
+    assert 1 in order_nums
     assert 2 in order_nums
     assert 3 in order_nums
 

--- a/scripts/dep-graph/tests/test_derive.py
+++ b/scripts/dep-graph/tests/test_derive.py
@@ -5,7 +5,8 @@ All tests use synthetic gh_issues dicts; no GitHub API calls.
 
 from __future__ import annotations
 
-from dep_graph.derive import derive_lane, derive_standalone_order
+import pytest
+from dep_graph.derive import _build_par_groups, derive_lane, derive_standalone_order
 
 REPO = "Owner/repo"
 
@@ -301,3 +302,180 @@ def test_derive_standalone_order_excludes_closed():
     result = derive_standalone_order(gh, REPO)
     issue_nums = [r["issue"] for r in result]
     assert issue_nums == [2]
+
+
+# ---------------------------------------------------------------------------
+# T2 (G4) — Epic exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_derive_lane_epic_excluded_same_repo():
+    """Epic issue in same repo is excluded from derived order."""
+    lane = {**_lane("ep"), "epic": {"repo": REPO, "issue": 5}}
+    gh = _gh(
+        _issue(5, lane="ep"),
+        _issue(6, lane="ep"),
+    )
+    result = derive_lane(lane, gh, REPO)
+    order_nums = [r["issue"] for r in result["order"]]
+    assert 5 not in order_nums
+    assert 6 in order_nums
+
+
+def test_derive_lane_epic_not_excluded_when_issue_is_cross_repo():
+    """Cross-repo issue matching epic number is NOT excluded.
+
+    _collect_lane_issues excludes only when `num == epic_issue_num AND
+    repo == primary_repo` (derive.py:134). An issue whose repo differs from
+    primary_repo falls through — this is the dark branch the same-repo test
+    above does not exercise.
+    """
+    lane = {**_lane("ep2"), "epic": {"repo": REPO, "issue": 5}}
+    cross_repo_entry = {
+        "repo": "Other/other",
+        "number": 5,
+        "title": "cross #5",
+        "state": "open",
+        "labels": ["graph:lane/ep2"],
+        "lane_label": "ep2",
+        "standalone": False,
+        "defer": False,
+        "blocked_by": [],
+        "blocking": [],
+    }
+    gh = {"Other/other#5": cross_repo_entry, **_gh(_issue(6, lane="ep2"))}
+    result = derive_lane(lane, gh, REPO)
+    order_pairs = [(r["repo"], r["issue"]) for r in result["order"]]
+    # Cross-repo #5 IS included (repo != primary_repo, so exclusion skipped)
+    assert ("Other/other", 5) in order_pairs
+    # Primary-repo #6 also included
+    assert (REPO, 6) in order_pairs
+
+
+# ---------------------------------------------------------------------------
+# T3 (G5) — derive_standalone_order malformed + default_repo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        None,
+        {},
+        {"standalone": True},
+        {"standalone": False, "number": 1, "state": "open"},
+    ],
+)
+def test_derive_standalone_order_skips_malformed(entry):
+    """Malformed or non-standalone entries produce empty result."""
+    gh = {"key": entry}
+    result = derive_standalone_order(gh, REPO)
+    assert result == []
+
+
+def test_derive_standalone_order_defaults_repo():
+    """Entry with standalone=True but no repo field defaults to primary_repo."""
+    gh = {
+        "norepkey": {
+            "standalone": True,
+            "number": 5,
+            "state": "open",
+        }
+    }
+    result = derive_standalone_order(gh, REPO)
+    assert result == [{"repo": REPO, "issue": 5}]
+
+
+# ---------------------------------------------------------------------------
+# T4 (G6) — Empty-lane fast path
+# ---------------------------------------------------------------------------
+
+
+def test_derive_lane_empty_fast_path():
+    """Lane with no matching issues produces empty order, par_groups, and bands."""
+    result = derive_lane(_lane("nomatch"), _gh(_issue(1, lane="other")), REPO)
+    assert result["order"] == []
+    assert result["par_groups"] == {}
+    assert result["bands"] == []
+
+
+# ---------------------------------------------------------------------------
+# T5 (G7) — Single-node par_groups guard
+# ---------------------------------------------------------------------------
+
+
+def test_derive_lane_single_node_no_par_group():
+    """Single issue in a lane produces no par_groups entry."""
+    result = derive_lane(_lane("s"), _gh(_issue(1, lane="s")), REPO)
+    assert result["par_groups"] == {}
+
+
+# ---------------------------------------------------------------------------
+# T6 (G8) — Milestone transitions
+# ---------------------------------------------------------------------------
+
+
+def test_derive_bands_none_to_named():
+    """None → named milestone inserts 1 band before the named issue."""
+    gh = _gh(
+        _issue(1, lane="mb1"),
+        _issue(2, lane="mb1", blocked_by=[1], milestone="M1"),
+    )
+    result = derive_lane(_lane("mb1"), gh, REPO)
+    bands = result["bands"]
+    assert len(bands) == 1
+    assert bands[0]["before"]["issue"] == 2
+
+
+def test_derive_bands_named_to_none():
+    """Named → None milestone: band only for the named group."""
+    gh = _gh(
+        _issue(1, lane="mb2", milestone="M1"),
+        _issue(2, lane="mb2", blocked_by=[1]),
+    )
+    result = derive_lane(_lane("mb2"), gh, REPO)
+    bands = result["bands"]
+    # One band for M1 before #1; no band when transitioning from named to None
+    assert len(bands) == 1
+    assert bands[0]["before"]["issue"] == 1
+
+
+def test_derive_bands_all_same_milestone():
+    """All issues sharing one milestone produce exactly 1 band at the start."""
+    gh = _gh(
+        _issue(1, lane="mb3", milestone="M1"),
+        _issue(2, lane="mb3", blocked_by=[1], milestone="M1"),
+        _issue(3, lane="mb3", blocked_by=[2], milestone="M1"),
+    )
+    result = derive_lane(_lane("mb3"), gh, REPO)
+    bands = result["bands"]
+    assert len(bands) == 1
+    assert bands[0]["before"]["issue"] == 1
+
+
+# ---------------------------------------------------------------------------
+# T7 (G9) — _build_par_groups has_inner_edge skip
+# ---------------------------------------------------------------------------
+
+
+def test_build_par_groups_has_inner_edge_skip():
+    """Bucket with an intra-bucket edge is skipped (no par_group created)."""
+    # Issues 2 and 3 both at depth 1; edge 2→3 is an inner edge
+    sorted_issues = [(REPO, 1), (REPO, 2), (REPO, 3)]
+    depth_map = {(REPO, 1): 0, (REPO, 2): 1, (REPO, 3): 1}
+    edges = {(REPO, 2): [(REPO, 3)], (REPO, 3): []}
+    result = _build_par_groups("lane", sorted_issues, depth_map, edges)
+    # Depth-1 bucket has inner edge → must be skipped
+    assert not any(
+        {m["issue"] for m in members} == {2, 3} for members in result.values()
+    )
+
+
+def test_build_par_groups_creates_group_without_inner_edge():
+    """Bucket with no intra-bucket edges creates a par_group entry."""
+    sorted_issues = [(REPO, 1), (REPO, 2), (REPO, 3)]
+    depth_map = {(REPO, 1): 0, (REPO, 2): 1, (REPO, 3): 1}
+    edges = {(REPO, 2): [], (REPO, 3): []}
+    result = _build_par_groups("lane", sorted_issues, depth_map, edges)
+    # Depth-1 bucket has no inner edges → must appear as a par_group
+    assert any({m["issue"] for m in members} == {2, 3} for members in result.values())

--- a/scripts/dep-graph/tests/test_fetch.py
+++ b/scripts/dep-graph/tests/test_fetch.py
@@ -1,0 +1,32 @@
+"""Unit tests for dep_graph.fetch — label-parsing helpers.
+
+All tests are pure input/output; no filesystem or network access.
+"""
+
+from __future__ import annotations
+
+from dep_graph.fetch import _derive_size_from_labels
+
+# ---------------------------------------------------------------------------
+# _derive_size_from_labels tests
+# ---------------------------------------------------------------------------
+
+
+def test_derive_size_empty_list_returns_none():
+    """Empty label list → None."""
+    assert _derive_size_from_labels([]) is None
+
+
+def test_derive_size_no_size_prefix_returns_none():
+    """Labels present but none with 'size:' prefix → None."""
+    assert _derive_size_from_labels(["bug", "priority:high", "graph:lane/x"]) is None
+
+
+def test_derive_size_valid_label_returns_value():
+    """Single 'size:M' label → 'M'."""
+    assert _derive_size_from_labels(["size:M"]) == "M"
+
+
+def test_derive_size_multiple_size_labels_returns_first():
+    """Multiple 'size:*' labels → first one wins."""
+    assert _derive_size_from_labels(["size:S", "size:L"]) == "S"

--- a/scripts/dep-graph/uv.lock
+++ b/scripts/dep-graph/uv.lock
@@ -32,6 +32,7 @@ validate = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jsonschema" },
     { name = "pytest" },
 ]
 
@@ -40,7 +41,10 @@ requires-dist = [{ name = "jsonschema", marker = "extra == 'validate'", specifie
 provides-extras = ["validate"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "jsonschema", specifier = ">=4.0" },
+    { name = "pytest", specifier = ">=8.0" },
+]
 
 [[package]]
 name = "iniconfig"

--- a/scripts/dep-graph/uv.lock
+++ b/scripts/dep-graph/uv.lock
@@ -42,7 +42,7 @@ provides-extras = ["validate"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "jsonschema", specifier = ">=4.0" },
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "pytest", specifier = ">=8.0" },
 ]
 


### PR DESCRIPTION
## Summary
- Close 9 enumerated coverage gaps flagged by the `tester` agent after PR #739 (auto-derive lane order/par_groups/bands).
- Adds 33 new unit tests across 4 files; total dep-graph suite now 44 tests (was 11). Zero production code changes under `scripts/dep-graph/dep_graph/`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #740: test(dep-graph): fill test coverage gaps from PR #739 review | OPEN |
| Frame | [artifacts/frames/740-test-coverage-gaps-frame.mdx](artifacts/frames/740-test-coverage-gaps-frame.mdx) | Approved |
| Spec | [artifacts/specs/740-test-coverage-gaps-spec.mdx](artifacts/specs/740-test-coverage-gaps-spec.mdx) | Approved |
| Plan | [artifacts/plans/740-test-coverage-gaps-plan.mdx](artifacts/plans/740-test-coverage-gaps-plan.mdx) | Approved |
| Implementation | 1 commit on `feat/740-test-coverage-gaps` (4 test files, 17 tasks) | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (44 passed, 33 new) · Mutation-catch 3/3 (G1, G6, G2f) · `dep_graph/` diff = 0 lines | Passed |

## Coverage gaps closed (9)

| Gap | File | What it covers |
|---|---|---|
| G1 | `fetch.py::_derive_size_from_labels` | empty list / no `size:` / valid label / multiple → first wins |
| G2a | `audit.py::_build_layout_sets` | explicit order / no order → auto_lane_codes / **epic missing `repo` → excluded** (dark branch at `audit.py:301`) |
| G2b | `audit.py::_collect_auto_placed` | empty auto_lane_codes / populated match / standalone.order absent → auto-mode |
| G2c | `audit.py::_check_placement` | empty layout_lane_of skip path + populated path |
| G2d | `audit.py::_check_meta` | forwards `auto_placed` to `_check_defer` only (not `_check_standalone`) |
| G2e | `audit.py::_check_standalone` | auto-mode (empty order) + explicit-order drift detection |
| G2f | `audit.py::_check_defer` | `auto_placed=None` (default) vs populated → excluded from drift |
| G3 | `build.py::_prepare_render_data` | `standalone.order` fallback: `derive_standalone_order` called when absent, NOT called when present. Patch target is `dep_graph.build.derive_standalone_order` (the imported name inside `build.py`) |
| G4 | `derive.py::_collect_lane_issues` | epic in same-repo excluded / cross-repo issue matching epic number NOT excluded |
| G5 | `derive.py::derive_standalone_order` | `{}` / missing `number` / `standalone=False` skipped · entry missing `repo` → defaults to `primary_repo` |
| G6 | `derive.py::derive_lane` empty-lane fast path | returns `{order:[], par_groups:{}, bands:[]}` |
| G7 | `derive.py::_build_par_groups` single-node guard | depth bucket ≤1 → no par_group |
| G8 | `derive.py::_derive_bands` | `None→named` inserts band · `named→None` inserts no band · all-same → 1 band |
| G9 | `derive.py::_build_par_groups` has_inner_edge | intra-bucket edge → skipped · no edge → created |

## Mutation spot-check

Per spec success criterion: 3 author-chosen gaps verified by mutating the production line, confirming a test turns red, and reverting. Each gap's target branch is the sole cause of failure.

- **G1** — `fetch.py:137` `return lbl[5:]` → `lbl[4:]` ⇒ `test_derive_size_valid_label_returns_value` fails with `':M' != 'M'`.
- **G6** — `derive.py:211` `"par_groups": {}` → `{"mutated": []}` ⇒ `test_derive_lane_empty_fast_path` fails.
- **G2f** — `audit.py:195` `already_ok = layout_ref_set | (auto_placed or set())` → `layout_ref_set` ⇒ `test_check_defer_auto_placed_populated_excludes_item` fails.

Reverts restored suite green in all 3 cases.

## Notes

- `scripts/dep-graph/pyproject.toml`: `jsonschema` moved from `[optional-dependencies].validate` to `[dependency-groups].dev`. `build.py` transitively imports `schema.py → jsonschema`, so tests that touch `build._prepare_render_data` need it installed during `uv sync --frozen`. Runtime behavior unchanged (`validate` extra still present for downstream consumers).
- No changes under `scripts/dep-graph/dep_graph/*.py` — constraint enforced by `git diff origin/staging -- scripts/dep-graph/dep_graph/` returning 0 lines.
- All new tests use synthetic dicts; no filesystem, no network (`grep -E 'open\(|json\.load|requests\.|gh\.json' tests/test_{fetch,audit,build}.py` returns nothing).

## Test Plan
- [ ] `cd scripts/dep-graph && uv run pytest -v` → 44 passed.
- [ ] `uv run ruff check scripts/dep-graph/tests/ && uv run ruff format --check scripts/dep-graph/tests/` clean.
- [ ] CI dep-graph job green on the PR branch (no workflow YAML changes).
- [ ] `git diff origin/staging -- scripts/dep-graph/dep_graph/` = 0 lines.

Closes #740

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`