### PR TITLE
feat(dep-graph): v5 reader on corpus.db (tree ∪ shared_subtree)

### DIFF
--- a/scripts/dep-graph/pyproject.toml
+++ b/scripts/dep-graph/pyproject.toml
@@ -22,7 +22,7 @@ packages = ["dep_graph", "v5"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "v5/tests"]
 addopts = "--import-mode=importlib"
-pythonpath = ["."]
+pythonpath = [".", "../.."]
 markers = [
     "integration: tests requiring local fixture files (not run in CI by default)",
 ]

--- a/scripts/dep-graph/pyproject.toml
+++ b/scripts/dep-graph/pyproject.toml
@@ -22,6 +22,9 @@ packages = ["dep_graph", "v5"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "v5/tests"]
 addopts = "--import-mode=importlib"
+# "." = scripts/dep-graph (dep_graph + v5 imports).
+# "../.." = repo root, required so v5/tests/test_corpus.py + test_load.py can
+# `from scripts.corpus.schema import bootstrap` to seed sqlite fixtures.
 pythonpath = [".", "../.."]
 markers = [
     "integration: tests requiring local fixture files (not run in CI by default)",

--- a/scripts/dep-graph/v5/data/corpus.py
+++ b/scripts/dep-graph/v5/data/corpus.py
@@ -30,6 +30,8 @@ def load_issues(db_path: Path | None = None) -> dict[str, dict[str, Any]]:
     the DB does not exist.
     """
     resolved = db_path if db_path is not None else DEFAULT_DB
+    # TOCTOU window between .exists() and connect() is acceptable for a
+    # local ~/.roxabi/corpus.db — no remote-mount concern today.
     if not resolved.exists():
         raise FileNotFoundError(
             f"corpus.db not found at {resolved}. Run `make corpus-sync` to populate it."
@@ -50,12 +52,15 @@ def load_issues(db_path: Path | None = None) -> dict[str, dict[str, Any]]:
 def _project_lane_size(labels: list[str]) -> tuple[str | None, str | None]:
     """Project lane_label + size from a label list.
 
-    SINGLE SWAP POINT for the roxabi-plugins#119 taxonomy migration. Once the
-    Roxabi Hub Project V2 has issues enrolled and corpus.db grows `lane` / `size`
-    columns, follow-up issue #872 flips this one function to read those columns
-    directly and drops the label-prefix logic.
+    SINGLE SWAP POINT for the cross-repo taxonomy migration:
+      1. `Roxabi/roxabi-plugins#119` enrolls every issue in the Roxabi Hub
+         Project V2 and backfills the Lane/Size single-select fields.
+      2. `Roxabi/lyra#872` then extends corpus.db with `lane` / `size`
+         columns pulled from `projectV2.items`, and flips the body of this
+         function to read those columns instead of the label prefixes.
 
-    Do NOT inline this function into load_issues — the indirection is the point.
+    Do NOT inline this function into load_issues — the indirection is the
+    point; the whole migration is one function's worth of code change.
     """
     lane: str | None = None
     size: str | None = None
@@ -85,8 +90,14 @@ def _fetch_labels(conn: sqlite3.Connection) -> dict[str, list[str]]:
 
 
 def _key_to_ref(key: str) -> dict[str, Any]:
-    """Parse `owner/repo#N` into an IssueRef dict `{repo, issue}`."""
-    repo, num = key.rsplit("#", 1)
+    """Parse `owner/repo#N` into an IssueRef dict `{repo, issue}`.
+
+    Raises ValueError with the offending key in the message on malformed
+    input (e.g. missing `#`), instead of an opaque unpack error.
+    """
+    repo, sep, num = key.rpartition("#")
+    if not sep or not repo:
+        raise ValueError(f"malformed corpus key (expected 'owner/repo#N'): {key!r}")
     return {"repo": repo, "issue": int(num)}
 
 

--- a/scripts/dep-graph/v5/data/corpus.py
+++ b/scripts/dep-graph/v5/data/corpus.py
@@ -1,0 +1,158 @@
+"""Adapter: read Roxabi org corpus (~/.roxabi/corpus.db) and project rows into the
+issue-dict shape v5 already consumes (same keys as the legacy gh.json cache).
+
+Single data source for v5: callers pass db_path or rely on the DEFAULT_DB constant.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
+
+LANE_LABEL_PREFIX = "graph:lane/"
+SIZE_LABEL_PREFIX = "size:"
+STANDALONE_LABEL = "graph:standalone"
+DEFER_LABEL = "graph:defer"
+
+
+def load_issues(db_path: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Load every issue + labels + edges from corpus.db into the v5 projected shape.
+
+    Returns `{key: dict}` keyed by canonical `owner/repo#N`. No repo filter —
+    caller (v5 compute_visible) handles visibility.
+
+    Raises FileNotFoundError (with a hint referencing `make corpus-sync`) when
+    the DB does not exist.
+    """
+    resolved = db_path if db_path is not None else DEFAULT_DB
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"corpus.db not found at {resolved}. Run `make corpus-sync` to populate it."
+        )
+
+    conn = sqlite3.connect(resolved)
+    try:
+        labels_by_key = _fetch_labels(conn)
+        blocking_by_key, blocked_by_key = _fetch_edges(conn)
+        return _fetch_issues(conn, labels_by_key, blocking_by_key, blocked_by_key)
+    finally:
+        conn.close()
+
+
+def _project_lane_size(labels: list[str]) -> tuple[str | None, str | None]:
+    """Project lane_label + size from a label list.
+
+    SINGLE SWAP POINT for the roxabi-plugins#119 taxonomy migration. Once the
+    Roxabi Hub Project V2 has issues enrolled and corpus.db grows `lane` / `size`
+    columns, follow-up issue #872 flips this one function to read those columns
+    directly and drops the label-prefix logic.
+
+    Do NOT inline this function into load_issues — the indirection is the point.
+    """
+    lane: str | None = None
+    size: str | None = None
+
+    for lbl in labels:
+        if lane is None and lbl.startswith(LANE_LABEL_PREFIX):
+            lane = lbl[len(LANE_LABEL_PREFIX):]
+        if size is None and lbl.startswith(SIZE_LABEL_PREFIX):
+            size = lbl[len(SIZE_LABEL_PREFIX):]
+        if lane is not None and size is not None:
+            break
+
+    return lane, size
+
+
+# ─── Private helpers ──────────────────────────────────────────────────────────
+
+
+def _fetch_labels(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    """Return {issue_key: [label_name, ...]} preserving insertion order."""
+    result: dict[str, list[str]] = {}
+    for issue_key, name in conn.execute(
+        "SELECT issue_key, name FROM labels ORDER BY rowid"
+    ):
+        result.setdefault(issue_key, []).append(name)
+    return result
+
+
+def _key_to_ref(key: str) -> dict[str, Any]:
+    """Parse `owner/repo#N` into an IssueRef dict `{repo, issue}`."""
+    repo, num = key.rsplit("#", 1)
+    return {"repo": repo, "issue": int(num)}
+
+
+def _fetch_edges(
+    conn: sqlite3.Connection,
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    """Return (blocking_by_key, blocked_by_key) from the edges table.
+
+    edge (src, dst) means src blocks dst:
+      blocking_by_key[src]  → refs of issues that src blocks
+      blocked_by_key[dst]   → refs of issues that block dst
+    """
+    blocking_by_key: dict[str, list[dict[str, Any]]] = {}
+    blocked_by_key: dict[str, list[dict[str, Any]]] = {}
+
+    for src_key, dst_key in conn.execute("SELECT src_key, dst_key FROM edges"):
+        blocking_by_key.setdefault(src_key, []).append(_key_to_ref(dst_key))
+        blocked_by_key.setdefault(dst_key, []).append(_key_to_ref(src_key))
+
+    return blocking_by_key, blocked_by_key
+
+
+def _fetch_issues(
+    conn: sqlite3.Connection,
+    labels_by_key: dict[str, list[str]],
+    blocking_by_key: dict[str, list[dict[str, Any]]],
+    blocked_by_key: dict[str, list[dict[str, Any]]],
+) -> dict[str, dict[str, Any]]:
+    """Build the final projected issue dict from the issues table."""
+    result: dict[str, dict[str, Any]] = {}
+
+    for row in conn.execute(
+        "SELECT key, repo, number, title, state, url, "
+        "created_at, updated_at, closed_at, milestone, is_stub "
+        "FROM issues"
+    ):
+        (
+            key,
+            repo,
+            number,
+            title,
+            state,
+            url,
+            created_at,
+            updated_at,
+            closed_at,
+            milestone,
+            is_stub,
+        ) = row
+
+        labels = labels_by_key.get(key, [])
+        lane_label, size = _project_lane_size(labels)
+
+        result[key] = {
+            "repo": repo,
+            "number": number,
+            "title": title,
+            "state": state,
+            "url": url,
+            "created_at": created_at,
+            "updated_at": updated_at,
+            "closed_at": closed_at,
+            "milestone": milestone,
+            "is_stub": bool(is_stub),
+            "labels": labels,
+            "lane_label": lane_label,
+            "size": size,
+            "standalone": STANDALONE_LABEL in labels,
+            "defer": DEFER_LABEL in labels,
+            "blocking": blocking_by_key.get(key, []),
+            "blocked_by": blocked_by_key.get(key, []),
+        }
+
+    return result

--- a/scripts/dep-graph/v5/data/corpus.py
+++ b/scripts/dep-graph/v5/data/corpus.py
@@ -10,6 +10,8 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
+from scripts.corpus.schema import connect as _connect_corpus
+
 DEFAULT_DB = Path.home() / ".roxabi" / "corpus.db"
 
 LANE_LABEL_PREFIX = "graph:lane/"
@@ -33,7 +35,10 @@ def load_issues(db_path: Path | None = None) -> dict[str, dict[str, Any]]:
             f"corpus.db not found at {resolved}. Run `make corpus-sync` to populate it."
         )
 
-    conn = sqlite3.connect(resolved)
+    # Use schema.connect for the single source of truth on connection pragmas
+    # (foreign_keys = ON). The adapter is read-only today; using the same
+    # connection contract prevents pragma drift if a write path is ever added.
+    conn = _connect_corpus(resolved)
     try:
         labels_by_key = _fetch_labels(conn)
         blocking_by_key, blocked_by_key = _fetch_edges(conn)
@@ -132,7 +137,10 @@ def _fetch_issues(
             is_stub,
         ) = row
 
-        labels = labels_by_key.get(key, [])
+        # Copy the label list so downstream mutation of the projected dict's
+        # `labels` cannot alias back into labels_by_key (which feeds derived
+        # fields below).
+        labels = list(labels_by_key.get(key, []))
         lane_label, size = _project_lane_size(labels)
 
         result[key] = {

--- a/scripts/dep-graph/v5/data/derive.py
+++ b/scripts/dep-graph/v5/data/derive.py
@@ -93,7 +93,10 @@ def _bfs(
     """BFS over blocking ∪ blocked_by edges.
 
     If restrict_to_repo is not None, only follows edges into nodes whose
-    repo matches (used for shared_subtree Q-local closure).
+    repo matches (used for shared_subtree Q-local closure). The caller
+    must ensure every seed key already satisfies that constraint — the
+    restrict filter applies to destinations discovered during traversal,
+    not to the initial seed.
     """
     closure = set(seed)
     stack = list(seed)

--- a/scripts/dep-graph/v5/data/derive.py
+++ b/scripts/dep-graph/v5/data/derive.py
@@ -56,33 +56,59 @@ def status_of(iss: dict[str, Any], issues: dict[str, dict[str, Any]]) -> str:
 
 
 def compute_visible(issues: dict[str, dict[str, Any]], primary_repo: str) -> set[str]:
-    """Visibility set per project-level rule.
+    """Visibility = tree(P) ∪ ⋃_{Q != P} shared_subtree(Q, P).
 
-    · Seed: all open items in primary repo.
-    · Forward cascade (blocking), any state, any repo.
-    · 1-hop backward (blocked_by) from anything already visible.
+    tree(P): seed = open issues in P; BFS closure over blocking ∪ blocked_by,
+             any state, any repo (no hop cap).
+    shared_subtree(Q, P): for each repo Q != P, BFS closure within Q of
+             (Q ∩ tree(P)) over Q-local edges (blocking ∪ blocked_by).
     """
-    visible: set[str] = {
+    seed = {
         k
         for k, i in issues.items()
         if i.get("repo") == primary_repo and i.get("state") == "open"
     }
+    tree = _bfs(issues, seed, restrict_to_repo=None)
 
-    stack = list(visible)
-    while stack:
-        for ref in issues.get(stack.pop(), {}).get("blocking", []):
-            rk = ref_key(ref)
-            if rk in issues and rk not in visible:
-                visible.add(rk)
-                stack.append(rk)
-
-    for k in list(visible):
-        for ref in issues.get(k, {}).get("blocked_by", []):
-            rk = ref_key(ref)
-            if rk in issues:
-                visible.add(rk)
-
+    visible = set(tree)
+    other_repos = {
+        i.get("repo")
+        for i in issues.values()
+        if i.get("repo") and i.get("repo") != primary_repo
+    }
+    for q in other_repos:
+        shared = {k for k in tree if issues[k].get("repo") == q}
+        if not shared:
+            continue
+        visible |= _bfs(issues, shared, restrict_to_repo=q)
     return visible
+
+
+def _bfs(
+    issues: dict[str, dict[str, Any]],
+    seed: set[str],
+    *,
+    restrict_to_repo: str | None,
+) -> set[str]:
+    """BFS over blocking ∪ blocked_by edges.
+
+    If restrict_to_repo is not None, only follows edges into nodes whose
+    repo matches (used for shared_subtree Q-local closure).
+    """
+    closure = set(seed)
+    stack = list(seed)
+    while stack:
+        current = issues.get(stack.pop(), {})
+        for field in ("blocking", "blocked_by"):
+            for ref in current.get(field, []):
+                rk = ref_key(ref)
+                if rk not in issues or rk in closure:
+                    continue
+                if restrict_to_repo is not None and issues[rk].get("repo") != restrict_to_repo:
+                    continue
+                closure.add(rk)
+                stack.append(rk)
+    return closure
 
 
 def epic_keys(layout_lanes: list[dict[str, Any]], primary_repo: str) -> set[str]:

--- a/scripts/dep-graph/v5/data/derive.py
+++ b/scripts/dep-graph/v5/data/derive.py
@@ -68,7 +68,7 @@ def compute_visible(issues: dict[str, dict[str, Any]], primary_repo: str) -> set
         for k, i in issues.items()
         if i.get("repo") == primary_repo and i.get("state") == "open"
     }
-    tree = _bfs(issues, seed, restrict_to_repo=None)
+    tree = _closure(issues, seed, restrict_to_repo=None)
 
     visible = set(tree)
     other_repos = {
@@ -80,17 +80,18 @@ def compute_visible(issues: dict[str, dict[str, Any]], primary_repo: str) -> set
         shared = {k for k in tree if issues[k].get("repo") == q}
         if not shared:
             continue
-        visible |= _bfs(issues, shared, restrict_to_repo=q)
+        visible |= _closure(issues, shared, restrict_to_repo=q)
     return visible
 
 
-def _bfs(
+def _closure(
     issues: dict[str, dict[str, Any]],
     seed: set[str],
     *,
     restrict_to_repo: str | None,
 ) -> set[str]:
-    """BFS over blocking ∪ blocked_by edges.
+    """Closure over blocking ∪ blocked_by edges (LIFO traversal; order
+    doesn't matter for set semantics).
 
     If restrict_to_repo is not None, only follows edges into nodes whose
     repo matches (used for shared_subtree Q-local closure). The caller

--- a/scripts/dep-graph/v5/data/load.py
+++ b/scripts/dep-graph/v5/data/load.py
@@ -68,7 +68,10 @@ def load(
 def load_from_dicts(layout: dict[str, Any], gh: dict[str, Any]) -> GraphData:
     lanes = [_parse_lane(raw) for raw in layout["lanes"]]
     issues = gh.get("issues", {})
-    primary_repo = layout["meta"]["repos"][0]
+    # Phase 3 will promote PRIMARY_REPO to a parameter (toolbar dropdown).
+    # Until then this constant is the single flip point; layout["meta"]["repos"]
+    # stays in the schema for Phase 3 to enumerate available projects.
+    primary_repo = PRIMARY_REPO
     ekeys = epic_keys(layout["lanes"], primary_repo)
     depth = compute_depth(issues)
     visible = compute_visible(issues, primary_repo)

--- a/scripts/dep-graph/v5/data/load.py
+++ b/scripts/dep-graph/v5/data/load.py
@@ -1,4 +1,4 @@
-"""Load layout.json + gh.json, derive matrix + counts, return GraphData."""
+"""Load layout.json + corpus.db, derive matrix + counts, return GraphData."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .corpus import load_issues
 from .derive import (
     build_matrix,
     compute_depth,
@@ -23,9 +24,8 @@ from .model import (
     parse_milestones,
 )
 
-FORGE = Path.home() / ".roxabi/forge/lyra/visuals"
-LAYOUT_PATH = FORGE / "lyra-v2-dependency-graph.layout.json"
-CACHE_PATH = FORGE / "lyra-v2-dependency-graph.gh.json"
+LAYOUT_PATH = Path.home() / ".roxabi/forge/lyra/visuals/lyra-v2-dependency-graph.layout.json"
+PRIMARY_REPO = "Roxabi/lyra"
 
 
 def _parse_lane(raw: dict[str, Any]) -> Lane:
@@ -47,19 +47,22 @@ def _parse_lane(raw: dict[str, Any]) -> Lane:
 
 def load(
     layout_path: Path | None = None,
-    cache_path: Path | None = None,
+    db_path: Path | None = None,
 ) -> GraphData:
+    """Load GraphData from layout.json + corpus.db.
+
+    Args:
+        layout_path: Path to layout.json. Defaults to LAYOUT_PATH.
+        db_path: Path to corpus.db. Defaults to DEFAULT_DB (in corpus module).
+                 Raises FileNotFoundError with a `make corpus-sync` hint if missing.
+    """
     layout_path = layout_path or LAYOUT_PATH
-    cache_path = cache_path or CACHE_PATH
     try:
         layout_raw = layout_path.read_text()
     except FileNotFoundError as exc:
         raise FileNotFoundError(f"layout not found: {layout_path}") from exc
-    try:
-        cache_raw = cache_path.read_text()
-    except FileNotFoundError as exc:
-        raise FileNotFoundError(f"gh cache not found: {cache_path}") from exc
-    return load_from_dicts(json.loads(layout_raw), json.loads(cache_raw))
+    issues = load_issues(db_path)
+    return load_from_dicts(json.loads(layout_raw), {"issues": issues})
 
 
 def load_from_dicts(layout: dict[str, Any], gh: dict[str, Any]) -> GraphData:

--- a/scripts/dep-graph/v5/data/model.py
+++ b/scripts/dep-graph/v5/data/model.py
@@ -111,10 +111,10 @@ class GraphData:
     # Cell matrix: (ms_label, lane_code) → [issue dicts], excludes epics.
     matrix: dict[tuple[str, str], list[dict[str, Any]]] = field(default_factory=dict)
     epic_keys: set[str] = field(default_factory=set)
-    # Visibility set — canonical keys the grid/graph should render. Rule:
-    #   · all open items in primary repo
-    #   · forward cascade (blocking edges), any state, any repo
-    #   · 1-hop backward (blocked_by), any state, any repo
+    # Visibility set — canonical keys the grid/graph should render.
+    # Rule: tree(P) ∪ ⋃_Q shared_subtree(Q, P).
+    #   tree(P): full BFS closure (blocking ∪ blocked_by) seeded by open P issues.
+    #   shared_subtree(Q, P): Q-local BFS from Q ∩ tree(P) — pulls sibling deps.
     visible: set[str] = field(default_factory=set)
     # Topological depth (counts all blockers, open + closed).
     depth_by_key: dict[str, int] = field(default_factory=dict)

--- a/scripts/dep-graph/v5/data/model.py
+++ b/scripts/dep-graph/v5/data/model.py
@@ -115,6 +115,9 @@ class GraphData:
     # Rule: tree(P) ∪ ⋃_Q shared_subtree(Q, P).
     #   tree(P): full BFS closure (blocking ∪ blocked_by) seeded by open P issues.
     #   shared_subtree(Q, P): Q-local BFS from Q ∩ tree(P) — pulls sibling deps.
+    # Note: this is a strict superset of the pre-#864 rule (open-in-P + forward
+    # cascade + 1-hop backward). Single-repo graphs may now show previously-
+    # hidden closed-blocker chains that were cut off at the 1-hop boundary.
     visible: set[str] = field(default_factory=set)
     # Topological depth (counts all blockers, open + closed).
     depth_by_key: dict[str, int] = field(default_factory=dict)

--- a/scripts/dep-graph/v5/tests/test_corpus.py
+++ b/scripts/dep-graph/v5/tests/test_corpus.py
@@ -1,0 +1,173 @@
+"""Tests for v5.data.corpus — corpus.db adapter + lane/size projector.
+
+RED state: scripts/dep-graph/v5/data/corpus.py does not exist yet.
+All tests will fail with ModuleNotFoundError until T2 (implementation) lands.
+
+Tests cover:
+- _project_lane_size() — unit tests for the isolated label projector
+- load_issues() — integration tests seeding a real sqlite DB via
+  scripts.corpus.schema.bootstrap + raw INSERTs, asserting the projected
+  issue dict shape matches spec §Data Model.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from v5.data.corpus import _project_lane_size, load_issues
+
+
+# ─── Unit: _project_lane_size ────────────────────────────────────────────────
+
+
+def test_project_lane_size_strips_prefixes() -> None:
+    """First graph:lane/* and size:* labels are stripped to bare values."""
+    # Arrange
+    labels = ["graph:lane/a2", "size:S", "foo"]
+
+    # Act
+    lane, size = _project_lane_size(labels)
+
+    # Assert
+    assert lane == "a2"
+    assert size == "S"
+
+
+def test_project_lane_size_first_wins() -> None:
+    """When multiple matching labels exist, the first match wins."""
+    # Arrange
+    labels = ["graph:lane/a1", "graph:lane/a2", "size:S", "size:M"]
+
+    # Act
+    lane, size = _project_lane_size(labels)
+
+    # Assert
+    assert lane == "a1"
+    assert size == "S"
+
+
+def test_project_lane_size_returns_none_when_absent() -> None:
+    """Returns (None, None) when neither graph:lane/ nor size: labels present."""
+    # Arrange
+    labels = ["graph:standalone", "priority:high", "unrelated"]
+
+    # Act
+    lane, size = _project_lane_size(labels)
+
+    # Assert
+    assert lane is None
+    assert size is None
+
+
+# ─── Integration: load_issues ────────────────────────────────────────────────
+
+
+def _seed_db(db_path: Path) -> None:
+    """Bootstrap schema and insert one issue with labels, no edges."""
+    from scripts.corpus.schema import bootstrap
+
+    bootstrap(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """INSERT INTO issues (key, repo, number, title, state, milestone, is_stub)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "Roxabi/lyra#1",
+                "Roxabi/lyra",
+                1,
+                "Test issue",
+                "open",
+                "M1 alpha",
+                0,
+            ),
+        )
+        for label in ["graph:lane/a1", "size:M", "graph:standalone"]:
+            conn.execute(
+                "INSERT INTO labels (issue_key, name) VALUES (?, ?)",
+                ("Roxabi/lyra#1", label),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_load_issues_projects_all_fields(tmp_path: Path) -> None:
+    """Projected dict carries every field documented in spec §Data Model."""
+    # Arrange
+    db_path = tmp_path / "corpus.db"
+    _seed_db(db_path)
+
+    # Act
+    issues = load_issues(db_path)
+
+    # Assert
+    assert "Roxabi/lyra#1" in issues
+    issue = issues["Roxabi/lyra#1"]
+
+    assert issue["repo"] == "Roxabi/lyra"
+    assert issue["number"] == 1
+    assert issue["title"] == "Test issue"
+    assert issue["state"] == "open"
+    assert set(issue["labels"]) == {"graph:lane/a1", "size:M", "graph:standalone"}
+    assert issue["lane_label"] == "a1"
+    assert issue["standalone"] is True
+    assert issue["defer"] is False
+    assert issue["milestone"] == "M1 alpha"
+    assert issue["size"] == "M"
+    assert issue["blocking"] == []
+    assert issue["blocked_by"] == []
+
+
+def test_edges_populate_blocking_and_blocked_by(tmp_path: Path) -> None:
+    """Edge src blocks dst → A.blocking has B ref; B.blocked_by has A ref."""
+    # Arrange
+    from scripts.corpus.schema import bootstrap
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executemany(
+            """INSERT INTO issues (key, repo, number, title, state, is_stub)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            [
+                ("Roxabi/lyra#1", "Roxabi/lyra", 1, "Issue A", "open", 0),
+                ("Roxabi/voiceCLI#10", "Roxabi/voiceCLI", 10, "Issue B", "open", 0),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO edges (src_key, dst_key) VALUES (?, ?)",
+            ("Roxabi/lyra#1", "Roxabi/voiceCLI#10"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Act
+    issues = load_issues(db_path)
+
+    # Assert — A blocks B
+    assert issues["Roxabi/lyra#1"]["blocking"] == [
+        {"repo": "Roxabi/voiceCLI", "issue": 10}
+    ]
+    assert issues["Roxabi/lyra#1"]["blocked_by"] == []
+
+    # Assert — B is blocked by A
+    assert issues["Roxabi/voiceCLI#10"]["blocked_by"] == [
+        {"repo": "Roxabi/lyra", "issue": 1}
+    ]
+    assert issues["Roxabi/voiceCLI#10"]["blocking"] == []
+
+
+def test_missing_db_hints_make_corpus_sync(tmp_path: Path) -> None:
+    """Missing db_path raises FileNotFoundError hinting at make corpus-sync."""
+    # Arrange
+    db_path = tmp_path / "nonexistent.db"
+
+    # Act / Assert
+    with pytest.raises(FileNotFoundError, match="make corpus-sync"):
+        load_issues(db_path)

--- a/scripts/dep-graph/v5/tests/test_corpus.py
+++ b/scripts/dep-graph/v5/tests/test_corpus.py
@@ -62,6 +62,12 @@ def test_project_lane_size_returns_none_when_absent() -> None:
     assert size is None
 
 
+def test_project_lane_size_empty_labels() -> None:
+    """Degenerate case: empty label list → (None, None) — exercised for
+    every issue with no labels in _fetch_issues."""
+    assert _project_lane_size([]) == (None, None)
+
+
 # ─── Integration: load_issues ────────────────────────────────────────────────
 
 
@@ -171,3 +177,62 @@ def test_missing_db_hints_make_corpus_sync(tmp_path: Path) -> None:
     # Act / Assert
     with pytest.raises(FileNotFoundError, match="make corpus-sync"):
         load_issues(db_path)
+
+
+def test_load_issues_is_stub_true_projection(tmp_path: Path) -> None:
+    """is_stub=1 in SQLite → is_stub: True in projected dict."""
+    # Arrange
+    from scripts.corpus.schema import bootstrap
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """INSERT INTO issues (key, repo, number, title, state, is_stub)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("Roxabi/lyra#1", "Roxabi/lyra", 1, "stub", "closed", 1),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Act
+    issues = load_issues(db_path)
+
+    # Assert
+    assert issues["Roxabi/lyra#1"]["is_stub"] is True
+
+
+def test_load_issues_dangling_edge_produces_orphan_ref(tmp_path: Path) -> None:
+    """Edge whose dst_key has no issues row → src.blocking still lists the
+    orphan ref (downstream compute_visible filters on `rk in issues`)."""
+    # Arrange
+    from scripts.corpus.schema import bootstrap
+
+    db_path = tmp_path / "corpus.db"
+    bootstrap(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """INSERT INTO issues (key, repo, number, title, state, is_stub)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("Roxabi/lyra#1", "Roxabi/lyra", 1, "A", "open", 0),
+        )
+        # Edge points at a key that has no issues row.
+        conn.execute(
+            "INSERT INTO edges (src_key, dst_key) VALUES (?, ?)",
+            ("Roxabi/lyra#1", "Roxabi/voiceCLI#999"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Act
+    issues = load_issues(db_path)
+
+    # Assert — orphan ref present on src side; no phantom issues entry.
+    assert issues["Roxabi/lyra#1"]["blocking"] == [
+        {"repo": "Roxabi/voiceCLI", "issue": 999}
+    ]
+    assert "Roxabi/voiceCLI#999" not in issues

--- a/scripts/dep-graph/v5/tests/test_derive.py
+++ b/scripts/dep-graph/v5/tests/test_derive.py
@@ -457,12 +457,12 @@ class TestLaneByCode:
 # All four MUST fail against the current (old) implementation.
 
 
-def _ref(repo: str, n: int) -> dict:
-    """Compact ref builder: {repo, issue}."""
-    return {"repo": repo, "issue": n}
-
-
 class TestComputeVisibleNewAlgebra:
+    @staticmethod
+    def _ref(repo: str, n: int) -> dict:
+        """Compact ref builder: {repo, issue}."""
+        return {"repo": repo, "issue": n}
+
     def test_tree_full_backward_closure(self):
         # Old rule: 1-hop backward — stops at {A, B}.
         # New rule: full backward closure through tree(P) — must reach C.
@@ -475,20 +475,20 @@ class TestComputeVisibleNewAlgebra:
             1,
             state="open",
             repo=repo,
-            blocked_by=[_ref(repo, 2)],
+            blocked_by=[self._ref(repo, 2)],
         )
         b = _make_issue(
             2,
             state="closed",
             repo=repo,
-            blocked_by=[_ref(repo, 3)],
-            blocking=[_ref(repo, 1)],
+            blocked_by=[self._ref(repo, 3)],
+            blocking=[self._ref(repo, 1)],
         )
         c = _make_issue(
             3,
             state="closed",
             repo=repo,
-            blocking=[_ref(repo, 2)],
+            blocking=[self._ref(repo, 2)],
         )
         issues = _issues(a, b, c)
 
@@ -507,7 +507,7 @@ class TestComputeVisibleNewAlgebra:
             11,
             state="closed",
             repo=voice,
-            blocking=[_ref(voice, 10)],
+            blocking=[self._ref(voice, 10)],
         )
         issues = _issues(l1, v10, v11)
 
@@ -526,27 +526,27 @@ class TestComputeVisibleNewAlgebra:
             1,
             state="open",
             repo=lyra,
-            blocked_by=[_ref(voice, 10)],
+            blocked_by=[self._ref(voice, 10)],
         )
         v10 = _make_issue(
             10,
             state="closed",
             repo=voice,
-            blocking=[_ref(lyra, 1)],
-            blocked_by=[_ref(voice, 11)],
+            blocking=[self._ref(lyra, 1)],
+            blocked_by=[self._ref(voice, 11)],
         )
         v11 = _make_issue(
             11,
             state="closed",
             repo=voice,
-            blocking=[_ref(voice, 10)],
-            blocked_by=[_ref(voice, 12)],
+            blocking=[self._ref(voice, 10)],
+            blocked_by=[self._ref(voice, 12)],
         )
         v12 = _make_issue(
             12,
             state="closed",
             repo=voice,
-            blocking=[_ref(voice, 11)],
+            blocking=[self._ref(voice, 11)],
         )
         issues = _issues(l1, v10, v11, v12)
 
@@ -577,14 +577,14 @@ class TestComputeVisibleNewAlgebra:
             3,
             state="open",
             repo=lyra,
-            blocked_by=[_ref(lyra, 4)],
+            blocked_by=[self._ref(lyra, 4)],
         )
         l4 = _make_issue(
             4,
             state="closed",
             repo=lyra,
-            blocking=[_ref(lyra, 3)],
-            blocked_by=[_ref(voice, 83)],
+            blocking=[self._ref(lyra, 3)],
+            blocked_by=[self._ref(voice, 83)],
         )
         l5 = _make_issue(5, state="open", repo=lyra)
 
@@ -593,14 +593,14 @@ class TestComputeVisibleNewAlgebra:
             83,
             state="closed",
             repo=voice,
-            blocking=[_ref(lyra, 4)],
-            blocked_by=[_ref(voice, 69)],
+            blocking=[self._ref(lyra, 4)],
+            blocked_by=[self._ref(voice, 69)],
         )
         v69 = _make_issue(
             69,
             state="open",
             repo=voice,
-            blocking=[_ref(voice, 83)],
+            blocking=[self._ref(voice, 83)],
         )
 
         issues = _issues(l1, l2, l3, l4, l5, v83, v69)
@@ -635,3 +635,27 @@ class TestComputeVisibleNewAlgebra:
 
         old_visible = _old_compute_visible(issues, lyra)
         assert old_visible <= new_visible
+
+    def test_cycle_does_not_infinite_loop(self):
+        # A ↔ B cycle (each blocks the other). The closure visited-set
+        # guard must terminate without RecursionError.
+        lyra = "Roxabi/lyra"
+        a = _make_issue(
+            1,
+            state="open",
+            repo=lyra,
+            blocking=[self._ref(lyra, 2)],
+            blocked_by=[self._ref(lyra, 2)],
+        )
+        b = _make_issue(
+            2,
+            state="closed",
+            repo=lyra,
+            blocking=[self._ref(lyra, 1)],
+            blocked_by=[self._ref(lyra, 1)],
+        )
+        issues = _issues(a, b)
+
+        visible = compute_visible(issues, lyra)
+
+        assert visible == {f"{lyra}#1", f"{lyra}#2"}

--- a/scripts/dep-graph/v5/tests/test_derive.py
+++ b/scripts/dep-graph/v5/tests/test_derive.py
@@ -12,7 +12,7 @@ from v5.data.derive import (
     status_of,
     tasks_for_graph,
 )
-from v5.data.model import COLUMN_GROUPS, MILESTONES, EpicMeta, GraphData, Lane
+from v5.data.model import COLUMN_GROUPS, MILESTONES, EpicMeta, GraphData, Lane, ref_key
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -247,7 +247,9 @@ class TestComputeVisible:
         visible = compute_visible(issues, "Roxabi/lyra")
         assert "Roxabi/voiceCLI#10" in visible
 
-    def test_backward_is_one_hop_only(self):
+    def test_backward_full_closure_same_repo(self):
+        # New rule: full backward closure within tree(P) — grand (#20) is reached
+        # because #10 is in tree(P) and #10 is blocked_by #20 (same repo, no hop cap).
         grand = _make_issue(20, state="closed")
         blocker = _make_issue(
             10,
@@ -262,7 +264,7 @@ class TestComputeVisible:
         issues = _issues(grand, blocker, iss)
         visible = compute_visible(issues, "Roxabi/lyra")
         assert "Roxabi/lyra#10" in visible
-        assert "Roxabi/lyra#20" not in visible
+        assert "Roxabi/lyra#20" in visible
 
 
 # ─── build_matrix ────────────────────────────────────────────────────────────
@@ -274,7 +276,7 @@ class TestBuildMatrix:
         task = _make_issue(1)
         issues = _issues(epic, task)
         data = _minimal_data(issues, epic_ks={"Roxabi/lyra#100"})
-        matrix, counts, total = build_matrix(data)
+        matrix, _counts, total = build_matrix(data)
         assert total == 1
         # Epic should not be in matrix
         for cell_issues in matrix.values():
@@ -445,3 +447,191 @@ class TestLaneByCode:
 
     def test_empty_lanes(self):
         assert lane_by_code([]) == {}
+
+
+# ─── compute_visible — new algebra (T8 RED tests) ────────────────────────────
+#
+# These tests pin the contract for the new rule:
+#   compute_visible = tree(P) ∪ ⋃_Q shared_subtree(Q, P)
+#
+# All four MUST fail against the current (old) implementation.
+
+
+def _ref(repo: str, n: int) -> dict:
+    """Compact ref builder: {repo, issue}."""
+    return {"repo": repo, "issue": n}
+
+
+class TestComputeVisibleNewAlgebra:
+    def test_tree_full_backward_closure(self):
+        # Old rule: 1-hop backward — stops at {A, B}.
+        # New rule: full backward closure through tree(P) — must reach C.
+        #
+        # A#1 open, blocked_by B#2
+        # B#2 closed, blocked_by C#3, blocking A#1
+        # C#3 closed, blocking B#2
+        repo = "Roxabi/lyra"
+        a = _make_issue(
+            1,
+            state="open",
+            repo=repo,
+            blocked_by=[_ref(repo, 2)],
+        )
+        b = _make_issue(
+            2,
+            state="closed",
+            repo=repo,
+            blocked_by=[_ref(repo, 3)],
+            blocking=[_ref(repo, 1)],
+        )
+        c = _make_issue(
+            3,
+            state="closed",
+            repo=repo,
+            blocking=[_ref(repo, 2)],
+        )
+        issues = _issues(a, b, c)
+
+        visible = compute_visible(issues, repo)
+
+        assert visible >= {f"{repo}#1", f"{repo}#2", f"{repo}#3"}
+
+    def test_shared_subtree_empty_when_disjoint(self):
+        # voiceCLI issues have no edge touching lyra — shared_subtree is empty.
+        # Only lyra#1 (open, no edges) should be visible.
+        lyra = "Roxabi/lyra"
+        voice = "Roxabi/voiceCLI"
+        l1 = _make_issue(1, state="open", repo=lyra)
+        v10 = _make_issue(10, state="open", repo=voice)
+        v11 = _make_issue(
+            11,
+            state="closed",
+            repo=voice,
+            blocking=[_ref(voice, 10)],
+        )
+        issues = _issues(l1, v10, v11)
+
+        visible = compute_visible(issues, lyra)
+
+        assert visible == {f"{lyra}#1"}
+
+    def test_shared_subtree_qlocal_closure(self):
+        # lyra#1 is blocked by voiceCLI#10.
+        # voiceCLI#10 is blocked by voiceCLI#11, which is blocked by voiceCLI#12.
+        # The Q-local chain (#10 → #11 → #12) should all be pulled in via
+        # shared_subtree — the old 1-hop backward rule would stop at #10.
+        lyra = "Roxabi/lyra"
+        voice = "Roxabi/voiceCLI"
+        l1 = _make_issue(
+            1,
+            state="open",
+            repo=lyra,
+            blocked_by=[_ref(voice, 10)],
+        )
+        v10 = _make_issue(
+            10,
+            state="closed",
+            repo=voice,
+            blocking=[_ref(lyra, 1)],
+            blocked_by=[_ref(voice, 11)],
+        )
+        v11 = _make_issue(
+            11,
+            state="closed",
+            repo=voice,
+            blocking=[_ref(voice, 10)],
+            blocked_by=[_ref(voice, 12)],
+        )
+        v12 = _make_issue(
+            12,
+            state="closed",
+            repo=voice,
+            blocking=[_ref(voice, 11)],
+        )
+        issues = _issues(l1, v10, v11, v12)
+
+        visible = compute_visible(issues, lyra)
+
+        assert visible >= {
+            f"{lyra}#1",
+            f"{voice}#10",
+            f"{voice}#11",
+            f"{voice}#12",
+        }
+
+    def test_superset_contains_voicecli_chain(self):
+        # Approximates the real lyra graph:
+        #   lyra has several open issues; one is transitively blocked by
+        #   voiceCLI#83.  voiceCLI#69 (open) blocks voiceCLI#83, forming a
+        #   Q-local sub-chain that must appear in the new visible set.
+        #
+        # The inline _old_compute_visible helper mirrors the CURRENT rule so we
+        # can prove: old_visible ⊆ new_visible (nothing regresses).
+        lyra = "Roxabi/lyra"
+        voice = "Roxabi/voiceCLI"
+
+        # lyra issues
+        l1 = _make_issue(1, state="open", repo=lyra)
+        l2 = _make_issue(2, state="open", repo=lyra)
+        l3 = _make_issue(
+            3,
+            state="open",
+            repo=lyra,
+            blocked_by=[_ref(lyra, 4)],
+        )
+        l4 = _make_issue(
+            4,
+            state="closed",
+            repo=lyra,
+            blocking=[_ref(lyra, 3)],
+            blocked_by=[_ref(voice, 83)],
+        )
+        l5 = _make_issue(5, state="open", repo=lyra)
+
+        # voiceCLI sub-chain: #69 → #83 (69 blocks 83)
+        v83 = _make_issue(
+            83,
+            state="closed",
+            repo=voice,
+            blocking=[_ref(lyra, 4)],
+            blocked_by=[_ref(voice, 69)],
+        )
+        v69 = _make_issue(
+            69,
+            state="open",
+            repo=voice,
+            blocking=[_ref(voice, 83)],
+        )
+
+        issues = _issues(l1, l2, l3, l4, l5, v83, v69)
+
+        new_visible = compute_visible(issues, lyra)
+
+        # Named chain must be present
+        assert f"{voice}#83" in new_visible
+        assert f"{voice}#69" in new_visible
+
+        # Superset invariant: old rule ⊆ new rule
+        def _old_compute_visible(iss: dict, primary: str) -> set[str]:
+            """Inline replica of the CURRENT (old) 1-hop-backward rule."""
+            vis: set[str] = {
+                k
+                for k, i in iss.items()
+                if i.get("repo") == primary and i.get("state") == "open"
+            }
+            stk = list(vis)
+            while stk:
+                for r in iss.get(stk.pop(), {}).get("blocking", []):
+                    rk = ref_key(r)
+                    if rk in iss and rk not in vis:
+                        vis.add(rk)
+                        stk.append(rk)
+            for k in list(vis):
+                for r in iss.get(k, {}).get("blocked_by", []):
+                    rk = ref_key(r)
+                    if rk in iss:
+                        vis.add(rk)
+            return vis
+
+        old_visible = _old_compute_visible(issues, lyra)
+        assert old_visible <= new_visible

--- a/scripts/dep-graph/v5/tests/test_load.py
+++ b/scripts/dep-graph/v5/tests/test_load.py
@@ -145,6 +145,22 @@ class TestLoadCorpusContract:
         with pytest.raises(FileNotFoundError, match="make corpus-sync"):
             load(layout_path=layout_path, db_path=db_path)
 
+    def test_load_missing_layout_raises_file_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """load() with non-existent layout_path raises FileNotFoundError
+        mentioning `layout not found` — distinct from the corpus-db error."""
+        # Arrange
+        from v5.data.load import load
+
+        db_path = tmp_path / "corpus.db"
+        _bootstrap_corpus(db_path)
+        layout_path = tmp_path / "missing.json"
+
+        # Act / Assert
+        with pytest.raises(FileNotFoundError, match="layout not found"):
+            load(layout_path=layout_path, db_path=db_path)
+
 
 # ─── load_from_dicts() — unchanged contract ─────────────────────────────────
 

--- a/scripts/dep-graph/v5/tests/test_load.py
+++ b/scripts/dep-graph/v5/tests/test_load.py
@@ -1,11 +1,151 @@
-"""Tests for v5.data.load — load_from_dicts and parse logic."""
+"""Tests for v5.data.load — load_from_dicts, parse logic, and corpus.db-based load().
+
+RED state for corpus-based load() tests: T5 has not landed yet.
+Tests asserting the new load() contract (db_path param, PRIMARY_REPO constant,
+removal of FORGE/CACHE_PATH) will FAIL until T5 is implemented.
+
+Tests for load_from_dicts() are orthogonal and must stay GREEN.
+"""
 
 from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
 
 import pytest
 
 from v5.data.load import load_from_dicts
 from v5.data.model import COLUMN_GROUPS, MILESTONES, GraphData
+from v5.tests.conftest import LAYOUT
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _bootstrap_corpus(db_path: Path) -> None:
+    """Bootstrap an empty corpus DB schema via scripts.corpus.schema."""
+    from scripts.corpus.schema import bootstrap
+
+    bootstrap(db_path)
+
+
+def _seed_open_lyra_issue(db_path: Path, number: int, lane: str) -> None:
+    """Insert one open Roxabi/lyra issue with a graph:lane label."""
+    conn = sqlite3.connect(db_path)
+    try:
+        key = f"Roxabi/lyra#{number}"
+        conn.execute(
+            """INSERT INTO issues (key, repo, number, title, state, milestone, is_stub)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (key, "Roxabi/lyra", number, f"Issue {number}", "open", "M0 alpha", 0),
+        )
+        conn.execute(
+            "INSERT INTO labels (issue_key, name) VALUES (?, ?)",
+            (key, f"graph:lane/{lane}"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_layout(tmp_path: Path) -> Path:
+    """Write the shared LAYOUT fixture to a JSON file and return its path."""
+    layout_path = tmp_path / "layout.json"
+    layout_path.write_text(json.dumps(LAYOUT))
+    return layout_path
+
+
+# ─── Module-level constant tests ────────────────────────────────────────────
+
+
+class TestLoadModuleConstants:
+    def test_primary_repo_constant_exists(self) -> None:
+        """PRIMARY_REPO module constant must be 'Roxabi/lyra' (T5 contract)."""
+        # Arrange / Act
+        import v5.data.load as loadmod
+
+        # Assert
+        assert loadmod.PRIMARY_REPO == "Roxabi/lyra"
+
+    def test_forge_constant_removed(self) -> None:
+        """FORGE module constant must be absent after T5 lands."""
+        # Arrange / Act
+        import v5.data.load as loadmod
+
+        # Assert
+        assert not hasattr(loadmod, "FORGE")
+
+    def test_cache_path_constant_removed(self) -> None:
+        """CACHE_PATH module constant must be absent after T5 lands."""
+        # Arrange / Act
+        import v5.data.load as loadmod
+
+        # Assert
+        assert not hasattr(loadmod, "CACHE_PATH")
+
+
+# ─── load() — corpus.db contract ────────────────────────────────────────────
+
+
+class TestLoadCorpusContract:
+    def test_load_empty_corpus_returns_empty_graph_data(
+        self, tmp_path: Path
+    ) -> None:
+        """load() with empty corpus DB returns GraphData with issues == {} and no matrix cells."""
+        # Arrange
+        from v5.data.load import load
+
+        db_path = tmp_path / "corpus.db"
+        _bootstrap_corpus(db_path)
+        layout_path = _write_layout(tmp_path)
+
+        # Act
+        result = load(layout_path=layout_path, db_path=db_path)
+
+        # Assert
+        assert isinstance(result, GraphData)
+        assert result.issues == {}
+        assert result.visible == set()
+        assert result.total == 0
+
+    def test_load_seeded_corpus_visible_contains_open_lyra_issue(
+        self, tmp_path: Path
+    ) -> None:
+        """load() with seeded corpus includes open Roxabi/lyra issue in visible set."""
+        # Arrange
+        from v5.data.load import load
+
+        db_path = tmp_path / "corpus.db"
+        _bootstrap_corpus(db_path)
+        _seed_open_lyra_issue(db_path, number=1, lane="a1")
+        _seed_open_lyra_issue(db_path, number=2, lane="b")
+        layout_path = _write_layout(tmp_path)
+
+        # Act
+        result = load(layout_path=layout_path, db_path=db_path)
+
+        # Assert — at least one open primary-repo issue is in visible
+        assert len(result.visible) > 0
+        # "Roxabi/lyra#1" is open and has a lane label → must be in visible
+        assert "Roxabi/lyra#1" in result.visible
+
+    def test_load_missing_db_raises_file_not_found_with_hint(
+        self, tmp_path: Path
+    ) -> None:
+        """load() with non-existent db_path raises FileNotFoundError mentioning make corpus-sync."""
+        # Arrange
+        from v5.data.load import load
+
+        layout_path = _write_layout(tmp_path)
+        db_path = tmp_path / "nope.db"
+
+        # Act / Assert
+        with pytest.raises(FileNotFoundError, match="make corpus-sync"):
+            load(layout_path=layout_path, db_path=db_path)
+
+
+# ─── load_from_dicts() — unchanged contract ─────────────────────────────────
 
 
 class TestLoadFromDicts:

--- a/scripts/dep-graph/v5/tests/test_load.py
+++ b/scripts/dep-graph/v5/tests/test_load.py
@@ -108,6 +108,7 @@ class TestLoadCorpusContract:
         assert result.issues == {}
         assert result.visible == set()
         assert result.total == 0
+        assert result.matrix == {}
 
     def test_load_seeded_corpus_visible_contains_open_lyra_issue(
         self, tmp_path: Path
@@ -226,10 +227,17 @@ class TestLoadFromDicts:
         # issue 3 blocked by 2 → depth 2
         assert data.depth_by_key.get("Roxabi/lyra#3") == 2
 
-    def test_missing_repos_key_raises(self):
-        bad_layout = {"meta": {}, "lanes": []}
-        with pytest.raises((KeyError, IndexError)):
-            load_from_dicts(bad_layout, {"issues": {}})
+    def test_load_uses_primary_repo_constant_not_meta_repos(self):
+        # load_from_dicts no longer reads layout.meta.repos — it uses the
+        # PRIMARY_REPO module constant. meta.repos stays in the schema for
+        # Phase 3's toolbar dropdown to enumerate available projects.
+        from v5.data.load import PRIMARY_REPO
+
+        layout_without_repos = {"meta": {}, "lanes": []}
+        result = load_from_dicts(layout_without_repos, {"issues": {}})
+        # Visibility computed against PRIMARY_REPO; empty-issues corpus → empty set.
+        assert result.visible == set()
+        assert PRIMARY_REPO == "Roxabi/lyra"
 
     def test_missing_lanes_key_raises(self):
         bad_layout = {"meta": {"repos": ["Roxabi/lyra"]}}


### PR DESCRIPTION
## Summary

- Swap v5 dep-graph reader from per-project `gh.json` to `~/.roxabi/corpus.db`; `FORGE` / `CACHE_PATH` removed, `PRIMARY_REPO = \"Roxabi/lyra\"` introduced as a named constant.
- Rewrite `compute_visible` as `tree(P) ∪ ⋃_Q shared_subtree(Q, P)` — full bi-directional closure from open-in-P plus Q-local subtrees that share a node with P. The voiceCLI `#69 → … → #83` chain now renders (previously blocked by the 1-hop backward cap).
- Lane/size projection isolated in `_project_lane_size(labels)` as the single swap point for the `roxabi-plugins#119` taxonomy migration (follow-up tracked as #872).

Ships in 3 reviewable commits: V1 adapter · V2 reader swap (algebra unchanged) · V3 new algebra.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #864: Phase 2 — v5 reader on corpus.db (tree ∪ shared_subtree) | OPEN |
| Frame | [864-corpus-sync-phase-2-v5-reader-frame.mdx](artifacts/frames/864-corpus-sync-phase-2-v5-reader-frame.mdx) | Approved |
| Spec | [864-corpus-sync-phase-2-v5-reader-spec.mdx](artifacts/specs/864-corpus-sync-phase-2-v5-reader-spec.mdx) | Approved |
| Plan | [864-corpus-sync-phase-2-v5-reader-plan.mdx](artifacts/plans/864-corpus-sync-phase-2-v5-reader-plan.mdx) | Approved |
| Implementation | 3 commits on `feat/864-corpus-sync-phase-2-v5-reader` (11 micro-tasks) | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (293 passed · +15 new) | Passed |

## Test Plan

- [ ] `uv run pytest scripts/dep-graph/v5/tests/` — 293 passed
- [ ] `make dep-graph build` — v5 HTML renders from corpus.db (no `gh.json` read)
- [ ] `grep -c voiceCLI ~/.roxabi/forge/lyra/visuals/lyra-v2-dependency-graph-v5.1.html` — cross-project chain present (currently 12 refs)
- [ ] Missing corpus.db → `FileNotFoundError` mentions `make corpus-sync`
- [ ] Pre-existing `compute_visible` 1-hop-cap test updated to reflect new full-closure contract
- [ ] `_project_lane_size` docstring names `roxabi-plugins#119` + follow-up #872

## Follow-ups (tracked separately)

- #872 — extend corpus.db with Lane/Size columns from projectV2 + flip `_project_lane_size` to read them (blocked on `roxabi-plugins#119` enrollment)
- Drop `layout.json` for GH-native presentation config — separate conversation, own frame

Closes #864

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`