### PR TITLE
feat(dep-graph): drive matrix config from layout.json

### DIFF
--- a/artifacts/analyses/827-dep-graph-matrix-config-consensus.mdx
+++ b/artifacts/analyses/827-dep-graph-matrix-config-consensus.mdx
@@ -1,0 +1,84 @@
+---
+title: "PR #842 post-review policy — Expert Consensus"
+issue: 827
+status: consensus-reached
+date: 2026-04-21
+panel: architect, backend-dev, tester
+confidence: high
+---
+
+## Problem
+
+PR #842 closes acceptance criterion 3a of #827 by making `milestones[]` and `column_groups[]` optional `layout.json` keys overriding Python defaults. Code review surfaced 0 blockers + 4 non-blocking design calls + 3 coverage gaps. All 4 design calls share one policy axis: **how defensive should this internal dev-tool config pipeline be?** Panel convened to settle the policy and the coverage implications.
+
+## Panel
+
+| α | Focus |
+|---|-------|
+| architect | soundness, maintainability, cohesion, forward-compat |
+| backend-dev | Python idioms, API clarity, implementation complexity |
+| tester | coverage strategy, test quality, regression protection |
+
+## Consensus Ruling
+
+**Meta-policy:** The dev-tool's `layout.json` is dev-authored and runs locally; `make dep-graph validate` (jsonschema) is the declared validation gate. Per lyra's global patterns ("Don't add error handling for scenarios that can't happen"), defensive guards inside the data-loading pipeline are YAGNI. Fail-fast at render time is the correct design signal.
+
+### Design findings
+
+| # | Finding | Ruling | Vote |
+|---|---------|--------|------|
+| F2 | `layout_graph.py` module-level `LANE_ORDER` / `MS_CODES` fallbacks | **A — keep** | 2-1 (tester dissent) |
+| F3 | `parse_*` bare `KeyError` on malformed input | **C — do nothing** | unanimous |
+| F8 | `data.lane_by_code[c]` fail-fast on absent lane | **A — document fail-fast with a test** | unanimous |
+| F9 | `GraphData` dual defaults (`default_factory` + explicit assign) | **A — remove `default_factory`, require fields** | unanimous |
+
+### Coverage findings
+
+| # | Gap | Ruling | Vote |
+|---|-----|--------|------|
+| F5 | `graph.render` with custom `milestones` override | **Must add** | unanimous |
+| F6 | `layout_grid(tasks, lane_order=..., ms_codes=...)` kwargs | **Add narrow unit tests** | 2-1 (backend-dev=YAGNI) |
+| F7 | `test_schema.py` fixture populating new keys | **Skip (YAGNI)** | 2-1 (tester=Should, weak) |
+
+## Rationale
+
+The panel converged on "trust the system boundary" as the governing principle:
+
+- **F3 unanimous C:** `jsonschema.validate` is already the declared gate via `make dep-graph validate`. Adding `isinstance` guards inside parsers duplicates validation and hides the gate's role. Raw `KeyError` with traceback is adequate for a dev audience.
+- **F8 unanimous A:** absent-lane is a `layout.json` authoring bug; silent `.get()` would produce malformed HTML. A test locking the `KeyError` contract prevents a "helpful" future soft-fail refactor.
+- **F9 unanimous A:** `default_factory` serves only direct-instantiation tests; `load_from_dicts` always sets the fields. Single source of truth wins. Tests can pass `list(COLUMN_GROUPS)` / `list(MILESTONES)` explicitly when they want defaults.
+- **F2 majority A:** module-level defaults ARE the defaults, not a separate source of truth. Forcing kwargs on callers adds coupling; only one caller exists (`graph.render`) and it already passes them.
+
+### Coverage follows from rulings
+
+F8 mandates a test; F5 exercises the override path end-to-end through the untested graph view; F6 pins the kwargs contract with cheap unit tests that also cover F8's absent-lane case. F7 is declined — the schema-layer test is an orthogonal concern and no schema bug exists.
+
+## Alternatives
+
+| Option | Proposer | Rejected because |
+|--------|----------|------------------|
+| F2-B: remove module fallbacks | tester | 2/3 panel viewed it as YAGNI; breaks direct test calls for zero production benefit |
+| F3-A: `ValueError` guards | (none voted for) | duplicates jsonschema |
+| F3-B: auto-validate in `load_from_dicts` | (none voted for) | adds runtime dep to hot path |
+| F8-B: soft-fail with `.get()` | (none voted for) | silently produces broken HTML |
+| F9-B: `__post_init__` assertion | (none voted for) | keeps dual paths, just asserts |
+| F7: schema fixture | tester (weak) | schema layer test is secondary; no regression risk |
+
+## Dissent
+
+- **F2 (tester):** testability concern — fallbacks enable tests to "pass" using stale defaults, hiding override-path coverage gaps. Majority noted this is mitigated by F6 (explicit kwarg tests) being added under the same consensus.
+
+## Implementation Notes
+
+Apply in order as a single commit:
+
+1. **F9** — in `v5/data/model.py`, change `column_groups: list[...] = field(default_factory=lambda: list(COLUMN_GROUPS))` to `column_groups: list[...]` (required); same for `milestones`. Update `conftest.py` and any direct-instantiation tests to pass explicit values.
+2. **F5** — in `v5/tests/test_views_graph.py`, add `TestGraphRenderLayoutOverride` class: custom 2-milestone layout → `graph.render(data)` → assert custom codes appear in `gg-msrow` output.
+3. **F6** — in `v5/tests/test_layout_graph.py`, add narrow unit tests for `layout_grid(tasks, lane_order=X, ms_codes=Y)` and `ms_idx("P1", ["P1", "P2"])`.
+4. **F8** — add a single test: `column_groups` override lists a lane absent from `lanes[]` → `grid.render(data)` raises `KeyError`.
+
+Then final push + `reviewed` label + PR comment. Skip F2/F3/F7 — no code changes.
+
+## Next
+
+Return to `/fix` Phase 6 (apply 1b1 decisions) with this ruling → Phase 7 final push + label → Phase 8 PR comment → `/dev` advances to `cleanup`.

--- a/scripts/dep-graph/README.md
+++ b/scripts/dep-graph/README.md
@@ -51,7 +51,30 @@ python -m dep_graph.cli build \
 
 See `layout.schema.json` for the full JSON Schema (Draft 7).
 
-Key fields:
+### Matrix config (optional): `milestones` + `column_groups`
+
+The v5 grid view renders a milestone × column_group matrix. Defaults live in `v5/data/model.py` (`MILESTONES`, `COLUMN_GROUPS`) and cover the current lyra roadmap (M0–M10 + Final, 15 columns a1–o). Override either list from `layout.json` to drive the matrix from config — useful when lane/milestone shape drifts on GitHub and you'd rather bump the layout than edit Python.
+
+Both keys are optional and independent (set one, the other, or both). When absent, the module defaults apply.
+
+```json
+{
+  "milestones": [
+    {"label": "M0  NATS hardening", "code": "M0", "short": "NATS hardening"},
+    {"label": "M1  Containerize",   "code": "M1", "short": "Containerize"}
+  ],
+  "column_groups": [
+    {"label": "NATS",      "tone": "a1", "lane_codes": ["a1", "a2", "a3"]},
+    {"label": "CONTAINER", "tone": "b",  "lane_codes": ["b"]}
+  ]
+}
+```
+
+- `milestones[].label` must match the GitHub milestone title with em-dashes stripped to double-space (same rule as the hardcoded defaults). `code` is the short code (`M0`), `short` is the row-header display name.
+- `column_groups[].lane_codes` lists the 1+ lane codes bundled under one column. `tone` is the CSS tone key used for the header color.
+- Visible issues lacking a milestone or lane land in sentinel `NO_MS` row / `NO_LANE` column — auto-hidden when empty, rendered when non-empty.
+
+### Other key fields
 
 ```json
 {

--- a/scripts/dep-graph/layout.schema.json
+++ b/scripts/dep-graph/layout.schema.json
@@ -77,6 +77,38 @@
         }
       }
     },
+    "milestones": {
+      "description": "OPTIONAL: milestone rows for the grid view. When absent, falls back to hardcoded defaults in v5/data/model.py::MILESTONES. 'label' must match the GitHub milestone title (em-dashes stripped to double-space); 'code' is the short code (e.g. 'M0'); 'short' is the display name for row headers.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "code", "short"],
+        "additionalProperties": false,
+        "properties": {
+          "label": { "type": "string" },
+          "code":  { "type": "string" },
+          "short": { "type": "string" }
+        }
+      }
+    },
+    "column_groups": {
+      "description": "OPTIONAL: column groups for the grid view. When absent, falls back to hardcoded defaults in v5/data/model.py::COLUMN_GROUPS. Each group bundles 1+ lane codes under a single column header. 'tone' is the CSS tone key used for the header color.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "tone", "lane_codes"],
+        "additionalProperties": false,
+        "properties": {
+          "label":      { "type": "string" },
+          "tone":       { "type": "string" },
+          "lane_codes": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
     "standalone": {
       "description": "OPTIONAL: standalone section. When order[] is absent, empty, or the entire object is {} (all three forms are equivalent), the section is auto-derived from graph:standalone labels.",
       "type": "object",

--- a/scripts/dep-graph/v5/compose.py
+++ b/scripts/dep-graph/v5/compose.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from .components.header import render_footer
 from .components.toggle import render_toggle
 from .components.toolbar import render_toolbar
-from .data.model import COLUMN_GROUPS, MILESTONES, GraphData
+from .data.model import GraphData
 from .views import graph as graph_view
 from .views import grid as grid_view
 
@@ -41,7 +41,7 @@ def _read_assets(names: tuple[str, ...]) -> str:
 def _subtitle(data: GraphData) -> str:
     c = data.counts
     return (
-        f"{len(MILESTONES)} milestones × {len(COLUMN_GROUPS)} columns · "
+        f"{len(data.milestones)} milestones × {len(data.column_groups)} columns · "
         f"{c.get('ready', 0)} ready · {c.get('blocked', 0)} blocked · "
         f"{c.get('done', 0)} done · {data.total} total · "
         f"toggle Graph/Table · hover a card to trace its dep chain"

--- a/scripts/dep-graph/v5/data/derive.py
+++ b/scripts/dep-graph/v5/data/derive.py
@@ -125,7 +125,9 @@ def tasks_for_graph(data: GraphData) -> list[dict[str, Any]]:
     status, milestone, lane, size, depth, blockers, unblocks.
     """
     col_of_lane = {c: label for label, _, codes in data.column_groups for c in codes}
+    # full_label → code (first → second tuple field)
     ms_short = {k: short for k, short, _ in data.milestones}
+    # code → short display label (via property)
     ms_name_by_code = data.ms_name_by_code
 
     tasks: list[dict[str, Any]] = []

--- a/scripts/dep-graph/v5/data/derive.py
+++ b/scripts/dep-graph/v5/data/derive.py
@@ -5,9 +5,6 @@ from collections import defaultdict
 from typing import Any
 
 from .model import (
-    COLUMN_GROUPS,
-    MILESTONES,
-    MS_NAME_BY_CODE,
     NO_LANE,
     NO_MS,
     GraphData,
@@ -127,8 +124,9 @@ def tasks_for_graph(data: GraphData) -> list[dict[str, Any]]:
     Keys match what v4/v4.5 layout math expects: num, title, url, state,
     status, milestone, lane, size, depth, blockers, unblocks.
     """
-    col_of_lane = {c: label for label, _, codes in COLUMN_GROUPS for c in codes}
-    ms_short = {k: short for k, short, _ in MILESTONES}
+    col_of_lane = {c: label for label, _, codes in data.column_groups for c in codes}
+    ms_short = {k: short for k, short, _ in data.milestones}
+    ms_name_by_code = data.ms_name_by_code
 
     tasks: list[dict[str, Any]] = []
     for key, iss in data.issues.items():
@@ -146,7 +144,7 @@ def tasks_for_graph(data: GraphData) -> list[dict[str, Any]]:
             "state": iss["state"],
             "status": status_of(iss, data.issues),
             "milestone": ms_short.get(ms, ms),
-            "milestone_name": MS_NAME_BY_CODE.get(ms_short.get(ms, ms), ms),
+            "milestone_name": ms_name_by_code.get(ms_short.get(ms, ms), ms),
             "lane": lane,
             "lane_name": lmeta.name if lmeta else "",
             "column": col_of_lane.get(lane, ""),

--- a/scripts/dep-graph/v5/data/layout_graph.py
+++ b/scripts/dep-graph/v5/data/layout_graph.py
@@ -19,7 +19,9 @@ from typing import Any
 
 from .model import COLUMN_GROUPS, MS_CODES
 
-# ─── Lane ordering (determines within-band tie-break) ───────────────────────
+# Default lane ordering (determines within-band tie-break). Computed from the
+# module-level defaults; callers that need a non-default order pass `lane_order`
+# explicitly into layout_grid / ms_idx.
 LANE_ORDER: list[str] = [code for _, _, codes in COLUMN_GROUPS for code in codes]
 
 # ─── Positioning constants ──────────────────────────────────────────────────
@@ -37,16 +39,18 @@ MAX_CELL_WIDTH_PCT = 4.0  # cap so small milestones don't stretch to full width
 
 # ─── Pure helpers ───────────────────────────────────────────────────────────
 
-def _lane_idx(lane_code: str) -> int:
+def _lane_idx(lane_code: str, lane_order: list[str] | None = None) -> int:
+    order = lane_order if lane_order is not None else LANE_ORDER
     try:
-        return LANE_ORDER.index(lane_code)
+        return order.index(lane_code)
     except ValueError:
-        return len(LANE_ORDER)
+        return len(order)
 
 
-def ms_idx(ms: str | None) -> int:
-    if ms in MS_CODES:
-        return MS_CODES.index(ms)
+def ms_idx(ms: str | None, ms_codes: list[str] | None = None) -> int:
+    codes = ms_codes if ms_codes is not None else MS_CODES
+    if ms in codes:
+        return codes.index(ms)
     return 99
 
 
@@ -160,11 +164,17 @@ def _place_ms_band(band_tasks: list[dict[str, Any]], ctx: _Placement) -> None:
 
 def layout_grid(
     tasks: list[dict[str, Any]],
+    *,
+    lane_order: list[str] | None = None,
+    ms_codes: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, int]]:
     """Returns (node_records, band_records, grid_size_per_ms).
 
     node record:  {task, x, y, lane_tone}
     band record:  {ms, depth, y, tasks, count}
+
+    `lane_order` / `ms_codes` override the module-level defaults when the
+    caller has layout.json-driven config.
     """
     by_ms: dict[str, dict[int, list[dict[str, Any]]]] = defaultdict(
         lambda: defaultdict(list),
@@ -179,7 +189,7 @@ def layout_grid(
 
     cell_of_num: dict[int, int] = {}
     x_of_num: dict[int, float] = {}
-    for ms in sorted(by_ms.keys(), key=ms_idx):
+    for ms in sorted(by_ms.keys(), key=lambda m: ms_idx(m, ms_codes)):
         ctx = _Placement(
             all_tasks=tasks,
             ms=ms,
@@ -190,13 +200,13 @@ def layout_grid(
         for depth in sorted(by_ms[ms].keys()):
             band_tasks = sorted(
                 by_ms[ms][depth],
-                key=lambda t: (_lane_idx(t["lane"]), t.get("num", 0)),
+                key=lambda t: (_lane_idx(t["lane"], lane_order), t.get("num", 0)),
             )
             _place_ms_band(band_tasks, ctx)
 
     sorted_band_keys: list[tuple[str, int]] = sorted(
         {(t.get("milestone") or "M9", t.get("depth", 0)) for t in tasks},
-        key=lambda k: (ms_idx(k[0]), k[1]),
+        key=lambda k: (ms_idx(k[0], ms_codes), k[1]),
     )
     n_bands = len(sorted_band_keys)
     step_y = (Y_BOT - Y_TOP) / max(n_bands - 1, 1)

--- a/scripts/dep-graph/v5/data/load.py
+++ b/scripts/dep-graph/v5/data/load.py
@@ -12,7 +12,15 @@ from .derive import (
     epic_keys,
     lane_by_code,
 )
-from .model import EpicMeta, GraphData, Lane
+from .model import (
+    COLUMN_GROUPS,
+    MILESTONES,
+    EpicMeta,
+    GraphData,
+    Lane,
+    parse_column_groups,
+    parse_milestones,
+)
 
 FORGE = Path.home() / ".roxabi/forge/lyra/visuals"
 LAYOUT_PATH = FORGE / "lyra-v2-dependency-graph.layout.json"
@@ -61,11 +69,24 @@ def load_from_dicts(layout: dict[str, Any], gh: dict[str, Any]) -> GraphData:
     depth = compute_depth(issues)
     visible = compute_visible(issues, primary_repo)
 
+    column_groups = (
+        parse_column_groups(layout["column_groups"])
+        if "column_groups" in layout
+        else list(COLUMN_GROUPS)
+    )
+    milestones = (
+        parse_milestones(layout["milestones"])
+        if "milestones" in layout
+        else list(MILESTONES)
+    )
+
     data = GraphData(
         meta=layout["meta"],
         lanes=lanes,
         lane_by_code=lane_by_code(lanes),
         issues=issues,
+        column_groups=column_groups,
+        milestones=milestones,
         epic_keys=ekeys,
         visible=visible,
         depth_by_key=depth,

--- a/scripts/dep-graph/v5/data/model.py
+++ b/scripts/dep-graph/v5/data/model.py
@@ -52,6 +52,28 @@ NO_MS: str = "__nomilestone__"
 NO_LANE: str = "__nolane__"
 
 
+# ─── Layout-driven config parsers ───────────────────────────────────────────
+
+def parse_column_groups(
+    raw: list[dict[str, Any]],
+) -> list[tuple[str, str, list[str]]]:
+    """Parse layout.json column_groups[] → internal tuple form."""
+    return [
+        (item["label"], item["tone"], list(item["lane_codes"]))
+        for item in raw
+    ]
+
+
+def parse_milestones(
+    raw: list[dict[str, Any]],
+) -> list[tuple[str, str, str]]:
+    """Parse layout.json milestones[] → internal tuple form."""
+    return [
+        (item["label"], item["code"], item["short"])
+        for item in raw
+    ]
+
+
 # ─── Domain dataclasses ─────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
@@ -77,6 +99,13 @@ class GraphData:
     lane_by_code: dict[str, Lane]
     # Raw issue dicts keyed by "owner/repo#N" — shape matches gh.json.
     issues: dict[str, dict[str, Any]]
+    # Effective matrix config — overridable via layout.json, else module defaults.
+    column_groups: list[tuple[str, str, list[str]]] = field(
+        default_factory=lambda: list(COLUMN_GROUPS)
+    )
+    milestones: list[tuple[str, str, str]] = field(
+        default_factory=lambda: list(MILESTONES)
+    )
     # Cell matrix: (ms_label, lane_code) → [issue dicts], excludes epics.
     matrix: dict[tuple[str, str], list[dict[str, Any]]] = field(default_factory=dict)
     epic_keys: set[str] = field(default_factory=set)
@@ -94,6 +123,14 @@ class GraphData:
     @property
     def primary_repo(self) -> str:
         return self.meta["repos"][0]
+
+    @property
+    def ms_codes(self) -> list[str]:
+        return [code for _, code, _ in self.milestones]
+
+    @property
+    def ms_name_by_code(self) -> dict[str, str]:
+        return {code: name for _, code, name in self.milestones}
 
 
 def ref_key(ref: dict[str, Any]) -> str:

--- a/scripts/dep-graph/v5/data/model.py
+++ b/scripts/dep-graph/v5/data/model.py
@@ -7,6 +7,8 @@ from typing import Any
 # ─── Static configuration (project-level) ───────────────────────────────────
 
 # Column grouping — each tuple is (label, tone_key, [lane_codes]).
+# Tuple positions are load-bearing: parse_column_groups and every consumer
+# unpacks by position; do not reorder without updating all call sites.
 COLUMN_GROUPS: list[tuple[str, str, list[str]]] = [
     ("NATS",      "a1", ["a1", "a2", "a3"]),
     ("CONTAINER", "b",  ["b"]),
@@ -25,8 +27,11 @@ COLUMN_GROUPS: list[tuple[str, str, list[str]]] = [
     ("FINAL",     "e",  ["o"]),
 ]
 
-# Milestones — (full label, code, short name).
-# NOTE: full label matches GitHub title with em-dashes stripped (double-space).
+# Milestones — (full_label, code, short_display).
+# Tuple positions are load-bearing: parse_milestones and every consumer
+# unpacks by position; do not reorder without updating all call sites.
+# NOTE: full_label matches GitHub title with em-dashes stripped (double-space).
+#       short_display is the row-header label used by the grid view (indexed by ms_name_by_code).
 MILESTONES: list[tuple[str, str, str]] = [
     ("M0  NATS hardening",               "M0",  "NATS hardening"),
     ("M1  NATS maturity  containerize",  "M1",  "NATS maturity / containerize"),
@@ -130,7 +135,18 @@ class GraphData:
 
     @property
     def ms_name_by_code(self) -> dict[str, str]:
+        """Map milestone code → short display label (position 2 of the tuple).
+
+        Name kept for backward-compat with the module-level `MS_NAME_BY_CODE`
+        constant; despite "name", the value is the short display string used
+        by row headers, not the full milestone label.
+        """
         return {code: name for _, code, name in self.milestones}
+
+    @property
+    def lane_order(self) -> list[str]:
+        """Flat lane-code order derived from column_groups (tie-break for graph layout)."""
+        return [code for _, _, codes in self.column_groups for code in codes]
 
 
 def ref_key(ref: dict[str, Any]) -> str:

--- a/scripts/dep-graph/v5/data/model.py
+++ b/scripts/dep-graph/v5/data/model.py
@@ -105,12 +105,11 @@ class GraphData:
     # Raw issue dicts keyed by "owner/repo#N" — shape matches gh.json.
     issues: dict[str, dict[str, Any]]
     # Effective matrix config — overridable via layout.json, else module defaults.
-    column_groups: list[tuple[str, str, list[str]]] = field(
-        default_factory=lambda: list(COLUMN_GROUPS)
-    )
-    milestones: list[tuple[str, str, str]] = field(
-        default_factory=lambda: list(MILESTONES)
-    )
+    # Required: load_from_dicts always sets these explicitly; direct-instantiation
+    # callers must pass `list(COLUMN_GROUPS)` / `list(MILESTONES)` when they want
+    # defaults. Single source of truth — no default_factory divergence risk.
+    column_groups: list[tuple[str, str, list[str]]]
+    milestones: list[tuple[str, str, str]]
     # Cell matrix: (ms_label, lane_code) → [issue dicts], excludes epics.
     matrix: dict[tuple[str, str], list[dict[str, Any]]] = field(default_factory=dict)
     epic_keys: set[str] = field(default_factory=set)

--- a/scripts/dep-graph/v5/tests/test_derive.py
+++ b/scripts/dep-graph/v5/tests/test_derive.py
@@ -11,7 +11,7 @@ from v5.data.derive import (
     status_of,
     tasks_for_graph,
 )
-from v5.data.model import EpicMeta, GraphData, Lane
+from v5.data.model import COLUMN_GROUPS, MILESTONES, EpicMeta, GraphData, Lane
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -55,6 +55,8 @@ def _minimal_data(issues: dict, epic_ks: set | None = None) -> GraphData:
         lanes=lanes,
         lane_by_code=lbc,
         issues=issues,
+        column_groups=list(COLUMN_GROUPS),
+        milestones=list(MILESTONES),
         epic_keys=epic_ks or set(),
         visible=set(issues.keys()),
         depth_by_key=compute_depth(issues),

--- a/scripts/dep-graph/v5/tests/test_layout_graph.py
+++ b/scripts/dep-graph/v5/tests/test_layout_graph.py
@@ -47,6 +47,20 @@ class TestMsIdx:
     def test_ordering_preserved(self):
         assert ms_idx("M0") < ms_idx("M1") < ms_idx("M2") < ms_idx("M5")
 
+    def test_custom_ms_codes_override_defaults(self):
+        # With explicit ms_codes, the function honors the override instead of MS_CODES.
+        assert ms_idx("P1", ["P0", "P1", "P2"]) == 1
+        assert ms_idx("P0", ["P0", "P1", "P2"]) == 0
+        assert ms_idx("P2", ["P0", "P1", "P2"]) == 2
+
+    def test_custom_ms_codes_unknown_returns_99(self):
+        # A default-list code not in the custom list → 99.
+        assert ms_idx("M0", ["P0", "P1"]) == 99
+
+    def test_empty_ms_codes_list(self):
+        # Explicit empty list treats everything as unknown.
+        assert ms_idx("M0", []) == 99
+
 
 # ─── edge_path ───────────────────────────────────────────────────────────────
 
@@ -244,3 +258,55 @@ class TestMsVerticalExtents:
         m0_top, _ = extents["M0"]
         m1_top, _ = extents["M1"]
         assert m0_top != m1_top
+
+
+class TestLayoutGridKwargs:
+    """layout_grid honors explicit lane_order / ms_codes (overrides over defaults)."""
+
+    def test_custom_ms_codes_band_ordering(self):
+        # Two milestones, custom codes. Bands must order per the ms_codes list.
+        tasks = [
+            _make_task(1, "P0", "a1", 0),
+            _make_task(2, "P1", "a1", 0),
+        ]
+        _, bands, _ = layout_grid(tasks, ms_codes=["P0", "P1"])
+        # band order follows ms_codes order (P0 before P1)
+        ms_seen = [b["ms"] for b in bands]
+        assert ms_seen == ["P0", "P1"]
+
+    def test_reversed_ms_codes_reverses_band_order(self):
+        tasks = [
+            _make_task(1, "P0", "a1", 0),
+            _make_task(2, "P1", "a1", 0),
+        ]
+        _, bands, _ = layout_grid(tasks, ms_codes=["P1", "P0"])
+        ms_seen = [b["ms"] for b in bands]
+        assert ms_seen == ["P1", "P0"]
+
+    def test_custom_lane_order_affects_depth_0_placement(self):
+        # Two tasks at depth 0, same milestone. lane_order determines
+        # within-band tie-break → cell index mirrors the custom order.
+        tasks = [
+            _make_task(1, "P0", "a1", 0),
+            _make_task(2, "P0", "b", 0),
+        ]
+        # Default-ish lane_order: 'a1' before 'b'.
+        nodes_default, _, _ = layout_grid(
+            tasks, lane_order=["a1", "b"], ms_codes=["P0"],
+        )
+        # Reversed order — 'b' before 'a1'.
+        nodes_reversed, _, _ = layout_grid(
+            tasks, lane_order=["b", "a1"], ms_codes=["P0"],
+        )
+        x_by_num_default = {n["task"]["num"]: n["x"] for n in nodes_default}
+        x_by_num_reversed = {n["task"]["num"]: n["x"] for n in nodes_reversed}
+        # In default order task #1 (a1) is left of #2 (b); reversed flips.
+        assert x_by_num_default[1] < x_by_num_default[2]
+        assert x_by_num_reversed[2] < x_by_num_reversed[1]
+
+    def test_kwargs_default_to_module_when_none(self):
+        # Omitting kwargs uses module-level LANE_ORDER / MS_CODES.
+        tasks = [_make_task(1, "M0", "a1", 0)]
+        nodes, bands, _ = layout_grid(tasks)
+        assert len(nodes) == 1
+        assert bands[0]["ms"] == "M0"

--- a/scripts/dep-graph/v5/tests/test_load.py
+++ b/scripts/dep-graph/v5/tests/test_load.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 
 from v5.data.load import load_from_dicts
-from v5.data.model import GraphData
+from v5.data.model import COLUMN_GROUPS, MILESTONES, GraphData
 
 
 class TestLoadFromDicts:
@@ -104,3 +104,59 @@ class TestLoadFromDicts:
         data = load_from_dicts(layout, gh)
         assert data.meta["title"] == "Lyra v2 dep graph"
         assert data.meta["date"] == "2026-04-20"
+
+
+class TestLayoutDrivenMatrixConfig:
+    """layout.json milestones + column_groups override module defaults."""
+
+    def test_defaults_when_absent(self, layout, gh):
+        # Fixture layout has neither 'milestones' nor 'column_groups' keys
+        data = load_from_dicts(layout, gh)
+        assert data.column_groups == list(COLUMN_GROUPS)
+        assert data.milestones == list(MILESTONES)
+
+    def test_column_groups_override(self, layout, gh):
+        custom = dict(layout)
+        custom["column_groups"] = [
+            {"label": "ALPHA", "tone": "a1", "lane_codes": ["a1", "a2"]},
+            {"label": "BETA",  "tone": "b",  "lane_codes": ["b"]},
+        ]
+        data = load_from_dicts(custom, gh)
+        assert data.column_groups == [
+            ("ALPHA", "a1", ["a1", "a2"]),
+            ("BETA",  "b",  ["b"]),
+        ]
+        # Defaults must stay untouched on module
+        assert len(COLUMN_GROUPS) == 15
+
+    def test_milestones_override(self, layout, gh):
+        custom = dict(layout)
+        custom["milestones"] = [
+            {"label": "Phase one", "code": "P1", "short": "Phase 1"},
+            {"label": "Phase two", "code": "P2", "short": "Phase 2"},
+        ]
+        data = load_from_dicts(custom, gh)
+        assert data.milestones == [
+            ("Phase one", "P1", "Phase 1"),
+            ("Phase two", "P2", "Phase 2"),
+        ]
+        assert data.ms_codes == ["P1", "P2"]
+        assert data.ms_name_by_code == {"P1": "Phase 1", "P2": "Phase 2"}
+
+    def test_partial_override_keeps_other_default(self, layout, gh):
+        custom = dict(layout)
+        custom["milestones"] = [
+            {"label": "Only one", "code": "X", "short": "X"},
+        ]
+        data = load_from_dicts(custom, gh)
+        assert len(data.milestones) == 1
+        # column_groups still the default
+        assert data.column_groups == list(COLUMN_GROUPS)
+
+    def test_empty_override_lists_yield_empty_matrix_config(self, layout, gh):
+        custom = dict(layout)
+        custom["column_groups"] = []
+        custom["milestones"] = []
+        data = load_from_dicts(custom, gh)
+        assert data.column_groups == []
+        assert data.milestones == []

--- a/scripts/dep-graph/v5/tests/test_load.py
+++ b/scripts/dep-graph/v5/tests/test_load.py
@@ -126,8 +126,8 @@ class TestLayoutDrivenMatrixConfig:
             ("ALPHA", "a1", ["a1", "a2"]),
             ("BETA",  "b",  ["b"]),
         ]
-        # Defaults must stay untouched on module
-        assert len(COLUMN_GROUPS) == 15
+        # Isolation: override must not mutate the module-level default
+        assert data.column_groups is not COLUMN_GROUPS
 
     def test_milestones_override(self, layout, gh):
         custom = dict(layout)

--- a/scripts/dep-graph/v5/tests/test_model.py
+++ b/scripts/dep-graph/v5/tests/test_model.py
@@ -137,6 +137,8 @@ class TestGraphData:
             lanes=[],
             lane_by_code={},
             issues={},
+            column_groups=list(COLUMN_GROUPS),
+            milestones=list(MILESTONES),
         )
         assert data.primary_repo == "Roxabi/lyra"
 
@@ -146,6 +148,8 @@ class TestGraphData:
             lanes=[],
             lane_by_code={},
             issues={},
+            column_groups=list(COLUMN_GROUPS),
+            milestones=list(MILESTONES),
         )
         assert data.matrix == {}
         assert data.epic_keys == set()

--- a/scripts/dep-graph/v5/tests/test_views_graph.py
+++ b/scripts/dep-graph/v5/tests/test_views_graph.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import re
 
 from v5.data.derive import tasks_for_graph
+from v5.data.load import load_from_dicts
 from v5.views import graph
 
 
@@ -129,3 +130,47 @@ class TestGraphRender:
         # ms_short values (M0, M1, ...) should be in the rendered output
         for ms_short in active_ms:
             assert ms_short in result
+
+
+class TestGraphRenderLayoutOverride:
+    """graph.render honors layout.json milestones + column_groups overrides."""
+
+    def test_custom_milestones_appear_in_msrow(self, layout, gh):
+        # Remap the fixture's milestone labels to custom codes.
+        mapped = {
+            "M0  NATS hardening":              ("P0", "Phase zero"),
+            "M1  NATS maturity  containerize": ("P1", "Phase one"),
+            "M2  LLM stack modernization":     ("P2", "Phase two"),
+            "M3  Observability":               ("P3", "Phase three"),
+            "M4  Hub statelessness":           ("P4", "Phase four"),
+        }
+        custom = dict(layout)
+        custom["milestones"] = [
+            {"label": label, "code": code, "short": short}
+            for label, (code, short) in mapped.items()
+        ]
+        data = load_from_dicts(custom, gh)
+        result = graph.render(data)
+        # ms_short in tasks_for_graph is keyed off milestone label → code
+        tasks = tasks_for_graph(data)
+        active_codes = {t["milestone"] for t in tasks}
+        # Codes must now be P-prefixed (overrides took effect)
+        for code in active_codes:
+            assert code.startswith("P"), f"expected override code, got {code}"
+            assert code in result
+
+    def test_custom_column_groups_affect_lane_ordering(self, layout, gh):
+        # Reorder the default lanes via an explicit column_groups override.
+        custom = dict(layout)
+        custom["column_groups"] = [
+            # Put 'b' before 'a1' — reverse of the default order.
+            {"label": "CONTAINER", "tone": "b", "lane_codes": ["b"]},
+            {"label": "NATS",      "tone": "a1", "lane_codes": ["a1"]},
+        ]
+        data = load_from_dicts(custom, gh)
+        # lane_order property reflects the override
+        assert data.lane_order == ["b", "a1"]
+        # Rendering succeeds end-to-end (graph.render passes lane_order
+        # through to layout_grid, honoring the override)
+        result = graph.render(data)
+        assert '<section class="view view-graph' in result

--- a/scripts/dep-graph/v5/tests/test_views_grid.py
+++ b/scripts/dep-graph/v5/tests/test_views_grid.py
@@ -118,8 +118,9 @@ class TestGridRenderLayoutOverride:
         result = grid.render(data)
         assert "P1" in result
         assert "Phase 1" in result
-        # Only one milestone row (+ possible sentinel) — not the 12 defaults
-        assert "M0" not in result or result.count('class="grid-row"') <= 2
+        # Exactly one configured row plus any sentinel (NO_MS) row.
+        expected_rows = 1 + _sentinel_rows(data)
+        assert result.count('class="grid-row"') == expected_rows
 
     def test_custom_cols_count_reflects_override(self, layout, gh):
         custom = dict(layout)

--- a/scripts/dep-graph/v5/tests/test_views_grid.py
+++ b/scripts/dep-graph/v5/tests/test_views_grid.py
@@ -1,6 +1,7 @@
 """Tests for v5.views.grid — grid view HTML output."""
 from __future__ import annotations
 
+from v5.data.load import load_from_dicts
 from v5.data.model import COLUMN_GROUPS, MILESTONES, NO_LANE, NO_MS
 from v5.views import grid
 
@@ -90,3 +91,46 @@ class TestGridRender:
     def test_data_view_attribute(self, graph_data):
         result = grid.render(graph_data)
         assert 'data-view="grid"' in result
+
+
+class TestGridRenderLayoutOverride:
+    """Grid view honors layout.json milestones + column_groups overrides."""
+
+    def test_custom_column_groups_render_labels(self, layout, gh):
+        custom = dict(layout)
+        custom["column_groups"] = [
+            {"label": "ALPHA", "tone": "a1", "lane_codes": ["a1"]},
+            {"label": "BETA",  "tone": "b",  "lane_codes": ["b"]},
+        ]
+        data = load_from_dicts(custom, gh)
+        result = grid.render(data)
+        assert "ALPHA" in result
+        assert "BETA" in result
+        # Default label gone
+        assert "CONTAINER" not in result
+
+    def test_custom_milestones_render_rows(self, layout, gh):
+        custom = dict(layout)
+        custom["milestones"] = [
+            {"label": "Phase one", "code": "P1", "short": "Phase 1"},
+        ]
+        data = load_from_dicts(custom, gh)
+        result = grid.render(data)
+        assert "P1" in result
+        assert "Phase 1" in result
+        # Only one milestone row (+ possible sentinel) — not the 12 defaults
+        assert "M0" not in result or result.count('class="grid-row"') <= 2
+
+    def test_custom_cols_count_reflects_override(self, layout, gh):
+        custom = dict(layout)
+        custom["column_groups"] = [
+            {"label": "ONE", "tone": "a1", "lane_codes": ["a1"]},
+        ]
+        data = load_from_dicts(custom, gh)
+        result = grid.render(data)
+        # 1 custom col + any sentinel lane col
+        expected_headers = 1 + (
+            1 if any(lane == NO_LANE and v for (_, lane), v in data.matrix.items())
+            else 0
+        )
+        assert result.count('class="col-header"') == expected_headers

--- a/scripts/dep-graph/v5/tests/test_views_grid.py
+++ b/scripts/dep-graph/v5/tests/test_views_grid.py
@@ -1,6 +1,8 @@
 """Tests for v5.views.grid — grid view HTML output."""
 from __future__ import annotations
 
+import pytest
+
 from v5.data.load import load_from_dicts
 from v5.data.model import COLUMN_GROUPS, MILESTONES, NO_LANE, NO_MS
 from v5.views import grid
@@ -135,3 +137,19 @@ class TestGridRenderLayoutOverride:
             else 0
         )
         assert result.count('class="col-header"') == expected_headers
+
+    def test_absent_lane_code_fails_fast(self, layout, gh):
+        """column_groups referencing a lane not in lanes[] → KeyError at render.
+
+        Locks the fail-fast contract documented in the PR #842 consensus: a
+        layout authoring bug must surface immediately rather than silently
+        producing a broken header.
+        """
+        custom = dict(layout)
+        custom["column_groups"] = [
+            # 'z99' is not declared in layout["lanes"] — render must raise.
+            {"label": "BROKEN", "tone": "a1", "lane_codes": ["z99"]},
+        ]
+        data = load_from_dicts(custom, gh)
+        with pytest.raises(KeyError):
+            grid.render(data)

--- a/scripts/dep-graph/v5/views/graph.py
+++ b/scripts/dep-graph/v5/views/graph.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from ..data import layout_graph as lg
 from ..data.derive import tasks_for_graph
-from ..data.model import MS_NAME_BY_CODE, GraphData
+from ..data.model import GraphData
 
 # Title truncation inside the pill before hover-expand.
 TITLE_CHARS = 28
@@ -125,13 +125,19 @@ def _render_edges(
     )
 
 
-def _render_msrows(bands: list[dict[str, Any]], container_h: int) -> str:
+def _render_msrows(
+    bands: list[dict[str, Any]],
+    container_h: int,
+    data: GraphData,
+) -> str:
     extents = lg.ms_vertical_extents(bands)
-    ordered = sorted(extents.items(), key=lambda kv: lg.ms_idx(kv[0]))
+    ms_codes = data.ms_codes
+    ms_name_by_code = data.ms_name_by_code
+    ordered = sorted(extents.items(), key=lambda kv: lg.ms_idx(kv[0], ms_codes))
     rows: list[str] = []
     seps: list[str] = []
     for ms, (top_pct, bot_pct) in ordered:
-        name = MS_NAME_BY_CODE.get(ms, "")
+        name = ms_name_by_code.get(ms, "")
         top_px = round(top_pct / 100 * container_h)
         height_px = round((bot_pct - top_pct) / 100 * container_h)
         rows.append(
@@ -151,10 +157,13 @@ def _render_msrows(bands: list[dict[str, Any]], container_h: int) -> str:
 
 def render(data: GraphData, *, active: bool = True) -> str:
     tasks = tasks_for_graph(data)
-    node_records, bands, _ = lg.layout_grid(tasks)
+    lane_order = [code for _, _, codes in data.column_groups for code in codes]
+    node_records, bands, _ = lg.layout_grid(
+        tasks, lane_order=lane_order, ms_codes=data.ms_codes,
+    )
     container_h = lg.container_height(bands)
 
-    msrows = _render_msrows(bands, container_h)
+    msrows = _render_msrows(bands, container_h, data)
     edges = _render_edges(tasks, node_records)
     nodes = _render_nodes(node_records)
     labels = _render_ilabels(node_records)

--- a/scripts/dep-graph/v5/views/graph.py
+++ b/scripts/dep-graph/v5/views/graph.py
@@ -157,9 +157,8 @@ def _render_msrows(
 
 def render(data: GraphData, *, active: bool = True) -> str:
     tasks = tasks_for_graph(data)
-    lane_order = [code for _, _, codes in data.column_groups for code in codes]
     node_records, bands, _ = lg.layout_grid(
-        tasks, lane_order=lane_order, ms_codes=data.ms_codes,
+        tasks, lane_order=data.lane_order, ms_codes=data.ms_codes,
     )
     container_h = lg.container_height(bands)
 

--- a/scripts/dep-graph/v5/views/grid.py
+++ b/scripts/dep-graph/v5/views/grid.py
@@ -11,8 +11,6 @@ from typing import Any
 from ..components.card import render_card
 from ..data.derive import sort_cards_in_cell, status_of
 from ..data.model import (
-    COLUMN_GROUPS,
-    MILESTONES,
     NO_LANE,
     NO_MS,
     GraphData,
@@ -105,7 +103,7 @@ def _render_col_headers(data: GraphData, with_no_lane: bool) -> list[str]:
             '<div class="col-epics"><span class="col-epic">No lane</span></div>'
             '</div>'
         )
-    for col_label, col_tone, codes in COLUMN_GROUPS:
+    for col_label, col_tone, codes in data.column_groups:
         epics: list[str] = []
         for c in codes:
             m = data.lane_by_code[c]
@@ -142,7 +140,7 @@ def _render_ms_row(
             f'{_render_sentinel_cell(cards, data)}'
             f'</div>'
         )
-    for col_label, _, codes in COLUMN_GROUPS:
+    for col_label, _, codes in data.column_groups:
         by_lane: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for code in codes:
             for iss in data.matrix.get((ms_key, code), []):
@@ -159,7 +157,7 @@ def _render_rows(data: GraphData, with_no_lane: bool) -> list[str]:
     rows: list[str] = []
     if _has_no_ms(data):
         rows.append(_render_ms_row(NO_MS, "—", "No milestone", data, with_no_lane))
-    for ms_key, ms_code, ms_name in MILESTONES:
+    for ms_key, ms_code, ms_name in data.milestones:
         rows.append(_render_ms_row(ms_key, ms_code, ms_name, data, with_no_lane))
     return rows
 
@@ -169,7 +167,7 @@ def render(data: GraphData, *, active: bool = False) -> str:
     with_no_lane = _has_no_lane(data)
     col_headers = _render_col_headers(data, with_no_lane)
     rows = _render_rows(data, with_no_lane)
-    n_cols = len(COLUMN_GROUPS) + (1 if with_no_lane else 0)
+    n_cols = len(data.column_groups) + (1 if with_no_lane else 0)
     return (
         f'<section class="view view-grid{active_cls}" data-view="grid">\n'
         f'<div class="lane-swim-grid" style="--cols: {n_cols};">\n'

--- a/scripts/dep-graph/v5/views/grid.py
+++ b/scripts/dep-graph/v5/views/grid.py
@@ -107,13 +107,15 @@ def _render_col_headers(data: GraphData, with_no_lane: bool) -> list[str]:
         epics: list[str] = []
         for c in codes:
             m = data.lane_by_code[c]
+            esc_c = html.escape(c)
             epics.append(
-                f'<span class="col-epic" data-tone="{c}">'
-                f'{c} · {html.escape(m.name)}</span>'
+                f'<span class="col-epic" data-tone="{esc_c}">'
+                f'{esc_c} · {html.escape(m.name)}</span>'
             )
         headers.append(
             f'<div class="col-header">'
-            f'<div class="col-label" data-tone="{col_tone}">{col_label}</div>'
+            f'<div class="col-label" data-tone="{html.escape(col_tone)}">'
+            f'{html.escape(col_label)}</div>'
             f'<div class="col-epics">{" ".join(epics)}</div>'
             f'</div>'
         )
@@ -127,16 +129,17 @@ def _render_ms_row(
     data: GraphData,
     with_no_lane: bool,
 ) -> str:
+    esc_ms_code = html.escape(ms_code)
     cells = [
         f'<div class="row-header">'
-        f'<div class="ms-code">{ms_code}</div>'
+        f'<div class="ms-code">{esc_ms_code}</div>'
         f'<div class="ms-name">{html.escape(ms_name)}</div>'
         f'</div>'
     ]
     if with_no_lane:
         cards = data.matrix.get((ms_key, NO_LANE), [])
         cells.append(
-            f'<div class="grid-cell" data-col="No lane" data-ms="{ms_code}">'
+            f'<div class="grid-cell" data-col="No lane" data-ms="{esc_ms_code}">'
             f'{_render_sentinel_cell(cards, data)}'
             f'</div>'
         )
@@ -146,11 +149,12 @@ def _render_ms_row(
             for iss in data.matrix.get((ms_key, code), []):
                 by_lane[code].append(iss)
         cells.append(
-            f'<div class="grid-cell" data-col="{col_label}" data-ms="{ms_code}">'
+            f'<div class="grid-cell" data-col="{html.escape(col_label)}" '
+            f'data-ms="{esc_ms_code}">'
             f'{_render_cell(by_lane, codes, data)}'
             f'</div>'
         )
-    return f'<div class="grid-row" data-ms="{ms_code}">{"".join(cells)}</div>'
+    return f'<div class="grid-row" data-ms="{esc_ms_code}">{"".join(cells)}</div>'
 
 
 def _render_rows(data: GraphData, with_no_lane: bool) -> list[str]:


### PR DESCRIPTION
## Summary
- Add optional `milestones[]` and `column_groups[]` keys to `layout.json` that override the hardcoded defaults in `v5/data/model.py`. When absent, the current defaults (12 milestones × 15 column groups) apply — so all existing layouts keep working unchanged.
- Closes acceptance criterion 3a of #827 (3b sentinel + 3c auto-hide already shipped in `fc20c37`).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #827: feat(dep-graph): milestone×lane matrix view with auto-hide empty rows/cols | Open |
| Implementation | 1 commit on `worktree-827-dep-graph-matrix-config` | Complete |
| Verification | Lint ✅ · Typecheck ✅ (no new errors) · Tests ✅ (267/267, +8 new override tests) | Passed |

## What changed

| File | Change |
|---|---|
| `v5/data/model.py` | `parse_column_groups` / `parse_milestones` parsers · `GraphData` gains `column_groups`, `milestones` fields + `ms_codes` / `ms_name_by_code` properties |
| `v5/data/load.py` | Read optional `layout["milestones"]` / `layout["column_groups"]`, fall back to module defaults |
| `v5/data/derive.py` · `compose.py` · `views/grid.py` · `views/graph.py` | Read from `GraphData` instead of module constants |
| `v5/data/layout_graph.py` | `layout_grid()` + `ms_idx()` accept explicit `lane_order` / `ms_codes` params so the graph view honors overrides |
| `layout.schema.json` | Optional `milestones` + `column_groups` schema definitions |
| `v5/tests/test_load.py` · `test_views_grid.py` | 8 new tests — `TestLayoutDrivenMatrixConfig` + `TestGridRenderLayoutOverride` |
| `README.md` · forge `DEPENDENCY-GRAPH-README.md` | Document the new keys |

## Test Plan
- [ ] `make dep-graph build` — renders with existing layout.json (no override) → identical output to before.
- [ ] Edit `~/.roxabi/forge/lyra/visuals/lyra-v2-dependency-graph.layout.json`, add `milestones` + `column_groups` entries, rebuild → new matrix shape reflects overrides.
- [ ] `make dep-graph validate` — schema accepts both the overridden and the bare forms.

## Note — unrelated pre-existing test failure

`tests/test_dep_graph_golden.py::test_output_matches_golden` fails on staging (confirmed before this branch) due to the golden HTML fixture not being regenerated after `fdd0fad feat(dep-graph): sticky header + toolbar on scroll`. Out of scope for this PR — needs a separate fix to regenerate the golden or wire it to the v5 output.

Closes #827

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`