### PR TITLE
refactor(roxabi-nats): per-adapter type_registry, delete global registry

### DIFF
--- a/docs/architecture/adr/045-roxabi-nats-sdk-uv-workspace-extraction.mdx
+++ b/docs/architecture/adr/045-roxabi-nats-sdk-uv-workspace-extraction.mdx
@@ -182,7 +182,7 @@ Both blocking prerequisites are resolved; the `roxabi-nats/v0.1.0` tag is unbloc
 
 ### Known design debt
 
-- **`_register_type_checking_import` global registry** — `_serialize.py` maintains `_TYPE_CHECKING_IMPORTS` as a process-global mutable list populated at lyra startup. This solves the TYPE_CHECKING-hint-resolution problem but imposes implicit global state on the SDK. The helper is kept hub-internal (underscore prefix, not in `__all__`) until a per-adapter explicit init param replaces it. Tracked in issue #729.
+- **Resolved in #729 (v0.2.0 — clean break, no deprecation shim).** The process-global `_TYPE_CHECKING_IMPORTS` list and its `_register_type_checking_import` mutator were deleted outright. Adapters now pass TYPE_CHECKING-only types via an explicit keyword-only `type_registry` argument on `NatsAdapterBase.__init__`; direct `serialize`/`deserialize` consumers pass a `resolver=` keyword argument. Lyra owns a single `TYPE_REGISTRY_RESOLVER` module constant in `src/lyra/nats/type_registry.py`. External `v0.1.x` consumers importing the removed private symbols hit a loud `ImportError` at load — the chosen failure mode over a silent `DeprecationWarning + no-op` shim that would have masked degraded type coercion.
 - **Public vs private submodule asymmetry** — lyra (as workspace host) imports `roxabi_nats._serialize`, `_sanitize`, etc. directly; external consumers are restricted to `__all__`. Python's underscore convention is social, not enforced — the contract is maintained via README and ADR documentation, not runtime guard.
 
 ### Neutral

--- a/packages/roxabi-nats/CHANGELOG.md
+++ b/packages/roxabi-nats/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog — roxabi-nats
+
+All notable changes to the `roxabi-nats` package are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] — 2026-04-17
+
+### Breaking
+
+- **`NatsAdapterBase.__init__` gains a keyword-only `type_registry` parameter.**
+  Adapter subclasses must declare their TYPE_CHECKING-only type hints at construction:
+  ```python
+  adapter = MyAdapter(
+      subject="lyra.inbound.tg.main",
+      queue_group="lyra-hub",
+      envelope_name="InboundMessage",
+      schema_version=1,
+      type_registry=[
+          ("lyra.core.commands.command_parser", "CommandContext"),
+      ],
+  )
+  ```
+  Adapters that do not need TYPE_CHECKING resolution can pass `type_registry=None` (the default).
+- **`serialize`, `deserialize`, `deserialize_dict` gain a keyword-only `resolver` parameter.**
+  Callers that decode dataclasses carrying TYPE_CHECKING-only annotations MUST pass a configured `_TypeHintResolver`. Bare calls default to an empty resolver and will fail to coerce types whose hints are only visible under `TYPE_CHECKING`.
+- **`_register_type_checking_import` removed.**
+  The process-global `_TYPE_CHECKING_IMPORTS` registry is gone. Consumers must construct a `_TypeHintResolver` and pass it explicitly.
+- **`_TYPE_CHECKING_IMPORTS` module-level list removed** from `roxabi_nats._serialize`.
+
+### Added
+
+- `_TypeHintResolver` class with fail-fast validation. Invalid module paths or missing attributes raise `ValueError` at resolver construction, not at deserialize time.
+- `_EMPTY_RESOLVER` module-level singleton — immutable null-object used as the default resolver for bare `serialize`/`deserialize` calls.
+
+### Migration
+
+Before (v0.1.x):
+
+```python
+from roxabi_nats._serialize import _register_type_checking_import
+
+_register_type_checking_import(
+    "my.package.types", "MyTypeCheckingOnlyType"
+)
+
+adapter = MyAdapter(...)
+```
+
+After (v0.2.0):
+
+```python
+adapter = MyAdapter(
+    ...,
+    type_registry=[
+        ("my.package.types", "MyTypeCheckingOnlyType"),
+    ],
+)
+```
+
+Direct `serialize`/`deserialize` consumers:
+
+```python
+# Before
+from roxabi_nats._serialize import deserialize
+msg = deserialize(data, MyDataclass)
+
+# After — build one resolver at module scope, reuse it
+from roxabi_nats._serialize import _TypeHintResolver, deserialize
+
+_RESOLVER = _TypeHintResolver([
+    ("my.package.types", "MyTypeCheckingOnlyType"),
+])
+msg = deserialize(data, MyDataclass, resolver=_RESOLVER)
+```
+
+External `v0.1.x` consumers (voiceCLI, roxabi-vault, imageCLI) that imported the private `_register_type_checking_import` helper will hit `ImportError` on upgrade. Either migrate to `type_registry=` at adapter construction or pin `roxabi-nats = ">=0.1.0,<0.2.0"` until the migration is complete.
+
+## [0.1.0] — 2026-04-14
+
+### Added
+
+- Initial extraction from the Lyra monorepo as a uv workspace subpackage. See `docs/architecture/adr/045-roxabi-nats-sdk-uv-workspace-extraction.mdx`.
+- `NatsAdapterBase` — ABC lifecycle host for NATS request-reply adapters.
+- `nats_connect` — seed-auth-aware NATS connection helper.
+- Internal helpers: `_serialize` (type-aware JSON codec), `_sanitize`, `_validate`, `_version_check`, `_tts_constants`.
+- Full test suite covering adapter lifecycle, circuit breaker, readiness probe, serialization round-trip, and version-gate drop handling.

--- a/packages/roxabi-nats/CHANGELOG.md
+++ b/packages/roxabi-nats/CHANGELOG.md
@@ -23,15 +23,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
   ```
   Adapters that do not need TYPE_CHECKING resolution can pass `type_registry=None` (the default).
 - **`serialize`, `deserialize`, `deserialize_dict` gain a keyword-only `resolver` parameter.**
-  Callers that decode dataclasses carrying TYPE_CHECKING-only annotations MUST pass a configured `_TypeHintResolver`. Bare calls default to an empty resolver and will fail to coerce types whose hints are only visible under `TYPE_CHECKING`.
+  Callers that decode dataclasses carrying TYPE_CHECKING-only annotations MUST pass a configured `TypeHintResolver`. Bare calls default to an empty resolver and will fail to coerce types whose hints are only visible under `TYPE_CHECKING`.
 - **`_register_type_checking_import` removed.**
   The process-global `_TYPE_CHECKING_IMPORTS` registry is gone. Consumers must construct a `_TypeHintResolver` and pass it explicitly.
 - **`_TYPE_CHECKING_IMPORTS` module-level list removed** from `roxabi_nats._serialize`.
 
 ### Added
 
-- `_TypeHintResolver` class with fail-fast validation. Invalid module paths or missing attributes raise `ValueError` at resolver construction, not at deserialize time.
-- `_EMPTY_RESOLVER` module-level singleton — immutable null-object used as the default resolver for bare `serialize`/`deserialize` calls.
+- **Public `TypeHintResolver`** exported from the package root (`from roxabi_nats import TypeHintResolver`). Wraps the internal `_TypeHintResolver` class; external consumers should use the public alias rather than reaching into `_serialize` / `_resolver`.
+- `_TypeHintResolver` class with fail-fast validation. Invalid module paths or missing attributes raise `ValueError` at resolver construction, not at deserialize time. Duplicate `type_name` with different `module_path` also fails loud (was silently last-wins internally during development).
+- Internal singleton `_EMPTY_RESOLVER` — immutable null-object used as the default resolver for bare `serialize`/`deserialize` calls. `resolved` is a `MappingProxyType` so attempted mutation raises `TypeError`.
+- Resolver instances carry a per-instance monotonic `_uid`; the hint cache pairs `(dc_type, resolver._uid)` so GC'd resolvers cannot poison cache entries of new resolvers that happen to land at the same `id()` address.
 
 ### Migration
 
@@ -66,9 +68,10 @@ from roxabi_nats._serialize import deserialize
 msg = deserialize(data, MyDataclass)
 
 # After — build one resolver at module scope, reuse it
-from roxabi_nats._serialize import _TypeHintResolver, deserialize
+from roxabi_nats import TypeHintResolver
+from roxabi_nats._serialize import deserialize
 
-_RESOLVER = _TypeHintResolver([
+_RESOLVER = TypeHintResolver([
     ("my.package.types", "MyTypeCheckingOnlyType"),
 ])
 msg = deserialize(data, MyDataclass, resolver=_RESOLVER)

--- a/packages/roxabi-nats/pyproject.toml
+++ b/packages/roxabi-nats/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-nats"
-version = "0.1.0"
+version = "0.2.0"
 description = "NATS transport SDK for Lyra and Roxabi plugin ecosystem"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/roxabi-nats/src/roxabi_nats/__init__.py
+++ b/packages/roxabi-nats/src/roxabi_nats/__init__.py
@@ -9,11 +9,13 @@ contract. ``_``-prefixed submodules (``_serialize``, ``_sanitize``,
 may change without notice — external consumers MUST NOT import them.
 """
 
+from ._serialize import _TypeHintResolver as TypeHintResolver
 from .adapter_base import CONTRACT_VERSION, NatsAdapterBase
 from .connect import nats_connect
 
 __all__ = [
     "CONTRACT_VERSION",
     "NatsAdapterBase",
+    "TypeHintResolver",
     "nats_connect",
 ]

--- a/packages/roxabi-nats/src/roxabi_nats/_resolver.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_resolver.py
@@ -1,0 +1,81 @@
+"""`_TypeHintResolver` — per-instance registry of TYPE_CHECKING-only types.
+
+Extracted from `_serialize.py` so that the serializer module stays within the
+300-line cap and the resolver has a single-responsibility home.  The public
+alias is re-exported from the package root as ``TypeHintResolver``
+(see `__init__.py`).
+"""
+
+from __future__ import annotations
+
+import importlib
+import itertools
+import types
+from collections.abc import Sequence
+from typing import Any
+
+# Per-instance monotonic counter — used as part of the `_hints_cache` key in
+# `_serialize._get_hints` so two resolvers never collide even if CPython
+# recycles `id()` after GC.  Plain `itertools.count()` is thread-safe for the
+# purpose of minting unique ints because of the GIL.
+_uid_counter = itertools.count()
+
+
+class _TypeHintResolver:
+    """Per-instance registry of TYPE_CHECKING-only types for deserialization.
+
+    Constructed at adapter/consumer init time. Eagerly imports every
+    (module_path, type_name) entry and caches the resolved type object so the
+    hot deserialization path never calls ``importlib``.  Non-existent
+    modules or attributes raise ``ValueError`` immediately — fail-fast at
+    construction, not on first message.
+
+    Each instance carries a monotonic ``_uid`` that callers pair with the
+    dataclass type to form the serializer's hint-cache key.  The UID is
+    unforgeable and never reused, so GC of a resolver cannot produce a stale
+    cache hit against a new resolver at the same ``id()`` address.
+    """
+
+    __slots__ = ("_uid", "entries", "resolved")
+
+    def __init__(self, entries: Sequence[tuple[str, str]]) -> None:
+        seen: set[tuple[str, str]] = set()
+        deduped: list[tuple[str, str]] = []
+        resolved: dict[str, type] = {}
+        for module_path, type_name in entries:
+            key = (module_path, type_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(key)
+            if type_name in resolved:
+                prev_module = next(
+                    m for m, n in deduped if n == type_name and (m, n) != key
+                )
+                raise ValueError(
+                    f"type_registry: duplicate type_name {type_name!r} from "
+                    f"{module_path!r} conflicts with earlier entry "
+                    f"from {prev_module!r}"
+                )
+            try:
+                mod = importlib.import_module(module_path)
+            except ImportError as exc:
+                raise ValueError(
+                    f"type_registry: cannot import {module_path}"
+                ) from exc
+            if not hasattr(mod, type_name):
+                raise ValueError(
+                    f"type_registry: {module_path} has no attribute {type_name}"
+                )
+            resolved[type_name] = getattr(mod, type_name)
+        self.entries: tuple[tuple[str, str], ...] = tuple(deduped)
+        self.resolved: types.MappingProxyType[str, type] = types.MappingProxyType(
+            resolved
+        )
+        self._uid: int = next(_uid_counter)
+
+    def localns(self) -> dict[str, Any]:
+        return dict(self.resolved)
+
+
+_EMPTY_RESOLVER = _TypeHintResolver(())

--- a/packages/roxabi-nats/src/roxabi_nats/_resolver.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_resolver.py
@@ -42,20 +42,20 @@ class _TypeHintResolver:
         seen: set[tuple[str, str]] = set()
         deduped: list[tuple[str, str]] = []
         resolved: dict[str, type] = {}
+        # name_to_module: type_name → module_path for the entry that first
+        # claimed it. O(1) lookup for the duplicate-name error; keeps the
+        # predicate unambiguous regardless of `seen`-set evolution.
+        name_to_module: dict[str, str] = {}
         for module_path, type_name in entries:
             key = (module_path, type_name)
             if key in seen:
                 continue
             seen.add(key)
-            deduped.append(key)
             if type_name in resolved:
-                prev_module = next(
-                    m for m, n in deduped if n == type_name and (m, n) != key
-                )
                 raise ValueError(
                     f"type_registry: duplicate type_name {type_name!r} from "
                     f"{module_path!r} conflicts with earlier entry "
-                    f"from {prev_module!r}"
+                    f"from {name_to_module[type_name]!r}"
                 )
             try:
                 mod = importlib.import_module(module_path)
@@ -68,6 +68,8 @@ class _TypeHintResolver:
                     f"type_registry: {module_path} has no attribute {type_name}"
                 )
             resolved[type_name] = getattr(mod, type_name)
+            name_to_module[type_name] = module_path
+            deduped.append(key)
         self.entries: tuple[tuple[str, str], ...] = tuple(deduped)
         self.resolved: types.MappingProxyType[str, type] = types.MappingProxyType(
             resolved

--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -25,9 +25,9 @@ from roxabi_nats._resolver import _EMPTY_RESOLVER, _TypeHintResolver
 T = TypeVar("T")
 
 _B64_PREFIX = "b64:"
-# Cache key pairs the dataclass type with the resolver's monotonic `_uid` —
-# unforgeable and never reused, so a GC'd resolver cannot collide with a new
-# one at the same `id()` address.
+# Cache key: (dc_type, resolver._uid). UIDs are unforgeable + never reused,
+# so GC'd resolvers can't collide. Growth bounded by adapters × dataclasses
+# in production; no eviction path.
 _hints_cache: dict[tuple[type, int], dict[str, Any]] = {}
 
 

--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -17,6 +17,7 @@ import json
 import sys
 import types
 import typing
+from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
 from typing import Any, TypeVar, get_type_hints
@@ -24,31 +25,52 @@ from typing import Any, TypeVar, get_type_hints
 T = TypeVar("T")
 
 _B64_PREFIX = "b64:"
-_hints_cache: dict[type, dict[str, Any]] = {}
-
-_TYPE_CHECKING_IMPORTS: list[tuple[str, str]] = []
+_hints_cache: dict[tuple[type, int], dict[str, Any]] = {}
 
 
-def _register_type_checking_import(module_path: str, type_name: str) -> None:
-    """Register a TYPE_CHECKING-only type for runtime hint resolution.
+class _TypeHintResolver:
+    """Per-instance registry of TYPE_CHECKING-only types for deserialization.
 
-    Hub-internal wiring. NOT public API — external SDK consumers must not
-    import this helper. Lyra (as the workspace host) is the only permitted
-    caller. See issue #729 for the planned refactor to a per-adapter
-    explicit init param that removes the global mutable registry.
-
-    Some dataclasses reference types imported only under ``TYPE_CHECKING``
-    (to avoid runtime circular imports). At deserialization time those names
-    must be resolvable. Consumers that send such dataclasses over NATS can
-    register them here once at startup; the serializer will attempt the
-    import lazily and fall back silently if unavailable.
-
-    Duplicate registrations are deduped. Registration after first
-    deserialization of the affected type has no effect (hints are cached).
+    Constructed at adapter/consumer init time. Eagerly imports every
+    (module_path, type_name) entry and caches the resolved type object so
+    `_get_hints` never pays `importlib.import_module` on the hot path.
+    Non-existent modules or attributes raise ValueError immediately —
+    fail-fast at construction, not on first message.
     """
-    entry = (module_path, type_name)
-    if entry not in _TYPE_CHECKING_IMPORTS:
-        _TYPE_CHECKING_IMPORTS.append(entry)
+
+    __slots__ = ("entries", "resolved")
+
+    def __init__(self, entries: Sequence[tuple[str, str]]) -> None:
+        seen: set[tuple[str, str]] = set()
+        deduped: list[tuple[str, str]] = []
+        resolved: dict[str, type] = {}
+        for module_path, type_name in entries:
+            key = (module_path, type_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(key)
+            try:
+                mod = importlib.import_module(module_path)
+            except ImportError as exc:
+                raise ValueError(
+                    f"type_registry: cannot import {module_path}"
+                ) from exc
+            if not hasattr(mod, type_name):
+                raise ValueError(
+                    f"type_registry: {module_path} has no attribute {type_name}"
+                )
+            resolved[type_name] = getattr(mod, type_name)
+        self.entries: tuple[tuple[str, str], ...] = tuple(deduped)
+        self.resolved: types.MappingProxyType[str, type] = (
+            types.MappingProxyType(resolved)
+        )
+
+    def localns(self) -> dict[str, Any]:
+        return dict(self.resolved)
+
+
+_EMPTY_RESOLVER = _TypeHintResolver(())
 
 
 # ---------------------------------------------------------------------------
@@ -56,33 +78,45 @@ def _register_type_checking_import(module_path: str, type_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def serialize(item: Any) -> bytes:
+def serialize(item: Any, *, resolver: _TypeHintResolver = _EMPTY_RESOLVER) -> bytes:
     """Serialize a dataclass instance to UTF-8 JSON bytes.
 
     Encodes Enum → .value, datetime → .isoformat(), bytes → "b64:<base64>".
     Callables are stripped from any dict-typed field (e.g. platform_meta).
+    The resolver parameter is accepted for API symmetry; the encode path
+    does not consult it.
     """
     encoded = _encode(item)
     return json.dumps(encoded, ensure_ascii=False).encode("utf-8")
 
 
-def deserialize(data: bytes, item_type: type[T]) -> T:
+def deserialize(
+    data: bytes,
+    item_type: type[T],
+    *,
+    resolver: _TypeHintResolver = _EMPTY_RESOLVER,
+) -> T:
     """Reconstruct a dataclass from UTF-8 JSON bytes.
 
     Parses JSON, then recursively reconstructs item_type from the resulting
     dict, rehydrating enums, datetimes, bytes fields, and nested dataclasses.
     """
     raw = json.loads(data.decode("utf-8"))
-    return _decode(raw, item_type)  # type: ignore[return-value]
+    return _decode(raw, item_type, resolver)  # type: ignore[return-value]
 
 
-def deserialize_dict(d: dict[str, Any], item_type: type[T]) -> T:
+def deserialize_dict(
+    d: dict[str, Any],
+    item_type: type[T],
+    *,
+    resolver: _TypeHintResolver = _EMPTY_RESOLVER,
+) -> T:
     """Reconstruct a dataclass from a pre-parsed dict.
 
     Same as :func:`deserialize` but skips the JSON parse step — use when
     the caller already has a ``dict`` (e.g. from a prior ``json.loads``).
     """
-    return _decode(d, item_type)  # type: ignore[return-value]
+    return _decode(d, item_type, resolver)  # type: ignore[return-value]
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +129,7 @@ def _strip_callables(d: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in d.items() if not callable(v)}
 
 
-def _get_hints(dc_type: type) -> dict[str, Any]:
+def _get_hints(dc_type: type, resolver: _TypeHintResolver) -> dict[str, Any]:
     """Get type hints for a dataclass, handling TYPE_CHECKING-only imports.
 
     Uses the class's own module globals as the resolution namespace so that
@@ -104,16 +138,21 @@ def _get_hints(dc_type: type) -> dict[str, Any]:
 
     Falls back to explicitly importing known TYPE_CHECKING-only types when
     NameError is raised (e.g. ``CommandContext`` imported under TYPE_CHECKING).
+    The supplement comes from resolver.localns() — no global mutable registry.
 
-    Results are cached per type to avoid repeated ``get_type_hints`` calls.
+    Cache key is (dc_type, id(resolver)) to prevent one resolver's empty hints
+    from poisoning another resolver's non-empty resolution for the same type.
+
+    Results are cached per (type, resolver) pair.
     """
-    cached = _hints_cache.get(dc_type)
+    cache_key = (dc_type, id(resolver))
+    cached = _hints_cache.get(cache_key)
     if cached is not None:
         return cached
 
     try:
         result = get_type_hints(dc_type)
-        _hints_cache[dc_type] = result
+        _hints_cache[cache_key] = result
         return result
     except NameError:
         pass
@@ -125,16 +164,13 @@ def _get_hints(dc_type: type) -> dict[str, Any]:
     globalns: dict[str, Any] = dict(vars(module)) if module is not None else {}
 
     # Supplement with TYPE_CHECKING-only types not present at runtime.
-    # The registry is populated by consumers via _register_type_checking_import();
+    # The resolver is populated by consumers at construction time;
     # the SDK itself knows no domain types.
-    localns: dict[str, Any] = {}
-    for module_path, type_name in _TYPE_CHECKING_IMPORTS:
-        if type_name not in globalns:
-            try:
-                mod = importlib.import_module(module_path)
-                localns[type_name] = getattr(mod, type_name)
-            except Exception:
-                pass
+    localns = resolver.localns()
+    for type_name in list(localns.keys()):
+        if type_name in globalns:
+            # Module globals win — don't shadow existing identifiers.
+            localns.pop(type_name)
 
     try:
         result = get_type_hints(dc_type, globalns=globalns, localns=localns)
@@ -143,7 +179,7 @@ def _get_hints(dc_type: type) -> dict[str, Any]:
         # Do NOT cache the empty fallback: a transient resolution failure
         # should not permanently disable type coercion for this type.
         return {}
-    _hints_cache[dc_type] = result
+    _hints_cache[cache_key] = result
     return result
 
 
@@ -192,7 +228,9 @@ def _encode(obj: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _decode_union(value: Any, args: tuple[Any, ...]) -> Any:
+def _decode_union(
+    value: Any, args: tuple[Any, ...], resolver: _TypeHintResolver
+) -> Any:
     """Decode value when the target is a Union / Optional type."""
     if value is None:
         return None
@@ -202,7 +240,7 @@ def _decode_union(value: Any, args: tuple[Any, ...]) -> Any:
         return base64.b64decode(value[len(_B64_PREFIX) :])
     # Single non-None candidate: decode as that type
     if len(non_none) == 1:
-        return _decode(value, non_none[0])
+        return _decode(value, non_none[0], resolver)
     # Multiple non-None: str | bytes without b64 prefix → keep as str
     if str in non_none and isinstance(value, str):
         return value
@@ -213,11 +251,11 @@ def _decode_union(value: Any, args: tuple[Any, ...]) -> Any:
             and isinstance(candidate, type)
             and isinstance(value, dict)
         ):
-            return _decode_dataclass(value, candidate)
+            return _decode_dataclass(value, candidate, resolver)
     return value
 
 
-def _decode_concrete(value: Any, target_type: Any) -> Any:
+def _decode_concrete(value: Any, target_type: Any, resolver: _TypeHintResolver) -> Any:
     """Decode value for concrete (non-generic, non-union) types."""
     # ── Dataclass ────────────────────────────────────────────────────────────
     if dataclasses.is_dataclass(target_type) and isinstance(target_type, type):
@@ -225,7 +263,7 @@ def _decode_concrete(value: Any, target_type: Any) -> Any:
             return None
         if not isinstance(value, dict):
             return value
-        return _decode_dataclass(value, target_type)
+        return _decode_dataclass(value, target_type, resolver)
 
     # ── Enum ──────────────────────────────────────────────────────────────────
     if isinstance(target_type, type) and issubclass(target_type, Enum):
@@ -251,7 +289,7 @@ def _decode_concrete(value: Any, target_type: Any) -> Any:
     return value
 
 
-def _decode(value: Any, target_type: Any) -> Any:
+def _decode(value: Any, target_type: Any, resolver: _TypeHintResolver) -> Any:
     """Reconstruct value as target_type.
 
     Handles: dataclass, Enum, datetime, bytes, list[X], Union/Optional, scalars.
@@ -267,25 +305,27 @@ def _decode(value: Any, target_type: Any) -> Any:
         hasattr(types, "UnionType") and isinstance(target_type, types.UnionType)
     )
     if is_union:
-        return _decode_union(value, args)
+        return _decode_union(value, args, resolver)
 
     # ── list[X] ──────────────────────────────────────────────────────────────
     if origin is list:
         if value is None:
             return value
         elem_type = args[0] if args else Any
-        return [_decode(item, elem_type) for item in value]
+        return [_decode(item, elem_type, resolver) for item in value]
 
     # ── Literal — return as-is ───────────────────────────────────────────────
     if origin is typing.Literal:
         return value
 
-    return _decode_concrete(value, target_type)
+    return _decode_concrete(value, target_type, resolver)
 
 
-def _decode_dataclass(d: dict[str, Any], dc_type: type) -> Any:
+def _decode_dataclass(
+    d: dict[str, Any], dc_type: type, resolver: _TypeHintResolver
+) -> Any:
     """Reconstruct a dataclass from a dict using field type hints for coercion."""
-    hints = _get_hints(dc_type)
+    hints = _get_hints(dc_type, resolver)
 
     kwargs: dict[str, Any] = {}
     for f in dataclasses.fields(dc_type):  # type: ignore[arg-type]
@@ -297,6 +337,6 @@ def _decode_dataclass(d: dict[str, Any], dc_type: type) -> Any:
         if field_type is None:
             kwargs[f.name] = raw_value
         else:
-            kwargs[f.name] = _decode(raw_value, field_type)
+            kwargs[f.name] = _decode(raw_value, field_type, resolver)
 
     return dc_type(**kwargs)

--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -12,63 +12,23 @@ from __future__ import annotations
 
 import base64
 import dataclasses
-import importlib
 import json
 import sys
 import types
 import typing
-from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
 from typing import Any, TypeVar, get_type_hints
 
+from roxabi_nats._resolver import _EMPTY_RESOLVER, _TypeHintResolver
+
 T = TypeVar("T")
 
 _B64_PREFIX = "b64:"
+# Cache key pairs the dataclass type with the resolver's monotonic `_uid` —
+# unforgeable and never reused, so a GC'd resolver cannot collide with a new
+# one at the same `id()` address.
 _hints_cache: dict[tuple[type, int], dict[str, Any]] = {}
-
-
-class _TypeHintResolver:
-    """Per-instance registry of TYPE_CHECKING-only types for deserialization.
-
-    Constructed at adapter/consumer init time. Eagerly imports every
-    (module_path, type_name) entry and caches the resolved type object so
-    `_get_hints` never pays `importlib.import_module` on the hot path.
-    Non-existent modules or attributes raise ValueError immediately —
-    fail-fast at construction, not on first message.
-    """
-
-    __slots__ = ("entries", "resolved")
-
-    def __init__(self, entries: Sequence[tuple[str, str]]) -> None:
-        seen: set[tuple[str, str]] = set()
-        deduped: list[tuple[str, str]] = []
-        resolved: dict[str, type] = {}
-        for module_path, type_name in entries:
-            key = (module_path, type_name)
-            if key in seen:
-                continue
-            seen.add(key)
-            deduped.append(key)
-            try:
-                mod = importlib.import_module(module_path)
-            except ImportError as exc:
-                raise ValueError(f"type_registry: cannot import {module_path}") from exc
-            if not hasattr(mod, type_name):
-                raise ValueError(
-                    f"type_registry: {module_path} has no attribute {type_name}"
-                )
-            resolved[type_name] = getattr(mod, type_name)
-        self.entries: tuple[tuple[str, str], ...] = tuple(deduped)
-        self.resolved: types.MappingProxyType[str, type] = types.MappingProxyType(
-            resolved
-        )
-
-    def localns(self) -> dict[str, Any]:
-        return dict(self.resolved)
-
-
-_EMPTY_RESOLVER = _TypeHintResolver(())
 
 
 # ---------------------------------------------------------------------------
@@ -138,12 +98,12 @@ def _get_hints(dc_type: type, resolver: _TypeHintResolver) -> dict[str, Any]:
     NameError is raised (e.g. ``CommandContext`` imported under TYPE_CHECKING).
     The supplement comes from resolver.localns() — no global mutable registry.
 
-    Cache key is (dc_type, id(resolver)) to prevent one resolver's empty hints
+    Cache key is (dc_type, resolver._uid) to prevent one resolver's empty hints
     from poisoning another resolver's non-empty resolution for the same type.
 
     Results are cached per (type, resolver) pair.
     """
-    cache_key = (dc_type, id(resolver))
+    cache_key = (dc_type, resolver._uid)
     cached = _hints_cache.get(cache_key)
     if cached is not None:
         return cached

--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -53,17 +53,15 @@ class _TypeHintResolver:
             try:
                 mod = importlib.import_module(module_path)
             except ImportError as exc:
-                raise ValueError(
-                    f"type_registry: cannot import {module_path}"
-                ) from exc
+                raise ValueError(f"type_registry: cannot import {module_path}") from exc
             if not hasattr(mod, type_name):
                 raise ValueError(
                     f"type_registry: {module_path} has no attribute {type_name}"
                 )
             resolved[type_name] = getattr(mod, type_name)
         self.entries: tuple[tuple[str, str], ...] = tuple(deduped)
-        self.resolved: types.MappingProxyType[str, type] = (
-            types.MappingProxyType(resolved)
+        self.resolved: types.MappingProxyType[str, type] = types.MappingProxyType(
+            resolved
         )
 
     def localns(self) -> dict[str, Any]:

--- a/packages/roxabi-nats/src/roxabi_nats/_test_stub_module.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_test_stub_module.py
@@ -1,9 +1,0 @@
-"""Hub-internal stub module — import target for resolver unit tests.
-
-Not part of any public API. Provides a stable (module_path, type_name)
-pair that tests can resolve without depending on lyra.
-"""
-
-
-class StubInner:  # noqa: D101
-    pass

--- a/packages/roxabi-nats/src/roxabi_nats/_test_stub_module.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_test_stub_module.py
@@ -1,0 +1,9 @@
+"""Hub-internal stub module — import target for resolver unit tests.
+
+Not part of any public API. Provides a stable (module_path, type_name)
+pair that tests can resolve without depending on lyra.
+"""
+
+
+class StubInner:  # noqa: D101
+    pass

--- a/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
@@ -17,9 +17,11 @@ import signal
 import socket
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 
 from nats.aio.client import Client as NATS
 
+from roxabi_nats._serialize import _EMPTY_RESOLVER, _TypeHintResolver
 from roxabi_nats._validate import validate_nats_token
 from roxabi_nats._version_check import check_contract_version, check_schema_version
 from roxabi_nats.connect import nats_connect
@@ -53,6 +55,7 @@ class NatsAdapterBase(ABC):
         *,
         heartbeat_subject: str | None = None,
         heartbeat_interval: float = 5.0,
+        type_registry: Sequence[tuple[str, str]] | None = None,
     ):
         validate_nats_token(subject, kind="subject")
         validate_nats_token(queue_group, kind="queue_group")
@@ -74,6 +77,9 @@ class NatsAdapterBase(ABC):
         raw_id = f"{queue_group}-{socket.gethostname()}-{os.getpid()}"
         self._worker_id = re.sub(r"[^A-Za-z0-9_-]", "_", raw_id)
         self._heartbeat_task: asyncio.Task | None = None
+        self._resolver: _TypeHintResolver = (
+            _TypeHintResolver(type_registry) if type_registry else _EMPTY_RESOLVER
+        )
 
     async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
         nc = await nats_connect(nats_url)

--- a/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
@@ -78,7 +78,9 @@ class NatsAdapterBase(ABC):
         self._worker_id = re.sub(r"[^A-Za-z0-9_-]", "_", raw_id)
         self._heartbeat_task: asyncio.Task | None = None
         self._resolver: _TypeHintResolver = (
-            _TypeHintResolver(type_registry) if type_registry else _EMPTY_RESOLVER
+            _TypeHintResolver(type_registry)
+            if type_registry is not None
+            else _EMPTY_RESOLVER
         )
 
     async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:

--- a/packages/roxabi-nats/tests/_stub_fixture.py
+++ b/packages/roxabi-nats/tests/_stub_fixture.py
@@ -1,0 +1,17 @@
+"""Stub module used as a (module_path, type_name) target by resolver tests.
+
+Registered in :mod:`sys.modules` under the synthetic name
+``roxabi_nats_test_stub`` from this package's ``conftest.py`` so
+``_TypeHintResolver([("roxabi_nats_test_stub", "StubInner")])`` resolves
+to :class:`StubInner` below — without shipping any test-only file inside
+the production wheel (which only packages ``src/roxabi_nats``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class StubInner:  # noqa: D101
+    value: str = "stub"

--- a/packages/roxabi-nats/tests/conftest.py
+++ b/packages/roxabi-nats/tests/conftest.py
@@ -8,17 +8,44 @@ fixture are automatically skipped when nats-server is not found.
 
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import socket
 import subprocess
+import sys
 import time
 from collections.abc import AsyncGenerator, Generator
+from pathlib import Path
 
 import pytest
 from nats.aio.client import Client as NATS
 
 import nats
 from roxabi_nats import _version_check as _vc_mod
+
+
+def _register_stub_fixture() -> None:
+    """Register ``_stub_fixture.py`` under ``roxabi_nats_test_stub`` at collection time.
+
+    Resolver tests construct ``_TypeHintResolver([("roxabi_nats_test_stub", ...)])``.
+    Keeping the stub a sibling of this ``conftest.py`` excludes it from the
+    wheel (hatch only packages ``src/roxabi_nats/``) while preserving a stable
+    absolute module path for ``importlib.import_module``.
+    """
+    if "roxabi_nats_test_stub" in sys.modules:
+        return
+    path = Path(__file__).parent / "_stub_fixture.py"
+    spec = importlib.util.spec_from_file_location("roxabi_nats_test_stub", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            "failed to build import spec for roxabi_nats_test_stub"
+        )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["roxabi_nats_test_stub"] = mod
+    spec.loader.exec_module(mod)
+
+
+_register_stub_fixture()
 
 
 @pytest.fixture(autouse=True)

--- a/packages/roxabi-nats/tests/test_adapter_base.py
+++ b/packages/roxabi-nats/tests/test_adapter_base.py
@@ -1146,3 +1146,39 @@ class TestHeartbeatRun:
 
         # Assert
         assert adapter._heartbeat_task is None
+
+
+# ---------------------------------------------------------------------------
+# T4 (issue #729) — type_registry construction-time validation
+# ---------------------------------------------------------------------------
+
+from roxabi_nats._serialize import _EMPTY_RESOLVER  # noqa: E402
+
+
+def test_type_registry_fail_fast_invalid_module() -> None:
+    """NatsAdapterBase raises ValueError at init when module is missing."""
+    # Arrange — module "no.such.module" does not exist
+    # Act / Assert
+    with pytest.raises(ValueError, match="cannot import no.such.module"):
+        _ConcreteAdapter(
+            subject="test.subj",
+            queue_group="test.qg",
+            envelope_name="test",
+            schema_version=1,
+            type_registry=[("no.such.module", "X")],
+        )
+
+
+def test_type_registry_none_ok() -> None:
+    """NatsAdapterBase with type_registry=None binds the empty resolver singleton."""
+    # Arrange / Act
+    adapter = _ConcreteAdapter(
+        subject="test.subj",
+        queue_group="test.qg",
+        envelope_name="test",
+        schema_version=1,
+        type_registry=None,
+    )
+
+    # Assert
+    assert adapter._resolver is _EMPTY_RESOLVER

--- a/packages/roxabi-nats/tests/test_readiness.py
+++ b/packages/roxabi-nats/tests/test_readiness.py
@@ -15,18 +15,26 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import shutil
 
 import pytest
 from nats.aio.client import Client as NATS
 
 import nats
-from conftest import requires_nats_server  # noqa: PLC2701
 from roxabi_nats.readiness import (
     PROBE_INTERVAL_S,
     PROBE_TIMEOUT_S,
     READINESS_SUBJECT,
     start_readiness_responder,
     wait_for_hub,
+)
+
+# Mark inlined to avoid cross-conftest import path problems when the package
+# test suite is collected under the repo-root rootdir. The package's own
+# conftest.py defines the same marker for other test files in this dir.
+requires_nats_server = pytest.mark.skipif(
+    shutil.which("nats-server") is None,
+    reason="nats-server not found in PATH — install via 'make nats-install'",
 )
 
 # ---------------------------------------------------------------------------

--- a/packages/roxabi-nats/tests/test_readiness.py
+++ b/packages/roxabi-nats/tests/test_readiness.py
@@ -20,6 +20,7 @@ import pytest
 from nats.aio.client import Client as NATS
 
 import nats
+from conftest import requires_nats_server  # noqa: PLC2701
 from roxabi_nats.readiness import (
     PROBE_INTERVAL_S,
     PROBE_TIMEOUT_S,
@@ -27,8 +28,6 @@ from roxabi_nats.readiness import (
     start_readiness_responder,
     wait_for_hub,
 )
-
-from .conftest import requires_nats_server
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/packages/roxabi-nats/tests/test_type_hint_resolver.py
+++ b/packages/roxabi-nats/tests/test_type_hint_resolver.py
@@ -1,9 +1,4 @@
-"""RED-phase tests for _TypeHintResolver and clean-break removal of the global
-registry (issue #729).
-
-All tests are expected to fail with ImportError until T2 implements
-_TypeHintResolver and removes _register_type_checking_import / _TYPE_CHECKING_IMPORTS
-from _serialize.py.
+"""Tests for _TypeHintResolver and clean-break removal of the global registry (#729).
 
 Covers:
 - (a) non-empty resolver round-trip resolves the stub type
@@ -13,11 +8,14 @@ Covers:
 - (e) non-existent attribute raises ValueError at resolver construction
 - (f) clean-break guard: _register_type_checking_import and _TYPE_CHECKING_IMPORTS
       are not importable from roxabi_nats._serialize
+- (g) hint cache isolates resolvers (no cross-resolver poisoning)
+- (h) duplicate type_name with different module_path rejected
 """
 
 from __future__ import annotations
 
 import importlib
+import types
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -31,7 +29,11 @@ from roxabi_nats._serialize import (
 )
 
 if TYPE_CHECKING:
-    from roxabi_nats._test_stub_module import StubInner
+    # `roxabi_nats_test_stub` is registered in `sys.modules` at test-collection
+    # time by this package's conftest.py — it does NOT exist on disk under that
+    # name, so pyright cannot statically resolve it and we suppress the import
+    # error. Runtime imports still work everywhere the stub is actually needed.
+    from roxabi_nats_test_stub import StubInner  # type: ignore[import-not-found]
 
 
 @dataclass
@@ -46,16 +48,26 @@ class _StubOuter:
 
 
 def test_resolver_resolves_stub_type() -> None:
-    """A resolver with the stub module entry correctly round-trips _StubOuter."""
+    """A resolver with the stub module entry correctly round-trips _StubOuter.
+
+    Exercises resolver-driven type coercion: the inner field is typed as
+    StubInner under TYPE_CHECKING only; the resolver provides it at runtime
+    so deserialize can reconstruct the nested dataclass from a raw dict.
+    """
     # Arrange
-    r = _TypeHintResolver([("roxabi_nats._test_stub_module", "StubInner")])
-    payload = serialize(_StubOuter(name="x"))
+    from roxabi_nats_test_stub import (
+        StubInner,  # noqa: PLC0415  # type: ignore[import-not-found]
+    )
+
+    r = _TypeHintResolver([("roxabi_nats_test_stub", "StubInner")])
+    payload = serialize(_StubOuter(name="x", inner=StubInner()))
 
     # Act
-    round = deserialize(payload, _StubOuter, resolver=r)
+    result = deserialize(payload, _StubOuter, resolver=r)
 
     # Assert
-    assert round.name == "x"
+    assert result.name == "x"
+    assert isinstance(result.inner, StubInner)
 
 
 # ---------------------------------------------------------------------------
@@ -90,8 +102,8 @@ def test_duplicate_entries_deduped() -> None:
     # Arrange / Act
     r = _TypeHintResolver(
         [
-            ("roxabi_nats._test_stub_module", "StubInner"),
-            ("roxabi_nats._test_stub_module", "StubInner"),
+            ("roxabi_nats_test_stub", "StubInner"),
+            ("roxabi_nats_test_stub", "StubInner"),
         ]
     )
 
@@ -120,7 +132,7 @@ def test_non_existent_attribute_raises() -> None:
     """Constructing with a missing attribute on a real module raises ValueError."""
     # Arrange / Act / Assert
     with pytest.raises(ValueError, match="has no attribute DoesNotExist"):
-        _TypeHintResolver([("roxabi_nats._test_stub_module", "DoesNotExist")])
+        _TypeHintResolver([("roxabi_nats_test_stub", "DoesNotExist")])
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +160,60 @@ def test_clean_break_global_registry_removed() -> None:
 
 
 def test_empty_resolver_singleton_is_module_level() -> None:
-    """_EMPTY_RESOLVER is a module-level instance with an empty entries tuple."""
-    # Arrange / Act / Assert
+    """_EMPTY_RESOLVER is a module-level instance with an empty entries tuple,
+    an immutable MappingProxyType resolved dict, and rejects mutation.
+    """
+    # Assert entries empty
     assert _EMPTY_RESOLVER.entries == ()
+    # Assert resolved is a MappingProxyType (immutable)
+    assert isinstance(_EMPTY_RESOLVER.resolved, types.MappingProxyType)
+    # Assert mutation raises TypeError
+    with pytest.raises(TypeError):
+        _EMPTY_RESOLVER.resolved["x"] = 1  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Cache isolation across resolvers
+# ---------------------------------------------------------------------------
+
+
+def test_hints_cache_isolated_across_resolvers() -> None:
+    """id(resolver) belongs to the _hints_cache key — resolvers never poison each other.
+
+    Empty resolver leaves inner as None (no StubInner type in scope → NameError
+    fallback → field coercion skipped).  Non-empty resolver reconstructs StubInner
+    from the raw dict.
+    """
+    from roxabi_nats_test_stub import (
+        StubInner,  # noqa: PLC0415  # type: ignore[import-not-found]
+    )
+
+    r_non_empty = _TypeHintResolver([("roxabi_nats_test_stub", "StubInner")])
+    r_empty = _TypeHintResolver(())
+
+    inner = StubInner()
+    payload = serialize(_StubOuter(name="cache-test", inner=inner))
+
+    # Non-empty resolver: StubInner resolved → inner is a StubInner instance
+    result_full = deserialize(payload, _StubOuter, resolver=r_non_empty)
+    assert isinstance(result_full.inner, StubInner)
+
+    # Empty resolver: StubInner not in scope → inner stays as raw dict (not coerced)
+    result_empty = deserialize(payload, _StubOuter, resolver=r_empty)
+    assert not isinstance(result_empty.inner, StubInner)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate type_name collision detection
+# ---------------------------------------------------------------------------
+
+
+def test_type_registry_duplicate_type_name_rejected() -> None:
+    """Same type_name with different module_path raises ValueError (fail-loud)."""
+    with pytest.raises(ValueError, match="duplicate type_name"):
+        _TypeHintResolver(
+            [
+                ("roxabi_nats_test_stub", "StubInner"),
+                ("nonexistent.path", "StubInner"),
+            ]
+        )

--- a/packages/roxabi-nats/tests/test_type_hint_resolver.py
+++ b/packages/roxabi-nats/tests/test_type_hint_resolver.py
@@ -1,0 +1,150 @@
+"""RED-phase tests for _TypeHintResolver and clean-break removal of the global
+registry (issue #729).
+
+All tests are expected to fail with ImportError until T2 implements
+_TypeHintResolver and removes _register_type_checking_import / _TYPE_CHECKING_IMPORTS
+from _serialize.py.
+
+Covers:
+- (a) non-empty resolver round-trip resolves the stub type
+- (b) empty resolver round-trip of a dataclass with no TYPE_CHECKING hints
+- (c) duplicate (module, name) entries deduped
+- (d) non-existent module raises ValueError at resolver construction
+- (e) non-existent attribute raises ValueError at resolver construction
+- (f) clean-break guard: _register_type_checking_import and _TYPE_CHECKING_IMPORTS
+      are not importable from roxabi_nats._serialize
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from roxabi_nats._serialize import (
+    _EMPTY_RESOLVER,
+    _TypeHintResolver,
+    deserialize,
+    serialize,
+)
+
+if TYPE_CHECKING:
+    from roxabi_nats._test_stub_module import StubInner
+
+
+@dataclass
+class _StubOuter:
+    name: str
+    inner: "StubInner | None" = None
+
+
+# ---------------------------------------------------------------------------
+# (a) non-empty resolver round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_resolves_stub_type() -> None:
+    """A resolver with the stub module entry correctly round-trips _StubOuter."""
+    # Arrange
+    r = _TypeHintResolver([("roxabi_nats._test_stub_module", "StubInner")])
+    payload = serialize(_StubOuter(name="x"))
+
+    # Act
+    round = deserialize(payload, _StubOuter, resolver=r)
+
+    # Assert
+    assert round.name == "x"
+
+
+# ---------------------------------------------------------------------------
+# (b) empty resolver — no TYPE_CHECKING hints
+# ---------------------------------------------------------------------------
+
+
+def test_empty_resolver_no_typechecking_hints() -> None:
+    """Empty resolver round-trips a plain dataclass with no TYPE_CHECKING fields."""
+    # Arrange
+    @dataclass
+    class Plain:
+        n: int
+
+    r = _TypeHintResolver(())
+
+    # Act
+    result = deserialize(serialize(Plain(n=5)), Plain, resolver=r)
+
+    # Assert
+    assert result.n == 5
+
+
+# ---------------------------------------------------------------------------
+# (c) duplicate entries deduped
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_entries_deduped() -> None:
+    """Duplicate (module, name) pairs collapse to a single entry."""
+    # Arrange / Act
+    r = _TypeHintResolver([
+        ("roxabi_nats._test_stub_module", "StubInner"),
+        ("roxabi_nats._test_stub_module", "StubInner"),
+    ])
+
+    # Assert
+    assert len(r.entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# (d) non-existent module raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_non_existent_module_raises() -> None:
+    """Constructing with an unimportable module raises ValueError."""
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="cannot import roxabi_nats._does_not_exist"):
+        _TypeHintResolver([("roxabi_nats._does_not_exist", "StubInner")])
+
+
+# ---------------------------------------------------------------------------
+# (e) non-existent attribute raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_non_existent_attribute_raises() -> None:
+    """Constructing with a missing attribute on a real module raises ValueError."""
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="has no attribute DoesNotExist"):
+        _TypeHintResolver([("roxabi_nats._test_stub_module", "DoesNotExist")])
+
+
+# ---------------------------------------------------------------------------
+# (f) clean-break guard — global registry removed
+# ---------------------------------------------------------------------------
+
+
+def test_clean_break_register_helper_removed() -> None:
+    """_register_type_checking_import must not exist on _serialize."""
+    # Arrange / Act / Assert
+    mod = importlib.import_module("roxabi_nats._serialize")
+    assert not hasattr(mod, "_register_type_checking_import")
+
+
+def test_clean_break_global_registry_removed() -> None:
+    """_TYPE_CHECKING_IMPORTS must not exist on _serialize."""
+    # Arrange / Act / Assert
+    mod = importlib.import_module("roxabi_nats._serialize")
+    assert not hasattr(mod, "_TYPE_CHECKING_IMPORTS")
+
+
+# ---------------------------------------------------------------------------
+# _EMPTY_RESOLVER sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_empty_resolver_singleton_is_module_level() -> None:
+    """_EMPTY_RESOLVER is a module-level instance with an empty entries tuple."""
+    # Arrange / Act / Assert
+    assert _EMPTY_RESOLVER.entries == ()

--- a/packages/roxabi-nats/tests/test_type_hint_resolver.py
+++ b/packages/roxabi-nats/tests/test_type_hint_resolver.py
@@ -178,11 +178,10 @@ def test_empty_resolver_singleton_is_module_level() -> None:
 
 
 def test_hints_cache_isolated_across_resolvers() -> None:
-    """id(resolver) belongs to the _hints_cache key — resolvers never poison each other.
+    """resolver._uid belongs to _hints_cache key — resolvers do not poison each other.
 
-    Empty resolver leaves inner as None (no StubInner type in scope → NameError
-    fallback → field coercion skipped).  Non-empty resolver reconstructs StubInner
-    from the raw dict.
+    Empty resolver leaves inner uncoerced (NameError fallback → {}).  Non-empty
+    resolver reconstructs StubInner.  Order: non-empty first, then empty.
     """
     from roxabi_nats_test_stub import (
         StubInner,  # noqa: PLC0415  # type: ignore[import-not-found]
@@ -201,6 +200,33 @@ def test_hints_cache_isolated_across_resolvers() -> None:
     # Empty resolver: StubInner not in scope → inner stays as raw dict (not coerced)
     result_empty = deserialize(payload, _StubOuter, resolver=r_empty)
     assert not isinstance(result_empty.inner, StubInner)
+
+
+def test_hints_cache_no_poisoning_when_empty_runs_first() -> None:
+    """Mirror of the isolation test — run the empty resolver FIRST.
+
+    Canonical cache-poisoning scenario: under a dc_type-only cache key, the
+    empty resolver caches `{}` for `_StubOuter`, then the non-empty resolver
+    hits the cached empty hints and fails to coerce StubInner. The per-UID
+    cache key prevents this; the test asserts the second resolver still sees
+    correct coercion regardless of ordering.
+    """
+    from roxabi_nats_test_stub import (
+        StubInner,  # noqa: PLC0415  # type: ignore[import-not-found]
+    )
+
+    r_empty = _TypeHintResolver(())
+    r_non_empty = _TypeHintResolver([("roxabi_nats_test_stub", "StubInner")])
+
+    payload = serialize(_StubOuter(name="mirror", inner=StubInner()))
+
+    # Empty FIRST (would poison a dc_type-only cache)
+    result_empty = deserialize(payload, _StubOuter, resolver=r_empty)
+    assert not isinstance(result_empty.inner, StubInner)
+
+    # Non-empty SECOND — per-UID cache isolation must still give us StubInner
+    result_full = deserialize(payload, _StubOuter, resolver=r_non_empty)
+    assert isinstance(result_full.inner, StubInner)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/roxabi-nats/tests/test_type_hint_resolver.py
+++ b/packages/roxabi-nats/tests/test_type_hint_resolver.py
@@ -65,6 +65,7 @@ def test_resolver_resolves_stub_type() -> None:
 
 def test_empty_resolver_no_typechecking_hints() -> None:
     """Empty resolver round-trips a plain dataclass with no TYPE_CHECKING fields."""
+
     # Arrange
     @dataclass
     class Plain:
@@ -87,10 +88,12 @@ def test_empty_resolver_no_typechecking_hints() -> None:
 def test_duplicate_entries_deduped() -> None:
     """Duplicate (module, name) pairs collapse to a single entry."""
     # Arrange / Act
-    r = _TypeHintResolver([
-        ("roxabi_nats._test_stub_module", "StubInner"),
-        ("roxabi_nats._test_stub_module", "StubInner"),
-    ])
+    r = _TypeHintResolver(
+        [
+            ("roxabi_nats._test_stub_module", "StubInner"),
+            ("roxabi_nats._test_stub_module", "StubInner"),
+        ]
+    )
 
     # Assert
     assert len(r.entries) == 1

--- a/src/lyra/adapters/_inbound_cache.py
+++ b/src/lyra/adapters/_inbound_cache.py
@@ -14,7 +14,8 @@ import logging
 import time
 
 from lyra.core.message import InboundMessage
-from roxabi_nats._serialize import deserialize_dict
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+from roxabi_nats._serialize import _TypeHintResolver, deserialize_dict
 
 log = logging.getLogger(__name__)
 
@@ -27,11 +28,12 @@ REAPER_INTERVAL_SECONDS = 30
 class InboundCache:
     """stream_id → InboundMessage cache with TTL reaper."""
 
-    __slots__ = ("_msgs", "_ts")
+    __slots__ = ("_msgs", "_resolver", "_ts")
 
-    def __init__(self) -> None:
+    def __init__(self, *, resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
         self._msgs: dict[str, InboundMessage] = {}
         self._ts: dict[str, float] = {}
+        self._resolver = resolver
 
     # -- public API --------------------------------------------------
 
@@ -88,7 +90,7 @@ class InboundCache:
             raw = data.get("original_msg")
             if raw is not None:
                 try:
-                    msg = deserialize_dict(raw, InboundMessage)
+                    msg = deserialize_dict(raw, InboundMessage, resolver=self._resolver)
                 except Exception:
                     log.warning(
                         "InboundCache: bad embedded original_msg for %s stream_id=%r",

--- a/src/lyra/adapters/_inbound_cache.py
+++ b/src/lyra/adapters/_inbound_cache.py
@@ -15,7 +15,8 @@ import time
 
 from lyra.core.message import InboundMessage
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
-from roxabi_nats._serialize import _TypeHintResolver, deserialize_dict
+from roxabi_nats import TypeHintResolver
+from roxabi_nats._serialize import deserialize_dict
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class InboundCache:
 
     __slots__ = ("_msgs", "_resolver", "_ts")
 
-    def __init__(self, *, resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
+    def __init__(self, *, resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
         self._msgs: dict[str, InboundMessage] = {}
         self._ts: dict[str, float] = {}
         self._resolver = resolver

--- a/src/lyra/adapters/nats_envelope_handlers.py
+++ b/src/lyra/adapters/nats_envelope_handlers.py
@@ -19,6 +19,8 @@ from lyra.core.message import (
     OutboundAudio,
     OutboundMessage,
 )
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+from roxabi_nats._serialize import _TypeHintResolver
 from roxabi_nats._serialize import deserialize_dict as _deserialize_dict
 from roxabi_nats._version_check import check_schema_version
 
@@ -31,7 +33,12 @@ _MAX_STREAMS = 100
 _MAX_QUEUE_SIZE = 256
 
 
-async def handle_send(listener: "NatsOutboundListener", data: dict) -> None:
+async def handle_send(
+    listener: "NatsOutboundListener",
+    data: dict,
+    *,
+    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+) -> None:
     """Handle 'send' envelope — resolve cached msg, deserialize, dispatch."""
     resolved = listener._cache.resolve(data, "send")
     if resolved is None:
@@ -44,7 +51,7 @@ async def handle_send(listener: "NatsOutboundListener", data: dict) -> None:
     if not _check_outbound_version(listener, outbound_data, "OutboundMessage"):
         return
     try:
-        outbound = _deserialize_dict(outbound_data, OutboundMessage)
+        outbound = _deserialize_dict(outbound_data, OutboundMessage, resolver=resolver)
     except Exception:
         log.warning("NatsOutboundListener: failed to deserialize outbound message")
         return
@@ -52,7 +59,12 @@ async def handle_send(listener: "NatsOutboundListener", data: dict) -> None:
     listener._cache.pop(stream_id)
 
 
-async def handle_attachment(listener: "NatsOutboundListener", data: dict) -> None:
+async def handle_attachment(
+    listener: "NatsOutboundListener",
+    data: dict,
+    *,
+    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+) -> None:
     """Handle 'attachment' envelope type — resolve, deserialize, dispatch to adapter."""
     resolved = listener._cache.resolve(data, "attachment")
     if resolved is None:
@@ -65,7 +77,9 @@ async def handle_attachment(listener: "NatsOutboundListener", data: dict) -> Non
     if not _check_outbound_version(listener, attachment_data, "OutboundAttachment"):
         return
     try:
-        attachment = _deserialize_dict(attachment_data, OutboundAttachment)
+        attachment = _deserialize_dict(
+            attachment_data, OutboundAttachment, resolver=resolver
+        )
     except Exception:
         log.warning("NatsOutboundListener: failed to deserialize attachment")
         return
@@ -73,7 +87,12 @@ async def handle_attachment(listener: "NatsOutboundListener", data: dict) -> Non
     listener._cache.pop(stream_id)
 
 
-async def handle_audio(listener: "NatsOutboundListener", data: dict) -> None:
+async def handle_audio(
+    listener: "NatsOutboundListener",
+    data: dict,
+    *,
+    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+) -> None:
     """Handle 'audio' envelope type — resolve, deserialize, dispatch to adapter."""
     resolved = listener._cache.resolve(data, "audio")
     if resolved is None:
@@ -84,7 +103,7 @@ async def handle_audio(listener: "NatsOutboundListener", data: dict) -> None:
         log.warning("NatsOutboundListener: missing 'audio' key in envelope")
         return
     try:
-        audio = _deserialize_dict(audio_data, OutboundAudio)
+        audio = _deserialize_dict(audio_data, OutboundAudio, resolver=resolver)
     except Exception:
         log.warning("NatsOutboundListener: failed to deserialize audio")
         return
@@ -92,7 +111,12 @@ async def handle_audio(listener: "NatsOutboundListener", data: dict) -> None:
     listener._cache.pop(stream_id)
 
 
-def handle_stream_start(listener: "NatsOutboundListener", data: dict) -> None:
+def handle_stream_start(
+    listener: "NatsOutboundListener",
+    data: dict,
+    *,
+    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+) -> None:
     """Handle 'stream_start' envelope — store outbound metadata for streaming."""
     stream_id = data.get("stream_id")
     outbound_data = data.get("outbound")
@@ -110,7 +134,7 @@ def handle_stream_start(listener: "NatsOutboundListener", data: dict) -> None:
         return
     try:
         listener._stream_outbound[stream_id] = _deserialize_dict(
-            outbound_data, OutboundMessage
+            outbound_data, OutboundMessage, resolver=resolver
         )
         raw_orig = data.get("original_msg")  # bounded by _MAX_STREAMS guard above
         if raw_orig is not None:
@@ -160,7 +184,12 @@ async def handle_chunk(listener: "NatsOutboundListener", data: dict) -> None:
         )
 
 
-async def handle_raw_message(listener: "NatsOutboundListener", msg: Msg) -> None:
+async def handle_raw_message(
+    listener: "NatsOutboundListener",
+    msg: Msg,
+    *,
+    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+) -> None:
     """Parse raw NATS message and dispatch to appropriate envelope handler."""
     try:
         data = json.loads(msg.data)
@@ -169,15 +198,15 @@ async def handle_raw_message(listener: "NatsOutboundListener", msg: Msg) -> None
         return
     msg_type = data.get("type")
     if msg_type == "send":
-        await handle_send(listener, data)
+        await handle_send(listener, data, resolver=resolver)
     elif msg_type == "stream_start":
-        handle_stream_start(listener, data)
+        handle_stream_start(listener, data, resolver=resolver)
     elif msg_type == "stream_error":
         listener._handle_stream_error(data)
     elif msg_type == "attachment":
-        await handle_attachment(listener, data)
+        await handle_attachment(listener, data, resolver=resolver)
     elif msg_type == "audio":
-        await handle_audio(listener, data)
+        await handle_audio(listener, data, resolver=resolver)
     elif "stream_id" in data and "seq" in data:
         await handle_chunk(listener, data)
     else:

--- a/src/lyra/adapters/nats_envelope_handlers.py
+++ b/src/lyra/adapters/nats_envelope_handlers.py
@@ -20,7 +20,7 @@ from lyra.core.message import (
     OutboundMessage,
 )
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
-from roxabi_nats._serialize import _TypeHintResolver
+from roxabi_nats import TypeHintResolver
 from roxabi_nats._serialize import deserialize_dict as _deserialize_dict
 from roxabi_nats._version_check import check_schema_version
 
@@ -37,7 +37,7 @@ async def handle_send(
     listener: "NatsOutboundListener",
     data: dict,
     *,
-    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+    resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
 ) -> None:
     """Handle 'send' envelope — resolve cached msg, deserialize, dispatch."""
     resolved = listener._cache.resolve(data, "send")
@@ -63,7 +63,7 @@ async def handle_attachment(
     listener: "NatsOutboundListener",
     data: dict,
     *,
-    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+    resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
 ) -> None:
     """Handle 'attachment' envelope type — resolve, deserialize, dispatch to adapter."""
     resolved = listener._cache.resolve(data, "attachment")
@@ -91,7 +91,7 @@ async def handle_audio(
     listener: "NatsOutboundListener",
     data: dict,
     *,
-    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+    resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
 ) -> None:
     """Handle 'audio' envelope type — resolve, deserialize, dispatch to adapter."""
     resolved = listener._cache.resolve(data, "audio")
@@ -115,7 +115,7 @@ def handle_stream_start(
     listener: "NatsOutboundListener",
     data: dict,
     *,
-    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+    resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
 ) -> None:
     """Handle 'stream_start' envelope — store outbound metadata for streaming."""
     stream_id = data.get("stream_id")
@@ -188,7 +188,7 @@ async def handle_raw_message(
     listener: "NatsOutboundListener",
     msg: Msg,
     *,
-    resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+    resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
 ) -> None:
     """Parse raw NATS message and dispatch to appropriate envelope handler."""
     try:

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -21,7 +21,7 @@ from lyra.adapters.nats_stream_decoder import (
 )
 from lyra.core.message import InboundMessage, OutboundMessage, Platform
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
-from roxabi_nats._serialize import _TypeHintResolver
+from roxabi_nats import TypeHintResolver
 from roxabi_nats._serialize import deserialize_dict as _deserialize_dict
 from roxabi_nats._validate import validate_nats_token
 
@@ -45,7 +45,7 @@ class NatsOutboundListener:
         adapter: "ChannelAdapter",
         *,
         queue_group: str = "",
-        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+        resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> None:
         validate_nats_token(queue_group, kind="queue_group", allow_empty=True)
         self._nc = nc

--- a/src/lyra/adapters/nats_outbound_listener.py
+++ b/src/lyra/adapters/nats_outbound_listener.py
@@ -20,6 +20,8 @@ from lyra.adapters.nats_stream_decoder import (
     handle_stream_error as _handle_stream_error_impl,
 )
 from lyra.core.message import InboundMessage, OutboundMessage, Platform
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+from roxabi_nats._serialize import _TypeHintResolver
 from roxabi_nats._serialize import deserialize_dict as _deserialize_dict
 from roxabi_nats._validate import validate_nats_token
 
@@ -35,7 +37,7 @@ _MAX_QUEUE_SIZE = 256
 class NatsOutboundListener:
     """NATS outbound subscriber → adapter dispatch (send/attachment/stream)."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         nc: NATS,
         platform: Platform,
@@ -43,6 +45,7 @@ class NatsOutboundListener:
         adapter: "ChannelAdapter",
         *,
         queue_group: str = "",
+        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> None:
         validate_nats_token(queue_group, kind="queue_group", allow_empty=True)
         self._nc = nc
@@ -50,8 +53,9 @@ class NatsOutboundListener:
         self._bot_id = bot_id
         self._adapter = adapter
         self._queue_group = queue_group
+        self._resolver = resolver
         self._subject = f"lyra.outbound.{platform.value}.{bot_id}"
-        self._cache = InboundCache()
+        self._cache = InboundCache(resolver=resolver)
         self._stream_queues: dict[str, asyncio.Queue[dict]] = {}
         self._stream_tasks: dict[str, asyncio.Task[None]] = {}
         self._stream_outbound: dict[str, OutboundMessage] = {}
@@ -101,7 +105,7 @@ class NatsOutboundListener:
 
     async def _handle(self, msg: Any) -> None:
         """Dispatch raw NATS message to envelope handlers."""
-        await handle_raw_message(self, msg)
+        await handle_raw_message(self, msg, resolver=self._resolver)
 
     def _handle_stream_error(self, data: dict) -> None:
         """Dispatch to the stream_error handler in nats_stream_decoder."""
@@ -114,7 +118,9 @@ class NatsOutboundListener:
             raw = self._stream_original_msgs.pop(stream_id, None)
             if raw is not None:
                 try:
-                    original_msg = _deserialize_dict(raw, InboundMessage)
+                    original_msg = _deserialize_dict(
+                        raw, InboundMessage, resolver=self._resolver
+                    )
                 except Exception:
                     log.warning(
                         "NatsOutboundListener: bad embedded original_msg"

--- a/src/lyra/adapters/nats_stream_decoder.py
+++ b/src/lyra/adapters/nats_stream_decoder.py
@@ -58,6 +58,7 @@ async def decode_stream_events(
     """
     from lyra.nats.render_event_codec import NatsRenderEventCodec
 
+    _codec = NatsRenderEventCodec()
     expected_seq = 0
     while True:
         try:
@@ -89,7 +90,7 @@ async def decode_stream_events(
             break
         payload = chunk.get("payload", {})
         is_done = chunk.get("done", False)
-        event = NatsRenderEventCodec.decode(event_type, payload, counter=counter)
+        event = _codec.decode(event_type, payload, counter=counter)
         if event is not None:
             yield event
         if NatsRenderEventCodec.is_terminal(event_type, is_done):

--- a/src/lyra/bootstrap/stt_adapter_standalone.py
+++ b/src/lyra/bootstrap/stt_adapter_standalone.py
@@ -35,6 +35,7 @@ class SttAdapterStandalone(NatsAdapterBase):
             1,
             heartbeat_subject="lyra.voice.stt.heartbeat",
             heartbeat_interval=5.0,
+            type_registry=None,
         )
         self._active_count: int = 0
         self._base_stt_cfg = load_stt_config()

--- a/src/lyra/bootstrap/tts_adapter_standalone.py
+++ b/src/lyra/bootstrap/tts_adapter_standalone.py
@@ -59,6 +59,7 @@ class TtsAdapterStandalone(NatsAdapterBase):
             1,
             heartbeat_subject="lyra.voice.tts.heartbeat",
             heartbeat_interval=5.0,
+            type_registry=None,
         )
         self._active_count: int = 0
         tts_cfg = load_tts_config()

--- a/src/lyra/core/commands/command_router.py
+++ b/src/lyra/core/commands/command_router.py
@@ -1,7 +1,4 @@
-"""Command router — dispatch slash commands to builtins, processor commands, or plugins.
-
-Builtins: builtin_commands.py, workspace_commands.py. Processors: processor_registry.py.
-"""
+"""Command router — dispatch slash commands to builtins, processors, or plugins."""
 
 from __future__ import annotations
 
@@ -114,6 +111,7 @@ class CommandRouter:
         try:
             importlib.import_module("lyra.core.processors")
             from lyra.core.processor_registry import registry as _proc_registry
+
             for cmd, desc in _proc_registry.descriptions().items():
                 if cmd in self._passthroughs:
                     result.append((cmd, desc, False))
@@ -165,6 +163,7 @@ class CommandRouter:
 
     def _build_builtin_handlers(self) -> dict[str, BuiltinHandler]:
         """Build dispatch table for builtin commands."""
+
         def _stop(_a: list, _m: InboundMessage, p: Pool | None) -> Response:
             if p:
                 p.cancel()
@@ -181,6 +180,7 @@ class CommandRouter:
             if p:
                 p.voice_mode = False
             return Response(content="Voice mode off — text-only replies.")
+
         return {
             "/help": lambda a, m, p: builtin_commands.help_command(
                 self._builtins,

--- a/src/lyra/nats/__init__.py
+++ b/src/lyra/nats/__init__.py
@@ -3,21 +3,15 @@
 Transport primitives (NatsAdapterBase, nats_connect, circuit breaker,
 version checks, sanitizers, serializer) now live in the roxabi_nats
 package — see docs/architecture/adr/045-*.mdx.
-"""
 
-# Hub-internal wiring: roxabi_nats._serialize exposes an internal registry
-# for TYPE_CHECKING-only type hints that must be resolved at deserialization
-# time. Lyra, as the workspace host, is the only permitted caller of this
-# private helper — external SDK consumers must not import from _-prefixed
-# submodules. Tracked for refactor in issue #729 (per-adapter explicit init
-# param, replacing the global mutable registry).
-from roxabi_nats._serialize import _register_type_checking_import
+The TYPE_CHECKING-only hint registry that used to live here as a
+process-global has moved to an explicit per-consumer resolver; see
+``lyra.nats.type_registry`` for the single source of truth.
+"""
 
 from .nats_bus import NatsBus
 from .nats_channel_proxy import NatsChannelProxy
 from .render_event_codec import NatsRenderEventCodec
-
-_register_type_checking_import("lyra.core.commands.command_parser", "CommandContext")
 
 __all__ = [
     "NatsBus",

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -47,8 +47,9 @@ from lyra.core.message import (
     Platform,
 )
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+from roxabi_nats import TypeHintResolver
 from roxabi_nats._sanitize import sanitize_platform_meta
-from roxabi_nats._serialize import _TypeHintResolver, deserialize_dict, serialize
+from roxabi_nats._serialize import deserialize_dict, serialize
 from roxabi_nats._validate import validate_nats_token
 from roxabi_nats._version_check import check_schema_version
 
@@ -97,7 +98,7 @@ class NatsBus(Generic[T]):
         staging_maxsize: int = 500,
         queue_group: str = "",
         publish_only: bool = False,
-        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+        resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> None:
         validate_nats_token(subject_prefix, kind="subject_prefix")
         validate_nats_token(queue_group, kind="queue_group", allow_empty=True)

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -46,8 +46,9 @@ from lyra.core.message import (
     InboundMessage,
     Platform,
 )
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
 from roxabi_nats._sanitize import sanitize_platform_meta
-from roxabi_nats._serialize import deserialize_dict, serialize
+from roxabi_nats._serialize import _TypeHintResolver, deserialize_dict, serialize
 from roxabi_nats._validate import validate_nats_token
 from roxabi_nats._version_check import check_schema_version
 
@@ -79,14 +80,11 @@ class NatsBus(Generic[T]):
 
     Args:
         nc: Already-connected ``nats.NATS`` client.
-        bot_id: Default bot identifier used when ``register()`` is called
-            without an explicit ``bot_id``.
-        item_type: Concrete type used for deserialization (e.g. ``InboundMessage``).
+        bot_id: Default bot id for ``register()`` when no explicit one is given.
+        item_type: Concrete type used for deserialization.
         subject_prefix: NATS subject prefix. Defaults to ``"lyra.inbound"``.
-            Use a different prefix (e.g. ``"lyra.inbound.audio"``) to avoid
-            subject collisions between different message types.
-        publish_only: If ``True``, ``start()`` is a no-op and ``get()`` raises.
-            For adapter-side buses that only publish (see #541).
+        publish_only: If ``True``, ``start()`` is a no-op and ``get()`` raises
+            (adapter-side buses that only publish, see #541).
     """
 
     def __init__(  # noqa: PLR0913
@@ -99,6 +97,7 @@ class NatsBus(Generic[T]):
         staging_maxsize: int = 500,
         queue_group: str = "",
         publish_only: bool = False,
+        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> None:
         validate_nats_token(subject_prefix, kind="subject_prefix")
         validate_nats_token(queue_group, kind="queue_group", allow_empty=True)
@@ -108,6 +107,7 @@ class NatsBus(Generic[T]):
         self._subject_prefix = subject_prefix
         self._queue_group = queue_group
         self._publish_only = publish_only
+        self._resolver = resolver
         self._started = False
         self._registrations: set[tuple[Platform, str]] = set()
         self._subscriptions: dict[tuple[Platform, str], Subscription] = {}
@@ -265,7 +265,9 @@ class NatsBus(Generic[T]):
                 return  # helper already logged + incremented counter
 
             try:
-                item = deserialize_dict(payload, self._item_type)
+                item = deserialize_dict(
+                    payload, self._item_type, resolver=self._resolver
+                )
                 if hasattr(item, "platform_meta"):
                     _item: Any = item
                     item = dataclasses.replace(

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -25,7 +25,8 @@ from lyra.core.message import (
 from lyra.core.render_events import RenderEvent
 from lyra.core.trust import TrustLevel
 from lyra.nats.render_event_codec import NatsRenderEventCodec
-from roxabi_nats._serialize import serialize
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+from roxabi_nats._serialize import _TypeHintResolver, serialize
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +47,14 @@ class NatsChannelProxy:
     render_audio_stream() and render_voice_stream() are not yet implemented (C5).
     """
 
-    def __init__(self, nc: NATS, platform: Platform, bot_id: str) -> None:
+    def __init__(
+        self,
+        nc: NATS,
+        platform: Platform,
+        bot_id: str,
+        *,
+        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+    ) -> None:
         """Store nc, platform, bot_id. No I/O."""
         if not re.fullmatch(r"[A-Za-z0-9_-]+", bot_id):
             raise ValueError(
@@ -56,6 +64,7 @@ class NatsChannelProxy:
         self._nc = nc
         self._platform = platform
         self._bot_id = bot_id
+        self._resolver = resolver
         self._active_streams: set[str] = set()
 
     # ------------------------------------------------------------------
@@ -89,8 +98,12 @@ class NatsChannelProxy:
         envelope = {
             "type": "send",
             "stream_id": original_msg.id,
-            "outbound": json.loads(serialize(outbound).decode("utf-8")),
-            "original_msg": json.loads(serialize(original_msg).decode("utf-8")),
+            "outbound": json.loads(
+                serialize(outbound, resolver=self._resolver).decode("utf-8")
+            ),
+            "original_msg": json.loads(
+                serialize(original_msg, resolver=self._resolver).decode("utf-8")
+            ),
         }
         payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
         await self._nc.publish(subject, payload)
@@ -112,8 +125,12 @@ class NatsChannelProxy:
             header = {
                 "type": "stream_start",
                 "stream_id": original_msg.id,
-                "outbound": json.loads(serialize(outbound).decode("utf-8")),
-                "original_msg": json.loads(serialize(original_msg).decode("utf-8")),
+                "outbound": json.loads(
+                    serialize(outbound, resolver=self._resolver).decode("utf-8")
+                ),
+                "original_msg": json.loads(
+                    serialize(original_msg, resolver=self._resolver).decode("utf-8")
+                ),
             }
             await self._nc.publish(
                 subject,
@@ -215,8 +232,12 @@ class NatsChannelProxy:
         envelope = {
             "type": "audio",
             "stream_id": inbound.id,
-            "audio": json.loads(serialize(msg).decode("utf-8")),
-            "original_msg": json.loads(serialize(inbound).decode("utf-8")),
+            "audio": json.loads(
+                serialize(msg, resolver=self._resolver).decode("utf-8")
+            ),
+            "original_msg": json.loads(
+                serialize(inbound, resolver=self._resolver).decode("utf-8")
+            ),
         }
         payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
         await self._nc.publish(subject, payload)
@@ -259,7 +280,9 @@ class NatsChannelProxy:
         envelope = {
             "type": "attachment",
             "stream_id": inbound.id,
-            "attachment": json.loads(serialize(msg).decode("utf-8")),
+            "attachment": json.loads(
+                serialize(msg, resolver=self._resolver).decode("utf-8")
+            ),
         }
         payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
         await self._nc.publish(subject, payload)

--- a/src/lyra/nats/nats_channel_proxy.py
+++ b/src/lyra/nats/nats_channel_proxy.py
@@ -26,7 +26,8 @@ from lyra.core.render_events import RenderEvent
 from lyra.core.trust import TrustLevel
 from lyra.nats.render_event_codec import NatsRenderEventCodec
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
-from roxabi_nats._serialize import _TypeHintResolver, serialize
+from roxabi_nats import TypeHintResolver
+from roxabi_nats._serialize import serialize
 
 log = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ class NatsChannelProxy:
         platform: Platform,
         bot_id: str,
         *,
-        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
+        resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> None:
         """Store nc, platform, bot_id. No I/O."""
         if not re.fullmatch(r"[A-Za-z0-9_-]+", bot_id):

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -19,7 +19,8 @@ from lyra.core.render_events import (
     ToolSummaryRenderEvent,
 )
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
-from roxabi_nats._serialize import _TypeHintResolver, deserialize, serialize
+from roxabi_nats import TypeHintResolver
+from roxabi_nats._serialize import deserialize, serialize
 from roxabi_nats._version_check import check_schema_version
 
 
@@ -40,7 +41,7 @@ class NatsRenderEventCodec:
     ``NatsChannelProxy``; ``decode()`` returns ``None`` for it.
     """
 
-    def __init__(self, *, resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
+    def __init__(self, *, resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
         self._resolver = resolver
 
     @staticmethod
@@ -56,13 +57,12 @@ class NatsRenderEventCodec:
         # ToolSummaryRenderEvent
         return "tool_summary", payload, event.is_complete
 
-    @staticmethod
     def decode(
+        self,
         event_type: str,
         payload: dict,
         *,
         counter: dict[str, int] | None = None,
-        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> RenderEvent | None:
         """Reconstruct a ``RenderEvent`` from *(event_type, payload_dict)*.
 
@@ -76,7 +76,6 @@ class NatsRenderEventCodec:
             counter:    Caller-owned mutable dict; incremented at
                         ``counter[envelope_name]`` on every version-check drop.
                         Pass ``None`` to skip counting.
-            resolver:   Type-hint resolver for deserialization.
         """
         if event_type == "text":
             if not check_schema_version(
@@ -89,7 +88,7 @@ class NatsRenderEventCodec:
             return deserialize(
                 json.dumps(payload, ensure_ascii=False).encode("utf-8"),
                 TextRenderEvent,
-                resolver=resolver,
+                resolver=self._resolver,
             )
         if event_type == "tool_summary":
             if not check_schema_version(

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -18,14 +18,13 @@ from lyra.core.render_events import (
     TextRenderEvent,
     ToolSummaryRenderEvent,
 )
-from roxabi_nats._serialize import deserialize, serialize
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+from roxabi_nats._serialize import _TypeHintResolver, deserialize, serialize
 from roxabi_nats._version_check import check_schema_version
 
 
 class NatsRenderEventCodec:
     """Encode/decode pair for RenderEvent ↔ NATS chunk payload.
-
-    All methods are static — instantiation is not required.
 
     Wire format per chunk::
 
@@ -40,6 +39,9 @@ class NatsRenderEventCodec:
     ``"stream_end"`` is a synthetic terminal sentinel emitted by
     ``NatsChannelProxy``; ``decode()`` returns ``None`` for it.
     """
+
+    def __init__(self, *, resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
+        self._resolver = resolver
 
     @staticmethod
     def encode(event: RenderEvent) -> tuple[str, dict, bool]:
@@ -60,6 +62,7 @@ class NatsRenderEventCodec:
         payload: dict,
         *,
         counter: dict[str, int] | None = None,
+        resolver: _TypeHintResolver = TYPE_REGISTRY_RESOLVER,
     ) -> RenderEvent | None:
         """Reconstruct a ``RenderEvent`` from *(event_type, payload_dict)*.
 
@@ -73,6 +76,7 @@ class NatsRenderEventCodec:
             counter:    Caller-owned mutable dict; incremented at
                         ``counter[envelope_name]`` on every version-check drop.
                         Pass ``None`` to skip counting.
+            resolver:   Type-hint resolver for deserialization.
         """
         if event_type == "text":
             if not check_schema_version(
@@ -85,6 +89,7 @@ class NatsRenderEventCodec:
             return deserialize(
                 json.dumps(payload, ensure_ascii=False).encode("utf-8"),
                 TextRenderEvent,
+                resolver=resolver,
             )
         if event_type == "tool_summary":
             if not check_schema_version(

--- a/src/lyra/nats/type_registry.py
+++ b/src/lyra/nats/type_registry.py
@@ -1,0 +1,32 @@
+"""Lyra-side registry of TYPE_CHECKING-only types needed at NATS deserialization.
+
+Single source of truth. Every Lyra NATS consumer that calls any
+``roxabi_nats._serialize.deserialize*`` function imports
+``TYPE_REGISTRY_RESOLVER`` from this module and passes it in — either as a
+constructor kwarg (for class-based consumers: ``NatsBus``,
+``NatsRenderEventCodec``, ``NatsChannelProxy``, ``NatsOutboundListener``) or
+as a function parameter (for module-level free functions in
+``nats_envelope_handlers`` and the ``_inbound_cache`` factory).
+
+Fail-fast: any drift (module renamed, type deleted) raises ``ValueError`` at
+module import, not at first message. This replaces the old process-global
+``_TYPE_CHECKING_IMPORTS`` registry removed in #729.
+
+Defaults semantics: every Lyra consumer sets
+``resolver=TYPE_REGISTRY_RESOLVER`` as the default argument so downstream
+callers (bootstrap, tests) can construct them with no explicit
+resolver argument and still get correct ``CommandContext`` resolution.
+Tests that need alternative resolvers pass them explicitly.
+"""
+
+from __future__ import annotations
+
+from roxabi_nats._serialize import _TypeHintResolver
+
+TYPE_REGISTRY: tuple[tuple[str, str], ...] = (
+    ("lyra.core.commands.command_parser", "CommandContext"),
+)
+
+TYPE_REGISTRY_RESOLVER = _TypeHintResolver(TYPE_REGISTRY)
+
+__all__ = ["TYPE_REGISTRY", "TYPE_REGISTRY_RESOLVER"]

--- a/src/lyra/nats/type_registry.py
+++ b/src/lyra/nats/type_registry.py
@@ -21,12 +21,12 @@ Tests that need alternative resolvers pass them explicitly.
 
 from __future__ import annotations
 
-from roxabi_nats._serialize import _TypeHintResolver
+from roxabi_nats import TypeHintResolver
 
 TYPE_REGISTRY: tuple[tuple[str, str], ...] = (
     ("lyra.core.commands.command_parser", "CommandContext"),
 )
 
-TYPE_REGISTRY_RESOLVER = _TypeHintResolver(TYPE_REGISTRY)
+TYPE_REGISTRY_RESOLVER = TypeHintResolver(TYPE_REGISTRY)
 
 __all__ = ["TYPE_REGISTRY", "TYPE_REGISTRY_RESOLVER"]

--- a/tests/bootstrap/test_hub_builder.py
+++ b/tests/bootstrap/test_hub_builder.py
@@ -82,10 +82,13 @@ class TestRegisterAgents:
 
         import lyra.bootstrap.hub_builder as hub_builder_mod
 
-        with patch.object(hub, "register_agent") as mock_register, patch.object(
-            hub_builder_mod,
-            "_resolve_agents",
-            return_value={"alpha": mock_alpha, "beta": mock_beta},
+        with (
+            patch.object(hub, "register_agent") as mock_register,
+            patch.object(
+                hub_builder_mod,
+                "_resolve_agents",
+                return_value={"alpha": mock_alpha, "beta": mock_beta},
+            ),
         ):
             # Act
             register_agents(

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -24,6 +24,7 @@ from lyra.core.message import (
 )
 from lyra.core.trust import TrustLevel
 from lyra.nats.nats_bus import NatsBus
+from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
 from roxabi_nats._serialize import deserialize, serialize
 from tests.nats.conftest import requires_nats_server
 
@@ -96,7 +97,7 @@ class TestSerialize:
 
         # Act
         payload = serialize(msg)
-        result = deserialize(payload, InboundMessage)
+        result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
         # Assert
         assert "_session_update_fn" not in result.platform_meta
@@ -122,7 +123,7 @@ class TestSerialize:
 
         # Act
         payload = serialize(msg)
-        result = deserialize(payload, InboundMessage)
+        result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
         # Assert
         assert result.platform_meta["chat_id"] == 42
@@ -137,7 +138,7 @@ class TestSerialize:
 
         # Act
         payload = serialize(msg)
-        result = deserialize(payload, InboundMessage)
+        result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
         # Assert
         assert result.trust_level == TrustLevel.TRUSTED
@@ -163,11 +164,51 @@ class TestSerialize:
 
         # Act
         payload = serialize(msg)
-        result = deserialize(payload, InboundMessage)
+        result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
         # Assert — same UTC moment, timezone-aware
         assert result.timestamp.utctimetuple() == ts.utctimetuple()
         assert result.timestamp.tzinfo is not None
+
+    def test_nats_bus_defaults_to_type_registry_resolver(self) -> None:
+        """NatsBus stores TYPE_REGISTRY_RESOLVER when no resolver kwarg is given.
+
+        Guards the lyra-side wiring invariant from #729: every NatsBus instance
+        must be able to resolve CommandContext and any other TYPE_CHECKING-only
+        hint in InboundMessage without an explicit construction argument.
+        """
+        # Arrange — no nc needed; we only inspect construction-time state.
+        # Act
+        bus: NatsBus[InboundMessage] = NatsBus(
+            nc=None,  # type: ignore[arg-type]
+            bot_id="main",
+            item_type=InboundMessage,
+        )
+        # Assert
+        assert bus._resolver is TYPE_REGISTRY_RESOLVER
+        assert (
+            "lyra.core.commands.command_parser",
+            "CommandContext",
+        ) in bus._resolver.entries
+
+    def test_nats_bus_round_trips_inbound_with_non_empty_resolver(self) -> None:
+        """Round-trip InboundMessage via the module API using the non-empty
+        lyra resolver; type coercion survives CommandContext TYPE_CHECKING hints.
+
+        Covers spec SC-tests(lyra-side NatsBus non-empty resolver).
+        """
+        # Arrange
+        msg = _make_msg(Platform.TELEGRAM)
+
+        # Act
+        payload = serialize(msg)
+        result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
+
+        # Assert — enum, datetime, and platform_meta all survive coercion
+        assert isinstance(result.trust_level, TrustLevel)
+        assert result.trust_level == TrustLevel.TRUSTED
+        assert result.timestamp.tzinfo is not None
+        assert result.platform_meta["chat_id"] == 123
 
     def test_bytes_roundtrip(self) -> None:
         """bytes field (Attachment.url_or_path_or_bytes) survives as bytes."""
@@ -196,7 +237,7 @@ class TestSerialize:
 
         # Act
         payload = serialize(msg)
-        result = deserialize(payload, InboundMessage)
+        result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
         # Assert
         assert len(result.attachments) == 1

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -29,10 +29,11 @@ class TestRenderEventCodecVersionCheck:
     def test_text_match_decodes(self) -> None:
         """v1 text payload decodes to TextRenderEvent; counter stays empty."""
         # Arrange
+        codec = NatsRenderEventCodec()
         counter: dict[str, int] = {}
 
         # Act
-        result = NatsRenderEventCodec.decode(
+        result = codec.decode(
             "text",
             {"schema_version": 1, "text": "hi", "is_final": True},
             counter=counter,
@@ -47,10 +48,11 @@ class TestRenderEventCodecVersionCheck:
     def test_text_legacy_decodes(self) -> None:
         """text payload without schema_version defaults to v1 and decodes normally."""
         # Arrange
+        codec = NatsRenderEventCodec()
         counter: dict[str, int] = {}
 
         # Act
-        result = NatsRenderEventCodec.decode(
+        result = codec.decode(
             "text",
             {"text": "hi", "is_final": True},
             counter=counter,
@@ -69,11 +71,12 @@ class TestRenderEventCodecVersionCheck:
     def test_text_mismatch_drops(self, caplog: pytest.LogCaptureFixture) -> None:
         """v2 text payload returns None, increments counter, emits log.error."""
         # Arrange
+        codec = NatsRenderEventCodec()
         counter: dict[str, int] = {}
 
         # Act
         with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
-            result = NatsRenderEventCodec.decode(
+            result = codec.decode(
                 "text",
                 {"schema_version": 2, "text": "hi", "is_final": True},
                 counter=counter,
@@ -95,10 +98,11 @@ class TestRenderEventCodecVersionCheck:
     def test_tool_summary_match_decodes(self) -> None:
         """v1 tool_summary payload decodes to ToolSummaryRenderEvent; counter empty."""
         # Arrange
+        codec = NatsRenderEventCodec()
         counter: dict[str, int] = {}
 
         # Act
-        result = NatsRenderEventCodec.decode(
+        result = codec.decode(
             "tool_summary",
             {
                 "schema_version": 1,
@@ -131,6 +135,7 @@ class TestRenderEventCodecVersionCheck:
         A passing test proves the version gate short-circuits before the landmine.
         """
         # Arrange — payload that would blow up if extracted
+        codec = NatsRenderEventCodec()
         counter: dict[str, int] = {}
         landmine_payload = {
             "schema_version": 2,
@@ -139,7 +144,7 @@ class TestRenderEventCodecVersionCheck:
 
         # Act — must NOT raise
         with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
-            result = NatsRenderEventCodec.decode(
+            result = codec.decode(
                 "tool_summary",
                 landmine_payload,
                 counter=counter,
@@ -159,22 +164,23 @@ class TestRenderEventCodecVersionCheck:
     def test_counter_isolation_between_decodes(self) -> None:
         """Two independent counter dicts accumulate only their own drops."""
         # Arrange
+        codec = NatsRenderEventCodec()
         c1: dict[str, int] = {}
         c2: dict[str, int] = {}
 
         # Act — two drops into c1
-        NatsRenderEventCodec.decode(
+        codec.decode(
             "text",
             {"schema_version": 2, "text": "x", "is_final": True},
             counter=c1,
         )
-        NatsRenderEventCodec.decode(
+        codec.decode(
             "text",
             {"schema_version": 2, "text": "x", "is_final": True},
             counter=c1,
         )
         # One drop into c2
-        NatsRenderEventCodec.decode(
+        codec.decode(
             "text",
             {"schema_version": 2, "text": "y", "is_final": True},
             counter=c2,

--- a/uv.lock
+++ b/uv.lock
@@ -2289,7 +2289,7 @@ provides-extras = ["testing"]
 
 [[package]]
 name = "roxabi-nats"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/roxabi-nats" }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary

- Replace `roxabi_nats._serialize._TYPE_CHECKING_IMPORTS` (process-global mutable registry mutated via `_register_type_checking_import`) with a `_TypeHintResolver` instance passed through `type_registry=` on `NatsAdapterBase.__init__` and `resolver=` on `serialize`/`deserialize`/`deserialize_dict`.
- Clean break in `v0.2.0` — no deprecation shim, no `DeprecationWarning`; the hub-internal helper + the module-level list are deleted outright. External `v0.1.x` consumers that imported the private symbols hit a loud `ImportError` on upgrade (documented trade-off over silent degraded type coercion).
- Lyra-side wiring funnels through a single `TYPE_REGISTRY_RESOLVER` module constant in `src/lyra/nats/type_registry.py`; every NATS consumer (NatsBus, NatsRenderEventCodec, NatsChannelProxy, NatsOutboundListener, InboundCache, nats_envelope_handlers, stt/tts adapters) defaults to it via keyword-only kwarg.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #729: refactor(roxabi-nats): replace global type-checking registry with explicit per-adapter init param | OPEN |
| Frame | [729-replace-global-type-registry-frame.mdx](artifacts/frames/729-replace-global-type-registry-frame.mdx) | Approved |
| Spec | [729-replace-global-type-registry-spec.mdx](artifacts/specs/729-replace-global-type-registry-spec.mdx) | Approved |
| Plan | [729-replace-global-type-registry-plan.mdx](artifacts/plans/729-replace-global-type-registry-plan.mdx) | 22 tasks across V1–V3 |
| Implementation | 3 commits on `feat/729-replace-global-type-registry` (V1 SDK core · V2 adapter base · V3 lyra migration + release) | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (2972/76 skipped, 84% cov) · ruff-format ✅ · check-file-length ✅ | Passed |

## Test Plan

- [ ] `uv run pytest packages/roxabi-nats/` → 178 pass, 7 skipped (SDK core + adapter base + resolver unit tests)
- [ ] `uv run pytest tests/nats/` → green, includes new `test_nats_bus_defaults_to_type_registry_resolver` and `test_nats_bus_round_trips_inbound_with_non_empty_resolver` (SC-tests lyra-side NatsBus)
- [ ] Boot Lyra via `make lyra` with the unified NATS mode — verify inbound `CommandContext`-bearing payloads deserialize with typed fields (trust_level enum, timestamp datetime, attachments bytes)
- [ ] Grep guards: `grep -rE "_TYPE_CHECKING_IMPORTS|_register_type_checking_import" packages/roxabi-nats/src/ src/lyra/` returns zero production matches (documentation + guard-test references only)
- [ ] `packages/roxabi-nats/pyproject.toml` shows `version = "0.2.0"`; `packages/roxabi-nats/CHANGELOG.md` has a `[0.2.0]` Breaking entry with migration snippet
- [ ] ADR-045 Consequences: "known design debt" entry replaced with "Resolved in #729 (v0.2.0 — clean break, no deprecation shim)"

### Drive-by fixes

- `packages/roxabi-nats/tests/test_readiness.py` — pre-existing `from .conftest import` issue left over from PR #724; inlined the `requires_nats_server` marker so test collection works across rootdirs.
- `src/lyra/core/commands/command_router.py` + `tests/bootstrap/test_hub_builder.py` — ruff-format whitespace/grouping cleanups incidental to the migration.
- Two files trimmed (docstring compression in `nats_bus.py`, module docstring in `command_router.py`) to stay at/under the 300-line limit after the resolver threading.

Closes #729

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`