### PR TITLE
feat(contracts): add response builder helpers for NATS workers

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
@@ -6,6 +6,10 @@ re-exported here — it must be imported explicitly as
 ``from roxabi_contracts.voice.fixtures import ...``.
 """
 
+from roxabi_contracts.voice.builders import (
+    build_stt_response,
+    build_tts_response,
+)
 from roxabi_contracts.voice.models import (
     SttRequest,
     SttResponse,
@@ -25,6 +29,8 @@ __all__ = [
     "SttResponse",
     "TtsRequest",
     "TtsResponse",
+    "build_stt_response",
+    "build_tts_response",
     "per_worker_stt",
     "per_worker_tts",
     "validate_worker_id",

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/builders.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/builders.py
@@ -1,0 +1,103 @@
+"""Response builder helpers for NATS workers.
+
+Provides fail-safe construction of SttResponse and TtsResponse with
+auto-populated envelope fields (contract_version, trace_id, issued_at).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.voice.models import SttResponse, TtsResponse
+
+__all__ = ["build_stt_response", "build_tts_response"]
+
+
+def build_stt_response(  # noqa: PLR0913
+    payload: dict,
+    *,
+    ok: bool,
+    text: str | None = None,
+    language: str | None = None,
+    duration_seconds: float | None = None,
+    error: str | None = None,
+) -> str:
+    """Build a valid SttResponse JSON string with auto-populated envelope fields.
+
+    Args:
+        payload: Request payload dict (must contain 'request_id')
+        ok: Success flag
+        text: Transcribed text (required when ok=True)
+        language: Detected language (required when ok=True)
+        duration_seconds: Audio duration (required when ok=True)
+        error: Error message (set when ok=False)
+
+    Returns:
+        JSON string of SttResponse
+
+    Raises:
+        KeyError: If 'request_id' is missing from payload
+    """
+    request_id = payload["request_id"]
+    trace_id = payload.get("trace_id") or request_id
+    issued_at = datetime.now(timezone.utc)
+
+    response = SttResponse(
+        contract_version=CONTRACT_VERSION,
+        trace_id=trace_id,
+        issued_at=issued_at,
+        ok=ok,
+        request_id=request_id,
+        text=text,
+        language=language,
+        duration_seconds=duration_seconds,
+        error=error,
+    )
+    return response.model_dump_json()
+
+
+def build_tts_response(  # noqa: PLR0913
+    payload: dict,
+    *,
+    ok: bool,
+    audio_b64: str | None = None,
+    mime_type: str | None = None,
+    duration_ms: int | None = None,
+    error: str | None = None,
+    waveform_b64: str | None = None,
+) -> str:
+    """Build a valid TtsResponse JSON string with auto-populated envelope fields.
+
+    Args:
+        payload: Request payload dict (must contain 'request_id')
+        ok: Success flag
+        audio_b64: Base64-encoded audio (required when ok=True)
+        mime_type: Audio MIME type (required when ok=True)
+        duration_ms: Audio duration in ms (required when ok=True)
+        error: Error message (set when ok=False)
+        waveform_b64: Optional waveform visualization
+
+    Returns:
+        JSON string of TtsResponse
+
+    Raises:
+        KeyError: If 'request_id' is missing from payload
+    """
+    request_id = payload["request_id"]
+    trace_id = payload.get("trace_id") or request_id
+    issued_at = datetime.now(timezone.utc)
+
+    response = TtsResponse(
+        contract_version=CONTRACT_VERSION,
+        trace_id=trace_id,
+        issued_at=issued_at,
+        ok=ok,
+        request_id=request_id,
+        audio_b64=audio_b64,
+        mime_type=mime_type,
+        duration_ms=duration_ms,
+        error=error,
+        waveform_b64=waveform_b64,
+    )
+    return response.model_dump_json()

--- a/packages/roxabi-contracts/tests/test_voice_builders.py
+++ b/packages/roxabi-contracts/tests/test_voice_builders.py
@@ -1,7 +1,10 @@
 """Tests for response builder helpers."""
 
+import json
+
 import pytest
 
+from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.voice import build_stt_response, build_tts_response
 
 # === STT Builder Tests ===
@@ -25,7 +28,7 @@ def test_build_stt_response_success():
     data = json.loads(json_str)
 
     # Envelope fields
-    assert data["contract_version"] == "1"
+    assert data["contract_version"] == CONTRACT_VERSION
     assert data["trace_id"] == "trace-abc"
     assert "issued_at" in data
 
@@ -74,7 +77,7 @@ def test_build_tts_response_success():
     data = json.loads(json_str)
 
     # Envelope fields
-    assert data["contract_version"] == "1"
+    assert data["contract_version"] == CONTRACT_VERSION
     assert data["trace_id"] == "req-789"  # Falls back to request_id
     assert "issued_at" in data
 
@@ -170,3 +173,22 @@ def test_missing_request_id_raises_keyerror_tts():
             mime_type="audio/wav",
             duration_ms=1000,
         )
+
+
+def test_build_tts_response_success_with_waveform():
+    """TTS builder passes through optional waveform_b64 field."""
+    payload = {"request_id": "req-wave"}
+
+    json_str = build_tts_response(
+        payload,
+        ok=True,
+        audio_b64="base64encodedaudio",
+        mime_type="audio/wav",
+        duration_ms=1500,
+        waveform_b64="base64encodedwaveform",
+    )
+
+    data = json.loads(json_str)
+
+    assert data["ok"] is True
+    assert data["waveform_b64"] == "base64encodedwaveform"

--- a/packages/roxabi-contracts/tests/test_voice_builders.py
+++ b/packages/roxabi-contracts/tests/test_voice_builders.py
@@ -1,0 +1,172 @@
+"""Tests for response builder helpers."""
+
+import pytest
+
+from roxabi_contracts.voice import build_stt_response, build_tts_response
+
+# === STT Builder Tests ===
+
+
+def test_build_stt_response_success():
+    """STT builder returns valid JSON with all envelope fields for success case."""
+    payload = {"request_id": "req-123", "trace_id": "trace-abc"}
+
+    json_str = build_stt_response(
+        payload,
+        ok=True,
+        text="Hello world",
+        language="en",
+        duration_seconds=2.5,
+    )
+
+    # Parse and verify
+    import json
+
+    data = json.loads(json_str)
+
+    # Envelope fields
+    assert data["contract_version"] == "1"
+    assert data["trace_id"] == "trace-abc"
+    assert "issued_at" in data
+
+    # Response fields
+    assert data["ok"] is True
+    assert data["request_id"] == "req-123"
+    assert data["text"] == "Hello world"
+    assert data["language"] == "en"
+    assert data["duration_seconds"] == 2.5
+    assert data.get("error") is None
+
+
+def test_build_stt_response_error():
+    """STT builder returns valid JSON for error case."""
+    payload = {"request_id": "req-456"}
+
+    json_str = build_stt_response(
+        payload,
+        ok=False,
+        error="Transcription failed",
+    )
+
+    import json
+
+    data = json.loads(json_str)
+
+    assert data["ok"] is False
+    assert data["error"] == "Transcription failed"
+    assert data.get("text") is None
+
+
+def test_build_tts_response_success():
+    """TTS builder returns valid JSON with all envelope fields for success case."""
+    payload = {"request_id": "req-789"}
+
+    json_str = build_tts_response(
+        payload,
+        ok=True,
+        audio_b64="base64encodedaudio",
+        mime_type="audio/wav",
+        duration_ms=1500,
+    )
+
+    import json
+
+    data = json.loads(json_str)
+
+    # Envelope fields
+    assert data["contract_version"] == "1"
+    assert data["trace_id"] == "req-789"  # Falls back to request_id
+    assert "issued_at" in data
+
+    # Response fields
+    assert data["ok"] is True
+    assert data["request_id"] == "req-789"
+    assert data["audio_b64"] == "base64encodedaudio"
+    assert data["mime_type"] == "audio/wav"
+    assert data["duration_ms"] == 1500
+    assert data.get("error") is None
+
+
+def test_build_tts_response_error():
+    """TTS builder returns valid JSON for error case."""
+    payload = {"request_id": "req-error"}
+
+    json_str = build_tts_response(
+        payload,
+        ok=False,
+        error="Synthesis failed",
+    )
+
+    import json
+
+    data = json.loads(json_str)
+
+    assert data["ok"] is False
+    assert data["error"] == "Synthesis failed"
+    assert data.get("audio_b64") is None
+
+
+def test_trace_id_fallback():
+    """trace_id falls back to request_id when not in payload."""
+    payload = {"request_id": "req-fallback"}  # No trace_id
+
+    json_str = build_stt_response(
+        payload,
+        ok=True,
+        text="test",
+        language="en",
+        duration_seconds=1.0,
+    )
+
+    import json
+
+    data = json.loads(json_str)
+
+    assert data["trace_id"] == "req-fallback"
+
+
+def test_trace_id_preserved_when_present():
+    """Explicit trace_id is preserved when present in payload."""
+    payload = {"request_id": "req-123", "trace_id": "explicit-trace"}
+
+    json_str = build_stt_response(
+        payload,
+        ok=True,
+        text="test",
+        language="en",
+        duration_seconds=1.0,
+    )
+
+    import json
+
+    data = json.loads(json_str)
+
+    assert data["trace_id"] == "explicit-trace"
+
+
+def test_missing_request_id_raises_keyerror():
+    """Missing request_id raises KeyError for STT builder."""
+    payload = {"trace_id": "no-request-id"}
+
+    with pytest.raises(KeyError):
+        build_stt_response(
+            payload,
+            ok=True,
+            text="test",
+            language="en",
+            duration_seconds=1.0,
+        )
+
+
+def test_missing_request_id_raises_keyerror_tts():
+    """Missing request_id raises KeyError for TTS builder."""
+    payload = {"trace_id": "no-request-id"}
+
+    with pytest.raises(KeyError):
+        build_tts_response(
+            payload,
+            ok=True,
+            audio_b64="test",
+            mime_type="audio/wav",
+            duration_ms=1000,
+        )


### PR DESCRIPTION
## Summary
- Add `build_stt_response()` and `build_tts_response()` helper functions to `roxabi-contracts/voice/builders.py`
- Auto-populate required envelope fields (`contract_version`, `trace_id`, `issued_at`) with `trace_id` fallback to `request_id`
- Export builders from `roxabi_contracts.voice.__init__`
- Add 8 unit tests covering success, error, and edge cases

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #896: feat(contracts): add response builder helper | Open |
| Frame | [896-response-builder-frame.mdx](artifacts/frames/896-response-builder-frame.mdx) | Approved |
| Spec | [896-response-builder-spec.mdx](artifacts/specs/896-response-builder-spec.mdx) | Approved |
| Plan | [896-response-builder-plan.mdx](artifacts/plans/896-response-builder-plan.mdx) | Complete |
| Implementation | 1 commit on `feat/896-response-builder` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (8 new) | Passed |

## Test Plan
- [ ] Verify imports work: `from roxabi_contracts.voice import build_stt_response, build_tts_response`
- [ ] Run tests: `uv run pytest packages/roxabi-contracts/tests/test_voice_builders.py -v`
- [ ] Test trace_id fallback: payload without `trace_id` uses `request_id`
- [ ] Test missing `request_id` raises `KeyError`

Closes #896

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`