### PR TITLE
feat(contracts): scaffold packages/roxabi-contracts skeleton + envelope.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ See `docs/ARCHITECTURE.md` for full context.
 | `deploy/nats/nats-container.conf` | NATS config for container deployment (no TLS, 0.0.0.0 bind) |
 | `scripts/dep-graph/` | GitHub-driven dep-graph generator (`dep_graph/` package + `layout.schema.json`). Run via `make dep-graph [fetch\|build\|audit\|validate\|open]`. Artifacts (layout.json, gh.json cache, HTML output) live in `~/.roxabi/forge/lyra/visuals/`. Precursor to roxabi-dashboard. |
 | `packages/roxabi-nats/` | NATS transport SDK (uv workspace subpackage) — adapter_base, connect, circuit_breaker, readiness, serialization. Extracted per ADR-045. |
+| `packages/roxabi-contracts/` | Shared Pydantic schemas for cross-project NATS contracts (uv workspace subpackage). v0.1.0 ships `ContractEnvelope` only; per-domain submodules (voice, image, memory, llm) added in later tags. Pure Pydantic runtime; transport via `[testing]` extra only. Extracted per ADR-049. |
 | `deploy/agents.yml` | Declarative agent registry for supervisord conf.d generation. Run `make gen-conf` to regenerate. |
 | `deploy/gen-supervisor-conf.py` | Python generator: agents.yml → supervisord conf.d/*.conf. |
 

--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -1,0 +1,22 @@
+# roxabi-contracts
+
+Shared Pydantic schemas for Lyra cross-project NATS contracts. Per-domain submodules (voice, image, memory, llm) import `ContractEnvelope` from this package as their common base. Extracted from Lyra as a uv workspace subpackage per [ADR-049](../../docs/architecture/adr/049-roxabi-contracts-shared-schema-package.mdx).
+
+## Install (external projects)
+
+```toml
+[tool.uv.sources]
+roxabi-contracts = {
+  git = "https://github.com/Roxabi/lyra.git",
+  subdirectory = "packages/roxabi-contracts",
+  tag = "roxabi-contracts/v0.1.0"
+}
+```
+
+## Public API contract
+
+The stable external contract is defined by `__all__` in `roxabi_contracts/__init__.py`. v0.1.0 ships:
+
+- `ContractEnvelope` — base Pydantic model for all per-domain contract schemas
+
+Future domain submodules (voice, image, memory, llm) arrive in subsequent tags. See ADR-049 §Versioning for SemVer rules.

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -9,6 +9,10 @@ authors = [{ name = "Roxabi SAS", email = "mickael@bouly.io" }]
 dependencies = ["pydantic>=2"]
 
 [project.optional-dependencies]
+# Workspace-only: roxabi-nats is not published to PyPI (ADR-045 §PyPI deferral).
+# The bare name resolves inside the uv workspace via lockfile editable reference.
+# External consumers installing roxabi-contracts[testing] from a git tag must
+# declare their own [tool.uv.sources] roxabi-nats = { git = ... } entry.
 testing = ["nats-py>=2.6", "roxabi-nats"]
 
 [project.urls]

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "roxabi-contracts"
+version = "0.1.0"
+description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.12"
+authors = [{ name = "Roxabi SAS", email = "mickael@bouly.io" }]
+dependencies = ["pydantic>=2"]
+
+[project.optional-dependencies]
+testing = ["nats-py>=2.6", "roxabi-nats"]
+
+[project.urls]
+Repository = "https://github.com/Roxabi/lyra"
+Issues = "https://github.com/Roxabi/lyra/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/roxabi_contracts"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
@@ -1,0 +1,12 @@
+"""roxabi_contracts — shared Pydantic schemas for Lyra cross-project NATS contracts.
+
+See docs/architecture/adr/049-roxabi-contracts-shared-schema-package.mdx.
+
+Public API: only the names in ``__all__`` are part of the stable external
+contract. v0.1.0 ships ``ContractEnvelope`` only; per-domain submodules
+(voice, image, memory, llm) arrive in later tags.
+"""
+
+from .envelope import ContractEnvelope
+
+__all__ = ["ContractEnvelope"]

--- a/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
@@ -1,0 +1,25 @@
+"""Envelope base for all roxabi-contracts domain models.
+
+See docs/architecture/adr/049-roxabi-contracts-shared-schema-package.mdx.
+CONTRACT_VERSION is NOT defined here — it is migrated from
+roxabi_nats.adapter_base in a follow-up issue (#765).
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ContractEnvelope(BaseModel):
+    """Common base for every per-domain NATS contract model.
+
+    All subclasses inherit ``extra="ignore"`` so a v0.1.0 consumer
+    receiving a v0.2.0 payload with new optional fields parses cleanly.
+    Unknown fields are silently dropped (ADR-049 §Versioning).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    contract_version: str
+    trace_id: str
+    issued_at: datetime

--- a/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
@@ -6,8 +6,9 @@ roxabi_nats.adapter_base in a follow-up issue (#765).
 """
 
 from datetime import datetime
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, StringConstraints
 
 
 class ContractEnvelope(BaseModel):
@@ -16,10 +17,27 @@ class ContractEnvelope(BaseModel):
     All subclasses inherit ``extra="ignore"`` so a v0.1.0 consumer
     receiving a v0.2.0 payload with new optional fields parses cleanly.
     Unknown fields are silently dropped (ADR-049 §Versioning).
+
+    .. warning::
+       Consumers MUST NOT call ``model_validate_json()`` or
+       ``model_validate()`` directly on raw NATS ``msg.data`` bytes.
+       The correct call site is ``roxabi_nats.deserialize()``, which
+       enforces the pre-validation byte-size gate before Pydantic
+       parses the payload (ADR-049 §Trust Model).
     """
 
+    # Forward-compat via extra="ignore": unknown fields from a newer
+    # payload version parse cleanly (ADR-049 §Versioning). This makes
+    # additive field introduction safe — EXCEPT for security-bearing
+    # fields (caller identity, auth scopes, signed tokens, audit
+    # provenance). Any such field MUST be introduced via a MAJOR bump
+    # with coordinated satellite upgrade, NEVER as an additive minor.
+    # A v1 satellite silently ignoring an auth_token field is exactly
+    # the bug class this exclusion prevents (ADR-049 §Versioning
+    # §Security-bearing fields exclusion). Each domain contract ADR
+    # must list which fields (if any) are security-bearing.
     model_config = ConfigDict(extra="ignore")
 
     contract_version: str
-    trace_id: str
+    trace_id: Annotated[str, StringConstraints(min_length=1)]
     issued_at: datetime

--- a/packages/roxabi-contracts/tests/test_envelope.py
+++ b/packages/roxabi-contracts/tests/test_envelope.py
@@ -16,6 +16,26 @@ def test_instantiation_with_required_fields() -> None:
     assert isinstance(env.issued_at, datetime)
 
 
+def test_naive_datetime_string_is_accepted_without_timezone() -> None:
+    """Characterize current permissive behavior on naive ISO datetime strings.
+
+    ContractEnvelope declares ``issued_at: datetime`` with no timezone
+    constraint at the base layer — per-domain subclasses may tighten.
+    Pydantic v2 accepts naive ISO strings and produces ``datetime``
+    objects with ``tzinfo is None``. This test locks that behavior so
+    any future ``@field_validator`` enforcing tz-awareness surfaces as
+    a test failure rather than a silent downstream breakage.
+    """
+    env = ContractEnvelope.model_validate(
+        {
+            "contract_version": "1",
+            "trace_id": "abc-123",
+            "issued_at": "2026-04-16T12:00:00",
+        }
+    )
+    assert env.issued_at.tzinfo is None
+
+
 def test_extra_fields_silently_dropped() -> None:
     """Forward-compat invariant: unknown fields MUST be dropped, not raise.
 

--- a/packages/roxabi-contracts/tests/test_envelope.py
+++ b/packages/roxabi-contracts/tests/test_envelope.py
@@ -1,0 +1,36 @@
+"""Tests for roxabi_contracts.envelope.ContractEnvelope."""
+
+from datetime import datetime, timezone
+
+from roxabi_contracts import ContractEnvelope
+
+
+def test_instantiation_with_required_fields() -> None:
+    env = ContractEnvelope(
+        contract_version="1",
+        trace_id="abc-123",
+        issued_at=datetime.now(timezone.utc),
+    )
+    assert env.contract_version == "1"
+    assert env.trace_id == "abc-123"
+    assert isinstance(env.issued_at, datetime)
+
+
+def test_extra_fields_silently_dropped() -> None:
+    """Forward-compat invariant: unknown fields MUST be dropped, not raise.
+
+    ADR-049 §Versioning: a v0.1.0 satellite receiving a v0.2.0 payload
+    with a new optional field parses cleanly.
+    """
+    env = ContractEnvelope.model_validate(
+        {
+            "contract_version": "1",
+            "trace_id": "abc-123",
+            "issued_at": "2026-04-16T12:00:00+00:00",
+            "future_field": "this should not raise",
+            "another_unknown": 42,
+        }
+    )
+    assert env.contract_version == "1"
+    assert not hasattr(env, "future_field")
+    assert not hasattr(env, "another_unknown")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,10 @@ override-dependencies = [
 pkuseg = ["numpy"]
 
 [tool.uv.workspace]
-members = ["packages/roxabi-nats"]
+members = ["packages/roxabi-nats", "packages/roxabi-contracts"]
 
 [tool.uv.sources]
+roxabi-contracts = { workspace = true }
 roxabi-nats = { workspace = true }
 roxabi-vault = { git = "https://github.com/Roxabi/roxabi-vault.git", branch = "staging" }
 voicecli = { git = "https://github.com/Roxabi/voiceCLI.git", branch = "staging" }
@@ -97,7 +98,7 @@ show_missing = true
 [tool.pyright]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
-include = ["src", "tests", "packages/roxabi-nats/src"]
+include = ["src", "tests", "packages/roxabi-nats/src", "packages/roxabi-contracts/src"]
 exclude = ["tests/dep_graph"]
 venvPath = "."
 venv = ".venv"
@@ -127,7 +128,7 @@ reportUnknownLambdaType = "none"
 reportMissingTypeArgument = "none"
 
 [tool.ruff]
-src = ["src", "tests", "packages/roxabi-nats/src", "packages/roxabi-nats/tests"]
+src = ["src", "tests", "packages/roxabi-nats/src", "packages/roxabi-nats/tests", "packages/roxabi-contracts/src", "packages/roxabi-contracts/tests"]
 exclude = [".claude/worktrees", "deploy"]
 
 [tool.ruff.lint]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "lyra",
+    "roxabi-contracts",
     "roxabi-nats",
 ]
 overrides = [
@@ -2263,6 +2264,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f4
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
+
+[[package]]
+name = "roxabi-contracts"
+version = "0.1.0"
+source = { editable = "packages/roxabi-contracts" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+testing = [
+    { name = "nats-py" },
+    { name = "roxabi-nats" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "nats-py", marker = "extra == 'testing'", specifier = ">=2.6" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "roxabi-nats", marker = "extra == 'testing'", editable = "packages/roxabi-nats" },
+]
+provides-extras = ["testing"]
 
 [[package]]
 name = "roxabi-nats"


### PR DESCRIPTION
## Summary

- Creates `packages/roxabi-contracts/` as the second uv workspace subpackage per ADR-049, with `ContractEnvelope` as the shared Pydantic base for every future per-domain NATS contract model
- Registers the new package in root tooling: `[tool.uv.workspace].members`, `[tool.uv.sources]`, `[tool.pyright].include`, `[tool.ruff].src` (mirrors roxabi-nats precedent) + regenerated `uv.lock`
- Ships envelope-only — voice models (#763), CONTRACT_VERSION migration (#765), and root pytest integration (#768) are explicitly out of scope for this scaffold
- Updates `CLAUDE.md` Key files table with the new subpackage entry (per project CLAUDE.md hygiene rule)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#762](https://github.com/Roxabi/lyra/issues/762): scaffold packages/roxabi-contracts skeleton + envelope.py | OPEN |
| Frame | [762-scaffold-roxabi-contracts-skeleton-frame.mdx](artifacts/frames/762-scaffold-roxabi-contracts-skeleton-frame.mdx) | Approved (F-lite) |
| Spec | [762-scaffold-roxabi-contracts-skeleton-spec.mdx](artifacts/specs/762-scaffold-roxabi-contracts-skeleton-spec.mdx) | Approved (14 ACs, reviewed by architect + doc-writer + product-lead) |
| Plan | [762-scaffold-roxabi-contracts-skeleton-plan.mdx](artifacts/plans/762-scaffold-roxabi-contracts-skeleton-plan.mdx) | 9 micro-tasks across 3 agents |
| Implementation | 1 commit on `feat/762-scaffold-roxabi-contracts` (5 new files + 3 modified) | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (2 new, both pass) · Cross-package import ✅ | Passed |

## Key decisions (from spec review)

- **CONTRACT_VERSION deferred to #765** — ADR-049 §Migration step 5 sequences this explicitly. Defining the constant in two places across a merge window would create drift risk.
- **uv.lock regenerated + committed** — required for `uv sync --frozen` on the deploy machine (ADR-049 §Migration step 8).
- **`[tool.pytest.ini_options]` with `asyncio_mode = "auto"`** in the subpackage manifest — prevents silent failure when async tests land in #763/#764.
- **`extra="ignore"` forward-compat invariant** — a v0.1.0 consumer receiving a v0.2.0 payload with new optional fields parses cleanly (ADR-049 §Versioning). Enforced by `test_extra_fields_silently_dropped`.

## Epic context

First issue of Epic #761 (adopt ADR-049 — roxabi-contracts shared schema package). Downstream child issues #763–#769 depend on this scaffold.

## Test Plan

- [x] `uv sync` succeeds at repo root
- [x] `uv run pyright packages/roxabi-contracts/src` — 0 errors
- [x] `uv run ruff check packages/roxabi-contracts/` — clean
- [x] `cd packages/roxabi-contracts && uv run pytest tests/test_envelope.py -v` — 2/2 passed
- [x] `uv run python -c "from roxabi_contracts import ContractEnvelope; print(ContractEnvelope.__name__)"` — prints `ContractEnvelope`
- [ ] CI pipeline green on staging base

Closes #762

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`
