### PR TITLE
refactor(core): move cross-layer exceptions to core/exceptions.py

### DIFF
--- a/src/lyra/adapters/nats/nats_stream_decoder.py
+++ b/src/lyra/adapters/nats/nats_stream_decoder.py
@@ -18,18 +18,14 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
+from lyra.core.exceptions import StreamChunkTimeout
+
 if TYPE_CHECKING:
     from lyra.core.hub.hub_protocol import RenderEvent
 
 log = logging.getLogger(__name__)
 
 _CHUNK_TIMEOUT_SECONDS = 120.0
-
-
-class StreamChunkTimeout(TimeoutError):
-    """Raised when the outbound chunk queue was idle past _CHUNK_TIMEOUT_SECONDS."""
-
-
 _MAX_TERMINATED_STREAMS = 500
 
 

--- a/src/lyra/adapters/shared/_shared_streaming_state.py
+++ b/src/lyra/adapters/shared/_shared_streaming_state.py
@@ -11,7 +11,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from lyra.adapters.nats.nats_stream_decoder import StreamChunkTimeout
+from lyra.core.exceptions import StreamChunkTimeout
 from lyra.core.messaging.message import GENERIC_ERROR_REPLY
 from lyra.core.messaging.render_events import TextRenderEvent
 

--- a/src/lyra/commands/add_vault/handlers.py
+++ b/src/lyra/commands/add_vault/handlers.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from lyra.core.exceptions import VaultWriteFailed
 from lyra.core.messaging.message import InboundMessage, Response
-from lyra.integrations.base import SessionTools, VaultWriteFailed
+from lyra.integrations.base import SessionTools
 
 if TYPE_CHECKING:
     from lyra.llm.base import LlmProvider

--- a/src/lyra/core/exceptions.py
+++ b/src/lyra/core/exceptions.py
@@ -1,0 +1,29 @@
+"""Cross-layer exception classes.
+
+These exceptions are raised and caught across multiple layers.
+They live in the innermost layer (core) to avoid downward imports.
+"""
+
+from typing import Literal
+
+
+class StreamChunkTimeout(TimeoutError):
+    """Raised when the outbound chunk queue was idle past the timeout threshold."""
+
+
+class ScrapeFailed(Exception):
+    """Raised when the scraper fails or is not available."""
+
+    def __init__(
+        self, reason: Literal["not_available", "timeout", "subprocess_error"]
+    ) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+class VaultWriteFailed(Exception):
+    """Raised when the vault write fails or is not available."""
+
+    def __init__(self, reason: str = "") -> None:
+        self.reason = reason
+        super().__init__(reason)

--- a/src/lyra/core/processors/_scraping.py
+++ b/src/lyra/core/processors/_scraping.py
@@ -15,8 +15,8 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from lyra.core.exceptions import ScrapeFailed
 from lyra.core.processors.processor_registry import BaseProcessor
-from lyra.integrations.base import ScrapeFailed
 
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage

--- a/src/lyra/core/processors/vault_add.py
+++ b/src/lyra/core/processors/vault_add.py
@@ -14,13 +14,13 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+from lyra.core.exceptions import VaultWriteFailed
 from lyra.core.messaging.message import Response
 from lyra.core.processors._scraping import (
     ScrapingProcessor,
     _extract_and_validate_url,
 )
 from lyra.core.processors.processor_registry import register
-from lyra.integrations.base import VaultWriteFailed
 
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage

--- a/src/lyra/integrations/base.py
+++ b/src/lyra/integrations/base.py
@@ -17,24 +17,6 @@ from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
 
 
-class ScrapeFailed(Exception):
-    """Raised when the scraper fails or is not available."""
-
-    def __init__(
-        self, reason: Literal["not_available", "timeout", "subprocess_error"]
-    ) -> None:
-        self.reason = reason
-        super().__init__(reason)
-
-
-class VaultWriteFailed(Exception):
-    """Raised when the vault write fails or is not available."""
-
-    def __init__(self, reason: str = "") -> None:
-        self.reason = reason
-        super().__init__(reason)
-
-
 @runtime_checkable
 class ScrapeProvider(Protocol):
     """Async scraper: fetch URL → return text content."""

--- a/src/lyra/integrations/vault_cli.py
+++ b/src/lyra/integrations/vault_cli.py
@@ -16,7 +16,7 @@ import logging
 import re
 from asyncio.subprocess import PIPE
 
-from lyra.integrations.base import VaultWriteFailed
+from lyra.core.exceptions import VaultWriteFailed
 
 _SAFE_CLI_ARG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 

--- a/src/lyra/integrations/web_intel.py
+++ b/src/lyra/integrations/web_intel.py
@@ -16,7 +16,7 @@ import os
 from asyncio.subprocess import PIPE
 from pathlib import Path
 
-from lyra.integrations.base import ScrapeFailed
+from lyra.core.exceptions import ScrapeFailed
 
 log = logging.getLogger(__name__)
 

--- a/tests/adapters/test_streaming_session.py
+++ b/tests/adapters/test_streaming_session.py
@@ -14,11 +14,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.adapters.nats.nats_stream_decoder import (
-    StreamChunkTimeout,
-    decode_stream_events,
-)
+from lyra.adapters.nats.nats_stream_decoder import decode_stream_events
 from lyra.adapters.shared._shared_streaming import PlatformCallbacks, StreamingSession
+from lyra.core.exceptions import StreamChunkTimeout
 from lyra.core.messaging.message import GENERIC_ERROR_REPLY, OutboundMessage
 from lyra.core.messaging.render_events import TextRenderEvent, ToolSummaryRenderEvent
 

--- a/tests/core/processors/test_add_vault.py
+++ b/tests/core/processors/test_add_vault.py
@@ -18,8 +18,9 @@ from lyra.commands.add_vault.handlers import (
 )
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandContext
+from lyra.core.exceptions import VaultWriteFailed
 from lyra.core.messaging.message import InboundMessage
-from lyra.integrations.base import SessionTools, VaultWriteFailed
+from lyra.integrations.base import SessionTools
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/core/processors/test_scraping.py
+++ b/tests/core/processors/test_scraping.py
@@ -11,6 +11,7 @@ import pytest
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandContext
+from lyra.core.exceptions import ScrapeFailed
 from lyra.core.messaging.message import InboundMessage
 from lyra.core.processors._scraping import (
     _SAFE_SCRAPE_MAX_CHARS,
@@ -18,7 +19,7 @@ from lyra.core.processors._scraping import (
     _extract_and_validate_url,
     _scrape_with_fallback,
 )
-from lyra.integrations.base import ScrapeFailed, SessionTools
+from lyra.integrations.base import SessionTools
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/core/processors/test_vault_add_post.py
+++ b/tests/core/processors/test_vault_add_post.py
@@ -9,9 +9,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandContext
+from lyra.core.exceptions import VaultWriteFailed
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.processors.vault_add import VaultAddProcessor
-from lyra.integrations.base import SessionTools, VaultWriteFailed
+from lyra.integrations.base import SessionTools
 
 
 def make_tools(

--- a/tests/core/processors/test_vault_add_pre.py
+++ b/tests/core/processors/test_vault_add_pre.py
@@ -8,10 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandContext
+from lyra.core.exceptions import ScrapeFailed
 from lyra.core.messaging.message import InboundMessage
 from lyra.core.processors._scraping import _SAFE_SCRAPE_MAX_CHARS
 from lyra.core.processors.vault_add import VaultAddProcessor
-from lyra.integrations.base import ScrapeFailed, SessionTools
+from lyra.integrations.base import SessionTools
 
 
 def make_tools(

--- a/tests/integrations/test_vault_cli.py
+++ b/tests/integrations/test_vault_cli.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from lyra.integrations.base import VaultProvider, VaultWriteFailed
+from lyra.core.exceptions import VaultWriteFailed
+from lyra.integrations.base import VaultProvider
 from lyra.integrations.vault_cli import VaultCli
 
 

--- a/tests/integrations/test_web_intel.py
+++ b/tests/integrations/test_web_intel.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from lyra.integrations.base import ScrapeFailed, ScrapeProvider
+from lyra.core.exceptions import ScrapeFailed
+from lyra.integrations.base import ScrapeProvider
 from lyra.integrations.web_intel import WebIntelScraper
 
 


### PR DESCRIPTION
## Summary
- Move `StreamChunkTimeout`, `ScrapeFailed`, `VaultWriteFailed` to `lyra/core/exceptions.py`
- Eliminates layer violations: core→integrations and adapters→nats imports
- Update all importers across adapters, core, integrations, commands, and tests

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #856: move cross-layer exception classes | Open |
| Implementation | 1 commit on `worktree-856-move-exceptions` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (106 passed) | Passed |
| Import-linter | 2 contracts KEPT (was 0 broken) | Passed |

## Test Plan
- [ ] Verify import-linter passes with both contracts KEPT
- [ ] Verify exception classes work identically from new location
- [ ] Run affected test suites (processors, integrations, streaming)

Fixes #856

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`