### PR TITLE
fix(test): TtsRequest speed assertion should compare strings

### DIFF
--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -173,7 +173,7 @@ class TestCircuitBreaker:
         payload_bytes = call_args.args[1]
         request_dict = json.loads(payload_bytes)
         assert request_dict["engine"] == "chatterbox"
-        assert request_dict["speed"] == 1.2
+        assert request_dict["speed"] == "1.2"
         # contract_version is always stamped (ADR-044)
         assert request_dict["contract_version"] == "1"
         # All unset fields (None) must be absent from the NATS payload


### PR DESCRIPTION
## Summary

One-line hotfix for a broken assertion introduced in fcd8cec which changed `TtsRequest.speed: float → str` without updating the matching test.

```python
# Before
assert request_dict["speed"] == 1.2
# After
assert request_dict["speed"] == "1.2"
```

Discovered while rebasing #831 onto latest staging — CI failed on an otherwise-unrelated PR.

## Test Plan
- [x] `uv run pytest tests/nats/test_nats_tts_client.py::TestCircuitBreaker::test_agent_tts_fields_forwarded_in_request` → 1 passed

---
Generated with [Claude Code](https://claude.com/claude-code)