### PR TITLE
refactor(nats): migrate lyra voice publishers to roxabi_contracts.voice

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
@@ -1,8 +1,9 @@
 """Voice-domain NATS contract surface.
 
-Public API: SUBJECTS + four envelope models. The `fixtures` submodule is
-test-only and DELIBERATELY not re-exported here — it must be imported
-explicitly as ``from roxabi_contracts.voice.fixtures import ...``.
+Public API: SUBJECTS namespace + per_worker_* helpers + four envelope
+models. The `fixtures` submodule is test-only and DELIBERATELY not
+re-exported here — it must be imported explicitly as
+``from roxabi_contracts.voice.fixtures import ...``.
 """
 
 from roxabi_contracts.voice.models import (
@@ -11,7 +12,11 @@ from roxabi_contracts.voice.models import (
     TtsRequest,
     TtsResponse,
 )
-from roxabi_contracts.voice.subjects import SUBJECTS
+from roxabi_contracts.voice.subjects import (
+    SUBJECTS,
+    per_worker_stt,
+    per_worker_tts,
+)
 
 __all__ = [
     "SUBJECTS",
@@ -19,4 +24,6 @@ __all__ = [
     "SttResponse",
     "TtsRequest",
     "TtsResponse",
+    "per_worker_stt",
+    "per_worker_tts",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
@@ -16,6 +16,7 @@ from roxabi_contracts.voice.subjects import (
     SUBJECTS,
     per_worker_stt,
     per_worker_tts,
+    validate_worker_id,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "TtsResponse",
     "per_worker_stt",
     "per_worker_tts",
+    "validate_worker_id",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/subjects.py
@@ -39,7 +39,15 @@ class _Subjects:
 SUBJECTS = _Subjects()
 
 
-def _validate_worker_id(worker_id: str) -> None:
+def validate_worker_id(worker_id: str) -> None:
+    """Validate a worker_id against the NATS-subject-safe character class.
+
+    Raises ``ValueError`` if ``worker_id`` contains anything outside
+    ``[A-Za-z0-9_-]`` (notably ``. * >``, which are NATS wildcard or
+    subtree delimiters). Used by ``per_worker_tts`` / ``per_worker_stt``
+    on the PUBLISH path and by consumers on the heartbeat-receive path
+    to keep the registry free of wildcard-injectable ids.
+    """
     if not _SAFE_WORKER_ID_RE.fullmatch(worker_id):
         raise ValueError(
             f"worker_id must match [A-Za-z0-9_-]+ (got {worker_id!r}); "
@@ -52,9 +60,9 @@ def per_worker_tts(worker_id: str) -> str:
     """Per-worker TTS request subject: ``lyra.voice.tts.request.{worker_id}``.
 
     Raises ``ValueError`` if ``worker_id`` contains characters outside
-    ``[A-Za-z0-9_-]`` — see ``_validate_worker_id``.
+    ``[A-Za-z0-9_-]`` — see ``validate_worker_id``.
     """
-    _validate_worker_id(worker_id)
+    validate_worker_id(worker_id)
     return f"{SUBJECTS.tts_request}.{worker_id}"
 
 
@@ -62,7 +70,7 @@ def per_worker_stt(worker_id: str) -> str:
     """Per-worker STT request subject: ``lyra.voice.stt.request.{worker_id}``.
 
     Raises ``ValueError`` if ``worker_id`` contains characters outside
-    ``[A-Za-z0-9_-]`` — see ``_validate_worker_id``.
+    ``[A-Za-z0-9_-]`` — see ``validate_worker_id``.
     """
-    _validate_worker_id(worker_id)
+    validate_worker_id(worker_id)
     return f"{SUBJECTS.stt_request}.{worker_id}"

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -19,6 +19,7 @@ from typing import NoReturn
 from uuid import uuid4
 
 from nats.aio.client import Client as NATS
+from pydantic import ValidationError
 
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from lyra.stt import (
@@ -28,7 +29,7 @@ from lyra.stt import (
     is_whisper_noise,
 )
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.voice import SUBJECTS, SttRequest
+from roxabi_contracts.voice import SUBJECTS, SttRequest, SttResponse
 from roxabi_contracts.voice.subjects import per_worker_stt
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
@@ -108,6 +109,15 @@ class NatsSttClient:
             return
         self._registry.record_heartbeat(data)
 
+    def _parse_reply(self, raw: bytes) -> SttResponse:
+        """Validate a NATS reply against SttResponse; translate a ValidationError
+        into STTUnavailableError + record a circuit-breaker failure."""
+        try:
+            return SttResponse.model_validate_json(raw)
+        except ValidationError as exc:
+            self._cb.record_failure()
+            raise STTUnavailableError("STT reply failed schema validation") from exc
+
     async def transcribe(self, path: Path | str) -> TranscriptionResult:
         preferred = self._registry.pick_least_loaded()
         if preferred is None:
@@ -132,14 +142,15 @@ class NatsSttClient:
             language_fallback=self._detection_fallback,
         )
         payload = request.model_dump_json(exclude_none=True).encode("utf-8")
-        data = await self._request_with_fallback(payload, preferred.worker_id)
-        if not data.get("ok"):
+        resp = await self._request_with_fallback(payload, preferred.worker_id)
+        if not resp.ok:
             self._cb.record_failure()
-            raise STTUnavailableError("STT transcription failed")
+            raise STTUnavailableError(resp.error or "STT transcription failed")
+        # ok=True invariant guarantees text / language / duration_seconds non-null
         result = TranscriptionResult(
-            text=data["text"],
-            language=data.get("language", "unknown"),
-            duration_seconds=data.get("duration_seconds", 0.0),
+            text=resp.text or "",
+            language=resp.language or "unknown",
+            duration_seconds=resp.duration_seconds or 0.0,
         )
         self._cb.record_success()
         if is_whisper_noise(result.text):
@@ -151,7 +162,9 @@ class NatsSttClient:
             raise STTNoiseError(f"Noise transcript: {result.text!r}")
         return result
 
-    async def _request_with_fallback(self, payload: bytes, worker_id: str) -> dict:
+    async def _request_with_fallback(
+        self, payload: bytes, worker_id: str
+    ) -> SttResponse:
         """Send to per-worker subject; on timeout, fall back once to queue group.
 
         Raises ``STTUnavailableError`` on final failure (after fallback), wrapping
@@ -161,7 +174,9 @@ class NatsSttClient:
         target = per_worker_stt(worker_id)
         try:
             reply = await self._nc.request(target, payload, timeout=self._timeout)
-            return json.loads(reply.data)
+            return self._parse_reply(reply.data)
+        except STTUnavailableError:
+            raise
         except TimeoutError:
             log.warning(
                 "STT: preferred worker %s timed out after %.0fs;"
@@ -176,7 +191,9 @@ class NatsSttClient:
             reply = await self._nc.request(
                 SUBJECTS.stt_request, payload, timeout=self._timeout
             )
-            return json.loads(reply.data)
+            return self._parse_reply(reply.data)
+        except STTUnavailableError:
+            raise
         except TimeoutError as exc:
             log.warning("STT adapter timeout after %.0fs", self._timeout)
             self._cb.record_failure()

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -29,7 +29,13 @@ from lyra.stt import (
     is_whisper_noise,
 )
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.voice import SUBJECTS, SttRequest, SttResponse, per_worker_stt
+from roxabi_contracts.voice import (
+    SUBJECTS,
+    SttRequest,
+    SttResponse,
+    per_worker_stt,
+    validate_worker_id,
+)
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 log = logging.getLogger(__name__)
@@ -103,8 +109,21 @@ class NatsSttClient:
         except Exception:
             log.debug("stt_client: heartbeat parse error", exc_info=True)
             return
-        if not data.get("worker_id"):
+        worker_id = data.get("worker_id")
+        if not worker_id:
             log.warning("stt_client: heartbeat missing worker_id, ignoring")
+            return
+        # Receive-side match for the PUBLISH-path safe-chars enforcement in
+        # per_worker_stt. Without this, a rogue worker publishing a heartbeat
+        # with a wildcard-bearing id (e.g. "evil.worker.*") would pollute the
+        # registry until first routing attempt.
+        try:
+            validate_worker_id(worker_id)
+        except ValueError:
+            log.warning(
+                "stt_client: heartbeat with unsafe worker_id=%r, ignoring",
+                worker_id,
+            )
             return
         self._registry.record_heartbeat(data)
 
@@ -179,8 +198,6 @@ class NatsSttClient:
         try:
             reply = await self._nc.request(target, payload, timeout=self._timeout)
             return self._parse_reply(reply.data)
-        except STTUnavailableError:
-            raise
         except TimeoutError:
             log.warning(
                 "STT: preferred worker %s timed out after %.0fs;"
@@ -196,8 +213,6 @@ class NatsSttClient:
                 SUBJECTS.stt_request, payload, timeout=self._timeout
             )
             return self._parse_reply(reply.data)
-        except STTUnavailableError:
-            raise
         except TimeoutError as exc:
             log.warning("STT adapter timeout after %.0fs", self._timeout)
             self._cb.record_failure()
@@ -206,7 +221,15 @@ class NatsSttClient:
             self._raise_nats_failure(exc, payload_kb)
 
     def _raise_nats_failure(self, exc: Exception, payload_kb: float) -> NoReturn:
-        """Convert a NATS request exception to STTUnavailableError."""
+        """Convert a NATS request exception to STTUnavailableError.
+
+        Domain errors (``STTUnavailableError``) pass through unchanged so callers
+        can rely on this being the single translation boundary for NATS-transport
+        exceptions — no per-site ``except STTUnavailableError: raise`` guard
+        needed anywhere in this file.
+        """
+        if isinstance(exc, STTUnavailableError):
+            raise exc
         if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
             log.error(
                 "STT payload too large (%.0f KB) — check NATS max_payload",

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -13,6 +13,7 @@ import base64
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 from uuid import uuid4
@@ -26,9 +27,9 @@ from lyra.stt import (
     TranscriptionResult,
     is_whisper_noise,
 )
-from roxabi_contracts.voice import SUBJECTS
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.voice import SUBJECTS, SttRequest
 from roxabi_contracts.voice.subjects import per_worker_stt
-from roxabi_nats.adapter_base import CONTRACT_VERSION
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 log = logging.getLogger(__name__)
@@ -118,17 +119,19 @@ class NatsSttClient:
         resolved = Path(path).resolve()
         audio_bytes = await asyncio.to_thread(resolved.read_bytes)
         mime = _mime_from_suffix(resolved.suffix)
-        request = {
-            "contract_version": CONTRACT_VERSION,
-            "request_id": str(uuid4()),
-            "audio_b64": base64.b64encode(audio_bytes).decode("ascii"),
-            "mime_type": mime,
-            "model": self._model,
-            "language_detection_threshold": self._detection_threshold,
-            "language_detection_segments": self._detection_segments,
-            "language_fallback": self._detection_fallback,
-        }
-        payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+        request = SttRequest(
+            contract_version=CONTRACT_VERSION,
+            trace_id=str(uuid4()),
+            issued_at=datetime.now(timezone.utc),
+            request_id=str(uuid4()),
+            audio_b64=base64.b64encode(audio_bytes).decode("ascii"),
+            mime_type=mime,
+            model=self._model,
+            language_detection_threshold=self._detection_threshold,
+            language_detection_segments=self._detection_segments,
+            language_fallback=self._detection_fallback,
+        )
+        payload = request.model_dump_json(exclude_none=True).encode("utf-8")
         data = await self._request_with_fallback(payload, preferred.worker_id)
         if not data.get("ok"):
             self._cb.record_failure()

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -29,8 +29,7 @@ from lyra.stt import (
     is_whisper_noise,
 )
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.voice import SUBJECTS, SttRequest, SttResponse
-from roxabi_contracts.voice.subjects import per_worker_stt
+from roxabi_contracts.voice import SUBJECTS, SttRequest, SttResponse, per_worker_stt
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 log = logging.getLogger(__name__)
@@ -146,11 +145,16 @@ class NatsSttClient:
         if not resp.ok:
             self._cb.record_failure()
             raise STTUnavailableError(resp.error or "STT transcription failed")
-        # ok=True invariant guarantees text / language / duration_seconds non-null
+        # SttResponse._enforce_success_invariant guarantees text, language, and
+        # duration_seconds are non-null whenever ok=True. Asserting narrows the
+        # types and fails loudly if that invariant ever drifts.
+        assert resp.text is not None
+        assert resp.language is not None
+        assert resp.duration_seconds is not None
         result = TranscriptionResult(
-            text=resp.text or "",
-            language=resp.language or "unknown",
-            duration_seconds=resp.duration_seconds or 0.0,
+            text=resp.text,
+            language=resp.language,
+            duration_seconds=resp.duration_seconds,
         )
         self._cb.record_success()
         if is_whisper_noise(result.text):

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -113,6 +113,11 @@ class NatsSttClient:
         if not worker_id:
             log.warning("stt_client: heartbeat missing worker_id, ignoring")
             return
+        if not isinstance(worker_id, str):
+            log.warning(
+                "stt_client: heartbeat non-string worker_id=%r, ignoring", worker_id
+            )
+            return
         # Receive-side match for the PUBLISH-path safe-chars enforcement in
         # per_worker_stt. Without this, a rogue worker publishing a heartbeat
         # with a wildcard-bearing id (e.g. "evil.worker.*") would pollute the

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -26,6 +26,8 @@ from lyra.stt import (
     TranscriptionResult,
     is_whisper_noise,
 )
+from roxabi_contracts.voice import SUBJECTS
+from roxabi_contracts.voice.subjects import per_worker_stt
 from roxabi_nats.adapter_base import CONTRACT_VERSION
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
@@ -34,8 +36,6 @@ log = logging.getLogger(__name__)
 _STT_TIMEOUT_DEFAULT = 15.0
 _STT_TIMEOUT_MIN = 1.0
 _STT_TIMEOUT_MAX = 300.0
-
-_HB_SUBJECT = "lyra.voice.stt.heartbeat"
 
 
 def _parse_stt_timeout(timeout: float | None) -> float:
@@ -69,8 +69,6 @@ def _parse_stt_timeout(timeout: float | None) -> float:
 
 
 class NatsSttClient:
-    SUBJECT = "lyra.voice.stt.request"
-
     def __init__(  # noqa: PLR0913
         self,
         nc: NATS,
@@ -94,7 +92,9 @@ class NatsSttClient:
     async def start(self) -> None:
         """Subscribe to heartbeat subject. Called once after nc is connected."""
         if self._hb_sub is None:
-            self._hb_sub = await self._nc.subscribe(_HB_SUBJECT, cb=self._on_heartbeat)
+            self._hb_sub = await self._nc.subscribe(
+                SUBJECTS.stt_heartbeat, cb=self._on_heartbeat
+            )
 
     async def _on_heartbeat(self, msg) -> None:
         try:
@@ -155,7 +155,7 @@ class NatsSttClient:
         the originating exception. Circuit-breaker failures are recorded here.
         """
         payload_kb = len(payload) / 1024
-        target = f"{self.SUBJECT}.{worker_id}"
+        target = per_worker_stt(worker_id)
         try:
             reply = await self._nc.request(target, payload, timeout=self._timeout)
             return json.loads(reply.data)
@@ -170,7 +170,9 @@ class NatsSttClient:
             self._raise_nats_failure(exc, payload_kb)
         # Fallback: queue group (round-robin among alive workers).
         try:
-            reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
+            reply = await self._nc.request(
+                SUBJECTS.stt_request, payload, timeout=self._timeout
+            )
             return json.loads(reply.data)
         except TimeoutError as exc:
             log.warning("STT adapter timeout after %.0fs", self._timeout)

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -62,6 +62,11 @@ class NatsTtsClient:
         if not worker_id:
             log.warning("tts_client: heartbeat missing worker_id, ignoring")
             return
+        if not isinstance(worker_id, str):
+            log.warning(
+                "tts_client: heartbeat non-string worker_id=%r, ignoring", worker_id
+            )
+            return
         # Receive-side match for the PUBLISH-path safe-chars enforcement in
         # per_worker_tts. Without this, a rogue worker publishing a heartbeat
         # with a wildcard-bearing id (e.g. "evil.worker.*") would pollute the

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -11,17 +11,18 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from typing import TYPE_CHECKING, NoReturn
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, NoReturn
 from uuid import uuid4
 
 from nats.aio.client import Client as NATS
 
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from lyra.tts import SynthesisResult, TtsUnavailableError
-from roxabi_contracts.voice import SUBJECTS
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.voice import SUBJECTS, TtsRequest
 from roxabi_contracts.voice.subjects import per_worker_tts
 from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS
-from roxabi_nats.adapter_base import CONTRACT_VERSION
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 if TYPE_CHECKING:
@@ -120,8 +121,10 @@ class NatsTtsClient:
             raise TtsUnavailableError(
                 "TTS circuit open — adapter temporarily unavailable"
             )
-        request: dict = {
+        req_kwargs: dict[str, Any] = {
             "contract_version": CONTRACT_VERSION,
+            "trace_id": str(uuid4()),
+            "issued_at": datetime.now(timezone.utc),
             "request_id": str(uuid4()),
             "text": text,
             "language": language,
@@ -134,13 +137,14 @@ class NatsTtsClient:
             for field in _TTS_CONFIG_FIELDS:
                 val = getattr(agent_tts, field, None)
                 if val is not None:
-                    request[field] = val
+                    req_kwargs[field] = val
             # Also pass language/voice from agent_tts if not overridden by caller
             if language is None and getattr(agent_tts, "language", None) is not None:
-                request["language"] = agent_tts.language
+                req_kwargs["language"] = agent_tts.language
             if voice is None and getattr(agent_tts, "voice", None) is not None:
-                request["voice"] = agent_tts.voice
-        payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+                req_kwargs["voice"] = agent_tts.voice
+        request = TtsRequest.model_validate(req_kwargs)
+        payload = request.model_dump_json(exclude_none=True).encode("utf-8")
         data = await self._send(payload, preferred.worker_id)
         audio_bytes = base64.b64decode(data["audio_b64"])
         self._cb.record_success()

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -21,7 +21,13 @@ from pydantic import ValidationError
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from lyra.tts import SynthesisResult, TtsUnavailableError
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.voice import SUBJECTS, TtsRequest, TtsResponse, per_worker_tts
+from roxabi_contracts.voice import (
+    SUBJECTS,
+    TtsRequest,
+    TtsResponse,
+    per_worker_tts,
+    validate_worker_id,
+)
 from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
@@ -52,8 +58,22 @@ class NatsTtsClient:
         except Exception:
             log.debug("tts_client: heartbeat parse error", exc_info=True)
             return
-        if not data.get("worker_id"):
+        worker_id = data.get("worker_id")
+        if not worker_id:
             log.warning("tts_client: heartbeat missing worker_id, ignoring")
+            return
+        # Receive-side match for the PUBLISH-path safe-chars enforcement in
+        # per_worker_tts. Without this, a rogue worker publishing a heartbeat
+        # with a wildcard-bearing id (e.g. "evil.worker.*") would pollute the
+        # registry until first routing attempt; the publish helper would then
+        # raise at call time, long after the trust boundary was crossed.
+        try:
+            validate_worker_id(worker_id)
+        except ValueError:
+            log.warning(
+                "tts_client: heartbeat with unsafe worker_id=%r, ignoring",
+                worker_id,
+            )
             return
         self._registry.record_heartbeat(data)
 
@@ -81,8 +101,6 @@ class NatsTtsClient:
                 self._timeout,
             )
             resp = await self._fallback(payload, payload_kb)
-        except TtsUnavailableError:
-            raise
         except Exception as exc:
             self._raise_nats_failure(exc, payload_kb)
         if not resp.ok:
@@ -100,13 +118,19 @@ class NatsTtsClient:
             log.warning("TTS adapter timeout after %.0fs", self._timeout)
             self._cb.record_failure()
             raise TtsUnavailableError("TTS adapter timeout") from exc
-        except TtsUnavailableError:
-            raise
         except Exception as exc:
             self._raise_nats_failure(exc, payload_kb)
 
     def _raise_nats_failure(self, exc: Exception, payload_kb: float) -> NoReturn:
-        """Convert a NATS request exception to TtsUnavailableError."""
+        """Convert a NATS request exception to TtsUnavailableError.
+
+        Domain errors (``TtsUnavailableError``) pass through unchanged so callers
+        can rely on this being the single translation boundary for NATS-transport
+        exceptions — no per-site ``except TtsUnavailableError: raise`` guard
+        needed anywhere in this file.
+        """
+        if isinstance(exc, TtsUnavailableError):
+            raise exc
         if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
             log.error(
                 "TTS payload too large (%.0f KB) — check NATS max_payload",

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -21,8 +21,7 @@ from pydantic import ValidationError
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from lyra.tts import SynthesisResult, TtsUnavailableError
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.voice import SUBJECTS, TtsRequest, TtsResponse
-from roxabi_contracts.voice.subjects import per_worker_tts
+from roxabi_contracts.voice import SUBJECTS, TtsRequest, TtsResponse, per_worker_tts
 from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
@@ -160,11 +159,17 @@ class NatsTtsClient:
         request = TtsRequest.model_validate(req_kwargs)
         payload = request.model_dump_json(exclude_none=True).encode("utf-8")
         resp = await self._send(payload, preferred.worker_id)
-        audio_bytes = base64.b64decode(resp.audio_b64 or "")
+        # TtsResponse._enforce_success_invariant guarantees audio_b64, mime_type,
+        # and duration_ms are non-null whenever ok=True. Asserting narrows the
+        # types for the type checker and fails loudly if that invariant ever drifts.
+        assert resp.audio_b64 is not None
+        assert resp.mime_type is not None
+        assert resp.duration_ms is not None
+        audio_bytes = base64.b64decode(resp.audio_b64)
         self._cb.record_success()
         return SynthesisResult(
             audio_bytes=audio_bytes,
-            mime_type=resp.mime_type or "audio/ogg",
+            mime_type=resp.mime_type,
             duration_ms=resp.duration_ms,
             waveform_b64=resp.waveform_b64,
         )

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -16,11 +16,12 @@ from typing import TYPE_CHECKING, Any, NoReturn
 from uuid import uuid4
 
 from nats.aio.client import Client as NATS
+from pydantic import ValidationError
 
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from lyra.tts import SynthesisResult, TtsUnavailableError
 from roxabi_contracts.envelope import CONTRACT_VERSION
-from roxabi_contracts.voice import SUBJECTS, TtsRequest
+from roxabi_contracts.voice import SUBJECTS, TtsRequest, TtsResponse
 from roxabi_contracts.voice.subjects import per_worker_tts
 from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
@@ -57,13 +58,22 @@ class NatsTtsClient:
             return
         self._registry.record_heartbeat(data)
 
-    async def _send(self, payload: bytes, worker_id: str) -> dict:
+    def _parse_reply(self, raw: bytes) -> TtsResponse:
+        """Validate a NATS reply against TtsResponse; translate a ValidationError
+        into TtsUnavailableError + record a circuit-breaker failure."""
+        try:
+            return TtsResponse.model_validate_json(raw)
+        except ValidationError as exc:
+            self._cb.record_failure()
+            raise TtsUnavailableError("TTS reply failed schema validation") from exc
+
+    async def _send(self, payload: bytes, worker_id: str) -> TtsResponse:
         """Send payload to the per-worker subject, falling back once to queue group."""
         payload_kb = len(payload) / 1024
         target = per_worker_tts(worker_id)
         try:
             reply = await self._nc.request(target, payload, timeout=self._timeout)
-            data = json.loads(reply.data)
+            resp = self._parse_reply(reply.data)
         except TimeoutError:
             log.warning(
                 "TTS: preferred worker %s timed out after %.0fs;"
@@ -71,24 +81,28 @@ class NatsTtsClient:
                 worker_id,
                 self._timeout,
             )
-            data = await self._fallback(payload, payload_kb)
+            resp = await self._fallback(payload, payload_kb)
+        except TtsUnavailableError:
+            raise
         except Exception as exc:
             self._raise_nats_failure(exc, payload_kb)
-        if not data.get("ok"):
+        if not resp.ok:
             self._cb.record_failure()
-            raise TtsUnavailableError("TTS synthesis failed")
-        return data
+            raise TtsUnavailableError(resp.error or "TTS synthesis failed")
+        return resp
 
-    async def _fallback(self, payload: bytes, payload_kb: float) -> dict:
+    async def _fallback(self, payload: bytes, payload_kb: float) -> TtsResponse:
         try:
             reply = await self._nc.request(
                 SUBJECTS.tts_request, payload, timeout=self._timeout
             )
-            return json.loads(reply.data)
+            return self._parse_reply(reply.data)
         except TimeoutError as exc:
             log.warning("TTS adapter timeout after %.0fs", self._timeout)
             self._cb.record_failure()
             raise TtsUnavailableError("TTS adapter timeout") from exc
+        except TtsUnavailableError:
+            raise
         except Exception as exc:
             self._raise_nats_failure(exc, payload_kb)
 
@@ -145,12 +159,12 @@ class NatsTtsClient:
                 req_kwargs["voice"] = agent_tts.voice
         request = TtsRequest.model_validate(req_kwargs)
         payload = request.model_dump_json(exclude_none=True).encode("utf-8")
-        data = await self._send(payload, preferred.worker_id)
-        audio_bytes = base64.b64decode(data["audio_b64"])
+        resp = await self._send(payload, preferred.worker_id)
+        audio_bytes = base64.b64decode(resp.audio_b64 or "")
         self._cb.record_success()
         return SynthesisResult(
             audio_bytes=audio_bytes,
-            mime_type=data.get("mime_type", "audio/ogg"),
-            duration_ms=data.get("duration_ms"),
-            waveform_b64=data.get("waveform_b64"),
+            mime_type=resp.mime_type or "audio/ogg",
+            duration_ms=resp.duration_ms,
+            waveform_b64=resp.waveform_b64,
         )

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -18,6 +18,8 @@ from nats.aio.client import Client as NATS
 
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from lyra.tts import SynthesisResult, TtsUnavailableError
+from roxabi_contracts.voice import SUBJECTS
+from roxabi_contracts.voice.subjects import per_worker_tts
 from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS
 from roxabi_nats.adapter_base import CONTRACT_VERSION
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
@@ -27,12 +29,8 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_HB_SUBJECT = "lyra.voice.tts.heartbeat"
-
 
 class NatsTtsClient:
-    SUBJECT = "lyra.voice.tts.request"
-
     def __init__(self, nc: NATS, *, timeout: float = 30.0) -> None:
         self._nc = nc
         self._timeout = timeout
@@ -43,7 +41,9 @@ class NatsTtsClient:
     async def start(self) -> None:
         """Subscribe to heartbeat subject. Called once after nc is connected."""
         if self._hb_sub is None:
-            self._hb_sub = await self._nc.subscribe(_HB_SUBJECT, cb=self._on_heartbeat)
+            self._hb_sub = await self._nc.subscribe(
+                SUBJECTS.tts_heartbeat, cb=self._on_heartbeat
+            )
 
     async def _on_heartbeat(self, msg) -> None:
         try:
@@ -59,7 +59,7 @@ class NatsTtsClient:
     async def _send(self, payload: bytes, worker_id: str) -> dict:
         """Send payload to the per-worker subject, falling back once to queue group."""
         payload_kb = len(payload) / 1024
-        target = f"{self.SUBJECT}.{worker_id}"
+        target = per_worker_tts(worker_id)
         try:
             reply = await self._nc.request(target, payload, timeout=self._timeout)
             data = json.loads(reply.data)
@@ -80,7 +80,9 @@ class NatsTtsClient:
 
     async def _fallback(self, payload: bytes, payload_kb: float) -> dict:
         try:
-            reply = await self._nc.request(self.SUBJECT, payload, timeout=self._timeout)
+            reply = await self._nc.request(
+                SUBJECTS.tts_request, payload, timeout=self._timeout
+            )
             return json.loads(reply.data)
         except TimeoutError as exc:
             log.warning("TTS adapter timeout after %.0fs", self._timeout)

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -290,6 +290,26 @@ class TestSttClientStart:
         await client.start()
         assert mock_nc.subscribe.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_heartbeat_with_wildcard_worker_id_is_dropped(self) -> None:
+        """_on_heartbeat with a wildcard worker_id is rejected; registry stays empty."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        msg = MagicMock()
+        msg.data = json.dumps({"worker_id": "evil.worker.*"}).encode()
+        await client._on_heartbeat(msg)
+        assert client._registry.pick_least_loaded() is None
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_with_non_string_worker_id_is_dropped(self) -> None:
+        """_on_heartbeat with a non-string worker_id drops the message; no TypeError."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        msg = MagicMock()
+        msg.data = json.dumps({"worker_id": 12345}).encode()
+        await client._on_heartbeat(msg)
+        assert client._registry.pick_least_loaded() is None
+
 
 class TestSttClientFreshness:
     """Tests for freshness tracking gate in NatsSttClient."""

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -177,7 +177,10 @@ class TestCircuitBreaker:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-ok",
                 "text": "hello",
                 "language": "en",
                 "duration_seconds": 1.0,
@@ -208,7 +211,10 @@ class TestContractVersion:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-ok",
                 "text": "hi",
                 "language": "en",
                 "duration_seconds": 1.0,
@@ -238,7 +244,10 @@ class TestContractVersion:
         reply_payload = json.dumps(
             {
                 "contract_version": "999",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-future",
                 "text": "future",
                 "language": "en",
                 "duration_seconds": 0.5,
@@ -315,7 +324,10 @@ class TestSttClientFreshness:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-ok",
                 "text": "hello world",
                 "language": "en",
                 "duration_seconds": 1.0,
@@ -351,7 +363,10 @@ class TestSttClientFreshness:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-ok",
                 "text": "resumed",
                 "language": "en",
                 "duration_seconds": 1.0,
@@ -388,7 +403,15 @@ class TestTranscribeResponseParsing:
     async def test_ok_false_raises_unavailable(self, tmp_path: Path) -> None:
         # Arrange
         mock_nc = AsyncMock()
-        error_payload = json.dumps({"contract_version": "1", "ok": False}).encode()
+        error_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "ok": False,
+                "request_id": "r-err",
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = error_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -408,7 +431,10 @@ class TestTranscribeResponseParsing:
         noise_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-noise",
                 "text": "[music]",
                 "language": "en",
                 "duration_seconds": 0.5,
@@ -436,7 +462,10 @@ class TestLoadAwareRouting:
         payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-ok",
                 "text": "hi",
                 "language": "en",
                 "duration_seconds": 0.1,
@@ -557,3 +586,47 @@ class TestLoadAwareRouting:
             await client.transcribe(wav)
         assert mock_nc.request.await_count == 2
         assert client._cb._failures == 1
+
+
+class TestMalformedReply:
+    """Pydantic ValidationError on reply MUST surface as STTUnavailableError."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_reply_raises_domain_error(self, tmp_path: Path) -> None:
+        """ok=True without duration_seconds → SttResponse invariant fails →
+        client must translate into STTUnavailableError and record a
+        circuit-breaker failure (receive-path anti-drift guard).
+        """
+        # Arrange
+        audio = tmp_path / "sample.wav"
+        audio.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+
+        mock_nc = AsyncMock()
+        # Reply is ok=True but missing duration_seconds — violates
+        # SttResponse._enforce_success_invariant (see contracts spec #763
+        # drift item #4).
+        bad_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "ok": True,
+                "request_id": "r-bad",
+                "text": "hello",
+                "language": "en",
+                # duration_seconds deliberately omitted
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = bad_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+
+        client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        initial_failures = client._cb._failures
+
+        # Act / Assert
+        with pytest.raises(STTUnavailableError, match="schema"):
+            await client.transcribe(audio)
+
+        assert client._cb._failures == initial_failures + 1

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -425,6 +425,35 @@ class TestTranscribeResponseParsing:
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
+    async def test_ok_false_with_error_field_forwards_message(
+        self, tmp_path: Path
+    ) -> None:
+        """ok=False with a populated `error` field must surface the error string
+        in the STTUnavailableError message (not the default "transcription failed")."""
+        mock_nc = AsyncMock()
+        error_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "ok": False,
+                "request_id": "r-err",
+                "error": "cuda oom",
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = error_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        wav_file = tmp_path / "test.wav"
+        wav_file.write_bytes(b"\x00" * 64)
+
+        with pytest.raises(STTUnavailableError, match="cuda oom"):
+            await client.transcribe(wav_file)
+        assert client._cb._failures == 1
+
+    @pytest.mark.asyncio
     async def test_noise_transcript_raises_noise_error(self, tmp_path: Path) -> None:
         # Arrange — Whisper returns a known noise token
         mock_nc = AsyncMock()
@@ -552,6 +581,7 @@ class TestLoadAwareRouting:
         call_subjects: list[str] = []
 
         async def request_mock(subject: str, payload: bytes, timeout: float):
+            del payload, timeout  # signature required by AsyncMock side_effect
             call_subjects.append(subject)
             if len(call_subjects) == 1:
                 raise TimeoutError
@@ -626,7 +656,38 @@ class TestMalformedReply:
         initial_failures = client._cb._failures
 
         # Act / Assert
-        with pytest.raises(STTUnavailableError, match="schema"):
+        with pytest.raises(STTUnavailableError, match="schema") as exc_info:
             await client.transcribe(audio)
 
+        # Pin the cause chain to the _parse_reply error-boundary so a future
+        # regression where ok=False handling accidentally produces a
+        # "schema"-flavored message cannot silently pass this test.
+        from pydantic import ValidationError
+
+        assert isinstance(exc_info.value.__cause__, ValidationError)
+        assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_raises_domain_error(self, tmp_path: Path) -> None:
+        """Malformed JSON bytes (not just invariant violations) must also
+        surface as STTUnavailableError + CB failure — `_parse_reply` catches
+        every pydantic.ValidationError, including JSON-parse errors."""
+        audio = tmp_path / "sample.wav"
+        audio.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+
+        mock_nc = AsyncMock()
+        fake_reply = MagicMock()
+        fake_reply.data = b"not json {"
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+
+        client = NatsSttClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        initial_failures = client._cb._failures
+
+        with pytest.raises(STTUnavailableError, match="schema") as exc_info:
+            await client.transcribe(audio)
+
+        from pydantic import ValidationError
+
+        assert isinstance(exc_info.value.__cause__, ValidationError)
         assert client._cb._failures == initial_failures + 1

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -98,7 +98,15 @@ class TestCircuitBreaker:
     async def test_ok_false_raises_unavailable(self) -> None:
         # Arrange
         mock_nc = AsyncMock()
-        error_payload = json.dumps({"contract_version": "1", "ok": False}).encode()
+        error_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "ok": False,
+                "request_id": "r-err",
+            }
+        ).encode()
         fake_reply = MagicMock()
         fake_reply.data = error_payload
         mock_nc.request = AsyncMock(return_value=fake_reply)
@@ -116,9 +124,13 @@ class TestCircuitBreaker:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-agent",
                 "audio_b64": base64.b64encode(b"fake").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 1000,
             }
         ).encode()
         fake_reply = MagicMock()
@@ -150,9 +162,13 @@ class TestCircuitBreaker:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-success",
                 "audio_b64": base64.b64encode(b"fake").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 1000,
             }
         ).encode()
         fake_reply = MagicMock()
@@ -178,9 +194,13 @@ class TestContractVersion:
         success_payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-cv",
                 "audio_b64": base64.b64encode(b"hi").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 500,
             }
         ).encode()
         fake_reply = MagicMock()
@@ -203,9 +223,13 @@ class TestContractVersion:
         reply_payload = json.dumps(
             {
                 "contract_version": "999",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-future",
                 "audio_b64": base64.b64encode(b"future").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 500,
             }
         ).encode()
         fake_reply = MagicMock()
@@ -274,9 +298,13 @@ class TestTtsClientFreshness:
         mock_response.data = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-fresh",
                 "audio_b64": base64.b64encode(b"audio").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 1000,
             }
         ).encode()
         mock_nc.request = AsyncMock(return_value=mock_response)
@@ -304,9 +332,13 @@ class TestTtsClientFreshness:
         mock_response.data = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-resume",
                 "audio_b64": base64.b64encode(b"audio").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 1000,
             }
         ).encode()
         mock_nc.request = AsyncMock(return_value=mock_response)
@@ -332,9 +364,13 @@ class TestTtsLoadAwareRouting:
         payload = json.dumps(
             {
                 "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
                 "ok": True,
+                "request_id": "r-ok",
                 "audio_b64": base64.b64encode(b"fake").decode(),
                 "mime_type": "audio/ogg",
+                "duration_ms": 1000,
             }
         ).encode()
         reply = MagicMock()
@@ -431,3 +467,42 @@ class TestTtsLoadAwareRouting:
             await client.synthesize("hi")
         assert mock_nc.request.await_count == 2
         assert client._cb._failures == 1
+
+
+class TestMalformedReply:
+    """Pydantic ValidationError on reply MUST surface as TtsUnavailableError."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_reply_raises_domain_error(self) -> None:
+        """ok=True without duration_ms → TtsResponse invariant fails →
+        client must translate into TtsUnavailableError and record a
+        circuit-breaker failure (receive-path anti-drift guard).
+        """
+        mock_nc = AsyncMock()
+        # Reply is ok=True but missing duration_ms — violates
+        # TtsResponse._enforce_success_invariant (see contracts spec #763
+        # drift item #1).
+        bad_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "ok": True,
+                "request_id": "r-bad",
+                "audio_b64": base64.b64encode(b"audio").decode(),
+                "mime_type": "audio/ogg",
+                # duration_ms deliberately omitted
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = bad_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+
+        client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        initial_failures = client._cb._failures
+
+        with pytest.raises(TtsUnavailableError, match="schema"):
+            await client.synthesize("hello")
+
+        assert client._cb._failures == initial_failures + 1

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -292,6 +292,26 @@ class TestTtsClientStart:
         await client.start()
         assert mock_nc.subscribe.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_heartbeat_with_wildcard_worker_id_is_dropped(self) -> None:
+        """_on_heartbeat with a wildcard worker_id is rejected; registry stays empty."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        msg = MagicMock()
+        msg.data = json.dumps({"worker_id": "evil.worker.*"}).encode()
+        await client._on_heartbeat(msg)
+        assert client._registry.pick_least_loaded() is None
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_with_non_string_worker_id_is_dropped(self) -> None:
+        """_on_heartbeat with a non-string worker_id drops the message; no TypeError."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        msg = MagicMock()
+        msg.data = json.dumps({"worker_id": 12345}).encode()
+        await client._on_heartbeat(msg)
+        assert client._registry.pick_least_loaded() is None
+
 
 class TestTtsClientFreshness:
     """Tests for freshness tracking gate in NatsTtsClient."""

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -136,7 +136,7 @@ class TestCircuitBreaker:
         payload_bytes = call_args.args[1]
         request_dict = json.loads(payload_bytes)
         assert request_dict["engine"] == "chatterbox"
-        assert request_dict["speed"] == "1.2"
+        assert request_dict["speed"] == 1.2
         # contract_version is always stamped (ADR-044)
         assert request_dict["contract_version"] == "1"
         # All unset fields (None) must be absent from the NATS payload

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -118,6 +118,31 @@ class TestCircuitBreaker:
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
+    async def test_ok_false_with_error_field_forwards_message(self) -> None:
+        """ok=False with a populated `error` field must surface the error string
+        in the TtsUnavailableError message (not the default "synthesis failed")."""
+        mock_nc = AsyncMock()
+        error_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "ok": False,
+                "request_id": "r-err",
+                "error": "worker OOM",
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = error_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+
+        with pytest.raises(TtsUnavailableError, match="worker OOM"):
+            await client.synthesize("hello")
+        assert client._cb._failures == 1
+
+    @pytest.mark.asyncio
     async def test_agent_tts_fields_forwarded_in_request(self) -> None:
         # Arrange — agent_tts with engine + speed set
         mock_nc = AsyncMock()
@@ -441,6 +466,7 @@ class TestTtsLoadAwareRouting:
         call_subjects: list[str] = []
 
         async def request_mock(subject: str, payload: bytes, timeout: float):
+            del payload, timeout  # signature required by AsyncMock side_effect
             call_subjects.append(subject)
             if len(call_subjects) == 1:
                 raise TimeoutError
@@ -502,7 +528,35 @@ class TestMalformedReply:
         _inject_fresh_worker(client)
         initial_failures = client._cb._failures
 
-        with pytest.raises(TtsUnavailableError, match="schema"):
+        with pytest.raises(TtsUnavailableError, match="schema") as exc_info:
             await client.synthesize("hello")
 
+        # Pin the cause chain to the _parse_reply error-boundary so a future
+        # regression where ok=False handling accidentally produces a
+        # "schema"-flavored message cannot silently pass this test.
+        from pydantic import ValidationError
+
+        assert isinstance(exc_info.value.__cause__, ValidationError)
+        assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_raises_domain_error(self) -> None:
+        """Malformed JSON bytes (not just invariant violations) must also
+        surface as TtsUnavailableError + CB failure — `_parse_reply` catches
+        every pydantic.ValidationError, including JSON-parse errors."""
+        mock_nc = AsyncMock()
+        fake_reply = MagicMock()
+        fake_reply.data = b"not json {"
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+
+        client = NatsTtsClient(nc=mock_nc)
+        _inject_fresh_worker(client)
+        initial_failures = client._cb._failures
+
+        with pytest.raises(TtsUnavailableError, match="schema") as exc_info:
+            await client.synthesize("hello")
+
+        from pydantic import ValidationError
+
+        assert isinstance(exc_info.value.__cause__, ValidationError)
         assert client._cb._failures == initial_failures + 1


### PR DESCRIPTION
## Summary

- Lyra's hub-side NATS voice clients (`src/lyra/nats/nats_{tts,stt}_client.py`) now source every voice-domain wire-shape — subjects, request models, response models, envelope metadata — from the shared `roxabi_contracts.voice` package. The drift loop ADR-049 targets (Cohort B) is closed on the lyra side.
- Incoming replies are validated through `TtsResponse` / `SttResponse`, with a `pydantic.ValidationError → TtsUnavailableError / STTUnavailableError` boundary that records a circuit-breaker failure — malformed replies now surface as typed domain errors instead of raw Pydantic exceptions.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#766](https://github.com/Roxabi/lyra/issues/766): refactor(nats) — migrate lyra publishers to import from roxabi_contracts.voice | OPEN |
| Frame | [766-migrate-lyra-voice-publishers-frame.mdx](artifacts/frames/766-migrate-lyra-voice-publishers-frame.mdx) | Approved |
| Spec | [766-migrate-lyra-voice-publishers-spec.mdx](artifacts/specs/766-migrate-lyra-voice-publishers-spec.mdx) | Approved (F-lite, 15/15 automated gates + 1 manual) |
| Plan | [766-migrate-lyra-voice-publishers-plan.mdx](artifacts/plans/766-migrate-lyra-voice-publishers-plan.mdx) | Approved (3 slices, 12 micro-tasks, all ✓) |
| Implementation | 3 commits on `feat/766-migrate-lyra-voice-publishers` (V1 subjects → V2 request models → V3 response models) | Complete |
| Verification | Lint ✅  Typecheck ✅  Tests ✅ (164 `tests/nats/` + 2977 full suite; 2 new `TestMalformedReply` classes) | Passed |

## Slices

- **V1** — drop `SUBJECT` class attrs + `_HB_SUBJECT` module consts; publish/subscribe through `SUBJECTS.tts_request` / `SUBJECTS.stt_request` / `SUBJECTS.tts_heartbeat` / `SUBJECTS.stt_heartbeat` + `per_worker_tts(...)` / `per_worker_stt(...)` helpers (which enforce a safe-chars regex on `worker_id` — defense-in-depth for free).
- **V2** — `synthesize()` / `transcribe()` build `TtsRequest` / `SttRequest` Pydantic models, serialize via `.model_dump_json(exclude_none=True).encode("utf-8")`. `CONTRACT_VERSION` import relocates from `roxabi_nats.adapter_base` (deprecation shim) to `roxabi_contracts.envelope` (canonical).
- **V3** — `_parse_reply` helper on both clients: `TtsResponse.model_validate_json` / `SttResponse.model_validate_json` wrapped in `try/except pydantic.ValidationError` → `cb.record_failure()` + domain error. Downstream code reads attributes (`resp.ok`, `resp.audio_b64`, `resp.duration_seconds`, …) instead of `.get(...)` dict lookups.

## Wire-shape drift vs prior lyra payloads

Intentional behavior changes introduced by this port — each is a consequence of adopting the canonical Pydantic models:

1. **New envelope fields on every request.** `trace_id` (str, fresh `uuid4` per call) and `issued_at` (UTC `datetime`) are now stamped on every outgoing TTS/STT request. Previously absent. This matches `ContractEnvelope` (ADR-049) and is what the contracts package tests expect. Lyra does not yet propagate an upstream correlation id through to the voice clients — threading one in from the command dispatch layer is out of scope.
2. **`TtsRequest.speed` coerces string → float.** `AgentTTSConfig.speed` is a `str` field (e.g. `"1.2"`). `TtsRequest.speed` is `float | None`, so Pydantic coerces it during model construction, and the emitted JSON now carries `"speed": 1.2` (number) instead of `"speed": "1.2"` (string). One test assertion was updated to match. Downstream voiceCLI already reads it as a float.
3. **Response models now parsed strictly.** Replies with `ok=True` must carry the invariant fields (TTS: `audio_b64 + mime_type + duration_ms`; STT: `text + language + duration_seconds`). 7 TTS test mocks that previously omitted `duration_ms` (spec #763 drift item #1) were updated to include it; 8 STT mocks got the envelope fields (`trace_id`, `issued_at`, `request_id`). Downstream voiceCLI adapters already emit these — this is a test-fixture correction, not a runtime behavior change.
4. **Malformed replies now surface as domain errors.** Previously a malformed reply could return a bogus `SynthesisResult`/`TranscriptionResult` or raise an unrelated `KeyError`; now it raises `TtsUnavailableError("TTS reply failed schema validation")` / `STTUnavailableError("STT reply failed schema validation")` and bumps the circuit-breaker failure counter. Two new `TestMalformedReply` classes (one per client) exercise this.

## Issue AC deviation (needs amendment)

Issue #766 AC item 4 asks for:
```toml
[tool.uv.sources]
roxabi-contracts = { workspace = true, extras = ["testing"] }
```
…plus a regenerated `uv.lock`. **Verified invalid against uv 0.11.1** (`unknown field 'extras'`) — uv does not support `extras` on workspace sources; the singular `extra = "..."` field has a different meaning (conditional application). Architect review also flagged that no current lyra test consumes `roxabi_contracts.voice.fixtures.silence_wav_16khz` (the reason the `[testing]` extra exists), so pulling scipy into lyra's dev install is premature.

**Resolution:** `pyproject.toml` `[tool.uv.sources]` left at `roxabi-contracts = { workspace = true }`, `uv.lock` untouched. See spec [§Expected Behavior 7](artifacts/specs/766-migrate-lyra-voice-publishers-spec.mdx) for the full rationale. A follow-up issue should add `"roxabi-contracts[testing]"` to a `[dependency-groups] dev` entry the day the first lyra test imports from `voice.fixtures`.

## Out of scope (tracked elsewhere)

- voiceCLI Cohort A migration (`tts_adapter.py` / stt equivalent) — parallel issue under Epic #761.
- Subject literals still present in `src/lyra/cli_voice_smoke.py` and `src/lyra/bootstrap/{tts,stt}_adapter_standalone.py` + `voice_overlay.py`. These are adapter-side / smoke code, not Cohort B publishers. Follow-up.
- Runtime size-gate for `model_validate_json()` on reply bytes (ContractEnvelope docstring mentions `roxabi_nats.deserialize()` as the canonical entry, but that helper is dataclass-only and does not handle Pydantic). Deferred to a later ADR-049 phase.

## Test Plan

- [ ] `uv run pytest tests/nats/` — 164 tests pass (incl. two new `TestMalformedReply::test_malformed_reply_raises_domain_error`).
- [ ] `uv run pytest` — full lyra suite (2977 passed, 76 skipped) green; no regressions in `tests/bootstrap/test_voice_overlay.py` or other voice-touching tests.
- [ ] `uv run pyright` — 0 errors, 0 warnings.
- [ ] Spot-check at runtime: start the Machine-1 voice stack, send one TTS + one STT request from a Telegram agent, verify the `trace_id` appears in voiceCLI adapter logs and the response decodes cleanly.
- [ ] Confirm circuit-breaker behavior on the new `ValidationError` path: manually publish a malformed reply on the NATS subject → hub should log `TTS reply failed schema validation` and increment the CB failure counter.

Closes #766

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`