### PR TITLE
chore(provision): compute next-free subuid/subgid range

### DIFF
--- a/artifacts/analyses/825-subuid-review-followups-consensus.mdx
+++ b/artifacts/analyses/825-subuid-review-followups-consensus.mdx
@@ -1,0 +1,74 @@
+---
+title: "subuid/subgid review follow-ups — Expert Consensus"
+issue: 825
+status: consensus-reached
+date: 2026-04-22
+panel: architect, security-auditor, devops
+confidence: high
+---
+
+## Problem
+
+PR #869 (issue #825) replaces a hardcoded `100000-165535` subuid/subgid range in `deploy/provision.sh` with an HWM-computed next-free range. Two blockers from the initial review were auto-applied in PR #869: per-namespace HWM, `usermod` exit check, 32-bit UID space overflow guard.
+
+Four non-blocking findings remained; panel was convened to recommend apply / defer / skip per finding on this security-hardening PR whose original scope was explicitly deferred to a single-admin machine (`roxabituwer`).
+
+## Panel
+
+| α | Focus |
+|---|-------|
+| architect | arch soundness, maintainability, long-term invariants |
+| security-auditor | attack surface, threat model for the deployment context |
+| devops | ops payback for a run-once-per-install provisioning script |
+
+## Findings and votes
+
+| # | Finding | Architect | Security | Devops | Consensus |
+|---|---------|-----------|----------|--------|-----------|
+| 1 | Non-contiguous overlap detection (C=72%) | apply | defer | skip | **Defer → #875** |
+| 2 | TOCTOU between HWM read and usermod write (C=70%) | skip | skip | skip | **Skip (wontfix, documented inline)** |
+| 3 | `awk ... 2>/dev/null` swallows perm errors (C=78%) | apply | apply | defer | **Apply in PR #869** |
+| 4 | Re-run idempotency warn (C=75%) | defer | defer | defer | **Defer → #876** |
+
+## Consensus
+
+### F1 — Non-contiguous overlap: Defer (→ #875)
+
+**Rationale:** HWM protects against the single highest-ending entry. Out-of-order / manually-edited entries could hide an overlap. On a single-admin host where `/etc/subuid` is managed exclusively by `usermod`, the malformed-file vector requires manual misconfiguration that doesn't exist today. Architect's argument (closes HWM invariant gap) is valid long-term but security + devops both cite no current payback. Ship follow-up issue to capture the improvement.
+
+### F2 — TOCTOU: Skip (wontfix)
+
+**Rationale:** Unanimous. Reviewer's own admission: shadow-utils does not honor external `flock`. Any shell-level fix is security theater that gives a false safety signal. On a single-admin machine with one provisioner, no concurrent `usermod` exists. Better to record a wontfix comment in code than to file a ticket that invites a future implementer to add an ineffective flock.
+
+### F3 — awk error swallow: Apply now
+
+**Rationale:** 2-of-3 apply (devops agrees on substance, disagrees on timing). This is the only finding with a concrete silent-failure path on the target machine: an unreadable `/etc/subuid` (chmod drift, SELinux denial) currently falls through to the 65536 floor silently and could alias uid 0. Fix is a 3-line preflight: `[[ -e && ! -r ]] → error`. Consistency of intent — the whole PR exists to prevent silent wrong-range assignment.
+
+### F4 — Re-run idempotency warn: Defer (→ #876)
+
+**Rationale:** Unanimous. `has_sufficient_subids` is intentionally permissive to preserve idempotency. A badly-placed prior entry still satisfying count is an edge that surfaces via the `podman info` smoke test already present downstream in `provision.sh`. Warn-only overlap scan is legitimate but adds scope; revisit when `AGENT_USER` subuid provisioning is added.
+
+## Alternatives considered
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| Apply all 4 now | architect (F1) | Over-engineers for scenarios the issue body explicitly deferred to "another host class" / multi-user. |
+| TOCTOU flock fix | (none — security flagged it, but panel rejected) | Shadow-utils ignores external flock; false safety signal. |
+| Hard-fail idempotency on overlap | (rejected) | Breaks idempotent re-provision for no benefit on single-admin. Warn is the correct signal level, deferred. |
+| Skip F3 awk fix | devops (timing) | Silent fall-through to floor=65536 contradicts the PR's stated intent. Cost is ≤5 lines. |
+
+## Dissent
+
+- **Architect on F1** (apply now): the HWM invariant is incomplete without overlap detection; deferring leaves a silent-failure class on re-provision with a manually-edited file. Recorded — majority overruled on single-admin context but the concern is captured in #875.
+- **Devops on F3** (defer): agreed the fix is correct but argued timing; conceded in panel context given unanimous security + architect alignment.
+
+## Implementation Notes
+
+1. F3: add `[[ -e "$file" && ! -r "$file" ]]` preflight inside `next_free_subid_start`; call `error` on unreadable-but-present.
+2. F2: add a multi-line `# NOTE (TOCTOU wontfix):` block above the call site explaining the shadow-utils limitation and the single-admin constraint that makes the race unreachable.
+3. F1 → #875, F4 → #876. Both link back to #825 and PR #869.
+
+## Next
+
+- Apply F2 + F3 changes in the ongoing `/fix` pass on PR #869.
+- Re-run `/code-review` after fix commits to close the loop (≤2 iteration cap).

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -92,9 +92,27 @@ fi
 has_sufficient_subids() {
   awk -F: -v u="$ADMIN_USER" '$1 == u && $3 >= 65536 {found=1} END {exit !found}' "$1"
 }
+# Compute next-free range from current high-water mark across both files so we
+# never overlap with another user's allocation. `usermod --add-subuids` does no
+# overlap check (man page is explicit); on a host with pre-existing entries
+# (LDAP, container hosts, other humans with rootless containers) a hardcoded
+# range silently aliases another account's UID — a privilege-escalation path
+# from inside any rootless container. Floor of 65536 keeps us clear of the
+# normal UID space on systems with real UIDs in the 100000+ band.
+next_free_subid_start() {
+  local hwm
+  hwm=$(awk -F: '{print $2 + $3}' /etc/subuid /etc/subgid 2>/dev/null | sort -n | tail -1)
+  if [[ -n "$hwm" && "$hwm" -gt 65535 ]]; then
+    echo "$hwm"
+  else
+    echo 65536
+  fi
+}
 if ! has_sufficient_subids /etc/subuid || ! has_sufficient_subids /etc/subgid; then
-  warn "subuid/subgid ranges missing or too small for $ADMIN_USER — adding 100000-165535."
-  sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$ADMIN_USER"
+  start=$(next_free_subid_start)
+  end=$((start + 65535))
+  warn "subuid/subgid ranges missing or too small for $ADMIN_USER — adding ${start}-${end}."
+  sudo usermod --add-subuids "${start}-${end}" --add-subgids "${start}-${end}" "$ADMIN_USER"
   # Re-run migrate in case podman already has stale rootless state.
   # Guard against silent storage remap on partial re-runs: if the admin user
   # already has rootless images or named volumes, `podman system migrate` can

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -92,16 +92,18 @@ fi
 has_sufficient_subids() {
   awk -F: -v u="$ADMIN_USER" '$1 == u && $3 >= 65536 {found=1} END {exit !found}' "$1"
 }
-# Compute next-free range from current high-water mark across both files so we
-# never overlap with another user's allocation. `usermod --add-subuids` does no
+# Compute next-free range per file from the current high-water mark so we never
+# overlap with another user's allocation. `usermod --add-subuids` does no
 # overlap check (man page is explicit); on a host with pre-existing entries
 # (LDAP, container hosts, other humans with rootless containers) a hardcoded
 # range silently aliases another account's UID — a privilege-escalation path
-# from inside any rootless container. Floor of 65536 keeps us clear of the
-# normal UID space on systems with real UIDs in the 100000+ band.
+# from inside any rootless container. UID and GID subordinate namespaces are
+# independent, so HWM is computed per file to avoid cross-namespace waste.
+# Floor of 65536 keeps us clear of the normal UID space on systems with real
+# UIDs in the 100000+ band.
 next_free_subid_start() {
-  local hwm
-  hwm=$(awk -F: '{print $2 + $3}' /etc/subuid /etc/subgid 2>/dev/null | sort -n | tail -1)
+  local file="$1" hwm
+  hwm=$(awk -F: '{print $2 + $3}' "$file" 2>/dev/null | sort -n | tail -1)
   if [[ -n "$hwm" && "$hwm" -gt 65535 ]]; then
     echo "$hwm"
   else
@@ -109,10 +111,17 @@ next_free_subid_start() {
   fi
 }
 if ! has_sufficient_subids /etc/subuid || ! has_sufficient_subids /etc/subgid; then
-  start=$(next_free_subid_start)
-  end=$((start + 65535))
-  warn "subuid/subgid ranges missing or too small for $ADMIN_USER — adding ${start}-${end}."
-  sudo usermod --add-subuids "${start}-${end}" --add-subgids "${start}-${end}" "$ADMIN_USER"
+  uid_start=$(next_free_subid_start /etc/subuid)
+  gid_start=$(next_free_subid_start /etc/subgid)
+  uid_end=$((uid_start + 65535))
+  gid_end=$((gid_start + 65535))
+  # 32-bit UID space guard — usermod rejects ranges above 2^32-1.
+  if (( uid_end > 4294967295 || gid_end > 4294967295 )); then
+    error "subuid/subgid space exhausted (uid_end=${uid_end}, gid_end=${gid_end})"
+  fi
+  warn "subuid/subgid ranges missing or too small for $ADMIN_USER — adding subuid ${uid_start}-${uid_end}, subgid ${gid_start}-${gid_end}."
+  sudo usermod --add-subuids "${uid_start}-${uid_end}" --add-subgids "${gid_start}-${gid_end}" "$ADMIN_USER" \
+    || error "Failed to configure subuid/subgid for $ADMIN_USER"
   # Re-run migrate in case podman already has stale rootless state.
   # Guard against silent storage remap on partial re-runs: if the admin user
   # already has rootless images or named volumes, `podman system migrate` can

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -103,6 +103,12 @@ has_sufficient_subids() {
 # UIDs in the 100000+ band.
 next_free_subid_start() {
   local file="$1" hwm
+  # Missing file is fine (fresh install); unreadable-but-present is not —
+  # swallowing the error would silently fall through to the 65536 floor and
+  # could collide with an existing allocation.
+  if [[ -e "$file" && ! -r "$file" ]]; then
+    error "Cannot read $file (check permissions)."
+  fi
   hwm=$(awk -F: '{print $2 + $3}' "$file" 2>/dev/null | sort -n | tail -1)
   if [[ -n "$hwm" && "$hwm" -gt 65535 ]]; then
     echo "$hwm"
@@ -110,6 +116,11 @@ next_free_subid_start() {
     echo 65536
   fi
 }
+# NOTE (TOCTOU wontfix): the HWM read and subsequent `usermod` write are not
+# atomic against a concurrent `usermod`/`useradd`. A true fence would require
+# shadow-utils' own lock, which does not honor external flock. On a single-admin
+# machine running one provisioner the window is unreachable; revisit if
+# provision.sh is ever run concurrently (multi-host, parallel CI, etc.).
 if ! has_sufficient_subids /etc/subuid || ! has_sufficient_subids /etc/subgid; then
   uid_start=$(next_free_subid_start /etc/subuid)
   gid_start=$(next_free_subid_start /etc/subgid)

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -110,6 +110,9 @@ next_free_subid_start() {
     error "Cannot read $file (check permissions)."
   fi
   hwm=$(awk -F: '{print $2 + $3}' "$file" 2>/dev/null | sort -n | tail -1)
+  # Guard against garbage lines (truncated write, manual edit) — non-integer
+  # output from awk would break the arithmetic below or bypass the floor check.
+  [[ "$hwm" =~ ^[0-9]+$ ]] || hwm=""
   if [[ -n "$hwm" && "$hwm" -gt 65535 ]]; then
     echo "$hwm"
   else


### PR DESCRIPTION
## Summary
- `usermod --add-subuids` performs no overlap check — hardcoded `100000-165535` silently aliases another account's UID on hosts with pre-existing entries (LDAP, multi-user container hosts), opening a privilege-escalation path from inside any rootless container.
- Derive `start` from the high-water mark across `/etc/subuid` and `/etc/subgid`, floor at 65536 to stay clear of the normal UID space.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #825: chore(provision): compute next-free subuid/subgid range | Open |
| Implementation | 1 commit on \`chore/825-compute-next-free-subuid\` | Complete |
| Verification | Lint ✅ Typecheck ✅ bash -n ✅ | Passed |

## Test Plan
- [ ] Dry-run `next_free_subid_start` on a host with multiple `/etc/subuid` entries — asserts start > last allocation end.
- [ ] Empty `/etc/subuid`/`/etc/subgid` → falls through to 65536 floor.
- [ ] `usermod --add-subuids "${start}-${end}"` runs against \$ADMIN_USER without collision warnings.

Closes #825

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`