### PR TITLE
feat(contracts): port voice domain — models + subjects + fixtures (#763)

### DIFF
--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -20,3 +20,58 @@ The stable external contract is defined by `__all__` in `roxabi_contracts/__init
 - `ContractEnvelope` — base Pydantic model for all per-domain contract schemas
 
 Future domain submodules (voice, image, memory, llm) arrive in subsequent tags. See ADR-049 §Versioning for SemVer rules.
+
+## Voice domain
+
+First per-domain contract, ported from ADR-044 (`lyra` + `voiceCLI` Tts/Stt
+wire format). Import surface:
+
+```python
+from roxabi_contracts.voice import (
+    SUBJECTS,
+    TtsRequest,
+    TtsResponse,
+    SttRequest,
+    SttResponse,
+)
+```
+
+### Subjects
+
+`SUBJECTS` is a frozen namespace exposing:
+
+- `SUBJECTS.tts_request` → `"lyra.voice.tts.request"`
+- `SUBJECTS.tts_heartbeat` → `"lyra.voice.tts.heartbeat"`
+- `SUBJECTS.stt_request` → `"lyra.voice.stt.request"`
+- `SUBJECTS.stt_heartbeat` → `"lyra.voice.stt.heartbeat"`
+- `SUBJECTS.tts_workers` → `"tts_workers"` (queue group)
+- `SUBJECTS.stt_workers` → `"stt_workers"` (queue group)
+
+Helpers: `per_worker_tts(worker_id)` and `per_worker_stt(worker_id)` return the per-worker addressing subject (`"{subject}.{worker_id}"`).
+
+### Models
+
+All four models subclass `ContractEnvelope` and inherit its
+`ConfigDict(extra="ignore")` forward-compat invariant.
+
+| Model | Purpose |
+|---|---|
+| `TtsRequest` | Synthesis request from hub to voice worker |
+| `TtsResponse` | Synthesis reply; on success carries `audio_b64` + `mime_type` + `duration_ms` |
+| `SttRequest` | Transcription request (audio bytes in base64) |
+| `SttResponse` | Transcription reply; on success carries `text` + `language` + `duration_seconds` |
+
+### No-transport invariant
+
+`roxabi_contracts.voice` imports no NATS transport code. The submodule is
+pure Pydantic and safe to pull from any consumer — including environments
+that do not install `nats-py`. The `fixtures` submodule (synthesized
+`silence_wav_16khz` + `sample_transcript_en`) is test-only and is NOT
+re-exported from `roxabi_contracts.voice`; import it explicitly:
+
+```python
+from roxabi_contracts.voice.fixtures import silence_wav_16khz, sample_transcript_en
+```
+
+`scipy` is declared in `[project.optional-dependencies].testing` and is
+only pulled when a consumer requests the `[testing]` extra.

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = ["pydantic>=2"]
 # The bare name resolves inside the uv workspace via lockfile editable reference.
 # External consumers installing roxabi-contracts[testing] from a git tag must
 # declare their own [tool.uv.sources] roxabi-nats = { git = ... } entry.
-testing = ["nats-py>=2.6", "roxabi-nats"]
+testing = ["nats-py>=2.6", "roxabi-nats", "scipy>=1.11"]
 
 [project.urls]
 Repository = "https://github.com/Roxabi/lyra"

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
@@ -1,10 +1,22 @@
 """Voice-domain NATS contract surface.
 
-V1 minimal: re-exports the subject namespace only. The four envelope
-models land in the next slice and extend ``__all__`` accordingly. The
-``fixtures`` submodule is test-only and DELIBERATELY NOT re-exported.
+Public API: SUBJECTS + four envelope models. The `fixtures` submodule is
+test-only and DELIBERATELY not re-exported here — it must be imported
+explicitly as ``from roxabi_contracts.voice.fixtures import ...``.
 """
 
+from roxabi_contracts.voice.models import (
+    SttRequest,
+    SttResponse,
+    TtsRequest,
+    TtsResponse,
+)
 from roxabi_contracts.voice.subjects import SUBJECTS
 
-__all__ = ["SUBJECTS"]
+__all__ = [
+    "SUBJECTS",
+    "SttRequest",
+    "SttResponse",
+    "TtsRequest",
+    "TtsResponse",
+]

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
@@ -1,0 +1,10 @@
+"""Voice-domain NATS contract surface.
+
+V1 minimal: re-exports the subject namespace only. The four envelope
+models land in the next slice and extend ``__all__`` accordingly. The
+``fixtures`` submodule is test-only and DELIBERATELY NOT re-exported.
+"""
+
+from roxabi_contracts.voice.subjects import SUBJECTS
+
+__all__ = ["SUBJECTS"]

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/fixtures.py
@@ -16,8 +16,15 @@ from __future__ import annotations
 
 import io
 
-import numpy as np
-from scipy.io.wavfile import write as _wav_write
+try:
+    import numpy as np
+    from scipy.io.wavfile import write as _wav_write
+except ImportError as exc:  # pragma: no cover — exercised only without [testing]
+    raise ImportError(
+        "roxabi_contracts.voice.fixtures requires the `[testing]` extra "
+        "(numpy + scipy). Install with: `uv pip install roxabi-contracts[testing]` "
+        "or `uv sync --all-extras` inside the workspace."
+    ) from exc
 
 _SAMPLE_RATE_HZ: int = 16_000
 _DURATION_SECONDS: int = 1

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/fixtures.py
@@ -1,0 +1,38 @@
+# pyright: reportMissingTypeStubs=false
+"""Test fixtures for roxabi_contracts.voice.
+
+Pure synthesized data. NO real user audio, NO binary blobs committed,
+NO NATS imports. scipy is declared in [project.optional-dependencies].testing
+— production installs that do not request the testing extra will NOT pull
+this module's imports (fixtures.py is only loaded when tests import it).
+
+The pyright directive above is scoped to this file only. scipy/numpy ship
+stubs via PyPI packages that strict-mode pyright does not always pick up
+in a workspace lockfile; the suppression is scoped rather than global so
+production code elsewhere retains full strict typing.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+from scipy.io.wavfile import write as _wav_write
+
+_SAMPLE_RATE_HZ: int = 16_000
+_DURATION_SECONDS: int = 1
+
+
+def _build_silence_wav_16khz() -> bytes:
+    """Synthesize 1 s of 16 kHz mono int16 silence as a WAV bytes buffer."""
+    samples = np.zeros(_SAMPLE_RATE_HZ * _DURATION_SECONDS, dtype=np.int16)
+    buf = io.BytesIO()
+    _wav_write(buf, _SAMPLE_RATE_HZ, samples)
+    return buf.getvalue()
+
+
+silence_wav_16khz: bytes = _build_silence_wav_16khz()
+"""1 s of 16 kHz mono int16 silence, WAV-encoded. Header starts with ``b'RIFF'``."""
+
+sample_transcript_en: str = "Hello, this is a roxabi-contracts test fixture."
+"""Deterministic English transcript for STT fixtures. No PII, ≤120 chars."""

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
@@ -1,0 +1,85 @@
+"""Voice-domain NATS contract models.
+
+Pure Pydantic. No NATS imports. No transport logic. Every model subclasses
+ContractEnvelope, which provides (contract_version, trace_id, issued_at)
+plus ConfigDict(extra="ignore") for forward-compat.
+
+See artifacts/specs/763-port-voice-domain-spec.mdx §Known drift for the
+rationale on optional-but-invariant fields on response models.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+from roxabi_contracts.envelope import ContractEnvelope
+
+
+class TtsRequest(ContractEnvelope):
+    """TTS synthesis request. Canonical subject: ``lyra.voice.tts.request``."""
+
+    request_id: str
+    text: Annotated[str, StringConstraints(min_length=1)]
+    language: str | None = None
+    voice: str | None = None
+    fallback_language: str | None = None
+    default_language: str | None = None
+    languages: list[str] | None = None
+    chunked: bool = True
+    engine: str | None = None
+    accent: str | None = None
+    personality: str | None = None
+    speed: float | None = None
+    emotion: str | None = None
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    segment_gap: float | None = None
+    crossfade: float | None = None
+    chunk_size: int | None = None
+
+
+class TtsResponse(ContractEnvelope):
+    """TTS synthesis response.
+
+    Success-path invariant (asserted in test_voice_models.py): when ok=True,
+    audio_b64 AND mime_type AND duration_ms are all non-null. Error-path
+    (ok=False) omits them and sets error.
+    """
+
+    ok: bool
+    request_id: str
+    error: str | None = None
+    audio_b64: str | None = None
+    mime_type: str | None = None
+    duration_ms: int | None = None
+    waveform_b64: str | None = None
+
+
+class SttRequest(ContractEnvelope):
+    """STT transcription request. Canonical subject: ``lyra.voice.stt.request``."""
+
+    request_id: str
+    audio_b64: Annotated[str, StringConstraints(min_length=1)]
+    model: str
+    mime_type: str | None = None
+    language: str | None = None
+    language_detection_threshold: float | None = None
+    language_detection_segments: int | None = None
+    language_fallback: str | None = None
+
+
+class SttResponse(ContractEnvelope):
+    """STT transcription response.
+
+    Success-path invariant (asserted in test_voice_models.py): when ok=True,
+    text AND language AND duration_seconds are all non-null.
+    """
+
+    ok: bool
+    request_id: str
+    error: str | None = None
+    text: str | None = None
+    language: str | None = None
+    duration_seconds: float | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
@@ -10,9 +10,9 @@ rationale on optional-but-invariant fields on response models.
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Self
 
-from pydantic import StringConstraints
+from pydantic import StringConstraints, model_validator
 
 from roxabi_contracts.envelope import ContractEnvelope
 
@@ -43,9 +43,10 @@ class TtsRequest(ContractEnvelope):
 class TtsResponse(ContractEnvelope):
     """TTS synthesis response.
 
-    Success-path invariant (asserted in test_voice_models.py): when ok=True,
-    audio_b64 AND mime_type AND duration_ms are all non-null. Error-path
-    (ok=False) omits them and sets error.
+    Success-path invariant (enforced by ``_enforce_success_invariant``):
+    when ``ok=True``, ``audio_b64`` AND ``mime_type`` AND ``duration_ms``
+    are all non-null. Error-path (``ok=False``) omits them and sets
+    ``error``.
     """
 
     ok: bool
@@ -55,6 +56,19 @@ class TtsResponse(ContractEnvelope):
     mime_type: str | None = None
     duration_ms: int | None = None
     waveform_b64: str | None = None
+
+    @model_validator(mode="after")
+    def _enforce_success_invariant(self) -> Self:
+        if self.ok and (
+            self.audio_b64 is None
+            or self.mime_type is None
+            or self.duration_ms is None
+        ):
+            raise ValueError(
+                "TtsResponse with ok=True must carry audio_b64, mime_type, "
+                "and duration_ms (see spec #763 drift item #1)"
+            )
+        return self
 
 
 class SttRequest(ContractEnvelope):
@@ -73,8 +87,9 @@ class SttRequest(ContractEnvelope):
 class SttResponse(ContractEnvelope):
     """STT transcription response.
 
-    Success-path invariant (asserted in test_voice_models.py): when ok=True,
-    text AND language AND duration_seconds are all non-null.
+    Success-path invariant (enforced by ``_enforce_success_invariant``):
+    when ``ok=True``, ``text`` AND ``language`` AND ``duration_seconds``
+    are all non-null.
     """
 
     ok: bool
@@ -83,3 +98,16 @@ class SttResponse(ContractEnvelope):
     text: str | None = None
     language: str | None = None
     duration_seconds: float | None = None
+
+    @model_validator(mode="after")
+    def _enforce_success_invariant(self) -> Self:
+        if self.ok and (
+            self.text is None
+            or self.language is None
+            or self.duration_seconds is None
+        ):
+            raise ValueError(
+                "SttResponse with ok=True must carry text, language, and "
+                "duration_seconds (see spec #763 drift items #3+#4)"
+            )
+        return self

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
@@ -20,7 +20,7 @@ from roxabi_contracts.envelope import ContractEnvelope
 class TtsRequest(ContractEnvelope):
     """TTS synthesis request. Canonical subject: ``lyra.voice.tts.request``."""
 
-    request_id: str
+    request_id: Annotated[str, StringConstraints(min_length=1)]
     text: Annotated[str, StringConstraints(min_length=1)]
     language: str | None = None
     voice: str | None = None
@@ -50,7 +50,7 @@ class TtsResponse(ContractEnvelope):
     """
 
     ok: bool
-    request_id: str
+    request_id: Annotated[str, StringConstraints(min_length=1)]
     error: str | None = None
     audio_b64: str | None = None
     mime_type: str | None = None
@@ -74,7 +74,7 @@ class TtsResponse(ContractEnvelope):
 class SttRequest(ContractEnvelope):
     """STT transcription request. Canonical subject: ``lyra.voice.stt.request``."""
 
-    request_id: str
+    request_id: Annotated[str, StringConstraints(min_length=1)]
     audio_b64: Annotated[str, StringConstraints(min_length=1)]
     model: str
     mime_type: str | None = None
@@ -93,7 +93,7 @@ class SttResponse(ContractEnvelope):
     """
 
     ok: bool
-    request_id: str
+    request_id: Annotated[str, StringConstraints(min_length=1)]
     error: str | None = None
     text: str | None = None
     language: str | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
@@ -1,0 +1,36 @@
+"""Voice-domain NATS subject strings and per-worker helpers.
+
+Canonical values from ADR-044 §Subjects. Literal strings (no f-strings,
+no derivation) so grep can locate every reference across the monorepo.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class _Subjects:
+    """Frozen namespace of voice-domain subject strings.
+
+    Attribute access is pyright-checked: typos fail at type-check time
+    rather than silently returning None (cf. ADR-049 §API ergonomics).
+    """
+
+    tts_request: str = "lyra.voice.tts.request"
+    tts_heartbeat: str = "lyra.voice.tts.heartbeat"
+    stt_request: str = "lyra.voice.stt.request"
+    stt_heartbeat: str = "lyra.voice.stt.heartbeat"
+    tts_workers: str = "tts_workers"
+    stt_workers: str = "stt_workers"
+
+
+SUBJECTS = _Subjects()
+
+
+def per_worker_tts(worker_id: str) -> str:
+    """Per-worker TTS request subject: ``lyra.voice.tts.request.{worker_id}``."""
+    return f"{SUBJECTS.tts_request}.{worker_id}"
+
+
+def per_worker_stt(worker_id: str) -> str:
+    """Per-worker STT request subject: ``lyra.voice.stt.request.{worker_id}``."""
+    return f"{SUBJECTS.stt_request}.{worker_id}"

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
@@ -4,7 +4,14 @@ Canonical values from ADR-044 §Subjects. Literal strings (no f-strings,
 no derivation) so grep can locate every reference across the monorepo.
 """
 
+import re
 from dataclasses import dataclass
+
+# NATS subject tokens are `.`-separated. ``*`` matches any single token and
+# ``>`` matches a subtree. A worker id that contains any of those characters
+# would inject wildcards into the published subject and let a subscriber
+# claim more traffic than intended. Restrict to alphanumeric + ``-`` + ``_``.
+_SAFE_WORKER_ID_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,11 +33,30 @@ class _Subjects:
 SUBJECTS = _Subjects()
 
 
+def _validate_worker_id(worker_id: str) -> None:
+    if not _SAFE_WORKER_ID_RE.fullmatch(worker_id):
+        raise ValueError(
+            f"worker_id must match [A-Za-z0-9_-]+ (got {worker_id!r}); "
+            "NATS wildcard / subtree characters (. * >) are rejected to "
+            "prevent subject injection"
+        )
+
+
 def per_worker_tts(worker_id: str) -> str:
-    """Per-worker TTS request subject: ``lyra.voice.tts.request.{worker_id}``."""
+    """Per-worker TTS request subject: ``lyra.voice.tts.request.{worker_id}``.
+
+    Raises ``ValueError`` if ``worker_id`` contains characters outside
+    ``[A-Za-z0-9_-]`` — see ``_validate_worker_id``.
+    """
+    _validate_worker_id(worker_id)
     return f"{SUBJECTS.tts_request}.{worker_id}"
 
 
 def per_worker_stt(worker_id: str) -> str:
-    """Per-worker STT request subject: ``lyra.voice.stt.request.{worker_id}``."""
+    """Per-worker STT request subject: ``lyra.voice.stt.request.{worker_id}``.
+
+    Raises ``ValueError`` if ``worker_id`` contains characters outside
+    ``[A-Za-z0-9_-]`` — see ``_validate_worker_id``.
+    """
+    _validate_worker_id(worker_id)
     return f"{SUBJECTS.stt_request}.{worker_id}"

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
@@ -6,6 +6,7 @@ no derivation) so grep can locate every reference across the monorepo.
 
 import re
 from dataclasses import dataclass
+from typing import Literal
 
 # NATS subject tokens are `.`-separated. ``*`` matches any single token and
 # ``>`` matches a subtree. A worker id that contains any of those characters
@@ -20,14 +21,19 @@ class _Subjects:
 
     Attribute access is pyright-checked: typos fail at type-check time
     rather than silently returning None (cf. ADR-049 §API ergonomics).
+
+    Each field is typed as a ``Literal[...]`` — a typo in the default
+    value (e.g. ``"lyra.voice.tts.reuqest"``) fails type-checking
+    independently of the runtime string-equality assertions in
+    ``tests/test_voice_subjects.py``.
     """
 
-    tts_request: str = "lyra.voice.tts.request"
-    tts_heartbeat: str = "lyra.voice.tts.heartbeat"
-    stt_request: str = "lyra.voice.stt.request"
-    stt_heartbeat: str = "lyra.voice.stt.heartbeat"
-    tts_workers: str = "tts_workers"
-    stt_workers: str = "stt_workers"
+    tts_request: Literal["lyra.voice.tts.request"] = "lyra.voice.tts.request"
+    tts_heartbeat: Literal["lyra.voice.tts.heartbeat"] = "lyra.voice.tts.heartbeat"
+    stt_request: Literal["lyra.voice.stt.request"] = "lyra.voice.stt.request"
+    stt_heartbeat: Literal["lyra.voice.stt.heartbeat"] = "lyra.voice.stt.heartbeat"
+    tts_workers: Literal["tts_workers"] = "tts_workers"
+    stt_workers: Literal["stt_workers"] = "stt_workers"
 
 
 SUBJECTS = _Subjects()

--- a/packages/roxabi-contracts/tests/test_voice_extra_ignore.py
+++ b/packages/roxabi-contracts/tests/test_voice_extra_ignore.py
@@ -37,7 +37,9 @@ _REQUIRED: list[tuple[type[BaseModel], dict[str, Any]]] = [
 
 
 @pytest.mark.parametrize(
-    ("model", "required"), _REQUIRED, ids=lambda x: getattr(x, "__name__", "")
+    ("model", "required"),
+    _REQUIRED,
+    ids=["TtsRequest", "TtsResponse", "SttRequest", "SttResponse"],
 )
 def test_extra_field_dropped_dict_path(
     model: type[BaseModel], required: dict[str, Any]
@@ -51,7 +53,9 @@ def test_extra_field_dropped_dict_path(
 
 
 @pytest.mark.parametrize(
-    ("model", "required"), _REQUIRED, ids=lambda x: getattr(x, "__name__", "")
+    ("model", "required"),
+    _REQUIRED,
+    ids=["TtsRequest", "TtsResponse", "SttRequest", "SttResponse"],
 )
 def test_extra_field_dropped_json_path(
     model: type[BaseModel], required: dict[str, Any]

--- a/packages/roxabi-contracts/tests/test_voice_extra_ignore.py
+++ b/packages/roxabi-contracts/tests/test_voice_extra_ignore.py
@@ -1,0 +1,61 @@
+"""Forward-compat invariant for roxabi_contracts.voice models.
+
+ADR-049 §Versioning: a consumer of schema v0.1.0 receiving a v0.2.0
+payload with new optional fields must parse cleanly. Unknown fields
+are silently dropped (ConfigDict(extra="ignore") inherited from
+ContractEnvelope).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from roxabi_contracts.voice import (
+    SttRequest,
+    SttResponse,
+    TtsRequest,
+    TtsResponse,
+)
+
+_ENVELOPE: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "tst-trace",
+    "issued_at": datetime(2026, 4, 17, tzinfo=timezone.utc).isoformat(),
+}
+
+_REQUIRED: list[tuple[type[BaseModel], dict[str, Any]]] = [
+    (TtsRequest, {"request_id": "r1", "text": "hello"}),
+    (TtsResponse, {"ok": False, "request_id": "r1", "error": "engine_unavailable"}),
+    (SttRequest, {"request_id": "r2", "audio_b64": "AAAA", "model": "m"}),
+    (SttResponse, {"ok": False, "request_id": "r2", "error": "audio_decode_failed"}),
+]
+
+
+@pytest.mark.parametrize(
+    ("model", "required"), _REQUIRED, ids=lambda x: getattr(x, "__name__", "")
+)
+def test_extra_field_dropped_dict_path(
+    model: type[BaseModel], required: dict[str, Any]
+) -> None:
+    inst = model.model_validate(
+        {**_ENVELOPE, **required, "surprise_field": "x", "nested": {"a": 1}}
+    )
+    dumped = inst.model_dump()
+    assert "surprise_field" not in dumped
+    assert "nested" not in dumped
+
+
+@pytest.mark.parametrize(
+    ("model", "required"), _REQUIRED, ids=lambda x: getattr(x, "__name__", "")
+)
+def test_extra_field_dropped_json_path(
+    model: type[BaseModel], required: dict[str, Any]
+) -> None:
+    payload = json.dumps({**_ENVELOPE, **required, "future_v2_field": 42})
+    inst = model.model_validate_json(payload)
+    assert "future_v2_field" not in inst.model_dump()

--- a/packages/roxabi-contracts/tests/test_voice_models.py
+++ b/packages/roxabi-contracts/tests/test_voice_models.py
@@ -172,3 +172,57 @@ def test_stt_response_error_path_allows_null_success_fields() -> None:
     assert resp.text is None
     assert resp.language is None
     assert resp.duration_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Negative tests for `StringConstraints(min_length=1)` — pin the declared
+# constraints so a silent weakening (e.g. dropping the Annotated wrapper)
+# fails here. Covers drift-unrelated correctness guarantees on the base
+# envelope (trace_id) and the per-domain request models (text, audio_b64,
+# request_id).
+# ---------------------------------------------------------------------------
+
+_MIN_LENGTH_CASES: list[tuple[type[BaseModel], str]] = [
+    (TtsRequest, "text"),
+    (TtsRequest, "request_id"),
+    (TtsRequest, "trace_id"),
+    (SttRequest, "audio_b64"),
+    (SttRequest, "request_id"),
+    (SttRequest, "trace_id"),
+    (TtsResponse, "request_id"),
+    (TtsResponse, "trace_id"),
+    (SttResponse, "request_id"),
+    (SttResponse, "trace_id"),
+]
+
+
+def _valid_payload_for(model: type[BaseModel]) -> dict[str, Any]:
+    if model is TtsRequest:
+        return {**_ENVELOPE, "request_id": "r1", "text": sample_transcript_en}
+    if model is SttRequest:
+        return {
+            **_ENVELOPE,
+            "request_id": "r2",
+            "audio_b64": _b64(silence_wav_16khz),
+            "model": "large-v3-turbo",
+        }
+    if model is TtsResponse:
+        return {**_ENVELOPE, "ok": False, "request_id": "r1", "error": "x"}
+    if model is SttResponse:
+        return {**_ENVELOPE, "ok": False, "request_id": "r2", "error": "x"}
+    raise AssertionError(f"Unknown model {model!r}")
+
+
+@pytest.mark.parametrize(
+    ("model", "field"),
+    _MIN_LENGTH_CASES,
+    ids=[f"{m.__name__}.{f}" for m, f in _MIN_LENGTH_CASES],
+)
+def test_min_length_one_rejects_empty_string(
+    model: type[BaseModel], field: str
+) -> None:
+    """Empty string for any ``min_length=1`` field raises ValidationError."""
+    payload = _valid_payload_for(model)
+    payload[field] = ""
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)

--- a/packages/roxabi-contracts/tests/test_voice_models.py
+++ b/packages/roxabi-contracts/tests/test_voice_models.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from roxabi_contracts.voice import (
     SttRequest,
@@ -81,8 +81,8 @@ def test_roundtrip(model: type[BaseModel], payload: dict[str, Any]) -> None:
     assert parsed == inst
 
 
-def test_tts_response_success_invariant() -> None:
-    """Drift #1: ok=True implies audio_b64 + mime_type + duration_ms non-null."""
+def test_tts_response_success_accepts_complete_payload() -> None:
+    """Valid ok=True payload with all required success fields parses cleanly."""
     resp = TtsResponse(
         **_ENVELOPE,
         ok=True,
@@ -96,8 +96,27 @@ def test_tts_response_success_invariant() -> None:
     assert resp.duration_ms is not None
 
 
-def test_stt_response_success_invariant() -> None:
-    """Drift #3+#4: ok=True implies text + language + duration_seconds non-null."""
+@pytest.mark.parametrize(
+    "missing_field",
+    ["audio_b64", "mime_type", "duration_ms"],
+)
+def test_tts_response_ok_true_rejects_missing_field(missing_field: str) -> None:
+    """Drift #1: ok=True with any missing success field raises ValidationError."""
+    payload: dict[str, Any] = {
+        **_ENVELOPE,
+        "ok": True,
+        "request_id": "r1",
+        "audio_b64": _b64(silence_wav_16khz),
+        "mime_type": "audio/wav",
+        "duration_ms": 1000,
+    }
+    payload[missing_field] = None
+    with pytest.raises(ValidationError, match="must carry"):
+        TtsResponse.model_validate(payload)
+
+
+def test_stt_response_success_accepts_complete_payload() -> None:
+    """Valid ok=True payload with all required success fields parses cleanly."""
     resp = SttResponse(
         **_ENVELOPE,
         ok=True,
@@ -111,6 +130,25 @@ def test_stt_response_success_invariant() -> None:
     assert resp.duration_seconds is not None
 
 
+@pytest.mark.parametrize(
+    "missing_field",
+    ["text", "language", "duration_seconds"],
+)
+def test_stt_response_ok_true_rejects_missing_field(missing_field: str) -> None:
+    """Drift #3+#4: ok=True with any missing success field raises ValidationError."""
+    payload: dict[str, Any] = {
+        **_ENVELOPE,
+        "ok": True,
+        "request_id": "r2",
+        "text": "hello",
+        "language": "en",
+        "duration_seconds": 1.0,
+    }
+    payload[missing_field] = None
+    with pytest.raises(ValidationError, match="must carry"):
+        SttResponse.model_validate(payload)
+
+
 def test_tts_response_error_path_allows_null_mime_type() -> None:
     """Error path: mime_type is legitimately absent when ok=False."""
     resp = TtsResponse(
@@ -121,3 +159,16 @@ def test_tts_response_error_path_allows_null_mime_type() -> None:
     )
     assert resp.mime_type is None
     assert resp.audio_b64 is None
+
+
+def test_stt_response_error_path_allows_null_success_fields() -> None:
+    """Error path: text/language/duration_seconds absent when ok=False."""
+    resp = SttResponse(
+        **_ENVELOPE,
+        ok=False,
+        request_id="r2",
+        error="audio_decode_failed",
+    )
+    assert resp.text is None
+    assert resp.language is None
+    assert resp.duration_seconds is None

--- a/packages/roxabi-contracts/tests/test_voice_models.py
+++ b/packages/roxabi-contracts/tests/test_voice_models.py
@@ -1,0 +1,123 @@
+"""Roundtrip + success-path invariant tests for roxabi_contracts.voice models.
+
+Parametrized over all four envelope subclasses (TtsRequest/TtsResponse/
+SttRequest/SttResponse). Invariants per ADR-044 and spec #763 drift
+items 1, 3, 4.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from roxabi_contracts.voice import (
+    SttRequest,
+    SttResponse,
+    TtsRequest,
+    TtsResponse,
+)
+from roxabi_contracts.voice.fixtures import sample_transcript_en, silence_wav_16khz
+
+_ENVELOPE: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "tst-trace",
+    "issued_at": datetime(2026, 4, 17, tzinfo=timezone.utc),
+}
+
+
+def _b64(b: bytes) -> str:
+    return base64.b64encode(b).decode("ascii")
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (
+            TtsRequest,
+            {**_ENVELOPE, "request_id": "r1", "text": sample_transcript_en},
+        ),
+        (
+            TtsResponse,
+            {
+                **_ENVELOPE,
+                "ok": True,
+                "request_id": "r1",
+                "audio_b64": _b64(silence_wav_16khz),
+                "mime_type": "audio/wav",
+                "duration_ms": 1000,
+            },
+        ),
+        (
+            SttRequest,
+            {
+                **_ENVELOPE,
+                "request_id": "r2",
+                "audio_b64": _b64(silence_wav_16khz),
+                "model": "large-v3-turbo",
+            },
+        ),
+        (
+            SttResponse,
+            {
+                **_ENVELOPE,
+                "ok": True,
+                "request_id": "r2",
+                "text": sample_transcript_en,
+                "language": "en",
+                "duration_seconds": 1.0,
+            },
+        ),
+    ],
+    ids=["TtsRequest", "TtsResponse", "SttRequest", "SttResponse"],
+)
+def test_roundtrip(model: type[BaseModel], payload: dict[str, Any]) -> None:
+    """model.model_validate(payload) → dump_json → model_validate_json → equal."""
+    inst = model.model_validate(payload)
+    parsed = model.model_validate_json(inst.model_dump_json())
+    assert parsed == inst
+
+
+def test_tts_response_success_invariant() -> None:
+    """Drift #1: ok=True implies audio_b64 + mime_type + duration_ms non-null."""
+    resp = TtsResponse(
+        **_ENVELOPE,
+        ok=True,
+        request_id="r1",
+        audio_b64=_b64(silence_wav_16khz),
+        mime_type="audio/wav",
+        duration_ms=1000,
+    )
+    assert resp.audio_b64 is not None
+    assert resp.mime_type is not None
+    assert resp.duration_ms is not None
+
+
+def test_stt_response_success_invariant() -> None:
+    """Drift #3+#4: ok=True implies text + language + duration_seconds non-null."""
+    resp = SttResponse(
+        **_ENVELOPE,
+        ok=True,
+        request_id="r2",
+        text="hello",
+        language="en",
+        duration_seconds=1.0,
+    )
+    assert resp.text is not None
+    assert resp.language is not None
+    assert resp.duration_seconds is not None
+
+
+def test_tts_response_error_path_allows_null_mime_type() -> None:
+    """Error path: mime_type is legitimately absent when ok=False."""
+    resp = TtsResponse(
+        **_ENVELOPE,
+        ok=False,
+        request_id="r1",
+        error="engine_unavailable",
+    )
+    assert resp.mime_type is None
+    assert resp.audio_b64 is None

--- a/packages/roxabi-contracts/tests/test_voice_subjects.py
+++ b/packages/roxabi-contracts/tests/test_voice_subjects.py
@@ -6,6 +6,8 @@ locks those strings so a typo or accidental rename fails here, not silently
 in production.
 """
 
+import pytest
+
 from roxabi_contracts.voice import SUBJECTS
 from roxabi_contracts.voice.subjects import per_worker_stt, per_worker_tts
 
@@ -34,6 +36,68 @@ def test_queue_group_constants() -> None:
 def test_per_worker_helpers() -> None:
     assert per_worker_tts("w1") == "lyra.voice.tts.request.w1"
     assert per_worker_stt("w2") == "lyra.voice.stt.request.w2"
+
+
+_UNSAFE_WORKER_IDS = [
+    ("*", "wildcard-star"),
+    (">", "wildcard-subtree"),
+    ("a.b", "single-dot"),
+    ("worker.nested", "double-token"),
+    ("", "empty"),
+    ("with space", "space"),
+    ("w/slash", "slash"),
+    ("w\x00null", "null-byte"),
+]
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [bad for bad, _ in _UNSAFE_WORKER_IDS],
+    ids=[label for _, label in _UNSAFE_WORKER_IDS],
+)
+def test_per_worker_tts_rejects_unsafe_worker_id(bad_id: str) -> None:
+    """NATS subject injection guard — see subjects.py::_validate_worker_id."""
+    with pytest.raises(ValueError, match="[A-Za-z0-9_-]"):
+        per_worker_tts(bad_id)
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    ["*", ">", "a.b", "", "with space"],
+    ids=["wildcard-star", "wildcard-subtree", "dotted", "empty", "space"],
+)
+def test_per_worker_stt_rejects_unsafe_worker_id(bad_id: str) -> None:
+    """NATS subject injection guard — see subjects.py::_validate_worker_id."""
+    with pytest.raises(ValueError, match="[A-Za-z0-9_-]"):
+        per_worker_stt(bad_id)
+
+
+def test_voice_init_does_not_pull_nats_transports() -> None:
+    """Spec AC — Package surface: voice/__init__.py imports no transport code.
+
+    Fresh subprocess import of ``roxabi_contracts.voice`` must not load any
+    ``nats.*`` or ``roxabi_nats.*`` module. Guards the pure-Pydantic
+    invariant from a silent regression where a stray transport import
+    sneaks into models.py or subjects.py.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import roxabi_contracts.voice, sys; "
+                "bad = [m for m in sys.modules if m.startswith('nats') or "
+                "m.startswith('roxabi_nats')]; "
+                "assert not bad, f'transport modules leaked: {bad!r}'"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode()
 
 
 def test_voice_init_does_not_expose_fixtures() -> None:

--- a/packages/roxabi-contracts/tests/test_voice_subjects.py
+++ b/packages/roxabi-contracts/tests/test_voice_subjects.py
@@ -1,0 +1,71 @@
+"""Tests for roxabi_contracts.voice subjects namespace.
+
+ADR-044 defines the canonical subject strings used by lyra's NatsTtsClient /
+NatsSttClient and voiceCLI's TtsNatsAdapter / SttNatsAdapter. This file
+locks those strings so a typo or accidental rename fails here, not silently
+in production.
+"""
+
+from roxabi_contracts.voice import SUBJECTS
+from roxabi_contracts.voice.subjects import per_worker_stt, per_worker_tts
+
+
+def test_tts_request_subject() -> None:
+    assert SUBJECTS.tts_request == "lyra.voice.tts.request"
+
+
+def test_tts_heartbeat_subject() -> None:
+    assert SUBJECTS.tts_heartbeat == "lyra.voice.tts.heartbeat"
+
+
+def test_stt_request_subject() -> None:
+    assert SUBJECTS.stt_request == "lyra.voice.stt.request"
+
+
+def test_stt_heartbeat_subject() -> None:
+    assert SUBJECTS.stt_heartbeat == "lyra.voice.stt.heartbeat"
+
+
+def test_queue_group_constants() -> None:
+    assert SUBJECTS.tts_workers == "tts_workers"
+    assert SUBJECTS.stt_workers == "stt_workers"
+
+
+def test_per_worker_helpers() -> None:
+    assert per_worker_tts("w1") == "lyra.voice.tts.request.w1"
+    assert per_worker_stt("w2") == "lyra.voice.stt.request.w2"
+
+
+def test_voice_init_does_not_expose_fixtures() -> None:
+    """Fixtures are test-only — must NOT be in voice package surface.
+
+    Checked two ways: (1) ``fixtures`` is not advertised in ``__all__``
+    (what ``from roxabi_contracts.voice import *`` would see), and (2) a
+    subprocess with a fresh interpreter that imports
+    ``roxabi_contracts.voice`` does NOT pull ``.fixtures`` into
+    ``sys.modules``. The subprocess step guards against pytest's
+    session-level import cache masking a regression where another test's
+    ``from roxabi_contracts.voice.fixtures import ...`` has already
+    populated ``vars(voice_mod)`` via Python's submodule-attr behavior.
+    """
+    import subprocess
+    import sys
+
+    import roxabi_contracts.voice as voice_mod
+
+    assert "fixtures" not in voice_mod.__all__
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import roxabi_contracts.voice, sys; "
+                "assert 'roxabi_contracts.voice.fixtures' not in sys.modules, "
+                "'voice/__init__.py must not import fixtures'"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode()

--- a/uv.lock
+++ b/uv.lock
@@ -2277,6 +2277,7 @@ dependencies = [
 testing = [
     { name = "nats-py" },
     { name = "roxabi-nats" },
+    { name = "scipy" },
 ]
 
 [package.metadata]
@@ -2284,6 +2285,7 @@ requires-dist = [
     { name = "nats-py", marker = "extra == 'testing'", specifier = ">=2.6" },
     { name = "pydantic", specifier = ">=2" },
     { name = "roxabi-nats", marker = "extra == 'testing'", editable = "packages/roxabi-nats" },
+    { name = "scipy", marker = "extra == 'testing'", specifier = ">=1.11" },
 ]
 provides-extras = ["testing"]
 


### PR DESCRIPTION
## Summary

- Ships `roxabi_contracts.voice`: frozen `SUBJECTS` namespace + four `ContractEnvelope`-subclass Pydantic models (`TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse`) + synthesized test-only fixtures (`silence_wav_16khz`, `sample_transcript_en`).
- Reconciles six drift items between lyra's `NatsTtsClient`/`NatsSttClient` and voiceCLI's `TtsNatsAdapter`/`SttNatsAdapter`; see table below.
- No caller migration in this PR. lyra hub consumers migrate in #766; voiceCLI satellite in voiceCLI#69.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#763](https://github.com/Roxabi/lyra/issues/763): feat(contracts): port voice domain — models + subjects + fixtures | OPEN |
| Frame | `artifacts/frames/763-port-voice-domain-frame.mdx` | Approved |
| Spec | `artifacts/specs/763-port-voice-domain-spec.mdx` | Approved (27 binary acceptance criteria, 0 `[NEEDS CLARIFICATION]`) |
| Plan | `artifacts/plans/763-port-voice-domain-plan.mdx` | Approved (3 slices / 13 micro-tasks / TDD RED→GREEN→RED-GATE) |
| Implementation | 3 commits on `feat/763-port-voice-domain` | Complete |
| Verification | Lint ✅  Typecheck ✅  Tests ✅ (25 new: 7 subjects + 7 models + 8 extra-ignore + 3 invariants) | Passed |

Note: frame/spec/plan artifacts live on local `staging`. They land on `origin/staging` via the standard dev-core sync that runs alongside this PR.

## Slices (commit structure)

| Commit | Slice | Content |
|---|---|---|
| `8565f7d` | V1 | `voice/subjects.py`, minimal `voice/__init__.py` (SUBJECTS only), `tests/test_voice_subjects.py` |
| `545bef3` | V2 | `voice/models.py`, `voice/fixtures.py`, extended `voice/__init__.py`, `tests/test_voice_models.py`, `tests/test_voice_extra_ignore.py`, `pyproject.toml` (scipy in `[testing]`), `uv.lock` |
| `d9cdee1` | V3 | `README.md` — Voice domain public-API section |

## Drift reconciliation (6 items)

Six behavioral differences were found between lyra and voiceCLI implementations during the port. All are resolved in this PR as documented below:

| # | Field / concern | Where it surfaced | Resolution |
|---|---|---|---|
| 1 | **TTS `mime_type` on response** — voiceCLI always returns `"audio/wav"` on success, omits on error; lyra reads with fallback `"audio/ogg"` which is unreachable on the success path | voiceCLI `TtsNatsAdapter._run_synthesis` (`reply_fields["mime_type"] = "audio/wav"`); lyra `NatsTtsClient.synthesize` (`data.get("mime_type", "audio/ogg")`) | `TtsResponse.mime_type: str \| None = None`; **invariant asserted in tests:** `ok=True ⟹ mime_type is not None`. Lyra's `"audio/ogg"` fallback becomes dead code on success path post-#766. |
| 2 | **STT `language` request field** — voiceCLI accepts `language` in request payload; lyra never sends it | voiceCLI `SttNatsAdapter.handle` (validates `language` with `(str,)`); lyra `NatsSttClient.transcribe` omits the field | `SttRequest.language: str \| None = None`. Field is part of typed contract going forward; no behavioral change today. |
| 3 | **STT `language` response** — voiceCLI always fills `result.language` on success, omits on error; lyra reads with fallback `"unknown"` | voiceCLI `build_reply(ok=True, ..., language=result.language)`; lyra `data.get("language", "unknown")` | `SttResponse.language: str \| None = None`; **invariant asserted in tests:** `ok=True ⟹ language is not None`. The `"unknown"` string was consumer-side, not protocol. |
| 4 | **STT `duration_seconds` response** — same always-filled-on-success shape as `language` | voiceCLI `build_reply(ok=True, ..., duration_seconds=...)`; lyra `data.get("duration_seconds", 0.0)` | `SttResponse.duration_seconds: float \| None = None`; **invariant asserted in tests:** `ok=True ⟹ duration_seconds is not None`. |
| 5 | **TTS `default_language` / `languages`** — voiceCLI's `_AGENT_TTS_FIELDS` declares both as expected request fields; lyra's `_TTS_CONFIG_FIELDS` omits them so they're never sent today | `packages/roxabi-nats/src/roxabi_nats/_tts_constants.py` (both tuples); lyra `AgentTTSConfig` DOES have them (`src/lyra/core/agent_config.py:181-182`) | **Two-phase resolution.** Phase 1 (this PR): `TtsRequest.default_language: str \| None = None` and `TtsRequest.languages: list[str] \| None = None` are typed at the contract layer. Phase 2 (#766): `_TTS_CONFIG_FIELDS` in `roxabi-nats` is extended to forward them on the wire. The model surface is final; the hub publisher catches up in the caller migration. |
| 6 | **Envelope fields absent on current wire** ⚠️ **Migration obligation** | Neither `NatsTtsClient.synthesize` nor `NatsSttClient.transcribe` stamps `trace_id`/`issued_at` today (only `contract_version` is sent on requests). voiceCLI's adapters stamp zero envelope fields on replies. | All four models inherit `ContractEnvelope`'s REQUIRED `contract_version`/`trace_id`/`issued_at`. **#766 MUST** teach lyra's publishers to stamp `trace_id` (new UUID per message) + `issued_at` (current UTC datetime) + `contract_version` on BOTH request and response code paths BEFORE switching to `Model.model_validate()` at the consumer side. **voiceCLI#69 MUST** do the same on the satellite. Without this, the first consumer migration hits `ValidationError`. |

## Test Plan

- [x] `cd packages/roxabi-contracts && uv run pytest` — 56/56 passing after review fixes (subjects + models + extra-ignore + negative min_length + success-invariant enforcement + subject-injection guard)
- [x] `uv run pyright packages/roxabi-contracts/src` — 0 errors, 0 warnings
- [x] `uv run ruff check packages/roxabi-contracts/` — all clean
- [x] Integration smoke: `uv run python -c "from roxabi_contracts.voice import SUBJECTS, TtsRequest, TtsResponse, SttRequest, SttResponse; print(SUBJECTS.tts_request)"` → `lyra.voice.tts.request`
- [x] Fixture smoke: `uv run python -c "from roxabi_contracts.voice.fixtures import silence_wav_16khz; assert len(silence_wav_16khz) > 44 and silence_wav_16khz[:4] == b'RIFF'"`
- [x] No-NATS-import invariant: `uv run python -c "import roxabi_contracts.voice; import sys; bad=[m for m in sys.modules if m.startswith('nats') or m.startswith('roxabi_nats')]; assert not bad"`
- [x] `fixtures` NOT re-exported from `voice/__init__.py` — asserted via `__all__` check + subprocess fresh-import check in `test_voice_subjects.py`

## Out of scope (future PRs)

- lyra hub `NatsTtsClient` / `NatsSttClient` migration to consume these models — **#766**
- voiceCLI satellite migration — **voiceCLI#69**
- `image`, `memory`, `llm` domain ports — **#764, #765, and subsequent children of #761**
- Runtime transport helpers (publish/subscribe wrappers) — belong to `roxabi-nats`, not here

Closes #763

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`
