### PR TITLE
fix(docker): stt/tts stubs emit ADR-049 ContractEnvelope payloads

### DIFF
--- a/docker/stubs/stt_stub.py
+++ b/docker/stubs/stt_stub.py
@@ -7,6 +7,11 @@ Subscribes to:
 
 Publishes:
   lyra.voice.stt.heartbeat         (every 5s)
+
+Response envelope matches `roxabi_contracts.voice.SttResponse`
+(ok, request_id, contract_version, trace_id, issued_at, text, language,
+duration_seconds) — per ADR-049. trace_id + request_id are echoed from
+the incoming SttRequest so call sites can correlate.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ import json
 import os
 import signal
 import time
+from datetime import datetime, timezone
 
 import nats
 
@@ -25,6 +31,7 @@ VRAM_USED = int(os.getenv("STT_STUB_VRAM_USED_MB", "2400"))
 VRAM_TOTAL = int(os.getenv("STT_STUB_VRAM_TOTAL_MB", "16384"))
 TRANSCRIPT = os.getenv("STT_STUB_TRANSCRIPT", "hello from stub")
 HB_INTERVAL = float(os.getenv("STT_STUB_HB_INTERVAL", "5"))
+CONTRACT_VERSION = "1"
 
 _active = 0
 _start = time.monotonic()
@@ -35,10 +42,19 @@ async def handle_request(msg: nats.aio.client.Msg) -> None:
     global _active
     _active += 1
     try:
+        try:
+            request = json.loads(msg.data)
+        except Exception:
+            request = {}
         response = {
+            "ok": True,
+            "contract_version": request.get("contract_version", CONTRACT_VERSION),
+            "trace_id": request.get("trace_id", "stub-trace"),
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "request_id": request.get("request_id", "stub-req"),
             "text": TRANSCRIPT,
             "language": "en",
-            "duration": 1.0,
+            "duration_seconds": 1.0,
             "error": None,
         }
         await msg.respond(json.dumps(response).encode())

--- a/docker/stubs/tts_stub.py
+++ b/docker/stubs/tts_stub.py
@@ -7,6 +7,10 @@ Subscribes to:
 
 Publishes:
   lyra.voice.tts.heartbeat         (every 5s)
+
+Response envelope matches `roxabi_contracts.voice.TtsResponse` (ok,
+request_id, contract_version, trace_id, issued_at, audio_b64, mime_type,
+duration_ms) — per ADR-049.
 """
 
 from __future__ import annotations
@@ -17,6 +21,7 @@ import json
 import os
 import signal
 import time
+from datetime import datetime, timezone
 
 import nats
 
@@ -25,6 +30,7 @@ WORKER_ID = os.getenv("TTS_STUB_WORKER_ID", "tts-stub-01")
 VRAM_USED = int(os.getenv("TTS_STUB_VRAM_USED_MB", "4800"))
 VRAM_TOTAL = int(os.getenv("TTS_STUB_VRAM_TOTAL_MB", "16384"))
 HB_INTERVAL = float(os.getenv("TTS_STUB_HB_INTERVAL", "5"))
+CONTRACT_VERSION = "1"
 
 # Minimal valid WAV: 44-byte header + 1 sample of silence
 _SILENT_WAV = (
@@ -43,11 +49,20 @@ async def handle_request(msg: nats.aio.client.Msg) -> None:
     global _active
     _active += 1
     try:
+        try:
+            request = json.loads(msg.data)
+        except Exception:
+            request = {}
         response = {
+            "ok": True,
+            "contract_version": request.get("contract_version", CONTRACT_VERSION),
+            "trace_id": request.get("trace_id", "stub-trace"),
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "request_id": request.get("request_id", "stub-req"),
             "audio_b64": _SILENT_WAV_B64,
             "mime_type": "audio/wav",
-            "duration": 0.01,
-            "waveform": None,
+            "duration_ms": 10,
+            "waveform_b64": None,
             "error": None,
         }
         await msg.respond(json.dumps(response).encode())


### PR DESCRIPTION
## Summary
- Docker STT/TTS stubs from #604 emit a legacy pre-envelope response shape (no `ok`, `request_id`, `contract_version`, `trace_id`, `issued_at`; `duration` instead of `duration_seconds` / `duration_ms`). After #732 tightened the hub client to validate replies against `SttResponse` / `TtsResponse` (ADR-049), every stub reply was being rejected at `_parse_reply` and surfacing as `STTUnavailableError` / `TTSUnavailableError`.
- Net effect before this PR: the compose-based integration environment (`make test-integration` / `docker/docker-compose.test.yml`) was broken for its intended purpose — no compose-backed integration test could reach a successful reply.
- Both stubs now parse the incoming request, echo `request_id` + `trace_id`, stamp `contract_version = "1"` + current `issued_at`, set `ok = true`, and use envelope-compliant field names.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Origin | Silent gap between #604 (stubs) and #732 (client envelope validation) | — |
| Implementation | 1 commit on `feat/733-integration-tests-load-aware-routing` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Pre-commit gates ✅ · Unit suite ✅ (2932 passed) | Passed |

## Test Plan
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -m "not nats_integration"` — 2932 passed, 76 skipped, no regressions
- [x] Manual: `docker compose -f docker/docker-compose.test.yml up -d --wait` + hub-client `transcribe()` call — now returns a valid `TranscriptionResult` instead of raising (verified locally during #733 exploration)

## Notes for reviewers
- Scope intentionally narrow — this is a drop-in envelope fix, not a routing change. Originally discovered while wiring #733's integration tests; that work is deferred until the follow-up registry-authoritative routing issue ships (see below).
- No production `src/` changes; only fixture code in `docker/stubs/`.
- Response-shape changes are additive on the success path; error-path fields were already `None`-compatible.

## Follow-ups filed
- **New issue** — `feat(voice): registry-authoritative STT/TTS routing — drop NATS queue-group fallback` (blocks #733). Rationale: `_request_with_fallback` currently assumes the queue-group delivers only to healthy subscribers, but a paused / partitioned worker keeps its queue subscription alive and races the healthy one. Proper fix is to make the hub registry authoritative and walk it on failure instead of delegating to the NATS queue-group balancer.
- **#733** — integration tests (original scope of this branch) stay open; work resumes after the arch fix lands. Worktree artifacts preserved at `/tmp/733-work-in-progress/` locally for reference.

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`