### PR TITLE
refactor(nats): rename VoiceWorkerRegistry to WorkerRegistry

### DIFF
--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -1,6 +1,6 @@
 """NatsImageClient — hub-side NATS request-reply client for image generation.
 
-Maintains a ``VoiceWorkerRegistry`` populated from heartbeats, and routes each
+Maintains a ``WorkerRegistry`` populated from heartbeats, and routes each
 generation request to the least-loaded worker via the queue-group subject
 ``lyra.image.generate.request``. Falls back to ``ImageUnavailableError`` when
 the registry is stale, the circuit breaker is open, or the adapter times out.
@@ -18,7 +18,7 @@ from uuid import uuid4
 from nats.aio.client import Client as NATS
 from pydantic import ValidationError
 
-from lyra.nats.voice_health import VoiceWorkerRegistry
+from lyra.nats.worker_registry import WorkerRegistry
 from roxabi_contracts.envelope import CONTRACT_VERSION, ContractEnvelope
 from roxabi_contracts.voice.subjects import validate_worker_id
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
@@ -151,7 +151,7 @@ class NatsImageClient:
         self._nc = nc
         self._timeout = timeout
         self._cb = NatsCircuitBreaker()
-        self._registry = VoiceWorkerRegistry()
+        self._registry = WorkerRegistry()
         self._hb_sub = None  # set by start
 
     async def start(self) -> None:

--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -179,8 +179,8 @@ class NatsImageClient:
             return
         # Receive-side match for the PUBLISH-path safe-chars enforcement; blocks
         # wildcard-bearing ids (e.g. "evil.worker.*") from polluting the registry
-        # for up to the 15 s heartbeat-stale window. Mirrors voice canonical at
-        # nats_tts_client.py:70-82.
+        # for up to the 15 s heartbeat-stale window. Mirrors the heartbeat guard
+        # in nats_tts_client.py:70-82.
         try:
             validate_worker_id(worker_id)
         except ValueError:

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -1,6 +1,6 @@
 """NatsSttClient — hub-side NATS request-reply client for STT.
 
-Maintains a ``VoiceWorkerRegistry`` populated from heartbeats, and routes each
+Maintains a ``WorkerRegistry`` populated from heartbeats, and routes each
 transcription to the least-loaded worker via its per-worker subject
 ``lyra.voice.stt.request.{worker_id}``. Falls back once to the queue-group
 subject (``lyra.voice.stt.request``) if the targeted worker times out.
@@ -21,7 +21,7 @@ from uuid import uuid4
 from nats.aio.client import Client as NATS
 from pydantic import ValidationError
 
-from lyra.nats.voice_health import VoiceWorkerRegistry
+from lyra.nats.worker_registry import WorkerRegistry
 from lyra.stt import (
     STTNoiseError,
     STTUnavailableError,
@@ -93,7 +93,7 @@ class NatsSttClient:
         self._detection_segments = language_detection_segments
         self._detection_fallback = language_fallback
         self._cb = NatsCircuitBreaker()
-        self._registry = VoiceWorkerRegistry()
+        self._registry = WorkerRegistry()
         self._hb_sub = None  # set by start
 
     async def start(self) -> None:

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -1,6 +1,6 @@
 """NatsTtsClient — hub-side NATS request-reply client for TTS.
 
-Maintains a ``VoiceWorkerRegistry`` populated from heartbeats, and routes each
+Maintains a ``WorkerRegistry`` populated from heartbeats, and routes each
 synthesis to the least-loaded worker via its per-worker subject
 ``lyra.voice.tts.request.{worker_id}``. Falls back once to the queue-group
 subject (``lyra.voice.tts.request``) if the targeted worker times out.
@@ -18,7 +18,7 @@ from uuid import uuid4
 from nats.aio.client import Client as NATS
 from pydantic import ValidationError
 
-from lyra.nats.voice_health import VoiceWorkerRegistry
+from lyra.nats.worker_registry import WorkerRegistry
 from lyra.tts import SynthesisResult, TtsUnavailableError
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.voice import (
@@ -42,7 +42,7 @@ class NatsTtsClient:
         self._nc = nc
         self._timeout = timeout
         self._cb = NatsCircuitBreaker()
-        self._registry = VoiceWorkerRegistry()
+        self._registry = WorkerRegistry()
         self._hb_sub = None  # set by start
 
     async def start(self) -> None:

--- a/src/lyra/nats/worker_registry.py
+++ b/src/lyra/nats/worker_registry.py
@@ -1,9 +1,9 @@
-"""Voice worker registry + load-aware scoring.
+"""Worker registry + load-aware scoring.
 
-Consumes heartbeat payloads from STT/TTS adapters, maintains a live-worker
+Consumes heartbeat payloads from domain adapters, maintains a live-worker
 registry scored by ``(active_requests, vram_used_pct)``, and exposes selection
-helpers used by the hub-side clients (``NatsSttClient`` / ``NatsTtsClient``) to
-pick the least-loaded worker before routing a request.
+helpers used by hub-side clients to pick the least-loaded worker before
+routing a request.
 
 Scoring: ``score = active_requests * active_weight + vram_used_pct * vram_weight``.
 Lower is better. Workers without VRAM data (``vram_total_mb=0``) contribute only
@@ -37,7 +37,7 @@ class WorkerStats:
     active_requests: int = 0
 
 
-class VoiceWorkerRegistry:
+class WorkerRegistry:
     def __init__(
         self,
         *,
@@ -77,7 +77,7 @@ class VoiceWorkerRegistry:
             validate_nats_token(worker_id, kind="worker_id")
         except ValueError:
             log.warning(
-                "voice_health: rejecting heartbeat with invalid worker_id=%r",
+                "worker_registry: rejecting heartbeat with invalid worker_id=%r",
                 worker_id,
             )
             return
@@ -85,7 +85,7 @@ class VoiceWorkerRegistry:
         # ids past the cap is dropped (not silently, one log per incident).
         if worker_id not in self._workers and len(self._workers) >= MAX_WORKERS:
             log.warning(
-                "voice_health: registry full (%d workers); dropping new id=%r",
+                "worker_registry: registry full (%d workers); dropping new id=%r",
                 MAX_WORKERS,
                 worker_id,
             )

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.nats.nats_stt_client import NatsSttClient
-from lyra.nats.voice_health import WorkerStats
+from lyra.nats.worker_registry import WorkerStats
 from lyra.stt import STTNoiseError, STTUnavailableError
 
 
@@ -408,7 +408,7 @@ class TestSttClientFreshness:
         assert result.text == "resumed"
 
     # NOTE: registry-level aliveness / pruning semantics are covered by
-    # ``tests/nats/test_voice_health.py`` — no need to duplicate here.
+    # ``tests/nats/test_worker_registry.py`` — no need to duplicate here.
 
 
 class TestTranscribeResponseParsing:

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -11,7 +11,7 @@ import pytest
 
 from lyra.core.agent.agent_config import AgentTTSConfig
 from lyra.nats.nats_tts_client import _TTS_CONFIG_FIELDS, NatsTtsClient
-from lyra.nats.voice_health import WorkerStats
+from lyra.nats.worker_registry import WorkerStats
 from lyra.tts import TtsUnavailableError
 
 
@@ -398,7 +398,7 @@ class TestTtsClientFreshness:
         assert result.audio_bytes == b"audio"
 
     # NOTE: registry-level aliveness / pruning semantics are covered by
-    # ``tests/nats/test_voice_health.py`` — no need to duplicate here.
+    # ``tests/nats/test_worker_registry.py`` — no need to duplicate here.
 
 
 class TestTtsLoadAwareRouting:

--- a/tests/nats/test_worker_registry.py
+++ b/tests/nats/test_worker_registry.py
@@ -1,4 +1,4 @@
-"""Tests for VoiceWorkerRegistry — scoring, selection, freshness pruning."""
+"""Tests for WorkerRegistry — scoring, selection, freshness pruning."""
 
 from __future__ import annotations
 
@@ -6,11 +6,11 @@ import time
 
 import pytest
 
-from lyra.nats.voice_health import (
+from lyra.nats.worker_registry import (
     DEFAULT_ACTIVE_WEIGHT,
     DEFAULT_VRAM_WEIGHT,
     MAX_WORKERS,
-    VoiceWorkerRegistry,
+    WorkerRegistry,
     WorkerStats,
 )
 
@@ -23,7 +23,7 @@ def _hb(worker_id: str, **kwargs: int) -> dict:
 
 class TestRecordHeartbeat:
     def test_upserts_worker(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(_hb("w1", vram_used_mb=1000, vram_total_mb=16000))
         alive = reg.alive_workers()
         assert len(alive) == 1
@@ -33,7 +33,7 @@ class TestRecordHeartbeat:
         assert alive[0].active_requests == 0
 
     def test_missing_worker_id_is_ignored(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat({"vram_used_mb": 1000})
         reg.record_heartbeat({"worker_id": ""})
         reg.record_heartbeat({"worker_id": None})  # type: ignore[dict-item]
@@ -41,14 +41,14 @@ class TestRecordHeartbeat:
 
     def test_invalid_worker_id_rejected(self) -> None:
         """Subject-injection guard: wildcard / space chars rejected at ingress."""
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         for bad_id in ("*.evil", "foo.>", "has space", "pipe|bad", ">"):
             reg.record_heartbeat({"worker_id": bad_id})
         assert reg.alive_workers() == []
 
     def test_cap_drops_new_ids_at_max(self) -> None:
         """Hard cap drops new worker ids past ``MAX_WORKERS``; existing ones update."""
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         for i in range(MAX_WORKERS):
             reg.record_heartbeat({"worker_id": f"w-{i}"})
         assert len(reg.alive_workers()) == MAX_WORKERS
@@ -61,7 +61,7 @@ class TestRecordHeartbeat:
         assert w0.active_requests == 42
 
     def test_coerces_numeric_fields(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(
             {
                 "worker_id": "w1",
@@ -76,7 +76,7 @@ class TestRecordHeartbeat:
         assert alive[0].active_requests == 0
 
     def test_updates_existing_worker(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(_hb("w1", active_requests=0))
         reg.record_heartbeat(_hb("w1", active_requests=3))
         alive = reg.alive_workers()
@@ -86,7 +86,7 @@ class TestRecordHeartbeat:
 
 class TestPruning:
     def test_evicts_entries_older_than_ttl_times_two(self) -> None:
-        reg = VoiceWorkerRegistry(hb_ttl=15.0)
+        reg = WorkerRegistry(hb_ttl=15.0)
         reg._workers["ancient"] = WorkerStats(
             worker_id="ancient",
             last_heartbeat=time.monotonic() - 35.0,
@@ -108,7 +108,7 @@ class TestPruning:
         assert "fresh" in reg._workers
 
     def test_alive_only_returns_within_ttl(self) -> None:
-        reg = VoiceWorkerRegistry(hb_ttl=15.0)
+        reg = WorkerRegistry(hb_ttl=15.0)
         reg._workers["fresh"] = WorkerStats(
             worker_id="fresh",
             last_heartbeat=time.monotonic() - 5.0,
@@ -123,7 +123,7 @@ class TestPruning:
 
 class TestScoring:
     def test_score_formula_active_plus_vram_pct(self) -> None:
-        reg = VoiceWorkerRegistry(
+        reg = WorkerRegistry(
             active_weight=DEFAULT_ACTIVE_WEIGHT, vram_weight=DEFAULT_VRAM_WEIGHT
         )
         w = WorkerStats(
@@ -137,7 +137,7 @@ class TestScoring:
         assert reg.score(w) == pytest.approx(225.0)
 
     def test_score_when_vram_total_zero(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         w = WorkerStats(
             worker_id="w",
             last_heartbeat=time.monotonic(),
@@ -151,11 +151,11 @@ class TestScoring:
 
 class TestSelection:
     def test_pick_none_when_no_workers(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         assert reg.pick_least_loaded() is None
 
     def test_pick_only_fresh_worker(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg._workers["stale"] = WorkerStats(
             worker_id="stale",
             last_heartbeat=time.monotonic() - 20.0,
@@ -165,7 +165,7 @@ class TestSelection:
         assert pick is not None and pick.worker_id == "fresh"
 
     def test_pick_lowest_vram_pct_when_tied_active(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(_hb("heavy", vram_used_mb=12000, vram_total_mb=16000))
         reg.record_heartbeat(_hb("light", vram_used_mb=2000, vram_total_mb=16000))
         pick = reg.pick_least_loaded()
@@ -173,7 +173,7 @@ class TestSelection:
 
     def test_active_requests_dominate_vram(self) -> None:
         """A fuller-VRAM but idle worker beats a lighter-VRAM busy worker."""
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(
             _hb("busy-light", vram_used_mb=2000, vram_total_mb=16000, active_requests=1)
         )
@@ -192,17 +192,17 @@ class TestSelection:
 
     def test_deterministic_tiebreak_by_worker_id(self) -> None:
         """When scores tie, the lexically smallest worker_id wins."""
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(_hb("worker-b"))
         reg.record_heartbeat(_hb("worker-a"))
         pick = reg.pick_least_loaded()
         assert pick is not None and pick.worker_id == "worker-a"
 
     def test_any_alive_true_when_one_fresh(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         reg.record_heartbeat(_hb("w"))
         assert reg.any_alive() is True
 
     def test_any_alive_false_when_empty(self) -> None:
-        reg = VoiceWorkerRegistry()
+        reg = WorkerRegistry()
         assert reg.any_alive() is False


### PR DESCRIPTION
## Summary
- Rename `VoiceWorkerRegistry` → `WorkerRegistry` and move `src/lyra/nats/voice_health.py` → `src/lyra/nats/worker_registry.py`.
- Registry holds no voice-specific state; image (#754) already imports it and memory/llm will too. The voice-prefixed name asserted ownership that no longer exists.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #805: refactor(nats): rename VoiceWorkerRegistry → WorkerRegistry (cross-domain) | OPEN |
| Implementation | 1 commit on `feat/805-rename-worker-registry` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (181 passed, 35 skipped) | Passed |

## Test Plan
- [x] `grep -r "VoiceWorkerRegistry" src/ tests/` returns 0 hits
- [x] `uv run pytest tests/nats/` passes unchanged
- [x] `uv run ruff check` + `uv run pyright` clean

Closes #805

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`