### PR TITLE
chore(deploy): formalize role enum for agents.yml dispatch

### DIFF
--- a/artifacts/analyses/807-hub-override-parity-consensus.mdx
+++ b/artifacts/analyses/807-hub-override-parity-consensus.mdx
@@ -1,0 +1,91 @@
+---
+title: "Hub + command_override parity check — Expert Consensus"
+issue: 807
+status: consensus-reached
+date: 2026-04-21
+panel: architect, devops, product-lead
+confidence: high
+---
+
+## Problem
+
+During PR #846 review (issue #807 implementation), the product-lead reviewer flagged at 75% confidence that `resolve_role` in `deploy/gen-supervisor-conf.py` enforces 4 cross-check invariants on explicit `role` values but is asymmetric:
+
+- Rule 3: `role=lyra-adapter` with `command_override` → raises (the stray override would be silently ignored).
+- Missing rule: `role=hub` with `command_override` → **silently accepted**, even though the hub path always dispatches to `run_hub.sh` and the override is equally dead.
+
+Spec `artifacts/specs/807-agents-role-enum-spec.mdx` SC-6 mandates only the hub-name check. The spec's list of acceptance criteria includes a line reading "exactly 4 test functions for the error cases" (line 168) — adding a 5th test requires a spec amendment.
+
+### Options considered
+
+1. **Solution 1** — Add parity check (3 lines in `resolve_role` + 1 test, same shape as rule 3).
+2. **Solution 2** — Leave it; document that hub ignores `command_override`, or don't.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | validation-contract symmetry, maintainability, refactor safety |
+| devops | deploy-time vs. runtime failure, config-drift blast radius |
+| product-lead | maintainer ergonomics, scope discipline, spec-contract consistency |
+
+## Consensus recommendation
+
+**Solution 1 — Apply the parity check.**
+
+Unanimous (3–0) in round 1. No debate round required.
+
+### Rationale
+
+All three experts converged on the same core argument: the current gap is a footgun, not a harmless liberty. Three independent framings agreed:
+
+- **architect:** "An `agents.yml` author debugging rule 3 will reasonably expect the same guard on rule 4 and be surprised it is absent." Refactor risk: if `generate_conf` is ever patched to honor `command_override` on hub (e.g. a secondary hub variant), a stray override silently activates. Failing loudly now is cheaper than tracking down silent activation later.
+- **devops:** "Supervisord will silently run `run_hub.sh` regardless of `command_override`, creating a debugging trap that only surfaces under incident conditions." Blast radius is minimal — one `if` branch, one test, no schema changes.
+- **product-lead:** "Adapters reject overrides but hub silently eats them' is a latent trap every time someone edits `agents.yml`." Scope fit: 3 lines + 1 test alongside 11 other tests already in scope; deferring creates a follow-up issue whose tracking cost exceeds the fix cost.
+
+### Trade-offs
+
+1. **Strengthens the validation contract symmetry** (every role that ignores a field rejects it at declaration time). Cost: one more schema rule, one more test.
+2. **Requires a spec amendment** before landing: SC-6's "exactly 4 test functions" line must become "exactly 5" and add the hub+override error case.
+3. **Zero behavioral change for valid configs.** Existing `deploy/agents.yml` (5 entries, none with hub+override) passes unchanged. The check fires only on authoring errors.
+
+## Alternatives
+
+| Option | Proposed by | Rejected because |
+|--------|-------------|------------------|
+| Solution 2 — leave it, document ignore behavior | (considered and rejected by all 3) | "Documenting the ignore behavior does not prevent the misconfiguration, it only makes the surprise easier to trace post-hoc" (architect). "Silent ignores in deploy-time generators accumulate into config drift" (devops). "Silent acceptance is antithetical to the validation layer's entire value of fail-fast" (product-lead). |
+
+## Dissent
+
+**None on the outcome.** Unanimous recommendation for Solution 1.
+
+**Procedural flag (shared by architect + product-lead):** the spec's SC-6 enumerates exactly 4 error-case tests (line 168). Implementing Solution 1 without first amending the spec puts the implementation out of sync with the artifact. Both experts asked that the spec amendment land before (or together with) the code change. Devops did not flag this but did not object.
+
+Required spec amendment:
+- Line 168: change "4 test functions for the error cases (unknown value, external-satellite without command_override, lyra-adapter with command_override, hub on wrong name)" → "5 test functions for the error cases (unknown value, external-satellite without command_override, lyra-adapter with command_override, hub on wrong name, hub with command_override)".
+- Extend the `## Success Criteria` list with one new checkbox: "`role=hub` with `command_override` raises `ValueError` naming the agent."
+
+## Implementation notes
+
+Order of operations:
+
+1. **Amend spec** `artifacts/specs/807-agents-role-enum-spec.mdx` — one SC line + one criteria checkbox (per "Dissent" block above). Commit as `docs(spec): add hub+command_override parity criterion to #807 spec`.
+2. **Add check** in `deploy/gen-supervisor-conf.py:resolve_role`, after the existing hub-name rule:
+   ```python
+   if role == "hub" and has_override:
+       raise ValueError(
+           f"role=hub must not set command_override (agent {name!r})"
+       )
+   ```
+3. **Add test** `test_resolve_role_raises_hub_with_override` in `tests/deploy/test_gen_supervisor_conf.py`, same shape as `test_resolve_role_raises_lyra_adapter_with_override`:
+   ```python
+   def test_resolve_role_raises_hub_with_override(tmp_path: Path) -> None:
+       p = _write_agents(tmp_path, {"hub": {"role": "hub", "command_override": "x"}})
+       err = _run_dry(p, expect_fail=True)
+       assert "must not set command_override" in err and "agent 'hub'" in err
+   ```
+4. Bundle spec + code + test in a single commit for PR #846: `fix(deploy): enforce hub+command_override parity check (#807)`.
+
+## Next
+
+Resume `/fix` 1b1 walkthrough on PR #846. Apply Solution 1 for finding 2/6 following the order above, then continue to finding 3/6.

--- a/artifacts/analyses/807-remaining-findings-consensus.mdx
+++ b/artifacts/analyses/807-remaining-findings-consensus.mdx
@@ -1,0 +1,101 @@
+---
+title: "PR #846 remaining findings (#6, #7, #8, #9) — Expert Consensus"
+issue: 807
+status: consensus-reached
+date: 2026-04-21
+panel: architect, devops, product-lead
+confidence: high
+---
+
+## Problem
+
+PR #846 (issue #807 — role enum in `agents.yml`) has 4 trailing code-review findings not yet resolved in the 1b1 walkthrough. The panel was asked for a unified verdict — Apply, Defer, or Skip — for each one.
+
+Findings already closed before this consensus:
+- #1 (security-auditor, 88%) — agent-name shell-metachar allowlist → applied in commit `00b22fd`.
+- #2 (product-lead, 75%) — hub + `command_override` parity check → consensus reached (`artifacts/analyses/807-hub-override-parity-consensus.mdx`), to be applied.
+- #3 (product-lead, 85%) — `_run_dry(expect_fail=True)` should assert non-zero exit → auto-applied in commit `4b32f42`.
+- #4 (tester, 88%) — T6 inference tests duplicated fallback tests → auto-applied in commit `4b32f42`.
+- #5 (tester, 72%) — external-satellite inference test lacks negative launcher assertions → already covered by the same `4b32f42` auto-apply (assertions present at `tests/deploy/test_gen_supervisor_conf.py:217-218`).
+
+Findings brought to this panel:
+
+### #6 — Error message for `role=hub` uses Python `==` repr (architect, 75%)
+
+`deploy/gen-supervisor-conf.py:95` raises `ValueError(f"role=hub requires name=={HUB_NAME!r} (got {name!r})")`, producing `role=hub requires name=='hub' (got 'side_hub')`. The three peer error messages in the same function use natural-language phrasing (`(agent {name!r})`). The `==` exposes Python operator syntax in a user-facing string.
+
+### #7 — Strip `role`/`command_override` from `cfg` defensively (devops, 90%)
+
+`deploy/gen-supervisor-conf.py:171`: `cfg = {**defaults, **agent}` leaks `role:` into the merged dict. The current output loop is an explicit whitelist so nothing reaches `.conf`; a future `cfg.get(...)`-style refactor would silently emit `role=hub` and supervisord would reject the program. A previous verifier stated at 95% confidence that the defensive strip is NOT needed because the whitelist is load-bearing.
+
+### #8 — `ROLES`/`HUB_NAME` annotation style inconsistency (architect, 70%)
+
+`ROLES: frozenset[str] = ...` is annotated; `HUB_NAME`, `RUN_HUB`, `RUN_ADAPTER` are plain strings with no annotation. Minor style asymmetry; pyright infers both cases fine.
+
+### #9 — `command:` field in `agents.yml` is dead with no marker (architect, 82%, question)
+
+Every entry in `deploy/agents.yml` carries a `command: lyra hub`-style field that the generator does not read (documented in spec as dead/documentation). Without an inline marker, future maintainers may assume the field drives generation.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | contract clarity, maintainability, future-reader signal-to-noise |
+| devops | deploy-time error quality, config-drift prevention, operational hygiene |
+| product-lead | maintainer cognitive load, scope discipline, bundle-vs-defer economics |
+
+## Consensus recommendations (unanimous 3–0 on every finding)
+
+| Finding | Verdict | Chosen Solution |
+|---------|---------|-----------------|
+| #6 — Python `==` repr in hub error message | **Apply** | Solution 1: normalize to natural language |
+| #7 — Strip `role` from `cfg` defensively | **Skip** | Solution 2: leave as-is |
+| #8 — Annotation style inconsistency | **Skip** | Solution 3: accept deliberate asymmetry |
+| #9 — `command:` field dead marker | **Apply** | Solution 1: inline comment marking field as documentation-only |
+
+### Rationale per finding
+
+**#6 — Apply.** All three experts agreed the `==` leak is real noise during a deploy-time failure. Ops engineers reading the error should see natural language consistent with peer messages; the test assertion update is mechanical. Zero-risk text change.
+
+**#7 — Skip.** All three experts aligned with the counter-perspective (95% verifier): the explicit whitelist at the output loop is the load-bearing guard. A defensive `pop` adds a second mechanism whose maintenance burden and signal cost exceed its benefit — it implies to future readers that the whitelist alone is insufficient, which is false. If a future refactor moves to `cfg.get(...)` emission, that refactor owns the hygiene work; speculating defense now is noise.
+
+**#8 — Skip.** Unanimous: style inconsistency in a deploy script has no downstream contract impact. Pyright infers both cases correctly; the `frozenset[str]` annotation is justified (type not obvious without it) while plain string constants need none. Forcing uniformity is churn with no maintainer benefit.
+
+**#9 — Apply.** Unanimous: `agents.yml` is the primary file maintainers edit; a silent no-op field is a real silent-drift risk. Future readers editing `command:` expect effect. A single inline comment closes the ambiguity at two-line cost. Spec already defers removal, so the comment is the minimal useful action within this PR's scope.
+
+### Confidence
+
+**High (unanimous on all 4 findings, no debate round required).**
+
+## Alternatives
+
+| Option | Finding | Rejected because |
+|--------|---------|------------------|
+| Leave #6 | #6 | Creates asymmetry across 4 error messages in the same function; zero-cost fix is strictly better. |
+| Apply Solution 1 to #7 | #7 | Doubles the safeguard surface without closing a real gap today; misleads future readers about the whitelist's role. |
+| Apply Solution 1 or 2 to #8 | #8 | Style churn in dev tooling, zero contract impact; the asymmetry is deliberate (inferrable types get no annotation). |
+| Defer #9 to follow-up issue | #9 | Tracking tax exceeds the cost of a one-line comment; the trap stays live in the primary operational file in the interim. |
+
+## Dissent
+
+**None — unanimous on all 4 findings, across all 3 experts.**
+
+## Implementation notes
+
+Order of operations:
+
+1. **Finding #2 (hub+override parity)** — per prior consensus in `807-hub-override-parity-consensus.mdx`: amend spec SC-6 first (4→5 error cases), then add the check + test.
+2. **Finding #6 (`==` repr)** — edit `deploy/gen-supervisor-conf.py:95` to `f"role=hub requires name={HUB_NAME!r}, got {name!r} (agent {name!r})"` (or similar natural-language phrasing aligned with peers), then update the assertion in `tests/deploy/test_gen_supervisor_conf.py` that currently checks for `"name=='hub'"` and `"got 'side_hub'"`.
+3. **Finding #9 (`command:` marker)** — add a header comment block above the first agent entry in `deploy/agents.yml` (single, not per-entry) noting the `command:` field is documentation-only and not read by the generator.
+4. **#7 and #8 — no action.** Record skip decisions in PR fix comment.
+
+Bundling strategy: #2, #6, and #9 can land as one `fix(deploy): address review findings from PR #846` commit, or as separate commits per finding. Single bundled commit is recommended — all three are small, independent, and tighten the same artifact surface.
+
+## Next
+
+1. Amend spec SC-6 (count: 4 → 5 error-case tests + new criterion).
+2. Apply fixes for #2, #6, #9.
+3. Run `make gen-conf` → verify byte-identical output (regression guard).
+4. Run `uv run pytest tests/deploy/` → verify all tests green.
+5. Commit + push.
+6. Post "Review Fixes Applied" comment on PR #846 per `/fix` Phase 8.

--- a/artifacts/specs/807-agents-role-enum-spec.mdx
+++ b/artifacts/specs/807-agents-role-enum-spec.mdx
@@ -159,13 +159,14 @@ agents.yml entry  →  resolve_role(name, agent)  →  Role  (raises on any misc
 - [ ] `role=external-satellite` without `command_override` raises `ValueError` naming the agent.
 - [ ] `role=lyra-adapter` with `command_override` raises `ValueError` naming the agent.
 - [ ] `role=hub` when the agent name is not `"hub"` raises `ValueError` naming the agent and the expected name.
+- [ ] `role=hub` when `command_override` is present raises `ValueError` naming the agent (parity with `role=lyra-adapter` — the override would be silently ignored on the hub branch).
 - [ ] All validation cross-checks live inside `resolve_role` (not in `generate_conf`), so `generate_conf` receives a guaranteed-valid role.
 - [ ] `generate_conf` dispatches the launcher exclusively via the resolved `Role` (the three original branches collapse into a role-keyed dispatch).
 - [ ] `generate_conf` still invokes `validate_command_override` on the `external-satellite` branch before emitting the `command=` line (the pre-existing garbage-character guard is not bypassed by the refactor).
 - [ ] Running `uv run deploy/gen-supervisor-conf.py --dry-run` against the current `deploy/agents.yml` (with added `role:` lines) produces output byte-identical to the pre-change output of the same command against pre-change `deploy/agents.yml`.
 - [ ] `deploy/agents.yml` contains explicit `role:` on every one of the 5 existing entries.
 - [ ] `deploy/agents.yml` header comment documents the `role` field, its 3 values, and the default-when-absent rule using the canonical wording from N7.
-- [ ] `tests/deploy/test_gen_supervisor_conf.py` contains exactly: 3 test functions for happy paths (one per role, including an `external-satellite` entry with a valid `command_override`), 4 test functions for the error cases (unknown value, external-satellite without command_override, lyra-adapter with command_override, hub on wrong name), 3 test functions for inference-when-absent (one per role), and 1 test function asserting that a garbage-character `command_override` on a valid `role=external-satellite` entry still raises through `validate_command_override`.
+- [ ] `tests/deploy/test_gen_supervisor_conf.py` contains exactly: 3 test functions for happy paths (one per role, including an `external-satellite` entry with a valid `command_override`), 5 test functions for the error cases (unknown value, external-satellite without command_override, lyra-adapter with command_override, hub on wrong name, hub with command_override), 3 test functions for inference-when-absent (one per role), and 1 test function asserting that a garbage-character `command_override` on a valid `role=external-satellite` entry still raises through `validate_command_override`.
 - [ ] Pre-existing tests (`test_command_override_used_verbatim`, `test_fallback_run_hub_for_hub_name`, `test_fallback_run_adapter_for_other_names`) remain green. Any fixture modification is limited to adding explicit `role:` lines.
 
 ## Out of Scope

--- a/deploy/agents.yml
+++ b/deploy/agents.yml
@@ -3,6 +3,12 @@
 
 schema_version: "1.0"
 
+# Per-entry `role:` controls launcher dispatch in deploy/gen-supervisor-conf.py:
+#   role: hub                 → run_hub.sh (name must be 'hub')
+#   role: lyra-adapter        → run_adapter.sh <name> (default)
+#   role: external-satellite  → command_override (required on the entry)
+# Optional — inferred when absent; see resolve_role in gen-supervisor-conf.py.
+
 defaults:
   autostart: false
   autorestart: true
@@ -22,6 +28,7 @@ defaults:
 
 agents:
   hub:
+    role: hub
     command: lyra hub
     priority: 100
     startsecs: 10
@@ -30,16 +37,19 @@ agents:
       LYRA_HEALTH_PORT: "8443"
 
   telegram:
+    role: lyra-adapter
     command: lyra adapter telegram
     priority: 200
     nkey: telegram-adapter.seed
 
   discord:
+    role: lyra-adapter
     command: lyra adapter discord
     priority: 200
     nkey: discord-adapter.seed
 
   stt:
+    role: lyra-adapter
     command: lyra adapter stt
     priority: 200
     nkey: stt-adapter.seed
@@ -47,6 +57,7 @@ agents:
       LYRA_STT_ENABLED: "1"
 
   tts:
+    role: lyra-adapter
     command: lyra adapter tts
     priority: 200
     nkey: tts-adapter.seed

--- a/deploy/agents.yml
+++ b/deploy/agents.yml
@@ -8,6 +8,9 @@ schema_version: "1.0"
 #   role: lyra-adapter        → run_adapter.sh <name> (default)
 #   role: external-satellite  → command_override (required on the entry)
 # Optional — inferred when absent; see resolve_role in gen-supervisor-conf.py.
+#
+# Per-entry `command:` is documentation-only — not read by the generator.
+# Removal deferred to a follow-up issue (see #807 spec Out of Scope).
 
 defaults:
   autostart: false

--- a/deploy/gen-supervisor-conf.py
+++ b/deploy/gen-supervisor-conf.py
@@ -46,6 +46,47 @@ def validate_command_override(value: str) -> bool:
     # Must be non-empty and entirely within a safe character class
     return bool(value) and bool(re.match(r"^[A-Za-z0-9/_.\- ]+$", value))
 
+
+HUB_NAME = "hub"
+ROLES: frozenset[str] = frozenset({"hub", "lyra-adapter", "external-satellite"})
+
+
+def resolve_role(name: str, agent: dict[str, Any]) -> str:
+    """Resolve + validate the launcher-dispatch role for an agent entry.
+
+    If `role` is present, validate it is in ROLES and that cross-checks hold.
+    If absent, infer: command_override present → external-satellite; else
+    name == HUB_NAME → hub; else → lyra-adapter.
+
+    Raises ValueError with agent name on any misconfig.
+    """
+    has_override = "command_override" in agent
+    if "role" in agent:
+        role = agent["role"]
+        if role not in ROLES:
+            raise ValueError(
+                f"unknown role {role!r} (agent {name!r}); "
+                f"expected one of: {', '.join(sorted(ROLES))}"
+            )
+        if role == "external-satellite" and not has_override:
+            raise ValueError(
+                f"role=external-satellite requires command_override (agent {name!r})"
+            )
+        if role == "lyra-adapter" and has_override:
+            raise ValueError(
+                f"role=lyra-adapter must not set command_override (agent {name!r})"
+            )
+        if role == "hub" and name != HUB_NAME:
+            raise ValueError(f"role=hub requires name=={HUB_NAME!r} (got {name!r})")
+        return role
+    # Inference fallback (intentionally retained for backward-compat, see #807 spec)
+    if has_override:
+        return "external-satellite"
+    if name == HUB_NAME:
+        return "hub"
+    return "lyra-adapter"
+
+
 # Template defaults matching existing conf.d/*.conf structure
 DEFAULTS: dict[str, Any] = {
     "autostart": False,
@@ -111,20 +152,18 @@ def generate_conf(
     # Merge defaults with agent overrides
     cfg = {**defaults, **agent}
 
-    # Determine command:
-    #   1. explicit command_override in agents.yml — used verbatim (for external-satellite
-    #      programs like imagecli nats-serve that are not lyra CLI subcommands).
-    #   2. name == "hub" — deploy/supervisor/scripts/run_hub.sh.
-    #   3. default — deploy/supervisor/scripts/run_adapter.sh <name>.
-    if "command_override" in agent:
+    role = resolve_role(name, agent)
+
+    if role == "external-satellite":
         cmd_path = agent["command_override"]
         if not validate_command_override(cmd_path):
             raise ValueError(
-                f"Invalid command_override for {name!r} (shell-metachar or empty): {cmd_path!r}"
+                f"Invalid command_override for {name!r}"
+                f" (shell-metachar or empty): {cmd_path!r}"
             )
-    elif name == "hub":
+    elif role == "hub":
         cmd_path = RUN_HUB.format(home=ctx["home"])
-    else:
+    else:  # lyra-adapter
         cmd_path = f"{RUN_ADAPTER.format(home=ctx['home'])} {name}"
 
     lines = [f"[program:{program}]"]

--- a/deploy/gen-supervisor-conf.py
+++ b/deploy/gen-supervisor-conf.py
@@ -47,6 +47,21 @@ def validate_command_override(value: str) -> bool:
     return bool(value) and bool(re.match(r"^[A-Za-z0-9/_.\- ]+$", value))
 
 
+def validate_agent_name(name: str) -> bool:
+    """Validate agent name — alphanumerics, underscore, hyphen only.
+
+    For `lyra-adapter` entries, `name` is appended verbatim to the
+    supervisord ``command=`` line (via ``run_adapter.sh <name>``), which
+    supervisord feeds to /bin/sh. The repo-authored trust boundary of
+    `agents.yml` already constrains who can set this, but the same
+    shell-metachar discipline as `validate_command_override` applies as
+    defense-in-depth.
+    """
+    import re
+
+    return bool(name) and bool(re.match(r"^[A-Za-z0-9_-]+$", name))
+
+
 HUB_NAME = "hub"
 ROLES: frozenset[str] = frozenset({"hub", "lyra-adapter", "external-satellite"})
 
@@ -147,6 +162,9 @@ def generate_conf(
     name: str, agent: dict[str, Any], defaults: dict[str, Any], ctx: dict[str, str]
 ) -> str:
     """Generate a supervisor [program:...] config block."""
+    if not validate_agent_name(name):
+        raise ValueError(f"Invalid agent name (shell-metachar or empty): {name!r}")
+
     program = f"lyra_{name}"
 
     # Merge defaults with agent overrides

--- a/deploy/gen-supervisor-conf.py
+++ b/deploy/gen-supervisor-conf.py
@@ -92,7 +92,13 @@ def resolve_role(name: str, agent: dict[str, Any]) -> str:
                 f"role=lyra-adapter must not set command_override (agent {name!r})"
             )
         if role == "hub" and name != HUB_NAME:
-            raise ValueError(f"role=hub requires name=={HUB_NAME!r} (got {name!r})")
+            raise ValueError(
+                f"role=hub requires name {HUB_NAME!r}, got {name!r} (agent {name!r})"
+            )
+        if role == "hub" and has_override:
+            raise ValueError(
+                f"role=hub must not set command_override (agent {name!r})"
+            )
         return role
     # Inference fallback (intentionally retained for backward-compat, see #807 spec)
     if has_override:

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -233,3 +233,17 @@ def test_command_override_validation_chain_still_enforced(tmp_path: Path) -> Non
     err = _run_dry(p, expect_fail=True)
     # Assert
     assert "Invalid command_override" in err and "'sat'" in err
+
+
+# Agent-name validation (defense-in-depth, same allowlist style as
+# validate_env_key / validate_command_override).
+
+
+def test_invalid_agent_name_raises(tmp_path: Path) -> None:
+    # Arrange — name with a shell metachar would land on the command= line
+    # for a lyra-adapter agent via `run_adapter.sh <name>`.
+    p = _write_agents(tmp_path, {"telegram; rm -rf /": {"role": "lyra-adapter"}})
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "Invalid agent name" in err and "'telegram; rm -rf /'" in err

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -142,7 +142,7 @@ def test_resolve_role_raises_on_unknown_value(tmp_path: Path) -> None:
 
 def test_resolve_role_raises_external_satellite_without_override(
     tmp_path: Path,
-) -> None:  # noqa: E501
+) -> None:
     # Arrange
     p = _write_agents(tmp_path, {"sat": {"role": "external-satellite"}})
     # Act
@@ -195,7 +195,7 @@ def test_resolve_role_infers_lyra_adapter_default(tmp_path: Path) -> None:
 
 def test_resolve_role_infers_external_satellite_from_command_override(
     tmp_path: Path,
-) -> None:  # noqa: E501
+) -> None:
     # Arrange
     p = _write_agents(
         tmp_path,

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -28,6 +28,9 @@ def _run_dry(tmp_agents: Path, *, expect_fail: bool = False) -> str:
         timeout=10,
     )
     if expect_fail:
+        assert result.returncode != 0, (
+            f"Expected failure but exit=0; stderr={result.stderr}"
+        )
         return result.stderr
     if result.returncode != 0:
         import pytest as _pytest
@@ -180,8 +183,10 @@ def test_resolve_role_infers_hub_from_name(tmp_path: Path) -> None:
     p = _write_agents(tmp_path, {"hub": {"priority": 100}})
     # Act
     out = _run_dry(p)
-    # Assert
-    assert "run_hub.sh" in out and "run_adapter.sh hub" not in out
+    # Assert — inference routes to the hub launcher and nothing else.
+    assert "run_hub.sh" in out
+    assert "run_adapter.sh" not in out
+    assert "command=" in out
 
 
 def test_resolve_role_infers_lyra_adapter_default(tmp_path: Path) -> None:
@@ -189,8 +194,11 @@ def test_resolve_role_infers_lyra_adapter_default(tmp_path: Path) -> None:
     p = _write_agents(tmp_path, {"telegram": {"priority": 200}})
     # Act
     out = _run_dry(p)
-    # Assert
+    # Assert — inference routes to the adapter launcher with the agent name,
+    # never to the hub launcher.
     assert "run_adapter.sh telegram" in out
+    assert "run_hub.sh" not in out
+    assert "command=" in out
 
 
 def test_resolve_role_infers_external_satellite_from_command_override(
@@ -203,8 +211,11 @@ def test_resolve_role_infers_external_satellite_from_command_override(
     )
     # Act
     out = _run_dry(p)
-    # Assert
+    # Assert — inference picks the override verbatim; neither the hub nor
+    # adapter launcher may appear on the command line.
     assert "command=foo bar" in out
+    assert "run_adapter.sh" not in out
+    assert "run_hub.sh" not in out
 
 
 # T7 — validate_command_override pass-through

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -172,7 +172,22 @@ def test_resolve_role_raises_hub_on_wrong_name(tmp_path: Path) -> None:
     # Act
     err = _run_dry(p, expect_fail=True)
     # Assert
-    assert "name=='hub'" in err and "got 'side_hub'" in err
+    assert "role=hub requires name 'hub'" in err and "got 'side_hub'" in err
+
+
+def test_resolve_role_raises_hub_with_override(tmp_path: Path) -> None:
+    # Parity with test_resolve_role_raises_lyra_adapter_with_override:
+    # the hub branch dispatches to run_hub.sh and never honors a stray
+    # `command_override`, so the entry is rejected at validation time.
+    # Arrange
+    p = _write_agents(
+        tmp_path,
+        {"hub": {"role": "hub", "command_override": "x"}},
+    )
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "role=hub must not set command_override" in err and "agent 'hub'" in err
 
 
 # T6 — inference when role is absent

--- a/tests/deploy/test_gen_supervisor_conf.py
+++ b/tests/deploy/test_gen_supervisor_conf.py
@@ -1,4 +1,5 @@
 """Tests for deploy/gen-supervisor-conf.py command-generation behavior."""
+
 from __future__ import annotations
 
 import subprocess
@@ -6,7 +7,6 @@ import sys
 from pathlib import Path
 
 import yaml
-
 
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT = REPO / "deploy" / "gen-supervisor-conf.py"
@@ -87,3 +87,138 @@ def test_fallback_run_adapter_for_other_names(tmp_path: Path) -> None:
     assert "run_adapter.sh telegram" in out
     assert "imagecli nats-serve" not in out
     assert "run_hub.sh" not in out
+
+
+# T4 — explicit role: happy paths
+
+
+def test_resolve_role_explicit_hub(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"hub": {"role": "hub", "priority": 100}})
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "run_hub.sh" in out
+
+
+def test_resolve_role_explicit_lyra_adapter(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"telegram": {"role": "lyra-adapter", "priority": 200}})
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "run_adapter.sh telegram" in out
+
+
+def test_resolve_role_explicit_external_satellite(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(
+        tmp_path,
+        {
+            "sat": {
+                "role": "external-satellite",
+                "command_override": "foo bar",
+                "priority": 200,
+            }
+        },
+    )
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "command=foo bar" in out
+
+
+# T5 — error cases
+
+
+def test_resolve_role_raises_on_unknown_value(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"x": {"role": "adapter"}})
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "unknown role 'adapter'" in err and "agent 'x'" in err
+
+
+def test_resolve_role_raises_external_satellite_without_override(
+    tmp_path: Path,
+) -> None:  # noqa: E501
+    # Arrange
+    p = _write_agents(tmp_path, {"sat": {"role": "external-satellite"}})
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "requires command_override" in err and "agent 'sat'" in err
+
+
+def test_resolve_role_raises_lyra_adapter_with_override(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(
+        tmp_path,
+        {"telegram": {"role": "lyra-adapter", "command_override": "x"}},
+    )
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "must not set command_override" in err and "agent 'telegram'" in err
+
+
+def test_resolve_role_raises_hub_on_wrong_name(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"side_hub": {"role": "hub"}})
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "name=='hub'" in err and "got 'side_hub'" in err
+
+
+# T6 — inference when role is absent
+
+
+def test_resolve_role_infers_hub_from_name(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"hub": {"priority": 100}})
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "run_hub.sh" in out and "run_adapter.sh hub" not in out
+
+
+def test_resolve_role_infers_lyra_adapter_default(tmp_path: Path) -> None:
+    # Arrange
+    p = _write_agents(tmp_path, {"telegram": {"priority": 200}})
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "run_adapter.sh telegram" in out
+
+
+def test_resolve_role_infers_external_satellite_from_command_override(
+    tmp_path: Path,
+) -> None:  # noqa: E501
+    # Arrange
+    p = _write_agents(
+        tmp_path,
+        {"sat": {"command_override": "foo bar", "priority": 200}},
+    )
+    # Act
+    out = _run_dry(p)
+    # Assert
+    assert "command=foo bar" in out
+
+
+# T7 — validate_command_override pass-through
+
+
+def test_command_override_validation_chain_still_enforced(tmp_path: Path) -> None:
+    # A valid role but a garbage command_override must still raise via
+    # validate_command_override — the refactor must not bypass that guard.
+    # Arrange
+    p = _write_agents(
+        tmp_path,
+        {"sat": {"role": "external-satellite", "command_override": "foo; rm -rf /"}},
+    )
+    # Act
+    err = _run_dry(p, expect_fail=True)
+    # Assert
+    assert "Invalid command_override" in err and "'sat'" in err


### PR DESCRIPTION
## Summary
- Replace the 3-branch command-selection if/elif in `deploy/gen-supervisor-conf.py` with a role-keyed dispatch driven by a new `resolve_role(name, agent)` that combines inference and full validation.
- Add `role: {hub | lyra-adapter | external-satellite}` to all 5 entries in `deploy/agents.yml` + a 5-line canonical header comment. Generated `conf.d/*.conf` is byte-identical to pre-change.
- Add 11 new tests (3 happy paths, 4 error cases, 3 inference-when-absent paths, 1 `validate_command_override` pass-through). Pre-existing 3 tests remain green with no fixture edits.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#807](https://github.com/Roxabi/lyra/issues/807) | OPEN |
| Frame | [807-agents-role-enum-frame.mdx](artifacts/frames/807-agents-role-enum-frame.mdx) | Approved |
| Spec | [807-agents-role-enum-spec.mdx](artifacts/specs/807-agents-role-enum-spec.mdx) | Approved |
| Plan | [807-agents-role-enum-plan.mdx](artifacts/plans/807-agents-role-enum-plan.mdx) | 10 tasks, 4 slices |
| Implementation | 4 commits on \`feat/807-agents-role-enum\` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (11 new) | Passed |

## Test Plan
- [ ] \`uv run pytest tests/deploy/test_gen_supervisor_conf.py -v\` → 14 passed
- [ ] \`uv run deploy/gen-supervisor-conf.py --dry-run\` produces output byte-identical to pre-change (regression guardrail)
- [ ] Try adding \`voicecli_stt: {role: external-satellite}\` (no \`command_override\`) and run \`make gen-conf\` → descriptive \`ValueError\` naming the agent
- [ ] Mistype \`role: adapter\` on an entry → \`unknown role 'adapter'\` error

Closes #807

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`