### PR TITLE
ci(coverage): install nats-server for roxabi_contracts tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,17 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install -y portaudio19-dev
 
+      - name: Install nats-server
+        env:
+          NATS_VERSION: "2.10.22"
+        run: |
+          ARCH=$(dpkg --print-architecture)
+          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
+            | tar -xz -C /tmp
+          sudo install -m 755 /tmp/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server /usr/local/bin/nats-server
+          nats-server --version
+
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,14 @@ jobs:
         run: |
           ARCH=$(dpkg --print-architecture)
           TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
+          TMPDIR=$(mktemp -d)
           curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
-            | tar -xz -C /tmp
-          sudo install -m 755 /tmp/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server /usr/local/bin/nats-server
+            -o "${TMPDIR}/${TARBALL}"
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
+            -o "${TMPDIR}/SHA256SUMS"
+          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
+          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
           nats-server --version
 
       - name: Install uv


### PR DESCRIPTION
## Summary
- Install nats-server binary in CI before running coverage steps
- Enables tests marked with `@requires_nats_server` to execute instead of skip
- Closes coverage gap where skipped tests inflated coverage denominator

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #800: ci(coverage): install nats-server in CI | Open |
| Implementation | 1 commit on `worktree-800-ci-nats-server` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ | Passed |

## Test Plan
- [ ] CI runs with nats-server installed
- [ ] `@requires_nats_server` tests execute (no longer skip)
- [ ] Coverage reflects actual test execution

Closes #800

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`