### PR TITLE
refactor(adapters): remove deprecated auth= constructor parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,11 @@ packages = ["src/lyra"]
 asyncio_mode = "auto"
 testpaths = ["tests", "packages/roxabi-nats/tests", "packages/roxabi-contracts/tests", "scripts/corpus/tests"]
 addopts = "--import-mode=importlib -n auto"
+filterwarnings = [
+    "ignore:'audioop' is deprecated:DeprecationWarning",
+    "ignore:websockets.legacy is deprecated:DeprecationWarning",
+    "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -36,7 +36,6 @@ from lyra.adapters.discord_voice_commands import (
     handle_voice_command as _handle_voice_command_impl,
     register_voice_app_commands as _register_voice_app_commands,
 )
-from lyra.core.authenticator import _DENY_ALL, Authenticator
 from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.guard import BlockedGuard, GuardChain
 from lyra.core.trust import TrustLevel
@@ -72,7 +71,6 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         msg_manager: MessageManager | None = None,
         auto_thread: bool = True,
         thread_hot_hours: int = 36,
-        auth: Authenticator = _DENY_ALL,
         thread_store: ThreadStore | None = None,
         watch_channels: frozenset[int] = frozenset(),
         turn_store: "TurnStore | None" = None,
@@ -83,22 +81,12 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         super().__init__(intents=intents)
         self.tree = discord.app_commands.CommandTree(self)
         _register_voice_app_commands(self.tree, self)
-        if auth is not _DENY_ALL:
-            import warnings
-
-            warnings.warn(
-                "DiscordAdapter(auth=...) is deprecated after C3 — "
-                "use hub.register_authenticator() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         self._inbound_bus = inbound_bus
         self._bot_id = bot_id
         self._circuit_registry = circuit_registry
         self._msg_manager = msg_manager
         self._auto_thread = auto_thread
         self._thread_hot_hours = thread_hot_hours
-        self._auth: Authenticator = auth
         self._guard_chain: GuardChain = GuardChain([BlockedGuard()])
         self._max_audio_bytes: int = int(
             os.environ.get("LYRA_MAX_AUDIO_BYTES", 5 * 1024 * 1024)

--- a/src/lyra/adapters/telegram.py
+++ b/src/lyra/adapters/telegram.py
@@ -38,7 +38,6 @@ from lyra.adapters.telegram_outbound import (
     build_streaming_callbacks as _build_streaming_callbacks,
     send as _send_impl,
 )
-from lyra.core.authenticator import _DENY_ALL, Authenticator
 from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.guard import BlockedGuard, GuardChain
 from lyra.core.trust import TrustLevel
@@ -94,19 +93,9 @@ class TelegramAdapter(OutboundAdapterBase):
         webhook_secret: str = "",
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
-        auth: Authenticator = _DENY_ALL,
         turn_store: "TurnStore | None" = None,
     ) -> None:
         super().__init__()  # no-op today, future-proofs cooperative chain
-        if auth is not _DENY_ALL:
-            import warnings
-
-            warnings.warn(
-                "TelegramAdapter(auth=...) is deprecated after C3 — "
-                "use hub.register_authenticator() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         self._bot_id = bot_id
         self._token = token
         self._webhook_secret = webhook_secret
@@ -118,7 +107,6 @@ class TelegramAdapter(OutboundAdapterBase):
         self._inbound_bus = inbound_bus
         self._circuit_registry = circuit_registry
         self._msg_manager = msg_manager
-        self._auth: Authenticator = auth
         self._guard_chain: GuardChain = GuardChain([BlockedGuard()])
         self._turn_store: "TurnStore | None" = turn_store
         _raw_tmp = os.environ.get("LYRA_AUDIO_TMP") or None

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -16,7 +16,6 @@ import pytest
 
 from lyra.adapters.discord import DiscordAdapter
 from lyra.adapters.telegram import TelegramAdapter
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.message import InboundMessage
 from lyra.core.trust import TrustLevel
@@ -242,7 +241,7 @@ def _make_telegram_adapter() -> TelegramAdapter:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     return adapter
 

--- a/tests/adapters/test_discord_audio.py
+++ b/tests/adapters/test_discord_audio.py
@@ -11,7 +11,6 @@ import pytest
 
 from lyra.adapters.discord import DiscordAdapter
 from lyra.core.audio_payload import AudioPayload
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.message import InboundMessage
 
 
@@ -54,7 +53,6 @@ def _make_adapter() -> DiscordAdapter:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
 
@@ -129,7 +127,6 @@ async def test_on_message_enqueues_audio_on_inbound_bus() -> None:
         bot_id="main",
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     # Use a valid OGG magic header so the magic-byte check passes.
@@ -195,7 +192,6 @@ async def test_on_message_audio_invalid_magic_bytes_sends_reply() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     attachment_obj = SimpleNamespace(
@@ -222,7 +218,6 @@ async def test_on_message_audio_too_large_sends_reply() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     attachment_obj = SimpleNamespace(
@@ -249,7 +244,6 @@ async def test_on_message_does_not_call_normalize_audio_for_non_audio() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     image_attachment = SimpleNamespace(
@@ -289,7 +283,6 @@ async def test_on_message_returns_after_audio_skips_text_path() -> None:
         bot_id="main",
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     attachment_obj = SimpleNamespace(

--- a/tests/adapters/test_discord_edge.py
+++ b/tests/adapters/test_discord_edge.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.messages import MessageManager
 from lyra.core.trust import TrustLevel
@@ -78,7 +77,6 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
         bot_id="main",
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -127,7 +125,6 @@ async def test_on_message_drops_silently_when_hub_circuit_open() -> None:
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
         circuit_registry=registry,
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -166,7 +163,6 @@ async def test_on_message_notifies_user_when_hub_circuit_open_dm() -> None:
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
         circuit_registry=registry,
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -278,7 +274,6 @@ async def test_discord_msg_manager_injection_backpressure_ack() -> None:
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
         msg_manager=mm,
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -318,7 +313,6 @@ def test_normalize_empty_text() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
     discord_msg = SimpleNamespace(

--- a/tests/adapters/test_discord_normalize.py
+++ b/tests/adapters/test_discord_normalize.py
@@ -9,8 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
-
 # ---------------------------------------------------------------------------
 # T2 — _normalize() builds correct DiscordContext
 # ---------------------------------------------------------------------------
@@ -25,7 +23,6 @@ def test_normalize_builds_correct_discord_context() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -63,7 +60,6 @@ def test_is_mention_true_when_bot_in_mentions() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -96,7 +92,6 @@ def test_is_mention_false_when_bot_not_in_mentions() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -129,7 +124,6 @@ def test_normalize_bot_user_none_is_mention_false() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     # _bot_user stays None (default, before on_ready fires)
 
@@ -161,7 +155,6 @@ def test_mention_prefix_stripped_from_content() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -190,7 +183,6 @@ def test_mention_prefix_stripped_nickname_variant() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -224,7 +216,6 @@ def test_normalize_dm_no_guild() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -259,7 +250,6 @@ def test_normalize_uses_display_name_when_present() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -288,7 +278,6 @@ def test_normalize_falls_back_to_name_when_display_name_none() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -327,7 +316,6 @@ def test_discord_token_not_in_logs(
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     with caplog.at_level(logging.DEBUG):
@@ -364,7 +352,6 @@ def test_normalize_guild_channel_user_scoped_scope_id() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -393,7 +380,6 @@ def test_normalize_dm_scope_id_unchanged() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -420,7 +406,6 @@ def test_normalize_thread_scope_id_unchanged() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -454,7 +439,6 @@ def test_two_users_same_guild_channel_share_pool_id() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 

--- a/tests/adapters/test_discord_outbound.py
+++ b/tests/adapters/test_discord_outbound.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.message import (
     Button,
     OutboundMessage,
@@ -29,7 +28,6 @@ def _make_discord_adapter():
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
 
@@ -52,7 +50,6 @@ async def test_own_message_is_filtered() -> None:
         bot_id="main",
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     bot_user = SimpleNamespace(id=999, bot=True)
     adapter._bot_user = bot_user
@@ -86,7 +83,6 @@ async def test_send_reply_on_mention() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -117,7 +113,6 @@ async def test_send_reply_on_no_mention() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -148,7 +143,6 @@ async def test_send_stores_reply_message_id_channel_send() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     sent_msg = SimpleNamespace(id=888)
@@ -181,7 +175,6 @@ async def test_send_stores_reply_message_id_msg_reply() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     sent_msg = SimpleNamespace(id=7777)
@@ -214,7 +207,6 @@ async def test_send_no_reply_message_id_on_failure() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -376,7 +368,6 @@ async def test_discord_fallback_sets_reply_message_id() -> None:
     import discord
 
     from lyra.adapters.discord import DiscordAdapter
-    from lyra.core.authenticator import _ALLOW_ALL
     from lyra.core.message import InboundMessage, OutboundMessage
     from lyra.core.trust import TrustLevel
 
@@ -384,7 +375,6 @@ async def test_discord_fallback_sets_reply_message_id() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     # Use a message with no message_id so should_reply=False (avoids reply() path)

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -9,8 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
-
 # ---------------------------------------------------------------------------
 # Tests for Discord auto_thread (issue #127)
 # ---------------------------------------------------------------------------
@@ -35,7 +33,6 @@ class TestDiscordAutoThread:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
         )
         bot_user = SimpleNamespace(id=999, bot=True)
         adapter._bot_user = bot_user
@@ -87,7 +84,6 @@ class TestDiscordAutoThread:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
         )
         bot_user = SimpleNamespace(id=999, bot=True)
         adapter._bot_user = bot_user
@@ -130,7 +126,6 @@ class TestDiscordAutoThread:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=False,
-            auth=_ALLOW_ALL,
         )
         bot_user = SimpleNamespace(id=999, bot=True)
         adapter._bot_user = bot_user
@@ -169,7 +164,6 @@ class TestDiscordAutoThread:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
         )
         bot_user = SimpleNamespace(id=999, bot=True)
         adapter._bot_user = bot_user
@@ -210,7 +204,6 @@ class TestDiscordAutoThread:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
         )
         bot_user = SimpleNamespace(id=999, bot=True)
         adapter._bot_user = bot_user
@@ -324,7 +317,6 @@ class TestPersistThreadClaimFailurePath:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
         )
         bot_user = SimpleNamespace(id=999, bot=True)
         adapter._bot_user = bot_user

--- a/tests/adapters/test_discord_typing.py
+++ b/tests/adapters/test_discord_typing.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.message import OutboundMessage
 from lyra.core.render_events import TextRenderEvent
 
@@ -68,7 +67,6 @@ async def test_start_typing_creates_background_task() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     mock_channel = AsyncMock()
     mock_channel.typing = AsyncMock()
@@ -95,7 +93,6 @@ async def test_cancel_typing_cancels_task() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     mock_channel = AsyncMock()
     mock_channel.typing = AsyncMock()
@@ -119,7 +116,6 @@ async def test_send_cancels_typing_task_at_start() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     mock_message = AsyncMock()
@@ -153,7 +149,6 @@ async def test_send_streaming_cancels_typing_task_at_start() -> None:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
 
     mock_placeholder = AsyncMock()
@@ -207,7 +202,6 @@ async def test_on_message_does_not_cancel_typing_when_message_queued() -> None:
         bot_id="main",
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 
@@ -254,7 +248,6 @@ async def test_on_message_cancels_typing_when_message_dropped_queue_full() -> No
         bot_id="main",
         inbound_bus=inbound_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
 

--- a/tests/adapters/test_discord_voice_commands.py
+++ b/tests/adapters/test_discord_voice_commands.py
@@ -14,7 +14,6 @@ from lyra.adapters.discord_voice import (
     VoiceDependencyError,
     VoiceMode,
 )
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.message import OutboundAudioChunk
 from lyra.core.trust import TrustLevel
 
@@ -355,7 +354,6 @@ class TestOnMessageVoiceCommandWiring:
             bot_id="main",
             inbound_bus=inbound_bus,
         )
-        adapter._auth = _ALLOW_ALL  # permit the message
         # Mock _handle_voice_command to return True (simulates voice command handled)
         adapter._handle_voice_command = AsyncMock(return_value=True)
 

--- a/tests/adapters/test_discord_watch.py
+++ b/tests/adapters/test_discord_watch.py
@@ -9,8 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
-
 
 class TestWatchChannels:
     """Watch channel feature: messages in designated channels bypass mention filter."""
@@ -28,7 +26,6 @@ class TestWatchChannels:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
             watch_channels=frozenset({333}),
         )
         bot_user = SimpleNamespace(id=999, bot=True)
@@ -73,7 +70,6 @@ class TestWatchChannels:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
             watch_channels=frozenset({333}),
         )
         bot_user = SimpleNamespace(id=999, bot=True)
@@ -121,7 +117,6 @@ class TestWatchChannels:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
             watch_channels=frozenset({999}),  # different channel
         )
         bot_user = SimpleNamespace(id=999, bot=True)
@@ -156,7 +151,6 @@ class TestWatchChannels:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=False,
-            auth=_ALLOW_ALL,
             watch_channels=frozenset({333}),
         )
         bot_user = SimpleNamespace(id=999, bot=True)
@@ -202,7 +196,6 @@ class TestWatchChannels:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
             watch_channels=frozenset({333}),
         )
         bot_user = SimpleNamespace(id=999, bot=True)
@@ -242,7 +235,6 @@ class TestWatchChannels:
             inbound_bus=inbound_bus,
             intents=discord.Intents.none(),
             auto_thread=True,
-            auth=_ALLOW_ALL,
             watch_channels=frozenset({333}),
         )
         bot_user = SimpleNamespace(id=999, bot=True)

--- a/tests/adapters/test_scope_id.py
+++ b/tests/adapters/test_scope_id.py
@@ -21,7 +21,6 @@ import discord
 
 from lyra.adapters.discord import DiscordAdapter
 from lyra.adapters.telegram_normalize import _make_scope_id
-from lyra.core.authenticator import _ALLOW_ALL
 
 # ---------------------------------------------------------------------------
 # Discord — two users in same guild channel
@@ -33,7 +32,7 @@ def _make_discord_adapter() -> DiscordAdapter:
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
     return adapter

--- a/tests/adapters/test_telegram_normalize_fields.py
+++ b/tests/adapters/test_telegram_normalize_fields.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.message import InboundMessage
 
 # ---------------------------------------------------------------------------
@@ -28,7 +27,7 @@ def test_normalize_private_chat_context() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
 
     aiogram_msg = SimpleNamespace(
@@ -67,7 +66,7 @@ def test_is_mention_false_in_private_chat() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
 
     aiogram_msg = SimpleNamespace(
@@ -92,7 +91,7 @@ def test_is_mention_true_when_entity_at_offset_zero() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter._bot_username = "lyra_bot"  # simulate resolve_identity()
 
@@ -125,7 +124,7 @@ def test_token_not_in_logs(caplog: pytest.LogCaptureFixture) -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
 
     aiogram_msg = SimpleNamespace(
@@ -158,7 +157,7 @@ def test_normalize_captures_message_id() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -191,7 +190,7 @@ def test_normalize_message_id_none_when_absent() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -225,7 +224,7 @@ def test_normalize_captures_topic_and_message_id_for_forum() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=456, type="supergroup"),
@@ -256,7 +255,7 @@ def test_normalize_empty_text() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -286,7 +285,7 @@ def test_normalize_sets_reply_to_id_when_reply_present() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     reply_msg = SimpleNamespace(message_id=77)
     aiogram_msg = SimpleNamespace(
@@ -313,7 +312,7 @@ def test_normalize_reply_to_id_none_when_no_reply() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     aiogram_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -344,7 +343,7 @@ def test_normalize_group_chat_user_scoped_scope_id() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter._bot_username = "lyra_bot"
 
@@ -373,7 +372,7 @@ def test_normalize_group_chat_no_mention_shared_scope() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
 
     aiogram_msg = SimpleNamespace(
@@ -400,7 +399,7 @@ def test_normalize_forum_topic_shared_scope_id() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter._bot_username = "lyra_bot"
 
@@ -428,7 +427,7 @@ def test_normalize_private_chat_scope_id_unchanged() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
 
     aiogram_msg = SimpleNamespace(
@@ -456,7 +455,7 @@ def test_two_users_same_group_share_pool_id() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter._bot_username = "lyra_bot"
 

--- a/tests/adapters/test_telegram_on_message.py
+++ b/tests/adapters/test_telegram_on_message.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.messages import MessageManager
 
@@ -63,7 +62,7 @@ async def test_backpressure_sends_ack_when_bus_full() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=inbound_bus,
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 
@@ -106,7 +105,7 @@ async def test_telegram_msg_manager_injection_backpressure_ack() -> None:
         token="test-token-secret",
         inbound_bus=inbound_bus,
         msg_manager=mm,
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 
@@ -143,7 +142,7 @@ async def test_on_message_drops_bot_text_message() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=inbound_bus,
-        auth=_ALLOW_ALL,
+        
     )
     bot_msg = SimpleNamespace(
         chat=SimpleNamespace(id=123, type="private"),
@@ -183,7 +182,7 @@ async def test_on_message_drops_and_notifies_when_hub_circuit_open() -> None:
         token="test-token-secret",
         inbound_bus=inbound_bus,
         circuit_registry=registry,
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 

--- a/tests/adapters/test_telegram_outbound_send.py
+++ b/tests/adapters/test_telegram_outbound_send.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.message import (  # noqa: F401
     InboundMessage,
     OutboundMessage,
@@ -38,7 +37,7 @@ async def test_send_calls_bot_send_message() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 
@@ -92,7 +91,7 @@ async def test_send_skips_when_platform_context_is_not_telegram(
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 
@@ -143,7 +142,7 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 

--- a/tests/adapters/test_telegram_typing.py
+++ b/tests/adapters/test_telegram_typing.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
 from lyra.core.render_events import TextRenderEvent
 from lyra.core.trust import TrustLevel
 
@@ -135,7 +134,7 @@ async def test_send_cancels_typing_task() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 
@@ -200,7 +199,7 @@ async def test_send_streaming_cancels_typing_task_after_placeholder() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=MagicMock(),
-        auth=_ALLOW_ALL,
+        
     )
     adapter.bot = bot
 

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lyra.adapters.telegram import TelegramAdapter
-from lyra.core.authenticator import _ALLOW_ALL
 
 
 def _make_voice_msg(  # noqa: PLR0913 — test factory with optional overrides
@@ -58,7 +57,7 @@ def _make_adapter() -> tuple[TelegramAdapter, MagicMock]:
         bot_id="main",
         token="tok",
         inbound_bus=inbound_bus,
-        auth=_ALLOW_ALL,
+        
     )
     bot_mock = AsyncMock()
     bot_mock.send_chat_action = AsyncMock()

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -33,13 +33,11 @@ from .conftest import _RC_DC, _RC_TG, make_routing_inbound
 class TestTelegramNormalizeRouting:
     def test_routing_populated(self) -> None:
         from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.authenticator import _ALLOW_ALL
 
         adapter = TelegramAdapter(
             bot_id="main",
             token="fake",
             inbound_bus=MagicMock(),
-            auth=_ALLOW_ALL,
         )
 
         raw = SimpleNamespace(
@@ -68,13 +66,11 @@ class TestTelegramNormalizeRouting:
 
     def test_routing_with_topic(self) -> None:
         from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.authenticator import _ALLOW_ALL
 
         adapter = TelegramAdapter(
             bot_id="main",
             token="fake",
             inbound_bus=MagicMock(),
-            auth=_ALLOW_ALL,
         )
 
         raw = SimpleNamespace(
@@ -101,13 +97,11 @@ class TestTelegramNormalizeRouting:
     def test_routing_platform_meta_is_copy(self) -> None:
         """RoutingContext.platform_meta must not alias InboundMessage.platform_meta."""
         from lyra.adapters.telegram import TelegramAdapter
-        from lyra.core.authenticator import _ALLOW_ALL
 
         adapter = TelegramAdapter(
             bot_id="main",
             token="fake",
             inbound_bus=MagicMock(),
-            auth=_ALLOW_ALL,
         )
 
         raw = SimpleNamespace(
@@ -140,13 +134,11 @@ class TestTelegramNormalizeRouting:
 class TestDiscordNormalizeRouting:
     def test_routing_populated(self) -> None:
         from lyra.adapters.discord import DiscordAdapter
-        from lyra.core.authenticator import _ALLOW_ALL
 
         adapter = DiscordAdapter.__new__(DiscordAdapter)
         adapter._bot_id = "main"
         adapter._bot_user = None
         adapter._mention_re = None
-        adapter._auth = _ALLOW_ALL
 
         channel = MagicMock(spec=[])
         channel.id = 789

--- a/tests/integration/test_session_dm_discord.py
+++ b/tests/integration/test_session_dm_discord.py
@@ -11,8 +11,6 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
-
 pytestmark = pytest.mark.asyncio
 
 
@@ -79,7 +77,6 @@ async def test_discord_dm_injects_thread_session_id() -> None:
         bot_id="main",
         inbound_bus=mock_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
         turn_store=fake_turn_store,  # type: ignore[arg-type]
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
@@ -122,7 +119,6 @@ async def test_discord_dm_no_turn_store_does_not_inject() -> None:
         bot_id="main",
         inbound_bus=mock_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
         # No turn_store
     )
     adapter._bot_user = SimpleNamespace(id=999, bot=True)
@@ -149,7 +145,6 @@ async def test_discord_dm_turn_store_attribute_stored() -> None:
         bot_id="main",
         inbound_bus=mock_bus,
         intents=discord.Intents.none(),
-        auth=_ALLOW_ALL,
         turn_store=fake_turn_store,  # type: ignore[arg-type]
     )
 

--- a/tests/integration/test_session_telegram.py
+++ b/tests/integration/test_session_telegram.py
@@ -10,8 +10,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.core.authenticator import _ALLOW_ALL
-
 pytestmark = pytest.mark.asyncio
 
 
@@ -80,7 +78,6 @@ def _make_telegram_adapter(fake_turn_store=None, mock_bus=None):
         bot_id="main",
         token="test-token-secret",
         inbound_bus=mock_bus,
-        auth=_ALLOW_ALL,
     )
     if fake_turn_store is not None:
         kwargs["turn_store"] = fake_turn_store
@@ -158,7 +155,6 @@ async def test_telegram_no_turn_store_no_injection() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=mock_bus,
-        auth=_ALLOW_ALL,
     )
     adapter.bot = AsyncMock()
     adapter.bot.get_me = AsyncMock(return_value=SimpleNamespace(username="lyra_bot"))
@@ -188,7 +184,6 @@ async def test_telegram_turn_store_attribute_stored() -> None:
         bot_id="main",
         token="test-token-secret",
         inbound_bus=mock_bus,
-        auth=_ALLOW_ALL,
         turn_store=fake_turn_store,  # type: ignore[arg-type]
     )
 

--- a/tests/tts/test_voice_command.py
+++ b/tests/tts/test_voice_command.py
@@ -284,13 +284,10 @@ class TestTelegramAdapterRenderAudio:
     """
 
     def _make_adapter(self) -> TelegramAdapter:
-        from lyra.core.authenticator import _ALLOW_ALL
-
         adapter = TelegramAdapter(
             bot_id="main",
             token="test-token",
             inbound_bus=MagicMock(),
-            auth=_ALLOW_ALL,
         )
         adapter.bot = AsyncMock()
         return adapter


### PR DESCRIPTION
## Summary
- Remove deprecated `auth=` constructor parameter from TelegramAdapter and DiscordAdapter
- Remove associated deprecation warning code and `self._auth` attribute
- Migrate all test files from `auth=_ALLOW_ALL` pattern
- Add filterwarnings for upstream deprecation warnings in pytest config

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #847: refactor(adapters): remove deprecated auth= constructor parameter | OPEN |
| Frame | [847-remove-deprecated-auth-param-frame.mdx](artifacts/frames/847-remove-deprecated-auth-param-frame.mdx) | Present |
| Spec | [847-remove-deprecated-auth-param-spec.mdx](artifacts/specs/847-remove-deprecated-auth-param-spec.mdx) | Present |
| Implementation | 1 commit on `feat/847-remove-deprecated-auth-param` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2757 passed) | Passed |

## Test Plan
- [x] All 2757 tests pass
- [x] No deprecation warnings from Lyra code
- [x] Upstream warnings suppressed in pytest config
- [x] Type checker passes

Closes #847

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`