### PR TITLE
refactor(nats): extract acl-matrix.json as SSoT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check ACL matrix spec drift
+        run: bash scripts/check-acl-matrix-spec.sh
+
       - name: Enforce import layers
         run: uv run lint-imports
 

--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -80,6 +80,7 @@ classDiagram
 
 Derived from the audit (see §Audit Provenance). `PUB` = identity publishes to this subject. `SUB` = identity subscribes. Reply subjects (NATS `_INBOX.>`) are granted automatically by `allow_responses: true` — they do **not** appear in the matrix.
 
+<!-- acl-matrix:begin -->
 | Subject | hub | telegram-adapter | discord-adapter | tts-adapter | stt-adapter | llm-worker | monitor |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — |
@@ -95,6 +96,7 @@ Derived from the audit (see §Audit Provenance). `PUB` = identity publishes to t
 | `lyra.llm.health.*` [^health] | SUB | — | — | — | — | PUB | — |
 | `_INBOX.>` [^inbox] | SUB | — | — | — | — | — | — |
 | `lyra.monitor.>` (reserved) [^monitor] | — | — | — | — | — | — | PUB+SUB |
+<!-- acl-matrix:end -->
 
 [^ready]: Readiness probe uses request/reply. Adapter publishes `lyra.system.ready` with `reply=<ephemeral>`; hub subscribes, responds via `msg.respond()`. The reply subject is covered by `allow_responses: true` on the hub.
 [^health]: Code uses single-token wildcard `*` (`lyra.llm.health.*`) not `>` — matches `lyra.llm.health.<driver>` today; tightening to `.*` prevents a future multi-segment publish from silently landing via a `>`-based ACL.

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -1,0 +1,137 @@
+{
+  "version": "1",
+  "identities": {
+    "hub": {
+      "owner": "lyra",
+      "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image workers. _INBOX.> required for NatsLlmDriver.stream() manual inbox subscription (tighten in #715).",
+      "publish": [
+        "lyra.outbound.telegram.>",
+        "lyra.outbound.discord.>",
+        "lyra.voice.tts.request.>",
+        "lyra.voice.stt.request.>",
+        "lyra.llm.request",
+        "lyra.image.generate.request"
+      ],
+      "subscribe": [
+        "lyra.inbound.telegram.>",
+        "lyra.inbound.discord.>",
+        "lyra.voice.tts.heartbeat",
+        "lyra.voice.stt.heartbeat",
+        "lyra.llm.health.*",
+        "lyra.system.ready",
+        "_INBOX.>",
+        "lyra.image.heartbeat"
+      ]
+    },
+    "telegram-adapter": {
+      "owner": "lyra",
+      "description": "Telegram bot adapter — _INBOX.> required for readiness probe via nc.request() on lyra.system.ready; allow_responses covers replier side only, not requester inbox. Tighten to per-identity inbox prefix tracked in #717.",
+      "publish": [
+        "lyra.inbound.telegram.>",
+        "lyra.system.ready"
+      ],
+      "subscribe": [
+        "lyra.outbound.telegram.>",
+        "_INBOX.>"
+      ]
+    },
+    "discord-adapter": {
+      "owner": "lyra",
+      "description": "Discord bot adapter — same readiness-probe _INBOX.> requirement as telegram-adapter.",
+      "publish": [
+        "lyra.inbound.discord.>",
+        "lyra.system.ready"
+      ],
+      "subscribe": [
+        "lyra.outbound.discord.>",
+        "_INBOX.>"
+      ]
+    },
+    "tts-adapter": {
+      "owner": "lyra",
+      "description": "Lyra-side TTS voice satellite (retired in #690 cutover). Readiness probe via nc.request('lyra.system.ready') needs _INBOX.>/_inbox.> — both forms included because nats-py historically emits lowercase inboxes and NATS subjects are case-sensitive.",
+      "publish": [
+        "lyra.voice.tts.heartbeat",
+        "lyra.system.ready"
+      ],
+      "subscribe": [
+        "lyra.voice.tts.request",
+        "lyra.voice.tts.request.>",
+        "_INBOX.>",
+        "_inbox.>"
+      ]
+    },
+    "stt-adapter": {
+      "owner": "lyra",
+      "description": "Lyra-side STT voice satellite (retired in #690 cutover). Same readiness-probe _INBOX.>/_inbox.> requirement as tts-adapter.",
+      "publish": [
+        "lyra.voice.stt.heartbeat",
+        "lyra.system.ready"
+      ],
+      "subscribe": [
+        "lyra.voice.stt.request",
+        "lyra.voice.stt.request.>",
+        "_INBOX.>",
+        "_inbox.>"
+      ]
+    },
+    "voice-tts": {
+      "owner": "voicecli",
+      "description": "voicecli nats-serve TTS worker on Machine 1 (#689). AdapterBase subscribes to heartbeat_subject (no-op callback) in addition to publishing — ACL must allow both pub and sub on heartbeat.",
+      "publish": [
+        "lyra.voice.tts.heartbeat",
+        "_INBOX.>"
+      ],
+      "subscribe": [
+        "lyra.voice.tts.request",
+        "lyra.voice.tts.request.>",
+        "lyra.voice.tts.heartbeat"
+      ]
+    },
+    "voice-stt": {
+      "owner": "voicecli",
+      "description": "voicecli nats-serve STT worker on Machine 1 (#689). Same heartbeat pub+sub pattern as voice-tts.",
+      "publish": [
+        "lyra.voice.stt.heartbeat",
+        "_INBOX.>"
+      ],
+      "subscribe": [
+        "lyra.voice.stt.request",
+        "lyra.voice.stt.request.>",
+        "lyra.voice.stt.heartbeat"
+      ]
+    },
+    "llm-worker": {
+      "owner": "reserved",
+      "description": "Reserved LLM worker identity — publishes health status, subscribes to LLM request queue.",
+      "publish": [
+        "lyra.llm.health.*"
+      ],
+      "subscribe": [
+        "lyra.llm.request"
+      ]
+    },
+    "image-worker": {
+      "owner": "imagecli",
+      "description": "imagecli nats-serve satellite (ADR-050, imageCLI#50 + #754). _INBOX.>/_inbox.> defensively included for reply-path robustness, mirroring voice-tts/voice-stt — allow_responses alone may not cover every nats-server version's reply publish path.",
+      "publish": [
+        "lyra.image.heartbeat",
+        "_INBOX.>",
+        "_inbox.>"
+      ],
+      "subscribe": [
+        "lyra.image.generate.request"
+      ]
+    },
+    "monitor": {
+      "owner": "reserved",
+      "description": "Monitoring identity — full pub+sub on lyra.monitor.> namespace.",
+      "publish": [
+        "lyra.monitor.>"
+      ],
+      "subscribe": [
+        "lyra.monitor.>"
+      ]
+    }
+  }
+}

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -8,6 +8,10 @@
 #                              tts-adapter, stt-adapter, voice-tts, voice-stt,
 #                              llm-worker, image-worker, monitor
 #
+# ACL matrix (identities + publish/subscribe allow-lists) is sourced from
+# deploy/nats/acl-matrix.json — do not edit inline; update the JSON instead.
+# Requires jq >= 1.6 on $PATH.
+#
 # Usage: sudo ./deploy/nats/gen-nkeys.sh
 #        sudo ./deploy/nats/gen-nkeys.sh --fix-perms        # re-apply permissions without regenerating
 #        sudo ./deploy/nats/gen-nkeys.sh --show             # print existing public keys
@@ -33,65 +37,64 @@ info()  { echo -e "${GREEN}[+]${NC} $1" >&2; }
 warn()  { echo -e "${YELLOW}[!]${NC} $1" >&2; }
 error() { echo -e "${RED}[x]${NC} $1" >&2; exit 1; }
 
-# ── ACL matrix (T1.2) ─────────────────────────────────────────────────────────
-# Source of truth: artifacts/specs/706-per-role-nkeys-acls-spec.mdx §Data Model
-# If spec matrix changes, update these arrays — they are the executable copy.
-# TODO(ADR-045): when roxabi-nats SDK lands, extend with plugin identity entries
-#                scoped to "lyra.plugin.<name>.>" — see spec §Out-of-scope.
-declare -A PUB_ALLOW SUB_ALLOW
+MATRIX_JSON="$(dirname "${BASH_SOURCE[0]}")/acl-matrix.json"
 
-PUB_ALLOW[hub]='"lyra.outbound.telegram.>","lyra.outbound.discord.>","lyra.voice.tts.request.>","lyra.voice.stt.request.>","lyra.llm.request","lyra.image.generate.request"'
-# NOTE: "_INBOX.>" is broader than this role needs — required because
-# NatsLlmDriver.stream() uses a manual inbox subscription. Tightening tracked
-# in issue #715 (migrate to nc.request() → drop "_INBOX.>" from this list).
-SUB_ALLOW[hub]='"lyra.inbound.telegram.>","lyra.inbound.discord.>","lyra.voice.tts.heartbeat","lyra.voice.stt.heartbeat","lyra.llm.health.*","lyra.system.ready","_INBOX.>","lyra.image.heartbeat"'
+# ── load_matrix ───────────────────────────────────────────────────────────────
+# Reads deploy/nats/acl-matrix.json and populates PUB_ALLOW, SUB_ALLOW, IDENTITIES.
+# Aborts with a clear error if jq is missing/too old, JSON is absent/malformed,
+# .version != "1", or any identity has an invalid schema.
+load_matrix() {
+  # Assert jq on $PATH
+  command -v jq >/dev/null 2>&1 \
+    || error "jq is required (apt-get install -y jq) — not found on \$PATH"
 
-PUB_ALLOW[telegram-adapter]='"lyra.inbound.telegram.>","lyra.system.ready"'
-# _INBOX.> required: adapter uses nc.request() for readiness probe on
-# lyra.system.ready; allow_responses covers the replier side only, not the
-# requester's own reply inbox. Without this, NATS logs "Subscription Violation"
-# on every probe. Tightening to per-identity inbox prefix tracked in #717.
-SUB_ALLOW[telegram-adapter]='"lyra.outbound.telegram.>","_INBOX.>"'
+  # Assert jq >= 1.6
+  local jqver
+  jqver=$(jq --version 2>/dev/null | sed 's/^jq-//')
+  local jq_major jq_minor
+  jq_major=$(echo "${jqver}" | cut -d. -f1)
+  jq_minor=$(echo "${jqver}" | cut -d. -f2)
+  if [ "${jq_major}" -lt 1 ] || { [ "${jq_major}" -eq 1 ] && [ "${jq_minor}" -lt 6 ]; }; then
+    error "jq >= 1.6 required (found: ${jqver})"
+  fi
 
-PUB_ALLOW[discord-adapter]='"lyra.inbound.discord.>","lyra.system.ready"'
-# See telegram-adapter note above — same readiness-probe requirement.
-SUB_ALLOW[discord-adapter]='"lyra.outbound.discord.>","_INBOX.>"'
+  # Assert MATRIX_JSON exists
+  [ -f "${MATRIX_JSON}" ] \
+    || error "ACL matrix not found: ${MATRIX_JSON}"
 
-# tts-adapter / stt-adapter: lyra-side voice satellites (retired in #690 cutover).
-# Readiness probe via nc.request('lyra.system.ready') needs pub on system.ready
-# + sub on _INBOX.*.* for reply. Uppercase + lowercase forms included because
-# nats-py historically emits lowercase inboxes and NATS subjects are case-sensitive.
-PUB_ALLOW[tts-adapter]='"lyra.voice.tts.heartbeat","lyra.system.ready"'
-SUB_ALLOW[tts-adapter]='"lyra.voice.tts.request","lyra.voice.tts.request.>","_INBOX.>","_inbox.>"'
+  # Assert .version == "1"
+  local v
+  v=$(jq -r '.version' "${MATRIX_JSON}")
+  [ "${v}" = "1" ] \
+    || error "unsupported acl-matrix.json version: ${v} (expected \"1\")"
 
-PUB_ALLOW[stt-adapter]='"lyra.voice.stt.heartbeat","lyra.system.ready"'
-SUB_ALLOW[stt-adapter]='"lyra.voice.stt.request","lyra.voice.stt.request.>","_INBOX.>","_inbox.>"'
+  # Validate all identities and populate arrays
+  declare -gA PUB_ALLOW SUB_ALLOW
+  IDENTITIES=()
 
-# voice-tts: voicecli nats-serve worker on Machine 1 (#689)
-# NB: voicecli.nats.base.AdapterBase subscribes to heartbeat_subject
-#     (no-op callback) in addition to publishing — ACL must allow both.
-PUB_ALLOW[voice-tts]='"lyra.voice.tts.heartbeat","_INBOX.>"'
-SUB_ALLOW[voice-tts]='"lyra.voice.tts.request","lyra.voice.tts.request.>","lyra.voice.tts.heartbeat"'
+  local valid_owners="lyra voicecli imagecli reserved"
+  while IFS= read -r name; do
+    IDENTITIES+=("${name}")
 
-# voice-stt: voicecli nats-serve worker on Machine 1 (#689)
-PUB_ALLOW[voice-stt]='"lyra.voice.stt.heartbeat","_INBOX.>"'
-SUB_ALLOW[voice-stt]='"lyra.voice.stt.request","lyra.voice.stt.request.>","lyra.voice.stt.heartbeat"'
+    for field in owner description publish subscribe; do
+      local has
+      has=$(jq -r --arg n "${name}" --arg f "${field}" \
+        'if .identities[$n] | has($f) then "yes" else "no" end' "${MATRIX_JSON}")
+      [ "${has}" = "yes" ] \
+        || error "acl-matrix.json: identity '${name}' missing field '${field}'"
+    done
 
-PUB_ALLOW[llm-worker]='"lyra.llm.health.*"'
-SUB_ALLOW[llm-worker]='"lyra.llm.request"'
+    local o
+    o=$(jq -r --arg n "${name}" '.identities[$n].owner' "${MATRIX_JSON}")
+    echo " ${valid_owners} " | grep -qw "${o}" \
+      || error "acl-matrix.json: identity '${name}' has invalid owner '${o}'"
 
-# image-worker: imagecli nats-serve satellite. Heartbeat-publish + request-subscribe.
-# Contract: ADR-050. Shipped via imageCLI#50 (satellite) + #754 (lyra-side).
-# _INBOX.>/_inbox.> defensively included for reply-path robustness, mirroring
-# voice-tts/voice-stt — allow_responses: true alone may not cover every
-# nats-server version's reply publish path.
-PUB_ALLOW[image-worker]='"lyra.image.heartbeat","_INBOX.>","_inbox.>"'
-SUB_ALLOW[image-worker]='"lyra.image.generate.request"'
-
-PUB_ALLOW[monitor]='"lyra.monitor.>"'
-SUB_ALLOW[monitor]='"lyra.monitor.>"'
-
-IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker image-worker monitor)
+    PUB_ALLOW[$name]=$(jq -r --arg n "${name}" \
+      '.identities[$n].publish | map("\"" + . + "\"") | join(",")' "${MATRIX_JSON}")
+    SUB_ALLOW[$name]=$(jq -r --arg n "${name}" \
+      '.identities[$n].subscribe | map("\"" + . + "\"") | join(",")' "${MATRIX_JSON}")
+  done < <(jq -r '.identities | keys_unsorted[]' "${MATRIX_JSON}")
+}
 
 # ── emit_user (T1.3) ──────────────────────────────────────────────────────────
 # Writes one authorization users[] entry block to stdout.
@@ -130,6 +133,9 @@ while [[ $# -gt 0 ]]; do
     *) error "Unknown option: $1" ;;
   esac
 done
+
+# ── load ACL matrix ───────────────────────────────────────────────────────────
+load_matrix
 
 # ── auth.conf renderer (shared by --template-only and regenerate paths) ──────
 # Accepts the name of an associative array of pubkeys as $1. Writes the full
@@ -194,6 +200,7 @@ apply_permissions() {
   chown "${LYRA_USER}:${LYRA_USER}" "${SEEDS_DIR}"
   chmod 0700 "${SEEDS_DIR}"
   # T1.5: extended to 7 identities; #689 adds voice-tts, voice-stt (9 total); #754 adds image-worker (10 total)
+  # TODO(#717): drive from acl-matrix.json identities list — out of scope for this refactor
   for seed in hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker image-worker monitor; do
     if [ -f "${SEEDS_DIR}/${seed}.seed" ]; then
       chown "${LYRA_USER}:${LYRA_USER}" "${SEEDS_DIR}/${seed}.seed"

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -19,6 +19,7 @@
 #        sudo ./deploy/nats/gen-nkeys.sh --regenerate --yes # non-interactive regenerate
 #        sudo ./deploy/nats/gen-nkeys.sh --regen-authconf   # re-render auth.conf from EXISTING seeds (no key rotation)
 #             ./deploy/nats/gen-nkeys.sh --template-only    # write auth.conf skeleton to stdout (no root needed)
+#             ./deploy/nats/gen-nkeys.sh --validate-supervisor   # verify each owner==lyra identity has its seed wired into a supervisor conf or quadlet container
 #
 # Idempotent — skips if auth.conf already exists. Delete auth.conf + seeds dir to regenerate.
 # Override seeds location: SEEDS_DIR=/custom/path sudo ./gen-nkeys.sh
@@ -69,7 +70,7 @@ load_matrix() {
     || error "unsupported acl-matrix.json version: ${v} (expected \"1\")"
 
   # Validate all identities and populate arrays
-  declare -gA PUB_ALLOW SUB_ALLOW
+  declare -gA PUB_ALLOW SUB_ALLOW OWNER
   IDENTITIES=()
 
   local valid_owners="lyra voicecli imagecli reserved"
@@ -93,6 +94,7 @@ load_matrix() {
       '.identities[$n].publish | map("\"" + . + "\"") | join(",")' "${MATRIX_JSON}")
     SUB_ALLOW[$name]=$(jq -r --arg n "${name}" \
       '.identities[$n].subscribe | map("\"" + . + "\"") | join(",")' "${MATRIX_JSON}")
+    OWNER[$name]=$(jq -r --arg n "${name}" '.identities[$n].owner' "${MATRIX_JSON}")
   done < <(jq -r '.identities | keys_unsorted[]' "${MATRIX_JSON}")
 }
 
@@ -114,6 +116,37 @@ emit_user() {
 USER
 }
 
+# ── validate_supervisor ────────────────────────────────────────────────────────
+# Checks that every owner==lyra identity has NATS_NKEY_SEED_PATH wired into at
+# least one supervisor conf or quadlet container file. No root required.
+validate_supervisor() {
+  local -a missing=()
+  local name count
+  local SCRIPT_DIR
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local REPO_ROOT
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+  local SUPERVISOR_GLOB="${REPO_ROOT}/deploy/supervisor/conf.d/*.conf"
+  local QUADLET_GLOB="${REPO_ROOT}/deploy/quadlet/*.container"
+  local lyra_count=0
+  for name in "${IDENTITIES[@]}"; do
+    [ "${OWNER[$name]}" = "lyra" ] || continue
+    lyra_count=$((lyra_count + 1))
+    # Match both supervisor (quoted) and quadlet (unquoted) forms:
+    #   environment=...,NATS_NKEY_SEED_PATH=".../<name>.seed"
+    #   Environment=NATS_NKEY_SEED_PATH=/run/secrets/<name>.seed
+    count=$({ grep -lE "NATS_NKEY_SEED_PATH=[\"']?[^\"'[:space:],]*${name}\.seed" \
+                   $SUPERVISOR_GLOB $QUADLET_GLOB 2>/dev/null || true; } | wc -l)
+    if [ "$count" -eq 0 ]; then
+      missing+=("$name")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    error "no supervisor/quadlet wiring for owner=lyra identities: ${missing[*]}"
+  fi
+  info "validated ${lyra_count} lyra-owned identities across supervisor + quadlet"
+}
+
 # ── flag parsing ───────────────────────────────────────────────────────────────
 SHOW_ONLY=false
 FIX_PERMS=false
@@ -121,21 +154,29 @@ TEMPLATE_ONLY=false
 REGENERATE=false
 REGEN_AUTHCONF=false
 AUTO_YES=false
+VALIDATE_SUPERVISOR=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --show)            SHOW_ONLY=true;      shift ;;
-    --fix-perms)       FIX_PERMS=true;      shift ;;
-    --template-only)   TEMPLATE_ONLY=true;  shift ;;
-    --regenerate)      REGENERATE=true;     shift ;;
-    --regen-authconf)  REGEN_AUTHCONF=true; shift ;;
-    --yes)             AUTO_YES=true;       shift ;;
+    --show)                SHOW_ONLY=true;           shift ;;
+    --fix-perms)           FIX_PERMS=true;           shift ;;
+    --template-only)       TEMPLATE_ONLY=true;       shift ;;
+    --regenerate)          REGENERATE=true;           shift ;;
+    --regen-authconf)      REGEN_AUTHCONF=true;      shift ;;
+    --yes)                 AUTO_YES=true;             shift ;;
+    --validate-supervisor) VALIDATE_SUPERVISOR=true;  shift ;;
     *) error "Unknown option: $1" ;;
   esac
 done
 
 # ── load ACL matrix ───────────────────────────────────────────────────────────
 load_matrix
+
+# ── validate-supervisor mode — no root required ────────────────────────────────
+if $VALIDATE_SUPERVISOR; then
+  validate_supervisor
+  exit 0
+fi
 
 # ── auth.conf renderer (shared by --template-only and regenerate paths) ──────
 # Accepts the name of an associative array of pubkeys as $1. Writes the full

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# check-acl-matrix-spec.sh — verify acl-matrix.json is in sync with the
+# sentinel-bracketed table in artifacts/specs/706-per-role-nkeys-acls-spec.mdx.
+#
+# Strategy: cell-by-cell assert. For each cell in the spec table where the
+# expected value is PUB or SUB (not —), we verify the JSON publish/subscribe
+# arrays back that claim. Cells that read — in the spec are not asserted
+# (the spec intentionally omits supplementary ACLs present in the JSON for
+# other identities / other features). Drift = spec claims PUB/SUB but JSON
+# disagrees, or spec claims — but JSON would produce PUB+SUB.
+#
+# We render a full table from JSON and diff against the spec sentinel block.
+# The render uses a hard-coded subject→JSON-lookup mapping that reproduces
+# the spec exactly: for each (subject, identity) we look up only the specific
+# JSON subjects that the spec intends to cover per row.
+#
+# Exit 0  → no drift.
+# Exit 1  → drift; unified diff to stdout.
+#
+# Dependencies: jq, awk, diff (standard on CI).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JSON="${REPO_ROOT}/deploy/nats/acl-matrix.json"
+SPEC="${REPO_ROOT}/artifacts/specs/706-per-role-nkeys-acls-spec.mdx"
+
+# ---------------------------------------------------------------------------
+# Identity column order — 7 of the 10 identities in JSON (#706 scope)
+# ---------------------------------------------------------------------------
+IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter llm-worker monitor)
+
+# ---------------------------------------------------------------------------
+# Subject rows — "display_label|json_pub_subject|json_sub_subject"
+#
+# json_pub_subject: the exact JSON publish subject to check for PUB.
+#   May differ from display (e.g. spec row "lyra.voice.tts.request" but hub
+#   publishes "lyra.voice.tts.request.>" in JSON).  Use "NONE" if no publish
+#   subject is relevant for this row.
+# json_sub_subject: exact JSON subscribe subject for SUB. "NONE" if n/a.
+#
+# This hard-coded mapping reproduces the spec table verbatim. It is intentional
+# that some JSON entries (e.g. tts/stt-adapter publishing lyra.system.ready,
+# adapters subscribing _INBOX.>) are not represented here — those are
+# supplementary ACLs outside the #706 matrix scope.
+# ---------------------------------------------------------------------------
+# Format: "display|pub_subject|sub_subject"
+ROWS=(
+  '`lyra.inbound.telegram.>`|lyra.inbound.telegram.>|lyra.inbound.telegram.>'
+  '`lyra.inbound.discord.>`|lyra.inbound.discord.>|lyra.inbound.discord.>'
+  '`lyra.outbound.telegram.>`|lyra.outbound.telegram.>|lyra.outbound.telegram.>'
+  '`lyra.outbound.discord.>`|lyra.outbound.discord.>|lyra.outbound.discord.>'
+  '`lyra.system.ready` [^ready]|lyra.system.ready|lyra.system.ready'
+  '`lyra.voice.tts.request`|lyra.voice.tts.request.>|lyra.voice.tts.request'
+  '`lyra.voice.tts.heartbeat`|lyra.voice.tts.heartbeat|lyra.voice.tts.heartbeat'
+  '`lyra.voice.stt.request`|lyra.voice.stt.request.>|lyra.voice.stt.request'
+  '`lyra.voice.stt.heartbeat`|lyra.voice.stt.heartbeat|lyra.voice.stt.heartbeat'
+  '`lyra.llm.request`|lyra.llm.request|lyra.llm.request'
+  '`lyra.llm.health.*` [^health]|lyra.llm.health.*|lyra.llm.health.*'
+  '`_INBOX.>` [^inbox]|_INBOX.>|_INBOX.>'
+  '`lyra.monitor.>` (reserved) [^monitor]|lyra.monitor.>|lyra.monitor.>'
+)
+
+# ---------------------------------------------------------------------------
+# Identities that are in scope for each row's pub/sub check.
+# For rows where some identities have — in the spec, we must NOT assert PUB
+# or SUB from JSON for those identities. We instead only assert the cells
+# that the spec claims are non-—.
+#
+# Implementation: for each cell, compute what JSON says using the row's
+# specific pub/sub subjects, then emit the result. The diff will catch
+# any disagreement with the spec.
+# ---------------------------------------------------------------------------
+
+# Returns "true" or "false": does the JSON array for identity+key contain subject?
+json_has() {
+  local identity="$1"
+  local key="$2"   # "publish" or "subscribe"
+  local subject="$3"
+  jq --arg id "$identity" --arg key "$key" --arg subj "$subject" '
+    .identities[$id][$key] // [] | map(select(. == $subj)) | length > 0
+  ' "$JSON"
+}
+
+# Compute cell value: PUB | SUB | PUB+SUB | —
+# Uses the row's dedicated pub_subject and sub_subject (may differ per row).
+cell_value() {
+  local identity="$1"
+  local pub_subject="$2"
+  local sub_subject="$3"
+
+  local is_pub="false"
+  local is_sub="false"
+
+  [[ "$pub_subject" != "NONE" ]] && is_pub=$(json_has "$identity" "publish" "$pub_subject")
+  [[ "$sub_subject" != "NONE" ]] && is_sub=$(json_has "$identity" "subscribe" "$sub_subject")
+
+  if [[ "$is_pub" == "true" && "$is_sub" == "true" ]]; then
+    echo "PUB+SUB"
+  elif [[ "$is_pub" == "true" ]]; then
+    echo "PUB"
+  elif [[ "$is_sub" == "true" ]]; then
+    echo "SUB"
+  else
+    echo "—"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Special overrides: cells where JSON ACL exists but spec intentionally shows —
+# because that identity's permission on this subject is out of #706 scope.
+# Rather than encoding exceptions in the logic, we compare rendered vs spec
+# and let the diff show any real discrepancy. The spec is ground truth for
+# the 7-identity matrix; if the spec shows — and JSON agrees → fine.
+# If spec shows PUB/SUB and JSON disagrees → drift.
+#
+# The key insight: for system.ready, only hub/telegram/discord are in scope;
+# for _INBOX.>, only hub is in scope. The pub/sub subjects for those rows
+# are correct per row, so json_has will return false for out-of-scope identities
+# that don't have exactly that subject in their arrays.
+#
+# tts-adapter: publishes "lyra.system.ready" — this WILL show as PUB for that
+# row and differ from spec's "—". We need scope guards.
+# ---------------------------------------------------------------------------
+# Scope table: "row_index:identity" pairs that are out of scope (force —).
+# Row indices are 0-based matching ROWS array order.
+OUT_OF_SCOPE=(
+  # lyra.system.ready (row 4): tts-adapter and stt-adapter publish it but
+  # spec shows — because #706 does not track voice satellite system.ready pub.
+  "4:tts-adapter"
+  "4:stt-adapter"
+  # _INBOX.> (row 11): adapters subscribe but spec shows — (not in #706 scope)
+  "11:telegram-adapter"
+  "11:discord-adapter"
+  "11:tts-adapter"
+  "11:stt-adapter"
+)
+
+is_out_of_scope() {
+  local row_idx="$1"
+  local identity="$2"
+  local entry
+  for entry in "${OUT_OF_SCOPE[@]}"; do
+    if [[ "$entry" == "${row_idx}:${identity}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Render the table from JSON
+# ---------------------------------------------------------------------------
+render_table() {
+  # Header
+  local header="| Subject |"
+  for id in "${IDENTITIES[@]}"; do
+    header+=" ${id} |"
+  done
+  echo "$header"
+
+  # Separator
+  local sep="|---|"
+  for id in "${IDENTITIES[@]}"; do
+    sep+=":-:|"
+  done
+  echo "$sep"
+
+  # Data rows
+  local row_idx=0
+  for row in "${ROWS[@]}"; do
+    local display="${row%%|*}"
+    local rest="${row#*|}"
+    local pub_subject="${rest%%|*}"
+    local sub_subject="${rest##*|}"
+    local line="| ${display} |"
+    for id in "${IDENTITIES[@]}"; do
+      local val
+      if is_out_of_scope "$row_idx" "$id"; then
+        val="—"
+      else
+        val=$(cell_value "$id" "$pub_subject" "$sub_subject")
+      fi
+      line+=" ${val} |"
+    done
+    echo "$line"
+    (( row_idx++ )) || true
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Extract sentinel block from spec (without the marker lines themselves)
+# ---------------------------------------------------------------------------
+TMPDIR_LOCAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+SPEC_BLOCK="${TMPDIR_LOCAL}/spec_block.txt"
+RENDERED="${TMPDIR_LOCAL}/rendered.txt"
+
+awk '/<!-- acl-matrix:begin -->/{found=1; next} /<!-- acl-matrix:end -->/{found=0} found' \
+  "$SPEC" > "$SPEC_BLOCK"
+
+render_table > "$RENDERED"
+
+# ---------------------------------------------------------------------------
+# Diff — exit 0 on match, 1 on drift
+# ---------------------------------------------------------------------------
+if diff -u "$SPEC_BLOCK" "$RENDERED"; then
+  exit 0
+else
+  exit 1
+fi

--- a/tests/nats/test_gen_nkeys_acls.sh
+++ b/tests/nats/test_gen_nkeys_acls.sh
@@ -30,31 +30,16 @@ trap 'rm -f "$OUT"' EXIT
 ./deploy/nats/gen-nkeys.sh --template-only > "$OUT"
 echo "PASS: template-only produced output ($(wc -l < "$OUT") lines)"
 
-# ── Expected allow-lists (authoritative copy mirrors spec §Data Model matrix) ──
-# If the spec matrix changes, update both deploy/nats/gen-nkeys.sh AND this file.
+# ── Expected allow-lists loaded from acl-matrix.json (SSoT per #717) ──
+MATRIX_JSON="deploy/nats/acl-matrix.json"
+[ -f "$MATRIX_JSON" ] || { echo "FAIL: $MATRIX_JSON not found"; exit 1; }
 declare -A EXPECTED_PUB EXPECTED_SUB
-EXPECTED_PUB[hub]='lyra.outbound.telegram.> lyra.outbound.discord.> lyra.voice.tts.request.> lyra.voice.stt.request.> lyra.llm.request lyra.image.generate.request'
-EXPECTED_SUB[hub]='lyra.inbound.telegram.> lyra.inbound.discord.> lyra.voice.tts.heartbeat lyra.voice.stt.heartbeat lyra.llm.health.* lyra.system.ready _INBOX.> lyra.image.heartbeat'
-EXPECTED_PUB[telegram-adapter]='lyra.inbound.telegram.> lyra.system.ready'
-EXPECTED_SUB[telegram-adapter]='lyra.outbound.telegram.>'
-EXPECTED_PUB[discord-adapter]='lyra.inbound.discord.> lyra.system.ready'
-EXPECTED_SUB[discord-adapter]='lyra.outbound.discord.>'
-EXPECTED_PUB[tts-adapter]='lyra.voice.tts.heartbeat lyra.system.ready'
-EXPECTED_SUB[tts-adapter]='lyra.voice.tts.request lyra.voice.tts.request.> _INBOX.> _inbox.>'
-EXPECTED_PUB[stt-adapter]='lyra.voice.stt.heartbeat lyra.system.ready'
-EXPECTED_SUB[stt-adapter]='lyra.voice.stt.request lyra.voice.stt.request.> _INBOX.> _inbox.>'
-EXPECTED_PUB[voice-tts]='lyra.voice.tts.heartbeat _INBOX.>'
-EXPECTED_SUB[voice-tts]='lyra.voice.tts.request lyra.voice.tts.request.> lyra.voice.tts.heartbeat'
-EXPECTED_PUB[voice-stt]='lyra.voice.stt.heartbeat _INBOX.>'
-EXPECTED_SUB[voice-stt]='lyra.voice.stt.request lyra.voice.stt.request.> lyra.voice.stt.heartbeat'
-EXPECTED_PUB[llm-worker]='lyra.llm.health.*'
-EXPECTED_SUB[llm-worker]='lyra.llm.request'
-EXPECTED_PUB[image-worker]='lyra.image.heartbeat _INBOX.> _inbox.>'
-EXPECTED_SUB[image-worker]='lyra.image.generate.request'
-EXPECTED_PUB[monitor]='lyra.monitor.>'
-EXPECTED_SUB[monitor]='lyra.monitor.>'
-
-IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter voice-tts voice-stt llm-worker image-worker monitor)
+IDENTITIES=()
+while IFS= read -r name; do
+  IDENTITIES+=("$name")
+  EXPECTED_PUB[$name]=$(jq -r --arg n "$name" '.identities[$n].publish | join(" ")' "$MATRIX_JSON")
+  EXPECTED_SUB[$name]=$(jq -r --arg n "$name" '.identities[$n].subscribe | join(" ")' "$MATRIX_JSON")
+done < <(jq -r '.identities | keys_unsorted[]' "$MATRIX_JSON")
 
 # ── extract_block: print the user{} block for a given identity name ────────────
 # B9: the closing-brace condition records `entry_depth` when the identity's


### PR DESCRIPTION
## Summary

- Extract the NATS subject→identity ACL matrix from three duplicate copies (`gen-nkeys.sh` bash arrays · `test_gen_nkeys_acls.sh` expected arrays · #706 spec prose) into a single `deploy/nats/acl-matrix.json` consumed by all three.
- Add `--validate-supervisor` subcommand to `gen-nkeys.sh` — greps `deploy/supervisor/conf.d/*.conf` and `deploy/quadlet/*.container` for each `owner == lyra` identity's `NATS_NKEY_SEED_PATH` wiring.
- Add `scripts/check-acl-matrix-spec.sh` CI drift-check that renders the #706 spec matrix table from JSON and diffs it against sentinel-bracketed content; wire into `.github/workflows/ci.yml` between `Check supervisor conf drift` and `Enforce import layers`.
- Byte-identical `auth.conf` output preserved — verified against a baseline captured from `staging` before the refactor.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#717](https://github.com/Roxabi/lyra/issues/717): refactor(nats) extract acl-matrix.json as SSoT | OPEN |
| Frame | [717-acl-matrix-json-ssot-frame.mdx](../blob/staging/artifacts/frames/717-acl-matrix-json-ssot-frame.mdx) | Approved |
| Spec | [717-acl-matrix-json-ssot-spec.mdx](../blob/staging/artifacts/specs/717-acl-matrix-json-ssot-spec.mdx) | Approved |
| Plan | [717-acl-matrix-json-ssot-plan.mdx](../blob/staging/artifacts/plans/717-acl-matrix-json-ssot-plan.mdx) | Approved (13 micro-tasks, 4 slices) |
| Implementation | 6 commits on `feat/717-acl-matrix-json-ssot` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (181 nats tests pass) · Byte-identical auth.conf ✅ | Passed |

## Key design decisions (locked in frame, validated in spec)

- **Spec sync strategy:** CI drift-check rather than live-render — preserves the #706 spec's footnotes (`[^ready]`, `[^health]`, `[^inbox]`, `[^monitor]`, `[^inbox-fix]`) and narrative. The drift-check uses sentinel markers (`<!-- acl-matrix:begin --> / :end -->`) bracketing only the matrix table.
- **Validation scope:** `--validate-supervisor` uses a per-identity `owner` field in the JSON (`lyra` / `voicecli` / `imagecli` / `reserved`). Only `owner == lyra` identities are required to have local process wiring; migration-in-progress quadlet containers are searched alongside supervisor confs.

## Known trade-offs

- `check-acl-matrix-spec.sh` uses an `OUT_OF_SCOPE` guard (6 cells) where the #706 spec matrix doesn't reflect post-`[^inbox-fix]` reality (tts/stt-adapter publishing `lyra.system.ready`; adapters subscribing `_INBOX.>`). Reconciling the #706 spec matrix itself is out of scope here — filed as follow-up.
- `apply_permissions` in `gen-nkeys.sh` still has a hardcoded seed list (line ~197); marked with a `TODO(#717)` comment. Sweep in a follow-up; adding an identity to the JSON still requires a separate edit for `--fix-perms` to touch its seed file.

## Test Plan

- [ ] `bash tests/nats/test_gen_nkeys_acls.sh` exits 0 (7 assertions a–g + 5 #754 assertions pass).
- [ ] `./deploy/nats/gen-nkeys.sh --template-only` output is byte-identical to pre-refactor (verified locally via `diff` against `staging` baseline; reviewers can re-run).
- [ ] `./deploy/nats/gen-nkeys.sh --validate-supervisor` prints `validated 5 lyra-owned identities across supervisor + quadlet`, exits 0.
- [ ] `bash scripts/check-acl-matrix-spec.sh` exits 0 on staging; returns exit 1 + unified diff when either `acl-matrix.json` diverges from spec or a cell inside sentinels is mutated.
- [ ] Preflight aborts correctly: missing `acl-matrix.json`, `jq` < 1.6, `.version != "1"`, or identity missing required field each return exit 1 with a specific diagnostic.
- [ ] `uv run pytest -q tests/nats/` — 181 passed, 35 skipped.

Closes #717

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`