### PR TITLE
docs(adr): ADR-048 introduce lyra.infrastructure layer for persistence

### DIFF
--- a/artifacts/frames/653-stores-infrastructure-frame.mdx
+++ b/artifacts/frames/653-stores-infrastructure-frame.mdx
@@ -1,0 +1,75 @@
+---
+title: "frame(arch): introduce lyra.infrastructure layer — relocate SQLite store implementations out of lyra.core"
+issue: 653
+status: approved
+tier: F-lite
+date: 2026-04-16
+---
+
+## Problem
+
+`src/lyra/core/stores/` contains 10 SQLite implementation files that import `aiosqlite` and/or `sqlite3`. This places infrastructure drivers inside `lyra.core`, the innermost layer of the clean-architecture stack — a direct violation of the dependency rule that innermost layers must have zero infrastructure imports.
+
+The violation is currently undetected by import-linter because most store imports are inside function bodies (lazy), which static module-level analysis cannot see. The violation is real at runtime: `aiosqlite` is loaded whenever store methods execute. Once the forbidden contract in `.importlinter` is added, CI will fail on the first PR that activates it — unless the files have already moved.
+
+The original fix in issue #653 targeted `adapters/stores/` (Option A). That approach was rejected by ADR-048: placing SQLite persistence alongside I/O transport adapters (Telegram, Discord, CLI, NATS) degrades the taxonomy irreversibly. ADR-048 establishes the correct destination: a new `lyra.infrastructure` layer.
+
+**Decision authority:** ADR-048 (`docs/architecture/adr/048-lyra-infrastructure-layer-for-persistence.mdx`) — accepted, authoritative.
+
+## Tier: F-lite
+
+Justification: scope is clear, domain is single (backend/structural), all 10 moves are mechanical, acceptance criteria are binary. The 84 affected import lines and 50 files span multiple files but zero architectural unknowns — the pattern (move + shim + caller update + shim delete) is identical for every store. No novel design decisions remain after ADR-048.
+
+## Scope
+
+**In scope:**
+- Create `src/lyra/infrastructure/` module + `src/lyra/infrastructure/CLAUDE.md`
+- Move 10 SQLite implementation files from `core/stores/` to `infrastructure/stores/`
+- Add re-export shims at old paths during transition (deleted per-store when callers updated)
+- `core/stores/__init__.py` surgery: remove `SqliteStore` re-export (pulls `aiosqlite` at import time)
+- Update `.importlinter`: add `lyra.infrastructure` layer entry + forbidden contract on `lyra.core.stores` blocking `aiosqlite` / `sqlite3`
+- Update `src/lyra/core/CLAUDE.md` to remove implementation file entries, retain protocol entries
+
+**Out of scope:**
+- `pairing.py` business logic concerns — orthogonal cleanup, separate issue if needed
+- `packages/roxabi-persistence/` subpackage extraction — no external consumer exists; explicitly excluded by ADR-048
+- Store interface changes (protocols stay as-is)
+- SQLite schema or query changes
+- Any functional behavior change — pure structural relocation
+
+## Files: Stay vs Move
+
+| Decision | Files |
+|----------|-------|
+| MOVE to `infrastructure/stores/` | `sqlite_base.py`, `agent_store.py`, `auth_store.py`, `credential_store.py`, `identity_alias_store.py`, `message_index.py`, `pairing.py`, `prefs_store.py`, `thread_store.py`, `turn_store.py` |
+| STAY in `core/stores/` | `agent_store_protocol.py` (protocol + factory), `json_agent_store.py` (test double, no aiosqlite), `pairing_config.py` (pure Pydantic dataclass) |
+| SURGERY | `core/stores/__init__.py` — remove `SqliteStore` re-export |
+
+## Layering After Migration
+
+```
+lyra.core ← lyra.llm | lyra.nats ← lyra.infrastructure ← lyra.adapters ← lyra.bootstrap
+```
+
+`lyra.core` becomes genuinely infrastructure-free. Import-linter enforces this via the new forbidden contract.
+
+## Call-Site Scale
+
+- 84 import lines across 50 files
+- 56 module-level (visible to import-linter today)
+- 28 function-body / lazy (currently invisible to import-linter)
+- Rollout: per-store PRs with shims bridging the transition
+
+## Constraints
+
+- Must preserve all existing store behavior — zero functional changes
+- Shims MUST NOT re-import `aiosqlite` directly (forbidden contract activates on PR 1)
+- `src/lyra/core/CLAUDE.md` must be updated per project hygiene rule
+- `src/lyra/infrastructure/CLAUDE.md` must be created per project hygiene rule
+- CI gate (`uv run lint-imports`) is already in `.github/workflows/ci.yml:32` — no new CI wiring needed
+- #417 (schema migration blocker) is CLOSED — work can proceed immediately
+
+## Who
+
+- **Primary:** Developers maintaining clean architecture boundaries
+- **Secondary:** CI pipeline — import-linter enforcement becomes gated once forbidden contract is added

--- a/artifacts/plans/653-stores-infrastructure-plan.mdx
+++ b/artifacts/plans/653-stores-infrastructure-plan.mdx
@@ -10,7 +10,7 @@ generated: "2026-04-16T00:00:00Z"
 
 Incremental rollout: one prep PR establishes the `lyra.infrastructure` layer and activates the import-linter forbidden contract, then one PR per SQLite store moves it to `infrastructure/stores/` with a backward-compatible shim, then a final cleanup PR removes all shims and does the `core/stores/__init__.py` surgery. Each PR is independently mergeable and revertable. No behavior changes throughout.
 
-**PR count: 13** (1 prep + 10 store moves + 1 sqlite_base + 1 final cleanup — see breakdown below)
+**PR count: 12** (1 prep + 1 sqlite_base + 9 other store moves + 1 final cleanup — see breakdown below). A buffer slot is held between the last store move and the final PR for any caller-update follow-up that spills out of its primary PR.
 
 ## Architecture
 
@@ -172,13 +172,13 @@ lyra.hub, lyra.adapters, lyra.agents, lyra.commands (type-hint against protocols
 
 ---
 
-### PR 12 — Move `turn_store.py` ... (overlap check)
+### PR 12 — Buffer slot (optional follow-up caller updates)
 
-_Note: PRs 4–11 are listed in recommended order but may proceed in any order after PR 3. Each is independently mergeable. The numbering here reflects a reasonable sequencing — adjust based on developer bandwidth._
+_Policy slot, not a dedicated move. Use ONLY if a per-store PR (PRs 2–11) needs a follow-up caller-update PR that could not land in the original move. PRs 4–11 are listed in recommended order but may proceed in any order after PR 3; each is independently mergeable. If all callers are updated inside their primary PRs, this slot goes unused and the count effectively becomes 11 + Final._
 
 ---
 
-### PR 13 (Final) — `__init__.py` surgery + CLAUDE.md cleanup
+### PR Final — `__init__.py` surgery + CLAUDE.md cleanup
 
 **Goal:** Remove all remaining shims. Do `core/stores/__init__.py` surgery. Update documentation.
 
@@ -219,7 +219,7 @@ _Note: PRs 4–11 are listed in recommended order but may proceed in any order a
 | 9 | `prefs_store.py` | Move + callers | Yes |
 | 10 | `thread_store.py` | Move + callers | Yes |
 | 11 | `turn_store.py` | Move + callers | Yes |
-| 12 | `auth_store.py` (if split needed) | — | — |
+| 12 | Buffer slot | — (used only if a per-store PR needs a caller-update follow-up) | — |
 | Final | `__init__.py` surgery + CLAUDE.md cleanup | `core/stores/__init__.py`, `core/CLAUDE.md`, `infrastructure/CLAUDE.md` | Yes |
 
 **Total: 12 PRs** (1 prep + 10 store moves + 1 final). PR 12 slot left as buffer for any store that needs a follow-up caller-update PR after its shim period.

--- a/artifacts/plans/653-stores-infrastructure-plan.mdx
+++ b/artifacts/plans/653-stores-infrastructure-plan.mdx
@@ -1,0 +1,265 @@
+---
+title: "Plan: Introduce lyra.infrastructure layer — per-store PR rollout"
+issue: 653
+spec: artifacts/specs/653-stores-infrastructure-spec.mdx
+tier: F-lite
+generated: "2026-04-16T00:00:00Z"
+---
+
+## Summary
+
+Incremental rollout: one prep PR establishes the `lyra.infrastructure` layer and activates the import-linter forbidden contract, then one PR per SQLite store moves it to `infrastructure/stores/` with a backward-compatible shim, then a final cleanup PR removes all shims and does the `core/stores/__init__.py` surgery. Each PR is independently mergeable and revertable. No behavior changes throughout.
+
+**PR count: 13** (1 prep + 10 store moves + 1 sqlite_base + 1 final cleanup — see breakdown below)
+
+## Architecture
+
+### Layering Before → After
+
+```
+Before:
+lyra.core (contains aiosqlite imports) ← lyra.llm | lyra.nats ← lyra.adapters ← lyra.bootstrap
+
+After:
+lyra.core (zero infra) ← lyra.llm | lyra.nats ← lyra.infrastructure (aiosqlite here) ← lyra.adapters ← lyra.bootstrap
+```
+
+### Per-Store PR Pattern
+
+```
+1. Move <x>.py  →  src/lyra/infrastructure/stores/<x>.py
+2. Add shim     →  src/lyra/core/stores/<x>.py
+                   (from lyra.infrastructure.stores.<x> import XxxStore  # noqa: F401)
+                   MUST NOT import aiosqlite directly
+3. Update call sites  →  all src/ and tests/ that import from lyra.core.stores.<x>
+4. Delete shim  →  remove src/lyra/core/stores/<x>.py
+   (steps 3+4 may be in same PR or follow-up — shim provides backward compat)
+```
+
+### Dependency Graph After Full Migration
+
+```
+lyra.core.stores (protocols only)
+    ↑
+lyra.infrastructure.stores (implementations — aiosqlite freely imported here)
+    ↑
+lyra.bootstrap.bootstrap_stores (factory wiring — only site that imports from infrastructure.stores)
+    ↑
+lyra.hub, lyra.adapters, lyra.agents, lyra.commands (type-hint against protocols only)
+```
+
+## PR Breakdown
+
+### PR 1 — Prep: create infrastructure layer + importlinter contracts
+
+**Goal:** Structural scaffolding only. Zero file moves. Forbidden contract activates here (vacuous until PR 2).
+
+**Tasks:**
+- Create `src/lyra/infrastructure/__init__.py` (empty)
+- Create `src/lyra/infrastructure/stores/__init__.py` (empty)
+- Create `src/lyra/infrastructure/CLAUDE.md` — list all 10 stores as "pending migration" with their destination paths
+- Extend `.importlinter` layering contract: insert `lyra.infrastructure` between `lyra.llm | lyra.nats` and `lyra.adapters`
+- Add forbidden contract `core-stores-no-sqlite` blocking `aiosqlite` + `sqlite3` from `lyra.core.stores`
+
+**Verify:** `uv run lint-imports` passes. Contract is vacuous (no files moved yet) — this is expected.
+
+**Rollback:** Revert single PR. No callers affected.
+
+---
+
+### PR 2 — Move `sqlite_base.py` (must be FIRST store move)
+
+**Rationale:** `sqlite_base.py` defines `SqliteStore`, the base class all other implementation files inherit. Moving it first means all subsequent PRs can import from the correct location.
+
+**Tasks:**
+- Move `src/lyra/core/stores/sqlite_base.py` → `src/lyra/infrastructure/stores/sqlite_base.py`
+- Add shim at `src/lyra/core/stores/sqlite_base.py`:
+  ```python
+  from lyra.infrastructure.stores.sqlite_base import SqliteStore  # noqa: F401
+  ```
+- Update all callers that import directly from `lyra.core.stores.sqlite_base` → `lyra.infrastructure.stores.sqlite_base`
+- Update `src/lyra/infrastructure/CLAUDE.md`: mark `sqlite_base.py` as migrated
+- Delete shim once all callers updated
+
+**Verify:**
+- `uv run lint-imports` passes (forbidden contract: shim imports nothing from aiosqlite directly)
+- `grep -r "from lyra.core.stores.sqlite_base" src/ tests/` returns nothing
+- `uv run pytest` passes
+
+**Rollback:** Revert this PR. Other stores still import via `core/stores/` shims or unchanged paths.
+
+---
+
+### PR 3 — Move `agent_store.py`
+
+**Rationale:** Protocol already partially drafted (`agent_store_protocol.py` in `core/stores/`). Move the implementation second.
+
+**Tasks:**
+- Move `src/lyra/core/stores/agent_store.py` → `src/lyra/infrastructure/stores/agent_store.py`
+- Add shim at `src/lyra/core/stores/agent_store.py`
+- Update all callers in `src/` and `tests/` importing from `lyra.core.stores.agent_store` or `lyra.core.stores` (AgentStore symbol)
+- Note: `agent_store_protocol.py` STAYS — callers type-hinting `AgentStoreProtocol` do NOT change
+- Delete shim
+- Update `src/lyra/infrastructure/CLAUDE.md`
+
+**Verify:**
+- `grep -r "from lyra.core.stores.agent_store import" src/ tests/` returns nothing (protocol imports from `agent_store_protocol` — unchanged)
+- `uv run pytest` passes
+
+---
+
+### PR 4 — Move `auth_store.py`
+
+**Tasks:** Same pattern as PR 3.
+- Move → `src/lyra/infrastructure/stores/auth_store.py`
+- Shim → update callers → delete shim
+- Update `src/lyra/infrastructure/CLAUDE.md`
+
+**Callers to check:** `bootstrap_stores.py`, `bootstrap_wiring.py`, any auth middleware.
+
+---
+
+### PR 5 — Move `credential_store.py`
+
+**Tasks:** Same pattern.
+
+**Edge case — mock patch strings:** `tests/cli/test_cli_setup.py` patches `"lyra.core.stores.credential_store.LyraKeyring.load_or_create"` and `"lyra.core.stores.credential_store.CredentialStore"`. These must be updated to patch at `"lyra.infrastructure.stores.credential_store.*"` or at the bootstrap import site, depending on which module the test is testing. Verify patch semantics before updating strings.
+
+---
+
+### PR 6 — Move `identity_alias_store.py`
+
+**Tasks:** Same pattern.
+- Callers: `commands/identity/handlers.py`, `bootstrap_stores.py`, related tests.
+
+---
+
+### PR 7 — Move `message_index.py`
+
+**Tasks:** Same pattern.
+- Callers: hub session routing, `bootstrap_stores.py`, `tests/core/test_message_index.py`.
+
+---
+
+### PR 8 — Move `pairing.py`
+
+**Tasks:** Same pattern.
+
+**Classification note:** `pairing.py` moves because it inherits `SqliteStore` — not because of its business responsibility. `pairing_config.py` (pure Pydantic dataclass, zero DB logic) STAYS in `core/stores/`. Callers importing `PairingConfig` or `PairingError` from `lyra.core.stores.pairing_config` do NOT change.
+
+- Callers: `commands/pairing/handlers.py`, `bootstrap_stores.py`, related tests.
+
+---
+
+### PR 9 — Move `prefs_store.py`
+
+**Tasks:** Same pattern.
+- Callers: `bootstrap_stores.py`, prefs commands, related tests.
+
+---
+
+### PR 10 — Move `thread_store.py`
+
+**Tasks:** Same pattern.
+- Callers: `adapters/discord.py`, `adapters/discord_threads.py`, `bootstrap_stores.py`, related tests.
+
+---
+
+### PR 11 — Move `turn_store.py`
+
+**Tasks:** Same pattern.
+- Callers: hub, `adapters/telegram.py`, `adapters/discord.py`, `bootstrap_stores.py`, related tests.
+
+---
+
+### PR 12 — Move `turn_store.py` ... (overlap check)
+
+_Note: PRs 4–11 are listed in recommended order but may proceed in any order after PR 3. Each is independently mergeable. The numbering here reflects a reasonable sequencing — adjust based on developer bandwidth._
+
+---
+
+### PR 13 (Final) — `__init__.py` surgery + CLAUDE.md cleanup
+
+**Goal:** Remove all remaining shims. Do `core/stores/__init__.py` surgery. Update documentation.
+
+**Tasks:**
+- `core/stores/__init__.py` surgery: remove `SqliteStore` re-export. Retain only:
+  - `AgentStoreProtocol`
+  - `make_agent_store()`
+  - Any other protocol-safe symbols
+- Confirm no shims remain in `core/stores/` (all `infrastructure/stores/<x>.py` shims deleted in their respective PRs)
+- Update `src/lyra/core/CLAUDE.md`:
+  - Remove all 10 implementation file entries
+  - Retain: `agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py`, `__init__.py`
+  - Add note: "SQLite implementations live in `src/lyra/infrastructure/stores/`"
+- Update `src/lyra/infrastructure/CLAUDE.md`: mark all 10 files as fully migrated, remove "pending" markers
+- Update `CLAUDE.md` root if it references `core/stores/` implementation files
+
+**Verify:**
+- `grep -r "aiosqlite" src/lyra/core/` returns nothing
+- `grep -r "sqlite3" src/lyra/core/stores/` returns nothing (excluding `pairing_config.py` DDL constants if present — verify)
+- `uv run lint-imports` passes (layering + forbidden contract)
+- `uv run pytest` passes
+- `ls src/lyra/core/stores/` shows exactly: `__init__.py`, `agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py`
+
+---
+
+## PR Summary Table
+
+| PR | Focus | Files touched | Independently revertable |
+|----|-------|--------------|--------------------------|
+| 1 | Prep: infrastructure layer + importlinter | `.importlinter`, `infrastructure/__init__.py`, `infrastructure/stores/__init__.py`, `infrastructure/CLAUDE.md` | Yes |
+| 2 | `sqlite_base.py` | Move + callers (all stores depend on this) | Yes |
+| 3 | `agent_store.py` | Move + callers | Yes |
+| 4 | `auth_store.py` | Move + callers | Yes |
+| 5 | `credential_store.py` | Move + callers + mock patch strings | Yes |
+| 6 | `identity_alias_store.py` | Move + callers | Yes |
+| 7 | `message_index.py` | Move + callers | Yes |
+| 8 | `pairing.py` | Move + callers (pairing_config.py STAYS) | Yes |
+| 9 | `prefs_store.py` | Move + callers | Yes |
+| 10 | `thread_store.py` | Move + callers | Yes |
+| 11 | `turn_store.py` | Move + callers | Yes |
+| 12 | `auth_store.py` (if split needed) | — | — |
+| Final | `__init__.py` surgery + CLAUDE.md cleanup | `core/stores/__init__.py`, `core/CLAUDE.md`, `infrastructure/CLAUDE.md` | Yes |
+
+**Total: 12 PRs** (1 prep + 10 store moves + 1 final). PR 12 slot left as buffer for any store that needs a follow-up caller-update PR after its shim period.
+
+## Estimates
+
+| Phase | Effort |
+|-------|--------|
+| PR 1 (prep) | ~1 hour |
+| PR 2 (sqlite_base) | ~2-3 hours (most callers inherit from here; need to verify all) |
+| PRs 3–11 (stores, per store) | ~2 hours each |
+| Final PR | ~1-2 hours |
+| **Total** | **~1.5–2 days** |
+
+## Agents
+
+| Agent | Tasks |
+|-------|-------|
+| backend-dev | All file moves, import updates, shim writes, shim deletes, `__init__.py` surgery |
+| doc-writer | `infrastructure/CLAUDE.md` creation, `core/CLAUDE.md` updates, root `CLAUDE.md` if needed |
+| tester | `uv run pytest` + `uv run lint-imports` verification after each PR |
+
+## Consistency Report
+
+- Criteria covered: 9/9 (all success criteria from spec have at least one verifying task)
+- No gold plating: business logic changes explicitly deferred (pairing.py behavior OUT of scope)
+- No schema changes in scope
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: PR1 — Prep: create infrastructure layer + importlinter contracts
+- T2: PR2 — Move sqlite_base.py + update callers
+- T3: PR3 — Move agent_store.py + update callers
+- T4: PR4 — Move auth_store.py + update callers
+- T5: PR5 — Move credential_store.py + update callers + mock patch strings
+- T6: PR6 — Move identity_alias_store.py + update callers
+- T7: PR7 — Move message_index.py + update callers
+- T8: PR8 — Move pairing.py + update callers
+- T9: PR9 — Move prefs_store.py + update callers
+- T10: PR10 — Move thread_store.py + update callers
+- T11: PR11 — Move turn_store.py + update callers
+- T12: Final — __init__.py surgery + CLAUDE.md cleanup

--- a/artifacts/plans/653-stores-infrastructure-plan.mdx
+++ b/artifacts/plans/653-stores-infrastructure-plan.mdx
@@ -36,6 +36,8 @@ lyra.core (zero infra) ← lyra.llm | lyra.nats ← lyra.infrastructure (aiosqli
    (steps 3+4 may be in same PR or follow-up — shim provides backward compat)
 ```
 
+**IMPORTANT:** the shim also creates a `core → infrastructure` downward import. Add the shim path to `.importlinter`'s `layers` contract `exclude_modules` list for the duration of the shim. Remove the exclusion when the shim is deleted.
+
 ### Dependency Graph After Full Migration
 
 ```
@@ -60,8 +62,9 @@ lyra.hub, lyra.adapters, lyra.agents, lyra.commands (type-hint against protocols
 - Create `src/lyra/infrastructure/CLAUDE.md` — list all 10 stores as "pending migration" with their destination paths
 - Extend `.importlinter` layering contract: insert `lyra.infrastructure` between `lyra.llm | lyra.nats` and `lyra.adapters`
 - Add forbidden contract `core-stores-no-sqlite` blocking `aiosqlite` + `sqlite3` from `lyra.core.stores`
+- **Surgery on `src/lyra/core/stores/__init__.py`:** remove `from .sqlite_base import SqliteStore` and drop `SqliteStore` + `AgentStore` + `AuthStore` + `IdentityAliasStore` from `__all__`. Keep only `AgentStoreProtocol`, `make_agent_store`. Required BEFORE the forbidden contract activates, because the current `__init__.py` has a module-level `from .sqlite_base import SqliteStore` which would create a direct `core.stores → aiosqlite` chain that the forbidden contract catches. Callers that import `SqliteStore` from `lyra.core.stores` (not from `.sqlite_base`) must update in this PR too; survey: `grep -rn 'from lyra.core.stores import.*SqliteStore\|from lyra.core.stores import.*AgentStore\|from lyra.core.stores import.*AuthStore' src/ tests/`.
 
-**Verify:** `uv run lint-imports` passes. Contract is vacuous (no files moved yet) — this is expected.
+**Verify:** `uv run lint-imports` passes. Both the layers contract and the forbidden contract are active. The forbidden contract passes because `__init__.py` no longer re-exports `SqliteStore`; individual implementation files still live under `lyra.core.stores` but their `aiosqlite` imports are already there (pre-existing state, contract shape does not flag them until `source_modules` resolution walks into them via `__init__`). If CI fails on PR 1, the __init__.py surgery scope is wider than expected — expand this PR rather than defer.
 
 **Rollback:** Revert single PR. No callers affected.
 
@@ -114,6 +117,7 @@ lyra.hub, lyra.adapters, lyra.agents, lyra.commands (type-hint against protocols
 - Move → `src/lyra/infrastructure/stores/auth_store.py`
 - Shim → update callers → delete shim
 - Update `src/lyra/infrastructure/CLAUDE.md`
+- Decide treatment of `src/lyra/core/authenticator.py`'s function-body `AuthStore` import. Options: (a) DI refactor + new `AuthStoreProtocol`; (b) `exclude_modules` entry for `lyra.core.authenticator`. Confirm choice in PR description.
 
 **Callers to check:** `bootstrap_stores.py`, `bootstrap_wiring.py`, any auth middleware.
 
@@ -131,6 +135,7 @@ lyra.hub, lyra.adapters, lyra.agents, lyra.commands (type-hint against protocols
 
 **Tasks:** Same pattern.
 - Callers: `commands/identity/handlers.py`, `bootstrap_stores.py`, related tests.
+- Apply same treatment decided in PR 4 to `core/authenticator.py`'s `IdentityAliasStore` import.
 
 ---
 
@@ -197,7 +202,7 @@ _Policy slot, not a dedicated move. Use ONLY if a per-store PR (PRs 2–11) need
 
 **Verify:**
 - `grep -r "aiosqlite" src/lyra/core/` returns nothing
-- `grep -r "sqlite3" src/lyra/core/stores/` returns nothing (excluding `pairing_config.py` DDL constants if present — verify)
+- `grep -r "sqlite3" src/lyra/core/stores/` returns nothing
 - `uv run lint-imports` passes (layering + forbidden contract)
 - `uv run pytest` passes
 - `ls src/lyra/core/stores/` shows exactly: `__init__.py`, `agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py`
@@ -244,9 +249,22 @@ _Policy slot, not a dedicated move. Use ONLY if a per-store PR (PRs 2–11) need
 
 ## Consistency Report
 
-- Criteria covered: 9/9 (all success criteria from spec have at least one verifying task)
 - No gold plating: business logic changes explicitly deferred (pairing.py behavior OUT of scope)
 - No schema changes in scope
+
+### Success Criteria → PR Traceability
+
+| # | Success Criterion (from spec) | Verified in PR | Check |
+|---|-------------------------------|:--------------:|-------|
+| 1 | `src/lyra/infrastructure/stores/` contains the 10 moved implementation files | PR 2–11 | `ls src/lyra/infrastructure/stores/` shows 10 files after PR 11 |
+| 2 | `src/lyra/core/stores/` contains exactly: `__init__.py`, `agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py` | Final | `ls src/lyra/core/stores/` diff |
+| 3 | `grep -r "aiosqlite" src/lyra/core/` returns nothing | Final | grep check |
+| 4 | `grep -r "sqlite3" src/lyra/core/stores/` returns nothing | Final | grep check |
+| 5 | `uv run lint-imports` passes (layering + forbidden contract both satisfied) | PR 1 activates, verified every PR | CI gate |
+| 6 | `uv run pytest` passes unchanged | Every PR | CI gate |
+| 7 | `src/lyra/core/CLAUDE.md` has no SQLite implementation entries; retains protocol entries | Final | diff check |
+| 8 | `src/lyra/infrastructure/CLAUDE.md` exists and lists all 10 moved files | PR 1 (initial) + Final (complete) | presence check |
+| 9 | No re-export shims remain in `core/stores/` | Every per-store PR deletes its own shim; Final verifies | `ls src/lyra/core/stores/` diff |
 
 ## Task IDs
 

--- a/artifacts/specs/653-stores-infrastructure-spec.mdx
+++ b/artifacts/specs/653-stores-infrastructure-spec.mdx
@@ -77,15 +77,15 @@ The shim MUST NOT import `aiosqlite` directly — the forbidden contract activat
 **1. Extended layering contract** — `lyra.infrastructure` inserted between `lyra.llm | lyra.nats` and `lyra.adapters`:
 
 ```ini
-[importlinter:contract:layers]
-name = Lyra layer ordering
+[importlinter:contract:clean-architecture-layers]
+name = Clean architecture layers (core ← llm/nats ← infrastructure ← adapters ← bootstrap)
 type = layers
 layers =
-    lyra.core
-    lyra.llm | lyra.nats
-    lyra.infrastructure
-    lyra.adapters
     lyra.bootstrap
+    lyra.adapters
+    lyra.infrastructure
+    lyra.llm | lyra.nats
+    lyra.core
 ```
 
 **2. New forbidden contract** — blocks SQLite drivers from entering `lyra.core`:
@@ -99,6 +99,7 @@ source_modules =
 forbidden_modules =
     aiosqlite
     sqlite3
+allow_indirect_imports = true
 ```
 
 ### Dependency Graph After Migration
@@ -188,15 +189,17 @@ classDiagram
 
 **Edge case — mock patch strings:** Two mock patch strings in `tests/cli/test_cli_setup.py` use the full dotted path to `credential_store`. These must be updated to `lyra.infrastructure.stores.credential_store.*` or patched at the `bootstrap` import site, whichever is correct for the test's intent.
 
+> **Architectural violation site — `src/lyra/core/authenticator.py`:** function-body imports of `AuthStore` and `IdentityAliasStore` (verified: lines ~17-18). After migration this becomes `lyra.core → lyra.infrastructure` — a downward import that violates the `layers` contract. Resolution options: (a) refactor `authenticator.py` to receive store instances via DI and type-hint against `AuthStoreProtocol` / `IdentityAliasStoreProtocol` (requires creating those protocols first — additional scope); (b) add `lyra.core.authenticator` to the `layers` contract's `exclude_modules` list as a documented exception. Option (a) is preferred long-term; option (b) is acceptable as a transitional accommodation if `authenticator.py` refactoring is out of scope. Track as a follow-up decision during PR 4 (`auth_store.py` move) and PR 6 (`identity_alias_store.py` move).
+
 ## Slices
 
-| Slice | Description | Demo |
-|-------|-------------|------|
-| V1 | Prep: create `infrastructure/`, extend `.importlinter`, verify CI passes (contract vacuous until first move) | `uv run lint-imports` passes |
-| V2 | Move `sqlite_base.py`, add shim at `core/stores/sqlite_base.py`, update callers | `grep -r "from lyra.core.stores.sqlite_base" src/` returns nothing |
-| V3 | Move `agent_store.py`, add shim, update callers, delete shim | `grep -r "from lyra.core.stores.agent_store import" src/ tests/` returns nothing (protocol stays) |
-| V4–V11 | One PR per remaining store (any order): auth, credential, identity_alias, message_index, pairing, prefs, thread, turn | Per-store: `grep -r "from lyra.core.stores.<x>" src/ tests/` returns nothing |
-| V12 | Final cleanup: `core/stores/__init__.py` surgery (remove SqliteStore re-export), update `core/CLAUDE.md`, create `infrastructure/CLAUDE.md` | `grep "aiosqlite" src/lyra/core/` returns nothing |
+| Slice | Plan PR(s) | Description | Demo |
+|-------|-----------|-------------|------|
+| V1 | PR 1 | Prep: create `infrastructure/`, extend `.importlinter`, __init__.py surgery, verify CI passes | `uv run lint-imports` passes |
+| V2 | PR 2 | Move `sqlite_base.py`, add shim at `core/stores/sqlite_base.py`, update callers | `grep -r "from lyra.core.stores.sqlite_base" src/` returns nothing |
+| V3 | PR 3 | Move `agent_store.py`, add shim, update callers, delete shim | `grep -r "from lyra.core.stores.agent_store import" src/ tests/` returns nothing (protocol stays) |
+| V4–V11 | PR 4–11 | One PR per remaining store: auth, credential, identity_alias, message_index, pairing, prefs, thread, turn | Per-store: `grep -r "from lyra.core.stores.<x>" src/ tests/` returns nothing |
+| V12 | PR Final | Final cleanup: remove shims, verify __init__.py surgery complete, update `core/CLAUDE.md`, finalize `infrastructure/CLAUDE.md` | `grep "aiosqlite" src/lyra/core/` returns nothing |
 
 ## Constraints
 
@@ -206,6 +209,7 @@ classDiagram
 - `src/lyra/core/CLAUDE.md` must be updated to remove implementation file entries, retain protocol entries
 - `src/lyra/infrastructure/CLAUDE.md` must be created (project CLAUDE.md hygiene rule)
 - CI gate `uv run lint-imports` at `.github/workflows/ci.yml:32` — no new CI wiring needed
+- During the shim period, the `layers` contract would flag `lyra.core.stores.<x>` → `lyra.infrastructure.stores.<x>` as a forbidden downward import (core → infrastructure). Each per-store PR that adds a shim MUST also add the shim module path to the `layers` contract's `exclude_modules` list, and remove it when the shim is deleted. Document as part of each store's PR checklist.
 
 ## Non-Goals
 
@@ -222,7 +226,7 @@ classDiagram
 - [ ] `src/lyra/infrastructure/stores/` contains the 10 moved implementation files
 - [ ] `src/lyra/core/stores/` contains exactly: `__init__.py`, `agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py`
 - [ ] `grep -r "aiosqlite" src/lyra/core/` returns nothing
-- [ ] `grep -r "sqlite3" src/lyra/core/stores/` returns nothing (except `pairing_config.py` DDL constants if any — verify)
+- [ ] `grep -r "sqlite3" src/lyra/core/stores/` returns nothing
 - [ ] `uv run lint-imports` passes (layering + forbidden contract both satisfied)
 - [ ] `uv run pytest` passes unchanged
 - [ ] `src/lyra/core/CLAUDE.md` has no SQLite implementation entries; retains protocol entries

--- a/artifacts/specs/653-stores-infrastructure-spec.mdx
+++ b/artifacts/specs/653-stores-infrastructure-spec.mdx
@@ -1,0 +1,234 @@
+---
+title: "Spec: Introduce lyra.infrastructure layer — move SQLite store implementations from core/stores/ to infrastructure/stores/"
+description: Relocate 10 SQLite store implementations to the new lyra.infrastructure layer, leaving protocols and test doubles in core/stores/, to restore the clean-architecture dependency rule.
+issue: 653
+status: approved
+tier: F-lite
+date: 2026-04-16
+---
+
+## Context
+
+**GitHub issue:** #653
+**Promoted from:** [Frame: stores infrastructure](../frames/653-stores-infrastructure-frame.mdx)
+**ADR authority:** [ADR-048](../../docs/architecture/adr/048-lyra-infrastructure-layer-for-persistence.mdx)
+
+`src/lyra/core/stores/` violates the clean-architecture rule that `lyra.core`, the innermost layer, must have zero infrastructure imports. Ten files import `aiosqlite` / `sqlite3` directly or inherit from `SqliteStore` which does. The violation is currently invisible to import-linter (lazy function-body imports bypass static analysis) but is real at runtime.
+
+The original issue #653 targeted `adapters/stores/` as the destination. ADR-048 rejected that path — placing SQLite persistence inside `lyra.adapters` (I/O transport channels) erodes the taxonomy. The accepted decision is Option C: a new `lyra.infrastructure` layer between `lyra.llm | lyra.nats` and `lyra.adapters`.
+
+## Goal
+
+Move the 10 SQLite implementation files from `src/lyra/core/stores/` to `src/lyra/infrastructure/stores/`. Leave the 3 infrastructure-free files (`agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py`) in `core/stores/`. Update all 84 affected import lines. Add the `lyra.infrastructure` layer to `.importlinter` and enforce a forbidden contract blocking `aiosqlite` / `sqlite3` from `lyra.core.stores`. Zero behavior changes.
+
+## Users & Use Cases
+
+- **Primary:** Developers maintaining clean architecture boundaries — `core/` becomes importable with zero infra deps
+- **Secondary:** CI pipeline — import-linter enforcement of the forbidden contract becomes viable the moment the prep PR merges
+
+## Expected Behavior
+
+### File Classification
+
+**MOVE to `src/lyra/infrastructure/stores/`** (10 files — all import `aiosqlite` directly or inherit `SqliteStore`):
+
+| File | Notes |
+|------|-------|
+| `sqlite_base.py` | Base class — imports `aiosqlite` and `sqlite3` directly. Move FIRST. |
+| `agent_store.py` | SQLite + write-through cache for agent config |
+| `auth_store.py` | SQLite + write-through cache for authorization grants |
+| `credential_store.py` | SQLite-backed encrypted bot token storage |
+| `identity_alias_store.py` | SQLite — cross-platform identity linking |
+| `message_index.py` | SQLite — session routing index for reply-to resume |
+| `pairing.py` | SQLite — `PairingManager`, invite-code access control. Moves because it inherits `SqliteStore`, NOT because of its business responsibility. Business logic concerns are out of scope. |
+| `prefs_store.py` | SQLite — per-user TTS/STT preferences |
+| `thread_store.py` | SQLite — Discord thread ownership persistence |
+| `turn_store.py` | SQLite — raw conversation turn logging (L1 memory) |
+
+**STAY in `src/lyra/core/stores/`** (3 files — zero infrastructure deps):
+
+| File | Notes |
+|------|-------|
+| `agent_store_protocol.py` | Defines `AgentStoreProtocol` + `make_agent_store()` factory — zero SQLite dep. The partially-executed prototype this ADR generalises. |
+| `json_agent_store.py` | Test double for `AgentStore` — in-memory + JSON file, no `aiosqlite`. Activated via `LYRA_DB=json`. Stays in `core/` because it has zero infrastructure imports and is the seam that enables store-level unit tests without infrastructure. |
+| `pairing_config.py` | Pure Pydantic dataclass (`PairingConfig`, `PairingError`, SQL DDL constants) — no DB logic, no `aiosqlite`. |
+
+**SURGERY required:**
+
+| File | Action |
+|------|--------|
+| `core/stores/__init__.py` | Currently re-exports `SqliteStore` from `sqlite_base`, pulling `aiosqlite` at package-import time. Must be updated: remove `SqliteStore` re-export; export only protocol-safe symbols (`AgentStoreProtocol`, `make_agent_store`) once `sqlite_base.py` moves. |
+
+### Transition Shim Pattern
+
+During migration, a re-export shim is placed at the old path for each moved file:
+
+```python
+# core/stores/sqlite_base.py  (shim — temporary)
+from lyra.infrastructure.stores.sqlite_base import SqliteStore  # noqa: F401
+```
+
+The shim MUST NOT import `aiosqlite` directly — the forbidden contract activates on the prep PR and will reject any such import in `lyra.core.stores`. The shim is deleted in the same PR that moves its store file (or a follow-up PR after all callers are updated).
+
+### Import-Linter Contract Changes
+
+`.importlinter` gains two changes:
+
+**1. Extended layering contract** — `lyra.infrastructure` inserted between `lyra.llm | lyra.nats` and `lyra.adapters`:
+
+```ini
+[importlinter:contract:layers]
+name = Lyra layer ordering
+type = layers
+layers =
+    lyra.core
+    lyra.llm | lyra.nats
+    lyra.infrastructure
+    lyra.adapters
+    lyra.bootstrap
+```
+
+**2. New forbidden contract** — blocks SQLite drivers from entering `lyra.core`:
+
+```ini
+[importlinter:contract:core-stores-no-sqlite]
+name = core/stores protocols must not import SQLite drivers
+type = forbidden
+source_modules =
+    lyra.core.stores
+forbidden_modules =
+    aiosqlite
+    sqlite3
+```
+
+### Dependency Graph After Migration
+
+```
+lyra.core.stores (protocols)
+    ↑ imported by
+lyra.infrastructure.stores (implementations — imports aiosqlite, lyra.core.stores)
+    ↑ imported by
+lyra.bootstrap.bootstrap_stores (factories — make_xxx_store)
+    ↑ imported by
+lyra.hub, lyra.adapters, lyra.agents, lyra.commands (consumers — see protocol only)
+```
+
+No arrow from `lyra.infrastructure` to `lyra.adapters` or above. No arrow from `lyra.core` to `lyra.infrastructure`.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class SqliteStore {
+        &lt;&lt;abstract&gt;&gt;
+        +db_path: Path
+        +db: Connection
+    }
+
+    class AgentStore
+    class AuthStore
+    class CredentialStore
+    class IdentityAliasStore
+    class PrefsStore
+    class ThreadStore
+    class TurnStore
+    class MessageIndex
+    class PairingManager
+
+    SqliteStore &lt;|-- AgentStore
+    SqliteStore &lt;|-- AuthStore
+    SqliteStore &lt;|-- CredentialStore
+    SqliteStore &lt;|-- IdentityAliasStore
+    SqliteStore &lt;|-- PrefsStore
+    SqliteStore &lt;|-- ThreadStore
+    SqliteStore &lt;|-- TurnStore
+    SqliteStore &lt;|-- MessageIndex
+    SqliteStore &lt;|-- PairingManager
+```
+
+| Consumer | Stores Used | When |
+|----------|-------------|------|
+| Hub | AgentStore, TurnStore, ThreadStore | Every request |
+| Bootstrap (`bootstrap_stores.py`) | All stores | Startup — only site that imports from `lyra.infrastructure.stores` |
+| Adapters (Telegram, Discord) | TurnStore, ThreadStore | Every message |
+| Commands (identity, pairing) | IdentityAliasStore, PairingManager | On-demand |
+
+## Call-Site Breadboard
+
+### Summary
+
+| Scope | Import lines | Type |
+|-------|-------------|------|
+| `src/lyra/` | ~56 module-level | Visible to import-linter today |
+| `src/lyra/` | ~28 function-body | Currently invisible to import-linter |
+| `tests/` | 27 files | Must update; includes mock patch strings |
+| **Total** | **84 import lines, 50 files** | |
+
+### src/ consumers (representative — not exhaustive)
+
+| File | Old import root | New import root |
+|------|----------------|----------------|
+| `bootstrap/bootstrap_stores.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+| `bootstrap/bootstrap_wiring.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+| `adapters/adapter_standalone.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+| `adapters/telegram.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+| `adapters/discord.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+| `commands/identity/handlers.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+| `commands/pairing/handlers.py` | `lyra.core.stores.*` | `lyra.infrastructure.stores.*` |
+
+### tests/ consumers (representative — not exhaustive)
+
+| File | Notes |
+|------|-------|
+| `tests/core/conftest.py` | 6 import lines |
+| `tests/core/test_json_agent_store.py` | 9 import lines — `json_agent_store` stays in `core/`; imports stay at `lyra.core.stores` |
+| `tests/cli/test_cli_setup.py` | Mock patch strings: `"lyra.core.stores.credential_store.*"` → `"lyra.infrastructure.stores.credential_store.*"` |
+
+**Edge case — `test_json_agent_store.py`:** `json_agent_store.py` STAYS in `core/stores/`. Its test imports from `lyra.core.stores.json_agent_store` — these do NOT change.
+
+**Edge case — mock patch strings:** Two mock patch strings in `tests/cli/test_cli_setup.py` use the full dotted path to `credential_store`. These must be updated to `lyra.infrastructure.stores.credential_store.*` or patched at the `bootstrap` import site, whichever is correct for the test's intent.
+
+## Slices
+
+| Slice | Description | Demo |
+|-------|-------------|------|
+| V1 | Prep: create `infrastructure/`, extend `.importlinter`, verify CI passes (contract vacuous until first move) | `uv run lint-imports` passes |
+| V2 | Move `sqlite_base.py`, add shim at `core/stores/sqlite_base.py`, update callers | `grep -r "from lyra.core.stores.sqlite_base" src/` returns nothing |
+| V3 | Move `agent_store.py`, add shim, update callers, delete shim | `grep -r "from lyra.core.stores.agent_store import" src/ tests/` returns nothing (protocol stays) |
+| V4–V11 | One PR per remaining store (any order): auth, credential, identity_alias, message_index, pairing, prefs, thread, turn | Per-store: `grep -r "from lyra.core.stores.<x>" src/ tests/` returns nothing |
+| V12 | Final cleanup: `core/stores/__init__.py` surgery (remove SqliteStore re-export), update `core/CLAUDE.md`, create `infrastructure/CLAUDE.md` | `grep "aiosqlite" src/lyra/core/` returns nothing |
+
+## Constraints
+
+- No behavior changes — pure structural relocation
+- Shims MUST NOT re-import `aiosqlite` (forbidden contract active from prep PR)
+- Each PR must be independently mergeable and revertable
+- `src/lyra/core/CLAUDE.md` must be updated to remove implementation file entries, retain protocol entries
+- `src/lyra/infrastructure/CLAUDE.md` must be created (project CLAUDE.md hygiene rule)
+- CI gate `uv run lint-imports` at `.github/workflows/ci.yml:32` — no new CI wiring needed
+
+## Non-Goals
+
+- `pairing.py` business-logic refactoring
+- `packages/roxabi-persistence/` extraction (explicitly out of scope per ADR-048)
+- Protocol interface changes
+- New stores
+- SQLite schema or query changes
+- Performance optimizations
+- Renaming `core/stores/` to `core/ports/` (deliberate non-change per ADR-048)
+
+## Success Criteria
+
+- [ ] `src/lyra/infrastructure/stores/` contains the 10 moved implementation files
+- [ ] `src/lyra/core/stores/` contains exactly: `__init__.py`, `agent_store_protocol.py`, `json_agent_store.py`, `pairing_config.py`
+- [ ] `grep -r "aiosqlite" src/lyra/core/` returns nothing
+- [ ] `grep -r "sqlite3" src/lyra/core/stores/` returns nothing (except `pairing_config.py` DDL constants if any — verify)
+- [ ] `uv run lint-imports` passes (layering + forbidden contract both satisfied)
+- [ ] `uv run pytest` passes unchanged
+- [ ] `src/lyra/core/CLAUDE.md` has no SQLite implementation entries; retains protocol entries
+- [ ] `src/lyra/infrastructure/CLAUDE.md` exists and lists all 10 moved files
+- [ ] No re-export shims remain in `core/stores/`
+
+## Open Questions
+
+None — ADR-048 is accepted and resolves all architectural choices.

--- a/artifacts/specs/653-stores-infrastructure-spec.mdx
+++ b/artifacts/specs/653-stores-infrastructure-spec.mdx
@@ -213,7 +213,7 @@ classDiagram
 
 ## Non-Goals
 
-- `pairing.py` business-logic refactoring
+- `pairing.py` business-logic refactoring — tracked separately in #751 (blocked by this issue)
 - `packages/roxabi-persistence/` extraction (explicitly out of scope per ADR-048)
 - Protocol interface changes
 - New stores

--- a/docs/architecture/adr/048-lyra-infrastructure-layer-for-persistence.mdx
+++ b/docs/architecture/adr/048-lyra-infrastructure-layer-for-persistence.mdx
@@ -1,0 +1,228 @@
+---
+title: "ADR-048: Introduce lyra.infrastructure layer for persistence — move SQLite store implementations out of lyra.core"
+description: Add a new lyra.infrastructure layer between lyra.core and lyra.adapters to house SQLite store implementations, eliminating the aiosqlite import violation in the innermost layer while preserving dependency-inversion via protocols in core/stores/.
+---
+
+## Status
+
+Accepted
+
+## Context
+
+### Current layering
+
+Import-linter enforces the following dependency order (innermost to outermost):
+
+```
+lyra.core ← lyra.llm | lyra.nats ← lyra.adapters ← lyra.bootstrap
+```
+
+`lyra.core` is the innermost layer. By the dependency rule, it must have zero infrastructure dependencies — no database drivers, no I/O libraries, no framework imports.
+
+### The violation
+
+`src/lyra/core/stores/sqlite_base.py` imports both `aiosqlite` and `sqlite3`. This places SQLite drivers inside `lyra.core`, which is a clean-architecture violation: the innermost layer is importing from infrastructure.
+
+The violation is currently **undetected by import-linter** because most store-module imports are inside function bodies (lazy imports). Import-linter performs module-level static analysis only; function-body imports are invisible to it. The violation is real at runtime — `aiosqlite` is loaded whenever the store methods execute — but no CI gate catches it today.
+
+### Scope of the problem
+
+14 files live in `src/lyra/core/stores/` (13 `.py` + `__init__.py`), classified below by what moves and what stays:
+
+**Moves to `infrastructure/stores/` — SQLite implementations (inherit `SqliteStore` or import `aiosqlite` directly):**
+
+| File | Notes |
+|---|---|
+| `sqlite_base.py` | Base class — imports `aiosqlite` and `sqlite3` directly |
+| `agent_store.py` | SQLite + write-through cache for agent config |
+| `auth_store.py` | SQLite + write-through cache for authorization grants |
+| `credential_store.py` | SQLite-backed encrypted bot token storage |
+| `identity_alias_store.py` | SQLite — cross-platform identity linking |
+| `message_index.py` | SQLite — session routing index for reply-to resume |
+| `pairing.py` | SQLite — `PairingManager`, invite-code access control |
+| `prefs_store.py` | SQLite — per-user TTS/STT preferences |
+| `thread_store.py` | SQLite — Discord thread ownership persistence |
+| `turn_store.py` | SQLite — raw conversation turn logging (L1 memory) |
+
+**Stays in `core/stores/` — no infrastructure deps:**
+
+| File | Notes |
+|---|---|
+| `agent_store_protocol.py` | Defines `AgentStoreProtocol` + `make_agent_store()` factory — zero SQLite dep; the partially-executed prototype this ADR generalises |
+| `json_agent_store.py` | Test double for `AgentStore` — in-memory + JSON file, no `aiosqlite`. Activated via `LYRA_DB=json`. Stays in `core/` because it has zero infrastructure imports and is the seam that makes store-level unit tests infrastructure-free. |
+| `pairing_config.py` | Pure Pydantic dataclass (`PairingConfig`, `PairingError`, SQL DDL constants) — no DB logic, no `aiosqlite`. Noted explicitly in `src/lyra/core/CLAUDE.md` as "sibling dataclass with no DB logic". |
+
+**Requires surgery during migration:**
+
+| File | Action |
+|---|---|
+| `__init__.py` | Currently re-exports `SqliteStore` from `sqlite_base`, pulling `aiosqlite` at package-import time. Must be updated to export only protocol-safe symbols (`AgentStoreProtocol`, `make_agent_store`) once `sqlite_base.py` moves. |
+
+Call-site survey: **84 total `from lyra.core.stores` import lines** across `src/lyra/` and `tests/` — **56 module-level** (visible to import-linter) and **28 function-body / lazy** (currently invisible to import-linter, but real at runtime).
+
+The existence of `agent_store_protocol.py` alongside `agent_store.py` shows the protocol-first instinct was already partially executed for one store — this ADR generalises that instinct to all stores and gives it a structural home.
+
+### Why this ADR supersedes issue #653's original approach
+
+Issue #653 originally scoped the fix as moving store implementations from `core/stores/` to `adapters/stores/` (Option A below). A worktree was created on branch `feat/653-stores-relocation` with 77 renamed files. That branch is being abandoned: the `adapters/` destination conflates persistence concerns with I/O transport concerns (Telegram, Discord, CLI, NATS adapters currently occupy `adapters/`), eroding the taxonomy. This ADR establishes the correct destination.
+
+## Options Considered
+
+### Option A: Move implementations to `adapters/stores/`
+
+The original proposal from issue #653. Move the 10 SQLite implementation files from `core/stores/` to `adapters/stores/`.
+
+- **Pros:** Minimal structural change. No new layer in the import graph. `adapters/` already sits outside `core/`, so `aiosqlite` imports become legal.
+- **Cons:** `lyra.adapters` currently means I/O transport adapters — the concrete implementations of Telegram, Discord, CLI, and NATS channels. Placing SQLite persistence implementations alongside them conflates two fundamentally different responsibilities under one label: "adapter" then means both "how lyra speaks to a messaging platform" and "how lyra persists data". Taxonomy erosion accumulates technical debt as future infrastructure concerns (telemetry, filesystem, cache) would have no principled home and would also land in `adapters/`, further diluting the concept.
+
+### Option B: Protocols-only extraction, keep implementations in `core/stores/` with factory indirection
+
+Keep all 13 files in `core/stores/`. Extract protocols for all stores (following the `agent_store_protocol.py` prototype). Callers type-hint against protocols. Implementations remain in `core/` but are hidden behind a factory (`make_agent_store()`, already present in `agent_store_protocol.py`).
+
+- **Pros:** Smallest change surface. Factory pattern already prototyped for one store. No new layer, no new directory structure.
+- **Cons:** `aiosqlite` remains in `lyra.core`. The dependency rule violation persists at runtime — only the call-site visibility is altered. Import-linter's module-level analysis still cannot catch the in-body imports. This approach hides the structural problem rather than fixing it: protocols and SQLite implementations continue to cohabit the innermost layer.
+
+### Option C: New `lyra.infrastructure` layer for persistence (chosen)
+
+Add `src/lyra/infrastructure/` as a new module sitting between `lyra.llm | lyra.nats` and `lyra.adapters` in the layering order. Move the 10 SQLite implementation files there. Leave protocols, the JSON test double, and the `PairingConfig` dataclass in `src/lyra/core/stores/`.
+
+- **Pros:** Clean taxonomy — `adapters/` = I/O transport channels; `infrastructure/` = persistence, telemetry, filesystem. The dependency rule is fully restored: `lyra.core` becomes genuinely infrastructure-free. Import-linter can enforce both the new layer ordering and an explicit forbidden contract on `core/stores/`. Opens a principled extension point for future cross-cutting concerns (`infrastructure/telemetry/`, `infrastructure/fs/`) without polluting either `core/` or `adapters/`. Dependency inversion is preserved: protocols in `core/`, implementations in `infrastructure/`, callers type-hint against protocols.
+- **Cons:** Adds one layer to the import graph. Import-linter contract requires a new `lyra.infrastructure` entry. 84 import lines across `src/lyra/` and `tests/` must be updated (56 module-level + 28 function-body). Three to four PRs of mechanical work.
+
+## Decision
+
+**Option C — introduce `lyra.infrastructure` as a new architectural layer.**
+
+The taxonomy argument is decisive. `lyra.adapters` is a named concept with a specific meaning in this codebase (platform I/O channels). Introducing persistence implementations there would be coherent only if "adapter" means "anything that is not core" — which is not how it has been used in any ADR to date. A dedicated `infrastructure/` layer maintains the conceptual integrity of both the `adapters/` label and the dependency-inversion pattern, at the cost of one additional layer entry.
+
+Option B is rejected because it does not fix the violation — it only obscures it. Option A is rejected because it degrades the taxonomy without compensating benefit.
+
+## Design
+
+### New layer structure
+
+```
+src/lyra/
+├── core/
+│   └── stores/               # zero-infra files only after migration
+│       ├── __init__.py                  # re-exports protocol-safe symbols only
+│       ├── agent_store_protocol.py      # AgentStoreProtocol + make_agent_store()
+│       ├── json_agent_store.py          # test double — no aiosqlite
+│       └── pairing_config.py            # PairingConfig dataclass — no DB logic
+├── infrastructure/
+│   └── stores/               # all SQLite implementations — aiosqlite freely imported
+│       ├── sqlite_base.py               # moved from core/stores/ — SqliteStore base
+│       ├── agent_store.py               # moved from core/stores/
+│       ├── auth_store.py                # moved from core/stores/
+│       ├── credential_store.py          # moved from core/stores/
+│       ├── identity_alias_store.py      # moved from core/stores/
+│       ├── message_index.py             # moved from core/stores/
+│       ├── pairing.py                   # moved from core/stores/ — PairingManager
+│       ├── prefs_store.py               # moved from core/stores/
+│       ├── thread_store.py              # moved from core/stores/
+│       └── turn_store.py                # moved from core/stores/
+├── llm/
+├── nats/
+├── adapters/                 # I/O transport channels only — Telegram, Discord, CLI, NATS
+└── bootstrap/
+    └── bootstrap_stores.py   # factory wiring — make_xxx_store() functions (already exists)
+```
+
+Protocols remain in `src/lyra/core/stores/`. The directory name `stores/` is retained (not renamed to `ports/`) — the codebase already uses `stores/` as a recognized label in CLAUDE.md, ARCHITECTURE.md, and existing ADRs. Renaming to `ports/` would be a documentation churn cost with no functional benefit at this stage. Future cleanup can rename if the `ports/` vocabulary becomes standard across other core sub-directories.
+
+### Updated import-linter contract
+
+The `.importlinter` contract file gains two changes:
+
+**1. Extended layering contract** — `lyra.infrastructure` is inserted between `lyra.llm | lyra.nats` and `lyra.adapters`:
+
+```ini
+[importlinter:contract:layers]
+name = Lyra layer ordering
+type = layers
+layers =
+    lyra.core
+    lyra.llm | lyra.nats
+    lyra.infrastructure
+    lyra.adapters
+    lyra.bootstrap
+```
+
+**2. New forbidden contract** — explicitly blocks SQLite drivers from entering `lyra.core`:
+
+```ini
+[importlinter:contract:core-stores-no-sqlite]
+name = core/stores protocols must not import SQLite drivers
+type = forbidden
+source_modules =
+    lyra.core.stores
+forbidden_modules =
+    aiosqlite
+    sqlite3
+```
+
+This contract makes the violation detectable at the module level going forward, closing the gap that lazy imports previously exploited.
+
+### Factory wiring
+
+`src/lyra/bootstrap/bootstrap_stores.py` (already exists) houses `make_xxx_store()` factory functions. These are the only sites that import from `lyra.infrastructure.stores`. All other callers — hub, agents, commands, adapters — receive store instances through dependency injection and type-hint against the protocols in `lyra.core.stores`.
+
+No DI container is introduced. The bootstrap layer is the composition root; factories are plain functions.
+
+### Dependency graph after migration
+
+```
+lyra.core.stores (protocols)
+    ↑ imported by
+lyra.infrastructure.stores (implementations — imports aiosqlite, lyra.core.stores)
+    ↑ imported by
+lyra.bootstrap.bootstrap_stores (factories — make_xxx_store)
+    ↑ imported by
+lyra.hub, lyra.adapters, lyra.agents, lyra.commands (consumers — see protocol only)
+```
+
+No arrow points from `lyra.infrastructure` to `lyra.adapters` or above. No arrow points from `lyra.core` to `lyra.infrastructure`.
+
+### Relation to ADR-045 (roxabi-nats subpackage)
+
+`packages/roxabi-nats/` was extracted because it has external consumers (voiceCLI, imageCLI, roxabi-vault). Store implementations have no external consumers — they are lyra-internal only. This ADR does NOT follow the workspace-subpackage path. Store implementations stay inside `src/lyra/infrastructure/` as a plain module, not a uv subpackage.
+
+A future `packages/roxabi-persistence/` promotion is noted as a possible trajectory IF a second Roxabi project (e.g., 2ndBrain) needs the same SQLite store pattern. That promotion requires its own ADR and is explicitly out of scope here.
+
+### Migration sequencing
+
+Issue #417 (auth.db → config.db schema split) is CLOSED. The migration-sequencing blocker from earlier drafts no longer applies — this work can proceed whenever. No active schema migration conflicts with the layer relocation.
+
+Rollout is incremental, store-by-store:
+
+1. **Per-store PR pattern:** Move `infrastructure/stores/<x>.py`. Add a re-export shim at the old path `core/stores/<x>.py` (`from lyra.infrastructure.stores.<x> import XxxStore`). Update call sites in the same PR or a follow-up. Delete the shim once all call sites are updated.
+2. **Order:** `sqlite_base.py` first (it is the shared base class; all implementation files depend on it). Agent store second (protocol already partially drafted). Remaining stores in any order.
+3. **Import-linter forbidden contract** activates on the first PR that moves `sqlite_base.py`. The shim at `core/stores/sqlite_base.py` must re-export without importing `aiosqlite` directly — the forbidden contract will catch any violation immediately.
+
+### CI gate
+
+`uv run lint-imports` is already gated in CI (`.github/workflows/ci.yml:32`). The new forbidden contract on `lyra.core.stores` will be enforced from the first PR that adds it to `.importlinter`. No new CI wiring required.
+
+## Consequences
+
+### Positive
+
+- `lyra.core` becomes genuinely infrastructure-free. The dependency rule is restored, not just papered over.
+- Import-linter gains a forbidden contract that makes the `aiosqlite`-in-core violation immediately detectable in CI for all future contributions.
+- `lyra.adapters` retains its precise meaning: I/O transport channels for messaging platforms.
+- `lyra.infrastructure/` is an explicit extension point for future cross-cutting concerns — telemetry, filesystem helpers, cache backends — without requiring another ADR for each addition, only for significant new patterns.
+- Protocols in `core/stores/` are caller-visible without any infrastructure dependency, making them safe to use from any layer.
+
+### Negative
+
+- 10 files move to `infrastructure/stores/`. `core/stores/__init__.py` requires surgery to remove the `SqliteStore` re-export. 84 import lines require updates (56 module-level, 28 function-body) across hub, bootstrap, agents, commands, and adapters.
+- `src/lyra/core/CLAUDE.md` must be updated to remove store implementation entries and retain only protocol entries.
+- A new `src/lyra/infrastructure/CLAUDE.md` must be created per the project CLAUDE.md hygiene rule.
+- Teams working on store-adjacent features must coordinate with the rollout to avoid merge conflicts on the `__init__.py` surgery and the incremental per-store moves.
+
+### Neutral
+
+- The `core/stores/` directory name is retained (not renamed to `core/ports/`). This is a deliberate non-change — existing documentation and CLAUDE.md references remain valid.
+- `packages/roxabi-nats/` is unaffected. Its role as pure NATS transport is orthogonal to persistence infrastructure.
+- `src/lyra/infrastructure/` opens the door to `infrastructure/telemetry/`, `infrastructure/fs/`, etc. — scope of this ADR is stores only. Future additions do not require a new ADR unless they introduce a new cross-cutting pattern.
+- The worktree `feat/653-stores-relocation` (77 renamed files, `adapters/stores/` destination) is abandoned. That branch is superseded by `feat/653-stores-infrastructure`.

--- a/docs/architecture/adr/048-lyra-infrastructure-layer-for-persistence.mdx
+++ b/docs/architecture/adr/048-lyra-infrastructure-layer-for-persistence.mdx
@@ -137,15 +137,15 @@ The `.importlinter` contract file gains two changes:
 **1. Extended layering contract** — `lyra.infrastructure` is inserted between `lyra.llm | lyra.nats` and `lyra.adapters`:
 
 ```ini
-[importlinter:contract:layers]
-name = Lyra layer ordering
+[importlinter:contract:clean-architecture-layers]
+name = Clean architecture layers (core ← llm/nats ← infrastructure ← adapters ← bootstrap)
 type = layers
 layers =
-    lyra.core
-    lyra.llm | lyra.nats
-    lyra.infrastructure
-    lyra.adapters
     lyra.bootstrap
+    lyra.adapters
+    lyra.infrastructure
+    lyra.llm | lyra.nats
+    lyra.core
 ```
 
 **2. New forbidden contract** — explicitly blocks SQLite drivers from entering `lyra.core`:
@@ -159,26 +159,30 @@ source_modules =
 forbidden_modules =
     aiosqlite
     sqlite3
+allow_indirect_imports = true
 ```
 
 This contract makes the violation detectable at the module level going forward, closing the gap that lazy imports previously exploited.
 
+`allow_indirect_imports = true` scopes the contract to *direct* imports only. This accommodates the transitional shim period (see 'Migration sequencing' below), during which a shim at `core/stores/<x>.py` re-exports from `lyra.infrastructure.stores.<x>`. Once all shims are deleted in the Final PR, removing this flag hardens the contract to catch transitive chains too.
+
 ### Factory wiring
 
-`src/lyra/bootstrap/bootstrap_stores.py` (already exists) houses `make_xxx_store()` factory functions. These are the only sites that import from `lyra.infrastructure.stores`. All other callers — hub, agents, commands, adapters — receive store instances through dependency injection and type-hint against the protocols in `lyra.core.stores`.
+`src/lyra/bootstrap/bootstrap_stores.py` (already exists) houses `make_xxx_store()` factory functions. Bootstrap is the only site that imports store **factories** from `lyra.infrastructure.stores`. Adapter modules (Telegram, Discord) additionally import the store **type names** from `lyra.infrastructure.stores` at runtime for per-request access — these type imports are legal under the new layering (`adapters` is above `infrastructure`), but they do mean adapters are non-trivial consumers of `lyra.infrastructure`. Non-adapter callers — hub, agents, commands — receive store instances through dependency injection and type-hint against the protocols in `lyra.core.stores`.
 
 No DI container is introduced. The bootstrap layer is the composition root; factories are plain functions.
 
 ### Dependency graph after migration
 
 ```
+lyra.hub, lyra.adapters, lyra.agents, lyra.commands (consumers — type-hint against protocol)
+    ↓ imports (type-hint only)
 lyra.core.stores (protocols)
     ↑ imported by
-lyra.infrastructure.stores (implementations — imports aiosqlite, lyra.core.stores)
+lyra.infrastructure.stores (implementations — imports aiosqlite + lyra.core.stores for protocol)
     ↑ imported by
-lyra.bootstrap.bootstrap_stores (factories — make_xxx_store)
-    ↑ imported by
-lyra.hub, lyra.adapters, lyra.agents, lyra.commands (consumers — see protocol only)
+lyra.bootstrap.bootstrap_stores (factories — make_xxx_store; only call site for infrastructure factories)
+    + adapters import concrete store TYPES from lyra.infrastructure.stores at runtime
 ```
 
 No arrow points from `lyra.infrastructure` to `lyra.adapters` or above. No arrow points from `lyra.core` to `lyra.infrastructure`.
@@ -188,6 +192,8 @@ No arrow points from `lyra.infrastructure` to `lyra.adapters` or above. No arrow
 `packages/roxabi-nats/` was extracted because it has external consumers (voiceCLI, imageCLI, roxabi-vault). Store implementations have no external consumers — they are lyra-internal only. This ADR does NOT follow the workspace-subpackage path. Store implementations stay inside `src/lyra/infrastructure/` as a plain module, not a uv subpackage.
 
 A future `packages/roxabi-persistence/` promotion is noted as a possible trajectory IF a second Roxabi project (e.g., 2ndBrain) needs the same SQLite store pattern. That promotion requires its own ADR and is explicitly out of scope here.
+
+If no second Roxabi project has required these stores within 12 months of ADR-048 acceptance, the `packages/roxabi-persistence/` extraction is explicitly abandoned — `infrastructure/stores/` remains the permanent home. This negative trigger prevents the deferral from becoming permanent undecided debt.
 
 ### Migration sequencing
 
@@ -207,7 +213,7 @@ Rollout is incremental, store-by-store:
 
 ### Positive
 
-- `lyra.core` becomes genuinely infrastructure-free. The dependency rule is restored, not just papered over.
+- `lyra.core.stores` becomes genuinely infrastructure-free (enforced by the forbidden contract). Other `lyra.core` submodules are not directly covered by this contract — it is scoped to `lyra.core.stores` where the original violation lived. The dependency rule for the stores surface is restored, not just papered over; extending the guard to the rest of `lyra.core` is a follow-up if further violations surface.
 - Import-linter gains a forbidden contract that makes the `aiosqlite`-in-core violation immediately detectable in CI for all future contributions.
 - `lyra.adapters` retains its precise meaning: I/O transport channels for messaging platforms.
 - `lyra.infrastructure/` is an explicit extension point for future cross-cutting concerns — telemetry, filesystem helpers, cache backends — without requiring another ADR for each addition, only for significant new patterns.
@@ -225,4 +231,5 @@ Rollout is incremental, store-by-store:
 - The `core/stores/` directory name is retained (not renamed to `core/ports/`). This is a deliberate non-change — existing documentation and CLAUDE.md references remain valid.
 - `packages/roxabi-nats/` is unaffected. Its role as pure NATS transport is orthogonal to persistence infrastructure.
 - `src/lyra/infrastructure/` opens the door to `infrastructure/telemetry/`, `infrastructure/fs/`, etc. — scope of this ADR is stores only. Future additions do not require a new ADR unless they introduce a new cross-cutting pattern.
+- **Governance rule:** any new subdirectory under `infrastructure/` (e.g. `infrastructure/telemetry/`, `infrastructure/fs/`, `infrastructure/cache/`) requires its own ADR. Adding files to an existing subdirectory does not. This prevents the "junk drawer" drift that would otherwise follow from the "add freely" note above.
 - The worktree `feat/653-stores-relocation` (77 renamed files, `adapters/stores/` destination) is abandoned. That branch is superseded by `feat/653-stores-infrastructure`.

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -44,6 +44,7 @@
     "044-lyra-voicecli-nats-contract",
     "045-roxabi-nats-sdk-uv-workspace-extraction",
     "046-nkey-provisioning-declarative-authconf",
-    "047-nats-connector-ownership-pattern"
+    "047-nats-connector-ownership-pattern",
+    "048-lyra-infrastructure-layer-for-persistence"
   ]
 }


### PR DESCRIPTION
## Summary

- **New architectural layer** — `lyra.infrastructure/` between `core/` and `adapters/`, housing SQLite store implementations.
- **Supersedes** the abandoned `core/stores/ → adapters/stores/` approach (branch `feat/653-stores-relocation`). The `adapters/` layer retains its precise meaning: I/O transport channels (Telegram, Discord, CLI, NATS).
- **Docs + decision only** — no code changes in this PR. Implementation follows as 12 incremental PRs after merge.

## Why this path

| | Option A (adapters/stores/) | Option B (protocols only) | **Option C (infrastructure/) ← chosen** |
|---|---|---|---|
| Taxonomy clean | ❌ mixes transport + persistence | ✓ | ✓ |
| Violation fixed | ✓ | ❌ aiosqlite stays in core/ | ✓ |
| Layer churn | 0 | 0 | +1 layer |

Full rationale in ADR-048.

## Verified facts (not inferred)

- **10 files move** → `infrastructure/stores/`: sqlite_base, agent_store, auth_store, credential_store, identity_alias_store, message_index, pairing, prefs_store, thread_store, turn_store
- **3 files stay** in `core/stores/`: agent_store_protocol (protocol), json_agent_store (test double), pairing_config (pure Pydantic)
- **core/stores/__init__.py surgery** — currently re-exports SqliteStore, pulling aiosqlite at package-import time
- **84 import lines across 50 files** — 56 module-level, 28 function-body (the 28 are why import-linter hasnt caught the violation today)
- **uv run lint-imports already gated** at .github/workflows/ci.yml:32 — no new CI wiring needed
- **#417 closed** — no schema-migration blocker

## Rollout plan (12 PRs, post-merge)

1. Prep: create infrastructure/, extend .importlinter layers, add forbidden contract
2. Move sqlite_base.py + re-export shim + caller updates
3-11. One store per PR (agent_store first since protocol exists)
12. Cleanup: strip __init__.py re-exports, update src/lyra/core/CLAUDE.md

Each PR independently mergeable; rollback = revert the single PR.

## Out of scope (separate follow-ups)

- pairing.py / pairing_config.py dont belong in stores/ conceptually — cleanup issue after #653 closes
- packages/roxabi-persistence/ extraction — only if another project needs the same pattern; new ADR required

Refs #653

## Test plan

- [ ] ADR reviewed by team — taxonomy argument accepted
- [ ] Frame / spec / plan reviewed — 12-PR breakdown realistic
- [x] Pre-commit hooks pass locally (lint / typecheck / import-layers / trufflehog / license)
- [ ] CI green on this PR (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)