### PR TITLE
docs(contracts): document Renovate pin-freshness rule for satellites

### DIFF
--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -13,6 +13,39 @@ roxabi-contracts = {
 }
 ```
 
+## Satellite pin freshness (Renovate)
+
+Satellites pin `roxabi-contracts` (and `roxabi-nats`) by git tag. Without an automated pin-freshness rule, pins silently drift as new tags are cut and the SDK → satellite → hub triangle ships mixed versions. Every satellite repo MUST add the following Renovate rule to `renovate.json`:
+
+```json5
+// renovate.json — satellite repos (voiceCLI, imageCLI, roxabi-vault, …)
+{
+  "packageRules": [{
+    "matchDatasources": ["git-refs"],
+    "matchSourceUrls": ["https://github.com/Roxabi/lyra"],
+    "matchPackageNames": ["roxabi-nats", "roxabi-contracts"],
+    "groupName": "roxabi sdk",
+    "schedule": ["before 6am on monday"]
+  }]
+}
+```
+
+### Why `matchDatasources: ["git-refs"]` is mandatory
+
+Renovate resolves git-sourced `uv` pins through the **`git-refs`** datasource, NOT the default `pypi` datasource. Omit this field and the rule silently does not fire — Renovate matches nothing, no PR is opened, and the pin stays stale indefinitely. This is the single most common misconfiguration; prominent so it is not repeated.
+
+### Why both packages in one rule
+
+`roxabi-nats` (transport) and `roxabi-contracts` (schemas) form a single coordinated SDK. Grouping them under `groupName: "roxabi sdk"` prevents partial upgrades — e.g., bumping `roxabi-contracts` past a `CONTRACT_VERSION` migration while leaving `roxabi-nats` on an older release, which would produce a version mismatch at envelope parse time. One grouped PR per week per satellite keeps the two coordinates in lockstep.
+
+### Why the weekly Monday schedule
+
+`before 6am on monday` gives a satellite a **stability window**: a contributor merging on Friday has the weekend before the next Renovate wave, and the Monday-morning PR lands before the week's work begins. Batching also avoids PR noise — SDK tags may cut mid-week but satellites see them consolidated once, not piecemeal.
+
+### End-state
+
+Renovate reads the `tag = "..."` pin in `[tool.uv.sources]`, observes a newer tag on the upstream repo, and opens a PR each Monday. Without this rule, pin freshness is purely documentation and drift becomes inevitable (ADR-049 §Satellite pin freshness).
+
 ## Public API contract
 
 The stable external contract is defined by `__all__` in `roxabi_contracts/__init__.py`. v0.1.0 ships:


### PR DESCRIPTION
## Summary

- Add a self-contained **Satellite pin freshness (Renovate)** section to `packages/roxabi-contracts/README.md` so voiceCLI, imageCLI, and roxabi-vault can adopt the mandatory rule without ADR hunting.
- Covers the complete `renovate.json` rule (both `roxabi-nats` + `roxabi-contracts` grouped under `roxabi sdk`), prominently flags `matchDatasources: ["git-refs"]` as mandatory (Renovate resolves git-sourced `uv` pins through `git-refs`, not the default `pypi` datasource — silent no-op otherwise), and explains the grouping + weekly-Monday rationale.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#769](https://github.com/Roxabi/lyra/issues/769): docs(satellites): document Renovate rule for roxabi-contracts pin freshness | OPEN |
| Implementation | 1 commit on `feat/769-document-renovate-rule` (+33 lines, 1 file) | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (2975 passed, 84.38% cov) · Pre-commit hooks ✅ | Passed |

## Acceptance Criteria (from #769)

- [x] Documentation section in `packages/roxabi-contracts/README.md` shows the complete Renovate rule
- [x] `matchDatasources: ["git-refs"]` prominently noted as mandatory with explanation
- [x] Both `roxabi-nats` and `roxabi-contracts` covered in the same rule (grouped)
- [x] No satellite has to discover this requirement via ADR hunting — README is self-contained

## Epic context

Issue #769 is the final documentation deliverable of Epic #761 (adopt ADR-049 — roxabi-contracts shared schema package). Direct predecessor #767 (release-please wiring) is already closed, so this PR unblocks the last acceptance criterion of the epic.

## Test Plan

- [ ] CI pipeline green on staging base
- [ ] Reviewer confirms the rule copy-pastes into a satellite's `renovate.json` as-is
- [ ] Reviewer confirms the `git-refs` warning is unmissable

## References

- ADR-049 §Satellite pin freshness
- Epic #761

Closes #769

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`