### PR TITLE
feat(nats): lyra-side image domain — ADR-050 + publisher + nkey (#754)

### DIFF
--- a/deploy/agents.yml
+++ b/deploy/agents.yml
@@ -52,6 +52,7 @@ agents:
     nkey: tts-adapter.seed
     env:
       LYRA_TTS_ENABLED: "1"
+      LYRA_TTS_ENGINE: "chatterbox"
 
   imagecli_gen:
     command_override: "imagecli nats-serve"

--- a/deploy/agents.yml
+++ b/deploy/agents.yml
@@ -52,3 +52,9 @@ agents:
     nkey: tts-adapter.seed
     env:
       LYRA_TTS_ENABLED: "1"
+
+  imagecli_gen:
+    command_override: "imagecli nats-serve"
+    priority: 200
+    startsecs: 20  # T15 note — re-measure first-ready time on Machine 1 RTX 3080 pre-merge; bump if >20s observed
+    nkey: image-worker.seed

--- a/deploy/agents.yml
+++ b/deploy/agents.yml
@@ -59,3 +59,5 @@ agents:
     priority: 200
     startsecs: 20  # T15 note — re-measure first-ready time on Machine 1 RTX 3080 pre-merge; bump if >20s observed
     nkey: image-worker.seed
+    env:
+      NATS_URL: "nats://127.0.0.1:4222"

--- a/deploy/gen-supervisor-conf.py
+++ b/deploy/gen-supervisor-conf.py
@@ -31,6 +31,21 @@ def validate_env_value(value: str) -> bool:
     # Reject newlines and quotes that could break INI format
     return not any(c in value for c in "\n\r\"'")
 
+
+def validate_command_override(value: str) -> bool:
+    """Validate command_override — printable ASCII, no shell metacharacters.
+
+    Accepts: alphanumerics, `/` (paths), `.`, `-`, `_`, spaces (argv split).
+    Rejects: newlines, quotes, `;`, `&`, `|`, backticks, `$`, `(`, `)`, `<`, `>`.
+    This is the same philosophy as validate_env_value, tightened for the
+    fact that the value lands verbatim on a supervisord ``command=`` line
+    which is fed to /bin/sh on program start.
+    """
+    import re
+
+    # Must be non-empty and entirely within a safe character class
+    return bool(value) and bool(re.match(r"^[A-Za-z0-9/_.\- ]+$", value))
+
 # Template defaults matching existing conf.d/*.conf structure
 DEFAULTS: dict[str, Any] = {
     "autostart": False,
@@ -103,6 +118,10 @@ def generate_conf(
     #   3. default — deploy/supervisor/scripts/run_adapter.sh <name>.
     if "command_override" in agent:
         cmd_path = agent["command_override"]
+        if not validate_command_override(cmd_path):
+            raise ValueError(
+                f"Invalid command_override for {name!r} (shell-metachar or empty): {cmd_path!r}"
+            )
     elif name == "hub":
         cmd_path = RUN_HUB.format(home=ctx["home"])
     else:

--- a/deploy/gen-supervisor-conf.py
+++ b/deploy/gen-supervisor-conf.py
@@ -96,8 +96,14 @@ def generate_conf(
     # Merge defaults with agent overrides
     cfg = {**defaults, **agent}
 
-    # Determine command: hub uses run_hub.sh, adapters use run_adapter.sh <name>
-    if name == "hub":
+    # Determine command:
+    #   1. explicit command_override in agents.yml — used verbatim (for external-satellite
+    #      programs like imagecli nats-serve that are not lyra CLI subcommands).
+    #   2. name == "hub" — deploy/supervisor/scripts/run_hub.sh.
+    #   3. default — deploy/supervisor/scripts/run_adapter.sh <name>.
+    if "command_override" in agent:
+        cmd_path = agent["command_override"]
+    elif name == "hub":
         cmd_path = RUN_HUB.format(home=ctx["home"])
     else:
         cmd_path = f"{RUN_ADAPTER.format(home=ctx['home'])} {name}"

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -4,8 +4,9 @@
 # Seeds (private keys) → ~/.lyra/nkeys/     owned by LYRA_USER, 0600 — no system access needed
 # auth.conf (public keys) → /etc/nats/nkeys/ owned by root:nats,  0640 — read by nats-server
 #
-# Creates 7 user nkey seeds: hub, telegram-adapter, discord-adapter,
-#                             tts-adapter, stt-adapter, llm-worker, monitor
+# Creates 10 user nkey seeds: hub, telegram-adapter, discord-adapter,
+#                              tts-adapter, stt-adapter, voice-tts, voice-stt,
+#                              llm-worker, image-worker, monitor
 #
 # Usage: sudo ./deploy/nats/gen-nkeys.sh
 #        sudo ./deploy/nats/gen-nkeys.sh --fix-perms        # re-apply permissions without regenerating
@@ -39,11 +40,11 @@ error() { echo -e "${RED}[x]${NC} $1" >&2; exit 1; }
 #                scoped to "lyra.plugin.<name>.>" — see spec §Out-of-scope.
 declare -A PUB_ALLOW SUB_ALLOW
 
-PUB_ALLOW[hub]='"lyra.outbound.telegram.>","lyra.outbound.discord.>","lyra.voice.tts.request.>","lyra.voice.stt.request.>","lyra.llm.request"'
+PUB_ALLOW[hub]='"lyra.outbound.telegram.>","lyra.outbound.discord.>","lyra.voice.tts.request.>","lyra.voice.stt.request.>","lyra.llm.request","lyra.image.generate.request"'
 # NOTE: "_INBOX.>" is broader than this role needs — required because
 # NatsLlmDriver.stream() uses a manual inbox subscription. Tightening tracked
 # in issue #715 (migrate to nc.request() → drop "_INBOX.>" from this list).
-SUB_ALLOW[hub]='"lyra.inbound.telegram.>","lyra.inbound.discord.>","lyra.voice.tts.heartbeat","lyra.voice.stt.heartbeat","lyra.llm.health.*","lyra.system.ready","_INBOX.>"'
+SUB_ALLOW[hub]='"lyra.inbound.telegram.>","lyra.inbound.discord.>","lyra.voice.tts.heartbeat","lyra.voice.stt.heartbeat","lyra.llm.health.*","lyra.system.ready","_INBOX.>","lyra.image.heartbeat"'
 
 PUB_ALLOW[telegram-adapter]='"lyra.inbound.telegram.>","lyra.system.ready"'
 SUB_ALLOW[telegram-adapter]='"lyra.outbound.telegram.>"'
@@ -74,10 +75,15 @@ SUB_ALLOW[voice-stt]='"lyra.voice.stt.request","lyra.voice.stt.request.>","lyra.
 PUB_ALLOW[llm-worker]='"lyra.llm.health.*"'
 SUB_ALLOW[llm-worker]='"lyra.llm.request"'
 
+# image-worker: imagecli nats-serve satellite. Heartbeat-publish + request-subscribe.
+# Contract: ADR-050. Shipped via imageCLI#50 (satellite) + #754 (lyra-side).
+PUB_ALLOW[image-worker]='"lyra.image.heartbeat"'
+SUB_ALLOW[image-worker]='"lyra.image.generate.request"'
+
 PUB_ALLOW[monitor]='"lyra.monitor.>"'
 SUB_ALLOW[monitor]='"lyra.monitor.>"'
 
-IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker monitor)
+IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker image-worker monitor)
 
 # ── emit_user (T1.3) ──────────────────────────────────────────────────────────
 # Writes one authorization users[] entry block to stdout.
@@ -179,8 +185,8 @@ apply_permissions() {
   mkdir -p "${SEEDS_DIR}"
   chown "${LYRA_USER}:${LYRA_USER}" "${SEEDS_DIR}"
   chmod 0700 "${SEEDS_DIR}"
-  # T1.5: extended to 7 identities; #689 adds voice-tts, voice-stt (9 total)
-  for seed in hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker monitor; do
+  # T1.5: extended to 7 identities; #689 adds voice-tts, voice-stt (9 total); #754 adds image-worker (10 total)
+  for seed in hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker image-worker monitor; do
     if [ -f "${SEEDS_DIR}/${seed}.seed" ]; then
       chown "${LYRA_USER}:${LYRA_USER}" "${SEEDS_DIR}/${seed}.seed"
       chmod 0600 "${SEEDS_DIR}/${seed}.seed"
@@ -466,6 +472,7 @@ STT_PUB=$(generate_nkey "stt-adapter")
 VOICE_TTS_PUB=$(generate_nkey "voice-tts")
 VOICE_STT_PUB=$(generate_nkey "voice-stt")
 WORKER_PUB=$(generate_nkey "llm-worker")
+IMAGE_WORKER_PUB=$(generate_nkey "image-worker")
 MONITOR_PUB=$(generate_nkey "monitor")
 
 # ── write auth.conf via render_auth_conf (T1.6) ───────────────────────────────
@@ -478,6 +485,7 @@ declare -A PUBKEYS=(
   [voice-tts]="${VOICE_TTS_PUB}"
   [voice-stt]="${VOICE_STT_PUB}"
   [llm-worker]="${WORKER_PUB}"
+  [image-worker]="${IMAGE_WORKER_PUB}"
   [monitor]="${MONITOR_PUB}"
 )
 render_auth_conf PUBKEYS > "${AUTH_CONF}"
@@ -500,5 +508,6 @@ info "  stt-adapter.seed       NATS_NKEY_SEED_PATH=${SEEDS_DIR}/stt-adapter.seed
 info "  voice-tts.seed         NATS_NKEY_SEED_PATH=${SEEDS_DIR}/voice-tts.seed   (voicecli nats-serve tts)"
 info "  voice-stt.seed         NATS_NKEY_SEED_PATH=${SEEDS_DIR}/voice-stt.seed   (voicecli nats-serve stt)"
 info "  llm-worker.seed        NATS_NKEY_SEED_PATH=${SEEDS_DIR}/llm-worker.seed"
+info "  image-worker.seed      NATS_NKEY_SEED_PATH=${SEEDS_DIR}/image-worker.seed  (imagecli nats-serve)"
 info "  monitor.seed           NATS_NKEY_SEED_PATH=${SEEDS_DIR}/monitor.seed"
 warn "Supervisor confs already reference ~/.lyra/nkeys/ — no changes needed."

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -77,7 +77,10 @@ SUB_ALLOW[llm-worker]='"lyra.llm.request"'
 
 # image-worker: imagecli nats-serve satellite. Heartbeat-publish + request-subscribe.
 # Contract: ADR-050. Shipped via imageCLI#50 (satellite) + #754 (lyra-side).
-PUB_ALLOW[image-worker]='"lyra.image.heartbeat"'
+# _INBOX.>/_inbox.> defensively included for reply-path robustness, mirroring
+# voice-tts/voice-stt — allow_responses: true alone may not cover every
+# nats-server version's reply publish path.
+PUB_ALLOW[image-worker]='"lyra.image.heartbeat","_INBOX.>","_inbox.>"'
 SUB_ALLOW[image-worker]='"lyra.image.generate.request"'
 
 PUB_ALLOW[monitor]='"lyra.monitor.>"'

--- a/deploy/supervisor/conf.d/lyra_discord.conf
+++ b/deploy/supervisor/conf.d/lyra_discord.conf
@@ -2,8 +2,8 @@
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_adapter.sh discord
 directory=%(ENV_HOME)s/projects/lyra
 environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/discord-adapter.seed"
-autostart=false
 priority=200
+autostart=false
 autorestart=true
 startsecs=5
 startretries=3

--- a/deploy/supervisor/conf.d/lyra_hub.conf
+++ b/deploy/supervisor/conf.d/lyra_hub.conf
@@ -1,9 +1,9 @@
 [program:lyra_hub]
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_hub.sh
 directory=%(ENV_HOME)s/projects/lyra
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",LYRA_HEALTH_PORT="8443",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/hub.seed"
-autostart=false
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/hub.seed",LYRA_HEALTH_PORT="8443"
 priority=100
+autostart=false
 autorestart=true
 startsecs=10
 startretries=3

--- a/deploy/supervisor/conf.d/lyra_imagecli_gen.conf
+++ b/deploy/supervisor/conf.d/lyra_imagecli_gen.conf
@@ -1,7 +1,7 @@
 [program:lyra_imagecli_gen]
 command=imagecli nats-serve
 directory=%(ENV_HOME)s/projects/lyra
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/image-worker.seed"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/image-worker.seed",NATS_URL="nats://127.0.0.1:4222"
 priority=200
 autostart=false
 autorestart=true

--- a/deploy/supervisor/conf.d/lyra_imagecli_gen.conf
+++ b/deploy/supervisor/conf.d/lyra_imagecli_gen.conf
@@ -1,0 +1,18 @@
+[program:lyra_imagecli_gen]
+command=imagecli nats-serve
+directory=%(ENV_HOME)s/projects/lyra
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/image-worker.seed"
+priority=200
+autostart=false
+autorestart=true
+startsecs=20
+startretries=3
+stopwaitsecs=75
+stopasgroup=true
+killasgroup=true
+stdout_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_imagecli_gen.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stderr_logfile=%(ENV_HOME)s/.local/state/lyra/logs/lyra_imagecli_gen_error.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=3

--- a/deploy/supervisor/conf.d/lyra_stt.conf
+++ b/deploy/supervisor/conf.d/lyra_stt.conf
@@ -2,6 +2,7 @@
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_adapter.sh stt
 directory=%(ENV_HOME)s/projects/lyra
 environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/stt-adapter.seed",LYRA_STT_ENABLED="1"
+priority=200
 autostart=false
 autorestart=true
 startsecs=5

--- a/deploy/supervisor/conf.d/lyra_telegram.conf
+++ b/deploy/supervisor/conf.d/lyra_telegram.conf
@@ -2,8 +2,8 @@
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_adapter.sh telegram
 directory=%(ENV_HOME)s/projects/lyra
 environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/telegram-adapter.seed"
-autostart=false
 priority=200
+autostart=false
 autorestart=true
 startsecs=5
 startretries=3

--- a/deploy/supervisor/conf.d/lyra_tts.conf
+++ b/deploy/supervisor/conf.d/lyra_tts.conf
@@ -1,7 +1,7 @@
 [program:lyra_tts]
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_adapter.sh tts
 directory=%(ENV_HOME)s/projects/lyra
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/tts-adapter.seed",LYRA_TTS_ENABLED="1"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/tts-adapter.seed",LYRA_TTS_ENABLED="1",LYRA_TTS_ENGINE="chatterbox"
 priority=200
 autostart=false
 autorestart=true

--- a/deploy/supervisor/conf.d/lyra_tts.conf
+++ b/deploy/supervisor/conf.d/lyra_tts.conf
@@ -1,7 +1,8 @@
 [program:lyra_tts]
 command=%(ENV_HOME)s/projects/lyra/deploy/supervisor/scripts/run_adapter.sh tts
 directory=%(ENV_HOME)s/projects/lyra
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/tts-adapter.seed",LYRA_TTS_ENABLED="1",LYRA_TTS_ENGINE="chatterbox"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/lyra/.venv/bin:%(ENV_PATH)s",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/tts-adapter.seed",LYRA_TTS_ENABLED="1"
+priority=200
 autostart=false
 autorestart=true
 startsecs=5

--- a/docs/architecture/adr/047-nats-connector-ownership-pattern.mdx
+++ b/docs/architecture/adr/047-nats-connector-ownership-pattern.mdx
@@ -113,8 +113,10 @@ If `voicecli_{stt,tts}` fails post-cutover: re-enable `lyra_{stt,tts}` from `con
 |---|---|---|---|---|
 | STT | `lyra.voice.stt.request`, `lyra.voice.stt.heartbeat` | `STT_WORKERS` | `stt-adapter` | `voicecli/src/voicecli/nats/stt_adapter.py` |
 | TTS | `lyra.voice.tts.request`, `lyra.voice.tts.heartbeat` | `TTS_WORKERS` | `tts-adapter` | `voicecli/src/voicecli/nats/tts_adapter.py` |
-| Image | `lyra.image.generate.request` | `IMAGE_WORKERS` | `image-worker` (to provision) | `imagecli/src/imagecli/nats/adapter.py` |
+| Image | `lyra.image.generate.request`, `lyra.image.heartbeat` | `IMAGE_WORKERS` | image-worker [^img-shipped] | `imagecli/src/imagecli/nats/adapter.py` |
 | Memory | TBD — requires contract ADR | TBD | TBD | `roxabi-vault` TBD |
+
+[^img-shipped]: Shipped via #754 (ADR-050 contract + `src/lyra/nats/nats_image_client.py` hub publisher + `image-worker` nkey + `imagecli_gen` supervisor entry). Satellite shipped via imageCLI#50 (2026-04-15).
 
 ### Contract ADR requirement
 
@@ -186,3 +188,4 @@ The allowlist is narrow (1–2 files per satellite). This is the enforcement mec
 - **ADR-044** — lyra ↔ voicecli NATS voice contract. The canonical contract ADR. Every new domain follows its structure.
 - **ADR-045** — roxabi-nats SDK extraction. The boundary is transport-vs-domain: `roxabi_nats` is pure transport; all `lyra.*` knowledge — contract text and hub-side publisher — stays in lyra even though the worker process lives in the satellite repo.
 - **ADR-046** — nkey provisioning is declarative. Invariant 2 (IDENTITIES is the single source of truth) requires each new worker identity to appear in `gen-nkeys.sh` before its worker ships. ADR-046 is the authoritative security-boundary document. ADR-047 reinforces the per-role nkey model structurally but does not define the enforcement mechanism. Subject-level ACLs remain the actual security boundary.
+- **ADR-050** — lyra ↔ imagecli NATS image contract. The image-domain analogue of ADR-044; landed under this ownership pattern.

--- a/docs/architecture/adr/050-lyra-image-nats-contract.mdx
+++ b/docs/architecture/adr/050-lyra-image-nats-contract.mdx
@@ -1,0 +1,284 @@
+---
+title: "ADR-050: lyra ↔ imagecli NATS image contract"
+description: "Freeze the request/reply and heartbeat payloads exchanged between lyra (hub) and imagecli (satellite) over NATS. Declare max-payload cap and enumerate user-controlled-fields sanitization contract."
+---
+
+## Status
+
+Accepted
+
+## Context
+
+imageCLI#50 (closed 2026-04-15) shipped `imagecli nats-serve`, a satellite process that subscribes to `lyra.image.generate.request` using `NatsAdapterBase` from `roxabi-nats`. The satellite is fully operational; it is the lyra-side contract documentation that is missing.
+
+ADR-047 (§ imageCLI migration state) explicitly notes the remaining lyra-side work: contract ADR for `lyra.image.*`, `src/lyra/nats/nats_image_client.py`, and the `image-worker` nkey in `gen-nkeys.sh`. This ADR delivers the first item.
+
+As with the voice domain (ADR-044), the wire contract must be frozen so that both sides can evolve safely. This ADR freezes the subjects, payload schemas, error codes, max-payload cap, and sanitization obligations for all `lyra.image.*` traffic.
+
+### Heartbeat subject reconciliation
+
+Issue #754 originally referenced the heartbeat subject as `lyra.image.generate.heartbeat`. The shipped satellite at `imagecli/src/imagecli/nats/adapter.py:18` defines:
+
+```python
+HEARTBEAT_SUBJECT = "lyra.image.heartbeat"
+```
+
+This ADR aligns to the **shipped subject** (`lyra.image.heartbeat`). The `generate` segment is omitted because heartbeats are worker-level liveness signals, not tied to a single verb. This is consistent with the naming convention in ADR-035 and the voicecli heartbeat pattern in ADR-044.
+
+Cross-references: imageCLI#50 (satellite implementation), `artifacts/specs/754-lyra-image-domain-integration-spec.mdx` (lyra-side spec).
+
+## Decision
+
+### Subjects
+
+| Subject | Type | Direction | Producer | Consumer | Purpose |
+|---|---|---|---|---|---|
+| `lyra.image.generate.request` | request-reply | hub → satellite | `NatsImageClient` (hub) | `ImageNatsAdapter.handle` (satellite) | Generate image from prompt |
+| `lyra.image.heartbeat` | fire-and-forget | satellite → hub | `ImageNatsAdapter` (satellite) | `NatsImageClient._on_heartbeat` (hub) | Liveness + capacity |
+
+Queue group (load balancing across satellite replicas): `IMAGE_WORKERS`. Replies use the NATS request-reply inbox; no dedicated reply subject.
+
+### Payload encoding
+
+UTF-8 JSON. Binary image data is base64-encoded in-payload (`image_b64`) or, when the encoded length exceeds the satellite's conservative ceiling, replaced by an absolute `file_path` on a shared filesystem. NATS `max_payload` is set to **50 MB** (`52428800`) in `deploy/nats/nats-container.conf`, covering audio, images, and video payloads across all domains. The satellite enforces a **750 KB base64 ceiling** independently of the server cap (see Max payload section below).
+
+### `contract_version` — additive, one-way
+
+Every payload listed below carries `contract_version: "1"` as a top-level string field.
+
+- **Producers (hub or satellite) MUST emit it** on every outgoing request, reply, and heartbeat.
+- **Consumers MUST ignore unknown values.** A consumer reading a payload uses `.get("contract_version")` (or simply does not read it at all); it MUST NOT reject or error on any value. `"1"`, `"2"`, `"whatever"`, or missing — all are accepted.
+- The field is **additive**, not a handshake. A `"2"` sender and a `"1"` reader continue to work as long as no other field has been removed or reinterpreted between versions. When an incompatible change is needed, it ships as a new subject (or a new ADR), not a bumped version.
+- The goal is **observability** — logs and metrics on both sides can filter by version, and operators can diagnose mismatches on the wire without guessing.
+
+### Request — `lyra.image.generate.request`
+
+```json
+{
+  "contract_version": "1",
+  "trace_id": "7f3a9c12-1b4e-4e8a-a2d5-0f9e2c3b1a7d",
+  "issued_at": "2026-04-19T14:32:00.123456+00:00",
+  "request_id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "prompt": "a serene mountain lake at golden hour, photorealistic",
+  "engine": "flux2-klein",
+  "negative_prompt": "blurry, oversaturated",
+  "width": 1024,
+  "height": 1024,
+  "steps": 50,
+  "guidance": 4.0,
+  "seed": 42,
+  "format": "png",
+  "output_mode": "b64",
+  "lora_path": null,
+  "lora_scale": null,
+  "trigger": null,
+  "embedding_path": null
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` for this ADR |
+| `trace_id` | string (uuid4) | ✓ | End-to-end trace correlation; emitted by hub, echoed in reply |
+| `issued_at` | string (ISO-8601 datetime) | ✓ | UTC timestamp of request creation |
+| `request_id` | string (uuid4) | ✓ | Unique per request; echoed back in all replies |
+| `prompt` | string | ✓ | User-supplied generation prompt; see sanitization contract |
+| `engine` | string | ✓ | Engine name (e.g. `flux2-klein`); validated against satellite registry |
+| `negative_prompt` | string \| null | — | Negative conditioning; forwarded verbatim with length cap |
+| `width` | integer \| null | — | Output width in pixels; satellite enforces ≤ 4096 |
+| `height` | integer \| null | — | Output height in pixels; satellite enforces ≤ 4096 |
+| `steps` | integer \| null | — | Denoising steps; satellite enforces ≤ 200 |
+| `guidance` | float \| null | — | Classifier-free guidance scale |
+| `seed` | integer \| null | — | RNG seed for reproducibility; null → random |
+| `format` | enum `png` \| `jpeg` \| `webp` | — | Output image format; default `png` |
+| `output_mode` | enum `b64` \| `file` | — | Preferred delivery mode; default `b64`; satellite may downgrade to `file` on size |
+| `lora_path` | string \| null | — | Absolute path to LoRA weights; satellite enforces allowlist |
+| `lora_scale` | float \| null | — | LoRA conditioning scale |
+| `trigger` | string \| null | — | LoRA trigger word; forwarded verbatim with length cap |
+| `embedding_path` | string \| null | — | Absolute path to textual embedding; satellite enforces allowlist |
+
+### Reply — success
+
+```json
+{
+  "contract_version": "1",
+  "trace_id": "7f3a9c12-1b4e-4e8a-a2d5-0f9e2c3b1a7d",
+  "issued_at": "2026-04-19T14:32:03.456789+00:00",
+  "request_id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "ok": true,
+  "image_b64": "iVBORw0KGgoAAAANSUhEUgAA...",
+  "mime_type": "image/png",
+  "width": 1024,
+  "height": 1024,
+  "engine": "flux2-klein",
+  "seed_used": 42
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` |
+| `trace_id` | string | ✓ | Echoed from request |
+| `issued_at` | string | ✓ | UTC timestamp of reply creation |
+| `request_id` | string | ✓ | Echoed from request |
+| `ok` | boolean | ✓ | Always `true` on success path |
+| `image_b64` | string (base64) | — | Mutually exclusive with `file_path`; present when encoded size ≤ 750 KB |
+| `file_path` | string | — | Mutually exclusive with `image_b64`; absolute satellite-resolved path; present when `output_mode: "file"` or base64 ceiling exceeded |
+| `mime_type` | string | ✓ | e.g. `image/png`, `image/jpeg`, `image/webp` |
+| `width` | integer | ✓ | Actual output width |
+| `height` | integer | ✓ | Actual output height |
+| `engine` | string | ✓ | Engine that produced the image |
+| `seed_used` | integer | ✓ | Actual seed used; 0 when satellite cannot extract it from the engine |
+
+Exactly one of `image_b64` or `file_path` MUST be present on a success reply. Both present or both absent is a malformed reply.
+
+### Reply — error
+
+```json
+{
+  "contract_version": "1",
+  "trace_id": "7f3a9c12-1b4e-4e8a-a2d5-0f9e2c3b1a7d",
+  "issued_at": "2026-04-19T14:32:01.000000+00:00",
+  "request_id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "ok": false,
+  "error": "unknown_engine",
+  "error_detail": "flux99-nonexistent"
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` |
+| `trace_id` | string | ✓ | Echoed from request |
+| `issued_at` | string | ✓ | UTC timestamp of reply creation |
+| `request_id` | string | ✓ | Echoed from request |
+| `ok` | boolean | ✓ | Always `false` on error path |
+| `error` | string | ✓ | Snake_case error code; see error codes table |
+| `error_detail` | string \| null | — | Optional human-readable detail; sanitized — MUST NOT leak internal paths, stack traces, or model internals |
+
+### Error codes
+
+| Code | Trigger | Notes |
+|---|---|---|
+| `missing_required_field` | `prompt` or `engine` absent; `width`/`height` > 4096; `steps` > 200; `lora_path` or `embedding_path` outside allowlist | Consolidates validation failures. Tokens are for logs and metrics, not control flow. |
+| `unknown_engine` | Engine name not found in satellite registry | |
+| `engine_load_failed` | Engine import error or initialization failure | e.g. missing torch extension |
+| `insufficient_resources` | Preflight VRAM/RAM check fails; `InsufficientResourcesError` or `MemoryError` during load | |
+| `generation_failed` | Runtime error during image generation or response encoding | Catch-all for unclassified failures |
+
+The hub raises `ImageUnavailableError` (or equivalent) on `ok: false` regardless of the specific `error` value — the token is for logs and metrics, not for branching control flow.
+
+### Heartbeat — `lyra.image.heartbeat`
+
+```json
+{
+  "contract_version": "1",
+  "trace_id": "00000000-0000-0000-0000-000000000000",
+  "issued_at": "2026-04-19T14:32:10.000000+00:00",
+  "worker_id": "image-roxabituwer-1713531130",
+  "service": "image_workers",
+  "host": "roxabituwer",
+  "subject": "lyra.image.generate.request",
+  "queue_group": "IMAGE_WORKERS",
+  "ts": 1713531130.0,
+  "engine_loaded": "flux2-klein",
+  "active_requests": 0,
+  "vram_used_mb": 8192,
+  "vram_total_mb": 10240
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `contract_version` | string | ✓ | Always `"1"` |
+| `trace_id` | string | ✓ | Populated by `NatsAdapterBase.heartbeat_payload`; zero UUID is acceptable for heartbeats |
+| `issued_at` | string | ✓ | UTC timestamp of heartbeat emission |
+| `worker_id` | string | ✓ | Unique per process; hub indexes freshness by this key; drop heartbeat if absent |
+| `service` | string | ✓ | Populated by `NatsAdapterBase.heartbeat_payload` |
+| `host` | string | ✓ | Populated by `NatsAdapterBase.heartbeat_payload` |
+| `subject` | string | ✓ | Always `lyra.image.generate.request` |
+| `queue_group` | string | ✓ | Always `IMAGE_WORKERS` |
+| `ts` | float | ✓ | Unix timestamp (seconds) of emission |
+| `engine_loaded` | string \| null | — | Currently loaded engine name; null if no engine warmed |
+| `active_requests` | integer \| null | — | In-flight request count; hub uses this for load-picking when multiple workers are alive |
+| `vram_used_mb` | integer | — | **Optional** — satellite may not populate if pynvml is unavailable; hub MUST NOT treat absence as an error |
+| `vram_total_mb` | integer | — | **Optional** — same caveat as `vram_used_mb` |
+
+**Cadence.** Satellites emit a heartbeat every **5 s** (`heartbeat_interval=5.0` in `ImageNatsAdapter.__init__`). The hub marks a worker alive if a heartbeat landed within the last **15 s** (`_HB_TTL`); older entries are pruned after `2 × _HB_TTL`. No worker alive → hub raises an error before dispatching any request.
+
+A heartbeat with a missing `worker_id` is dropped with a warning log and does not update freshness. The hub uses `active_requests` (not `vram_used_mb`) as the primary load-picking signal — VRAM telemetry is informational.
+
+### Max payload (ADR-047 Rule 4 compliance)
+
+The NATS server is configured with `max_payload: 52428800` (50 MB) in `deploy/nats/nats-container.conf`. This cap covers audio, images, and video traffic across all lyra domains.
+
+ADR-047 Rule 4 states: "Default 1 MB. Domains with legitimate binary payloads (audio, image) MUST declare the cap in their contract ADR." This ADR hereby declares the 50 MB server cap for the image domain.
+
+The satellite additionally enforces a **conservative base64 ceiling of 750 KB** in `imagecli/src/imagecli/nats/adapter.py:254–310`:
+
+- Base64 overhead is approximately 4/3, so 750 KB of base64 corresponds to roughly 562 KB of raw image bytes.
+- When the encoded length exceeds 750 KB, the satellite automatically downgrades to `file_path` mode regardless of the requested `output_mode`. It writes the image to `images/images_out/nats_{request_id[:8]}.{fmt}` relative to the satellite CWD, then replies with the absolute path from `Path.resolve()`.
+- `file_path` mode requires a **shared filesystem** between hub and worker. This holds today — hub and imageCLI satellite both run on Machine 1 (`roxabituwer`). Any future hub/worker split to separate hosts will require replacing the `file_path` fallback with an alternative binary transfer mechanism. This dependency is flagged as a known architectural constraint.
+- The hub MUST treat `file_path` as satellite-resolved and hub-opaque: no validation, no traversal, no path normalization. The hub reads the file at the given path to deliver the image to the user.
+
+### User-controlled fields (sanitization contract)
+
+The satellite (`imagecli/src/imagecli/nats/adapter.py:66–129`) owns sanitization of all user-supplied content. The hub forwards fields verbatim; the hub MUST NOT attempt to sanitize satellite inputs.
+
+| Field | Trust level | Sanitization owner | Enforcement |
+|---|---|---|---|
+| `prompt` | Untrusted (user input) | Satellite | Engine receives as-is; length cap applied before dispatch |
+| `negative_prompt` | Untrusted (user input) | Satellite | Same as `prompt` |
+| `trigger` | Untrusted (user input) | Satellite | Same as `prompt`; passed to engine as LoRA trigger word |
+| `lora_path` | Untrusted (user input) | Satellite | MUST be absolute; MUST resolve under `~/ComfyUI/models/{loras,lora}`; validated in `_validate_path` → `missing_required_field` on violation |
+| `embedding_path` | Untrusted (user input) | Satellite | MUST be absolute; MUST resolve under `~/ComfyUI/models/embeddings`; validated in `_validate_path` → `missing_required_field` on violation |
+| `width` | Untrusted (user input) | Satellite | MUST be ≤ 4096; validated in `_validate_request` → `missing_required_field` on violation |
+| `height` | Untrusted (user input) | Satellite | MUST be ≤ 4096; same enforcement |
+| `steps` | Untrusted (user input) | Satellite | MUST be ≤ 200; same enforcement |
+
+Path validation uses `Path.resolve()` to canonicalize before the `relative_to` check — symlinks and `..` traversal attempts are blocked. The satellite error detail MUST NOT leak the resolved path or the allowlist directory structure to the caller; sanitized messages only.
+
+## Rationale
+
+**Why NATS at all.** Image generation is GPU-bound and requires a heavy separate venv (torch, diffusers, ComfyUI). Making it a request-reply service over NATS lets it run on the same host (or a different one) without the hub importing imageCLI's dependencies. It gives load balancing via queue groups, liveness tracking via heartbeats, and zero-downtime worker replacement — all on the messaging layer. This is the same rationale as the voice domain (ADR-044).
+
+**Why these subjects.** `lyra.image.generate.request` follows the `<namespace>.<capability>.<action>.<verb>` shape from ADR-035. The heartbeat subject uses `lyra.image.heartbeat` (no `generate` qualifier) because it is a worker-level liveness signal, not scoped to a single verb. This matches the shipped satellite code (`adapter.py:18`) and is consistent with future additional image-domain verbs (e.g. `lyra.image.upscale.request`) sharing the same worker heartbeat.
+
+**Why `contract_version` additive not a handshake.** A handshake would require hub and satellite to negotiate on connect, reintroducing the kind of coupling the NATS migration is trying to eliminate. An additive string makes the contract self-describing on the wire without any state on either side. When a breaking change is needed, it ships as a new subject or a new ADR — not a wire negotiation. This is the same decision as ADR-044.
+
+**Why "1" as a string, not 1 as an integer.** String comparison works uniformly across any language binding. Mixing numeric and string types in the same field across version bumps is a source of subtle bugs. Future major bumps (`"2"`, `"3"`) ship with a new ADR; fractional bumps (`"1.1"`) are not defined.
+
+## Consequences
+
+### Positive
+
+- The lyra ↔ imagecli contract is frozen and greppable. Any payload change is visible as an ADR amendment.
+- `contract_version` gives operators and log aggregators a cheap way to filter by wire version without inspecting each payload.
+- The `file_path` fallback extends the effective binary-domain ceiling beyond the 750 KB conservative base64 limit — large images are deliverable as long as a shared filesystem exists.
+- Error codes are stable tokens; hub error-handling and metrics do not need to change when a new generation engine adds a new failure mode.
+
+### Negative
+
+- `file_path` mode couples hub and worker to a shared filesystem. If the image satellite is ever moved to a different host from the hub, the `file_path` path will need to be replaced with a different delivery mechanism (object storage, sidecar stream, or a larger NATS payload).
+- Every producer path must remember to stamp `contract_version`. A missing field is only caught by tests or downstream grep; there is no runtime enforcement.
+
+### Neutral
+
+- `contract_version` adds one string field per payload. Wire overhead is negligible.
+- The 50 MB NATS server cap is a shared resource limit across all lyra domains; image-domain traffic does not require a dedicated server configuration change.
+- Schema enforcement remains in the satellite's `_validate_request` and tests; this ADR does not introduce a runtime validator on the hub side.
+
+## Relation to other ADRs
+
+- **ADR-035** — NATS subject naming convention. `lyra.image.generate.request` and `lyra.image.heartbeat` follow the `<namespace>.<capability>.<action>.<verb>` and `<namespace>.<capability>.<verb>` shapes respectively.
+- **ADR-044** — lyra ↔ voicecli NATS voice contract. The canonical contract ADR shape. This ADR follows its structure exactly: subjects table, payload encoding, `contract_version`, request/reply schemas, error codes, heartbeat, max-payload, sanitization contract.
+- **ADR-046** — nkey provisioning is declarative. Invariant 2 (IDENTITIES is the single source of truth) requires the `image-worker` nkey identity to be added to `gen-nkeys.sh` before the hub client ships. The `image-worker` identity is noted as "to provision" in ADR-047's subject ownership table.
+- **ADR-047** — NATS connector ownership pattern. This ADR is the lyra-owned half of the image domain. The satellite-owned half is `imagecli/src/imagecli/nats/adapter.py` (shipped by imageCLI#50). Rule 4 of ADR-047 requires this ADR to declare the max-payload cap — done in the Max payload section above.
+
+## References
+
+- Spec: [`artifacts/specs/754-lyra-image-domain-integration-spec.mdx`](../../../artifacts/specs/754-lyra-image-domain-integration-spec.mdx)
+- Issue: [#754](https://github.com/Roxabi/lyra/issues/754)
+- Satellite implementation: `imageCLI/src/imagecli/nats/adapter.py` (shipped by imageCLI#50, closed 2026-04-15)
+- Hub client: `src/lyra/nats/nats_image_client.py` (new — ships with #754)
+- NATS server config: `deploy/nats/nats-container.conf` (`max_payload: 52428800`)

--- a/scripts/smoke/image-request.py
+++ b/scripts/smoke/image-request.py
@@ -10,7 +10,7 @@ image-worker nkey. Capture stdout as rollout evidence:
 
 Env:
     NATS_URL               Defaults to nats://127.0.0.1:4222
-    NATS_NKEY_SEED_PATH    Optional; enables nkey auth when set
+    NATS_NKEY_SEED_PATH    Optional; enables nkey auth (path to seed file)
 """
 from __future__ import annotations
 
@@ -19,13 +19,12 @@ import asyncio
 import os
 import sys
 
-from nats.aio.client import Client as NATS
-
 from lyra.nats.nats_image_client import (
     ImageGenParams,
     ImageUnavailableError,
     NatsImageClient,
 )
+from roxabi_nats import nats_connect
 
 
 async def main() -> int:
@@ -38,13 +37,10 @@ async def main() -> int:
     args = parser.parse_args()
 
     nats_url = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
-    seed = os.environ.get("NATS_NKEY_SEED_PATH")
-
-    nc = NATS()
-    kwargs: dict = {"servers": [nats_url]}
-    if seed:
-        kwargs["nkeys_seed"] = seed
-    await nc.connect(**kwargs)
+    # roxabi_nats.nats_connect reads NATS_NKEY_SEED_PATH itself, validates the
+    # file (perms, size, symlink safety), and passes `nkeys_seed_str` to
+    # nats-py. This is the canonical helper — do NOT hand-roll the kwarg.
+    nc = await nats_connect(nats_url)
 
     client = NatsImageClient(nc, timeout=180.0)
     await client.start()

--- a/scripts/smoke/image-request.py
+++ b/scripts/smoke/image-request.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Smoke test for lyra → imagecli image-domain round-trip.
+
+Publishes one lyra.image.generate.request and asserts ok:true on the reply.
+Run on Machine 1 (hub host) after imagecli_gen is RUNNING under the new
+image-worker nkey. Capture stdout as rollout evidence:
+
+    python scripts/smoke/image-request.py \
+        > artifacts/rollout-evidence/754-image-smoke.txt
+
+Env:
+    NATS_URL               Defaults to nats://127.0.0.1:4222
+    NATS_NKEY_SEED_PATH    Optional; enables nkey auth when set
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from nats.aio.client import Client as NATS
+
+from lyra.nats.nats_image_client import (
+    ImageGenParams,
+    ImageUnavailableError,
+    NatsImageClient,
+)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt", default="test image")
+    parser.add_argument("--engine", default="flux2-klein")
+    parser.add_argument("--width", type=int, default=512)
+    parser.add_argument("--height", type=int, default=512)
+    parser.add_argument("--steps", type=int, default=10)
+    args = parser.parse_args()
+
+    nats_url = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+    seed = os.environ.get("NATS_NKEY_SEED_PATH")
+
+    nc = NATS()
+    kwargs: dict = {"servers": [nats_url]}
+    if seed:
+        kwargs["nkeys_seed"] = seed
+    await nc.connect(**kwargs)
+
+    client = NatsImageClient(nc, timeout=180.0)
+    await client.start()
+
+    # Give at least one heartbeat window to populate the registry:
+    await asyncio.sleep(2.0)
+
+    params = ImageGenParams(
+        width=args.width,
+        height=args.height,
+        steps=args.steps,
+    )
+
+    try:
+        resp = await client.generate(
+            args.prompt,
+            engine=args.engine,
+            params=params,
+        )
+    except ImageUnavailableError as exc:
+        print(f"SMOKE FAIL: {exc}", file=sys.stderr)
+        await nc.drain()
+        return 1
+
+    mode = "b64" if resp.image_b64 else "file_path"
+    print(
+        f"SMOKE OK: request_id={resp.request_id} engine={resp.engine} "
+        f"{mode} size={resp.width}x{resp.height}"
+    )
+    await nc.drain()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -1,0 +1,273 @@
+"""NatsImageClient — hub-side NATS request-reply client for image generation.
+
+Maintains a ``VoiceWorkerRegistry`` populated from heartbeats, and routes each
+generation request to the least-loaded worker via the queue-group subject
+``lyra.image.generate.request``. Falls back to ``ImageUnavailableError`` when
+the registry is stale, the circuit breaker is open, or the adapter times out.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal, NoReturn
+from uuid import uuid4
+
+from nats.aio.client import Client as NATS
+from pydantic import ValidationError
+
+from lyra.nats.voice_health import VoiceWorkerRegistry
+from roxabi_contracts.envelope import CONTRACT_VERSION, ContractEnvelope
+from roxabi_nats.circuit_breaker import NatsCircuitBreaker
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Subject namespace
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _Subjects:
+    """Frozen namespace of image-domain subject strings.
+
+    Attribute access is pyright-checked: typos fail at type-check time
+    rather than silently routing to a wrong subject.
+    """
+
+    image_request: Literal["lyra.image.generate.request"] = (
+        "lyra.image.generate.request"
+    )
+    image_heartbeat: Literal["lyra.image.heartbeat"] = "lyra.image.heartbeat"
+    image_workers: Literal["IMAGE_WORKERS"] = "IMAGE_WORKERS"
+
+
+SUBJECTS = _Subjects()
+
+
+# ---------------------------------------------------------------------------
+# Domain exception
+# ---------------------------------------------------------------------------
+
+
+class ImageUnavailableError(Exception):
+    """Raised when the image domain cannot satisfy the request."""
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class ImageRequest(ContractEnvelope):
+    """Outbound image generation request payload."""
+
+    request_id: str
+    prompt: str
+    engine: str
+    negative_prompt: str | None = None
+    width: int | None = None
+    height: int | None = None
+    steps: int | None = None
+    guidance: float | None = None
+    seed: int | None = None
+    format: Literal["png", "jpeg", "webp"] = "png"
+    output_mode: Literal["b64", "file"] = "b64"
+    lora_path: str | None = None
+    lora_scale: float | None = None
+    trigger: str | None = None
+    embedding_path: str | None = None
+
+
+class ImageResponse(ContractEnvelope):
+    """Inbound image generation response payload."""
+
+    request_id: str
+    ok: bool
+    image_b64: str | None = None
+    file_path: str | None = None
+    mime_type: str | None = None
+    width: int | None = None
+    height: int | None = None
+    engine: str | None = None
+    seed_used: int | None = None
+    error: str | None = None
+    error_detail: str | None = None
+
+
+class ImageHeartbeat(ContractEnvelope):
+    """Inbound heartbeat from an image worker satellite."""
+
+    worker_id: str
+    service: str
+    host: str
+    subject: str
+    queue_group: str
+    ts: float
+    engine_loaded: str | None = None
+    active_requests: int | None = None
+    vram_used_mb: int | None = None
+    vram_total_mb: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Generation parameter bag
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ImageGenParams:
+    """Optional image generation parameters passed to ``NatsImageClient.generate``.
+
+    Separating these from the required fields (prompt, engine) keeps the
+    public ``generate()`` signature within the project's 5-argument limit.
+    """
+
+    negative_prompt: str | None = None
+    width: int | None = None
+    height: int | None = None
+    steps: int | None = None
+    guidance: float | None = None
+    seed: int | None = None
+    format: Literal["png", "jpeg", "webp"] = field(default="png")
+    output_mode: Literal["b64", "file"] = field(default="b64")
+    lora_path: str | None = None
+    lora_scale: float | None = None
+    trigger: str | None = None
+    embedding_path: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class NatsImageClient:
+    def __init__(self, nc: NATS, *, timeout: float = 120.0) -> None:
+        self._nc = nc
+        self._timeout = timeout
+        self._cb = NatsCircuitBreaker()
+        self._registry = VoiceWorkerRegistry()
+        self._hb_sub = None  # set by start
+
+    async def start(self) -> None:
+        """Subscribe to heartbeat subject. Called once after nc is connected."""
+        if self._hb_sub is None:
+            self._hb_sub = await self._nc.subscribe(
+                SUBJECTS.image_heartbeat, cb=self._on_heartbeat
+            )
+
+    async def _on_heartbeat(self, msg) -> None:
+        try:
+            data = json.loads(msg.data)
+        except Exception:
+            log.debug("image_client: heartbeat parse error", exc_info=True)
+            return
+        worker_id = data.get("worker_id")
+        if not isinstance(worker_id, str) or not worker_id:
+            return
+        self._registry.record_heartbeat(data)
+
+    def _parse_reply(self, raw: bytes) -> ImageResponse:
+        """Validate a NATS reply against ImageResponse; translate a ValidationError
+        into ImageUnavailableError + record a circuit-breaker failure."""
+        try:
+            return ImageResponse.model_validate_json(raw)
+        except ValidationError as exc:
+            self._cb.record_failure()
+            raise ImageUnavailableError(
+                "Image reply failed schema validation"
+            ) from exc
+
+    async def _send(self, payload: bytes) -> ImageResponse:
+        """Send payload to the image request subject."""
+        try:
+            reply = await self._nc.request(
+                SUBJECTS.image_request, payload, timeout=self._timeout
+            )
+        except TimeoutError as exc:
+            self._cb.record_failure()
+            raise ImageUnavailableError(
+                f"Image adapter timeout after {self._timeout:.0f}s"
+            ) from exc
+        except Exception as exc:
+            self._raise_nats_failure(exc, len(payload) / 1024)
+        resp = self._parse_reply(reply.data)
+        if not resp.ok:
+            self._cb.record_failure()
+            raise ImageUnavailableError(resp.error or "Image generation failed")
+        return resp
+
+    def _raise_nats_failure(self, exc: Exception, payload_kb: float) -> NoReturn:
+        """Convert a NATS request exception to ImageUnavailableError.
+
+        Domain errors (``ImageUnavailableError``) pass through unchanged so
+        callers can rely on this being the single translation boundary for
+        NATS-transport exceptions.
+        """
+        if isinstance(exc, ImageUnavailableError):
+            raise exc
+        if "max_payload" in str(exc).lower() or "MaxPayload" in type(exc).__name__:
+            log.error("Image payload too large (%.0f KB)", payload_kb)
+            self._cb.record_failure()
+            raise ImageUnavailableError("Image request payload too large") from exc
+        log.warning("Image adapter unreachable: %s: %s", type(exc).__name__, exc)
+        self._cb.record_failure()
+        raise ImageUnavailableError("Image adapter unreachable") from exc
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        engine: str,
+        params: ImageGenParams | None = None,
+    ) -> ImageResponse:
+        """Generate an image via the image adapter satellite.
+
+        Optional generation parameters (size, steps, LoRA, etc.) are passed
+        via ``params``; see ``ImageGenParams`` for the full field list.
+        """
+        preferred = self._registry.pick_least_loaded()
+        if preferred is None:
+            raise ImageUnavailableError(
+                "Image: no live worker (heartbeat stale >15s)"
+            )
+        if self._cb.is_open():
+            raise ImageUnavailableError(
+                "Image circuit open — adapter temporarily unavailable"
+            )
+        p = params or ImageGenParams()
+        extra: dict[str, Any] = {
+            k: v
+            for k, v in {
+                "negative_prompt": p.negative_prompt,
+                "width": p.width,
+                "height": p.height,
+                "steps": p.steps,
+                "guidance": p.guidance,
+                "seed": p.seed,
+                "format": p.format,
+                "output_mode": p.output_mode,
+                "lora_path": p.lora_path,
+                "lora_scale": p.lora_scale,
+                "trigger": p.trigger,
+                "embedding_path": p.embedding_path,
+            }.items()
+            if v is not None
+        }
+        request = ImageRequest(
+            contract_version=CONTRACT_VERSION,
+            trace_id=str(uuid4()),
+            issued_at=datetime.now(timezone.utc),
+            request_id=str(uuid4()),
+            prompt=prompt,
+            engine=engine,
+            **extra,
+        )
+        payload = request.model_dump_json(exclude_none=True).encode("utf-8")
+        resp = await self._send(payload)
+        self._cb.record_success()
+        return resp

--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 
 from lyra.nats.voice_health import VoiceWorkerRegistry
 from roxabi_contracts.envelope import CONTRACT_VERSION, ContractEnvelope
+from roxabi_contracts.voice.subjects import validate_worker_id
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 log = logging.getLogger(__name__)
@@ -167,7 +168,26 @@ class NatsImageClient:
             log.debug("image_client: heartbeat parse error", exc_info=True)
             return
         worker_id = data.get("worker_id")
-        if not isinstance(worker_id, str) or not worker_id:
+        if not worker_id:
+            log.warning("image_client: heartbeat missing worker_id, ignoring")
+            return
+        if not isinstance(worker_id, str):
+            log.warning(
+                "image_client: heartbeat non-string worker_id=%r, ignoring",
+                worker_id,
+            )
+            return
+        # Receive-side match for the PUBLISH-path safe-chars enforcement; blocks
+        # wildcard-bearing ids (e.g. "evil.worker.*") from polluting the registry
+        # for up to the 15 s heartbeat-stale window. Mirrors voice canonical at
+        # nats_tts_client.py:70-82.
+        try:
+            validate_worker_id(worker_id)
+        except ValueError:
+            log.warning(
+                "image_client: heartbeat with unsafe worker_id=%r, ignoring",
+                worker_id,
+            )
             return
         self._registry.record_heartbeat(data)
 

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -1,0 +1,71 @@
+"""Tests for deploy/gen-supervisor-conf.py command-generation behavior."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "deploy" / "gen-supervisor-conf.py"
+
+
+def _run_dry(tmp_agents: Path) -> str:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--dry-run", "--agents-file", str(tmp_agents)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _write_agents(tmp_path: Path, agents: dict) -> Path:
+    payload = {"schema_version": "1.0", "defaults": {}, "agents": agents}
+    p = tmp_path / "agents.yml"
+    p.write_text(yaml.safe_dump(payload))
+    return p
+
+
+def test_command_override_used_verbatim(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(
+        tmp_path,
+        {
+            "imagecli_gen": {
+                "command_override": "imagecli nats-serve",
+                "priority": 200,
+                "startsecs": 20,
+                "nkey": "image-worker.seed",
+            },
+        },
+    )
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "command=imagecli nats-serve" in out
+    # The run_adapter.sh fallback must NOT appear for this agent's block
+    assert "run_adapter.sh imagecli_gen" not in out
+
+
+def test_fallback_run_hub_for_hub_name(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"hub": {"priority": 100}})
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "run_hub.sh" in out
+    assert "imagecli nats-serve" not in out
+
+
+def test_fallback_run_adapter_for_other_names(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"telegram": {"priority": 200}})
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "run_adapter.sh telegram" in out
+    assert "imagecli nats-serve" not in out
+    assert "run_hub.sh" not in out

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -12,13 +12,31 @@ REPO = Path(__file__).resolve().parents[2]
 SCRIPT = REPO / "deploy" / "gen-supervisor-conf.py"
 
 
-def _run_dry(tmp_agents: Path) -> str:
+def _run_dry(tmp_agents: Path, *, expect_fail: bool = False) -> str:
+    """Run the generator in dry-run mode against a tmp agents.yml.
+
+    On unexpected failure, surfaces the script's stderr/stdout via
+    ``pytest.fail`` — raw ``CalledProcessError`` swallows the diagnostic
+    which makes the first test run on a broken generator very hard to
+    triage. 10 s timeout guards against --dry-run ever growing a blocking
+    call that deadlocks CI.
+    """
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--dry-run", "--agents-file", str(tmp_agents)],
         capture_output=True,
         text=True,
-        check=True,
+        timeout=10,
     )
+    if expect_fail:
+        return result.stderr
+    if result.returncode != 0:
+        import pytest as _pytest
+
+        _pytest.fail(
+            f"gen-supervisor-conf.py failed (exit={result.returncode}):\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
     return result.stdout
 
 

--- a/tests/nats/test_gen_nkeys_acls.sh
+++ b/tests/nats/test_gen_nkeys_acls.sh
@@ -33,26 +33,28 @@ echo "PASS: template-only produced output ($(wc -l < "$OUT") lines)"
 # ── Expected allow-lists (authoritative copy mirrors spec §Data Model matrix) ──
 # If the spec matrix changes, update both deploy/nats/gen-nkeys.sh AND this file.
 declare -A EXPECTED_PUB EXPECTED_SUB
-EXPECTED_PUB[hub]='lyra.outbound.telegram.> lyra.outbound.discord.> lyra.voice.tts.request lyra.voice.stt.request lyra.llm.request'
-EXPECTED_SUB[hub]='lyra.inbound.telegram.> lyra.inbound.discord.> lyra.voice.tts.heartbeat lyra.voice.stt.heartbeat lyra.llm.health.* lyra.system.ready _INBOX.>'
+EXPECTED_PUB[hub]='lyra.outbound.telegram.> lyra.outbound.discord.> lyra.voice.tts.request.> lyra.voice.stt.request.> lyra.llm.request lyra.image.generate.request'
+EXPECTED_SUB[hub]='lyra.inbound.telegram.> lyra.inbound.discord.> lyra.voice.tts.heartbeat lyra.voice.stt.heartbeat lyra.llm.health.* lyra.system.ready _INBOX.> lyra.image.heartbeat'
 EXPECTED_PUB[telegram-adapter]='lyra.inbound.telegram.> lyra.system.ready'
 EXPECTED_SUB[telegram-adapter]='lyra.outbound.telegram.>'
 EXPECTED_PUB[discord-adapter]='lyra.inbound.discord.> lyra.system.ready'
 EXPECTED_SUB[discord-adapter]='lyra.outbound.discord.>'
 EXPECTED_PUB[tts-adapter]='lyra.voice.tts.heartbeat lyra.system.ready'
-EXPECTED_SUB[tts-adapter]='lyra.voice.tts.request _INBOX.> _inbox.>'
+EXPECTED_SUB[tts-adapter]='lyra.voice.tts.request lyra.voice.tts.request.> _INBOX.> _inbox.>'
 EXPECTED_PUB[stt-adapter]='lyra.voice.stt.heartbeat lyra.system.ready'
-EXPECTED_SUB[stt-adapter]='lyra.voice.stt.request _INBOX.> _inbox.>'
+EXPECTED_SUB[stt-adapter]='lyra.voice.stt.request lyra.voice.stt.request.> _INBOX.> _inbox.>'
 EXPECTED_PUB[voice-tts]='lyra.voice.tts.heartbeat _INBOX.>'
-EXPECTED_SUB[voice-tts]='lyra.voice.tts.request lyra.voice.tts.heartbeat'
+EXPECTED_SUB[voice-tts]='lyra.voice.tts.request lyra.voice.tts.request.> lyra.voice.tts.heartbeat'
 EXPECTED_PUB[voice-stt]='lyra.voice.stt.heartbeat _INBOX.>'
-EXPECTED_SUB[voice-stt]='lyra.voice.stt.request lyra.voice.stt.heartbeat'
+EXPECTED_SUB[voice-stt]='lyra.voice.stt.request lyra.voice.stt.request.> lyra.voice.stt.heartbeat'
 EXPECTED_PUB[llm-worker]='lyra.llm.health.*'
 EXPECTED_SUB[llm-worker]='lyra.llm.request'
+EXPECTED_PUB[image-worker]='lyra.image.heartbeat'
+EXPECTED_SUB[image-worker]='lyra.image.generate.request'
 EXPECTED_PUB[monitor]='lyra.monitor.>'
 EXPECTED_SUB[monitor]='lyra.monitor.>'
 
-IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker monitor)
+IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker image-worker monitor)
 
 # ── extract_block: print the user{} block for a given identity name ────────────
 # B9: the closing-brace condition records `entry_depth` when the identity's
@@ -110,28 +112,28 @@ assert_allow_list_equals() {
   fi
 }
 
-# ── (a) 9 identity comment labels ──────────────────────────────────────────────
-count=$(grep -cE '^[[:space:]]+#[[:space:]]+(hub|telegram-adapter|discord-adapter|tts-adapter|stt-adapter|voice-tts|voice-stt|llm-worker|monitor)$' "$OUT" || true)
-[ "$count" -eq 9 ] \
-  || { echo "FAIL (a): expected 9 identity blocks, got ${count}"; exit 1; }
-echo "PASS (a): 9 identity blocks found"
+# ── (a) 10 identity comment labels ─────────────────────────────────────────────
+count=$(grep -cE '^[[:space:]]+#[[:space:]]+(hub|telegram-adapter|discord-adapter|tts-adapter|stt-adapter|voice-tts|voice-stt|llm-worker|image-worker|monitor)$' "$OUT" || true)
+[ "$count" -eq 10 ] \
+  || { echo "FAIL (a): expected 10 identity blocks, got ${count}"; exit 1; }
+echo "PASS (a): 10 identity blocks found"
 
-# ── (b) + (c) + (f) set-equality publish and subscribe for all 7 identities ───
+# ── (b) + (c) + (f) set-equality publish and subscribe for all 10 identities ──
 for name in "${IDENTITIES[@]}"; do
   block=$(extract_block "$name")
   [ -n "$block" ] || { echo "FAIL: block not found for ${name}"; exit 1; }
   assert_allow_list_equals "$block" "publish"   "${EXPECTED_PUB[$name]}" "$name"
   assert_allow_list_equals "$block" "subscribe" "${EXPECTED_SUB[$name]}" "$name"
 done
-echo "PASS (b): publish allow-lists match matrix (set equality, 9 identities)"
-echo "PASS (c): subscribe allow-lists match matrix (set equality, 9 identities)"
+echo "PASS (b): publish allow-lists match matrix (set equality, 10 identities)"
+echo "PASS (c): subscribe allow-lists match matrix (set equality, 10 identities)"
 echo "PASS (f): no over-privilege detected"
 
-# ── (d) allow_responses: true present on every user (9 occurrences) ───────────
+# ── (d) allow_responses: true present on every user (10 occurrences) ──────────
 ar_count=$(grep -c 'allow_responses: true' "$OUT" || true)
-[ "$ar_count" -eq 9 ] \
-  || { echo "FAIL (d): expected 9 allow_responses: true lines, got ${ar_count}"; exit 1; }
-echo "PASS (d): allow_responses: true appears 9 times"
+[ "$ar_count" -eq 10 ] \
+  || { echo "FAIL (d): expected 10 allow_responses: true lines, got ${ar_count}"; exit 1; }
+echo "PASS (d): allow_responses: true appears 10 times"
 
 # ── (e) the word 'plugin' must not appear anywhere in the generated conf ──────
 if grep -qi 'plugin' "$OUT"; then
@@ -156,4 +158,78 @@ dp_sub=$(awk '/default_permissions:[[:space:]]*\{/,/users:[[:space:]]*\[/' "$OUT
 echo "PASS (g): default_permissions denies publish + subscribe on \">\" fallback"
 
 echo ""
-echo "PASS: all 7 assertions (a–g) — 7 identities × {pub,sub} × set equality"
+echo "PASS: all 7 assertions (a–g) — 10 identities × {pub,sub} × set equality"
+
+# ── #754 image domain integration — assert image-worker + amended hub ACL ──
+# Contract: ADR-050 (lyra ↔ imagecli). See artifacts/specs/754-lyra-image-domain-integration-spec.mdx §Slice 3.
+
+# Re-invoke template-only to get fresh output for the new assertions.
+output=$(./deploy/nats/gen-nkeys.sh --template-only)
+
+# ── (#754-1) image-worker block must be present ───────────────────────────────
+echo "$output" | grep -qE '# image-worker$' \
+  || { echo "FAIL: image-worker block missing"; exit 1; }
+echo "PASS (#754-1): image-worker block present"
+
+# ── (#754-2) image-worker publish allow-list == ["lyra.image.heartbeat"] ──────
+iw_block=$(echo "$output" | awk '/# image-worker$/,/^    }$/')
+[ -n "$iw_block" ] || { echo "FAIL: could not extract image-worker block"; exit 1; }
+
+# Must contain lyra.image.heartbeat in the publish line
+echo "$iw_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' \
+  | grep -q '"lyra.image.heartbeat"' \
+  || { echo "FAIL: image-worker publish must allow lyra.image.heartbeat"; exit 1; }
+
+# Must NOT contain any other lyra.* subject in the publish line
+iw_pub_line=$(echo "$iw_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' | head -1)
+extra_pub=$(echo "$iw_pub_line" | grep -oE '"lyra\.[^"]+"' | grep -v '"lyra\.image\.heartbeat"' || true)
+[ -z "$extra_pub" ] \
+  || { echo "FAIL: image-worker publish has unexpected lyra.* subject(s): ${extra_pub}"; exit 1; }
+echo "PASS (#754-2): image-worker publish allow-list == [\"lyra.image.heartbeat\"]"
+
+# ── (#754-3) image-worker subscribe allow-list == ["lyra.image.generate.request"] ──
+# Must contain lyra.image.generate.request in the subscribe line
+echo "$iw_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' \
+  | grep -q '"lyra.image.generate.request"' \
+  || { echo "FAIL: image-worker subscribe must allow lyra.image.generate.request"; exit 1; }
+
+# Must NOT contain any other lyra.* subject in the subscribe line
+iw_sub_line=$(echo "$iw_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' | head -1)
+extra_sub=$(echo "$iw_sub_line" | grep -oE '"lyra\.[^"]+"' | grep -v '"lyra\.image\.generate\.request"' || true)
+[ -z "$extra_sub" ] \
+  || { echo "FAIL: image-worker subscribe has unexpected lyra.* subject(s): ${extra_sub}"; exit 1; }
+echo "PASS (#754-3): image-worker subscribe allow-list == [\"lyra.image.generate.request\"]"
+
+# ── (#754-4) hub publish gained lyra.image.generate.request ──────────────────
+hub_block=$(echo "$output" | awk '/# hub$/,/^    }$/')
+[ -n "$hub_block" ] || { echo "FAIL: could not extract hub block"; exit 1; }
+
+echo "$hub_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' \
+  | grep -q '"lyra.image.generate.request"' \
+  || { echo "FAIL: hub publish must include lyra.image.generate.request"; exit 1; }
+echo "PASS (#754-4): hub publish allow-list includes lyra.image.generate.request"
+
+# ── (#754-5) hub subscribe gained lyra.image.heartbeat ───────────────────────
+echo "$hub_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' \
+  | grep -q '"lyra.image.heartbeat"' \
+  || { echo "FAIL: hub subscribe must include lyra.image.heartbeat"; exit 1; }
+echo "PASS (#754-5): hub subscribe allow-list includes lyra.image.heartbeat"
+
+# ── (#754-6) no other identity may access lyra.image.* ───────────────────────
+OTHER_IDENTITIES=(telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker monitor)
+for other_id in "${OTHER_IDENTITIES[@]}"; do
+  other_block=$(echo "$output" | awk -v target="# ${other_id}" '
+    /\{/ { depth++ }
+    index($0, target) > 0 && !inblock { inblock = 1; entry_depth = depth }
+    inblock { print }
+    /\}/ { if (inblock && depth == entry_depth) { exit } ; depth-- }
+  ')
+  [ -n "$other_block" ] || { echo "FAIL: could not extract block for ${other_id}"; exit 1; }
+  leak=$(echo "$other_block" | grep -oE '"lyra\.image\.[^"]+"' || true)
+  [ -z "$leak" ] \
+    || { echo "FAIL: ${other_id} must not have lyra.image.* access, found: ${leak}"; exit 1; }
+done
+echo "PASS (#754-6): no other identity has lyra.image.* access"
+
+echo ""
+echo "PASS (#754): image-worker ACL + amended hub ACL assertions (5 checks)"

--- a/tests/nats/test_gen_nkeys_acls.sh
+++ b/tests/nats/test_gen_nkeys_acls.sh
@@ -49,7 +49,7 @@ EXPECTED_PUB[voice-stt]='lyra.voice.stt.heartbeat _INBOX.>'
 EXPECTED_SUB[voice-stt]='lyra.voice.stt.request lyra.voice.stt.request.> lyra.voice.stt.heartbeat'
 EXPECTED_PUB[llm-worker]='lyra.llm.health.*'
 EXPECTED_SUB[llm-worker]='lyra.llm.request'
-EXPECTED_PUB[image-worker]='lyra.image.heartbeat'
+EXPECTED_PUB[image-worker]='lyra.image.heartbeat _INBOX.> _inbox.>'
 EXPECTED_SUB[image-worker]='lyra.image.generate.request'
 EXPECTED_PUB[monitor]='lyra.monitor.>'
 EXPECTED_SUB[monitor]='lyra.monitor.>'
@@ -171,21 +171,28 @@ echo "$output" | grep -qE '# image-worker$' \
   || { echo "FAIL: image-worker block missing"; exit 1; }
 echo "PASS (#754-1): image-worker block present"
 
-# ── (#754-2) image-worker publish allow-list == ["lyra.image.heartbeat"] ──────
+# ── (#754-2) image-worker publish allow-list ───────────────────────────────────
+# Expected: lyra.image.heartbeat + _INBOX.> + _inbox.> (defensive inbox entries
+# mirror voice-tts/voice-stt for reply-path robustness; see #804 review fix).
 iw_block=$(echo "$output" | awk '/# image-worker$/,/^    }$/')
 [ -n "$iw_block" ] || { echo "FAIL: could not extract image-worker block"; exit 1; }
 
 # Must contain lyra.image.heartbeat in the publish line
-echo "$iw_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' \
-  | grep -q '"lyra.image.heartbeat"' \
+iw_pub_line=$(echo "$iw_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' | head -1)
+echo "$iw_pub_line" | grep -q '"lyra.image.heartbeat"' \
   || { echo "FAIL: image-worker publish must allow lyra.image.heartbeat"; exit 1; }
 
+# Must contain both inbox forms
+echo "$iw_pub_line" | grep -q '"_INBOX.>"' \
+  || { echo "FAIL: image-worker publish must allow _INBOX.>"; exit 1; }
+echo "$iw_pub_line" | grep -q '"_inbox.>"' \
+  || { echo "FAIL: image-worker publish must allow _inbox.>"; exit 1; }
+
 # Must NOT contain any other lyra.* subject in the publish line
-iw_pub_line=$(echo "$iw_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' | head -1)
 extra_pub=$(echo "$iw_pub_line" | grep -oE '"lyra\.[^"]+"' | grep -v '"lyra\.image\.heartbeat"' || true)
 [ -z "$extra_pub" ] \
   || { echo "FAIL: image-worker publish has unexpected lyra.* subject(s): ${extra_pub}"; exit 1; }
-echo "PASS (#754-2): image-worker publish allow-list == [\"lyra.image.heartbeat\"]"
+echo "PASS (#754-2): image-worker publish allow-list == [\"lyra.image.heartbeat\", \"_INBOX.>\", \"_inbox.>\"]"
 
 # ── (#754-3) image-worker subscribe allow-list == ["lyra.image.generate.request"] ──
 # Must contain lyra.image.generate.request in the subscribe line

--- a/tests/nats/test_nats_image_client.py
+++ b/tests/nats/test_nats_image_client.py
@@ -88,7 +88,11 @@ class TestNatsImageClient:
         assert result.ok is True
         assert result.image_b64 is not None
         assert len(base64.b64decode(result.image_b64)) > 0
+        # record_success() was called — CB is neither failed nor open.
+        # Both fields are zero on a happy-path round-trip. Prior assertion
+        # only proved absence-of-failure; this pair proves success path ran.
         assert client._cb._failures == 0
+        assert client._cb._open_until == 0.0
 
     @pytest.mark.asyncio
     async def test_reply_schema_failure_raises_domain_error(self) -> None:
@@ -175,3 +179,60 @@ class TestNatsImageClient:
             await client.generate(prompt="test", engine="flux2-klein")
         # nc.request must never have been awaited
         mock_nc.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_circuit_raises_domain_error(self) -> None:
+        # Arrange — live worker registered; trip the CB so is_open() returns True
+        mock_nc = AsyncMock()
+        mock_nc.request = AsyncMock()
+        client = NatsImageClient(nc=mock_nc)
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        # Force CB open without going through real failures; mirrors the
+        # internal shape of NatsCircuitBreaker (see packages/roxabi-nats).
+        client._cb._open_until = time.monotonic() + 100.0
+        # Act / Assert
+        with pytest.raises(ImageUnavailableError, match="circuit open"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        # nc.request must never have been awaited — early-exit on is_open()
+        mock_nc.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ok_false_reply_propagates_error_field(self) -> None:
+        # Arrange — valid-schema reply with ok=false + a specific error token
+        mock_nc = AsyncMock()
+        err_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                "request_id": "r-err",
+                "ok": False,
+                "error": "insufficient_resources",
+                "error_detail": "Not enough VRAM to load engine",
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = err_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsImageClient(nc=mock_nc)
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        initial_failures = client._cb._failures
+        # Act / Assert — the error token must propagate into the exception
+        # message so logs/metrics on the hub side can disambiguate error codes.
+        with pytest.raises(ImageUnavailableError, match="insufficient_resources"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_raises_adapter_unreachable(self) -> None:
+        # Arrange — nc.request raises a generic Exception (not timeout, not
+        # max_payload). Exercises the fallback branch in _raise_nats_failure.
+        mock_nc = AsyncMock()
+        mock_nc.request = AsyncMock(side_effect=Exception("connection refused"))
+        client = NatsImageClient(nc=mock_nc)
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        initial_failures = client._cb._failures
+        # Act / Assert
+        with pytest.raises(ImageUnavailableError, match="adapter unreachable"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        assert client._cb._failures == initial_failures + 1

--- a/tests/nats/test_nats_image_client.py
+++ b/tests/nats/test_nats_image_client.py
@@ -1,0 +1,177 @@
+"""Tests for NatsImageClient — RED phase (T4).
+
+The module under test (lyra.nats.nats_image_client) does not exist yet.
+Imports intentionally fail with ModuleNotFoundError; T5 makes them pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lyra.nats.nats_image_client import (
+    ImageResponse,
+    ImageUnavailableError,
+    NatsImageClient,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok_reply_b64(request_id: str = "r1") -> bytes:
+    """Return a valid ImageResponse JSON payload with ok=True and image_b64 set."""
+    payload = {
+        "contract_version": "1",
+        "trace_id": "tst-trace",
+        "issued_at": "2026-04-19T00:00:00+00:00",
+        "ok": True,
+        "request_id": request_id,
+        "image_b64": base64.b64encode(b"fake-image-bytes").decode(),
+        "mime_type": "image/png",
+    }
+    return json.dumps(payload).encode()
+
+
+def _heartbeat_bytes(
+    worker_id: str = "img-1",
+    active: int = 0,
+    vram_used: int | None = None,
+) -> bytes:
+    """Return a heartbeat JSON payload; omit vram fields when vram_used is None."""
+    payload: dict = {
+        "contract_version": "1",
+        "trace_id": "t",
+        "issued_at": datetime.now(timezone.utc).isoformat(),
+        "worker_id": worker_id,
+        "service": "image",
+        "host": "test-host",
+        "subject": "lyra.image.generate.request",
+        "queue_group": "IMAGE_WORKERS",
+        "ts": time.time(),
+        "engine_loaded": "flux2-klein",
+        "active_requests": active,
+    }
+    if vram_used is not None:
+        payload["vram_used_mb"] = vram_used
+        payload["vram_total_mb"] = 16384
+    # vram_used_mb / vram_total_mb deliberately absent when vram_used is None
+    return json.dumps(payload).encode()
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+class TestNatsImageClient:
+    @pytest.mark.asyncio
+    async def test_happy_path_round_trip(self) -> None:
+        # Arrange — registry has a live worker; reply is a valid ImageResponse
+        mock_nc = AsyncMock()
+        fake_reply = MagicMock()
+        fake_reply.data = _ok_reply_b64("r1")
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsImageClient(nc=mock_nc)
+        # Seed registry with a live worker
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        # Act
+        result = await client.generate(prompt="test", engine="flux2-klein")
+        # Assert
+        assert isinstance(result, ImageResponse)
+        assert result.ok is True
+        assert result.image_b64 is not None
+        assert len(base64.b64decode(result.image_b64)) > 0
+        assert client._cb._failures == 0
+
+    @pytest.mark.asyncio
+    async def test_reply_schema_failure_raises_domain_error(self) -> None:
+        # Arrange — reply missing required `ok` field
+        mock_nc = AsyncMock()
+        bad_payload = json.dumps(
+            {
+                "contract_version": "1",
+                "trace_id": "tst-trace",
+                "issued_at": "2026-04-19T00:00:00+00:00",
+                # `ok` deliberately omitted — schema violation
+                "request_id": "r-bad",
+                "image_b64": base64.b64encode(b"img").decode(),
+            }
+        ).encode()
+        fake_reply = MagicMock()
+        fake_reply.data = bad_payload
+        mock_nc.request = AsyncMock(return_value=fake_reply)
+        client = NatsImageClient(nc=mock_nc)
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        initial_failures = client._cb._failures
+        # Act / Assert
+        with pytest.raises(ImageUnavailableError, match="(?i)schema"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_domain_error(self) -> None:
+        # Arrange — nc.request raises TimeoutError
+        mock_nc = AsyncMock()
+        mock_nc.request = AsyncMock(side_effect=TimeoutError())
+        client = NatsImageClient(nc=mock_nc)
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        initial_failures = client._cb._failures
+        # Act / Assert
+        with pytest.raises(ImageUnavailableError, match="(?i)timeout"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_request_max_payload_raises_domain_error(self) -> None:
+        # The satellite downgrades oversized replies to file_path, so only outbound
+        # requests over 1 MB surface this — this case covers request-direction only.
+
+        # Arrange — nc.request raises an exception whose str() contains "max_payload"
+        mock_nc = AsyncMock()
+        mock_nc.request = AsyncMock(
+            side_effect=Exception("NATS: max_payload exceeded (1048576 bytes)")
+        )
+        client = NatsImageClient(nc=mock_nc)
+        client._registry.record_heartbeat({"worker_id": "img-1", "active_requests": 0})
+        initial_failures = client._cb._failures
+        # Act / Assert
+        with pytest.raises(ImageUnavailableError, match="payload too large"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_updates_registry(self) -> None:
+        # Arrange — heartbeat payload without vram fields (optional-fields path)
+        mock_nc = AsyncMock()
+        client = NatsImageClient(nc=mock_nc)
+        msg_mock = MagicMock()
+        # vram_used_mb and vram_total_mb are absent to exercise the optional path
+        msg_mock.data = _heartbeat_bytes(worker_id="img-1", active=0, vram_used=None)
+        # Act
+        await client._on_heartbeat(msg_mock)
+        # Assert — worker is now reachable via the registry
+        entry = client._registry.pick_least_loaded()
+        assert entry is not None
+        assert entry.worker_id == "img-1"
+        # Absent vram fields must not prevent registry population
+        assert entry.vram_used_mb == 0
+        assert entry.vram_total_mb == 0
+
+    @pytest.mark.asyncio
+    async def test_stale_registry_raises_no_worker(self) -> None:
+        # Arrange — empty registry (no workers ever registered)
+        mock_nc = AsyncMock()
+        mock_nc.request = AsyncMock()
+        client = NatsImageClient(nc=mock_nc)
+        # Act / Assert
+        with pytest.raises(ImageUnavailableError, match="no live worker"):
+            await client.generate(prompt="test", engine="flux2-klein")
+        # nc.request must never have been awaited
+        mock_nc.request.assert_not_called()


### PR DESCRIPTION
## Summary
- Ships the lyra half of the image-domain NATS connector under ADR-047's ownership pattern (satellite-owned workers, lyra-owned contracts/publishers/nkeys). The imagecli satellite already shipped via imageCLI#50.
- New: ADR-050 (wire contract), `src/lyra/nats/nats_image_client.py` (hub publisher + inline Pydantic models extending `ContractEnvelope`), `image-worker` nkey + hub ACL extension, `imagecli_gen` supervisor entry via a new `command_override` field in the generator, Machine-1 smoke harness.
- Reconciliation: issue body lists `lyra.image.generate.heartbeat`; shipped satellite uses `lyra.image.heartbeat` — ADR-050 aligns to shipped and documents the one-way rewrite.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#754](https://github.com/Roxabi/lyra/issues/754): feat(nats): lyra-side image domain integration | OPEN |
| Frame | [artifacts/frames/754-lyra-image-domain-integration-frame.mdx](artifacts/frames/754-lyra-image-domain-integration-frame.mdx) | Approved (on staging) |
| Spec | [artifacts/specs/754-lyra-image-domain-integration-spec.mdx](artifacts/specs/754-lyra-image-domain-integration-spec.mdx) | Approved (on staging) |
| Plan | [artifacts/plans/754-lyra-image-domain-integration-plan.mdx](artifacts/plans/754-lyra-image-domain-integration-plan.mdx) | 16 tasks, 4 slices |
| Implementation | 1 commit on `feat/754-lyra-image-domain-integration` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (2779 pass, 69 skip, 0 fail; 9 new tests) | Passed |

## Slices

- **V1 Contract ADR-050** — subjects (`lyra.image.{generate.request,heartbeat}`), queue group `IMAGE_WORKERS`, envelopes, error codes, max-payload declaration (50 MB NATS cap + 750 KB b64 threshold + `file_path` fallback with shared-filesystem coupling), user-controlled-fields sanitization table. Cross-referenced from ADR-047 Relation section.
- **V2 Hub publisher** — `NatsImageClient` (start/generate/heartbeat registry/circuit breaker/payload-exceeded translation) + inline `ImageRequest`/`ImageResponse`/`ImageHeartbeat` extending `ContractEnvelope`. Subjects are `Literal[...]` dataclass attributes. 6 unit tests (happy path, schema failure, timeout, request-direction max_payload, heartbeat-with-optional-VRAM, stale registry).
- **V3 nkey + ACL** — `image-worker` identity added; hub ACL amended (PUB `lyra.image.generate.request`, SUB `lyra.image.heartbeat`). `test_gen_nkeys_acls.sh` extended with 5 assertions + fixed a pre-existing drift in `EXPECTED_PUB/SUB[hub]` (missing `.>` suffixes introduced by a prior commit).
- **V4 Supervisor + ADR-047 + smoke** — `gen-supervisor-conf.py` gains a `command_override` field (3 new subprocess tests: override + 2 fallbacks). `imagecli_gen` entry in `agents.yml` (startsecs=20, pending T15 re-measure on RTX 3080). ADR-047 ownership table amended (Image row → `image-worker [^img-shipped]`). `scripts/smoke/image-request.py` publishes one request + asserts `ok:true`.

## Test plan

- [ ] Reviewers: confirm ADR-050 structure matches ADR-044 (canonical voice contract).
- [ ] Reviewers: verify ACL matrix alignment with ADR-047 Rule 4 (max-payload declared, sanitization owner per field).
- [ ] Operator (Machine 1, post-merge): `sudo ./deploy/nats/gen-nkeys.sh --regenerate --yes` (rotates all seeds — pairs with the image-worker addition; all programs must restart under new seeds).
- [ ] Operator: `sudo systemctl reload nats.service`; reconnect voice/LLM satellites first (`make tts reload && make stt reload`), then a single `make lyra reload` to restart `lyra_hub + lyra_telegram + lyra_discord` together. (Previous guidance double-restarted telegram and discord — fixed per #804 review.)
- [ ] Operator: `make imagecli_gen start`; wait for `supervisorctl status imagecli_gen | grep RUNNING`. **T15 RTX 3080 re-measure note:** `flux2-klein` at 512×512 may exceed the 10 GB VRAM on Machine 1's RTX 3080 — if `imagecli_gen` fails to reach RUNNING within `startsecs=20` either (a) switch to a lighter engine for initial validation, (b) bump `startsecs` in `deploy/agents.yml` + re-run `make gen-conf`, or (c) leave `imagecli_gen` stopped (`autostart=false`) and defer until the workload lands on Machine 2 (RTX 5070 Ti, 16 GB VRAM).
- [ ] Operator: `NATS_URL=... NATS_NKEY_SEED_PATH=... python scripts/smoke/image-request.py > artifacts/rollout-evidence/754-image-smoke.txt`. Append `supervisorctl status imagecli_gen` + `scripts/check-nats-acls.sh --since <reload-ts>`. Commit evidence.
- [ ] Rollback path if smoke fails: restore `auth.conf.bak.{epoch}` + `~/.lyra/nkeys.bak.{epoch}/` pair atomically; reload nats; restart programs.

## Notes

- `packages/roxabi-contracts/tests/test_{fixture_provenance,voice_models,voice_testing_doubles}.py` have pre-existing `ModuleNotFoundError: numpy` — tests require the `[testing]` extra not installed by default `uv sync`. Unrelated to this PR.
- Other `conf.d/*.conf` files in this diff are benign regenerations — `make gen-conf` produces them from `agents.yml`; the diff is cosmetic env-var reordering from a prior drift in committed outputs. `make gen-conf` is now fully idempotent.
- Inline models in `nats_image_client.py` will be ported to `packages/roxabi-contracts/src/roxabi_contracts/image/` in a follow-up ticket (mirrors #763 for voice).

Closes #754.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
