### PR TITLE
feat(arch): introduce lyra.infrastructure layer for persistence (PRs 1-3 of 12)

### DIFF
--- a/src/lyra/infrastructure/stores/auth_store.py
+++ b/src/lyra/infrastructure/stores/auth_store.py
@@ -8,8 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from lyra.core.trust import TrustLevel
-
-from .sqlite_base import SqliteStore
+from lyra.infrastructure.stores.sqlite_base import SqliteStore
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- Introduce `lyra.infrastructure` layer to house SQLite store implementations (ADR-048)
- Move `sqlite_base.py` from `core/stores/` to `infrastructure/stores/` (PR 2/12)
- Move `agent_store.py` from `core/stores/` to `infrastructure/stores/` (PR 3/12, merged)
- Add import-linter forbidden contract blocking `aiosqlite`/`sqlite3` from `lyra.core.stores`
- Update all caller imports for moved stores

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #653: move core/stores/ to resolve aiosqlite layer violation | OPEN |
| Frame | [653-stores-infrastructure-frame.mdx](artifacts/frames/653-stores-infrastructure-frame.mdx) | Present |
| Spec | [653-stores-infrastructure-spec.mdx](artifacts/specs/653-stores-infrastructure-spec.mdx) | Present |
| Plan | [653-stores-infrastructure-plan.mdx](artifacts/plans/653-stores-infrastructure-plan.mdx) | Present |
| Implementation | 7 commits on `feat/653-stores-infrastructure` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (71 passed) | Passed |

## Test Plan

- [ ] Verify `uv run lint-imports` passes (forbidden contract active)
- [ ] Verify `uv run pytest` passes
- [ ] Verify imports resolve correctly after store moves

Closes #653

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`