### PR TITLE
test(ci): replace asyncio.sleep with event-based sync in flaky suites

### DIFF
--- a/artifacts/analyses/861-review-findings-consensus.mdx
+++ b/artifacts/analyses/861-review-findings-consensus.mdx
@@ -1,0 +1,116 @@
+---
+title: "Review Findings — Expert Consensus"
+issue: 861
+status: consensus-reached
+date: 2026-04-22
+panel: architect, devops, tester
+confidence: high
+---
+
+## Problem
+
+PR #879 (event-based test coordination) received 4 non-blocking review findings requiring consensus on disposition.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | Architecture soundness, maintainability, scalability |
+| devops | CI/infra impact, test reliability |
+| tester | Test quality, flakiness prevention |
+
+## Consensus Recommendations
+
+### Finding 1: Local inline events — Leave as-is
+
+**Rationale:** The `asyncio.Event()` + `await event.wait()` pattern is self-documenting. Comments like `# explicit: never completes, tests timeout` make intent clear at usage site. A shared fixture would add indirection without real benefit for a 2-line idiom.
+
+**Trade-offs:**
+- Local naming preserves semantic context (`never_returns` vs `never_completes`)
+- No import coupling across test files
+- Future tests copy-paste pattern directly without fixture discovery friction
+
+**Action:** No action required.
+
+---
+
+### Finding 2: Duplicate `_drain` functions — Consolidate
+
+**Rationale:** Two identical `_drain` helpers with different timeout defaults (both 2.0s in practice) is DRY violation. Consolidation to `tests/conftest.py` with `TIMEOUT_IO` default provides single source of truth.
+
+**Trade-offs:**
+- Single source of truth for drain semantics
+- `TIMEOUT_IO = 2.0` already defined in root conftest
+- Future test files discover via import from root conftest
+
+**Action:** Create follow-up issue for consolidation. Not blocking current PR.
+
+---
+
+### Finding 3: Consecutive `yield_once()` calls — Document inline
+
+**Rationale:** Consecutive `yield_once()` calls at `test_discord_typing.py:100-108` represent start→cancel sequence, each needing a yield for the event loop to process. This is legitimate async test coordination, not timing uncertainty.
+
+**Trade-offs:**
+- Documentation clarifies intent without refactoring risk
+- Consecutive yields for multi-step async operations are a valid pattern
+- Converting to event coordination would over-engineer simple sequential calls
+
+**Action:** Add inline comments explaining why multiple yields are needed.
+
+---
+
+### Finding 4: Remaining `sleep(N>0)` patterns — Defer to follow-up
+
+**Rationale:** PR #879's stated scope is "replace `asyncio.sleep(N)` with event-based coordination for flaky tests." The remaining sleeps (0.05, 0.1, 0.15) are in different files with different contexts. Converting all now risks scope creep and introduces new flakiness vectors.
+
+**Trade-offs:**
+- Focused PR with clear scope = easier review + safer merge
+- Follow-up can address each file with appropriate test patterns per context
+- Some sleeps may actually need real timing for integration tests
+
+**Action:** Document in PR body with file list for follow-up. Create follow-up issue.
+
+---
+
+## Dissent
+
+**Finding 2 (devops):** Preferred "leave as-is" — argued both functions already have same 2.0s default and helper location follows test locality principle. Majority overruled on DRY grounds: consolidation prevents timeout drift.
+
+---
+
+## Alternatives
+
+| Finding | Rejected Option | Reason |
+|---------|-----------------|--------|
+| 1 | Add `never_completes_event()` fixture | Inline pattern with comment is more discoverable |
+| 2 | Leave as-is | Duplication hides bugs; one version can rot |
+| 3 | Use explicit event coordination | Would over-engineer simple sequential async calls |
+| 4 | Convert all now | Scope creep risks regressions in stable areas |
+
+---
+
+## Implementation Notes
+
+1. **Finding 2** — Consolidate `_drain` to `tests/conftest.py`:
+   - Use `TIMEOUT_IO = 2.0` as default
+   - Update imports in `tests/core/conftest.py` and `tests/fixtures/agent_harness.py`
+   - Remove duplicate definitions
+
+2. **Finding 3** — Add comments at `test_discord_typing.py`:
+   ```python
+   await yield_once()  # allow event loop to process _start_typing
+   # ... action ...
+   await yield_once()  # allow event loop to process _cancel_typing
+   ```
+
+3. **Finding 4** — PR body should note:
+   > Remaining `asyncio.sleep(N>0)` patterns are out of scope for this PR. These include timing tests (debounce windows), mock side effects, and integration tests requiring real delays. Follow-up issue will address each category.
+
+---
+
+## Next
+
+- Apply Finding 2 (consolidate `_drain`) and Finding 3 (add comments) as follow-up fix
+- Post updated review comment to PR #879
+- Proceed to merge

--- a/tests/adapters/test_discord_typing.py
+++ b/tests/adapters/test_discord_typing.py
@@ -12,6 +12,7 @@ import pytest
 
 from lyra.core.messaging.message import OutboundMessage
 from lyra.core.messaging.render_events import TextRenderEvent
+from tests.conftest import yield_once
 
 from .conftest import make_dc_inbound_msg
 
@@ -34,7 +35,7 @@ async def test_discord_typing_worker_uses_typing_context_manager() -> None:
         return mock_channel
 
     task = asyncio.create_task(_discord_typing_worker(resolve, channel_id=123))
-    await asyncio.sleep(0)  # yield to let the worker call typing()
+    await yield_once()  # yield to let the worker call typing()
     task.cancel()
     try:
         await task
@@ -59,7 +60,6 @@ async def test_discord_typing_worker_handles_exception_gracefully() -> None:
 @pytest.mark.asyncio
 async def test_start_typing_creates_background_task() -> None:
     """_start_typing() creates a task in _typing_tasks for the given channel."""
-    import asyncio
 
     from lyra.adapters.discord import DiscordAdapter
 
@@ -73,19 +73,18 @@ async def test_start_typing_creates_background_task() -> None:
     adapter.get_channel = MagicMock(return_value=mock_channel)
 
     adapter._start_typing(333)
-    await asyncio.sleep(0)  # let task start
+    await yield_once()  # let task start
 
     assert 333 in adapter._typing_tasks
     assert not adapter._typing_tasks[333].done()
 
     adapter._cancel_typing(333)
-    await asyncio.sleep(0)
+    await yield_once()
 
 
 @pytest.mark.asyncio
 async def test_cancel_typing_cancels_task() -> None:
     """_cancel_typing() cancels the background task and removes it from the dict."""
-    import asyncio
 
     from lyra.adapters.discord import DiscordAdapter
 
@@ -99,10 +98,10 @@ async def test_cancel_typing_cancels_task() -> None:
     adapter.get_channel = MagicMock(return_value=mock_channel)
 
     adapter._start_typing(333)
-    await asyncio.sleep(0)
+    await yield_once()
 
     adapter._cancel_typing(333)
-    await asyncio.sleep(0)
+    await yield_once()
 
     assert 333 not in adapter._typing_tasks
 
@@ -228,10 +227,8 @@ async def test_on_message_does_not_cancel_typing_when_message_queued() -> None:
     assert not adapter._typing_tasks[333].done()
 
     # Cleanup
-    import asyncio as _asyncio
-
     adapter._cancel_typing(333)
-    await _asyncio.sleep(0)
+    await yield_once()
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_discord_typing.py
+++ b/tests/adapters/test_discord_typing.py
@@ -98,10 +98,10 @@ async def test_cancel_typing_cancels_task() -> None:
     adapter.get_channel = MagicMock(return_value=mock_channel)
 
     adapter._start_typing(333)
-    await yield_once()
+    await yield_once()  # allow event loop to process _start_typing task spawn
 
     adapter._cancel_typing(333)
-    await yield_once()
+    await yield_once()  # allow event loop to process _cancel_typing task cleanup
 
     assert 333 not in adapter._typing_tasks
 

--- a/tests/bootstrap/test_embedded_nats.py
+++ b/tests/bootstrap/test_embedded_nats.py
@@ -129,8 +129,10 @@ class TestEmbeddedNatsStop:
         mock_proc.terminate = MagicMock()
         mock_proc.kill = MagicMock()
 
+        slow_wait_done = asyncio.Event()
+
         async def slow_wait():
-            await asyncio.sleep(10)
+            await slow_wait_done.wait()  # explicit: blocks until killed
 
         async def fast_wait():
             pass

--- a/tests/bootstrap/test_watchdog.py
+++ b/tests/bootstrap/test_watchdog.py
@@ -7,6 +7,7 @@ import asyncio
 import pytest
 
 from lyra.bootstrap.factory.utils import watchdog
+from tests.conftest import yield_once
 
 
 @pytest.fixture()
@@ -27,7 +28,7 @@ async def test_watchdog_returns_on_stop_event(stop: asyncio.Event) -> None:
         await asyncio.Event().wait()
 
     async def _set_stop_soon() -> None:
-        await asyncio.sleep(0)  # yield once so watchdog enters the loop
+        await yield_once()  # yield once so watchdog enters the loop
         stop.set()
 
     task = asyncio.create_task(_hang_forever(), name="forever")
@@ -97,7 +98,7 @@ async def test_watchdog_triggers_shutdown_on_unexpected_cancel(
         await asyncio.Event().wait()
 
     async def _cancel_soon(t: asyncio.Task[None]) -> None:
-        await asyncio.sleep(0)  # yield once so watchdog enters the loop
+        await yield_once()  # yield once so watchdog enters the loop
         t.cancel()
 
     task = asyncio.create_task(_hang_forever(), name="to-cancel")
@@ -120,7 +121,7 @@ async def test_watchdog_first_crash_among_many(stop: asyncio.Event) -> None:
         await asyncio.Event().wait()
 
     async def _crash_soon() -> None:
-        await asyncio.sleep(0)  # yield once so watchdog enters the loop
+        await yield_once()  # yield once so watchdog enters the loop
         raise RuntimeError("first down")
 
     healthy = asyncio.create_task(_hang_forever(), name="healthy")
@@ -153,7 +154,7 @@ async def test_watchdog_cleans_up_sentinel_on_crash(stop: asyncio.Event) -> None
     await asyncio.wait_for(watchdog([task], stop), timeout=2.0)
 
     # Give the event loop a tick to process cancellations.
-    await asyncio.sleep(0)
+    await yield_once()
 
     # No lingering tasks named watchdog-stop-sentinel.
     for t in asyncio.all_tasks():
@@ -170,7 +171,7 @@ async def test_watchdog_empty_task_list_waits_for_stop(stop: asyncio.Event) -> N
     """With no tasks, watchdog should wait for the stop event instead of returning."""
 
     async def _set_stop_soon() -> None:
-        await asyncio.sleep(0)
+        await yield_once()
         stop.set()
 
     asyncio.create_task(_set_stop_soon())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.auth.authenticator import Authenticator as AuthMiddleware
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.hub import Hub
+from lyra.core.pool import Pool
 from roxabi_nats import _version_check as _vc_mod
 
 
@@ -50,6 +51,13 @@ TIMEOUT_SLOW = 5.0  # Multi-step coordination, CI variance buffer
 async def yield_once() -> None:
     """Yield control to the event loop once. Replaces asyncio.sleep(0)."""
     await asyncio.sleep(0)
+
+
+async def _drain(pool: Pool, *, timeout: float = TIMEOUT_IO) -> None:
+    """Yield to the event loop then wait for the current task to finish."""
+    await yield_once()
+    if pool._current_task is not None:
+        await asyncio.wait_for(pool._current_task, timeout=timeout)
 
 
 AUTH_HEADERS = {"authorization": f"Bearer {HEALTH_SECRET}"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,18 @@ def _reset_version_check_log_state() -> None:
 # ---------------------------------------------------------------------------
 
 HEALTH_SECRET = "test-health-secret"
+
+# Timeout constants for event-based coordination
+TIMEOUT_FAST = 0.5  # In-memory operations
+TIMEOUT_IO = 2.0  # Single network round-trip
+TIMEOUT_SLOW = 5.0  # Multi-step coordination, CI variance buffer
+
+
+async def yield_once() -> None:
+    """Yield control to the event loop once. Replaces asyncio.sleep(0)."""
+    await asyncio.sleep(0)
+
+
 AUTH_HEADERS = {"authorization": f"Bearer {HEALTH_SECRET}"}
 
 
@@ -84,16 +96,26 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 class _FakeDp:
+    """Fake Dispatcher that blocks until explicitly stopped.
+
+    Uses an event that never fires (unless test sets it) instead of arbitrary sleep.
+    """
+
+    def __init__(self, shutdown_event: asyncio.Event | None = None) -> None:
+        self._shutdown = shutdown_event if shutdown_event else asyncio.Event()
+
     async def start_polling(self, bot: object, **kwargs: object) -> None:
-        await asyncio.sleep(1_000)
+        await self._shutdown.wait()  # explicit: wait for teardown signal
 
 
 class _FakeTgAdapter:
-    dp = _FakeDp()
     bot = MagicMock()
 
-    def __init__(self, **kwargs: object) -> None:
+    def __init__(
+        self, shutdown_event: asyncio.Event | None = None, **kwargs: object
+    ) -> None:
         self._bot_id = kwargs.get("bot_id", "main")
+        self.dp = _FakeDp(shutdown_event)
 
     async def send(self, msg: object, response: object) -> None:
         pass
@@ -103,14 +125,21 @@ class _FakeTgAdapter:
 
 
 class _FakeDcAdapter:
-    def __init__(self, **kwargs: object) -> None:
-        pass
+    """Fake Discord adapter that blocks until explicitly stopped.
+
+    Uses an event that never fires (unless test sets it) instead of arbitrary sleep.
+    """
+
+    def __init__(
+        self, shutdown_event: asyncio.Event | None = None, **kwargs: object
+    ) -> None:
+        self._shutdown = shutdown_event if shutdown_event else asyncio.Event()
 
     async def start(self, token: str) -> None:
-        await asyncio.sleep(1_000)
+        await self._shutdown.wait()  # explicit: wait for teardown signal
 
     async def close(self) -> None:
-        pass
+        self._shutdown.set()  # signal stop if still waiting
 
     async def send(self, msg: object, response: object) -> None:
         pass
@@ -269,7 +298,8 @@ def patch_all(
 
     class CapturingDcAdapter(_FakeDcAdapter):
         def __init__(self, **kwargs: object) -> None:
-            super().__init__(**kwargs)
+            shutdown = kwargs.pop("shutdown_event", None)  # type: ignore[assignment]
+            super().__init__(shutdown_event=shutdown, **kwargs)  # type: ignore[arg-type]
 
     mock_tg_auth, mock_dc_auth = MagicMock(), MagicMock()
     _auth_results = iter([mock_tg_auth, mock_dc_auth])

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -38,6 +38,7 @@ from lyra.core.pool import Pool
 from lyra.core.stores.pairing import PairingConfig, PairingManager
 from lyra.infrastructure.stores.agent_store import AgentRow, AgentStore
 from lyra.infrastructure.stores.auth_store import AuthStore
+from tests.conftest import yield_once
 
 # ---------------------------------------------------------------------------
 # MessageManager shared constants
@@ -701,7 +702,7 @@ def _make_hub(**kwargs: Any) -> Hub:
 
 async def _drain(pool: Pool, *, timeout: float = 2.0) -> None:
     """Yield to the event loop then wait for the current task to finish."""
-    await asyncio.sleep(0)
+    await yield_once()
     if pool._current_task is not None:
         await asyncio.wait_for(pool._current_task, timeout=timeout)
 
@@ -710,6 +711,9 @@ class SlowAgent:
     """Agent whose process() never returns within test timeouts."""
 
     name = "test_agent"
+
+    def __init__(self, shutdown_event: asyncio.Event | None = None) -> None:
+        self._shutdown = shutdown_event if shutdown_event else asyncio.Event()
 
     def is_backend_alive(self, pool_id: str) -> bool:
         return True
@@ -724,7 +728,7 @@ class SlowAgent:
         *,
         on_intermediate=None,
     ) -> Response:
-        await asyncio.sleep(10)  # never finishes in test
+        await self._shutdown.wait()  # explicit: never completes in test
         return Response(content="done")
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -38,7 +38,6 @@ from lyra.core.pool import Pool
 from lyra.core.stores.pairing import PairingConfig, PairingManager
 from lyra.infrastructure.stores.agent_store import AgentRow, AgentStore
 from lyra.infrastructure.stores.auth_store import AuthStore
-from tests.conftest import yield_once
 
 # ---------------------------------------------------------------------------
 # MessageManager shared constants
@@ -698,13 +697,6 @@ def _make_hub(**kwargs: Any) -> Hub:
         "telegram:main:*",
     )
     return hub
-
-
-async def _drain(pool: Pool, *, timeout: float = 2.0) -> None:
-    """Yield to the event loop then wait for the current task to finish."""
-    await yield_once()
-    if pool._current_task is not None:
-        await asyncio.wait_for(pool._current_task, timeout=timeout)
 
 
 class SlowAgent:

--- a/tests/core/conftest_cli_pool.py
+++ b/tests/core/conftest_cli_pool.py
@@ -36,9 +36,11 @@ def make_fake_proc(stdout_lines: list[bytes]) -> MagicMock:
     # termination: wait() blocks forever for alive processes (the spawn
     # early-liveness check uses wait_for with a short timeout — it must
     # timeout for alive procs, not return immediately).
+    _never_stops = asyncio.Event()
+
     async def _wait() -> int:
         if proc.returncode is None:
-            await asyncio.sleep(3600)  # block — will be cancelled by wait_for
+            await _never_stops.wait()  # explicit: block forever, cancelled by wait_for
         return proc.returncode or 0
 
     proc.terminate = MagicMock(side_effect=lambda: setattr(proc, "returncode", 0))

--- a/tests/core/hub/test_message_pipeline_stt.py
+++ b/tests/core/hub/test_message_pipeline_stt.py
@@ -50,12 +50,15 @@ class FakeSTT:
 
 
 class SlowSTT:
-    """STT that sleeps indefinitely — for timeout testing."""
+    """STT that never completes — for timeout testing."""
 
     timeout_ms: int = 30000
 
+    def __init__(self, shutdown_event: asyncio.Event | None = None) -> None:
+        self._shutdown = shutdown_event if shutdown_event else asyncio.Event()
+
     async def transcribe(self, path: Any) -> FakeTranscription:
-        await asyncio.sleep(9999)
+        await self._shutdown.wait()  # explicit: never completes in test
         return FakeTranscription(text="never")
 
 

--- a/tests/core/test_auth_store_check.py
+++ b/tests/core/test_auth_store_check.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from lyra.core.auth.trust import TrustLevel
+from tests.conftest import yield_once
 from tests.core.conftest import make_auth_store
 
 # ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ class TestAuthStoreCheck:
                 "expired-evict", TrustLevel.TRUSTED, past, "invite", "code-hash"
             )
             store.check("expired-evict")  # triggers eviction (schedules async task)
-            await asyncio.sleep(0)  # yield to event loop so revoke() task runs
+            await yield_once()  # yield to event loop so revoke() task runs
             assert store._db is not None
             async with store._db.execute(
                 "SELECT id FROM grants WHERE identity_key = ?", ("expired-evict",)

--- a/tests/core/test_cli_pool_streaming.py
+++ b/tests/core/test_cli_pool_streaming.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -13,6 +12,7 @@ from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.cli.cli_pool import CliPool, _ProcessEntry
 from lyra.core.cli.cli_protocol import StreamingIterator
 from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
+from tests.conftest import yield_once
 
 from .conftest_cli_pool import (
     _PATCH_TARGET,
@@ -69,7 +69,7 @@ class TestOnReapCallback:
 
         # Run one reaper iteration manually
         pool._last_sweep_at = None
-        await asyncio.sleep(0)  # let event loop tick
+        await yield_once()  # let event loop tick
 
         # Simulate the reaper logic inline (to avoid sleeping 60s)
         pool._last_sweep_at = time.monotonic()

--- a/tests/core/test_command_router_special.py
+++ b/tests/core/test_command_router_special.py
@@ -379,15 +379,17 @@ class TestSessionCommands:
     async def test_session_command_timeout_returns_timeout_message(
         self, tmp_path: Path
     ) -> None:
-        import asyncio as _asyncio
+        import asyncio
 
         from lyra.integrations.base import SessionTools
 
         router = make_router(tmp_path)
         router._session_driver = MagicMock()
 
+        never_fires = asyncio.Event()
+
         async def slow_handler(msg, driver, tools, args, timeout):
-            await _asyncio.sleep(10)
+            await never_fires.wait()  # intentional: never completes, tests timeout
             return Response(content="never")
 
         tools = SessionTools(scraper=MagicMock(), vault=MagicMock())

--- a/tests/core/test_debouncer_collect.py
+++ b/tests/core/test_debouncer_collect.py
@@ -9,6 +9,7 @@ import pytest
 
 from lyra.core.debouncer import MessageDebouncer
 from lyra.core.messaging.message import InboundMessage
+from tests.conftest import TIMEOUT_FAST, TIMEOUT_IO
 from tests.core.conftest import make_debouncer_msg
 
 # ---------------------------------------------------------------------------
@@ -27,7 +28,7 @@ class TestCollect:
         msg = make_debouncer_msg("hello")
         inbox.put_nowait(msg)
 
-        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=2.0)
+        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=TIMEOUT_IO)
         assert result == [msg]
 
     @pytest.mark.asyncio
@@ -45,7 +46,7 @@ class TestCollect:
         inbox.put_nowait(m2)
         inbox.put_nowait(m3)
 
-        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=2.0)
+        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=TIMEOUT_IO)
         assert len(result) == 3
         assert result == [m1, m2, m3]
 
@@ -57,7 +58,7 @@ class TestCollect:
         msg = make_debouncer_msg("fast")
         inbox.put_nowait(msg)
 
-        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=0.5)
+        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=TIMEOUT_FAST)
         assert result == [msg]
 
     @pytest.mark.asyncio
@@ -70,7 +71,7 @@ class TestCollect:
         inbox.put_nowait(m1)
         inbox.put_nowait(m2)
 
-        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=0.5)
+        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=TIMEOUT_FAST)
         assert len(result) == 2
 
     @pytest.mark.asyncio
@@ -90,6 +91,6 @@ class TestCollect:
 
         asyncio.create_task(_delay_put())
 
-        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=2.0)
+        result = await asyncio.wait_for(debouncer.collect(inbox), timeout=TIMEOUT_IO)
         assert len(result) == 1
         assert result[0] is m1

--- a/tests/core/test_debouncer_pool.py
+++ b/tests/core/test_debouncer_pool.py
@@ -129,6 +129,9 @@ class TestPoolCancelInFlight:
         agent = RecordingAgent()
         call_count = 0
         started = asyncio.Event()
+        never_returns = (
+            asyncio.Event()
+        )  # never set — simulates slow/infinite processing
         original_process = agent.process
 
         async def _slow_then_fast(
@@ -139,7 +142,7 @@ class TestPoolCancelInFlight:
             if call_count == 1:
                 # Signal that the first call has started, then block.
                 started.set()
-                await asyncio.sleep(10)
+                await never_returns.wait()  # explicit: never completes
                 return Response(content="should not reach")
             # Second call: fast — combined message
             return await original_process(msg, pool, on_intermediate=on_intermediate)

--- a/tests/core/test_debouncer_pool.py
+++ b/tests/core/test_debouncer_pool.py
@@ -11,6 +11,7 @@ import pytest
 
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
+from tests.conftest import TIMEOUT_SLOW
 from tests.core.conftest import (
     RecordingAgent,
     SlowAgent,
@@ -165,7 +166,7 @@ class TestPoolCancelInFlight:
         # Submit second message while agent is in-flight → cancel + re-dispatch.
         pool.submit(make_debouncer_msg("actually explain Y"))
 
-        await _drain(pool, timeout=5.0)
+        await _drain(pool, timeout=TIMEOUT_SLOW)
 
         # Agent called twice: first cancelled, second with combined.
         assert call_count == 2

--- a/tests/core/test_debouncer_pool.py
+++ b/tests/core/test_debouncer_pool.py
@@ -11,11 +11,10 @@ import pytest
 
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
-from tests.conftest import TIMEOUT_SLOW
+from tests.conftest import TIMEOUT_SLOW, _drain
 from tests.core.conftest import (
     RecordingAgent,
     SlowAgent,
-    _drain,
     _make_ctx_mock,
     make_debouncer_msg,
 )

--- a/tests/core/test_hub_streaming.py
+++ b/tests/core/test_hub_streaming.py
@@ -17,6 +17,7 @@ from lyra.core.messaging.message import (
 )
 from lyra.core.messaging.render_events import RenderEvent, TextRenderEvent
 from lyra.tts import TTSService
+from tests.conftest import TIMEOUT_FAST, TIMEOUT_SLOW
 from tests.core.conftest import MockAdapter, make_inbound_message, push_to_hub
 
 
@@ -288,10 +289,14 @@ class TestDispatchStreaming:
         try:
             # dispatch_streaming returns immediately (non-blocking for voice
             # with dispatcher); TTS fires as a background task.
-            await asyncio.wait_for(hub.dispatch_streaming(msg, gen()), timeout=5.0)
+            await asyncio.wait_for(
+                hub.dispatch_streaming(msg, gen()), timeout=TIMEOUT_SLOW
+            )
             # Wait for the dispatcher to consume the stream and TTS to fire.
             if hub._memory_tasks:
-                await asyncio.wait_for(asyncio.gather(*hub._memory_tasks), timeout=5.0)
+                await asyncio.wait_for(
+                    asyncio.gather(*hub._memory_tasks), timeout=TIMEOUT_SLOW
+                )
         finally:
             await dispatcher.stop()
 
@@ -348,7 +353,7 @@ class TestHubRunStreaming:
         await push_to_hub(hub, msg)
 
         try:
-            await asyncio.wait_for(hub.run(), timeout=0.5)
+            await asyncio.wait_for(hub.run(), timeout=TIMEOUT_FAST)
         except asyncio.TimeoutError:
             pass
 

--- a/tests/core/test_inbound_bus.py
+++ b/tests/core/test_inbound_bus.py
@@ -13,6 +13,7 @@ from lyra.core.messaging.message import (
     InboundMessage,
     Platform,
 )
+from tests.conftest import TIMEOUT_FAST
 
 
 def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
@@ -87,7 +88,7 @@ class TestInboundBusFeeder:
             await bus.put(Platform.TELEGRAM, msg)
 
             # Wait for feeder to forward to staging
-            received = await asyncio.wait_for(bus.get(), timeout=0.5)
+            received = await asyncio.wait_for(bus.get(), timeout=TIMEOUT_FAST)
             assert received is msg
         finally:
             await bus.stop()

--- a/tests/core/test_outbound_dispatcher_concurrent.py
+++ b/tests/core/test_outbound_dispatcher_concurrent.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from lyra.core.hub.outbound_dispatcher import OutboundDispatcher
 from lyra.core.messaging.message import InboundMessage, OutboundMessage
+from tests.conftest import yield_once
 
 from .conftest import make_dispatcher_msg
 
@@ -144,7 +145,7 @@ async def test_scope_locks_cleanup() -> None:
 
     # Wait for queue to drain so locks are released before stop().
     await dispatcher._queue.join()
-    await asyncio.sleep(0)  # yield to event loop for scope task cleanup
+    await yield_once()  # yield to event loop for scope task cleanup
 
     # Act
     await dispatcher.stop()

--- a/tests/core/test_outbound_dispatcher_coverage.py
+++ b/tests/core/test_outbound_dispatcher_coverage.py
@@ -21,6 +21,7 @@ from lyra.core.hub.outbound_dispatcher import OutboundDispatcher
 from lyra.core.hub.outbound_errors import _SCOPE_REAP_THRESHOLD
 from lyra.core.messaging.message import InboundMessage, OutboundMessage, RoutingContext
 from lyra.core.messaging.render_events import TextRenderEvent
+from tests.conftest import TIMEOUT_IO
 
 from .conftest import make_dispatcher_msg
 
@@ -232,7 +233,7 @@ async def test_transient_error_retried_and_succeeds() -> None:
         msg = make_dispatcher_msg()
         with patch("asyncio.sleep", new=fast_sleep):
             dispatcher.enqueue(msg, OutboundMessage.from_text("hi"))
-            await asyncio.wait_for(done_event.wait(), timeout=2.0)
+            await asyncio.wait_for(done_event.wait(), timeout=TIMEOUT_IO)
 
         assert call_count == 2
     finally:
@@ -359,7 +360,7 @@ class TestRetryExhaustion:
             ):
                 dispatcher.enqueue(msg, OutboundMessage.from_text("hi"))
                 # Act — wait until try_notify_user fires (exhaustion complete)
-                await asyncio.wait_for(done_event.wait(), timeout=2.0)
+                await asyncio.wait_for(done_event.wait(), timeout=TIMEOUT_IO)
 
             # Assert
             assert adapter.send.await_count == 4  # 1 initial + 3 retries

--- a/tests/core/test_pipeline_event_bus.py
+++ b/tests/core/test_pipeline_event_bus.py
@@ -23,6 +23,7 @@ from lyra.core.hub.pipeline_events import (
     PoolSubmitted,
     StageCompleted,
 )
+from tests.conftest import yield_once
 from tests.core.conftest import _make_hub, make_inbound_message
 
 
@@ -226,7 +227,7 @@ class TestAuditConsumer:
 
         # Start consumer, let it block on empty queue, then cancel
         task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0)  # consumer is now awaiting queue.get()
+        await yield_once()  # consumer is now awaiting queue.get()
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/tests/core/test_pool_advanced.py
+++ b/tests/core/test_pool_advanced.py
@@ -15,7 +15,8 @@ import pytest
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
-from tests.core.conftest import _drain, make_msg
+from tests.conftest import _drain
+from tests.core.conftest import make_msg
 
 # ---------------------------------------------------------------------------
 # File-local helper

--- a/tests/core/test_pool_streaming.py
+++ b/tests/core/test_pool_streaming.py
@@ -15,6 +15,7 @@ import pytest
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.messaging.render_events import TextRenderEvent
 from lyra.core.pool import Pool
+from tests.conftest import TIMEOUT_IO
 from tests.core.conftest import _make_ctx_mock, make_msg
 
 # ---------------------------------------------------------------------------
@@ -241,7 +242,7 @@ class TestPoolStreaming:
 
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         ctx.dispatch_streaming.assert_awaited_once()
 
@@ -257,7 +258,7 @@ class TestPoolStreaming:
 
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         ctx.dispatch_streaming.assert_awaited_once()
         ctx.record_circuit_success.assert_called()
@@ -283,7 +284,7 @@ class TestPoolStreaming:
 
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         ctx.dispatch_response.assert_awaited()
         response_arg: Response = ctx.dispatch_response.call_args[0][1]
@@ -316,7 +317,7 @@ class TestPoolStreaming:
         msg = make_msg("log content test")
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         assert logged == ["hello world"], f"expected full content, got {logged!r}"
 
@@ -342,7 +343,7 @@ class TestPoolStreaming:
         msg = make_msg("empty stream test")
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         assert logged == [""], f"expected empty string, got {logged!r}"
 
@@ -389,7 +390,7 @@ class TestPoolStreaming:
         msg = make_msg("supersede test")
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         # Assert: full content captured (no mid-stream cancel in this test path)
         assert logged == ["firstsecond"], f"expected full content, got {logged!r}"
@@ -447,7 +448,7 @@ class TestPoolStreaming:
         msg = make_msg("session id test")
         pool.submit(msg)
         if pool._current_task:
-            await asyncio.wait_for(pool._current_task, timeout=2.0)
+            await asyncio.wait_for(pool._current_task, timeout=TIMEOUT_IO)
 
         assert pool.session_id == "session-from-iterator", (
             f"expected session_id from original iterator, got {pool.session_id!r}"

--- a/tests/core/test_pool_tasks.py
+++ b/tests/core/test_pool_tasks.py
@@ -14,6 +14,7 @@ import pytest
 
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
+from tests.conftest import yield_once
 from tests.core.conftest import FastAgent, SlowAgent, _drain, make_msg
 
 # ---------------------------------------------------------------------------
@@ -266,7 +267,7 @@ class TestPoolCancel:
         msg = make_msg()
 
         pool.submit(msg)
-        await asyncio.sleep(0)  # let process_loop start and reach wait_for
+        await yield_once()  # let process_loop start and reach wait_for
         pool.cancel()
 
         if pool._current_task is not None:
@@ -309,7 +310,7 @@ class TestPoolExceptionHandling:
 
         pool.submit(msg1)
 
-        await asyncio.sleep(0)
+        await yield_once()
 
         ctx_mock._agents["test_agent"] = fast_agent
         pool.submit(msg2)

--- a/tests/core/test_pool_tasks.py
+++ b/tests/core/test_pool_tasks.py
@@ -14,8 +14,8 @@ import pytest
 
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
-from tests.conftest import TIMEOUT_IO, yield_once
-from tests.core.conftest import FastAgent, SlowAgent, _drain, make_msg
+from tests.conftest import TIMEOUT_IO, _drain, yield_once
+from tests.core.conftest import FastAgent, SlowAgent, make_msg
 
 # ---------------------------------------------------------------------------
 # File-local agent doubles

--- a/tests/core/test_pool_tasks.py
+++ b/tests/core/test_pool_tasks.py
@@ -14,7 +14,7 @@ import pytest
 
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
-from tests.conftest import yield_once
+from tests.conftest import TIMEOUT_IO, yield_once
 from tests.core.conftest import FastAgent, SlowAgent, _drain, make_msg
 
 # ---------------------------------------------------------------------------
@@ -194,7 +194,7 @@ class TestPoolTimeout:
         msg = make_msg()
 
         fast_pool.submit(msg)
-        await _drain(fast_pool, timeout=2.0)
+        await _drain(fast_pool, timeout=TIMEOUT_IO)
 
         ctx_mock.dispatch_response.assert_awaited_once()
         _args = ctx_mock.dispatch_response.call_args
@@ -214,7 +214,7 @@ class TestPoolTimeout:
 
         with caplog.at_level(logging.ERROR, logger="lyra.core.pool_processor"):
             fast_pool.submit(msg)
-            await _drain(fast_pool, timeout=2.0)
+            await _drain(fast_pool, timeout=TIMEOUT_IO)
 
         assert any("backend process died" in r.message for r in caplog.records)
 
@@ -229,7 +229,7 @@ class TestPoolTimeout:
 
         with caplog.at_level(logging.ERROR, logger="lyra.core.pool_processor"):
             fast_pool.submit(msg)
-            await _drain(fast_pool, timeout=2.0)
+            await _drain(fast_pool, timeout=TIMEOUT_IO)
 
         assert not any("backend process died" in r.message for r in caplog.records)
 
@@ -244,7 +244,7 @@ class TestPoolTimeout:
         initial_history_len = len(fast_pool.history)
 
         fast_pool.submit(msg)
-        await _drain(fast_pool, timeout=2.0)
+        await _drain(fast_pool, timeout=TIMEOUT_IO)
 
         assert len(fast_pool.history) == initial_history_len
 

--- a/tests/core/test_session_commands_bypass.py
+++ b/tests/core/test_session_commands_bypass.py
@@ -15,6 +15,7 @@ from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
 from lyra.core.processors.processor_registry import BaseProcessor, registry
 from lyra.integrations.base import SessionTools
+from tests.conftest import yield_once
 from tests.helpers import reload_processors
 
 
@@ -107,7 +108,7 @@ def _make_ctx(agent) -> MagicMock:
 async def _drain(pool: Pool, *, timeout: float = 3.0) -> None:
     import asyncio
 
-    await asyncio.sleep(0)
+    await yield_once()
     if pool._current_task is not None:
         await asyncio.wait_for(pool._current_task, timeout=timeout)
 

--- a/tests/core/test_session_commands_post.py
+++ b/tests/core/test_session_commands_post.py
@@ -15,6 +15,7 @@ from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
 from lyra.core.processors.processor_registry import registry
 from lyra.integrations.base import SessionTools
+from tests.conftest import yield_once
 from tests.helpers import reload_processors
 
 
@@ -84,7 +85,7 @@ def _make_ctx(agent) -> MagicMock:
 async def _drain(pool: Pool, *, timeout: float = 3.0) -> None:
     import asyncio
 
-    await asyncio.sleep(0)
+    await yield_once()
     if pool._current_task is not None:
         await asyncio.wait_for(pool._current_task, timeout=timeout)
 

--- a/tests/core/test_session_commands_pre.py
+++ b/tests/core/test_session_commands_pre.py
@@ -15,6 +15,7 @@ from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.pool import Pool
 from lyra.core.processors.processor_registry import registry
 from lyra.integrations.base import SessionTools
+from tests.conftest import yield_once
 from tests.helpers import reload_processors
 
 
@@ -84,7 +85,7 @@ def _make_ctx(agent) -> MagicMock:
 async def _drain(pool: Pool, *, timeout: float = 3.0) -> None:
     import asyncio
 
-    await asyncio.sleep(0)
+    await yield_once()
     if pool._current_task is not None:
         await asyncio.wait_for(pool._current_task, timeout=timeout)
 

--- a/tests/core/test_submit_middleware_context.py
+++ b/tests/core/test_submit_middleware_context.py
@@ -150,7 +150,8 @@ class TestReplyToResumePipeline:
         hub._message_index = cast("MessageIndex", mi)
 
         pool = hub.get_or_create_pool(pool_id, "lyra")
-        pool._current_task = asyncio.create_task(asyncio.sleep(10))
+        _busy_task_never_completes = asyncio.Event()
+        pool._current_task = asyncio.create_task(_busy_task_never_completes.wait())
 
         resumed: list[str] = []
 
@@ -287,7 +288,8 @@ class TestResolveContextMessageIndex:
         hub = _make_hub()
         hub._message_index = cast("MessageIndex", mi)
         pool = hub.get_or_create_pool(pool_id, "lyra")
-        pool._current_task = asyncio.create_task(asyncio.sleep(10))
+        _busy_task_never_completes = asyncio.Event()
+        pool._current_task = asyncio.create_task(_busy_task_never_completes.wait())
 
         resumed: list[str] = []
 
@@ -452,7 +454,8 @@ class TestResolveContextResumeStatus:
         pool_id = "telegram:main:chat:42"
         hub = _make_hub()
         pool = hub.get_or_create_pool(pool_id, "lyra")
-        pool._current_task = asyncio.create_task(asyncio.sleep(10))
+        _busy_task_never_completes = asyncio.Event()
+        pool._current_task = asyncio.create_task(_busy_task_never_completes.wait())
 
         _base = make_inbound_message(scope_id="chat:42")
         _meta = {**_base.platform_meta, "thread_session_id": "tss-busy"}

--- a/tests/fixtures/agent_harness.py
+++ b/tests/fixtures/agent_harness.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
+from tests.conftest import yield_once
+
 from lyra.agents.simple_agent import SimpleAgent
 from lyra.core.agent import Agent
 from lyra.core.auth.trust import TrustLevel
@@ -77,7 +79,7 @@ def _make_ctx_mock(agents: dict | None = None) -> MagicMock:
 
 async def _drain(pool: Pool, *, timeout: float = 2.0) -> None:
     """Yield to the event loop then wait for the current task to finish."""
-    await asyncio.sleep(0)
+    await yield_once()
     if pool._current_task is not None:
         await asyncio.wait_for(pool._current_task, timeout=timeout)
 

--- a/tests/fixtures/agent_harness.py
+++ b/tests/fixtures/agent_harness.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
-from tests.conftest import yield_once
+from tests.conftest import _drain
 
 from lyra.agents.simple_agent import SimpleAgent
 from lyra.core.agent import Agent
@@ -75,13 +75,6 @@ def _make_ctx_mock(agents: dict | None = None) -> MagicMock:
     ctx.record_circuit_failure = MagicMock()
     ctx._agents = _agents
     return ctx
-
-
-async def _drain(pool: Pool, *, timeout: float = 2.0) -> None:
-    """Yield to the event loop then wait for the current task to finish."""
-    await yield_once()
-    if pool._current_task is not None:
-        await asyncio.wait_for(pool._current_task, timeout=timeout)
 
 
 @dataclass

--- a/tests/fixtures/fake_drivers.py
+++ b/tests/fixtures/fake_drivers.py
@@ -147,9 +147,7 @@ class FakeClaudeCliDriver:
 
         result = self._queue.pop(0)
         if result.error:
-            yield ResultLlmEvent(
-                is_error=True, duration_ms=0, error_text=result.error
-            )
+            yield ResultLlmEvent(is_error=True, duration_ms=0, error_text=result.error)
             return
 
         # Yield text as a single chunk, then result event

--- a/tests/integration/test_command_sessions.py
+++ b/tests/integration/test_command_sessions.py
@@ -327,7 +327,8 @@ class TestSessionTimeout:
         driver = make_mock_driver()
 
         async def slow_handler(msg, driver, tools, args, timeout):  # noqa: ARG001
-            await asyncio.sleep(10)
+            _never_completes = asyncio.Event()
+            await _never_completes.wait()  # explicit: never completes, tests timeout
             return Response(content="never")
 
         router = CommandRouter(

--- a/tests/integration/test_session_reply_to.py
+++ b/tests/integration/test_session_reply_to.py
@@ -100,7 +100,8 @@ async def test_pending_session_id_set_when_pool_busy() -> None:
     pool = _make_pool("telegram:main:chat:42")
 
     # Make pool appear busy
-    pool._current_task = asyncio.create_task(asyncio.sleep(100))
+    _busy_task_never_completes = asyncio.Event()
+    pool._current_task = asyncio.create_task(_busy_task_never_completes.wait())
 
     try:
         message_index = _FakeMessageIndex({"msg-old": "session-abc"})

--- a/tests/llm/drivers/test_nats_driver.py
+++ b/tests/llm/drivers/test_nats_driver.py
@@ -24,6 +24,7 @@ import pytest
 from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
 from lyra.llm.drivers.nats_driver import HB_TTL, NatsLlmDriver
+from tests.conftest import yield_once
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -262,7 +263,7 @@ class TestStreamHappyPath:
             gen = await driver.stream("p", "hi", make_model_cfg(), "sys")
             # Feed chunks into the subscription after publishing
             task = asyncio.create_task(_drain(gen, events))
-            await asyncio.sleep(0)  # yield so task starts
+            await yield_once()  # yield so task starts
             for chunk in chunks:
                 await captured_cb(make_chunk_msg(chunk))
             await task
@@ -366,7 +367,7 @@ class TestStreamHappyPath:
             events = []
             gen = await driver.stream("p", "hi", make_model_cfg(), "sys")
             task = asyncio.create_task(_drain(gen, events))
-            await asyncio.sleep(0)
+            await yield_once()
             # Send a done result chunk
             await captured_cb(
                 make_chunk_msg(
@@ -418,7 +419,7 @@ class TestStreamCancellation:
         async def run_and_cancel():
             gen = await driver.stream("p", "hi", make_model_cfg(), "sys")
             task = asyncio.create_task(_consume(gen))
-            await asyncio.sleep(0)  # let task start waiting on queue
+            await yield_once()  # let task start waiting on queue
             task.cancel()
             try:
                 await task
@@ -687,7 +688,7 @@ class TestStreamDefensiveBranches:
             events: list = []
             gen = await driver.stream("p", "hi", make_model_cfg(), "sys")
             task = asyncio.create_task(_drain(gen, events))
-            await asyncio.sleep(0)
+            await yield_once()
             for chunk in chunks:
                 await captured_cb(make_chunk_msg(chunk))
             await task
@@ -730,7 +731,7 @@ class TestStreamDefensiveBranches:
             events: list = []
             gen = await driver.stream("p", "hi", make_model_cfg(), "sys")
             task = asyncio.create_task(_drain(gen, events))
-            await asyncio.sleep(0)
+            await yield_once()
             for chunk in chunks:
                 await captured_cb(make_chunk_msg(chunk))
             await task

--- a/tests/test_bootstrap_credential_resolution.py
+++ b/tests/test_bootstrap_credential_resolution.py
@@ -23,6 +23,7 @@ from tests.conftest import (
     _FakeTgAdapter,
     make_fake_stores,
     patch_bootstrap_common,
+    yield_once,
 )
 
 # ---------------------------------------------------------------------------
@@ -60,7 +61,8 @@ class TestCredentialResolution:
 
         class CapturingTgAdapter(_FakeTgAdapter):
             def __init__(self, **kwargs: object) -> None:
-                super().__init__(**kwargs)
+                shutdown = kwargs.pop("shutdown_event", None)  # type: ignore[assignment]
+                super().__init__(shutdown_event=shutdown, **kwargs)  # type: ignore[arg-type]
                 captured_kwargs.append(dict(kwargs))
 
         monkeypatch.setattr(wiring_mod, "TelegramAdapter", CapturingTgAdapter)
@@ -121,7 +123,7 @@ class TestCredentialResolution:
             async def start(self, token: str) -> None:
                 started_with.append(token)
                 # Yield control so the test doesn't hang waiting for this task
-                await asyncio.sleep(0)
+                await yield_once()
 
         monkeypatch.setattr(
             wiring_mod,

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -6,7 +6,6 @@ Classes: TestHealthUnauthenticated, TestHealthEndpoint, TestHubTimestamps.
 
 from __future__ import annotations
 
-import asyncio
 import time
 from datetime import datetime, timezone
 
@@ -20,7 +19,7 @@ from lyra.core.messaging.message import (
     InboundMessage,
     Platform,
 )
-from tests.conftest import AUTH_HEADERS, HEALTH_SECRET
+from tests.conftest import AUTH_HEADERS, HEALTH_SECRET, yield_once
 from tests.core.conftest import push_to_hub
 
 # ---------------------------------------------------------------------------
@@ -149,7 +148,7 @@ class TestHealthEndpoint:
             trust_level=TrustLevel.TRUSTED,
         )
         await push_to_hub(hub, msg)
-        await asyncio.sleep(0)  # let feeder task move message to staging
+        await yield_once()  # let feeder task move message to staging
 
         app = create_health_app(hub)
         transport = ASGITransport(app=app)


### PR DESCRIPTION
## Summary
- Add `TIMEOUT_FAST/IO/SLOW` constants and `yield_once()` helper for explicit event coordination
- Replace `asyncio.sleep(N)` in fake adapters with `shutdown_event.wait()` pattern
- Update SlowAgent, SlowSTT, and test mocks to use event-based blocking instead of arbitrary sleeps
- Replace `asyncio.sleep(0)` calls with `yield_once()` across 25 test files

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #861: replace asyncio.sleep with event-based sync in flaky suites | OPEN |
| Spec | [861-event-sync-flaky-tests-spec.mdx](artifacts/specs/861-event-sync-flaky-tests-spec.mdx) | Present |
| Implementation | 1 commit on `feat/861-event-sync-flaky-tests` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2821 passed) | Passed |

## Test Plan
- [x] All existing tests pass (2821 passed, 70 skipped)
- [x] Lint and typecheck pass
- [ ] CI runs on this PR verify no flaky failures

Closes #861

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`