### PR TITLE
ci(coverage): enable --cov-branch for all coverage steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,13 @@ jobs:
         run: uv run pyright
 
       - name: Coverage — lyra
-        run: uv run pytest tests/ --cov=lyra --cov-report=term-missing --cov-fail-under=50
+        run: uv run pytest tests/ --cov=lyra --cov-branch --cov-report=term-missing --cov-fail-under=50
 
       - name: Coverage — roxabi_nats
-        run: uv run pytest packages/roxabi-nats/tests --cov=roxabi_nats --cov-report=term-missing --cov-fail-under=70
+        run: uv run pytest packages/roxabi-nats/tests --cov=roxabi_nats --cov-branch --cov-report=term-missing --cov-fail-under=70
 
       - name: Coverage — roxabi_contracts
-        run: uv run pytest packages/roxabi-contracts/tests --cov=roxabi_contracts --cov-report=term-missing --cov-fail-under=80
+        run: uv run pytest packages/roxabi-contracts/tests --cov=roxabi_contracts --cov-branch --cov-report=term-missing --cov-fail-under=80
 
       - name: Test dep-graph sub-project
         working-directory: scripts/dep-graph


### PR DESCRIPTION
## Summary
- Adds `--cov-branch` flag to all three coverage steps in CI (lyra, roxabi_nats, roxabi_contracts)
- Branch coverage surfaces missing else paths, unchecked exception handlers, and short-circuit edge cases

Branch coverage actuals (measured locally):
| Package | Branch | Threshold | Policy Check |
|---|---:|---:|---|
| lyra | 85% | 50 | min(50, 83) = 50 ✓ |
| roxabi_nats | 83% | 70 | min(70, 81) = 70 ✓ |
| roxabi_contracts | 83% | 80 | min(80, 81) = 80 ✓ |

All thresholds remain valid — no changes needed.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #801: ci(coverage): enable --cov-branch and re-pin thresholds | OPEN |
| Implementation | 1 commit on `feat/801-cov-branch-enable` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ | Passed |

## Test Plan
- [ ] CI passes on this PR (coverage gates should pass with branch coverage enabled)

Closes #801

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`