### PR TITLE
chore(ci): split secrets (TruffleHog) scan into standalone workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,16 +97,3 @@ jobs:
       - name: Tear down Docker environment
         if: always()
         run: docker compose -f docker/docker-compose.test.yml down -v
-
-  secrets:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: TruffleHog secret scan
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
-        with:
-          extra_args: --only-verified

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,29 @@
+name: Secret Scan
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  workflow_dispatch: {}
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: false   # never preempt a security scan
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog secret scan
+        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6  # v3.94.3
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
## Summary
- Move `secrets` job from ci.yml to dedicated secret-scan.yml workflow
- Add independent concurrency block with `cancel-in-progress: false`
- Ensures every pushed SHA has a completed TruffleHog scan status

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #803: split secrets (TruffleHog) scan into standalone workflow | OPEN |
| Analysis | — | S-tier |
| Spec | — | S-tier |
| Implementation | 1 commit on `feat/803-split-secrets-scan` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ | Passed |

## Test Plan
- [ ] Verify new workflow triggers on push to staging/main
- [ ] Confirm TruffleHog runs with `fetch-depth: 0`
- [ ] Rapid second push does not cancel in-flight scan (acceptance criteria #3)

Closes #803

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`