### PR TITLE
feat(ops): lyra ops verify CLI — per-identity NATS ACL sanity check

### DIFF
--- a/src/lyra/cli.py
+++ b/src/lyra/cli.py
@@ -24,6 +24,7 @@ import typer
 
 from lyra.cli_agent import agent_app  # noqa: F401 — re-exported for tests
 from lyra.cli_bot import bot_app
+from lyra.cli_ops import ops_app
 from lyra.cli_setup import setup_app
 from lyra.cli_voice_smoke import voice_smoke_app
 
@@ -57,6 +58,7 @@ lyra_app.add_typer(config_app, name="config")
 lyra_app.add_typer(bot_app, name="bot")
 lyra_app.add_typer(setup_app, name="setup")
 lyra_app.add_typer(voice_smoke_app, name="voice-smoke")
+lyra_app.add_typer(ops_app, name="ops")
 
 hub_app = typer.Typer(name="hub", help="Run standalone Hub process (requires NATS).")
 lyra_app.add_typer(hub_app, name="hub")

--- a/src/lyra/cli_ops.py
+++ b/src/lyra/cli_ops.py
@@ -1,0 +1,290 @@
+"""lyra ops — operational sanity checks.
+
+`lyra ops verify` walks the IDENTITIES × allow-list matrix from
+``deploy/nats/acl-matrix.json`` and, for each identity, exercises the
+NATS server's ACL by:
+
+  - publishing on every allowed subject     → expect success
+  - publishing on a representative deny     → expect a NATS permissions
+                                              violation
+
+Reports a PASS/FAIL summary. Exit 0 = all checks pass, exit 1 = first
+offending row printed.
+
+Reads ``NATS_URL`` and ``NATS_CA_CERT`` from the environment, same as
+the rest of Lyra. Per-identity nkey seeds are picked up from
+``~/.lyra/nkeys/<identity>.seed`` (override via ``--seeds-dir``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import AsyncIterator
+
+import typer
+from nats.aio.client import Client as NATS
+
+from roxabi_nats.connect import nats_connect
+
+ops_app = typer.Typer(name="ops", help="Operational sanity checks.")
+
+_DEFAULT_NATS_URL = "nats://localhost:4222"
+_DEFAULT_MATRIX = "deploy/nats/acl-matrix.json"
+_DEFAULT_SEEDS_DIR = "~/.lyra/nkeys"
+_DENY_SUBJECT_PREFIX = "lyra.verify.deny"
+_FLUSH_TIMEOUT = 2
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckRow:
+    identity: str
+    subject: str
+    kind: str  # "pub" | "deny"
+    expected: str
+    actual: str
+    ok: bool
+
+
+@dataclass
+class IdentityResult:
+    identity: str
+    rows: list[CheckRow] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+    @property
+    def pub_passed(self) -> int:
+        return sum(1 for r in self.rows if r.kind == "pub" and r.ok)
+
+    @property
+    def deny_passed(self) -> int:
+        return sum(1 for r in self.rows if r.kind == "deny" and r.ok)
+
+    @property
+    def first_failure(self) -> CheckRow | None:
+        return next((r for r in self.rows if not r.ok), None)
+
+
+# ---------------------------------------------------------------------------
+# Matrix loading + subject expansion
+# ---------------------------------------------------------------------------
+
+
+def _load_matrix(path: Path) -> dict[str, dict]:
+    """Read acl-matrix.json and return its ``identities`` map."""
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        raise typer.BadParameter(f"matrix file not found: {path}")
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"matrix file is not valid JSON: {exc}")
+    identities = raw.get("identities")
+    if not isinstance(identities, dict) or not identities:
+        raise typer.BadParameter(f"matrix file has no `identities` map: {path}")
+    return identities
+
+
+def _expand_subject(subject: str) -> str:
+    """Replace NATS wildcards with a concrete `verify` token.
+
+    ``foo.>`` → ``foo.verify`` | ``foo.*.bar`` → ``foo.verify.bar``
+    """
+    return ".".join(
+        "verify" if tok in (">", "*") else tok for tok in subject.split(".")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-identity NATS connection
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _identity_connection(
+    nats_url: str, seed_path: Path, error_sink: list[str]
+) -> AsyncIterator[NATS]:
+    """Yield a NATS client authed as a specific identity.
+
+    Permissions violations sent by the server arrive on the async error
+    callback — we capture them in *error_sink* so the caller can inspect
+    them after a flush.
+    """
+    prev_seed = os.environ.get("NATS_NKEY_SEED_PATH")
+    os.environ["NATS_NKEY_SEED_PATH"] = str(seed_path)
+
+    async def _err_cb(exc: Exception) -> None:
+        error_sink.append(str(exc))
+
+    try:
+        nc = await nats_connect(nats_url, error_cb=_err_cb)
+    finally:
+        if prev_seed is None:
+            os.environ.pop("NATS_NKEY_SEED_PATH", None)
+        else:
+            os.environ["NATS_NKEY_SEED_PATH"] = prev_seed
+    try:
+        yield nc
+    finally:
+        await nc.drain()
+        await nc.close()
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+def _is_permission_error(message: str) -> bool:
+    msg = message.lower()
+    return "permission" in msg and "publish" in msg
+
+
+async def _probe_pub(nc: NATS, subject: str, errors: list[str]) -> tuple[bool, str]:
+    """Publish on *subject*; return (ok, actual)."""
+    before = len(errors)
+    await nc.publish(subject, b"verify")
+    try:
+        await nc.flush(timeout=_FLUSH_TIMEOUT)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"flush error: {exc}"
+    new = errors[before:]
+    if any(_is_permission_error(e) for e in new):
+        return False, "permission denied"
+    return True, "published"
+
+
+async def _probe_deny(nc: NATS, subject: str, errors: list[str]) -> tuple[bool, str]:
+    """Publish on a subject expected to be denied; return (ok, actual)."""
+    before = len(errors)
+    await nc.publish(subject, b"verify")
+    try:
+        await nc.flush(timeout=_FLUSH_TIMEOUT)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"flush error: {exc}"
+    new = errors[before:]
+    if any(_is_permission_error(e) for e in new):
+        return True, "permission denied"
+    return False, "publish accepted (expected deny)"
+
+
+async def _verify_identity(
+    nats_url: str,
+    name: str,
+    spec: dict,
+    seed_path: Path,
+) -> IdentityResult:
+    result = IdentityResult(identity=name)
+    if not seed_path.is_file():
+        result.skipped_reason = f"seed missing: {seed_path}"
+        return result
+
+    errors: list[str] = []
+    try:
+        async with _identity_connection(nats_url, seed_path, errors) as nc:
+            for subject in spec.get("publish", []):
+                expanded = _expand_subject(subject)
+                ok, actual = await _probe_pub(nc, expanded, errors)
+                result.rows.append(
+                    CheckRow(name, expanded, "pub", "published", actual, ok)
+                )
+            deny_subject = f"{_DENY_SUBJECT_PREFIX}.{name}"
+            ok, actual = await _probe_deny(nc, deny_subject, errors)
+            result.rows.append(
+                CheckRow(name, deny_subject, "deny", "permission denied", actual, ok)
+            )
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        result.skipped_reason = f"connect failed: {exc}"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+@ops_app.command("verify")
+def verify(
+    matrix: Path = typer.Option(  # noqa: B008
+        Path(_DEFAULT_MATRIX),
+        "--matrix",
+        help="Path to acl-matrix.json.",
+    ),
+    seeds_dir: Path = typer.Option(  # noqa: B008
+        Path(_DEFAULT_SEEDS_DIR),
+        "--seeds-dir",
+        help="Directory containing per-identity nkey seeds.",
+    ),
+    nats_url: str = typer.Option(  # noqa: B008
+        None,
+        "--nats-url",
+        help="NATS URL (default: NATS_URL env var, then nats://localhost:4222).",
+    ),
+    only: list[str] = typer.Option(  # noqa: B008
+        None,
+        "--only",
+        help="Restrict verification to specific identity names (repeatable).",
+    ),
+) -> None:
+    """Verify each identity's NATS publish ACL via the live server."""
+    resolved_url = nats_url or os.environ.get("NATS_URL", _DEFAULT_NATS_URL)
+    matrix_path = matrix.expanduser()
+    seeds_path = seeds_dir.expanduser()
+    identities = _load_matrix(matrix_path)
+    if only:
+        unknown = [n for n in only if n not in identities]
+        if unknown:
+            raise typer.BadParameter(f"unknown identity name(s): {', '.join(unknown)}")
+        identities = {n: identities[n] for n in only}
+
+    results = asyncio.run(_verify_all(resolved_url, identities, seeds_path))
+    exit_code = _print_report(results)
+    raise typer.Exit(exit_code)
+
+
+async def _verify_all(
+    nats_url: str, identities: dict[str, dict], seeds_dir: Path
+) -> list[IdentityResult]:
+    out: list[IdentityResult] = []
+    for name, spec in identities.items():
+        seed_path = seeds_dir / f"{name}.seed"
+        out.append(await _verify_identity(nats_url, name, spec, seed_path))
+    return out
+
+
+def _print_report(results: list[IdentityResult]) -> int:
+    total_pub_pass = sum(r.pub_passed for r in results)
+    total_pub = sum(1 for r in results for c in r.rows if c.kind == "pub")
+    total_deny_pass = sum(r.deny_passed for r in results)
+    total_deny = sum(1 for r in results for c in r.rows if c.kind == "deny")
+    skipped = [r for r in results if r.skipped_reason]
+    failed = [r for r in results if r.first_failure]
+
+    for r in skipped:
+        typer.echo(f"SKIP {r.identity}: {r.skipped_reason}")
+
+    if failed:
+        first = failed[0].first_failure
+        assert first is not None
+        typer.echo(
+            f"FAIL {first.identity} {first.kind} {first.subject} — "
+            f"expected {first.expected!r}, got {first.actual!r}"
+        )
+
+    typer.echo(
+        f"{len(results)} identities, "
+        f"{total_pub_pass}/{total_pub} pub checks passed, "
+        f"{total_deny_pass}/{total_deny} deny checks passed"
+        + (f", {len(skipped)} skipped" if skipped else "")
+    )
+    return 1 if failed or skipped else 0

--- a/src/lyra/cli_ops.py
+++ b/src/lyra/cli_ops.py
@@ -1,19 +1,9 @@
 """lyra ops — operational sanity checks.
 
-`lyra ops verify` walks the IDENTITIES × allow-list matrix from
-``deploy/nats/acl-matrix.json`` and, for each identity, exercises the
-NATS server's ACL by:
-
-  - publishing on every allowed subject     → expect success
-  - publishing on a representative deny     → expect a NATS permissions
-                                              violation
-
-Reports a PASS/FAIL summary. Exit 0 = all checks pass, exit 1 = first
-offending row printed.
-
-Reads ``NATS_URL`` and ``NATS_CA_CERT`` from the environment, same as
-the rest of Lyra. Per-identity nkey seeds are picked up from
-``~/.lyra/nkeys/<identity>.seed`` (override via ``--seeds-dir``).
+`lyra ops verify` walks ``deploy/nats/acl-matrix.json`` and, per identity,
+publishes on every allowed subject (expect success) plus one `lyra.verify.deny.*`
+probe (expect permission violation). Reads ``NATS_URL``/``NATS_CA_CERT`` from
+env; seeds from ``~/.lyra/nkeys/<id>.seed`` (override via ``--seeds-dir``).
 """
 
 from __future__ import annotations
@@ -21,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import stat as _stat
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,7 +20,8 @@ from typing import AsyncIterator
 import typer
 from nats.aio.client import Client as NATS
 
-from roxabi_nats.connect import nats_connect
+import nats
+from roxabi_nats.connect import _build_tls_context
 
 ops_app = typer.Typer(name="ops", help="Operational sanity checks.")
 
@@ -38,11 +30,6 @@ _DEFAULT_MATRIX = "deploy/nats/acl-matrix.json"
 _DEFAULT_SEEDS_DIR = "~/.lyra/nkeys"
 _DENY_SUBJECT_PREFIX = "lyra.verify.deny"
 _FLUSH_TIMEOUT = 2
-
-
-# ---------------------------------------------------------------------------
-# Result types
-# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -74,11 +61,6 @@ class IdentityResult:
         return next((r for r in self.rows if not r.ok), None)
 
 
-# ---------------------------------------------------------------------------
-# Matrix loading + subject expansion
-# ---------------------------------------------------------------------------
-
-
 def _load_matrix(path: Path) -> dict[str, dict]:
     """Read acl-matrix.json and return its ``identities`` map."""
     try:
@@ -103,9 +85,35 @@ def _expand_subject(subject: str) -> str:
     )
 
 
-# ---------------------------------------------------------------------------
-# Per-identity NATS connection
-# ---------------------------------------------------------------------------
+def _read_seed(seed_path: Path) -> str:
+    """Read an nkey seed from *seed_path* with the same hardening as roxabi-nats.
+
+    O_NOFOLLOW + live fstat — rejects symlinks, non-files, and any
+    group/world-readable mode. SystemExit on any failure (CLI semantics).
+    """
+    fd = -1
+    try:
+        fd = os.open(str(seed_path), os.O_RDONLY | os.O_NOFOLLOW)
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode):
+            raise typer.Exit(code=1)
+        if st.st_mode & 0o777 & 0o077:
+            raise typer.BadParameter(
+                f"seed {seed_path.name!r} has unsafe permissions"
+                f" {oct(st.st_mode & 0o777)} (use 0o600 or 0o400)"
+            )
+        with os.fdopen(fd, "r") as fh:
+            fd = -1
+            seed = fh.read().strip()
+    except OSError as exc:
+        if fd != -1:
+            os.close(fd)
+        raise typer.BadParameter(
+            f"seed {seed_path.name!r} unreadable: {exc.strerror or exc}"
+        )
+    if not seed:
+        raise typer.BadParameter(f"seed {seed_path.name!r} is empty")
+    return seed
 
 
 @asynccontextmanager
@@ -114,23 +122,22 @@ async def _identity_connection(
 ) -> AsyncIterator[NATS]:
     """Yield a NATS client authed as a specific identity.
 
+    The seed is read and passed to ``nats.connect`` directly — no env
+    mutation, so this is safe under concurrent ``asyncio.gather`` use.
     Permissions violations sent by the server arrive on the async error
-    callback — we capture them in *error_sink* so the caller can inspect
+    callback; we capture them in *error_sink* so callers can inspect
     them after a flush.
     """
-    prev_seed = os.environ.get("NATS_NKEY_SEED_PATH")
-    os.environ["NATS_NKEY_SEED_PATH"] = str(seed_path)
+    seed = _read_seed(seed_path)
 
     async def _err_cb(exc: Exception) -> None:
         error_sink.append(str(exc))
 
-    try:
-        nc = await nats_connect(nats_url, error_cb=_err_cb)
-    finally:
-        if prev_seed is None:
-            os.environ.pop("NATS_NKEY_SEED_PATH", None)
-        else:
-            os.environ["NATS_NKEY_SEED_PATH"] = prev_seed
+    kwargs: dict = {"error_cb": _err_cb, "nkeys_seed_str": seed}
+    tls_ctx = _build_tls_context()
+    if tls_ctx:
+        kwargs["tls"] = tls_ctx
+    nc = await nats.connect(nats_url, **kwargs)
     try:
         yield nc
     finally:
@@ -138,42 +145,35 @@ async def _identity_connection(
         await nc.close()
 
 
-# ---------------------------------------------------------------------------
-# Probes
-# ---------------------------------------------------------------------------
-
-
 def _is_permission_error(message: str) -> bool:
     msg = message.lower()
     return "permission" in msg and "publish" in msg
 
 
-async def _probe_pub(nc: NATS, subject: str, errors: list[str]) -> tuple[bool, str]:
-    """Publish on *subject*; return (ok, actual)."""
+async def _probe(
+    nc: NATS, subject: str, errors: list[str], *, expect_deny: bool
+) -> tuple[bool, str]:
+    """Publish on *subject* and report whether the outcome matched expectation.
+
+    NATS ``-ERR`` frames arrive on the async error callback after flush, so
+    we yield once before sampling *errors* to let already-buffered frames
+    reach the callback.
+    """
     before = len(errors)
     await nc.publish(subject, b"verify")
     try:
         await nc.flush(timeout=_FLUSH_TIMEOUT)
     except Exception as exc:  # noqa: BLE001
         return False, f"flush error: {exc}"
-    new = errors[before:]
-    if any(_is_permission_error(e) for e in new):
-        return False, "permission denied"
-    return True, "published"
-
-
-async def _probe_deny(nc: NATS, subject: str, errors: list[str]) -> tuple[bool, str]:
-    """Publish on a subject expected to be denied; return (ok, actual)."""
-    before = len(errors)
-    await nc.publish(subject, b"verify")
-    try:
-        await nc.flush(timeout=_FLUSH_TIMEOUT)
-    except Exception as exc:  # noqa: BLE001
-        return False, f"flush error: {exc}"
-    new = errors[before:]
-    if any(_is_permission_error(e) for e in new):
-        return True, "permission denied"
-    return False, "publish accepted (expected deny)"
+    await asyncio.sleep(0)
+    denied = any(_is_permission_error(e) for e in errors[before:])
+    if expect_deny:
+        return (
+            (True, "permission denied")
+            if denied
+            else (False, "publish accepted (expected deny)")
+        )
+    return (False, "permission denied") if denied else (True, "published")
 
 
 async def _verify_identity(
@@ -184,7 +184,7 @@ async def _verify_identity(
 ) -> IdentityResult:
     result = IdentityResult(identity=name)
     if not seed_path.is_file():
-        result.skipped_reason = f"seed missing: {seed_path}"
+        result.skipped_reason = f"seed missing: {seed_path.name}"
         return result
 
     errors: list[str] = []
@@ -192,12 +192,12 @@ async def _verify_identity(
         async with _identity_connection(nats_url, seed_path, errors) as nc:
             for subject in spec.get("publish", []):
                 expanded = _expand_subject(subject)
-                ok, actual = await _probe_pub(nc, expanded, errors)
+                ok, actual = await _probe(nc, expanded, errors, expect_deny=False)
                 result.rows.append(
                     CheckRow(name, expanded, "pub", "published", actual, ok)
                 )
             deny_subject = f"{_DENY_SUBJECT_PREFIX}.{name}"
-            ok, actual = await _probe_deny(nc, deny_subject, errors)
+            ok, actual = await _probe(nc, deny_subject, errors, expect_deny=True)
             result.rows.append(
                 CheckRow(name, deny_subject, "deny", "permission denied", actual, ok)
             )
@@ -206,11 +206,6 @@ async def _verify_identity(
     except Exception as exc:  # noqa: BLE001
         result.skipped_reason = f"connect failed: {exc}"
     return result
-
-
-# ---------------------------------------------------------------------------
-# CLI command
-# ---------------------------------------------------------------------------
 
 
 @ops_app.command("verify")
@@ -252,12 +247,25 @@ def verify(
     raise typer.Exit(exit_code)
 
 
+def _seed_path_for(seeds_dir: Path, name: str) -> Path:
+    """Resolve and validate that ``{seeds_dir}/{name}.seed`` stays inside *seeds_dir*.
+
+    Defends against malicious identity names from a tampered matrix file
+    (``../etc/passwd``, absolute paths, …).
+    """
+    candidate = (seeds_dir / f"{name}.seed").resolve()
+    base = seeds_dir.resolve()
+    if not candidate.is_relative_to(base):
+        raise typer.BadParameter(f"identity name {name!r} resolves outside seeds-dir")
+    return candidate
+
+
 async def _verify_all(
     nats_url: str, identities: dict[str, dict], seeds_dir: Path
 ) -> list[IdentityResult]:
     out: list[IdentityResult] = []
     for name, spec in identities.items():
-        seed_path = seeds_dir / f"{name}.seed"
+        seed_path = _seed_path_for(seeds_dir, name)
         out.append(await _verify_identity(nats_url, name, spec, seed_path))
     return out
 
@@ -274,12 +282,13 @@ def _print_report(results: list[IdentityResult]) -> int:
         typer.echo(f"SKIP {r.identity}: {r.skipped_reason}")
 
     if failed:
+        # `failed` is filtered by `first_failure`, so this is always non-None.
         first = failed[0].first_failure
-        assert first is not None
-        typer.echo(
-            f"FAIL {first.identity} {first.kind} {first.subject} — "
-            f"expected {first.expected!r}, got {first.actual!r}"
-        )
+        if first is not None:
+            typer.echo(
+                f"FAIL {first.identity} {first.kind} {first.subject} — "
+                f"expected {first.expected!r}, got {first.actual!r}"
+            )
 
     typer.echo(
         f"{len(results)} identities, "

--- a/tests/cli/test_ops_verify.py
+++ b/tests/cli/test_ops_verify.py
@@ -1,0 +1,283 @@
+"""Tests for `lyra ops verify` (issue #737)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lyra.cli import lyra_app
+from lyra.cli_ops import _expand_subject, _is_permission_error, _load_matrix
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("subject", "expected"),
+    [
+        ("lyra.outbound.telegram.>", "lyra.outbound.telegram.verify"),
+        ("lyra.llm.health.*", "lyra.llm.health.verify"),
+        ("lyra.foo.*.bar", "lyra.foo.verify.bar"),
+        ("lyra.simple", "lyra.simple"),
+        ("_INBOX.>", "_INBOX.verify"),
+    ],
+)
+def test_expand_subject(subject: str, expected: str) -> None:
+    assert _expand_subject(subject) == expected
+
+
+def test_is_permission_error() -> None:
+    assert _is_permission_error("Permissions Violation for Publish to lyra.foo")
+    assert _is_permission_error("nats: permissions violation for publish to X")
+    assert not _is_permission_error("connection lost")
+    assert not _is_permission_error("subscription denied")
+
+
+def _write_matrix(path: Path, identities: dict) -> None:
+    path.write_text(json.dumps({"version": "1", "identities": identities}))
+
+
+def test_load_matrix_missing(tmp_path: Path) -> None:
+    with pytest.raises(Exception, match="not found"):
+        _load_matrix(tmp_path / "missing.json")
+
+
+def test_load_matrix_invalid_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    with pytest.raises(Exception, match="not valid JSON"):
+        _load_matrix(p)
+
+
+def test_load_matrix_no_identities(tmp_path: Path) -> None:
+    p = tmp_path / "empty.json"
+    p.write_text(json.dumps({"version": "1"}))
+    with pytest.raises(Exception, match="no `identities`"):
+        _load_matrix(p)
+
+
+def test_load_matrix_ok(tmp_path: Path) -> None:
+    p = tmp_path / "ok.json"
+    _write_matrix(p, {"hub": {"publish": ["lyra.foo"], "subscribe": []}})
+    out = _load_matrix(p)
+    assert "hub" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI integration with mocked NATS
+# ---------------------------------------------------------------------------
+
+
+class _FakeNats:
+    """Stand-in NATS client. Records published subjects; never errors."""
+
+    def __init__(self, deny_subjects: set[str] | None = None) -> None:
+        self.published: list[str] = []
+        self._deny = deny_subjects or set()
+        self._error_cb = None
+
+    def set_error_cb(self, cb) -> None:
+        self._error_cb = cb
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append(subject)
+        if subject in self._deny and self._error_cb is not None:
+            await self._error_cb(
+                Exception(f'nats: Permissions Violation for Publish to "{subject}"')
+            )
+
+    async def flush(self, timeout: float = 2.0) -> None:  # noqa: ARG002
+        return None
+
+    async def drain(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+def _seed_dir(tmp_path: Path, names: list[str]) -> Path:
+    d = tmp_path / "nkeys"
+    d.mkdir()
+    for n in names:
+        (d / f"{n}.seed").write_text("SUFAKEKEYDATA")
+    return d
+
+
+@pytest.fixture
+def matrix_two(tmp_path: Path) -> Path:
+    p = tmp_path / "matrix.json"
+    _write_matrix(
+        p,
+        {
+            "hub": {
+                "publish": ["lyra.outbound.telegram.>", "lyra.llm.request"],
+                "subscribe": [],
+            },
+            "monitor": {
+                "publish": ["lyra.monitor.>"],
+                "subscribe": [],
+            },
+        },
+    )
+    return p
+
+
+def _patched_connect(deny_per_call: list[set[str]]) -> AsyncMock:
+    """Build a `nats_connect` async mock that returns one fake per call."""
+    iterator = iter(deny_per_call)
+
+    async def _factory(url, **kwargs):  # noqa: ARG001
+        fake = _FakeNats(next(iterator, set()))
+        fake.set_error_cb(kwargs.get("error_cb"))
+        return fake
+
+    return AsyncMock(side_effect=_factory)
+
+
+def test_verify_all_pass(tmp_path: Path, matrix_two: Path) -> None:
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    # Each identity: deny only its `lyra.verify.deny.<name>` probe.
+    deny = [{"lyra.verify.deny.hub"}, {"lyra.verify.deny.monitor"}]
+    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix_two),
+                "--seeds-dir",
+                str(seeds),
+                "--nats-url",
+                "nats://fake:4222",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout
+    assert "2 identities" in result.stdout
+    assert "3/3 pub checks passed" in result.stdout
+    assert "2/2 deny checks passed" in result.stdout
+
+
+def test_verify_pub_failure_reports_first_offender(
+    tmp_path: Path, matrix_two: Path
+) -> None:
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    # Hub: deny on an *allowed* subject + the verify-deny probe.
+    deny = [
+        {"lyra.outbound.telegram.verify", "lyra.verify.deny.hub"},
+        {"lyra.verify.deny.monitor"},
+    ]
+    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix_two),
+                "--seeds-dir",
+                str(seeds),
+            ],
+        )
+    assert result.exit_code == 1
+    assert "FAIL hub pub lyra.outbound.telegram.verify" in result.stdout
+
+
+def test_verify_deny_failure(tmp_path: Path, matrix_two: Path) -> None:
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    # Server *accepts* the verify-deny probe → deny check fails.
+    deny = [set(), set()]
+    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix_two),
+                "--seeds-dir",
+                str(seeds),
+            ],
+        )
+    assert result.exit_code == 1
+    assert "FAIL hub deny lyra.verify.deny.hub" in result.stdout
+
+
+def test_verify_skips_when_seed_missing(tmp_path: Path, matrix_two: Path) -> None:
+    seeds = _seed_dir(tmp_path, ["hub"])  # monitor.seed missing
+    deny = [{"lyra.verify.deny.hub"}]
+    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix_two),
+                "--seeds-dir",
+                str(seeds),
+            ],
+        )
+    assert result.exit_code == 1
+    assert "SKIP monitor: seed missing" in result.stdout
+    assert "1 skipped" in result.stdout
+
+
+def test_verify_only_filter(tmp_path: Path, matrix_two: Path) -> None:
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    deny = [{"lyra.verify.deny.monitor"}]
+    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix_two),
+                "--seeds-dir",
+                str(seeds),
+                "--only",
+                "monitor",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "1 identities" in result.stdout
+
+
+def test_verify_only_unknown_identity(tmp_path: Path, matrix_two: Path) -> None:
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    result = runner.invoke(
+        lyra_app,
+        [
+            "ops",
+            "verify",
+            "--matrix",
+            str(matrix_two),
+            "--seeds-dir",
+            str(seeds),
+            "--only",
+            "ghost",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "ghost" in result.output
+
+
+def test_verify_acl_matrix_repo_loads() -> None:
+    """The repo's real acl-matrix.json should load without error."""
+    repo_root = Path(__file__).resolve().parents[2]
+    matrix = repo_root / "deploy" / "nats" / "acl-matrix.json"
+    if not matrix.exists():
+        pytest.skip("acl-matrix.json not present")
+    identities = _load_matrix(matrix)
+    assert "hub" in identities
+    assert isinstance(identities["hub"]["publish"], list)

--- a/tests/cli/test_ops_verify.py
+++ b/tests/cli/test_ops_verify.py
@@ -108,7 +108,9 @@ def _seed_dir(tmp_path: Path, names: list[str]) -> Path:
     d = tmp_path / "nkeys"
     d.mkdir()
     for n in names:
-        (d / f"{n}.seed").write_text("SUFAKEKEYDATA")
+        seed = d / f"{n}.seed"
+        seed.write_text("SUFAKEKEYDATA")
+        seed.chmod(0o600)
     return d
 
 
@@ -147,7 +149,7 @@ def test_verify_all_pass(tmp_path: Path, matrix_two: Path) -> None:
     seeds = _seed_dir(tmp_path, ["hub", "monitor"])
     # Each identity: deny only its `lyra.verify.deny.<name>` probe.
     deny = [{"lyra.verify.deny.hub"}, {"lyra.verify.deny.monitor"}]
-    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+    with patch("lyra.cli_ops.nats.connect", _patched_connect(deny)):
         result = runner.invoke(
             lyra_app,
             [
@@ -176,7 +178,7 @@ def test_verify_pub_failure_reports_first_offender(
         {"lyra.outbound.telegram.verify", "lyra.verify.deny.hub"},
         {"lyra.verify.deny.monitor"},
     ]
-    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+    with patch("lyra.cli_ops.nats.connect", _patched_connect(deny)):
         result = runner.invoke(
             lyra_app,
             [
@@ -190,13 +192,16 @@ def test_verify_pub_failure_reports_first_offender(
         )
     assert result.exit_code == 1
     assert "FAIL hub pub lyra.outbound.telegram.verify" in result.stdout
+    # Summary line still reports counts after the FAIL row.
+    assert "2/3 pub checks passed" in result.stdout
+    assert "2/2 deny checks passed" in result.stdout
 
 
 def test_verify_deny_failure(tmp_path: Path, matrix_two: Path) -> None:
     seeds = _seed_dir(tmp_path, ["hub", "monitor"])
     # Server *accepts* the verify-deny probe → deny check fails.
     deny = [set(), set()]
-    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+    with patch("lyra.cli_ops.nats.connect", _patched_connect(deny)):
         result = runner.invoke(
             lyra_app,
             [
@@ -215,7 +220,7 @@ def test_verify_deny_failure(tmp_path: Path, matrix_two: Path) -> None:
 def test_verify_skips_when_seed_missing(tmp_path: Path, matrix_two: Path) -> None:
     seeds = _seed_dir(tmp_path, ["hub"])  # monitor.seed missing
     deny = [{"lyra.verify.deny.hub"}]
-    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+    with patch("lyra.cli_ops.nats.connect", _patched_connect(deny)):
         result = runner.invoke(
             lyra_app,
             [
@@ -235,7 +240,7 @@ def test_verify_skips_when_seed_missing(tmp_path: Path, matrix_two: Path) -> Non
 def test_verify_only_filter(tmp_path: Path, matrix_two: Path) -> None:
     seeds = _seed_dir(tmp_path, ["hub", "monitor"])
     deny = [{"lyra.verify.deny.monitor"}]
-    with patch("lyra.cli_ops.nats_connect", _patched_connect(deny)):
+    with patch("lyra.cli_ops.nats.connect", _patched_connect(deny)):
         result = runner.invoke(
             lyra_app,
             [
@@ -270,6 +275,100 @@ def test_verify_only_unknown_identity(tmp_path: Path, matrix_two: Path) -> None:
     )
     assert result.exit_code != 0
     assert "ghost" in result.output
+
+
+def test_verify_handles_empty_publish_list(tmp_path: Path) -> None:
+    """Identity with `publish: []` reports 0/0 pub but still runs the deny probe."""
+    matrix = tmp_path / "matrix.json"
+    _write_matrix(matrix, {"silent": {"publish": [], "subscribe": []}})
+    seeds = _seed_dir(tmp_path, ["silent"])
+    deny = [{"lyra.verify.deny.silent"}]
+    with patch("lyra.cli_ops.nats.connect", _patched_connect(deny)):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix),
+                "--seeds-dir",
+                str(seeds),
+            ],
+        )
+    assert result.exit_code == 0, result.stdout
+    assert (
+        "1 identities, 0/0 pub checks passed, 1/1 deny checks passed" in result.stdout
+    )
+
+
+class _FakeNatsDelayed(_FakeNats):
+    """Variant that fires the error_cb during flush(), not publish()."""
+
+    def __init__(self, deny_subjects: set[str] | None = None) -> None:
+        super().__init__(deny_subjects)
+        self._pending: list[str] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append(subject)
+        if subject in self._deny:
+            self._pending.append(subject)
+
+    async def flush(self, timeout: float = 2.0) -> None:  # noqa: ARG002
+        if self._error_cb is not None:
+            for subj in self._pending:
+                await self._error_cb(
+                    Exception(f'nats: Permissions Violation for Publish to "{subj}"')
+                )
+        self._pending.clear()
+
+
+def test_verify_handles_post_flush_error_arrival(
+    tmp_path: Path, matrix_two: Path
+) -> None:
+    """Permission error arriving on the next event-loop tick is still caught."""
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    deny = [{"lyra.verify.deny.hub"}, {"lyra.verify.deny.monitor"}]
+    iterator = iter(deny)
+
+    async def _factory(url, **kwargs):  # noqa: ARG001
+        fake = _FakeNatsDelayed(next(iterator, set()))
+        fake.set_error_cb(kwargs.get("error_cb"))
+        return fake
+
+    with patch("lyra.cli_ops.nats.connect", side_effect=_factory):
+        result = runner.invoke(
+            lyra_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix_two),
+                "--seeds-dir",
+                str(seeds),
+            ],
+        )
+    assert result.exit_code == 0, result.stdout
+    assert "2/2 deny checks passed" in result.stdout
+
+
+def test_verify_rejects_seed_outside_seeds_dir(tmp_path: Path) -> None:
+    """Identity name with `..` must not escape seeds-dir."""
+    matrix = tmp_path / "matrix.json"
+    _write_matrix(matrix, {"../escape": {"publish": ["lyra.foo"], "subscribe": []}})
+    seeds = _seed_dir(tmp_path, [])
+    result = runner.invoke(
+        lyra_app,
+        [
+            "ops",
+            "verify",
+            "--matrix",
+            str(matrix),
+            "--seeds-dir",
+            str(seeds),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "outside seeds-dir" in result.output
 
 
 def test_verify_acl_matrix_repo_loads() -> None:


### PR DESCRIPTION
## Summary
- Adds `lyra ops verify` — walks `deploy/nats/acl-matrix.json` and exercises each identity's publish ACL against the live NATS server (allowed subjects expect success, a `lyra.verify.deny.<id>` probe expects a permissions violation).
- Reports a one-line PASS/FAIL summary suitable for nightly CI on staging; first offending row printed when failing.
- Picks up `NATS_URL` / `NATS_CA_CERT` from env, per-identity seeds from `~/.lyra/nkeys/<id>.seed` (override via `--seeds-dir`); supports `--only` to scope verification to a subset.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #737: feat(ops): lyra ops verify CLI — per-identity auth sanity check | Open |
| Implementation | 1 commit on `feat/737-ops-verify` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (17 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/cli/test_ops_verify.py` — 17 unit tests pass (subject expansion, matrix loader, mocked CLI happy/sad paths, `--only` filter, missing-seed skip).
- [ ] On Machine 1 with NATS up: `uv run lyra ops verify` from `~/projects/lyra` → expect `10 identities, N/N pub checks passed, 10/10 deny checks passed` and exit 0.
- [ ] Negative: `uv run lyra ops verify --only ghost` → exits non-zero with "unknown identity name(s): ghost".
- [ ] Negative: rename one seed file → that identity reports `SKIP <id>: seed missing` and exit code 1.

Closes #737

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`