### PR TITLE
chore: promote staging to main (release-please fix)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
## Promotion: staging → main

Re-promote after #778 to ship the release-please workflow fix from #782.

### Single change

- **fix(ci): pin release-please target-branch to main** — release-please-action v4 ignores \`config.target-branch\`; needs the input set on the action itself.

### Post-merge

Release-please will re-trigger on this main push and open 3 fresh release PRs against main:
- \`lyra/v0.2.0\`
- \`roxabi-nats/v0.2.0\`
- \`roxabi-contracts/v0.2.0\` 🎯

Merging each creates the corresponding tag.

### ⚠️ Merge with MERGE COMMIT (not squash)

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/promote\`