### PR TITLE
chore(ci): include roxabi-contracts tests in pytest + fixture provenance

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -55,6 +55,11 @@ quality_gates:
     globs: ["src/**"]
     exemptions_file: tools/folder_exemptions.txt
 
+  duplicate_test_basenames:
+    enabled: true
+    script: tools/check_duplicate_test_basenames.sh
+    source: pyproject.toml [tool.pytest.ini_options].testpaths
+
   import_layers:
     enabled: true
     stage: pre-push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Check file length
         run: bash tools/check_file_length.sh
 
+      - name: Check duplicate test basenames
+        run: bash tools/check_duplicate_test_basenames.sh
+
       - name: Enforce import layers
         run: uv run lint-imports
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
     entry: tools/check_folder_size.sh
     language: system
     pass_filenames: false
+  - id: check-duplicate-test-basenames
+    name: check-duplicate-test-basenames
+    entry: tools/check_duplicate_test_basenames.sh
+    language: system
+    pass_filenames: false
   - id: import-layers
     name: import-layers
     entry: uv run lint-imports

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -29,3 +29,4 @@ packages = ["src/roxabi_contracts"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+addopts = "--import-mode=importlib"

--- a/packages/roxabi-contracts/tests/_markers.py
+++ b/packages/roxabi-contracts/tests/_markers.py
@@ -1,0 +1,19 @@
+"""Shared pytest markers for roxabi-contracts tests.
+
+Kept out of ``conftest.py`` so it can be imported by test modules. Tests in
+this package are intentionally not a Python package (no ``__init__.py``) —
+aligning with ``packages/roxabi-nats/tests`` prevents a conftest name
+collision when both are collected from the repo-root ``pyproject.toml``
+``testpaths``.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+requires_nats_server = pytest.mark.skipif(
+    shutil.which("nats-server") is None,
+    reason="nats-server not found in PATH — install via 'make nats-install'",
+)

--- a/packages/roxabi-contracts/tests/conftest.py
+++ b/packages/roxabi-contracts/tests/conftest.py
@@ -27,9 +27,7 @@ _TEST_DIR = str(Path(__file__).resolve().parent)
 if _TEST_DIR not in sys.path:
     sys.path.insert(0, _TEST_DIR)
 
-from _markers import requires_nats_server  # noqa: E402 — re-exported for marker callers
-
-__all__ = ["nats_server_url", "requires_nats_server"]
+from _markers import requires_nats_server as requires_nats_server  # noqa: E402
 
 _nats_server_available = shutil.which("nats-server") is not None
 

--- a/packages/roxabi-contracts/tests/conftest.py
+++ b/packages/roxabi-contracts/tests/conftest.py
@@ -11,16 +11,27 @@ from __future__ import annotations
 import shutil
 import socket
 import subprocess
+import sys
 import time
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 
+# Tests in this package deliberately have no ``__init__.py`` (aligns with
+# ``packages/roxabi-nats/tests`` — a package-level ``__init__.py`` makes
+# two conftest modules collide under ``tests.conftest``). Add the test
+# directory to sys.path so sibling helpers like ``_markers`` resolve both
+# here (conftest load, before pytest injects the path) and in test modules.
+_TEST_DIR = str(Path(__file__).resolve().parent)
+if _TEST_DIR not in sys.path:
+    sys.path.insert(0, _TEST_DIR)
+
+from _markers import requires_nats_server  # noqa: E402 — re-exported for marker callers
+
+__all__ = ["nats_server_url", "requires_nats_server"]
+
 _nats_server_available = shutil.which("nats-server") is not None
-requires_nats_server = pytest.mark.skipif(
-    not _nats_server_available,
-    reason="nats-server not found in PATH — install via 'make nats-install'",
-)
 
 
 def _free_port() -> int:

--- a/packages/roxabi-contracts/tests/conftest.py
+++ b/packages/roxabi-contracts/tests/conftest.py
@@ -19,9 +19,12 @@ from pathlib import Path
 
 import pytest
 
+_CANONICAL_MARKERS_KEY = "roxabi_contracts_test_markers"
+_ALIAS_MARKERS_KEY = "_markers"
+
 
 def _register_markers() -> None:
-    """Register ``_markers.py`` under ``_markers`` at collection time.
+    """Register ``_markers.py`` under a namespaced key at collection time.
 
     Tests in this package deliberately have no ``__init__.py`` (aligns with
     ``packages/roxabi-nats/tests`` — a package-level ``__init__.py`` makes
@@ -30,15 +33,25 @@ def _register_markers() -> None:
     depend on pytest-specific sys.path injection, which ``--import-mode=importlib``
     disables. Use the same spec-from-file-location pattern that
     ``packages/roxabi-nats/tests/conftest.py`` uses for ``_stub_fixture.py``.
+
+    The canonical ``sys.modules`` key is namespaced (``roxabi_contracts_test_markers``)
+    so it cannot collide with a similarly-named helper in another package's
+    conftest. The bare ``_markers`` name is exposed as an alias so callers
+    can keep writing ``from _markers import requires_nats_server`` — but the
+    idempotency guard checks the namespaced key, not the alias, so a collision
+    on ``_markers`` from elsewhere no longer short-circuits this loader with
+    the wrong module.
     """
-    if "_markers" in sys.modules:
+    if _CANONICAL_MARKERS_KEY in sys.modules:
+        sys.modules.setdefault(_ALIAS_MARKERS_KEY, sys.modules[_CANONICAL_MARKERS_KEY])
         return
     path = Path(__file__).parent / "_markers.py"
-    spec = importlib.util.spec_from_file_location("_markers", path)
+    spec = importlib.util.spec_from_file_location(_CANONICAL_MARKERS_KEY, path)
     if spec is None or spec.loader is None:
-        raise RuntimeError("failed to build import spec for _markers")
+        raise RuntimeError(f"failed to build import spec for {_CANONICAL_MARKERS_KEY}")
     mod = importlib.util.module_from_spec(spec)
-    sys.modules["_markers"] = mod
+    sys.modules[_CANONICAL_MARKERS_KEY] = mod
+    sys.modules[_ALIAS_MARKERS_KEY] = mod
     spec.loader.exec_module(mod)
 
 

--- a/packages/roxabi-contracts/tests/conftest.py
+++ b/packages/roxabi-contracts/tests/conftest.py
@@ -8,6 +8,7 @@ without cross-package dependency.
 
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import socket
 import subprocess
@@ -18,18 +19,30 @@ from pathlib import Path
 
 import pytest
 
-# Tests in this package deliberately have no ``__init__.py`` (aligns with
-# ``packages/roxabi-nats/tests`` — a package-level ``__init__.py`` makes
-# two conftest modules collide under ``tests.conftest``). Add the test
-# directory to sys.path so sibling helpers like ``_markers`` resolve both
-# here (conftest load, before pytest injects the path) and in test modules.
-_TEST_DIR = str(Path(__file__).resolve().parent)
-if _TEST_DIR not in sys.path:
-    sys.path.insert(0, _TEST_DIR)
 
-from _markers import requires_nats_server as requires_nats_server  # noqa: E402
+def _register_markers() -> None:
+    """Register ``_markers.py`` under ``_markers`` at collection time.
 
-_nats_server_available = shutil.which("nats-server") is not None
+    Tests in this package deliberately have no ``__init__.py`` (aligns with
+    ``packages/roxabi-nats/tests`` — a package-level ``__init__.py`` makes
+    two conftest modules collide under ``tests.conftest``). Without a
+    package, ``from _markers import ...`` from sibling test modules would
+    depend on pytest-specific sys.path injection, which ``--import-mode=importlib``
+    disables. Use the same spec-from-file-location pattern that
+    ``packages/roxabi-nats/tests/conftest.py`` uses for ``_stub_fixture.py``.
+    """
+    if "_markers" in sys.modules:
+        return
+    path = Path(__file__).parent / "_markers.py"
+    spec = importlib.util.spec_from_file_location("_markers", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to build import spec for _markers")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_markers"] = mod
+    spec.loader.exec_module(mod)
+
+
+_register_markers()
 
 
 def _free_port() -> int:
@@ -40,7 +53,7 @@ def _free_port() -> int:
 
 @pytest.fixture(scope="session")
 def nats_server_url() -> Generator[str, None, None]:
-    if not _nats_server_available:
+    if shutil.which("nats-server") is None:
         pytest.skip("nats-server not found in PATH")
     port = _free_port()
     url = f"nats://127.0.0.1:{port}"

--- a/packages/roxabi-contracts/tests/test_fixture_provenance.py
+++ b/packages/roxabi-contracts/tests/test_fixture_provenance.py
@@ -11,11 +11,22 @@ generator, an accidental real-data seed) fails CI.
 from __future__ import annotations
 
 import io
+import struct
 
 import numpy as np
 from scipy.io.wavfile import write as wav_write
 
 from roxabi_contracts.voice import fixtures
+
+# Pin the exact wire shape so a future scipy release that changes chunk
+# padding or sub-chunk ordering (making both the generator and the fixture
+# drift together) fails the test rather than silently matching.
+#
+# Derivation: PCM WAV header is 44 bytes (RIFF 'WAVE' + fmt + data chunks),
+# payload is ``16 000 samples × 2 bytes (int16)`` = 32 000 bytes.
+_EXPECTED_WAV_BYTE_COUNT = 44 + 16_000 * 2
+# RIFF size field at offset 4 excludes the first 8 bytes (``RIFF`` + size).
+_EXPECTED_RIFF_SIZE_FIELD = _EXPECTED_WAV_BYTE_COUNT - 8
 
 
 def test_silence_wav_16khz_is_byte_identical_to_generator() -> None:
@@ -31,6 +42,15 @@ def test_silence_wav_16khz_is_byte_identical_to_generator() -> None:
 
 def test_silence_wav_16khz_has_riff_header() -> None:
     assert fixtures.silence_wav_16khz.startswith(b"RIFF")
+
+
+def test_silence_wav_16khz_byte_count_is_pinned() -> None:
+    assert len(fixtures.silence_wav_16khz) == _EXPECTED_WAV_BYTE_COUNT
+
+
+def test_silence_wav_16khz_riff_size_field_is_pinned() -> None:
+    (riff_size,) = struct.unpack_from("<I", fixtures.silence_wav_16khz, 4)
+    assert riff_size == _EXPECTED_RIFF_SIZE_FIELD
 
 
 def test_sample_transcript_en_is_deterministic() -> None:

--- a/packages/roxabi-contracts/tests/test_fixture_provenance.py
+++ b/packages/roxabi-contracts/tests/test_fixture_provenance.py
@@ -1,0 +1,39 @@
+# pyright: reportMissingTypeStubs=false, reportMissingImports=false
+"""Byte-identical provenance tests for roxabi_contracts.voice.fixtures.
+
+ADR-049 §Fixture generation requires every binary fixture to be regenerable
+from a documented generator call. This test regenerates each fixture from
+its canonical recipe and asserts byte-identical equality with the value
+exported by ``fixtures.py``. Any drift (a hand-edited byte, a swapped
+generator, an accidental real-data seed) fails CI.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+from scipy.io.wavfile import write as wav_write
+
+from roxabi_contracts.voice import fixtures
+
+
+def test_silence_wav_16khz_is_byte_identical_to_generator() -> None:
+    sample_rate_hz = 16_000
+    duration_seconds = 1
+    samples = np.zeros(sample_rate_hz * duration_seconds, dtype=np.int16)
+    buf = io.BytesIO()
+    wav_write(buf, sample_rate_hz, samples)
+    expected = buf.getvalue()
+
+    assert fixtures.silence_wav_16khz == expected
+
+
+def test_silence_wav_16khz_has_riff_header() -> None:
+    assert fixtures.silence_wav_16khz.startswith(b"RIFF")
+
+
+def test_sample_transcript_en_is_deterministic() -> None:
+    expected = "Hello, this is a roxabi-contracts test fixture."
+    assert fixtures.sample_transcript_en == expected
+    assert len(fixtures.sample_transcript_en) <= 120

--- a/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
+++ b/packages/roxabi-contracts/tests/test_voice_testing_doubles.py
@@ -102,6 +102,7 @@ from typing import Any  # noqa: E402
 from nats.errors import NoServersError  # noqa: E402
 
 import nats as _nats  # noqa: E402
+from _markers import requires_nats_server  # noqa: E402
 from roxabi_contracts.voice import (  # noqa: E402
     SttRequest,
     SttResponse,
@@ -113,8 +114,6 @@ from roxabi_contracts.voice.fixtures import (  # noqa: E402
     silence_wav_16khz,
 )
 from roxabi_contracts.voice.subjects import SUBJECTS  # noqa: E402
-
-from .conftest import requires_nats_server  # noqa: E402
 
 _ENVELOPE: dict[str, Any] = {
     "contract_version": "1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ packages = ["src/lyra"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-testpaths = ["tests", "packages/roxabi-nats/tests"]
-addopts = "--import-mode=importlib --cov=lyra --cov=roxabi_nats --cov-report=term-missing --cov-report=xml --cov-fail-under=50"
+testpaths = ["tests", "packages/roxabi-nats/tests", "packages/roxabi-contracts/tests"]
+addopts = "--import-mode=importlib --cov=lyra --cov=roxabi_nats --cov=roxabi_contracts --cov-report=term-missing --cov-report=xml --cov-fail-under=50"
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ addopts = "--import-mode=importlib --cov=lyra --cov=roxabi_nats --cov=roxabi_con
 
 [tool.coverage.run]
 branch = true
-source = ["lyra"]
+source = ["lyra", "roxabi_nats", "roxabi_contracts"]
 
 [tool.coverage.report]
 show_missing = true

--- a/tools/check_duplicate_test_basenames.sh
+++ b/tools/check_duplicate_test_basenames.sh
@@ -46,6 +46,13 @@ done
 # A test file resolves to a bare basename iff its directory has no
 # ``__init__.py``. Collect only those files — they are the population at
 # risk of collision.
+#
+# Invariant: root ``tests/`` has a full ``__init__.py`` chain on every
+# subdirectory, so every file under it is fully qualified and is filtered
+# out here — including ``tests/`` in testpaths costs nothing. If that
+# invariant ever breaks (someone removes a ``tests/**/__init__.py``) this
+# guard would start flagging tests/-local basenames against package
+# testpaths, which is the desired behavior.
 BARE_FILES=$(
     find "${TESTPATHS[@]}" -type f -name 'test_*.py' \
         | while IFS= read -r f; do

--- a/tools/check_duplicate_test_basenames.sh
+++ b/tools/check_duplicate_test_basenames.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Fail if any two pytest ``testpaths`` files resolve to the same bare module
+# name under ``--import-mode=importlib``.
+#
+# Why: the root ``pyproject.toml`` sets ``--import-mode=importlib``. Under that
+# mode pytest imports a test file via the parent chain of ``__init__.py``
+# files — if an ``__init__.py`` is present, the module name is fully
+# qualified (e.g. ``tests.nats.test_sanitize``); if it is absent, the module
+# name is the file's bare basename (e.g. ``test_sanitize``).
+#
+# Two bare-basename files with the same name register under the same key in
+# ``sys.modules``; the second import silently reuses the first and its
+# assertions never run.
+#
+# Root ``tests/`` has a complete ``__init__.py`` chain, so its files are
+# always fully qualified — same-basename files inside it are safe. The
+# non-root testpaths (``packages/*/tests``) deliberately have no
+# ``__init__.py`` (see ``packages/roxabi-contracts/tests/conftest.py``
+# docstring for rationale), so they feed into the bare-basename pool. This
+# guard checks that pool for duplicates.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+TESTPATHS=(
+    "tests"
+    "packages/roxabi-nats/tests"
+    "packages/roxabi-contracts/tests"
+)
+
+for p in "${TESTPATHS[@]}"; do
+    [ -d "$p" ] || { echo "testpath not found: $p" >&2; exit 2; }
+done
+
+# A test file resolves to a bare basename iff its directory has no
+# ``__init__.py``. Collect only those files — they are the population at
+# risk of collision.
+BARE_FILES=$(
+    find "${TESTPATHS[@]}" -type f -name 'test_*.py' \
+        | while IFS= read -r f; do
+            [ -f "$(dirname "$f")/__init__.py" ] || printf '%s\n' "$f"
+          done
+)
+
+DUPES=$(
+    printf '%s\n' "$BARE_FILES" \
+        | awk -F/ 'NF > 0 { print $NF "\t" $0 }' \
+        | sort \
+        | awk -F'\t' '
+            { count[$1]++; paths[$1] = paths[$1] $2 "\n" }
+            END {
+                for (b in count) {
+                    if (count[b] > 1) {
+                        printf("duplicate bare basename: %s\n%s", b, paths[b])
+                    }
+                }
+            }
+          '
+)
+
+if [ -n "$DUPES" ]; then
+    echo "Duplicate bare test basenames across pytest testpaths:" >&2
+    echo "Files without __init__.py resolve to bare module names under" >&2
+    echo "--import-mode=importlib; duplicates shadow each other in sys.modules." >&2
+    echo >&2
+    printf '%s\n' "$DUPES" >&2
+    echo "Rename one (prefix with package name), or add __init__.py to a" >&2
+    echo "parent directory to force a fully-qualified module path." >&2
+    exit 1
+fi

--- a/tools/check_duplicate_test_basenames.sh
+++ b/tools/check_duplicate_test_basenames.sh
@@ -22,14 +22,25 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-TESTPATHS=(
-    "tests"
-    "packages/roxabi-nats/tests"
-    "packages/roxabi-contracts/tests"
-)
+# Single source of truth: read ``testpaths`` from ``[tool.pytest.ini_options]``
+# in the root ``pyproject.toml``. Guarantees this guard stays in sync with
+# actual pytest collection, so adding a new testpath in ``pyproject.toml``
+# automatically extends the check — no silent drift.
+mapfile -t TESTPATHS < <(python3 -c "
+import tomllib
+with open('pyproject.toml', 'rb') as f:
+    cfg = tomllib.load(f)
+for p in cfg['tool']['pytest']['ini_options']['testpaths']:
+    print(p)
+")
+
+if [ "${#TESTPATHS[@]}" -eq 0 ]; then
+    echo "no testpaths found in pyproject.toml [tool.pytest.ini_options]" >&2
+    exit 1
+fi
 
 for p in "${TESTPATHS[@]}"; do
-    [ -d "$p" ] || { echo "testpath not found: $p" >&2; exit 2; }
+    [ -d "$p" ] || { echo "testpath not found: $p" >&2; exit 1; }
 done
 
 # A test file resolves to a bare basename iff its directory has no
@@ -68,3 +79,5 @@ if [ -n "$DUPES" ]; then
     echo "parent directory to force a fully-qualified module path." >&2
     exit 1
 fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `packages/roxabi-contracts/tests` to root pytest `testpaths` and `roxabi_contracts` to `--cov=` so `uv run pytest` from the repo root now runs all three test directories (`tests`, `packages/roxabi-nats/tests`, `packages/roxabi-contracts/tests`).
- Add `test_fixture_provenance.py` — regenerates `silence_wav_16khz` via its canonical `scipy.io.wavfile.write` recipe and asserts byte-identical match with `fixtures.py`. Any drift (hand-edit, swapped generator, accidental real-data seed) now fails CI per ADR-049 §Fixture generation.
- Drop `packages/roxabi-contracts/tests/__init__.py` to align with `packages/roxabi-nats/tests`. Without this, both `conftest.py` files resolved to the same `tests.conftest` module name and pytest refused to register the second under root collection.
- Extract `requires_nats_server` into a shared `_markers.py` helper; `conftest.py` prepends its directory to `sys.path` so the marker resolves both at conftest load and in test modules. Replaces the previous `from .conftest import ...` relative import (which required the now-removed `__init__.py`).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#768](https://github.com/Roxabi/lyra/issues/768): chore(ci): include packages/roxabi-contracts/tests in pytest + add fixture provenance test | OPEN |
| Implementation | 1 commit on `feat/768-pytest-contracts-fixture-provenance` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new) | Passed |

## Test Plan
- [x] `uv run pytest` from repo root collects + runs all three test dirs — 3100 passed, 47 skipped, coverage 85.24%
- [x] `uv run pytest packages/roxabi-contracts/tests/test_fixture_provenance.py -v` — 3 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run lint-imports` — 2 contracts kept, 0 broken
- [ ] CI green on this PR

Closes #768

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`