### PR TITLE
fix(ci): pin release-please target-branch to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Why

Repo default branch is \`staging\`. The \`googleapis/release-please-action@v4\` reads \`target-branch\` from its own \`with:\` inputs, not from \`release-please-config.json\`. Without the input it falls back to the repo default branch, so release PRs were opened against \`staging\` instead of \`main\` on the previous promotion (#778).

PRs #779/#780/#781 were closed because of this.

## What

Add \`target-branch: main\` to the action inputs.

## Follow-up

Once this merges + a promote PR lands on main, release-please will open 3 clean PRs against main:
- \`lyra/v0.2.0\`
- \`roxabi-nats/v0.2.0\`
- \`roxabi-contracts/v0.2.0\` 🎯

---
Generated with [Claude Code](https://claude.com/claude-code)