### PR TITLE
chore(dep-graph): polish from #709 review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           uv sync --frozen
           uv run pytest tests/
 
+      - name: Validate dep-graph schema
+        working-directory: scripts/dep-graph
+        run: |
+          uv run python -c "from dep_graph.schema import validate_layout_dict; print('Schema module OK')"
+          # TODO: Add `uv run dep-graph validate` once layout.json is in repo
+
   secrets:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/dep-graph/dep_graph/build.py
+++ b/scripts/dep-graph/dep_graph/build.py
@@ -662,7 +662,7 @@ def render_untriaged(
     cards = []
     for repo, n in untriaged:
         gh_entry = gh_issues.get(format_key(repo, n))
-        title = escape(gh_entry["title"]) if gh_entry else f"#{n}"
+        title = escape(gh_entry.get("title", f"#{n}")) if gh_entry else f"#{n}"
         cards.append(
             f'    <div class="card ready">'
             f'<div class="top"><span class="num">#{n}</span></div>'

--- a/scripts/dep-graph/dep_graph/cli.py
+++ b/scripts/dep-graph/dep_graph/cli.py
@@ -150,8 +150,7 @@ def main(argv: list[str] | None = None) -> int:
         "migrate", help="Migrate layout to multi-repo format"
     )
     p_migrate.add_argument(
-        "layout",
-        nargs="?",
+        "--layout",
         default=str(DEFAULT_LAYOUT),
         metavar="PATH",
         help="Path to layout.json (default: %(default)s)",

--- a/scripts/dep-graph/dep_graph/schema.py
+++ b/scripts/dep-graph/dep_graph/schema.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from jsonschema import Draft7Validator
 
+from .keys import parse_key
+
 _schema_cache: dict | None = None
 _SCHEMA_PATH = Path(__file__).parent.parent / "layout.schema.json"
 
@@ -28,8 +30,10 @@ def _load_schema() -> dict:
     global _schema_cache
     if _schema_cache is None:
         _schema_cache = json.loads(_SCHEMA_PATH.read_text())
-    assert _schema_cache is not None
-    return _schema_cache
+    # Type narrow: _schema_cache is guaranteed set after the if-block.
+    # Using explicit local reference avoids `assert` (stripped by `python -O`).
+    result: dict = _schema_cache  # type: ignore[assignment]
+    return result
 
 
 def _assert_repo(ref: Any, path: str, allowed_repos: set[str]) -> None:
@@ -60,7 +64,10 @@ def _check_lanes(lanes: list, allowed_repos: set[str]) -> None:
 def _check_keyed_section(section: dict, prefix: str, allowed_repos: set[str]) -> None:
     """Check that owner/repo portion of each key in *section* is in allowed_repos."""
     for key in section:
-        repo = key.split("#", 1)[0]
+        try:
+            repo, _ = parse_key(key)
+        except ValueError as exc:
+            raise LayoutValidationError(f"{prefix}.{key}", str(exc)) from exc
         if repo not in allowed_repos:
             raise LayoutValidationError(
                 f"{prefix}.{key}",
@@ -92,7 +99,12 @@ def _check_refs(data: dict, allowed_repos: set[str]) -> None:
 
 
 def validate_layout_dict(data: dict) -> None:
-    """Validate a layout dict. Raises LayoutValidationError on any violation."""
+    """Validate a layout dict. Raises LayoutValidationError on any violation.
+
+    Two-phase validation:
+      1. JSON Schema validation — structural checks (types, required fields, enums).
+      2. Cross-reference validation — semantic checks (IssueRef.repo ∈ meta.repos[]).
+    """
     # Phase 1: JSON Schema validation
     validator = Draft7Validator(_load_schema())
     errors = sorted(validator.iter_errors(data), key=lambda e: e.absolute_path)

--- a/scripts/dep-graph/pyproject.toml
+++ b/scripts/dep-graph/pyproject.toml
@@ -7,10 +7,7 @@ name = "dep-graph"
 version = "0.1.0"
 description = "GitHub-driven dependency graph generator for Lyra"
 requires-python = ">=3.11"
-dependencies = []
-
-[project.optional-dependencies]
-validate = ["jsonschema>=4.0"]
+dependencies = ["jsonschema>=4.0"]
 
 [dependency-groups]
 dev = ["pytest>=8.0", "jsonschema>=4.26.0"]
@@ -24,3 +21,4 @@ packages = ["dep_graph"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--import-mode=importlib"
+pythonpath = ["."]

--- a/scripts/dep-graph/uv.lock
+++ b/scripts/dep-graph/uv.lock
@@ -24,9 +24,7 @@ wheels = [
 name = "dep-graph"
 version = "0.1.0"
 source = { editable = "." }
-
-[package.optional-dependencies]
-validate = [
+dependencies = [
     { name = "jsonschema" },
 ]
 
@@ -37,8 +35,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "jsonschema", marker = "extra == 'validate'", specifier = ">=4.0" }]
-provides-extras = ["validate"]
+requires-dist = [{ name = "jsonschema", specifier = ">=4.0" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/tests/dep_graph/test_build.py
+++ b/tests/dep_graph/test_build.py
@@ -1,7 +1,13 @@
-"""Tests for multi-repo builder — RED phase (T10)."""
+"""Tests for multi-repo builder — RED phase (T10).
+
+Golden test regeneration:
+    Run `make dep-graph build` from the lyra repo root to regenerate the HTML
+    fixture from the committed layout + gh.json cache.
+"""
 
 from __future__ import annotations
 
+import difflib
 import json
 from pathlib import Path
 
@@ -51,7 +57,11 @@ def _valid_single_lane_layout(*, repos, lane_order):
 
 
 def test_golden_html_byte_identical(tmp_path):
-    """Build fed the committed lyra-layout-golden.* fixtures produces byte-identical HTML."""
+    """Build fed the committed lyra-layout-golden.* fixtures produces byte-identical HTML.
+
+    To regenerate the golden fixture:
+        make dep-graph build
+    """
     layout_fx = FIXTURES / "lyra-layout-golden.layout.json"
     cache_fx = FIXTURES / "lyra-layout-golden.gh.json"
     html_fx = FIXTURES / "lyra-layout-golden.html"
@@ -66,7 +76,13 @@ def test_golden_html_byte_identical(tmp_path):
             layout_path=layout_fx, cache_path=cache_fx, out_path=out, bak_path=None
         )
     )
-    assert out.read_bytes() == html_fx.read_bytes(), "Golden HTML drift"
+
+    expected = html_fx.read_text().splitlines(keepends=True)
+    actual = out.read_text().splitlines(keepends=True)
+
+    if expected != actual:
+        diff = "".join(difflib.unified_diff(expected, actual, "expected", "actual"))
+        raise AssertionError(f"Golden HTML drift:\n{diff}")
 
 
 def test_repo_badge_on_foreign_card(tmp_path):

--- a/tests/dep_graph/test_cli.py
+++ b/tests/dep_graph/test_cli.py
@@ -1,0 +1,172 @@
+"""Tests for dep_graph CLI entry points.
+
+Covers:
+  - main() routing to correct subcommand
+  - _resolve_paths() deriving default cache/out paths from layout
+  - validate subcommand exit codes for valid/invalid/missing layouts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from dep_graph.cli import _resolve_paths, main
+
+# ---------------------------------------------------------------------------
+# _resolve_paths tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_paths_defaults_from_layout(tmp_path):
+    """_resolve_paths derives cache/out paths as siblings of layout."""
+    # Arrange
+    layout = tmp_path / "lyra-v2-dependency-graph.layout.json"
+    layout.touch()
+
+    args = argparse.Namespace(layout=str(layout), cache=None, out=None)
+
+    # Act
+    resolved_layout, cache_path, out_path = _resolve_paths(args)
+
+    # Assert
+    assert resolved_layout == layout
+    assert cache_path == tmp_path / "lyra-v2-dependency-graph.gh.json"
+    assert out_path == tmp_path / "lyra-v2-dependency-graph.html"
+
+
+def test_resolve_paths_explicit_cache_out(tmp_path):
+    """Explicit --cache and --out override default derivation."""
+    # Arrange
+    layout = tmp_path / "layout.json"
+    layout.touch()
+    explicit_cache = tmp_path / "custom.gh.json"
+    explicit_out = tmp_path / "custom.html"
+
+    args = argparse.Namespace(
+        layout=str(layout), cache=str(explicit_cache), out=str(explicit_out)
+    )
+
+    # Act
+    _, cache_path, out_path = _resolve_paths(args)
+
+    # Assert
+    assert cache_path == explicit_cache
+    assert out_path == explicit_out
+
+
+def test_resolve_paths_strips_layout_suffix(tmp_path):
+    """Stem removes '.layout' suffix when deriving cache/out names."""
+    # Arrange
+    layout = tmp_path / "my-deps.layout.json"
+    layout.touch()
+
+    args = argparse.Namespace(layout=str(layout), cache=None, out=None)
+
+    # Act
+    _, cache_path, out_path = _resolve_paths(args)
+
+    # Assert
+    assert cache_path.name == "my-deps.gh.json"
+    assert out_path.name == "my-deps.html"
+
+
+# ---------------------------------------------------------------------------
+# validate subcommand tests
+# ---------------------------------------------------------------------------
+
+
+def _valid_layout() -> dict:
+    """Minimal schema-valid multi-repo layout."""
+    return {
+        "meta": {
+            "title": "T",
+            "date": "2026-04-15",
+            "repos": ["Roxabi/lyra"],
+            "label_prefix": "graph:",
+        },
+        "lanes": [],
+        "standalone": {"order": []},
+        "overrides": {},
+        "extra_deps": {"extra_blocked_by": {}, "extra_blocking": {}},
+        "cross_deps": [],
+        "title_rules": [],
+    }
+
+
+def test_validate_valid_layout_exits_0(tmp_path, capsys):
+    """validate subcommand returns 0 for a schema-valid layout."""
+    # Arrange
+    layout = tmp_path / "layout.json"
+    layout.write_text(json.dumps(_valid_layout()))
+
+    # Act
+    result = main(["validate", "--layout", str(layout)])
+
+    # Assert
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Schema validation passed" in captured.out
+
+
+def test_validate_missing_layout_exits_1(tmp_path, capsys):
+    """validate subcommand returns 1 when layout file not found."""
+    # Arrange
+    missing = tmp_path / "missing.json"
+
+    # Act
+    result = main(["validate", "--layout", str(missing)])
+
+    # Assert
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "not found" in captured.err
+
+
+def test_validate_invalid_layout_exits_1(tmp_path, capsys):
+    """validate subcommand returns 1 for schema-invalid layout."""
+    # Arrange
+    layout = tmp_path / "layout.json"
+    layout.write_text(json.dumps({"invalid": True}))
+
+    # Act
+    result = main(["validate", "--layout", str(layout)])
+
+    # Assert
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "SCHEMA ERROR" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# migrate subcommand tests
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_uses_layout_flag(tmp_path):
+    """migrate subcommand accepts --layout flag (consistency with other subcommands)."""
+    # Arrange
+    old_layout = {
+        "meta": {
+            "title": "T",
+            "date": "2026-04-15",
+            "repo": "Roxabi/lyra",
+            "label_prefix": "graph:",
+        },
+        "lanes": [],
+        "standalone": {"order": []},
+        "overrides": {},
+        "extra_deps": {"extra_blocked_by": {}, "extra_blocking": {}},
+        "cross_deps": [],
+        "title_rules": [],
+    }
+    layout = tmp_path / "layout.json"
+    layout.write_text(json.dumps(old_layout))
+
+    # Act
+    result = main(["migrate", "--layout", str(layout)])
+
+    # Assert
+    assert result == 0
+    new = layout.with_suffix(layout.suffix + ".new")
+    assert new.exists()

--- a/tests/dep_graph/test_fetch.py
+++ b/tests/dep_graph/test_fetch.py
@@ -89,22 +89,39 @@ def test_iterates_meta_repos(tmp_path, monkeypatch):
 
 
 def test_dedupes_same_issue_from_two_repos(tmp_path, monkeypatch):
-    """If the same (repo, issue) appears in two label searches, gh.json has one entry."""
+    """If the same (repo, issue) appears in two label searches, gh.json has one entry.
+
+    Simulates two independent label-query calls (graph:standalone and graph:lane/a)
+    each returning the same issue #641.
+    """
     # Arrange
     from dep_graph.fetch import run_fetch
 
     layout = _layout_file(tmp_path, repos=["Roxabi/lyra"])
+    # Add lane codes so search_labeled_issues queries multiple labels
+    layout_data = json.loads(layout.read_text())
+    layout_data["lanes"] = [{"code": "a", "name": "A", "color": "a", "epic": {}, "order": [], "par_groups": {}, "bands": []}]
+    layout.write_text(json.dumps(layout_data))
+
     cache = tmp_path / "cache.gh.json"
     _patch_gh(monkeypatch)
+
+    call_count = {"label_list": 0}
 
     def fake_run(cmd, *a, **kw):
         cp = MagicMock()
         cp.stderr = ""
         cp.returncode = 0
         joined = " ".join(cmd)
-        # Label-list commands return issue 641 twice (simulating overlap across two label queries)
-        if "issue" in joined and "list" in joined and "--json" in joined:
-            cp.stdout = "[641, 641]"
+
+        # Label-list commands: simulate two independent calls each returning #641
+        if "issue" in joined and "list" in joined and "--json" in joined and "--label" in joined:
+            call_count["label_list"] += 1
+            # Each independent label query returns #641
+            cp.stdout = "[641]"
+        elif "/issues/" in joined and "/dependencies" not in joined:
+            # Issue meta request
+            cp.stdout = json.dumps({"number": 641, "title": "x", "state": "OPEN", "labels": []})
         else:
             cp.stdout = "[]"
         return cp
@@ -117,7 +134,8 @@ def test_dedupes_same_issue_from_two_repos(tmp_path, monkeypatch):
     # Assert — exactly one key for Roxabi/lyra#641 (not duplicated)
     data = json.loads(cache.read_text())
     keys_641 = [k for k in data.get("issues", {}) if k.endswith("#641")]
-    assert len(keys_641) <= 1, f"Duplicate keys for #641: {keys_641}"
+    assert len(keys_641) == 1, f"Expected 1 key for #641, got {len(keys_641)}: {keys_641}"
+    assert call_count["label_list"] >= 2, "Expected at least 2 label-list calls to simulate overlap"
 
 
 def test_extracts_issue_ref_from_dep_response(tmp_path, monkeypatch):

--- a/tests/dep_graph/test_migrate.py
+++ b/tests/dep_graph/test_migrate.py
@@ -49,12 +49,15 @@ def _old_layout():
 
 
 def test_migrates_bare_ints_to_issue_refs(tmp_path):
+    # Arrange
     p = tmp_path / "layout.json"
     p.write_text(json.dumps(_old_layout()))
 
+    # Act
     result = run_migrate(p)
     assert result == 0
 
+    # Assert
     new = p.with_suffix(p.suffix + ".new")
     assert new.exists()
     data = json.loads(new.read_text())
@@ -89,9 +92,14 @@ def test_migrates_bare_ints_to_issue_refs(tmp_path):
 
 
 def test_migrates_override_keys_to_owner_repo_hash(tmp_path):
+    # Arrange
     p = tmp_path / "layout.json"
     p.write_text(json.dumps(_old_layout()))
+
+    # Act
     run_migrate(p)
+
+    # Assert
     data = json.loads(p.with_suffix(p.suffix + ".new").read_text())
 
     # overrides keys rewritten
@@ -110,7 +118,7 @@ def test_migrates_override_keys_to_owner_repo_hash(tmp_path):
 
 
 def test_idempotent_on_already_migrated(tmp_path, capsys):
-    # Write an already-migrated layout, run migrate, expect "Already migrated." exit 0
+    # Arrange — already-migrated layout
     already = {
         "meta": {
             "title": "T",
@@ -127,7 +135,11 @@ def test_idempotent_on_already_migrated(tmp_path, capsys):
     }
     p = tmp_path / "layout.json"
     p.write_text(json.dumps(already))
+
+    # Act
     result = run_migrate(p)
+
+    # Assert
     assert result == 0
     out = capsys.readouterr().out
     assert "Already migrated" in out
@@ -136,7 +148,7 @@ def test_idempotent_on_already_migrated(tmp_path, capsys):
 
 
 def test_completes_partial_migration(tmp_path):
-    # Mix of new `meta.repos` with leftover bare ints in lanes — should be completed
+    # Arrange — mix of new `meta.repos` with leftover bare ints in lanes + overrides
     partial = {
         "meta": {
             "title": "T",
@@ -156,27 +168,41 @@ def test_completes_partial_migration(tmp_path):
             }
         ],
         "standalone": {"order": []},
-        "overrides": {},
+        "overrides": {"641": {"title": "override"}},  # bare-int key leftover
         "extra_deps": {"extra_blocked_by": {}, "extra_blocking": {}},
         "cross_deps": [],
         "title_rules": [],
     }
     p = tmp_path / "layout.json"
     p.write_text(json.dumps(partial))
+
+    # Act
     result = run_migrate(p)
+
+    # Assert
     assert result == 0
-    # Since it doesn't validate fully, migrate should produce a .new completing it
     new = p.with_suffix(p.suffix + ".new")
     assert new.exists()
     data = json.loads(new.read_text())
+
+    # lanes order wrapped
     assert data["lanes"][0]["order"] == [{"repo": "Roxabi/lyra", "issue": 641}]
+
+    # overrides key rewritten
+    assert "Roxabi/lyra#641" in data["overrides"]
+    assert data["overrides"]["Roxabi/lyra#641"] == {"title": "override"}
 
 
 def test_never_mutates_original(tmp_path):
+    # Arrange
     p = tmp_path / "layout.json"
     original = _old_layout()
     p.write_text(json.dumps(original, indent=2))
     before = p.read_bytes()
+
+    # Act
     run_migrate(p)
+
+    # Assert
     after = p.read_bytes()
     assert before == after, "migrate must not mutate the original file"


### PR DESCRIPTION
## Summary
- Code quality: `parse_key()` for clean errors, remove `assert`, safe `.get()` access
- Test + DX: new `test_cli.py`, golden test diff output, AAA markers
- Infra: `jsonschema` as core dep, pytest pythonpath, CI validation step

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #720: chore(dep-graph): deferred polish from #709 review | OPEN |
| Implementation | 1 commit on `feat/720-dep-graph-polish` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (6 new) | Passed |

## Test Plan
- [x] `uv run pytest tests/dep_graph/test_cli.py` — CLI entry point tests pass
- [x] `uv run pytest tests/dep_graph/` — dep-graph tests pass (pre-existing `test_derive.py` failure unrelated)
- [x] `uv run pyright scripts/dep-graph/dep_graph/` — typecheck passes

Closes #720

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`