### PR TITLE
feat(nats): per-identity _INBOX prefix retires bus-wide wildcard (ADR-051)

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -4,6 +4,7 @@ issue: 706
 status: approved
 tier: F-lite
 date: 2026-04-15
+updated: 2026-04-22
 promoted-from: artifacts/frames/706-per-role-nkeys-acls-frame.mdx
 ---
 
@@ -78,7 +79,7 @@ classDiagram
 
 ### Subject → Identity ACL matrix
 
-Derived from the audit (see §Audit Provenance). `PUB` = identity publishes to this subject. `SUB` = identity subscribes. Reply subjects (NATS `_INBOX.>`) are granted automatically by `allow_responses: true` — they do **not** appear in the matrix.
+Derived from the audit (see §Audit Provenance). `PUB` = identity publishes to this subject. `SUB` = identity subscribes. Per-identity inbox subjects (`_INBOX.<identity>.>`) are listed explicitly; `allow_responses: true` covers the replier side only and does not replace the explicit inbox subscribe grant (see `[^inbox-fix]`).
 
 <!-- acl-matrix:begin -->
 | Subject | hub | telegram-adapter | discord-adapter | tts-adapter | stt-adapter | llm-worker | monitor |
@@ -94,16 +95,20 @@ Derived from the audit (see §Audit Provenance). `PUB` = identity publishes to t
 | `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — |
 | `lyra.llm.request` | PUB | — | — | — | — | SUB | — |
 | `lyra.llm.health.*` [^health] | SUB | — | — | — | — | PUB | — |
-| `_INBOX.>` [^inbox] | SUB | SUB | SUB | SUB | SUB | — | — |
+| `_INBOX.hub.>` [^inbox] | SUB | — | — | — | — | — | — |
+| `_INBOX.telegram-adapter.>` [^inbox] | — | SUB | — | — | — | — | — |
+| `_INBOX.discord-adapter.>` [^inbox] | — | — | SUB | — | — | — | — |
+| `_INBOX.tts-adapter.>` [^inbox] | — | — | — | SUB | — | — | — |
+| `_INBOX.stt-adapter.>` [^inbox] | — | — | — | — | SUB | — | — |
 | `lyra.monitor.>` (reserved) [^monitor] | — | — | — | — | — | — | PUB+SUB |
 <!-- acl-matrix:end -->
 
 [^ready]: Readiness probe uses request/reply. Adapter publishes `lyra.system.ready` with `reply=<ephemeral>`; hub subscribes, responds via `msg.respond()`. The reply subject is covered by `allow_responses: true` on the hub.
 [^health]: Code uses single-token wildcard `*` (`lyra.llm.health.*`) not `>` — matches `lyra.llm.health.<driver>` today; tightening to `.*` prevents a future multi-segment publish from silently landing via a `>`-based ACL.
-[^inbox]: The `NatsLlmDriver.stream()` path in `src/lyra/llm/drivers/nats_driver.py:200` uses a manual inbox subscription (`self._nc.new_inbox()` + `subscribe(inbox)`) rather than `nc.request()`. `allow_responses: true` only covers auto-managed inboxes from `nc.request()`, so the hub needs `_INBOX.>` in its subscribe allow-list explicitly for LLM streaming to work. Other clients (adapters, workers) do not need this — they are responders via `msg.respond()`, which is covered by `allow_responses: true`.
+[^inbox]: Each lyra-owned identity connects with `inbox_prefix="_INBOX.<identity>"` (ADR-051), so nats-py's `new_inbox()` returns `_INBOX.<identity>.<nuid>` and the scoped ACL covers both `nc.request()` and manual inbox subscribe paths. The `NatsLlmDriver._stream_gen()` path (`self._nc.new_inbox()` + `subscribe(inbox)`) is unmodified — only the prefix narrows. See `[^inbox-fix]` for history.
 [^monitor]: Monitor has no code today (seed + ACL exist only to reserve the namespace). Kept in scope to avoid a second `gen-nkeys.sh --regenerate` + reload cycle when the monitor service lands.
 
-[^inbox-fix]: **Post-ship correction (2026-04-20).** The shipped spec claimed adapters only needed `allow_responses: true` because they are "responders via `msg.respond()`" (see `[^inbox]`). This was incomplete: telegram-adapter and discord-adapter also act as **requesters** for the readiness probe (`nc.request('lyra.system.ready', …)` via `roxabi_nats.readiness.wait_for_hub`), and `allow_responses` does not grant subscribe permission on the requester's own reply inbox. Symptom: `nats-server[…] Subscription Violation - Nkey "UD…" Subject "_INBOX.<uuid>.*"` every 22s during startup; each probe failed silently and the adapter degraded to "start anyway after 30s" graceful path. Fix: append `"_INBOX.>"` to `SUB_ALLOW` for both adapters in `deploy/nats/gen-nkeys.sh`; re-render with `sudo ./deploy/nats/gen-nkeys.sh --regen-authconf` + `sudo systemctl reload nats`. Tightening to per-identity `inbox_prefix` tracked in #717.
+[^inbox-fix]: **Resolved by ADR-051 (#715).** The original `_INBOX.>` grant was required because adapters acting as requesters (e.g. readiness probe via `nc.request()`) need subscribe permission on their own reply inbox, and `allow_responses: true` only covers the *replier* side. ADR-051 resolves this by setting `inbox_prefix="_INBOX.<identity>"` at `nats_connect()` time: nats-py's `new_inbox()` derives every ephemeral inbox from `self._inbox_prefix`, so all inboxes for a given identity land under `_INBOX.<identity>.<nuid>` and the narrowed per-identity ACL covers them. This replaces the bus-wide `_INBOX.>` grant and makes the `allow_responses` vs. requester-subscribe distinction moot — both paths are covered by the same scoped grant without any code change to `_stream_gen()` or the readiness probe. Supersedes #717.
 
 ### Consumer map (who uses which subjects)
 
@@ -130,11 +135,11 @@ The matrix above is authoritative. The table below is a per-identity rollup — 
 
 | Identity | Publishes | Subscribes | Uses `allow_responses` | Status |
 |---|---|---|:-:|---|
-| hub | `lyra.outbound.telegram.>`, `lyra.outbound.discord.>`, `lyra.voice.tts.request`, `lyra.voice.stt.request`, `lyra.llm.request` | `lyra.inbound.telegram.>`, `lyra.inbound.discord.>`, `lyra.voice.tts.heartbeat`, `lyra.voice.stt.heartbeat`, `lyra.llm.health.*`, `lyra.system.ready`, `_INBOX.>` | ✓ (requester) | This issue |
-| telegram-adapter | `lyra.inbound.telegram.>`, `lyra.system.ready` | `lyra.outbound.telegram.>`, `_INBOX.>` [^inbox-fix] | ✓ | This issue |
-| discord-adapter | `lyra.inbound.discord.>`, `lyra.system.ready` | `lyra.outbound.discord.>`, `_INBOX.>` [^inbox-fix] | ✓ | This issue |
-| tts-adapter | `lyra.voice.tts.heartbeat` | `lyra.voice.tts.request` | ✓ (responder) | This issue |
-| stt-adapter | `lyra.voice.stt.heartbeat` | `lyra.voice.stt.request` | ✓ (responder) | This issue |
+| hub | `lyra.outbound.telegram.>`, `lyra.outbound.discord.>`, `lyra.voice.tts.request`, `lyra.voice.stt.request`, `lyra.llm.request` | `lyra.inbound.telegram.>`, `lyra.inbound.discord.>`, `lyra.voice.tts.heartbeat`, `lyra.voice.stt.heartbeat`, `lyra.llm.health.*`, `lyra.system.ready`, `_INBOX.hub.>` [^inbox-fix] | ✓ (requester) | This issue |
+| telegram-adapter | `lyra.inbound.telegram.>`, `lyra.system.ready` | `lyra.outbound.telegram.>`, `_INBOX.telegram-adapter.>` [^inbox-fix] | ✓ | This issue |
+| discord-adapter | `lyra.inbound.discord.>`, `lyra.system.ready` | `lyra.outbound.discord.>`, `_INBOX.discord-adapter.>` [^inbox-fix] | ✓ | This issue |
+| tts-adapter | `lyra.voice.tts.heartbeat` | `lyra.voice.tts.request`, `_INBOX.tts-adapter.>` [^inbox-fix] | ✓ (responder) | This issue |
+| stt-adapter | `lyra.voice.stt.heartbeat` | `lyra.voice.stt.request`, `_INBOX.stt-adapter.>` [^inbox-fix] | ✓ (responder) | This issue |
 | llm-worker | `lyra.llm.health.*` | `lyra.llm.request` | ✓ (responder) | This issue |
 | monitor | `lyra.monitor.>` | `lyra.monitor.>` | ✓ | Reserved (no code; ACL is namespace squat — see footnote) |
 | plugin (`lyra.plugin.<name>.>`) | `lyra.plugin.<name>.>` | `lyra.plugin.<name>.>` | ✓ | **Deferred to ADR-045** |
@@ -195,7 +200,7 @@ The matrix above is authoritative. The table below is a per-identity rollup — 
 - [ ] `gen-nkeys.sh --regenerate` generates 7 seeds: `hub`, `telegram-adapter`, `discord-adapter`, `tts-adapter`, `stt-adapter`, `llm-worker`, `monitor` — each at `$SEEDS_DIR/<name>.seed` with mode 0600, owned by `$LYRA_USER`.
 - [ ] Generated `auth.conf` contains exactly 7 `users[]` entries; each entry has an `nkey`, a `permissions { publish { allow: [...] } subscribe { allow: [...] } allow_responses: true }` block.
 - [ ] The publish allow-list for each identity matches that identity's matrix row exactly (set equality, order-insensitive).
-- [ ] The subscribe allow-list for each identity matches that identity's matrix row exactly, including the hub's `_INBOX.>` subscription.
+- [ ] The subscribe allow-list for each identity matches that identity's matrix row exactly, including the hub's `_INBOX.hub.>` subscription (narrowed per ADR-051 / #715).
 - [ ] `plugin` nkey identity is **not** generated; auth.conf header comment references ADR-045 and says "plugin ACL deferred".
 
 ### Supervisor wiring
@@ -219,6 +224,6 @@ The matrix above is authoritative. The table below is a per-identity rollup — 
 
 > **Out of scope:** Plugin role ACL implementation. Expected shape for when ADR-045 lands: each plugin gets its own nkey (`<project>.seed`), permissions scoped to `lyra.plugin.<project>.>` for both publish and subscribe, `allow_responses: true`. The hub will need to add `SUB lyra.plugin.>` (or a scoped pattern) when plugins start calling into it — out of scope here.
 >
-> **Out of scope:** Per-identity `inbox_prefix` (scoped reply inboxes). Using `allow_responses: true` with the default `_INBOX.>` prefix means any authenticated identity could *subscribe* to any inbox if they guess the subject. Mitigation: reply inboxes are random UUIDs (unguessable in practice) and `allow_responses` limits responders to one reply per request within a 2-minute window. Tightening to per-identity `inbox_prefix` is a follow-up issue.
+> **Resolved in #715 / ADR-051:** Per-identity `inbox_prefix` (scoped reply inboxes). The bus-wide `_INBOX.>` grant has been retired for all lyra-owned identities (hub, telegram-adapter, discord-adapter, tts-adapter, stt-adapter); each now connects with `inbox_prefix="_INBOX.<identity>"` and holds only `_INBOX.<identity>.>` in its ACL. Satellite identities (voice-tts, voice-stt, image-worker) are narrowed in per-satellite follow-up PRs per ADR-047.
 >
 > **Out of scope:** Quadlet-path verification. `deploy/quadlet/hub.container` and `lyra-adapter@.container` already wire `NATS_NKEY_SEED_PATH` correctly; the quadlet path is tested only indirectly via the supervisor-path rollout on Machine 1.

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -3,7 +3,7 @@
   "identities": {
     "hub": {
       "owner": "lyra",
-      "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image workers. _INBOX.> required for NatsLlmDriver.stream() manual inbox subscription (tighten in #715).",
+      "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image workers. Inbox narrowed to _INBOX.hub.> per ADR-051 per-identity prefix invariant.",
       "publish": [
         "lyra.outbound.telegram.>",
         "lyra.outbound.discord.>",
@@ -19,37 +19,37 @@
         "lyra.voice.stt.heartbeat",
         "lyra.llm.health.*",
         "lyra.system.ready",
-        "_INBOX.>",
+        "_INBOX.hub.>",
         "lyra.image.heartbeat"
       ]
     },
     "telegram-adapter": {
       "owner": "lyra",
-      "description": "Telegram bot adapter — _INBOX.> required for readiness probe via nc.request() on lyra.system.ready; allow_responses covers replier side only, not requester inbox. Tighten to per-identity inbox prefix tracked in #717.",
+      "description": "Telegram bot adapter — inbox narrowed to _INBOX.telegram-adapter.> per ADR-051 per-identity prefix invariant.",
       "publish": [
         "lyra.inbound.telegram.>",
         "lyra.system.ready"
       ],
       "subscribe": [
         "lyra.outbound.telegram.>",
-        "_INBOX.>"
+        "_INBOX.telegram-adapter.>"
       ]
     },
     "discord-adapter": {
       "owner": "lyra",
-      "description": "Discord bot adapter — same readiness-probe _INBOX.> requirement as telegram-adapter.",
+      "description": "Discord bot adapter — inbox narrowed to _INBOX.discord-adapter.> per ADR-051 per-identity prefix invariant.",
       "publish": [
         "lyra.inbound.discord.>",
         "lyra.system.ready"
       ],
       "subscribe": [
         "lyra.outbound.discord.>",
-        "_INBOX.>"
+        "_INBOX.discord-adapter.>"
       ]
     },
     "tts-adapter": {
       "owner": "lyra",
-      "description": "Lyra-side TTS voice satellite (retired in #690 cutover). Readiness probe via nc.request('lyra.system.ready') needs _INBOX.>/_inbox.> — both forms included because nats-py historically emits lowercase inboxes and NATS subjects are case-sensitive.",
+      "description": "Lyra-side TTS voice satellite (retired in #690 cutover). Inbox narrowed to _INBOX.tts-adapter.> and _inbox.tts-adapter.> per ADR-051; both case variants retained for nats-py case-sensitivity compatibility.",
       "publish": [
         "lyra.voice.tts.heartbeat",
         "lyra.system.ready"
@@ -57,13 +57,13 @@
       "subscribe": [
         "lyra.voice.tts.request",
         "lyra.voice.tts.request.>",
-        "_INBOX.>",
-        "_inbox.>"
+        "_INBOX.tts-adapter.>",
+        "_inbox.tts-adapter.>"
       ]
     },
     "stt-adapter": {
       "owner": "lyra",
-      "description": "Lyra-side STT voice satellite (retired in #690 cutover). Same readiness-probe _INBOX.>/_inbox.> requirement as tts-adapter.",
+      "description": "Lyra-side STT voice satellite (retired in #690 cutover). Inbox narrowed to _INBOX.stt-adapter.> and _inbox.stt-adapter.> per ADR-051; both case variants retained for nats-py case-sensitivity compatibility.",
       "publish": [
         "lyra.voice.stt.heartbeat",
         "lyra.system.ready"
@@ -71,13 +71,13 @@
       "subscribe": [
         "lyra.voice.stt.request",
         "lyra.voice.stt.request.>",
-        "_INBOX.>",
-        "_inbox.>"
+        "_INBOX.stt-adapter.>",
+        "_inbox.stt-adapter.>"
       ]
     },
     "voice-tts": {
       "owner": "voicecli",
-      "description": "voicecli nats-serve TTS worker on Machine 1 (#689). AdapterBase subscribes to heartbeat_subject (no-op callback) in addition to publishing — ACL must allow both pub and sub on heartbeat.",
+      "description": "voicecli nats-serve TTS worker on Machine 1 (#689). AdapterBase subscribes to heartbeat_subject (no-op callback) in addition to publishing — ACL must allow both pub and sub on heartbeat. Inbox narrowing to _INBOX.voice-tts.> is sequenced behind the voiceCLI connect-site PR per ADR-047 rule 4.",
       "publish": [
         "lyra.voice.tts.heartbeat",
         "_INBOX.>"
@@ -90,7 +90,7 @@
     },
     "voice-stt": {
       "owner": "voicecli",
-      "description": "voicecli nats-serve STT worker on Machine 1 (#689). Same heartbeat pub+sub pattern as voice-tts.",
+      "description": "voicecli nats-serve STT worker on Machine 1 (#689). Same heartbeat pub+sub pattern as voice-tts. Inbox narrowing to _INBOX.voice-stt.> is sequenced behind the voiceCLI connect-site PR per ADR-047 rule 4.",
       "publish": [
         "lyra.voice.stt.heartbeat",
         "_INBOX.>"
@@ -113,7 +113,7 @@
     },
     "image-worker": {
       "owner": "imagecli",
-      "description": "imagecli nats-serve satellite (ADR-050, imageCLI#50 + #754). _INBOX.>/_inbox.> defensively included for reply-path robustness, mirroring voice-tts/voice-stt — allow_responses alone may not cover every nats-server version's reply publish path.",
+      "description": "imagecli nats-serve satellite (ADR-050, imageCLI#50 + #754). _INBOX.>/_inbox.> defensively included for reply-path robustness, mirroring voice-tts/voice-stt — allow_responses alone may not cover every nats-server version's reply publish path. Inbox narrowing to _INBOX.image-worker.> is sequenced behind the imageCLI connect-site PR per ADR-047 rule 4.",
       "publish": [
         "lyra.image.heartbeat",
         "_INBOX.>",

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -57,7 +57,11 @@ ROWS=(
   '`lyra.voice.stt.heartbeat`|lyra.voice.stt.heartbeat|lyra.voice.stt.heartbeat'
   '`lyra.llm.request`|lyra.llm.request|lyra.llm.request'
   '`lyra.llm.health.*` [^health]|lyra.llm.health.*|lyra.llm.health.*'
-  '`_INBOX.>` [^inbox]|_INBOX.>|_INBOX.>'
+  '`_INBOX.hub.>` [^inbox]|_INBOX.hub.>|_INBOX.hub.>'
+  '`_INBOX.telegram-adapter.>` [^inbox]|_INBOX.telegram-adapter.>|_INBOX.telegram-adapter.>'
+  '`_INBOX.discord-adapter.>` [^inbox]|_INBOX.discord-adapter.>|_INBOX.discord-adapter.>'
+  '`_INBOX.tts-adapter.>` [^inbox]|_INBOX.tts-adapter.>|_INBOX.tts-adapter.>'
+  '`_INBOX.stt-adapter.>` [^inbox]|_INBOX.stt-adapter.>|_INBOX.stt-adapter.>'
   '`lyra.monitor.>` (reserved) [^monitor]|lyra.monitor.>|lyra.monitor.>'
 )
 

--- a/src/lyra/bootstrap/infra/embedded_nats.py
+++ b/src/lyra/bootstrap/infra/embedded_nats.py
@@ -176,7 +176,7 @@ async def ensure_nats(
         log.info("Using external NATS at %s", scrub_nats_url(nats_url))
 
     try:
-        nc = await nats_connect(nats_url)
+        nc = await nats_connect(nats_url, inbox_prefix="_INBOX.hub")
         log.info("Connected to NATS at %s", scrub_nats_url(nats_url))
     except Exception as exc:
         if embedded:

--- a/src/lyra/bootstrap/standalone/adapter_standalone.py
+++ b/src/lyra/bootstrap/standalone/adapter_standalone.py
@@ -38,6 +38,8 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
     if not nats_url:
         sys.exit("NATS_URL required for standalone adapter mode")
 
+    platform_enum = Platform(platform)
+
     try:
         nc = await nats_connect(nats_url, inbox_prefix=f"_INBOX.{platform}-adapter")
         log.info(
@@ -46,8 +48,6 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
         )
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {scrub_nats_url(nats_url)!r}: {exc}")
-
-    platform_enum = Platform(platform)
 
     from lyra.nats.nats_bus import NatsBus
 

--- a/src/lyra/bootstrap/standalone/adapter_standalone.py
+++ b/src/lyra/bootstrap/standalone/adapter_standalone.py
@@ -39,7 +39,7 @@ async def _bootstrap_adapter_standalone(  # noqa: PLR0915, C901
         sys.exit("NATS_URL required for standalone adapter mode")
 
     try:
-        nc = await nats_connect(nats_url)
+        nc = await nats_connect(nats_url, inbox_prefix=f"_INBOX.{platform}-adapter")
         log.info(
             "adapter_standalone: connected to NATS at %s",
             scrub_nats_url(nats_url),

--- a/src/lyra/bootstrap/standalone/hub_standalone.py
+++ b/src/lyra/bootstrap/standalone/hub_standalone.py
@@ -64,7 +64,7 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
     acquire_lockfile()
 
     try:
-        nc = await nats_connect(nats_url)
+        nc = await nats_connect(nats_url, inbox_prefix="_INBOX.hub")
         log.info("Connected to NATS at %s", scrub_nats_url(nats_url))
     except Exception as exc:
         sys.exit(f"Failed to connect to NATS at {scrub_nats_url(nats_url)!r}: {exc}")

--- a/src/lyra/cli_ops.py
+++ b/src/lyra/cli_ops.py
@@ -21,6 +21,7 @@ import typer
 from nats.aio.client import Client as NATS
 
 import nats
+from lyra.ops_audit import emit_drift_report
 from roxabi_nats.connect import _build_tls_context
 
 ops_app = typer.Typer(name="ops", help="Operational sanity checks.")
@@ -242,9 +243,10 @@ def verify(
             raise typer.BadParameter(f"unknown identity name(s): {', '.join(unknown)}")
         identities = {n: identities[n] for n in only}
 
+    drift = emit_drift_report(identities, typer.echo)
     results = asyncio.run(_verify_all(resolved_url, identities, seeds_path))
     exit_code = _print_report(results)
-    raise typer.Exit(exit_code)
+    raise typer.Exit(max(exit_code, 1 if drift else 0))
 
 
 def _seed_path_for(seeds_dir: Path, name: str) -> Path:
@@ -281,14 +283,11 @@ def _print_report(results: list[IdentityResult]) -> int:
     for r in skipped:
         typer.echo(f"SKIP {r.identity}: {r.skipped_reason}")
 
-    if failed:
-        # `failed` is filtered by `first_failure`, so this is always non-None.
-        first = failed[0].first_failure
-        if first is not None:
-            typer.echo(
-                f"FAIL {first.identity} {first.kind} {first.subject} — "
-                f"expected {first.expected!r}, got {first.actual!r}"
-            )
+    if failed and (first := failed[0].first_failure):
+        typer.echo(
+            f"FAIL {first.identity} {first.kind} {first.subject} — "
+            f"expected {first.expected!r}, got {first.actual!r}"
+        )
 
     typer.echo(
         f"{len(results)} identities, "

--- a/src/lyra/ops_audit.py
+++ b/src/lyra/ops_audit.py
@@ -1,0 +1,61 @@
+"""ACL matrix audits used by ``lyra ops verify``.
+
+Static checks over ``deploy/nats/acl-matrix.json`` contents. Kept separate
+from ``cli_ops`` so the file-length gate stays under budget and the audit
+helpers remain trivially unit-testable without touching Typer.
+"""
+
+from __future__ import annotations
+
+LYRA_OWNED_IDENTITIES: frozenset[str] = frozenset(
+    {
+        "hub",
+        "telegram-adapter",
+        "discord-adapter",
+        "tts-adapter",
+        "stt-adapter",
+    }
+)
+
+BARE_INBOX_PATTERNS: frozenset[str] = frozenset({"_INBOX.>", "_inbox.>"})
+
+
+def audit_matrix_inbox_drift(
+    identities: dict[str, dict],
+) -> list[tuple[str, str, str]]:
+    """Flag lyra-owned identities still holding a bare inbox wildcard.
+
+    Returns a list of ``(identity, grant, direction)`` triples where
+    ``direction`` is ``"publish"`` or ``"subscribe"``. Per-identity scoped
+    grants (``_INBOX.<identity>.>``) are not flagged. Satellite identities
+    are excluded — their narrowing is tracked via per-satellite PRs
+    (ADR-047).
+    """
+    findings: list[tuple[str, str, str]] = []
+    for name, spec in identities.items():
+        if name not in LYRA_OWNED_IDENTITIES:
+            continue
+        for grant in spec.get("publish", []):
+            if grant in BARE_INBOX_PATTERNS:
+                findings.append((name, grant, "publish"))
+        for grant in spec.get("subscribe", []):
+            if grant in BARE_INBOX_PATTERNS:
+                findings.append((name, grant, "subscribe"))
+    return findings
+
+
+def format_drift_finding(finding: tuple[str, str, str]) -> str:
+    """Human-readable single-line rendering of a drift triple."""
+    identity, grant, direction = finding
+    return (
+        f"DRIFT: {identity}.{direction} still grants {grant}"
+        f" — should be _INBOX.{identity}.>"
+    )
+
+
+def emit_drift_report(identities: dict[str, dict], echo) -> bool:
+    """Emit one formatted line per drift finding; return True if any."""
+    drift = audit_matrix_inbox_drift(identities)
+    for finding in drift:
+        echo(format_drift_finding(finding), err=True)
+    return bool(drift)

--- a/src/lyra/ops_audit.py
+++ b/src/lyra/ops_audit.py
@@ -47,10 +47,11 @@ def audit_matrix_inbox_drift(
 def format_drift_finding(finding: tuple[str, str, str]) -> str:
     """Human-readable single-line rendering of a drift triple."""
     identity, grant, direction = finding
-    return (
-        f"DRIFT: {identity}.{direction} still grants {grant}"
-        f" — should be _INBOX.{identity}.>"
-    )
+    if direction == "publish":
+        verb = "publishes on"
+    else:
+        verb = "subscribes to"
+    return f"DRIFT: {identity} still {verb} {grant} — should be _INBOX.{identity}.>"
 
 
 def emit_drift_report(identities: dict[str, dict], echo) -> bool:

--- a/tests/llm/drivers/test_nats_driver.py
+++ b/tests/llm/drivers/test_nats_driver.py
@@ -38,7 +38,7 @@ def make_driver(nc: AsyncMock | None = None, timeout: float = 5.0) -> NatsLlmDri
     if nc is None:
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.abc123")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.abc123")
     return NatsLlmDriver(nc=nc, timeout=timeout)
 
 
@@ -224,7 +224,7 @@ class TestStreamHappyPath:
         # Arrange
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.x")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.aabbccdd")
 
         chunks = [
             {"event_type": "text", "text": "Hello", "done": False},
@@ -285,11 +285,70 @@ class TestStreamHappyPath:
         assert events[2].is_error is False
         assert events[2].duration_ms == 500
 
+    async def test_stream_inbox_subject_uses_hub_prefix(self) -> None:
+        """stream() subscribes to an inbox subject under _INBOX.hub.* (ADR-051)."""
+        # Arrange — new_inbox returns a hub-prefixed inbox
+        nc = AsyncMock()
+        nc.is_connected = True
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.00aabbcc")
+
+        captured_subject: list[str] = []
+
+        async def fake_subscribe(subject, cb=None):
+            captured_subject.append(subject)
+            return AsyncMock()
+
+        nc.subscribe = AsyncMock(side_effect=fake_subscribe)
+        nc.publish = AsyncMock()
+
+        driver = make_driver(nc)
+
+        async def collect():
+            events = []
+            gen = await driver.stream("p", "hi", make_model_cfg(), "sys")
+            task = asyncio.create_task(_drain(gen, events))
+            await asyncio.sleep(0)
+            # Terminate the stream so the task completes cleanly
+            await captured_cb_holder[0](
+                make_chunk_msg(
+                    {
+                        "event_type": "result",
+                        "is_error": False,
+                        "duration_ms": 0,
+                        "done": True,
+                    }
+                )
+            )
+            await task
+
+        captured_cb_holder: list = [None]
+
+        async def fake_subscribe_capture(subject, cb=None):
+            captured_subject.append(subject)
+            captured_cb_holder[0] = cb
+            return AsyncMock()
+
+        nc.subscribe = AsyncMock(side_effect=fake_subscribe_capture)
+
+        async def _drain(gen, events):
+            async for ev in gen:
+                events.append(ev)
+
+        # Act
+        await collect()
+
+        # Assert — subscription subject starts with _INBOX.hub.
+        assert len(captured_subject) == 1
+        inbox_subject = captured_subject[0]
+        assert inbox_subject.startswith("_INBOX.hub."), (
+            f"Expected inbox subject to start with '_INBOX.hub.', got {inbox_subject!r}"
+        )
+
     async def test_stream_request_has_stream_true(self) -> None:
         # Arrange
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.y")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.eeff0011")
 
         captured_cb: Any = None
 
@@ -344,7 +403,7 @@ class TestStreamCancellation:
         # Arrange
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.cancel")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.cc112233")
 
         sub_mock = AsyncMock()
 
@@ -567,7 +626,7 @@ class TestStreamInboxTimeout:
         # Arrange — very short timeout so wait_for expires immediately
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.timeout")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.dd334455")
 
         sub_mock = AsyncMock()
 
@@ -605,7 +664,7 @@ class TestStreamDefensiveBranches:
         # Arrange — "ping" chunk followed by result chunk
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.unknown")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.ee556677")
 
         chunks = [
             {"event_type": "ping", "done": False},
@@ -649,7 +708,7 @@ class TestStreamDefensiveBranches:
         # Arrange — text chunk with done=True (no result chunk)
         nc = AsyncMock()
         nc.is_connected = True
-        nc.new_inbox = MagicMock(return_value="_INBOX.test.synth")
+        nc.new_inbox = MagicMock(return_value="_INBOX.hub.ff778899")
 
         chunks = [
             {"event_type": "text", "text": "hi", "done": True},

--- a/tests/nats/test_gen_nkeys_acls.sh
+++ b/tests/nats/test_gen_nkeys_acls.sh
@@ -219,3 +219,73 @@ echo "PASS (#754-6): no other identity has lyra.image.* access"
 
 echo ""
 echo "PASS (#754): image-worker ACL + amended hub ACL assertions (5 checks)"
+
+# ── #715 / ADR-051 — per-identity inbox prefix assertions ────────────────────
+# For each lyra-owned identity the generated auth.conf MUST contain the
+# scoped prefix form and MUST NOT contain the bare wildcard in any allow-list.
+#
+# Scope:
+#   Lyra-owned (narrowed this PR): hub, telegram-adapter, discord-adapter,
+#                                   tts-adapter, stt-adapter
+#   Satellite (out of scope this PR, unchanged): voice-tts, voice-stt, image-worker
+#
+# Lowercase _inbox.<identity>.> is required for tts-adapter and stt-adapter
+# because both rows carried _inbox.> defensively (nats-py case sensitivity).
+
+LYRA_IDENTITIES=(hub telegram-adapter discord-adapter tts-adapter stt-adapter)
+
+for identity in "${LYRA_IDENTITIES[@]}"; do
+  id_block=$(extract_block "$identity")
+  [ -n "$id_block" ] || { echo "FAIL (#715): could not extract block for ${identity}"; exit 1; }
+
+  # Assert scoped inbox subject present in subscribe allow-list
+  scoped_inbox="_INBOX.${identity}.>"
+  echo "$id_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' \
+    | grep -qF "\"${scoped_inbox}\"" \
+    || { echo "FAIL (#715): ${identity} subscribe must contain \"${scoped_inbox}\""; exit 1; }
+
+  # Assert bare wildcard _INBOX.> NOT present in subscribe allow-list
+  echo "$id_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' \
+    | grep -qF '"_INBOX.>"' \
+    && { echo "FAIL (#715): ${identity} subscribe must NOT contain bare \"_INBOX.>\""; exit 1; } || true
+
+  echo "PASS (#715): ${identity} subscribe has \"${scoped_inbox}\" (no bare _INBOX.>)"
+done
+
+# tts-adapter and stt-adapter: lowercase _inbox.<identity>.> must also be present
+for identity in tts-adapter stt-adapter; do
+  id_block=$(extract_block "$identity")
+
+  scoped_inbox_lc="_inbox.${identity}.>"
+  echo "$id_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' \
+    | grep -qF "\"${scoped_inbox_lc}\"" \
+    || { echo "FAIL (#715): ${identity} subscribe must contain lowercase \"${scoped_inbox_lc}\""; exit 1; }
+
+  # Assert bare lowercase wildcard _inbox.> NOT present in subscribe allow-list
+  echo "$id_block" | grep -E 'subscribe:[[:space:]]*\{[[:space:]]*allow:' \
+    | grep -qF '"_inbox.>"' \
+    && { echo "FAIL (#715): ${identity} subscribe must NOT contain bare \"_inbox.>\""; exit 1; } || true
+
+  echo "PASS (#715): ${identity} subscribe has lowercase \"${scoped_inbox_lc}\" (no bare _inbox.>)"
+done
+
+# Satellite rows must still work (unchanged allow-lists — their _INBOX.> is in publish)
+# voice-tts and voice-stt: _INBOX.> in publish is still present (out of scope this PR)
+for identity in voice-tts voice-stt; do
+  id_block=$(extract_block "$identity")
+  [ -n "$id_block" ] || { echo "FAIL (#715): could not extract block for ${identity}"; exit 1; }
+  echo "$id_block" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' \
+    | grep -qF '"_INBOX.>"' \
+    || { echo "FAIL (#715-satellite): ${identity} publish must still contain \"_INBOX.>\" (out of scope this PR)"; exit 1; }
+  echo "PASS (#715-satellite): ${identity} publish still has \"_INBOX.>\" (satellite, out of scope)"
+done
+
+# image-worker: _INBOX.> and _inbox.> in publish are still present (out of scope this PR)
+iw_b=$(extract_block image-worker)
+echo "$iw_b" | grep -E 'publish:[[:space:]]*\{[[:space:]]*allow:' \
+  | grep -qF '"_INBOX.>"' \
+  || { echo "FAIL (#715-satellite): image-worker publish must still contain \"_INBOX.>\" (out of scope this PR)"; exit 1; }
+echo "PASS (#715-satellite): image-worker publish still has \"_INBOX.>\" (satellite, out of scope)"
+
+echo ""
+echo "PASS (#715/ADR-051): per-identity inbox prefix assertions (5 lyra + 3 satellite)"

--- a/tests/nats/test_hub_standalone.py
+++ b/tests/nats/test_hub_standalone.py
@@ -469,12 +469,15 @@ class TestAdapterStandaloneInboxPrefix:
         mock_nc = AsyncMock()
         mock_nc.is_connected = True
         mock_nc.close = AsyncMock()
-        mock_nats_connect = AsyncMock(return_value=mock_nc)
 
-        # Raise immediately after connect so we don't need to stub deep platform logic
-        mock_platform_enum = MagicMock(
+        # Raise immediately after connect so we don't need to stub deep platform logic.
+        # Platform validation now runs before nats_connect (fail-fast), so the sentinel
+        # is on nats_connect itself rather than Platform.
+        mock_nats_connect = AsyncMock(
             side_effect=SystemExit("test-sentinel: stop after connect")
         )
+
+        mock_platform_enum = MagicMock(return_value=MagicMock())
 
         with (
             patch(
@@ -490,7 +493,7 @@ class TestAdapterStandaloneInboxPrefix:
                 _bootstrap_adapter_standalone,
             )
 
-            # Act — exits at Platform(platform) after connect; that's expected
+            # Act — exits at nats_connect after Platform validation; that's expected
             with pytest.raises(SystemExit, match="test-sentinel"):
                 await _bootstrap_adapter_standalone(raw_config, platform)
 

--- a/tests/nats/test_hub_standalone.py
+++ b/tests/nats/test_hub_standalone.py
@@ -4,12 +4,15 @@ Covers:
 - NATS_URL guard (SystemExit when env var missing)
 - Lockfile lifecycle (acquire / release / stale PID / live PID block)
 - Health endpoint basic response (no NATS required)
+- inbox_prefix kwarg passed to nats_connect (ADR-051, #715)
 """
 
 from __future__ import annotations
 
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from nats.aio.client import Client as NATS
@@ -380,6 +383,124 @@ class TestStandaloneHubPipeline:
             await inbound_bus.stop()
             if hub_nc.is_connected:
                 await hub_nc.drain()
+
+
+# ---------------------------------------------------------------------------
+# T4 — hub_standalone passes inbox_prefix to nats_connect (ADR-051, #715)
+# ---------------------------------------------------------------------------
+
+
+class TestHubStandaloneInboxPrefix:
+    async def test_bootstrap_hub_standalone_passes_inbox_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bootstrap calls nats_connect with inbox_prefix='_INBOX.hub' (ADR-051)."""
+        # Arrange
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        raw_config = _test_config()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nats_connect = AsyncMock(return_value=mock_nc)
+
+        # Fake open_stores context manager — raises immediately so the test
+        # doesn't need to wire the full bootstrap pipeline.
+        @asynccontextmanager
+        async def _fake_open_stores(*_args, **_kwargs):
+            raise SystemExit("test-sentinel: stop after connect")
+            yield  # pragma: no cover — required for asynccontextmanager shape
+
+        with (
+            patch(
+                "lyra.bootstrap.standalone.hub_standalone.nats_connect",
+                mock_nats_connect,
+            ),
+            patch(
+                "lyra.bootstrap.standalone.hub_standalone.acquire_lockfile",
+            ),
+            patch(
+                "lyra.bootstrap.standalone.hub_standalone.release_lockfile",
+            ),
+            patch(
+                "lyra.bootstrap.standalone.hub_standalone.open_stores",
+                _fake_open_stores,
+            ),
+        ):
+            from lyra.bootstrap.standalone.hub_standalone import (
+                _bootstrap_hub_standalone,
+            )
+
+            # Act — exits at open_stores; that's fine, we only need the connect call
+            with pytest.raises(SystemExit, match="test-sentinel"):
+                await _bootstrap_hub_standalone(raw_config)
+
+        # Assert — nats_connect called once with the hub inbox prefix
+        mock_nats_connect.assert_awaited_once()
+        call_kwargs = mock_nats_connect.call_args.kwargs
+        assert call_kwargs.get("inbox_prefix") == "_INBOX.hub", (
+            f"Expected inbox_prefix='_INBOX.hub', got {call_kwargs!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T10b — adapter_standalone passes platform inbox_prefix (ADR-051, #715)
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterStandaloneInboxPrefix:
+    @pytest.mark.parametrize(
+        ("platform", "expected_prefix"),
+        [
+            ("telegram", "_INBOX.telegram-adapter"),
+            ("discord", "_INBOX.discord-adapter"),
+        ],
+    )
+    async def test_bootstrap_adapter_standalone_passes_platform_inbox_prefix(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        platform: str,
+        expected_prefix: str,
+    ) -> None:
+        """Adapter bootstrap passes per-platform inbox_prefix (ADR-051)."""
+        # Arrange
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        raw_config = _test_config()
+
+        mock_nc = AsyncMock()
+        mock_nc.is_connected = True
+        mock_nc.close = AsyncMock()
+        mock_nats_connect = AsyncMock(return_value=mock_nc)
+
+        # Raise immediately after connect so we don't need to stub deep platform logic
+        mock_platform_enum = MagicMock(
+            side_effect=SystemExit("test-sentinel: stop after connect")
+        )
+
+        with (
+            patch(
+                "lyra.bootstrap.standalone.adapter_standalone.nats_connect",
+                mock_nats_connect,
+            ),
+            patch(
+                "lyra.bootstrap.standalone.adapter_standalone.Platform",
+                mock_platform_enum,
+            ),
+        ):
+            from lyra.bootstrap.standalone.adapter_standalone import (
+                _bootstrap_adapter_standalone,
+            )
+
+            # Act — exits at Platform(platform) after connect; that's expected
+            with pytest.raises(SystemExit, match="test-sentinel"):
+                await _bootstrap_adapter_standalone(raw_config, platform)
+
+        # Assert — nats_connect called with platform-derived inbox prefix
+        mock_nats_connect.assert_awaited_once()
+        call_kwargs = mock_nats_connect.call_args.kwargs
+        assert call_kwargs.get("inbox_prefix") == expected_prefix, (
+            f"platform={platform!r}: expected inbox_prefix={expected_prefix!r},"
+            f" got {call_kwargs!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nats/test_ops_verify_matrix_drift.py
+++ b/tests/nats/test_ops_verify_matrix_drift.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from lyra.cli_ops import _load_matrix
-from lyra.ops_audit import audit_matrix_inbox_drift
+from lyra.ops_audit import audit_matrix_inbox_drift, format_drift_finding
 
 # ---------------------------------------------------------------------------
 # Test 1 — clean fixture: all lyra-owned identities use scoped subjects
@@ -126,6 +126,25 @@ def test_audit_multiple_drifts() -> None:
     identities_found = {(f[0], f[2]) for f in findings}
     assert ("hub", "publish") in identities_found
     assert ("discord-adapter", "subscribe") in identities_found
+
+
+# ---------------------------------------------------------------------------
+# Tests for format_drift_finding — direction-aware messages
+# ---------------------------------------------------------------------------
+
+
+def test_format_drift_finding_publish() -> None:
+    msg = format_drift_finding(("hub", "_INBOX.>", "publish"))
+    assert msg == "DRIFT: hub still publishes on _INBOX.> — should be _INBOX.hub.>"
+
+
+def test_format_drift_finding_subscribe() -> None:
+    msg = format_drift_finding(("telegram-adapter", "_INBOX.>", "subscribe"))
+    expected = (
+        "DRIFT: telegram-adapter still subscribes to _INBOX.>"
+        " — should be _INBOX.telegram-adapter.>"
+    )
+    assert msg == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nats/test_ops_verify_matrix_drift.py
+++ b/tests/nats/test_ops_verify_matrix_drift.py
@@ -1,0 +1,148 @@
+"""Tests for audit_matrix_inbox_drift — T11 (RED→GREEN via T8).
+
+Covers:
+  - clean fixtures (no findings)
+  - bare _INBOX.> drift on a lyra-owned identity
+  - lowercase _inbox.> drift
+  - satellite exclusion
+  - multiple drifts across identities
+  - integration smoke: real acl-matrix.json returns []
+"""
+
+from pathlib import Path
+
+import pytest
+
+from lyra.cli_ops import _load_matrix
+from lyra.ops_audit import audit_matrix_inbox_drift
+
+# ---------------------------------------------------------------------------
+# Test 1 — clean fixture: all lyra-owned identities use scoped subjects
+# ---------------------------------------------------------------------------
+
+_CLEAN_IDENTITIES: dict[str, dict] = {
+    "hub": {
+        "publish": ["lyra.outbound.telegram.>"],
+        "subscribe": ["lyra.inbound.telegram.>", "_INBOX.hub.>"],
+    },
+    "telegram-adapter": {
+        "publish": ["lyra.inbound.telegram.>"],
+        "subscribe": ["lyra.outbound.telegram.>", "_INBOX.telegram-adapter.>"],
+    },
+    # satellite — must not be flagged even with bare _INBOX.>
+    "voice-tts": {
+        "publish": ["lyra.voice.tts.heartbeat", "_INBOX.>"],
+        "subscribe": ["lyra.voice.tts.request.>"],
+    },
+}
+
+
+def test_audit_clean_returns_empty() -> None:
+    assert audit_matrix_inbox_drift(_CLEAN_IDENTITIES) == []
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — drift: hub still has bare _INBOX.> on subscribe
+# ---------------------------------------------------------------------------
+
+_DRIFT_HUB: dict[str, dict] = {
+    "hub": {
+        "publish": ["lyra.outbound.telegram.>"],
+        "subscribe": ["_INBOX.>", "lyra.>"],
+    },
+}
+
+
+def test_audit_flags_hub_subscribe_drift() -> None:
+    findings = audit_matrix_inbox_drift(_DRIFT_HUB)
+    assert len(findings) == 1
+    identity, grant, direction = findings[0]
+    assert identity == "hub"
+    assert grant == "_INBOX.>"
+    assert direction == "subscribe"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — lowercase _inbox.> drift on tts-adapter
+# ---------------------------------------------------------------------------
+
+_DRIFT_LOWERCASE: dict[str, dict] = {
+    "tts-adapter": {
+        "publish": ["lyra.voice.tts.heartbeat"],
+        "subscribe": ["_INBOX.tts-adapter.>", "_inbox.>"],
+    },
+}
+
+
+def test_audit_flags_lowercase_inbox_drift() -> None:
+    findings = audit_matrix_inbox_drift(_DRIFT_LOWERCASE)
+    assert len(findings) == 1
+    identity, grant, direction = findings[0]
+    assert identity == "tts-adapter"
+    assert grant == "_inbox.>"
+    assert direction == "subscribe"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — satellite exclusion: voice-tts with bare _INBOX.> is NOT flagged
+# ---------------------------------------------------------------------------
+
+_SATELLITE_ONLY: dict[str, dict] = {
+    "voice-tts": {
+        "publish": ["_INBOX.>"],
+        "subscribe": ["lyra.voice.tts.request.>"],
+    },
+}
+
+
+def test_audit_satellite_excluded() -> None:
+    assert audit_matrix_inbox_drift(_SATELLITE_ONLY) == []
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — multiple drifts across identities
+# ---------------------------------------------------------------------------
+
+_MULTI_DRIFT: dict[str, dict] = {
+    "hub": {
+        "publish": ["_INBOX.>"],
+        "subscribe": ["lyra.inbound.telegram.>"],
+    },
+    "discord-adapter": {
+        "publish": ["lyra.inbound.discord.>"],
+        "subscribe": ["_INBOX.>"],
+    },
+    # clean one in the middle — should not appear
+    "telegram-adapter": {
+        "publish": ["lyra.inbound.telegram.>"],
+        "subscribe": ["_INBOX.telegram-adapter.>"],
+    },
+}
+
+
+def test_audit_multiple_drifts() -> None:
+    findings = audit_matrix_inbox_drift(_MULTI_DRIFT)
+    assert len(findings) == 2
+    identities_found = {(f[0], f[2]) for f in findings}
+    assert ("hub", "publish") in identities_found
+    assert ("discord-adapter", "subscribe") in identities_found
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke — real acl-matrix.json must return [] (V3 narrowed)
+# ---------------------------------------------------------------------------
+
+_MATRIX_PATH = Path(__file__).parents[2] / "deploy" / "nats" / "acl-matrix.json"
+
+
+def test_real_matrix_has_no_drift() -> None:
+    """Acceptance criterion: the committed matrix is free of bare _INBOX.> for
+    all lyra-owned identities.  Failing this test means a regression was
+    introduced into deploy/nats/acl-matrix.json."""
+    if not _MATRIX_PATH.exists():
+        pytest.skip(f"matrix file not found: {_MATRIX_PATH}")
+    identities = _load_matrix(_MATRIX_PATH)
+    findings = audit_matrix_inbox_drift(identities)
+    assert findings == [], (
+        f"Residual bare _INBOX.> grants in acl-matrix.json: {findings}"
+    )


### PR DESCRIPTION
## Summary
- Pass `inbox_prefix="_INBOX.<identity>"` at every lyra-owned `nats_connect` call site (hub standalone, embedded NATS hub path, adapter standalone) so every ephemeral inbox nats-py creates lands under `_INBOX.<identity>.<nuid>`.
- Narrow `deploy/nats/acl-matrix.json` subscribe grants for `hub`, `telegram-adapter`, `discord-adapter`, `tts-adapter`, `stt-adapter` from `_INBOX.>` to `_INBOX.<identity>.>` (lowercase `_inbox.<identity>.>` where previously present). Retires the bus-wide wildcard for lyra-owned identities.
- Add `src/lyra/ops_audit.py` with `audit_matrix_inbox_drift` + `emit_drift_report`. `lyra ops verify` now flags residual `_INBOX.>` / `_inbox.>` on lyra-owned identities as drift and contributes to a non-zero exit code.
- Update spec #706 data model + footnote `[^inbox-fix]` to reflect the ADR-051 mechanism. Supersedes #717.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#715](https://github.com/Roxabi/lyra/issues/715): per-identity NATS inbox prefix | OPEN |
| Frame | [artifacts/frames/715-per-identity-nats-inbox-prefix-frame.mdx](artifacts/frames/715-per-identity-nats-inbox-prefix-frame.mdx) | approved |
| Spec | [artifacts/specs/715-per-identity-nats-inbox-prefix-spec.mdx](artifacts/specs/715-per-identity-nats-inbox-prefix-spec.mdx) | approved |
| Plan | [artifacts/plans/715-per-identity-nats-inbox-prefix-plan.mdx](artifacts/plans/715-per-identity-nats-inbox-prefix-plan.mdx) | approved |
| ADR | [docs/architecture/adr/051-per-identity-nats-inbox-prefix.mdx](docs/architecture/adr/051-per-identity-nats-inbox-prefix.mdx) | Accepted |
| Implementation | 3 commits on `feat/715-per-identity-nats-inbox-prefix` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (7 new) | Passed |

## Scope boundary (deliberate)

Only **lyra-owned** identities (hub + 4 adapters) are narrowed here. Satellite rows (`voice-tts`, `voice-stt`, `image-worker`) are **unchanged** — each is owned by its satellite repo per ADR-047 and must update its own `nats_connect` call site **before** the matching ACL row is narrowed, to avoid an auth-denial window on the requester side. Sequencing is: per-satellite connect-site PR → this PR (already the case here) → follow-up PR narrows each satellite row → regen `auth.conf` + reload NATS.

## Test Plan
- [ ] `uv run pytest tests/nats/ tests/llm/drivers/` — green locally (6 new drift tests + 2 connect-site kwarg tests + 1 driver prefix test).
- [ ] `bash tests/nats/test_gen_nkeys_acls.sh` — regen assertions pass for lyra-owned rows; satellite guard still passes.
- [ ] **Manual on M1** — required before merge for SC-9/SC-10/SC-11:
  1. Check out this branch on M1.
  2. `sudo ./deploy/nats/gen-nkeys.sh --regen-authconf`
  3. `sudo systemctl reload nats`
  4. With the hub seed, attempt `nats sub '_INBOX.>'` — expect `Subscription Violation` in `journalctl -u nats`.
  5. Save command sequence, reload timestamp, captured deny log line to `rollout-evidence.txt` at repo root (amend onto this branch via a new commit).
  6. `uv run lyra ops verify` — should report 0 drift findings for lyra-owned identities (satellite rows unflagged because they are satellite identities, excluded by design).

## Out of scope

- Satellite connect-site updates (voiceCLI, imageCLI) — per-satellite PRs per ADR-047.
- JetStream migration for LLM streaming — ADR-051 §Options Considered §Option A.

Closes #715
Supersedes #717

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`