### PR TITLE
test(agents): agent integration test harness

### DIFF
--- a/artifacts/analyses/851-test-coverage-consensus.mdx
+++ b/artifacts/analyses/851-test-coverage-consensus.mdx
@@ -1,0 +1,60 @@
+---
+title: "Test Coverage Fixes — Expert Consensus"
+issue: 851
+status: consensus-reached
+date: 2026-04-22
+panel: architect, tester, product-lead
+confidence: high
+---
+
+## Problem
+
+Code review identified 5 test coverage improvements for the agent integration harness. Need consensus on which to apply before merge.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | Arch soundness, test infrastructure reliability |
+| tester | Test coverage, edge cases, test quality |
+| product-lead | Time-to-market, value vs effort |
+
+## Consensus Recommendation
+
+**Apply:** #1 (FakeTts edge cases), #2 (FakeStt.last_audio), #4 (misleading test name)
+**Defer:** #3 (stream empty queue)
+**Skip:** #5 (messages parameter)
+
+### Rationale
+
+- **#1, #2:** Fakes are test infrastructure — unvalidated fakes undermine harness confidence. Architect + Tester agree.
+- **#4:** Zero risk rename, improves clarity for future maintainers. Unanimous.
+- **#3:** Legitimate edge case but low priority; defer to post-ship backlog.
+- **#5:** 70% confidence, optional API surface, no evidence of real-world need.
+
+## Trade-offs
+
+- Test infrastructure reliability vs test count increase
+- Quick clarity wins (#4) vs diminishing returns on mock internals
+- Ship velocity vs polish — majority chose balanced approach (3 fixes, ~15-20 lines)
+
+## Alternatives
+
+| Option | Proposed by | Rejected because |
+|--------|-------------|------------------|
+| Apply all 5 | Tester | Product-lead: time-to-market impact on non-blocking fixes |
+| Apply only #4 | Product-lead | Architect/Tester: fake validation is valuable |
+| Skip all | — | Unanimous: #4 is zero-risk improvement |
+
+## Dissent
+
+- **Product-lead** dissented on #1, #2: "Fake internals don't affect prod; diminishing returns on mock coverage."
+- Recorded and acknowledged. Domain experts (architect + tester) consider fake validation valuable.
+
+## Implementation Notes
+
+Effort: ~15-20 lines of test code across 2 test files.
+
+## Next
+
+Apply fixes #1, #2, #4 → commit → update PR → merge.

--- a/tests/fixtures/agent_harness.py
+++ b/tests/fixtures/agent_harness.py
@@ -1,0 +1,276 @@
+"""Agent harness for integration tests.
+
+Provides a fully-wired test environment with fake drivers for LLM, TTS, and STT.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tomllib
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+from lyra.agents.simple_agent import SimpleAgent
+from lyra.core.agent import Agent
+from lyra.core.auth.trust import TrustLevel
+from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.pool import Pool
+
+from .fake_drivers import FakeClaudeCliDriver, FakeStt, FakeTts
+
+if TYPE_CHECKING:
+    pass
+
+
+MINIMAL_TOML = """
+[agent]
+name = "test"
+system_prompt = "You are a test agent."
+
+[model]
+backend = "claude-cli"
+model = "claude-sonnet-4-6"
+"""
+
+
+def _parse_toml_config(toml: str) -> Agent:
+    """Parse TOML string into Agent config."""
+    data = tomllib.loads(toml)
+    agent_section = data.get("agent", {})
+    model_section = data.get("model", {})
+
+    name = agent_section.get("name") or model_section.get("name", "test")
+    system_prompt = agent_section.get("system_prompt", "")
+    memory_namespace = agent_section.get("memory_namespace", name)
+
+    from lyra.core.agent.agent_config import ModelConfig
+
+    model_cfg = ModelConfig(
+        backend=model_section.get("backend", "claude-cli"),
+        model=model_section.get("model", "claude-sonnet-4-6"),
+    )
+
+    return Agent(
+        name=name,
+        system_prompt=system_prompt,
+        memory_namespace=memory_namespace,
+        llm_config=model_cfg,
+    )
+
+
+def _make_ctx_mock(agents: dict | None = None) -> MagicMock:
+    """Build a minimal PoolContext mock (mirrors tests/core/conftest.py)."""
+    ctx = MagicMock()
+    _agents: dict = agents or {}
+    ctx.get_agent = MagicMock(side_effect=lambda name: _agents.get(name))
+    ctx.get_message = MagicMock(return_value=None)
+    ctx.dispatch_response = AsyncMock(return_value=None)
+    ctx.dispatch_streaming = AsyncMock(return_value=None)
+    ctx.record_circuit_success = MagicMock()
+    ctx.record_circuit_failure = MagicMock()
+    ctx._agents = _agents
+    return ctx
+
+
+async def _drain(pool: Pool, *, timeout: float = 2.0) -> None:
+    """Yield to the event loop then wait for the current task to finish."""
+    await asyncio.sleep(0)
+    if pool._current_task is not None:
+        await asyncio.wait_for(pool._current_task, timeout=timeout)
+
+
+@dataclass
+class AgentHarness:
+    """Test harness for agent integration tests.
+
+    Holds all components needed to test an agent with fake drivers.
+    """
+
+    agent: SimpleAgent
+    driver: FakeClaudeCliDriver
+    stt: FakeStt
+    tts: FakeTts
+    ctx: MagicMock  # PoolContext mock
+    pool: Pool
+
+    async def send(self, text: str, voice: str | None = None) -> Response:
+        """Send a text message to the agent and return the response.
+
+        Args:
+            text: The message text to send.
+            voice: Optional voice name to trigger TTS synthesis.
+
+        Returns:
+            The Response from the agent.
+        """
+        msg = InboundMessage(
+            id="msg-1",
+            platform="telegram",
+            bot_id="main",
+            scope_id="chat:1",
+            user_id="tg:user:1",
+            user_name="TestUser",
+            is_mention=False,
+            text=text,
+            text_raw=text,
+            trust_level=TrustLevel.TRUSTED,
+            timestamp=datetime.now(timezone.utc),
+            platform_meta={
+                "chat_id": 1,
+                "topic_id": None,
+                "message_id": None,
+                "is_group": False,
+            },
+        )
+
+        if voice is not None:
+            self.pool.voice_mode = True
+
+        self.pool.submit(msg)
+        await _drain(self.pool)
+
+        # Extract response from dispatch_response mock
+        self.ctx.dispatch_response.assert_awaited()
+        # call_args[0][1] is the Response argument
+        response: Response = self.ctx.dispatch_response.call_args[0][1]
+
+        # Simulate TTS dispatch (which would happen in Hub's OutboundRouter)
+        # In the real flow, voice_mode triggers TTS synthesis after response
+        if voice is not None and response.content:
+            await self.tts.synthesize(response.content, voice=voice)
+
+        return response
+
+    async def send_audio(self, audio_bytes: bytes, transcript: str) -> Response:
+        """Simulate sending an audio message that was already transcribed by STT.
+
+        In the real pipeline, STT middleware runs BEFORE the agent sees the message.
+        This method simulates that by:
+        1. Recording that STT was "called" with the audio bytes
+        2. Sending a voice-modality message with the transcript pre-filled
+
+        Args:
+            audio_bytes: Raw audio data (recorded for assertion).
+            transcript: The transcript (as if STT produced it).
+
+        Returns:
+            The Response from the agent.
+        """
+        # Record STT call for test assertions
+        self.stt.called = True
+        self.stt.last_audio = audio_bytes
+
+        # Send as a voice-modality message with transcript already filled
+        # (simulating post-STT-middleware state)
+        msg = InboundMessage(
+            id="msg-1",
+            platform="telegram",
+            bot_id="main",
+            scope_id="chat:1",
+            user_id="tg:user:1",
+            user_name="TestUser",
+            is_mention=False,
+            text=transcript,
+            text_raw=transcript,
+            trust_level=TrustLevel.TRUSTED,
+            timestamp=datetime.now(timezone.utc),
+            modality="voice",
+            platform_meta={
+                "chat_id": 1,
+                "topic_id": None,
+                "message_id": None,
+                "is_group": False,
+            },
+        )
+
+        self.pool.submit(msg)
+        await _drain(self.pool)
+
+        # Extract response from dispatch_response mock
+        self.ctx.dispatch_response.assert_awaited()
+        response: Response = self.ctx.dispatch_response.call_args[0][1]
+        return response
+
+    def assert_tts_called_with(self, voice: str) -> None:
+        """Assert that TTS was called with the specified voice.
+
+        Args:
+            voice: Expected voice name.
+
+        Raises:
+            AssertionError: If TTS was not called or voice doesn't match.
+        """
+        assert self.tts.called, "TTS was not called"
+        assert self.tts.last_voice == voice, (
+            f"TTS voice mismatch: expected {voice!r}, got {self.tts.last_voice!r}"
+        )
+
+
+@asynccontextmanager
+async def agent_harness(
+    agent_cls: type[SimpleAgent] = SimpleAgent,
+    toml: str = MINIMAL_TOML,
+) -> AsyncIterator[AgentHarness]:
+    """Create a fully-wired agent test harness.
+
+    Sets up:
+    - SimpleAgent with FakeClaudeCliDriver
+    - Pool with ctx_mock
+    - FakeStt and FakeTts instances
+    - Wires everything together
+
+    Args:
+        agent_cls: Agent class to instantiate (default: SimpleAgent).
+        toml: TOML config string for the agent.
+
+    Yields:
+        AgentHarness with all components ready for testing.
+    """
+    driver = FakeClaudeCliDriver()
+    stt = FakeStt()
+    tts = FakeTts()
+
+    config = _parse_toml_config(toml)
+
+    agent = agent_cls(
+        config=config,
+        provider=driver,  # type: ignore[arg-type]
+        stt=stt,
+        tts=tts,
+    )
+
+    ctx = _make_ctx_mock(agents={config.name: agent})
+
+    pool = Pool(
+        pool_id=f"test:{config.name}:chat:1",
+        agent_name=config.name,
+        ctx=ctx,
+        turn_timeout=60.0,
+        debounce_ms=0,
+    )
+
+    # Wire the agent's pool reference if needed
+    # (SimpleAgent doesn't need explicit pool wiring - it receives pool in process())
+
+    harness = AgentHarness(
+        agent=agent,
+        driver=driver,
+        stt=stt,
+        tts=tts,
+        ctx=ctx,
+        pool=pool,
+    )
+
+    try:
+        yield harness
+    finally:
+        # Cleanup: cancel any running task
+        if pool._current_task is not None and not pool._current_task.done():
+            pool._current_task.cancel()
+            try:
+                await pool._current_task
+            except asyncio.CancelledError:
+                pass

--- a/tests/fixtures/fake_drivers.py
+++ b/tests/fixtures/fake_drivers.py
@@ -1,0 +1,168 @@
+"""Fake drivers for integration tests (TTS, STT, LLM)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lyra.core.agent.agent_config import ModelConfig
+from lyra.core.messaging.events import LlmEvent, ResultLlmEvent, TextLlmEvent
+from lyra.llm.base import LlmResult
+from lyra.stt import TranscriptionResult
+from lyra.tts import SynthesisResult
+
+
+@dataclass
+class FakeTts:
+    """Fake TTS driver for testing.
+
+    Records all synthesize calls and returns configurable mock audio.
+    Supports error injection via raise_on_synthesize.
+    """
+
+    called: bool = False
+    last_text: str = ""
+    last_voice: str = ""
+    last_language: str | None = None
+    raise_on_synthesize: Exception | None = None
+    _audio_bytes: bytes = field(default_factory=lambda: b"RIFFmock_wav_data")
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        agent_tts=None,
+        language: str | None = None,
+        voice: str | None = None,
+        fallback_language: str | None = None,
+    ) -> SynthesisResult:
+        """Record call and return mock audio bytes."""
+        self.called = True
+        self.last_text = text
+        self.last_voice = voice or ""
+        self.last_language = language
+
+        if self.raise_on_synthesize:
+            raise self.raise_on_synthesize
+
+        return SynthesisResult(
+            audio_bytes=self._audio_bytes,
+            mime_type="audio/wav",
+            duration_ms=100,
+        )
+
+
+@dataclass
+class FakeStt:
+    """Fake STT driver for testing.
+
+    Returns preset transcript or raises if configured.
+    Records all transcribe calls for assertion.
+    """
+
+    preset_transcript: str = "Hello world"
+    called: bool = False
+    last_audio: bytes = field(default_factory=bytes)
+    last_path: Path | str | None = None
+    raise_on_transcribe: Exception | None = None
+
+    async def transcribe(self, path: Path | str) -> TranscriptionResult:
+        """Return preset transcript or raise if configured."""
+        self.called = True
+        self.last_path = path
+
+        try:
+            self.last_audio = Path(path).read_bytes()
+        except Exception:
+            self.last_audio = b""
+
+        if self.raise_on_transcribe:
+            raise self.raise_on_transcribe
+
+        return TranscriptionResult(
+            text=self.preset_transcript,
+            language="en",
+            duration_seconds=2.5,
+        )
+
+
+@dataclass
+class FakeClaudeCliDriver:
+    """Fake LLM driver for testing.
+
+    Implements the LlmProvider protocol with controllable responses.
+    Use queue_response() or queue_error() to preset results for tests.
+    """
+
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    _queue: list[LlmResult] = field(default_factory=list)
+    raise_on_complete: Exception | None = None
+
+    def queue_response(self, text: str, session_id: str = "test-sess") -> None:
+        """Queue a successful response to return on next complete() call."""
+        self._queue.append(LlmResult(result=text, session_id=session_id))
+
+    def queue_error(self, error: str) -> None:
+        """Queue an error response."""
+        self._queue.append(LlmResult(error=error))
+
+    async def complete(
+        self,
+        pool_id: str,
+        text: str,
+        model_cfg: ModelConfig,
+        system_prompt: str,
+        *,
+        messages: list[dict] | None = None,
+    ) -> LlmResult:
+        """Return queued LlmResult or raise if raise_on_complete is set."""
+        if self.raise_on_complete is not None:
+            raise self.raise_on_complete
+
+        if not self._queue:
+            return LlmResult(error="No queued response in FakeClaudeCliDriver")
+
+        return self._queue.pop(0)
+
+    async def stream(
+        self,
+        pool_id: str,
+        text: str,
+        model_cfg: ModelConfig,
+        system_prompt: str,
+        *,
+        messages: list[dict] | None = None,
+    ) -> AsyncIterator[LlmEvent]:
+        """Yield queued chunks as LlmEvents."""
+        if self.raise_on_complete is not None:
+            raise self.raise_on_complete
+
+        if not self._queue:
+            yield ResultLlmEvent(
+                is_error=True, duration_ms=0, error_text="No queued response"
+            )
+            return
+
+        result = self._queue.pop(0)
+        if result.error:
+            yield ResultLlmEvent(
+                is_error=True, duration_ms=0, error_text=result.error
+            )
+            return
+
+        # Yield text as a single chunk, then result event
+        yield TextLlmEvent(text=result.result)
+        yield ResultLlmEvent(is_error=False, duration_ms=0)
+
+    def is_alive(self, pool_id: str) -> bool:
+        """Always return True for tests."""
+        return True
+
+
+__all__ = [
+    "FakeClaudeCliDriver",
+    "FakeStt",
+    "FakeTts",
+]

--- a/tests/fixtures/test_agent_harness.py
+++ b/tests/fixtures/test_agent_harness.py
@@ -66,19 +66,13 @@ class TestAgentHarness:
             # Error content should be present
 
     @pytest.mark.asyncio
-    async def test_send_audio_raises_on_stt_error(self) -> None:
-        """h.send_audio handles STT errors gracefully."""
+    async def test_send_audio_handles_gracefully(self) -> None:
+        """h.send_audio returns Response even with invalid input."""
         async with agent_harness() as h:
-
-            # Simulate STT error
-            h.stt.raise_on_transcribe = RuntimeError("STT service down")
-            # Need to queue a response for the error handling path
-            h.driver.queue_response(
-                "Could not transcribe your message", session_id="test-sess"
-            )
-            # This should handle the error gracefully
-            resp = await h.send_audio(b"fake audio", transcript="should fail")
+            h.driver.queue_response("I heard you", session_id="test-sess")
+            resp = await h.send_audio(b"fake audio", transcript="hello")
             assert isinstance(resp, Response)
+            assert h.stt.called  # STT flag was set
 
     @pytest.mark.asyncio
     async def test_custom_toml_config(self) -> None:

--- a/tests/fixtures/test_agent_harness.py
+++ b/tests/fixtures/test_agent_harness.py
@@ -1,0 +1,111 @@
+"""Tests for agent_harness integration test utilities."""
+
+import pytest
+
+from lyra.core.messaging.message import Response
+
+from .agent_harness import agent_harness
+
+
+class TestAgentHarness:
+    """Tests for AgentHarness context manager."""
+
+    @pytest.mark.asyncio
+    async def test_context_manager_returns_harness(self) -> None:
+        """agent_harness returns an AgentHarness instance."""
+        async with agent_harness() as h:
+            assert h.agent is not None
+            assert h.driver is not None
+            assert h.stt is not None
+            assert h.tts is not None
+            assert h.pool is not None
+            assert h.ctx is not None
+
+    @pytest.mark.asyncio
+    async def test_send_returns_response(self) -> None:
+        """h.send(text) returns a Response with queued content."""
+        async with agent_harness() as h:
+            h.driver.queue_response("Hello back!", session_id="test-sess")
+            resp = await h.send("hello")
+            assert isinstance(resp, Response)
+            assert resp.content == "Hello back!"
+
+    @pytest.mark.asyncio
+    async def test_send_audio_triggers_stt(self) -> None:
+        """h.send_audio sets preset_transcript and triggers STT path."""
+        async with agent_harness() as h:
+            h.driver.queue_response("I heard you say 'hi'", session_id="test-sess")
+            resp = await h.send_audio(b"fake audio bytes", transcript="hi")
+            assert h.stt.called
+            assert isinstance(resp, Response)
+
+    @pytest.mark.asyncio
+    async def test_send_with_voice_triggers_tts(self) -> None:
+        """h.send with voice= triggers TTS synthesis."""
+        async with agent_harness() as h:
+            h.driver.queue_response("Speaking now", session_id="test-sess")
+            await h.send("speak this", voice="Sohee")
+            h.assert_tts_called_with(voice="Sohee")
+
+    @pytest.mark.asyncio
+    async def test_assert_tts_called_with_fails_when_not_called(self) -> None:
+        """assert_tts_called_with raises when TTS was not called."""
+        async with agent_harness() as h:
+            h.driver.queue_response("No speech", session_id="test-sess")
+            await h.send("no voice here")
+            with pytest.raises(AssertionError, match="TTS was not called"):
+                h.assert_tts_called_with(voice="Sohee")
+
+    @pytest.mark.asyncio
+    async def test_send_returns_error_on_driver_error(self) -> None:
+        """h.send returns error Response when driver queues error."""
+        async with agent_harness() as h:
+            h.driver.queue_error("Something went wrong")
+            resp = await h.send("hello")
+            assert isinstance(resp, Response)
+            # Error content should be present
+
+    @pytest.mark.asyncio
+    async def test_send_audio_raises_on_stt_error(self) -> None:
+        """h.send_audio handles STT errors gracefully."""
+        async with agent_harness() as h:
+
+            # Simulate STT error
+            h.stt.raise_on_transcribe = RuntimeError("STT service down")
+            # Need to queue a response for the error handling path
+            h.driver.queue_response(
+                "Could not transcribe your message", session_id="test-sess"
+            )
+            # This should handle the error gracefully
+            resp = await h.send_audio(b"fake audio", transcript="should fail")
+            assert isinstance(resp, Response)
+
+    @pytest.mark.asyncio
+    async def test_custom_toml_config(self) -> None:
+        """agent_harness accepts custom TOML config."""
+        custom_toml = """
+[agent]
+name = "custom_agent"
+system_prompt = "You are a custom test agent."
+
+[model]
+backend = "claude-cli"
+model = "claude-sonnet-4-6"
+"""
+        async with agent_harness(toml=custom_toml) as h:
+            assert h.agent.config.name == "custom_agent"
+            assert "custom test agent" in h.agent.config.system_prompt
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_conversation(self) -> None:
+        """Multiple sends in sequence work correctly."""
+        async with agent_harness() as h:
+            # First turn
+            h.driver.queue_response("Hello!", session_id="sess-1")
+            resp1 = await h.send("hi")
+            assert resp1.content == "Hello!"
+
+            # Second turn
+            h.driver.queue_response("How can I help?", session_id="sess-2")
+            resp2 = await h.send("what can you do?")
+            assert resp2.content == "How can I help?"

--- a/tests/fixtures/test_fake_drivers.py
+++ b/tests/fixtures/test_fake_drivers.py
@@ -1,0 +1,278 @@
+"""Tests for fake TTS/STT/LLM drivers."""
+
+from pathlib import Path
+
+import pytest
+from tests.fixtures.fake_drivers import (
+    FakeClaudeCliDriver,
+    FakeStt,
+    FakeTts,
+)
+
+from lyra.core.agent.agent_config import ModelConfig
+from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
+from lyra.stt import TranscriptionResult
+from lyra.tts import SynthesisResult
+
+
+class TestFakeTts:
+    """Tests for FakeTts driver."""
+
+    def test_fake_tts_default_state(self) -> None:
+        """Fresh instance should have default state."""
+        tts = FakeTts()
+        assert tts.called is False
+        assert tts.last_text == ""
+        assert tts.last_voice == ""
+        assert tts.raise_on_synthesize is None
+
+    @pytest.mark.asyncio
+    async def test_fake_tts_records_synthesize_call(self) -> None:
+        """Should record text and voice from synthesize call."""
+        tts = FakeTts()
+
+        result = await tts.synthesize("Test text", voice="alloy")
+
+        assert tts.called is True
+        assert tts.last_text == "Test text"
+        assert tts.last_voice == "alloy"
+        assert isinstance(result, SynthesisResult)
+        assert result.audio_bytes == tts._audio_bytes
+
+    @pytest.mark.asyncio
+    async def test_fake_tts_returns_synthesis_result(self) -> None:
+        """Should return FakeSynthesisResult with expected defaults."""
+        tts = FakeTts()
+
+        result = await tts.synthesize("Hello")
+
+        assert result.mime_type == "audio/wav"
+        assert result.duration_ms == 100
+        assert result.waveform_b64 is None
+
+    @pytest.mark.asyncio
+    async def test_fake_tts_records_optional_params(self) -> None:
+        """Should record language parameter."""
+        tts = FakeTts()
+
+        await tts.synthesize("Test", language="fr", voice="echo")
+
+        assert tts.last_language == "fr"
+        assert tts.last_voice == "echo"
+
+    @pytest.mark.asyncio
+    async def test_fake_tts_raises_when_configured(self) -> None:
+        """Should raise exception when raise_on_synthesize is set."""
+        tts = FakeTts(raise_on_synthesize=RuntimeError("TTS unavailable"))
+
+        with pytest.raises(RuntimeError, match="TTS unavailable"):
+            await tts.synthesize("Test")
+
+        assert tts.called is True  # Call was recorded before raise
+
+
+class TestFakeStt:
+    """Tests for FakeStt driver."""
+
+    def test_fake_stt_default_state(self) -> None:
+        """Fresh instance should have default state."""
+        stt = FakeStt()
+        assert stt.called is False
+        assert stt.preset_transcript == "Hello world"
+        assert stt.raise_on_transcribe is None
+
+    @pytest.mark.asyncio
+    async def test_fake_stt_returns_preset_transcript(self) -> None:
+        """Should return configured preset transcript."""
+        stt = FakeStt(preset_transcript="Custom transcript")
+
+        result = await stt.transcribe("/fake/audio.wav")
+
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "Custom transcript"
+        assert result.language == "en"
+
+    @pytest.mark.asyncio
+    async def test_fake_stt_records_call(self) -> None:
+        """Should record the path from transcribe call."""
+        stt = FakeStt()
+
+        await stt.transcribe("/path/to/audio.wav")
+
+        assert stt.called is True
+        assert stt.last_path == "/path/to/audio.wav"
+
+    @pytest.mark.asyncio
+    async def test_fake_stt_raises_when_configured(self) -> None:
+        """Should raise exception when raise_on_transcribe is set."""
+        stt = FakeStt(raise_on_transcribe=RuntimeError("STT unavailable"))
+
+        with pytest.raises(RuntimeError, match="STT unavailable"):
+            await stt.transcribe("/fake/audio.wav")
+
+        assert stt.called is True  # Call was recorded before raise
+
+    @pytest.mark.asyncio
+    async def test_fake_stt_accepts_path_object(self) -> None:
+        """Should accept Path object as argument."""
+        stt = FakeStt(preset_transcript="Path test")
+
+        result = await stt.transcribe(Path("/some/audio.wav"))
+
+        assert result.text == "Path test"
+        assert stt.last_path == Path("/some/audio.wav")
+
+
+class TestFakeClaudeCliDriver:
+    """Tests for FakeClaudeCliDriver."""
+
+    @pytest.fixture
+    def driver(self) -> FakeClaudeCliDriver:
+        """Create a fresh driver instance."""
+        return FakeClaudeCliDriver()
+
+    @pytest.fixture
+    def model_cfg(self) -> ModelConfig:
+        """Create a default model config."""
+        return ModelConfig()
+
+    @pytest.mark.asyncio
+    async def test_complete_returns_queued_response(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """complete() returns queued response."""
+        driver.queue_response("Hello, world!", session_id="sess-123")
+
+        result = await driver.complete(
+            pool_id="test-pool",
+            text="Hi",
+            model_cfg=model_cfg,
+            system_prompt="You are helpful.",
+        )
+
+        assert result.ok
+        assert result.result == "Hello, world!"
+        assert result.session_id == "sess-123"
+
+    @pytest.mark.asyncio
+    async def test_complete_returns_queued_error(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """complete() returns queued error."""
+        driver.queue_error("Something went wrong")
+
+        result = await driver.complete(
+            pool_id="test-pool",
+            text="Hi",
+            model_cfg=model_cfg,
+            system_prompt="You are helpful.",
+        )
+
+        assert not result.ok
+        assert result.error == "Something went wrong"
+
+    @pytest.mark.asyncio
+    async def test_complete_raises_when_configured(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """complete() raises raise_on_complete exception when set."""
+        driver.raise_on_complete = RuntimeError("Connection failed")
+        driver.queue_response("Should not be returned")
+
+        with pytest.raises(RuntimeError, match="Connection failed"):
+            await driver.complete(
+                pool_id="test-pool",
+                text="Hi",
+                model_cfg=model_cfg,
+                system_prompt="You are helpful.",
+            )
+
+    @pytest.mark.asyncio
+    async def test_complete_returns_error_when_queue_empty(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """complete() returns error result when no response queued."""
+        result = await driver.complete(
+            pool_id="test-pool",
+            text="Hi",
+            model_cfg=model_cfg,
+            system_prompt="You are helpful.",
+        )
+
+        assert not result.ok
+        assert "No queued response" in result.error
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_text_and_result_events(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """stream() yields TextLlmEvent followed by ResultLlmEvent."""
+        driver.queue_response("Hello from stream")
+
+        events = []
+        async for event in driver.stream(
+            pool_id="test-pool",
+            text="Hi",
+            model_cfg=model_cfg,
+            system_prompt="You are helpful.",
+        ):
+            events.append(event)
+
+        assert len(events) == 2
+        assert isinstance(events[0], TextLlmEvent)
+        assert events[0].text == "Hello from stream"
+        assert isinstance(events[1], ResultLlmEvent)
+        assert not events[1].is_error
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_error_event_on_error(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """stream() yields error ResultLlmEvent when queued error."""
+        driver.queue_error("Stream error")
+
+        events = []
+        async for event in driver.stream(
+            pool_id="test-pool",
+            text="Hi",
+            model_cfg=model_cfg,
+            system_prompt="You are helpful.",
+        ):
+            events.append(event)
+
+        assert len(events) == 1
+        assert isinstance(events[0], ResultLlmEvent)
+        assert events[0].is_error
+        assert events[0].error_text == "Stream error"
+
+    @pytest.mark.asyncio
+    async def test_stream_raises_when_configured(
+        self, driver: FakeClaudeCliDriver, model_cfg: ModelConfig
+    ) -> None:
+        """stream() raises raise_on_complete exception when set."""
+        driver.raise_on_complete = RuntimeError("Stream connection failed")
+        driver.queue_response("Should not be yielded")
+
+        with pytest.raises(RuntimeError, match="Stream connection failed"):
+            async for _ in driver.stream(
+                pool_id="test-pool",
+                text="Hi",
+                model_cfg=model_cfg,
+                system_prompt="You are helpful.",
+            ):
+                pass
+
+    def test_is_alive_always_true(self, driver: FakeClaudeCliDriver) -> None:
+        """is_alive() always returns True."""
+        assert driver.is_alive("any-pool")
+        assert driver.is_alive("different-pool")
+
+    def test_queue_fifo_order(self, driver: FakeClaudeCliDriver) -> None:
+        """Responses are returned in FIFO order."""
+        driver.queue_response("First")
+        driver.queue_response("Second")
+        driver.queue_response("Third")
+
+        assert driver._queue[0].result == "First"
+        assert driver._queue[1].result == "Second"
+        assert driver._queue[2].result == "Third"

--- a/tests/fixtures/test_fake_drivers.py
+++ b/tests/fixtures/test_fake_drivers.py
@@ -70,6 +70,27 @@ class TestFakeTts:
 
         assert tts.called is True  # Call was recorded before raise
 
+    @pytest.mark.asyncio
+    async def test_fake_tts_handles_empty_text(self) -> None:
+        """Should handle empty text gracefully."""
+        tts = FakeTts()
+
+        result = await tts.synthesize("")
+
+        assert tts.called is True
+        assert tts.last_text == ""
+        assert result.audio_bytes == tts._audio_bytes
+
+    @pytest.mark.asyncio
+    async def test_fake_tts_handles_none_voice(self) -> None:
+        """Should handle None voice gracefully."""
+        tts = FakeTts()
+
+        result = await tts.synthesize("Test text", voice=None)
+
+        assert tts.last_voice == ""
+        assert result.audio_bytes == tts._audio_bytes
+
 
 class TestFakeStt:
     """Tests for FakeStt driver."""
@@ -101,6 +122,34 @@ class TestFakeStt:
 
         assert stt.called is True
         assert stt.last_path == "/path/to/audio.wav"
+
+    @pytest.mark.asyncio
+    async def test_fake_stt_records_audio_bytes(self) -> None:
+        """Should record audio bytes from file path."""
+        import tempfile
+
+        stt = FakeStt()
+
+        # Create a temp file with fake audio bytes
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            f.write(b"fake audio data here")
+            temp_path = f.name
+
+        try:
+            await stt.transcribe(temp_path)
+
+            assert stt.last_audio == b"fake audio data here"
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_fake_stt_handles_missing_file(self) -> None:
+        """Should handle missing file gracefully (empty bytes)."""
+        stt = FakeStt()
+
+        await stt.transcribe("/nonexistent/audio.wav")
+
+        assert stt.last_audio == b""  # Graceful fallback
 
     @pytest.mark.asyncio
     async def test_fake_stt_raises_when_configured(self) -> None:


### PR DESCRIPTION
## Summary
- Add reusable test harness for agent integration tests with deterministic LLM responses
- Create FakeClaudeCliDriver, FakeTts, FakeStt mock implementations
- Implement AgentHarness async context manager with send(), send_audio(), assert_tts_called_with()

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #851: test(agents): agent integration test harness | OPEN |
| Spec | [851-agent-integration-test-harness-spec.mdx](artifacts/specs/851-agent-integration-test-harness-spec.mdx) | Present |
| Implementation | 1 commit on `feat/851-agent-integration-test-harness` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (28 new) | Passed |

## Test Plan
- [x] FakeClaudeCliDriver: queue_response(), queue_error(), complete(), stream()
- [x] FakeTts: synthesize(), call recording, error injection
- [x] FakeStt: preset_transcript, error injection
- [x] AgentHarness: async context manager wiring
- [x] send(): text messages return Response
- [x] send_audio(): voice messages with STT simulation
- [x] send(voice=): TTS synthesis triggered
- [x] assert_tts_called_with(): verify TTS calls
- [x] All 48 tests pass in <5s

Closes #851

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`