### PR TITLE
docs(adr): replace ADR-047 footnote status mechanism with Status column

### DIFF
--- a/docs/architecture/adr/047-nats-connector-ownership-pattern.mdx
+++ b/docs/architecture/adr/047-nats-connector-ownership-pattern.mdx
@@ -109,14 +109,14 @@ If `voicecli_{stt,tts}` fails post-cutover: re-enable `lyra_{stt,tts}` from `con
 
 ### Subject and nkey ownership table
 
-| Domain | Subjects | Queue group | lyra nkey identity | Satellite adapter module |
-|---|---|---|---|---|
-| STT | `lyra.voice.stt.request`, `lyra.voice.stt.heartbeat` | `STT_WORKERS` | `stt-adapter` | `voicecli/src/voicecli/nats/stt_adapter.py` |
-| TTS | `lyra.voice.tts.request`, `lyra.voice.tts.heartbeat` | `TTS_WORKERS` | `tts-adapter` | `voicecli/src/voicecli/nats/tts_adapter.py` |
-| Image | `lyra.image.generate.request`, `lyra.image.heartbeat` | `IMAGE_WORKERS` | image-worker [^img-shipped] | `imagecli/src/imagecli/nats/adapter.py` |
-| Memory | TBD — requires contract ADR | TBD | TBD | `roxabi-vault` TBD |
+| Domain | Subjects | Queue group | lyra nkey identity | Satellite adapter module | Status |
+|---|---|---|---|---|---|
+| STT | `lyra.voice.stt.request`, `lyra.voice.stt.heartbeat` | `STT_WORKERS` | `stt-adapter` | `voicecli/src/voicecli/nats/stt_adapter.py` | Partial |
+| TTS | `lyra.voice.tts.request`, `lyra.voice.tts.heartbeat` | `TTS_WORKERS` | `tts-adapter` | `voicecli/src/voicecli/nats/tts_adapter.py` | Partial |
+| Image | `lyra.image.generate.request`, `lyra.image.heartbeat` | `IMAGE_WORKERS` | `image-worker` | `imagecli/src/imagecli/nats/adapter.py` | Shipped |
+| Memory | TBD — requires contract ADR | TBD | TBD | `roxabi-vault` TBD | TBD |
 
-[^img-shipped]: Shipped via #754 (ADR-050 contract + `src/lyra/nats/nats_image_client.py` hub publisher + `image-worker` nkey + `imagecli_gen` supervisor entry). Satellite shipped via imageCLI#50 (2026-04-15).
+Status legend: **Shipped** — contract ADR accepted, hub client merged, satellite module live, nkey identity provisioned. **Partial** — contract ADR accepted and satellite module live, but lyra-side migration still in flight (tracked by open issues). **TBD** — contract ADR not yet written. Per-row shipping details (issue numbers, supervisor entries, nkey provisioning commits) live in the corresponding contract ADR's References section (ADR-044 for STT/TTS, ADR-050 for Image).
 
 ### Contract ADR requirement
 

--- a/docs/architecture/adr/047-nats-connector-ownership-pattern.mdx
+++ b/docs/architecture/adr/047-nats-connector-ownership-pattern.mdx
@@ -134,7 +134,7 @@ Every domain that moves from "TBD" to shipped requires:
 
 ### imageCLI migration state
 
-imageCLI#50 shipped a satellite-owned worker via the SDK on 2026-04-15. `imagecli nats-serve` subscribes to `lyra.image.generate.request` using `NatsAdapterBase`. Remaining lyra-side work: contract ADR for `lyra.image.*`, `src/lyra/nats/nats_image_client.py`, `image-worker` nkey + ACL in `gen-nkeys.sh`. File new lyra-side ticket.
+imageCLI#50 shipped a satellite-owned worker via the SDK on 2026-04-15. `imagecli nats-serve` subscribes to `lyra.image.generate.request` using `NatsAdapterBase`. Lyra-side work completed via #754: contract ADR-050, `src/lyra/nats/nats_image_client.py` hub client, `image-worker` nkey, `imagecli_gen` supervisor entry. See ADR-050 References.
 
 ### Enforcement
 
@@ -172,7 +172,7 @@ The allowlist is narrow (1–2 files per satellite). This is the enforcement mec
 1. **voiceCLI#69** — adopt `roxabi-nats` v0.1.0 SDK. Retire `voicecli/nats/base.py`, `voicecli/nats/connect.py`, duplicate validators/serializers. **Keep** `voicecli/nats/{stt,tts}_adapter.py` as the designated adapter modules. Size S. Open.
 2. **lyra#658 / #690 / #691** slices — delete `src/lyra/bootstrap/{stt,tts}_adapter_standalone.py`, `lyra adapter stt/tts` subcommands, `lyra_{stt,tts}.conf`. Strip voicecli imports from `src/lyra/{stt,tts}/__init__.py`. Drop `voicecli` from lyra's `pyproject.toml`. In flight. Size F-lite.
 3. **CI grep-gate** on satellite repos — forbid `lyra.*` subject literals outside the designated adapter module per satellite. A satellite-local allowlist (one file path per satellite) makes the exception explicit. File new tickets in each satellite repo. Size S each.
-4. **imageCLI#50** already closed as COMPLETED 2026-04-15 under this pattern. Lyra-side remainder: contract ADR for `lyra.image.*`, `src/lyra/nats/nats_image_client.py`, `image-worker` nkey + ACL in `gen-nkeys.sh`. File new lyra-side ticket. Size S.
+4. **imageCLI#50** already closed as COMPLETED 2026-04-15 under this pattern. Lyra-side work closed by #754 (ADR-050 contract, hub client, nkey, supervisor entry — see ADR-050 References).
 5. **Memory over NATS (roxabi-vault)** — deferred until its contract ADR is scoped.
 
 ### Neutral

--- a/docs/architecture/adr/050-lyra-image-nats-contract.mdx
+++ b/docs/architecture/adr/050-lyra-image-nats-contract.mdx
@@ -284,4 +284,3 @@ Path validation uses `Path.resolve()` to canonicalize before the `relative_to` c
 - NATS server config: `deploy/nats/nats-container.conf` (`max_payload: 52428800`)
 - nkey identity: `image-worker` (added to `IDENTITIES` in `deploy/nats/gen-nkeys.sh` per ADR-046 Invariant 2)
 - Supervisor entry: `imagecli_gen` in `deploy/supervisor/conf.d/` (satellite process managed by lyra's supervisord)
-- Marked **Shipped** in ADR-047 Subject and nkey ownership table.

--- a/docs/architecture/adr/050-lyra-image-nats-contract.mdx
+++ b/docs/architecture/adr/050-lyra-image-nats-contract.mdx
@@ -282,3 +282,6 @@ Path validation uses `Path.resolve()` to canonicalize before the `relative_to` c
 - Satellite implementation: `imageCLI/src/imagecli/nats/adapter.py` (shipped by imageCLI#50, closed 2026-04-15)
 - Hub client: `src/lyra/nats/nats_image_client.py` (new — ships with #754)
 - NATS server config: `deploy/nats/nats-container.conf` (`max_payload: 52428800`)
+- nkey identity: `image-worker` (added to `IDENTITIES` in `deploy/nats/gen-nkeys.sh` per ADR-046 Invariant 2)
+- Supervisor entry: `imagecli_gen` in `deploy/supervisor/conf.d/` (satellite process managed by lyra's supervisord)
+- Marked **Shipped** in ADR-047 Subject and nkey ownership table.

--- a/docs/architecture/adr/050-lyra-image-nats-contract.mdx
+++ b/docs/architecture/adr/050-lyra-image-nats-contract.mdx
@@ -272,7 +272,7 @@ Path validation uses `Path.resolve()` to canonicalize before the `relative_to` c
 
 - **ADR-035** — NATS subject naming convention. `lyra.image.generate.request` and `lyra.image.heartbeat` follow the `<namespace>.<capability>.<action>.<verb>` and `<namespace>.<capability>.<verb>` shapes respectively.
 - **ADR-044** — lyra ↔ voicecli NATS voice contract. The canonical contract ADR shape. This ADR follows its structure exactly: subjects table, payload encoding, `contract_version`, request/reply schemas, error codes, heartbeat, max-payload, sanitization contract.
-- **ADR-046** — nkey provisioning is declarative. Invariant 2 (IDENTITIES is the single source of truth) requires the `image-worker` nkey identity to be added to `gen-nkeys.sh` before the hub client ships. The `image-worker` identity is noted as "to provision" in ADR-047's subject ownership table.
+- **ADR-046** — nkey provisioning is declarative. Invariant 2 (IDENTITIES is the single source of truth) requires the `image-worker` nkey identity to be added to `gen-nkeys.sh` before the hub client ships. The `image-worker` identity is now provisioned; ADR-047's subject ownership table reflects Status: Shipped.
 - **ADR-047** — NATS connector ownership pattern. This ADR is the lyra-owned half of the image domain. The satellite-owned half is `imagecli/src/imagecli/nats/adapter.py` (shipped by imageCLI#50). Rule 4 of ADR-047 requires this ADR to declare the max-payload cap — done in the Max payload section above.
 
 ## References


### PR DESCRIPTION
## Summary
- Add `Status` column (Shipped | Partial | TBD) to the Subject and nkey ownership table in ADR-047 and drop the `[^img-shipped]` footnote — scales as more domains (Memory, LLM, vision, dashboard) come online.
- Move the footnote's cross-reference content (`image-worker` nkey provisioning, `imagecli_gen` supervisor entry, ADR-047 back-reference) into ADR-050's References section, keeping per-domain shipping details with each contract ADR.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #809: docs(adr): replace ADR-047 footnote status mechanism with Status column | Open |
| Implementation | 1 commit on `feat/809-replace-adr-047-footnote-status-mechanism-with-status-column` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests n/a (docs-only, 0 new) | Passed |

## Test Plan
- [ ] ADR-047 renders: table has 6 columns ending with `Status`; STT/TTS=Partial, Image=Shipped, Memory=TBD.
- [ ] ADR-047 no longer contains `[^img-shipped]` (marker or definition).
- [ ] ADR-050 References lists `image-worker` nkey, `imagecli_gen` supervisor entry, and a back-reference to ADR-047.
- [ ] No stray `[^img-shipped]` references surface in rendered docs (historical plan artifact `artifacts/plans/754-lyra-image-domain-integration-plan.mdx` intentionally left unmodified — frozen record of the shipped work).

Closes #809

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`