### PR TITLE
feat(contracts): test doubles — FakeTtsWorker + FakeSttWorker with three guards

### DIFF
--- a/artifacts/specs/764-voice-test-doubles-spec.mdx
+++ b/artifacts/specs/764-voice-test-doubles-spec.mdx
@@ -241,7 +241,7 @@ F11 test_voice_testing_doubles.py
    ├─ test_g3_rejects_localhost_subdomain[nats://localhost.evil.com:4222]
    ├─ test_tts_roundtrip_default_fixture — uses F12, drives publish → reply → assert calls
    ├─ test_stt_roundtrip_default_fixture — same, for STT
-   └─ test_calls_records_multiple_requests_in_order — issues 3 parallel requests, asserts len(calls) == 3 and preserves order
+   └─ test_calls_records_multiple_requests_in_order — issues 3 serial requests with distinct request_id values, asserts len(calls) == 3 and [r.request_id for r in calls] matches the send order. Amended from "parallel" per PR #789 review: NATS queue groups serialize dispatch per-message; serial send-order is the stronger, more reliable ordering assertion and avoids event-loop scheduling non-determinism on loaded CI runners.
 ```
 
 ## Slices

--- a/artifacts/specs/764-voice-test-doubles-spec.mdx
+++ b/artifacts/specs/764-voice-test-doubles-spec.mdx
@@ -36,7 +36,7 @@ After merge:
 
 - `from roxabi_contracts.voice.testing import FakeTtsWorker, FakeSttWorker` resolves **only** in an environment where `roxabi-contracts[testing]` is installed. In a bare `roxabi-contracts` install (no `[testing]` extra), the import fails with `ModuleNotFoundError: No module named 'nats'` (Guard 1 — see below for why this bites at module-top-level import).
 - `FakeTtsWorker(nats_url="nats://127.0.0.1:4222", reply_fixture=None)` is the canonical constructor. `reply_fixture=None` means the fake replies with `silence_wav_16khz` (TTS) or `sample_transcript_en` (STT) from `roxabi_contracts.voice.fixtures`.
-- Constructing with `os.environ.get("LYRA_ENV") == "production"` raises `RuntimeError("FakeTtsWorker cannot run in production")` (or `FakeSttWorker cannot run in production`). The guard fires **before** any field is stored on `self`, and **before** any NATS import is exercised lazily. No override flag exists — no kwarg, no subclass escape hatch, no environment flag to disable the guard. Security-by-obscurity is explicitly rejected per ADR-049.
+- Constructing with `os.environ.get("LYRA_ENV", "").casefold() == "production"` raises `RuntimeError("FakeTtsWorker cannot run in production")` (or `FakeSttWorker cannot run in production`). Comparison is **case-insensitive** — `PRODUCTION`, `Production`, `pRoDuCtIoN` all trip the guard (amended from exact-match per PR #789 review item W5; closes a latent case-sensitivity bypass). The guard fires **before** any field is stored on `self`, and **before** any NATS import is exercised lazily. No override flag exists — no kwarg, no subclass escape hatch, no environment flag to disable the guard. Security-by-obscurity is explicitly rejected per ADR-049.
 - Calling `await worker.start()` with a non-loopback URL raises `ValueError` with a message enumerating the allowed hosts (`127.0.0.1`, `localhost`). The guard fires **before** `nats_connect()` is called. No override. This closes the accidental-prod-queue-group-shadowing class of bugs even when Guard 2 is misconfigured.
 - Allowed URL hosts for Guard 3 (rationale in `## Risks`):
   - `127.0.0.1` (IPv4 loopback)
@@ -159,7 +159,7 @@ flowchart LR
 | ID | Name | Type | Handler | Data |
 |---|---|---|---|---|
 | F1 | `testing.py` module | module | Python import | `packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py` — defines `FakeTtsWorker`, `FakeSttWorker`, `__all__ = ["FakeTtsWorker", "FakeSttWorker"]`. Imports `nats` at module top (Guard 1 gate). |
-| F2 | `_assert_not_production` helper | function | direct call from `__init__` | `testing.py::_assert_not_production(cls_name: str) -> None` — raises `RuntimeError(f"{cls_name} cannot run in production")` when `os.environ.get("LYRA_ENV") == "production"`. Underscore-private. No kwargs. No override path. |
+| F2 | `_assert_not_production` helper | function | direct call from `__init__` | `testing.py::_assert_not_production(cls_name: str) -> None` — raises `RuntimeError(f"{cls_name} cannot run in production")` when `os.environ.get("LYRA_ENV", "").casefold() == "production"` (case-insensitive, per PR #789 amendment). Underscore-private. No kwargs. No override path. |
 | F3 | `_assert_loopback_url` helper | function | direct call from `start()` | `testing.py::_assert_loopback_url(url: str) -> None` — uses `urllib.parse.urlparse` to extract `.hostname`; raises `ValueError` if `hostname not in ALLOWED_LOOPBACK_HOSTS`. |
 | F4 | `ALLOWED_LOOPBACK_HOSTS` | module const | frozenset lookup | `frozenset({"127.0.0.1", "localhost", "::1"})`. Module-level, underscore-prefixed only if not documented in README; otherwise public for grepability. |
 | F5 | `FakeTtsWorker` class | class | instantiate → `await start()` → assertions on `.calls` → `await stop()` | `__init__(nats_url: str = "nats://127.0.0.1:4222", reply_fixture: bytes \| None = None)`; `calls: list[TtsRequest]`; `start()`; `stop()`. Constructor calls F2; `start()` calls F3 then connects. |
@@ -185,7 +185,7 @@ F1 (testing.py) — module top
    └─ __all__ = ["FakeTtsWorker", "FakeSttWorker"]
 
 F2 _assert_not_production(cls_name) ← called by F5.__init__ and F6.__init__ FIRST LINE
-   └─ os.environ.get("LYRA_ENV") == "production" → RuntimeError
+   └─ os.environ.get("LYRA_ENV", "").casefold() == "production" → RuntimeError  (case-insensitive; amended per PR #789 review)
 
 F3 _assert_loopback_url(url) ← called by F7 FIRST LINE (before nats_connect)
    ├─ parsed = urlparse(url)
@@ -237,8 +237,10 @@ F11 test_voice_testing_doubles.py
    ├─ test_g2_prod_env_raises_even_when_g3_would_pass[...]
    ├─ test_g3_non_loopback_raises[nats://10.0.0.5:4222]
    ├─ test_g3_rejects_wildcard_bind[nats://0.0.0.0:4222]
-   ├─ test_g3_accepts_ipv6_loopback[nats://[::1]:4222]
-   ├─ test_g3_rejects_localhost_subdomain[nats://localhost.evil.com:4222]
+   ├─ test_g3_accepts_ipv4_loopback[FakeTtsWorker|FakeSttWorker]  # URL nats://127.0.0.1:4222
+   ├─ test_g3_accepts_ipv6_loopback[FakeTtsWorker|FakeSttWorker]  # URL nats://[::1]:4222
+   ├─ test_g3_accepts_ipv6_loopback_full[FakeTtsWorker|FakeSttWorker]  # URL nats://[0:0:0:0:0:0:0:1]:4222
+   ├─ test_g3_rejects_localhost_subdomain[FakeTtsWorker|FakeSttWorker]  # URL nats://localhost.evil.com:4222
    ├─ test_tts_roundtrip_default_fixture — uses F12, drives publish → reply → assert calls
    ├─ test_stt_roundtrip_default_fixture — same, for STT
    └─ test_calls_records_multiple_requests_in_order — issues 3 serial requests with distinct request_id values, asserts len(calls) == 3 and [r.request_id for r in calls] matches the send order. Amended from "parallel" per PR #789 review: NATS queue groups serialize dispatch per-message; serial send-order is the stronger, more reliable ordering assertion and avoids event-loop scheduling non-determinism on loaded CI runners.
@@ -265,7 +267,8 @@ F11 test_voice_testing_doubles.py
 ### Guard 2 — `LYRA_ENV=production` assertion in `__init__`
 
 - [ ] `FakeTtsWorker.__init__` and `FakeSttWorker.__init__` call the private helper `_assert_not_production("FakeTtsWorker")` / `_assert_not_production("FakeSttWorker")` as their **first statement**, before any attribute assignment
-- [ ] `_assert_not_production(cls_name: str)` raises `RuntimeError(f"{cls_name} cannot run in production")` when `os.environ.get("LYRA_ENV") == "production"`, returns `None` otherwise
+- [ ] `_assert_not_production(cls_name: str)` raises `RuntimeError(f"{cls_name} cannot run in production")` when `os.environ.get("LYRA_ENV", "").casefold() == "production"` (case-insensitive per PR #789 amendment), returns `None` otherwise
+- [ ] `test_g2_prod_env_case_insensitive` parametrized over `["PRODUCTION", "Production", "pRoDuCtIoN"]` × both fakes — asserts the `RuntimeError` with class name message for each casing
 - [ ] `__init__` accepts only the two documented kwargs (`nats_url`, `reply_fixture`) — no additional kwargs exist that could bypass Guard 2 (structurally verifiable via pyright on the signature)
 - [ ] `test_g2_prod_env_raises[FakeTtsWorker]` and `[FakeSttWorker]` assert the `RuntimeError` with the class name in the message
 - [ ] `test_g2_prod_env_raises_even_when_g3_would_pass` sets `LYRA_ENV=production` AND passes a loopback URL → still `RuntimeError` (proves Guard 2 independent of Guard 3)
@@ -277,8 +280,9 @@ F11 test_voice_testing_doubles.py
 - [ ] Raises `ValueError` with a message naming the rejected hostname and listing the allowed set
 - [ ] `test_g3_non_loopback_raises[nats://10.0.0.5:4222]` → `ValueError`
 - [ ] `test_g3_rejects_wildcard_bind[nats://0.0.0.0:4222]` → `ValueError` (wildcard is NOT loopback)
-- [ ] `test_g3_accepts_ipv6_loopback[nats://[::1]:4222]` → call proceeds past the guard (asserts no `ValueError`; does not require a real nats-server at ::1)
-- [ ] `test_g3_accepts_ipv6_loopback_full[nats://[0:0:0:0:0:0:0:1]:4222]` → call proceeds past the guard (expanded IPv6 form also allowed)
+- [ ] `test_g3_accepts_ipv4_loopback[FakeTtsWorker|FakeSttWorker]` (URL `nats://127.0.0.1:4222`) → call proceeds past the guard
+- [ ] `test_g3_accepts_ipv6_loopback[FakeTtsWorker|FakeSttWorker]` (URL `nats://[::1]:4222`) → call proceeds past the guard (asserts no `ValueError`; does not require a real nats-server at ::1)
+- [ ] `test_g3_accepts_ipv6_loopback_full[FakeTtsWorker|FakeSttWorker]` (URL `nats://[0:0:0:0:0:0:0:1]:4222`) → call proceeds past the guard (expanded IPv6 form also allowed)
 - [ ] `test_g3_rejects_localhost_subdomain[nats://localhost.evil.com:4222]` → `ValueError` (URL parsing, not substring match)
 - [ ] `test_g3_non_loopback_raises_when_g2_unset` with `LYRA_ENV` unset → still `ValueError` (proves Guard 3 independent of Guard 2 state)
 - [ ] `start` takes no extra kwargs beyond `self` — no override surface for Guard 3 (structurally verifiable via pyright on the signature)

--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -108,3 +108,28 @@ from roxabi_contracts.voice.fixtures import silence_wav_16khz, sample_transcript
 
 `scipy` is declared in `[project.optional-dependencies].testing` and is
 only pulled when a consumer requests the `[testing]` extra.
+
+## Test doubles
+
+`roxabi_contracts.voice.testing` provides in-process replacements for a real
+voiceCLI satellite (`FakeTtsWorker`, `FakeSttWorker`) — intended for lyra hub
+tests and voiceCLI adapter tests that need to exercise the NATS request/reply
+cycle without a GPU or real model.
+
+Install with the `[testing]` optional extra:
+
+```bash
+uv pip install "roxabi-contracts[testing]"
+```
+
+Three non-bypassable guards prevent production contamination
+(see [ADR-049 §Test-double pattern](../../docs/architecture/adr/049-roxabi-contracts-shared-schema-package.mdx)):
+
+1. **Import-time gate.** `voice.testing` imports `nats` at module top. A
+   bare `roxabi-contracts` install (no `[testing]` extra) fails with
+   `ModuleNotFoundError: No module named 'nats'` before any runtime code runs.
+2. **Environment assertion.** `__init__` raises `RuntimeError` when
+   `LYRA_ENV=production`. No override flag.
+3. **Loopback-only URL.** `start()` raises `ValueError` on any non-loopback
+   NATS URL (`127.0.0.1`, `localhost`, `::1`, `0:0:0:0:0:0:0:1` are the only
+   accepted hosts). No override.

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 from pydantic import ValidationError
 
@@ -48,8 +49,8 @@ ALLOWED_LOOPBACK_HOSTS: frozenset[str] = frozenset(
 
 
 def _assert_not_production(cls_name: str) -> None:
-    """Guard 2 — raises RuntimeError when LYRA_ENV=production."""
-    if os.environ.get("LYRA_ENV") == "production":
+    """Guard 2 — raises RuntimeError when LYRA_ENV=production (case-insensitive)."""
+    if os.environ.get("LYRA_ENV", "").casefold() == "production":
         raise RuntimeError(f"{cls_name} cannot run in production")
 
 
@@ -91,20 +92,17 @@ class FakeTtsWorker:
         )
 
     async def stop(self) -> None:
-        if self._sub is not None:
-            await self._sub.unsubscribe()
-            self._sub = None
-        if self._nc is not None:
-            if self._nc.is_connected:
-                try:
-                    await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
-                except asyncio.TimeoutError:
-                    log.warning(
-                        "FakeTtsWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
-                    )
-            self._nc = None
+        if self._nc is not None and self._nc.is_connected:
+            try:
+                await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                log.warning(
+                    "FakeTtsWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
+                )
+        self._sub = None
+        self._nc = None
 
-    async def _dispatch(self, msg: nats.aio.msg.Msg) -> None:  # type: ignore[name-defined]
+    async def _dispatch(self, msg: Msg) -> None:
         try:
             req = TtsRequest.model_validate_json(msg.data)
         except ValidationError as exc:
@@ -154,20 +152,17 @@ class FakeSttWorker:
         )
 
     async def stop(self) -> None:
-        if self._sub is not None:
-            await self._sub.unsubscribe()
-            self._sub = None
-        if self._nc is not None:
-            if self._nc.is_connected:
-                try:
-                    await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
-                except asyncio.TimeoutError:
-                    log.warning(
-                        "FakeSttWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
-                    )
-            self._nc = None
+        if self._nc is not None and self._nc.is_connected:
+            try:
+                await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                log.warning(
+                    "FakeSttWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
+                )
+        self._sub = None
+        self._nc = None
 
-    async def _dispatch(self, msg: nats.aio.msg.Msg) -> None:  # type: ignore[name-defined]
+    async def _dispatch(self, msg: Msg) -> None:
         try:
             req = SttRequest.model_validate_json(msg.data)
         except ValidationError as exc:

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py
@@ -12,6 +12,15 @@ Guard 3 (loopback): start() raises ValueError on non-loopback NATS URL.
 
 from __future__ import annotations
 
+# Guard 1 tripwire — LOAD-BEARING. Do NOT move below other imports, and
+# do NOT wrap in try/except. This import is the first runtime event when
+# `roxabi_contracts.voice.testing` is loaded; without the [testing] extra,
+# `nats-py` is absent and the import fails with ModuleNotFoundError before
+# any class definition is reached. `test_g1_import_without_extra`
+# regression-guards this placement via a subprocess with a sabotaged
+# PYTHONPATH.
+import nats  # noqa: F401  # pyright: ignore[reportUnusedImport]  # isort:skip
+
 import asyncio
 import base64
 import logging
@@ -24,9 +33,6 @@ from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 from pydantic import ValidationError
 
-# Guard 1: fails at import with ModuleNotFoundError when [testing] extra
-# is not installed. Do NOT wrap in try/except — that would defeat Guard 1.
-import nats  # noqa: F401  # pyright: ignore[reportUnusedImport]
 from roxabi_contracts.voice.fixtures import sample_transcript_en, silence_wav_16khz
 from roxabi_contracts.voice.models import (
     SttRequest,
@@ -83,6 +89,12 @@ class FakeTtsWorker:
         _assert_loopback_url(self._nats_url)
         if self._nc is not None:
             raise RuntimeError("FakeTtsWorker already started")
+        # `allow_reconnect=False, connect_timeout=2` bound the nats-py handshake;
+        # the outer `asyncio.wait_for(..., timeout=3.0)` catches kernel-level
+        # stalls (e.g., kernel TCP socket stuck in SYN_SENT). Both layers are
+        # load-bearing for the Guard 3 loopback-accept tests where no nats-server
+        # is running on the loopback port — without them the tests would hang
+        # until the library's default 30s reconnect window elapses.
         self._nc = await asyncio.wait_for(
             nats_connect(self._nats_url, allow_reconnect=False, connect_timeout=2),
             timeout=3.0,
@@ -95,7 +107,9 @@ class FakeTtsWorker:
         if self._nc is not None and self._nc.is_connected:
             try:
                 await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
-            except asyncio.TimeoutError:
+            except asyncio.TimeoutError:  # pragma: no cover
+                # TODO(#761 follow-up): add explicit drain-timeout test when the first
+                # domain fake (TTS or image) hits a real slow-drain scenario in CI.
                 log.warning(
                     "FakeTtsWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
                 )
@@ -143,6 +157,12 @@ class FakeSttWorker:
         _assert_loopback_url(self._nats_url)
         if self._nc is not None:
             raise RuntimeError("FakeSttWorker already started")
+        # `allow_reconnect=False, connect_timeout=2` bound the nats-py handshake;
+        # the outer `asyncio.wait_for(..., timeout=3.0)` catches kernel-level
+        # stalls (e.g., kernel TCP socket stuck in SYN_SENT). Both layers are
+        # load-bearing for the Guard 3 loopback-accept tests where no nats-server
+        # is running on the loopback port — without them the tests would hang
+        # until the library's default 30s reconnect window elapses.
         self._nc = await asyncio.wait_for(
             nats_connect(self._nats_url, allow_reconnect=False, connect_timeout=2),
             timeout=3.0,
@@ -155,7 +175,9 @@ class FakeSttWorker:
         if self._nc is not None and self._nc.is_connected:
             try:
                 await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
-            except asyncio.TimeoutError:
+            except asyncio.TimeoutError:  # pragma: no cover
+                # TODO(#761 follow-up): add explicit drain-timeout test when the first
+                # domain fake (TTS or image) hits a real slow-drain scenario in CI.
                 log.warning(
                     "FakeSttWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
                 )

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py
@@ -1,0 +1,189 @@
+"""FakeTtsWorker + FakeSttWorker — test doubles for roxabi_contracts.voice.
+
+Three non-bypassable guards prevent production contamination. See spec #764
+and ADR-049 §Test-double pattern.
+
+Guard 1 (import-time): nats-py is imported at module top; installing
+    roxabi-contracts WITHOUT the [testing] extra fails with
+    ModuleNotFoundError at import.
+Guard 2 (env): __init__ raises RuntimeError when LYRA_ENV == "production".
+Guard 3 (loopback): start() raises ValueError on non-loopback NATS URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from nats.aio.client import Client as NATS
+from nats.aio.subscription import Subscription
+from pydantic import ValidationError
+
+# Guard 1: fails at import with ModuleNotFoundError when [testing] extra
+# is not installed. Do NOT wrap in try/except — that would defeat Guard 1.
+import nats  # noqa: F401  # pyright: ignore[reportUnusedImport]
+from roxabi_contracts.voice.fixtures import sample_transcript_en, silence_wav_16khz
+from roxabi_contracts.voice.models import (
+    SttRequest,
+    SttResponse,
+    TtsRequest,
+    TtsResponse,
+)
+from roxabi_contracts.voice.subjects import SUBJECTS
+from roxabi_nats.connect import nats_connect
+
+__all__: list[str] = ["FakeTtsWorker", "FakeSttWorker"]
+
+log = logging.getLogger(__name__)
+
+_DRAIN_TIMEOUT_S: float = 2.0
+
+ALLOWED_LOOPBACK_HOSTS: frozenset[str] = frozenset(
+    {"127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"}
+)
+
+
+def _assert_not_production(cls_name: str) -> None:
+    """Guard 2 — raises RuntimeError when LYRA_ENV=production."""
+    if os.environ.get("LYRA_ENV") == "production":
+        raise RuntimeError(f"{cls_name} cannot run in production")
+
+
+def _assert_loopback_url(url: str) -> None:
+    """Guard 3 — raises ValueError when the URL hostname is not loopback."""
+    host = urlparse(url).hostname
+    if host not in ALLOWED_LOOPBACK_HOSTS:
+        raise ValueError(
+            f"loopback NATS URL required — refusing host {host!r}; "
+            f"allowed: {sorted(ALLOWED_LOOPBACK_HOSTS)}"
+        )
+
+
+class FakeTtsWorker:
+    def __init__(
+        self,
+        nats_url: str = "nats://127.0.0.1:4222",
+        reply_fixture: bytes | None = None,
+    ) -> None:
+        _assert_not_production("FakeTtsWorker")
+        self._nats_url = nats_url
+        self._reply_fixture: bytes = (
+            reply_fixture if reply_fixture is not None else silence_wav_16khz
+        )
+        self._nc: NATS | None = None
+        self._sub: Subscription | None = None
+        self.calls: list[TtsRequest] = []
+
+    async def start(self) -> None:
+        _assert_loopback_url(self._nats_url)
+        if self._nc is not None:
+            raise RuntimeError("FakeTtsWorker already started")
+        self._nc = await asyncio.wait_for(
+            nats_connect(self._nats_url, allow_reconnect=False, connect_timeout=2),
+            timeout=3.0,
+        )
+        self._sub = await self._nc.subscribe(
+            SUBJECTS.tts_request, queue=SUBJECTS.tts_workers, cb=self._dispatch
+        )
+
+    async def stop(self) -> None:
+        if self._sub is not None:
+            await self._sub.unsubscribe()
+            self._sub = None
+        if self._nc is not None:
+            if self._nc.is_connected:
+                try:
+                    await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
+                except asyncio.TimeoutError:
+                    log.warning(
+                        "FakeTtsWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
+                    )
+            self._nc = None
+
+    async def _dispatch(self, msg: nats.aio.msg.Msg) -> None:  # type: ignore[name-defined]
+        try:
+            req = TtsRequest.model_validate_json(msg.data)
+        except ValidationError as exc:
+            log.warning("FakeTtsWorker dropped malformed request: %s", exc)
+            return
+        self.calls.append(req)
+        if not msg.reply or self._nc is None:
+            return
+        reply = TtsResponse(
+            contract_version=req.contract_version,
+            trace_id=req.trace_id,
+            issued_at=datetime.now(timezone.utc),
+            ok=True,
+            request_id=req.request_id,
+            audio_b64=base64.b64encode(self._reply_fixture).decode("ascii"),
+            mime_type="audio/wav",
+            duration_ms=1000,
+        )
+        await self._nc.publish(msg.reply, reply.model_dump_json().encode())
+
+
+class FakeSttWorker:
+    def __init__(
+        self,
+        nats_url: str = "nats://127.0.0.1:4222",
+        reply_fixture: str | None = None,
+    ) -> None:
+        _assert_not_production("FakeSttWorker")
+        self._nats_url = nats_url
+        self._reply_fixture: str = (
+            reply_fixture if reply_fixture is not None else sample_transcript_en
+        )
+        self._nc: NATS | None = None
+        self._sub: Subscription | None = None
+        self.calls: list[SttRequest] = []
+
+    async def start(self) -> None:
+        _assert_loopback_url(self._nats_url)
+        if self._nc is not None:
+            raise RuntimeError("FakeSttWorker already started")
+        self._nc = await asyncio.wait_for(
+            nats_connect(self._nats_url, allow_reconnect=False, connect_timeout=2),
+            timeout=3.0,
+        )
+        self._sub = await self._nc.subscribe(
+            SUBJECTS.stt_request, queue=SUBJECTS.stt_workers, cb=self._dispatch
+        )
+
+    async def stop(self) -> None:
+        if self._sub is not None:
+            await self._sub.unsubscribe()
+            self._sub = None
+        if self._nc is not None:
+            if self._nc.is_connected:
+                try:
+                    await asyncio.wait_for(self._nc.drain(), timeout=_DRAIN_TIMEOUT_S)
+                except asyncio.TimeoutError:
+                    log.warning(
+                        "FakeSttWorker drain timed out after %.1fs", _DRAIN_TIMEOUT_S
+                    )
+            self._nc = None
+
+    async def _dispatch(self, msg: nats.aio.msg.Msg) -> None:  # type: ignore[name-defined]
+        try:
+            req = SttRequest.model_validate_json(msg.data)
+        except ValidationError as exc:
+            log.warning("FakeSttWorker dropped malformed request: %s", exc)
+            return
+        self.calls.append(req)
+        if not msg.reply or self._nc is None:
+            return
+        reply = SttResponse(
+            contract_version=req.contract_version,
+            trace_id=req.trace_id,
+            issued_at=datetime.now(timezone.utc),
+            ok=True,
+            request_id=req.request_id,
+            text=self._reply_fixture,
+            language="en",
+            duration_seconds=1.0,
+        )
+        await self._nc.publish(msg.reply, reply.model_dump_json().encode())

--- a/packages/roxabi-contracts/tests/conftest.py
+++ b/packages/roxabi-contracts/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Pytest fixtures for roxabi-contracts tests.
+
+Ports the `nats_server_url` session-scoped fixture from
+`packages/roxabi-nats/tests/conftest.py` so integration tests for
+`voice.testing` can subscribe/publish against a real loopback NATS
+without cross-package dependency.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Generator
+
+import pytest
+
+_nats_server_available = shutil.which("nats-server") is not None
+requires_nats_server = pytest.mark.skipif(
+    not _nats_server_available,
+    reason="nats-server not found in PATH — install via 'make nats-install'",
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def nats_server_url() -> Generator[str, None, None]:
+    if not _nats_server_available:
+        pytest.skip("nats-server not found in PATH")
+    port = _free_port()
+    url = f"nats://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        ["nats-server", "-p", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        proc.terminate()
+        raise RuntimeError(f"nats-server did not start on port {port}")
+    yield url
+    proc.terminate()
+    proc.wait()

--- a/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
+++ b/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
@@ -1,0 +1,235 @@
+"""Three-guard tests for roxabi_contracts.voice.testing. See spec #764."""
+from __future__ import annotations
+
+import pytest
+
+# Imports are here (not inside fixtures) to prove the module loads in the
+# test env — Guard 1 (import-time) is exercised in a separate subprocess
+# test in Slice V3.
+from roxabi_contracts.voice.testing import FakeSttWorker, FakeTtsWorker
+
+
+@pytest.fixture(autouse=True)
+def _clear_lyra_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LYRA_ENV", raising=False)
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+def test_g2_prod_env_raises(cls, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LYRA_ENV", "production")
+    with pytest.raises(RuntimeError, match=f"{cls.__name__} cannot run in production"):
+        cls()
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+def test_g2_prod_env_raises_even_when_g3_would_pass(
+    cls, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LYRA_ENV", "production")
+    with pytest.raises(RuntimeError):
+        cls(nats_url="nats://127.0.0.1:4222")
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "nats://10.0.0.5:4222",
+        "nats://0.0.0.0:4222",
+        "nats://localhost.evil.com:4222",
+        "nats://example.com:4222",
+    ],
+)
+async def test_g3_non_loopback_raises(cls, bad_url: str) -> None:
+    w = cls(nats_url=bad_url)
+    with pytest.raises(ValueError, match="loopback"):
+        await w.start()
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+@pytest.mark.parametrize(
+    "ok_url",
+    ["nats://127.0.0.1:4222", "nats://[::1]:4222", "nats://[0:0:0:0:0:0:0:1]:4222"],
+)
+async def test_g3_accepts_loopback_but_refuses_connect_without_server(
+    cls, ok_url: str
+) -> None:
+    # No nats-server running on these ports in this unit test — assert the
+    # guard does NOT raise ValueError, but some other error (connection
+    # refused / timeout) occurs downstream. We only care that Guard 3 passed.
+    w = cls(nats_url=ok_url)
+    with pytest.raises(Exception) as exc_info:
+        await w.start()
+    assert not isinstance(exc_info.value, ValueError) or "loopback" not in str(
+        exc_info.value
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slice V2: roundtrip + ordering + idempotent/double-start tests
+# ---------------------------------------------------------------------------
+
+import base64  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import textwrap  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import Any  # noqa: E402
+
+import nats as _nats  # noqa: E402
+from roxabi_contracts.voice import (  # noqa: E402
+    SttRequest,
+    SttResponse,
+    TtsRequest,
+    TtsResponse,
+)
+from roxabi_contracts.voice.fixtures import (  # noqa: E402
+    sample_transcript_en,
+    silence_wav_16khz,
+)
+from roxabi_contracts.voice.subjects import SUBJECTS  # noqa: E402
+
+from .conftest import requires_nats_server  # noqa: E402
+
+_ENVELOPE: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "test-trace",
+    "issued_at": datetime(2026, 4, 18, tzinfo=timezone.utc),
+}
+
+
+@requires_nats_server
+async def test_tts_roundtrip_default_fixture(nats_server_url: str) -> None:
+    worker = FakeTtsWorker(nats_url=nats_server_url)
+    await worker.start()
+    try:
+        nc = await _nats.connect(nats_server_url)
+        req = TtsRequest(**_ENVELOPE, request_id="r1", text="hello")
+        msg = await nc.request(
+            SUBJECTS.tts_request, req.model_dump_json().encode(), timeout=2.0
+        )
+        reply = TtsResponse.model_validate_json(msg.data)
+        assert reply.ok is True
+        assert reply.request_id == "r1"
+        assert reply.mime_type == "audio/wav"
+        assert reply.audio_b64 is not None
+        assert base64.b64decode(reply.audio_b64) == silence_wav_16khz
+        assert len(worker.calls) == 1
+        assert worker.calls[0].text == "hello"
+        await nc.close()
+    finally:
+        await worker.stop()
+
+
+@requires_nats_server
+async def test_stt_roundtrip_default_fixture(nats_server_url: str) -> None:
+    worker = FakeSttWorker(nats_url=nats_server_url)
+    await worker.start()
+    try:
+        nc = await _nats.connect(nats_server_url)
+        req = SttRequest(
+            **_ENVELOPE,
+            request_id="r2",
+            audio_b64=base64.b64encode(silence_wav_16khz).decode("ascii"),
+            model="large-v3-turbo",
+        )
+        msg = await nc.request(
+            SUBJECTS.stt_request, req.model_dump_json().encode(), timeout=2.0
+        )
+        reply = SttResponse.model_validate_json(msg.data)
+        assert reply.ok is True
+        assert reply.request_id == "r2"
+        assert reply.text == sample_transcript_en
+        assert reply.language == "en"
+        assert reply.duration_seconds == 1.0
+        assert len(worker.calls) == 1
+        await nc.close()
+    finally:
+        await worker.stop()
+
+
+@requires_nats_server
+async def test_calls_records_multiple_requests_in_order(
+    nats_server_url: str,
+) -> None:
+    worker = FakeTtsWorker(nats_url=nats_server_url)
+    await worker.start()
+    try:
+        nc = await _nats.connect(nats_server_url)
+        for i in range(3):
+            req = TtsRequest(**_ENVELOPE, request_id=f"r{i}", text=f"msg-{i}")
+            await nc.request(
+                SUBJECTS.tts_request, req.model_dump_json().encode(), timeout=2.0
+            )
+        assert [r.request_id for r in worker.calls] == ["r0", "r1", "r2"]
+        await nc.close()
+    finally:
+        await worker.stop()
+
+
+async def test_stop_is_idempotent() -> None:
+    worker = FakeTtsWorker()
+    await worker.stop()
+    await worker.stop()  # second call: no exception
+
+
+async def test_start_twice_raises() -> None:
+    """start() with a live _nc must raise RuntimeError."""
+    # Bypass actual connection by setting _nc manually to exercise the check.
+    worker = FakeTtsWorker()
+    worker._nc = object()  # type: ignore[assignment]
+    with pytest.raises(RuntimeError, match="already started"):
+        await worker.start()
+
+
+# ---------------------------------------------------------------------------
+# Slice V3: Guard 1 subprocess test
+# ---------------------------------------------------------------------------
+
+
+def test_g1_import_without_extra(tmp_path: Path) -> None:
+    """Guard 1 — importing roxabi_contracts.voice.testing without nats-py
+    installed fails at import (not instantiation).
+
+    Implementation: craft a temp dir containing a sabotaging `nats.py`
+    that raises ModuleNotFoundError on execution, prepend it to
+    PYTHONPATH so the subprocess's `import nats` hits it before the real
+    package, then assert the import of `roxabi_contracts.voice.testing`
+    fails. This proves Guard 1 fires at module-top-level (line: `import nats`).
+
+    Regression guard: if a future change wraps `import nats` in a
+    try/except inside testing.py, this test will fail (subprocess exits 0
+    instead of 42), catching the regression before it reaches production.
+    """
+    sabotage = tmp_path / "nats.py"
+    sabotage.write_text(
+        textwrap.dedent(
+            """
+            raise ModuleNotFoundError("No module named 'nats' (sabotaged)")
+            """
+        ).lstrip()
+    )
+    script = textwrap.dedent(
+        """
+        import sys
+        try:
+            import roxabi_contracts.voice.testing  # noqa: F401
+        except ModuleNotFoundError as exc:
+            if "nats" in str(exc):
+                sys.exit(42)
+            raise
+        sys.exit(0)
+        """
+    ).lstrip()
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env={"PYTHONPATH": str(tmp_path), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 42, (
+        f"expected exit 42 (ModuleNotFoundError for nats), got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
+++ b/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
@@ -57,25 +57,28 @@ async def test_g3_accepts_loopback_but_refuses_connect_without_server(
     # No nats-server running on these ports in this unit test — assert the
     # guard does NOT raise ValueError, but some other error (connection
     # refused / timeout) occurs downstream. We only care that Guard 3 passed.
+    # If Guard 3 fired incorrectly, its ValueError would not match the tuple
+    # below and pytest.raises would fail, catching the regression.
     w = cls(nats_url=ok_url)
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises((OSError, asyncio.TimeoutError, NoServersError)):
         await w.start()
-    assert not isinstance(exc_info.value, ValueError) or "loopback" not in str(
-        exc_info.value
-    )
 
 
 # ---------------------------------------------------------------------------
 # Slice V2: roundtrip + ordering + idempotent/double-start tests
 # ---------------------------------------------------------------------------
 
+import asyncio  # noqa: E402
 import base64  # noqa: E402
+import os  # noqa: E402
 import subprocess  # noqa: E402
 import sys  # noqa: E402
 import textwrap  # noqa: E402
 from datetime import datetime, timezone  # noqa: E402
 from pathlib import Path  # noqa: E402
 from typing import Any  # noqa: E402
+
+from nats.errors import NoServersError  # noqa: E402
 
 import nats as _nats  # noqa: E402
 from roxabi_contracts.voice import (  # noqa: E402
@@ -184,8 +187,43 @@ async def test_start_twice_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Slice V3: Guard 1 subprocess test
+# Slice V3: Guard 1 subprocess test + API surface invariant
 # ---------------------------------------------------------------------------
+
+
+def test_voice_init_does_not_expose_testing() -> None:
+    """Regression guard — voice/__init__.py must NOT re-export testing.
+
+    The testing module lives behind the [testing] extra; accidental re-export
+    at the voice package root would mean a bare `import roxabi_contracts.voice`
+    in a production install would trigger Guard 1's ModuleNotFoundError even
+    when no caller wants test doubles. Spec #764 §API surface invariant.
+
+    Note: after *any* submodule import Python injects the submodule into the
+    parent package namespace, so `vars(voice_mod)` will contain 'testing'
+    once this test suite has imported it. The meaningful invariant is that
+    __init__.py does NOT import or list testing — checked via __all__ and
+    source inspection.
+    """
+    import roxabi_contracts.voice as voice_mod
+
+    # __all__ must not advertise the testing module
+    assert "testing" not in voice_mod.__all__
+    # __init__.py source must not contain an explicit import of testing
+    import inspect
+
+    src = inspect.getsource(voice_mod)
+    assert "testing" not in src
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+@pytest.mark.parametrize("value", ["PRODUCTION", "Production", "pRoDuCtIoN"])
+def test_g2_prod_env_case_insensitive(
+    cls, value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LYRA_ENV", value)
+    with pytest.raises(RuntimeError, match=f"{cls.__name__} cannot run in production"):
+        cls()
 
 
 def test_g1_import_without_extra(tmp_path: Path) -> None:
@@ -224,7 +262,10 @@ def test_g1_import_without_extra(tmp_path: Path) -> None:
     ).lstrip()
     result = subprocess.run(
         [sys.executable, "-c", script],
-        env={"PYTHONPATH": str(tmp_path), "PATH": "/usr/bin:/bin"},
+        env={
+            **os.environ,
+            "PYTHONPATH": f"{tmp_path}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+        },
         capture_output=True,
         text=True,
         timeout=10,

--- a/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
+++ b/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
@@ -46,21 +46,42 @@ async def test_g3_non_loopback_raises(cls, bad_url: str) -> None:
         await w.start()
 
 
-@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
-@pytest.mark.parametrize(
-    "ok_url",
-    ["nats://127.0.0.1:4222", "nats://[::1]:4222", "nats://[0:0:0:0:0:0:0:1]:4222"],
-)
-async def test_g3_accepts_loopback_but_refuses_connect_without_server(
-    cls, ok_url: str
-) -> None:
+async def _run_loopback_passes_guard(cls: type, url: str) -> None:
     # No nats-server running on these ports in this unit test — assert the
     # guard does NOT raise ValueError, but some other error (connection
     # refused / timeout) occurs downstream. We only care that Guard 3 passed.
     # If Guard 3 fired incorrectly, its ValueError would not match the tuple
     # below and pytest.raises would fail, catching the regression.
-    w = cls(nats_url=ok_url)
+    w = cls(nats_url=url)
     with pytest.raises((OSError, asyncio.TimeoutError, NoServersError)):
+        await w.start()
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+async def test_g3_accepts_ipv4_loopback(cls) -> None:
+    await _run_loopback_passes_guard(cls, "nats://127.0.0.1:4222")
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+async def test_g3_accepts_ipv6_loopback(cls) -> None:
+    await _run_loopback_passes_guard(cls, "nats://[::1]:4222")
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+async def test_g3_accepts_ipv6_loopback_full(cls) -> None:
+    await _run_loopback_passes_guard(cls, "nats://[0:0:0:0:0:0:0:1]:4222")
+
+
+@pytest.mark.parametrize("cls", [FakeTtsWorker, FakeSttWorker])
+async def test_g3_non_loopback_raises_when_g2_unset(cls) -> None:
+    """Guard 3 fires even with LYRA_ENV unset — proves G3 independent of G2.
+
+    The `_clear_lyra_env` autouse fixture ensures LYRA_ENV is unset for
+    this test. This mirrors the spec's guard independence matrix row
+    explicitly rather than relying on the autouse fixture implicitly.
+    """
+    w = cls(nats_url="nats://10.0.0.5:4222")
+    with pytest.raises(ValueError, match="loopback"):
         await w.start()
 
 
@@ -106,6 +127,7 @@ _ENVELOPE: dict[str, Any] = {
 async def test_tts_roundtrip_default_fixture(nats_server_url: str) -> None:
     worker = FakeTtsWorker(nats_url=nats_server_url)
     await worker.start()
+    assert worker.calls == []  # contamination check — prior test leaked?
     try:
         nc = await _nats.connect(nats_server_url)
         req = TtsRequest(**_ENVELOPE, request_id="r1", text="hello")
@@ -123,12 +145,14 @@ async def test_tts_roundtrip_default_fixture(nats_server_url: str) -> None:
         await nc.close()
     finally:
         await worker.stop()
+        await asyncio.sleep(0.05)  # session-scoped fixture drain barrier
 
 
 @requires_nats_server
 async def test_stt_roundtrip_default_fixture(nats_server_url: str) -> None:
     worker = FakeSttWorker(nats_url=nats_server_url)
     await worker.start()
+    assert worker.calls == []  # contamination check — prior test leaked?
     try:
         nc = await _nats.connect(nats_server_url)
         req = SttRequest(
@@ -150,6 +174,7 @@ async def test_stt_roundtrip_default_fixture(nats_server_url: str) -> None:
         await nc.close()
     finally:
         await worker.stop()
+        await asyncio.sleep(0.05)  # session-scoped fixture drain barrier
 
 
 @requires_nats_server
@@ -158,6 +183,7 @@ async def test_calls_records_multiple_requests_in_order(
 ) -> None:
     worker = FakeTtsWorker(nats_url=nats_server_url)
     await worker.start()
+    assert worker.calls == []  # contamination check — prior test leaked?
     try:
         nc = await _nats.connect(nats_server_url)
         for i in range(3):
@@ -169,6 +195,53 @@ async def test_calls_records_multiple_requests_in_order(
         await nc.close()
     finally:
         await worker.stop()
+        await asyncio.sleep(0.05)  # session-scoped fixture drain barrier
+
+
+@requires_nats_server
+async def test_dispatch_drops_malformed_json(nats_server_url: str) -> None:
+    """_dispatch silently drops requests that fail Pydantic validation.
+
+    Spec F8: `except ValidationError` path — log WARNING, no reply, no
+    entry in `.calls`. Proves the drop-on-drift contract.
+    """
+    worker = FakeTtsWorker(nats_url=nats_server_url)
+    await worker.start()
+    assert worker.calls == []  # contamination check — prior test leaked?
+    try:
+        nc = await _nats.connect(nats_server_url)
+        # Use publish (not request) because request would time out when
+        # no reply arrives — publish + sleep to let the dispatch run.
+        await nc.publish(SUBJECTS.tts_request, b"this is not json at all")
+        await asyncio.sleep(0.1)  # let dispatch run
+        assert worker.calls == []
+        await nc.close()
+    finally:
+        await worker.stop()
+        await asyncio.sleep(0.05)  # session-scoped fixture drain barrier
+
+
+@requires_nats_server
+async def test_dispatch_no_reply_records_call_without_publishing(
+    nats_server_url: str,
+) -> None:
+    """Fire-and-forget publish (no reply subject) records the call but
+    sends no reply. Spec F8: `if not msg.reply ... return` short-circuit.
+    """
+    worker = FakeTtsWorker(nats_url=nats_server_url)
+    await worker.start()
+    assert worker.calls == []  # contamination check — prior test leaked?
+    try:
+        nc = await _nats.connect(nats_server_url)
+        req = TtsRequest(**_ENVELOPE, request_id="r-fire", text="hello")
+        await nc.publish(SUBJECTS.tts_request, req.model_dump_json().encode())
+        await asyncio.sleep(0.1)
+        assert len(worker.calls) == 1
+        assert worker.calls[0].request_id == "r-fire"
+        await nc.close()
+    finally:
+        await worker.stop()
+        await asyncio.sleep(0.05)  # session-scoped fixture drain barrier
 
 
 async def test_stop_is_idempotent() -> None:


### PR DESCRIPTION
## Summary
- Ships `roxabi_contracts.voice.testing` (FakeTtsWorker + FakeSttWorker) behind the existing `[testing]` extra so lyra/voiceCLI tests can drive the voice NATS contract in-process without a GPU, real models, or a real voiceCLI worker.
- Three independent, non-bypassable guards prevent production contamination per ADR-049 §Test-double pattern:
  1. **Import-time gate** — unwrapped `import nats` at module top; bare `roxabi-contracts` install fails with `ModuleNotFoundError` before any runtime code executes.
  2. **`LYRA_ENV=production` assertion** in `__init__` → `RuntimeError`.
  3. **Loopback-only URL check** in `start()` → `ValueError` (accepted hosts: `127.0.0.1 · localhost · ::1 · 0:0:0:0:0:0:0:1`).
- Guard independence is asserted via a parametrized test matrix; Guard 1 has a dedicated subprocess-based regression test with a sabotaged `PYTHONPATH`.
- Roundtrip tests (publish → fake replies with fixture) run against a real `nats-server` when available via `@requires_nats_server` and skip cleanly otherwise.
- README gains a §Test doubles section documenting install + guard contract.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #764: feat(contracts): test doubles — FakeTtsWorker + FakeSttWorker with three guards | Open |
| Frame | [artifacts/frames/764-voice-test-doubles-frame.mdx](artifacts/frames/764-voice-test-doubles-frame.mdx) | approved |
| Spec | [artifacts/specs/764-voice-test-doubles-spec.mdx](artifacts/specs/764-voice-test-doubles-spec.mdx) | approved (34 binary acceptance criteria, 3 expert reviews) |
| Plan | [artifacts/plans/764-voice-test-doubles-plan.mdx](artifacts/plans/764-voice-test-doubles-plan.mdx) | approved (12 micro-tasks, 3 slices, 3 RED-GATE sentinels) |
| Implementation | 1 commit on `feat/764-voice-test-doubles` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (11 new, 79 total in package) | Passed |

## Files

| Path | Op | Lines |
|---|---|---|
| `packages/roxabi-contracts/src/roxabi_contracts/voice/testing.py` | NEW | 189 |
| `packages/roxabi-contracts/tests/test_voice_testing_doubles.py` | NEW | 235 |
| `packages/roxabi-contracts/tests/conftest.py` | NEW (ported from `roxabi-nats`) | 55 |
| `packages/roxabi-contracts/tests/__init__.py` | NEW (enables `from .conftest import requires_nats_server`) | 0 |
| `packages/roxabi-contracts/README.md` | MODIFY (+25) | — |

## Test Plan
- [ ] `cd packages/roxabi-contracts && uv run pytest tests/test_voice_testing_doubles.py -v` — 21 tests pass, 3 skip cleanly when `nats-server` is not in PATH, no errors
- [ ] `uv run pytest tests/test_voice_testing_doubles.py -k "g2 or g3"` — 18 parametrized guard tests pass (both fakes × both env+url independence matrices)
- [ ] `uv run pytest tests/test_voice_testing_doubles.py::test_g1_import_without_extra` — subprocess exits 42 (Guard 1 regression guard)
- [ ] With `nats-server` installed: roundtrip tests exercise publish → fake dispatches → fixture reply → envelope fields echoed, and the ordering test records 3 requests in send order
- [ ] `uv run pyright packages/roxabi-contracts/src packages/roxabi-contracts/tests` — 0 errors
- [ ] `uv run ruff check packages/roxabi-contracts/` — 0 findings

## Known drift from issue body / ADR-049
- Issue body references `FakeTtsWorker.connect()` for Guard 3 (lines in ADR-049 §Loopback-only); the ADR §API surface table defines `start()` / `stop()` only. This PR resolves the naming ambiguity in favour of `start()` — documented in the spec §Context. No separate `connect()` method.
- Spec added the full-form IPv6 loopback `0:0:0:0:0:0:0:1` to `ALLOWED_LOOPBACK_HOSTS` alongside `::1` per expert review (`urllib.parse.urlparse` does not normalize between the two forms).

Closes #764

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`