### PR TITLE
refactor(nats): transcribe() takes bytes not Path (#852)

### DIFF
--- a/src/lyra/agents/simple_agent_prompts.py
+++ b/src/lyra/agents/simple_agent_prompts.py
@@ -7,6 +7,7 @@ Provides helper functions for constructing LLM prompt text from user messages.
 
 from __future__ import annotations
 
+import asyncio
 import html
 import logging
 from pathlib import Path
@@ -78,10 +79,12 @@ async def _build_audio_text(
     Raises:
         STTError: If transcription fails
     """
-    from lyra.stt import is_whisper_noise
+    from lyra.stt import is_whisper_noise, mime_from_suffix
 
     try:
-        stt_result: TranscriptionResult = await stt.transcribe(tmp_path)
+        audio_bytes = await asyncio.to_thread(tmp_path.read_bytes)
+        mime = mime_from_suffix(tmp_path.suffix)
+        stt_result: TranscriptionResult = await stt.transcribe(audio_bytes, mime)
     except Exception as exc:
         raise STTError(str(exc)) from exc
     finally:

--- a/src/lyra/core/hub/middleware/middleware_stt.py
+++ b/src/lyra/core/hub/middleware/middleware_stt.py
@@ -15,9 +15,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import os
-import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...messaging.message import InboundMessage, Response
@@ -37,14 +34,6 @@ _STT_STAGE_OUTCOMES: dict[str, int] = {
     "noise": 0,
     "invalid": 0,
     "failed": 0,
-}
-
-_MIME_TO_EXT: dict[str, str] = {
-    "audio/ogg": ".ogg",
-    "audio/mpeg": ".mp3",
-    "audio/mp4": ".m4a",
-    "audio/wav": ".wav",
-    "audio/webm": ".webm",
 }
 
 
@@ -110,29 +99,10 @@ class SttMiddleware:
         timeout_s = getattr(hub._stt, "timeout_ms", 30000) / 1000.0
         if msg.audio is None:  # guaranteed by modality == "voice", guard for -O safety
             return _DROP
-        suffix = _MIME_TO_EXT.get(msg.audio.mime_type, ".ogg")
-
-        def _write_temp(data: bytes, ext: str) -> str:
-            fd, path = tempfile.mkstemp(suffix=ext)
-            try:
-                os.write(fd, data)
-            except BaseException:
-                os.close(fd)
-                Path(path).unlink(missing_ok=True)
-                raise
-            os.close(fd)
-            return path
-
-        tmp_path_str = await asyncio.to_thread(
-            _write_temp,
-            msg.audio.audio_bytes,
-            suffix,
-        )
-        tmp_path = Path(tmp_path_str)
 
         try:
             result = await asyncio.wait_for(
-                hub._stt.transcribe(tmp_path),
+                hub._stt.transcribe(msg.audio.audio_bytes, msg.audio.mime_type),
                 timeout=timeout_s,
             )
         except asyncio.TimeoutError:
@@ -157,8 +127,6 @@ class SttMiddleware:
             await self._dispatch_error(hub, msg, "stt_failed")
             _STT_STAGE_OUTCOMES["failed"] += 1
             return _DROP
-        finally:
-            tmp_path.unlink(missing_ok=True)
 
         # 5. Post-transcription guards (noise filtering is owned by the STT adapter).
         transcript = result.text.strip()

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -8,13 +8,11 @@ NoRespondersError, marking stale workers and trying the next candidate.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 import logging
 import os
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import NoReturn
 from uuid import uuid4
 
@@ -187,20 +185,17 @@ class NatsSttClient:
         self._cb.record_failure()
         raise STTUnavailableError("STT: all workers unresponsive") from last_exc
 
-    async def transcribe(self, path: Path | str) -> TranscriptionResult:
+    async def transcribe(self, audio: bytes, mime: str) -> TranscriptionResult:
         if self._cb.is_open():
             raise STTUnavailableError(
                 "STT circuit open — adapter temporarily unavailable"
             )
-        resolved = Path(path).resolve()
-        audio_bytes = await asyncio.to_thread(resolved.read_bytes)
-        mime = _mime_from_suffix(resolved.suffix)
         request = SttRequest(
             contract_version=CONTRACT_VERSION,
             trace_id=str(uuid4()),
             issued_at=datetime.now(timezone.utc),
             request_id=str(uuid4()),
-            audio_b64=base64.b64encode(audio_bytes).decode("ascii"),
+            audio_b64=base64.b64encode(audio).decode("ascii"),
             mime_type=mime,
             model=self._model,
             language_detection_threshold=self._detection_threshold,
@@ -255,13 +250,3 @@ class NatsSttClient:
         raise STTUnavailableError("STT adapter unreachable") from exc
 
 
-def _mime_from_suffix(suffix: str) -> str:
-    return {
-        ".ogg": "audio/ogg",
-        ".mp3": "audio/mpeg",
-        ".wav": "audio/wav",
-        ".m4a": "audio/mp4",
-        ".webm": "audio/webm",
-        ".flac": "audio/flac",
-        ".opus": "audio/ogg",
-    }.get(suffix.lower(), "audio/ogg")

--- a/src/lyra/stt/__init__.py
+++ b/src/lyra/stt/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel
@@ -20,12 +19,13 @@ __all__ = [
     "STTConfig",
     "load_stt_config",
     "is_whisper_noise",
+    "mime_from_suffix",
 ]
 
 
 @runtime_checkable
 class STTProtocol(Protocol):
-    async def transcribe(self, path: Path | str) -> "TranscriptionResult": ...
+    async def transcribe(self, audio: bytes, mime: str) -> "TranscriptionResult": ...
 
 
 class STTUnavailableError(Exception):
@@ -66,3 +66,21 @@ def is_whisper_noise(text: str) -> bool:
     """Return True if the text is empty or a known Whisper noise token."""
     stripped = text.strip().lower()
     return not stripped or stripped in WHISPER_NOISE_TOKENS
+
+
+def mime_from_suffix(suffix: str) -> str:
+    """Map a file extension (with leading dot) to its audio MIME type.
+
+    Relocated from lyra.nats.nats_stt_client — callers that receive audio as
+    a file path (e.g. attachment handlers) use this to derive the MIME type
+    before calling STTProtocol.transcribe(audio, mime).
+    """
+    return {
+        ".ogg": "audio/ogg",
+        ".mp3": "audio/mpeg",
+        ".wav": "audio/wav",
+        ".m4a": "audio/mp4",
+        ".webm": "audio/webm",
+        ".flac": "audio/flac",
+        ".opus": "audio/ogg",
+    }.get(suffix.lower(), "audio/ogg")

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -756,7 +756,7 @@ class FakeSTT:
     def __init__(self, text: str = "Hello world") -> None:
         self._text = text
 
-    async def transcribe(self, path):
+    async def transcribe(self, audio, mime):
         return FakeTranscription(text=self._text)
 
 

--- a/tests/core/hub/test_message_pipeline_stt.py
+++ b/tests/core/hub/test_message_pipeline_stt.py
@@ -45,7 +45,7 @@ class FakeSTT:
         self._text = text
         self.timeout_ms = timeout_ms
 
-    async def transcribe(self, path: Any) -> FakeTranscription:
+    async def transcribe(self, audio: Any, mime: Any) -> FakeTranscription:
         return FakeTranscription(text=self._text)
 
 
@@ -57,7 +57,7 @@ class SlowSTT:
     def __init__(self, shutdown_event: asyncio.Event | None = None) -> None:
         self._shutdown = shutdown_event if shutdown_event else asyncio.Event()
 
-    async def transcribe(self, path: Any) -> FakeTranscription:
+    async def transcribe(self, audio: Any, mime: Any) -> FakeTranscription:
         await self._shutdown.wait()  # explicit: never completes in test
         return FakeTranscription(text="never")
 
@@ -67,7 +67,7 @@ class NoisySTT:
 
     timeout_ms: int = 30000
 
-    async def transcribe(self, path: Any) -> FakeTranscription:
+    async def transcribe(self, audio: Any, mime: Any) -> FakeTranscription:
         from lyra.stt import STTNoiseError
 
         raise STTNoiseError("Noise transcript: ''")
@@ -78,7 +78,7 @@ class UnavailableSTT:
 
     timeout_ms: int = 30000
 
-    async def transcribe(self, path: Any) -> FakeTranscription:
+    async def transcribe(self, audio: Any, mime: Any) -> FakeTranscription:
         from lyra.stt import STTUnavailableError
 
         raise STTUnavailableError("model not loaded")
@@ -89,7 +89,7 @@ class ExplodingSTT:
 
     timeout_ms: int = 30000
 
-    async def transcribe(self, path: Any) -> FakeTranscription:
+    async def transcribe(self, audio: Any, mime: Any) -> FakeTranscription:
         raise RuntimeError("GPU exploded")
 
 

--- a/tests/fixtures/fake_drivers.py
+++ b/tests/fixtures/fake_drivers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 from lyra.core.agent.agent_config import ModelConfig
@@ -65,18 +64,14 @@ class FakeStt:
     preset_transcript: str = "Hello world"
     called: bool = False
     last_audio: bytes = field(default_factory=bytes)
-    last_path: Path | str | None = None
+    last_mime: str = ""
     raise_on_transcribe: Exception | None = None
 
-    async def transcribe(self, path: Path | str) -> TranscriptionResult:
+    async def transcribe(self, audio: bytes, mime: str) -> TranscriptionResult:
         """Return preset transcript or raise if configured."""
         self.called = True
-        self.last_path = path
-
-        try:
-            self.last_audio = Path(path).read_bytes()
-        except Exception:
-            self.last_audio = b""
+        self.last_audio = audio
+        self.last_mime = mime
 
         if self.raise_on_transcribe:
             raise self.raise_on_transcribe

--- a/tests/fixtures/test_fake_drivers.py
+++ b/tests/fixtures/test_fake_drivers.py
@@ -1,7 +1,5 @@
 """Tests for fake TTS/STT/LLM drivers."""
 
-from pathlib import Path
-
 import pytest
 from tests.fixtures.fake_drivers import (
     FakeClaudeCliDriver,
@@ -107,7 +105,7 @@ class TestFakeStt:
         """Should return configured preset transcript."""
         stt = FakeStt(preset_transcript="Custom transcript")
 
-        result = await stt.transcribe("/fake/audio.wav")
+        result = await stt.transcribe(b"fake audio", "audio/wav")
 
         assert isinstance(result, TranscriptionResult)
         assert result.text == "Custom transcript"
@@ -115,41 +113,32 @@ class TestFakeStt:
 
     @pytest.mark.asyncio
     async def test_fake_stt_records_call(self) -> None:
-        """Should record the path from transcribe call."""
+        """Should record audio and mime from transcribe call."""
         stt = FakeStt()
 
-        await stt.transcribe("/path/to/audio.wav")
+        await stt.transcribe(b"audio data", "audio/wav")
 
         assert stt.called is True
-        assert stt.last_path == "/path/to/audio.wav"
+        assert stt.last_audio == b"audio data"
+        assert stt.last_mime == "audio/wav"
 
     @pytest.mark.asyncio
     async def test_fake_stt_records_audio_bytes(self) -> None:
-        """Should record audio bytes from file path."""
-        import tempfile
-
+        """Should record audio bytes passed directly."""
         stt = FakeStt()
 
-        # Create a temp file with fake audio bytes
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(b"fake audio data here")
-            temp_path = f.name
+        await stt.transcribe(b"fake audio data here", "audio/wav")
 
-        try:
-            await stt.transcribe(temp_path)
-
-            assert stt.last_audio == b"fake audio data here"
-        finally:
-            Path(temp_path).unlink(missing_ok=True)
+        assert stt.last_audio == b"fake audio data here"
 
     @pytest.mark.asyncio
-    async def test_fake_stt_handles_missing_file(self) -> None:
-        """Should handle missing file gracefully (empty bytes)."""
+    async def test_fake_stt_records_mime(self) -> None:
+        """Should record the mime type passed to transcribe."""
         stt = FakeStt()
 
-        await stt.transcribe("/nonexistent/audio.wav")
+        await stt.transcribe(b"\x00" * 16, "audio/ogg")
 
-        assert stt.last_audio == b""  # Graceful fallback
+        assert stt.last_mime == "audio/ogg"
 
     @pytest.mark.asyncio
     async def test_fake_stt_raises_when_configured(self) -> None:
@@ -157,19 +146,19 @@ class TestFakeStt:
         stt = FakeStt(raise_on_transcribe=RuntimeError("STT unavailable"))
 
         with pytest.raises(RuntimeError, match="STT unavailable"):
-            await stt.transcribe("/fake/audio.wav")
+            await stt.transcribe(b"fake audio", "audio/wav")
 
         assert stt.called is True  # Call was recorded before raise
 
     @pytest.mark.asyncio
-    async def test_fake_stt_accepts_path_object(self) -> None:
-        """Should accept Path object as argument."""
-        stt = FakeStt(preset_transcript="Path test")
+    async def test_fake_stt_accepts_various_mime_types(self) -> None:
+        """Should accept any mime type string."""
+        stt = FakeStt(preset_transcript="mime test")
 
-        result = await stt.transcribe(Path("/some/audio.wav"))
+        result = await stt.transcribe(b"ogg data", "audio/ogg")
 
-        assert result.text == "Path test"
-        assert stt.last_path == Path("/some/audio.wav")
+        assert result.text == "mime test"
+        assert stt.last_mime == "audio/ogg"
 
 
 class TestFakeClaudeCliDriver:

--- a/tests/integration/test_voice_end_to_end.py
+++ b/tests/integration/test_voice_end_to_end.py
@@ -91,7 +91,7 @@ class _FakeSTT:
     def __init__(self, transcript: str = _FIXED_TRANSCRIPT) -> None:
         self._transcript = transcript
 
-    async def transcribe(self, path: Any) -> _FakeTranscription:
+    async def transcribe(self, audio: Any, mime: Any) -> _FakeTranscription:
         return _FakeTranscription(text=self._transcript, language="en")
 
 
@@ -251,7 +251,7 @@ class TestSlice2VoiceMessageReachesSTTMiddleware:
         class _TimeoutSTT:
             timeout_ms: int = 30000
 
-            async def transcribe(self, path: Any) -> None:
+            async def transcribe(self, audio: Any, mime: Any) -> None:
                 raise asyncio.TimeoutError
 
         hub = _make_hub_mock(stt=_TimeoutSTT())

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import time
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -12,6 +11,14 @@ import pytest
 from lyra.nats.nats_stt_client import NatsSttClient
 from lyra.nats.worker_registry import WorkerStats
 from lyra.stt import STTNoiseError, STTUnavailableError
+
+# Minimal WAV bytes fixture — just enough to be non-empty audio data
+WAV_BYTES = b"RIFF$\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x00\x00"
+
+
+@pytest.fixture()
+def wav_bytes() -> bytes:
+    return WAV_BYTES
 
 
 @pytest.fixture()
@@ -112,66 +119,58 @@ def _seed_worker_with_age(client: NatsSttClient, worker_id: str, age_s: float) -
 
 class TestCircuitBreaker:
     @pytest.mark.asyncio
-    async def test_cb_open_blocks_call(self, tmp_path: Path) -> None:
+    async def test_cb_open_blocks_call(self, wav_bytes: bytes) -> None:
         # Arrange — circuit manually forced open
         mock_nc = AsyncMock()
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
         client._cb._open_until = time.monotonic() + 100.0
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"")
         # Act / Assert
         with pytest.raises(STTUnavailableError, match="circuit open"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         mock_nc.request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_failure_records_on_timeout(self, tmp_path: Path) -> None:
+    async def test_failure_records_on_timeout(self, wav_bytes: bytes) -> None:
         # Arrange
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=TimeoutError())
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         # Act
         with pytest.raises(STTUnavailableError):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         # Assert
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
-    async def test_failure_records_on_unreachable(self, tmp_path: Path) -> None:
+    async def test_failure_records_on_unreachable(self, wav_bytes: bytes) -> None:
         # Arrange
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=Exception("NATS error"))
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         # Act
         with pytest.raises(STTUnavailableError):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         # Assert
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
-    async def test_failure_records_on_max_payload(self, tmp_path: Path) -> None:
+    async def test_failure_records_on_max_payload(self, wav_bytes: bytes) -> None:
         # Arrange
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=Exception("NATS: max_payload exceeded"))
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         # Act
         with pytest.raises(STTUnavailableError, match="payload too large"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         # Assert
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
-    async def test_success_clears_failures(self, tmp_path: Path) -> None:
+    async def test_success_clears_failures(self, wav_bytes: bytes) -> None:
         # Arrange — pre-inject 2 failures
         mock_nc = AsyncMock()
         success_payload = json.dumps(
@@ -192,10 +191,8 @@ class TestCircuitBreaker:
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
         client._cb._failures = 2
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         # Act
-        result = await client.transcribe(wav_file)
+        result = await client.transcribe(wav_bytes, "audio/wav")
         # Assert
         assert result.text == "hello"
         assert client._cb._failures == 0
@@ -205,7 +202,9 @@ class TestContractVersion:
     """Tests for the `contract_version` additive field (ADR-044)."""
 
     @pytest.mark.asyncio
-    async def test_request_payload_emits_contract_version(self, tmp_path: Path) -> None:
+    async def test_request_payload_emits_contract_version(
+        self, wav_bytes: bytes
+    ) -> None:
         """NatsSttClient.transcribe() stamps contract_version='1' on the request."""
         mock_nc = AsyncMock()
         success_payload = json.dumps(
@@ -225,10 +224,8 @@ class TestContractVersion:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
 
-        await client.transcribe(wav_file)
+        await client.transcribe(wav_bytes, "audio/wav")
 
         payload_bytes = mock_nc.request.call_args.args[1]
         request_dict = json.loads(payload_bytes)
@@ -236,7 +233,7 @@ class TestContractVersion:
 
     @pytest.mark.asyncio
     async def test_reply_with_unknown_contract_version_is_tolerated(
-        self, tmp_path: Path
+        self, wav_bytes: bytes
     ) -> None:
         """Hub ignores unknown contract_version values on reply (defensive read)."""
         mock_nc = AsyncMock()
@@ -258,10 +255,8 @@ class TestContractVersion:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
 
-        result = await client.transcribe(wav_file)
+        result = await client.transcribe(wav_bytes, "audio/wav")
 
         assert result.text == "future"
         assert result.language == "en"
@@ -315,30 +310,26 @@ class TestSttClientFreshness:
     """Tests for freshness tracking gate in NatsSttClient."""
 
     @pytest.mark.asyncio
-    async def test_no_workers_ever_raises_unavailable(self, tmp_path: Path) -> None:
+    async def test_no_workers_ever_raises_unavailable(self, wav_bytes: bytes) -> None:
         """transcribe() raises STTUnavailableError when _worker_freshness is empty."""
         mock_nc = AsyncMock()
         client = NatsSttClient(nc=mock_nc)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         with pytest.raises(STTUnavailableError, match="no live worker"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         mock_nc.request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_stale_worker_raises_unavailable(self, tmp_path: Path) -> None:
+    async def test_stale_worker_raises_unavailable(self, wav_bytes: bytes) -> None:
         """transcribe() raises STTUnavailableError when last heartbeat was >15s ago."""
         mock_nc = AsyncMock()
         client = NatsSttClient(nc=mock_nc)
         _seed_worker_with_age(client, "worker-1", 20.0)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         with pytest.raises(STTUnavailableError, match="no live worker"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         mock_nc.request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_fresh_worker_proceeds_to_request(self, tmp_path: Path) -> None:
+    async def test_fresh_worker_proceeds_to_request(self, wav_bytes: bytes) -> None:
         """transcribe() proceeds past freshness gate when a worker is fresh (<15s)."""
         mock_nc = AsyncMock()
         success_payload = json.dumps(
@@ -358,26 +349,24 @@ class TestSttClientFreshness:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
         _seed_worker_with_age(client, "worker-1", 5.0)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
-        result = await client.transcribe(wav_file)
+        result = await client.transcribe(wav_bytes, "audio/wav")
         assert result.text == "hello world"
         mock_nc.request.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_freshness_gate_before_circuit_breaker(self, tmp_path: Path) -> None:
+    async def test_freshness_gate_before_circuit_breaker(
+        self, wav_bytes: bytes
+    ) -> None:
         """STTUnavailableError from freshness gate does NOT trip circuit breaker."""
         mock_nc = AsyncMock()
         client = NatsSttClient(nc=mock_nc)
         # _worker_freshness is empty — freshness gate fires first
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         with pytest.raises(STTUnavailableError, match="no live worker"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         assert client._cb._failures == 0
 
     @pytest.mark.asyncio
-    async def test_heartbeat_resumes_reenables_worker(self, tmp_path: Path) -> None:
+    async def test_heartbeat_resumes_reenables_worker(self, wav_bytes: bytes) -> None:
         """After stale, a new heartbeat re-enables the worker immediately."""
         mock_nc = AsyncMock()
         success_payload = json.dumps(
@@ -398,13 +387,11 @@ class TestSttClientFreshness:
         client = NatsSttClient(nc=mock_nc)
         # First: stale
         _seed_worker_with_age(client, "worker-1", 20.0)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         with pytest.raises(STTUnavailableError, match="no live worker"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         # Simulate fresh heartbeat arrives
         _seed_worker_with_age(client, "worker-1", 0.0)
-        result = await client.transcribe(wav_file)
+        result = await client.transcribe(wav_bytes, "audio/wav")
         assert result.text == "resumed"
 
     # NOTE: registry-level aliveness / pruning semantics are covered by
@@ -420,7 +407,7 @@ class TestTranscribeResponseParsing:
     """
 
     @pytest.mark.asyncio
-    async def test_ok_false_raises_unavailable(self, tmp_path: Path) -> None:
+    async def test_ok_false_raises_unavailable(self, wav_bytes: bytes) -> None:
         # Arrange
         mock_nc = AsyncMock()
         error_payload = json.dumps(
@@ -437,16 +424,14 @@ class TestTranscribeResponseParsing:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         # Act / Assert
         with pytest.raises(STTUnavailableError, match="transcription failed"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
     async def test_ok_false_with_error_field_forwards_message(
-        self, tmp_path: Path
+        self, wav_bytes: bytes
     ) -> None:
         """ok=False with a populated `error` field must surface the error string
         in the STTUnavailableError message (not the default "transcription failed")."""
@@ -466,15 +451,13 @@ class TestTranscribeResponseParsing:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
 
         with pytest.raises(STTUnavailableError, match="cuda oom"):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         assert client._cb._failures == 1
 
     @pytest.mark.asyncio
-    async def test_noise_transcript_raises_noise_error(self, tmp_path: Path) -> None:
+    async def test_noise_transcript_raises_noise_error(self, wav_bytes: bytes) -> None:
         # Arrange — Whisper returns a known noise token
         mock_nc = AsyncMock()
         noise_payload = json.dumps(
@@ -494,11 +477,9 @@ class TestTranscribeResponseParsing:
         mock_nc.request = AsyncMock(return_value=fake_reply)
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client)
-        wav_file = tmp_path / "test.wav"
-        wav_file.write_bytes(b"\x00" * 64)
         # Act / Assert
         with pytest.raises(STTNoiseError):
-            await client.transcribe(wav_file)
+            await client.transcribe(wav_bytes, "audio/wav")
         # Noise is NOT a CB failure — record_success() runs before the noise check
         assert client._cb._failures == 0
 
@@ -526,32 +507,30 @@ class TestLoadAwareRouting:
 
     @pytest.mark.asyncio
     async def test_single_worker_targets_per_worker_subject(
-        self, tmp_path: Path
+        self, wav_bytes: bytes
     ) -> None:
         """With one worker alive, transcribe() targets ``<SUBJECT>.<worker_id>``."""
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(return_value=self._ok_reply())
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client, "stt-tower-01")
-        wav = tmp_path / "a.wav"
-        wav.write_bytes(b"\x00" * 16)
-        await client.transcribe(wav)
+        await client.transcribe(wav_bytes, "audio/wav")
         subject = mock_nc.request.call_args.args[0]
         assert subject == "lyra.voice.stt.request.stt-tower-01"
 
     @pytest.mark.asyncio
-    async def test_empty_registry_raises_without_request(self, tmp_path: Path) -> None:
+    async def test_empty_registry_raises_without_request(
+        self, wav_bytes: bytes
+    ) -> None:
         """Empty registry → immediate STTUnavailableError, no NATS request attempted."""
         mock_nc = AsyncMock()
         client = NatsSttClient(nc=mock_nc)
-        wav = tmp_path / "a.wav"
-        wav.write_bytes(b"\x00" * 16)
         with pytest.raises(STTUnavailableError, match="no live worker"):
-            await client.transcribe(wav)
+            await client.transcribe(wav_bytes, "audio/wav")
         mock_nc.request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_picks_least_loaded_by_score(self, tmp_path: Path) -> None:
+    async def test_picks_least_loaded_by_score(self, wav_bytes: bytes) -> None:
         """Two workers: heavy VRAM one is skipped, light one receives the request."""
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(return_value=self._ok_reply())
@@ -562,14 +541,12 @@ class TestLoadAwareRouting:
         _inject_fresh_worker(
             client, "stt-light", vram_used_mb=2400, vram_total_mb=16384
         )
-        wav = tmp_path / "a.wav"
-        wav.write_bytes(b"\x00" * 16)
-        await client.transcribe(wav)
+        await client.transcribe(wav_bytes, "audio/wav")
         subject = mock_nc.request.call_args.args[0]
         assert subject == "lyra.voice.stt.request.stt-light"
 
     @pytest.mark.asyncio
-    async def test_active_requests_dominate_vram(self, tmp_path: Path) -> None:
+    async def test_active_requests_dominate_vram(self, wav_bytes: bytes) -> None:
         """A busy worker (active_requests>0) loses to an idle higher-VRAM worker."""
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(return_value=self._ok_reply())
@@ -588,14 +565,12 @@ class TestLoadAwareRouting:
             vram_total_mb=16384,
             active_requests=0,
         )
-        wav = tmp_path / "a.wav"
-        wav.write_bytes(b"\x00" * 16)
-        await client.transcribe(wav)
+        await client.transcribe(wav_bytes, "audio/wav")
         subject = mock_nc.request.call_args.args[0]
         assert subject == "lyra.voice.stt.request.stt-idle-but-fuller"
 
     @pytest.mark.asyncio
-    async def test_timeout_walks_to_second_worker(self, tmp_path: Path) -> None:
+    async def test_timeout_walks_to_second_worker(self, wav_bytes: bytes) -> None:
         """Per-worker timeout marks worker stale and walks to second worker."""
         mock_nc = AsyncMock()
         call_subjects: list[str] = []
@@ -611,9 +586,7 @@ class TestLoadAwareRouting:
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client, "stt-01")
         _inject_fresh_worker(client, "stt-02")
-        wav = tmp_path / "a.wav"
-        wav.write_bytes(b"\x00" * 16)
-        result = await client.transcribe(wav)
+        result = await client.transcribe(wav_bytes, "audio/wav")
         assert result.text == "hi"
         # First worker timed out, second succeeded
         assert call_subjects == [
@@ -627,17 +600,15 @@ class TestLoadAwareRouting:
 
     @pytest.mark.asyncio
     async def test_single_worker_timeout_raises_and_records_failure(
-        self, tmp_path: Path
+        self, wav_bytes: bytes
     ) -> None:
         """Single worker timeout -> all workers unresponsive + record failure once."""
         mock_nc = AsyncMock()
         mock_nc.request = AsyncMock(side_effect=TimeoutError())
         client = NatsSttClient(nc=mock_nc)
         _inject_fresh_worker(client, "stt-01")
-        wav = tmp_path / "a.wav"
-        wav.write_bytes(b"\x00" * 16)
         with pytest.raises(STTUnavailableError, match="all workers unresponsive"):
-            await client.transcribe(wav)
+            await client.transcribe(wav_bytes, "audio/wav")
         # Only 1 request (per-worker), no queue-group fallback
         assert mock_nc.request.await_count == 1
         assert client._cb._failures == 1
@@ -647,15 +618,12 @@ class TestMalformedReply:
     """Pydantic ValidationError on reply MUST surface as STTUnavailableError."""
 
     @pytest.mark.asyncio
-    async def test_malformed_reply_raises_domain_error(self, tmp_path: Path) -> None:
+    async def test_malformed_reply_raises_domain_error(self, wav_bytes: bytes) -> None:
         """ok=True without duration_seconds → SttResponse invariant fails →
         client must translate into STTUnavailableError and record a
         circuit-breaker failure (receive-path anti-drift guard).
         """
         # Arrange
-        audio = tmp_path / "sample.wav"
-        audio.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
-
         mock_nc = AsyncMock()
         # Reply is ok=True but missing duration_seconds — violates
         # SttResponse._enforce_success_invariant (see contracts spec #763
@@ -682,7 +650,7 @@ class TestMalformedReply:
 
         # Act / Assert
         with pytest.raises(STTUnavailableError, match="schema") as exc_info:
-            await client.transcribe(audio)
+            await client.transcribe(wav_bytes, "audio/wav")
 
         # Pin the cause chain to the _parse_reply error-boundary so a future
         # regression where ok=False handling accidentally produces a
@@ -693,13 +661,10 @@ class TestMalformedReply:
         assert client._cb._failures == initial_failures + 1
 
     @pytest.mark.asyncio
-    async def test_malformed_json_raises_domain_error(self, tmp_path: Path) -> None:
+    async def test_malformed_json_raises_domain_error(self, wav_bytes: bytes) -> None:
         """Malformed JSON bytes (not just invariant violations) must also
         surface as STTUnavailableError + CB failure — `_parse_reply` catches
         every pydantic.ValidationError, including JSON-parse errors."""
-        audio = tmp_path / "sample.wav"
-        audio.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
-
         mock_nc = AsyncMock()
         fake_reply = MagicMock()
         fake_reply.data = b"not json {"
@@ -710,7 +675,7 @@ class TestMalformedReply:
         initial_failures = client._cb._failures
 
         with pytest.raises(STTUnavailableError, match="schema") as exc_info:
-            await client.transcribe(audio)
+            await client.transcribe(wav_bytes, "audio/wav")
 
         from pydantic import ValidationError
 


### PR DESCRIPTION
## Summary
- `NatsSttClient.transcribe()` now takes `(audio: bytes, mime: str)` instead of `Path | str`, eliminating the path-traversal surface flagged in the 2026-04-22 code quality audit.
- Removes tempfile round-trip in `middleware_stt.py` (callers already hold the audio bytes in memory).
- Relocates `mime_from_suffix` helper from `nats/nats_stt_client.py` to `lyra.stt` as a public util, so the NATS SDK is free of `Path` concerns while agent callers that still receive file paths (e.g. `simple_agent_prompts._build_audio_text`) can derive mime locally.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #852: refactor(nats): transcribe() takes bytes not Path | OPEN |
| Frame | [852-transcribe-bytes-signature-frame.mdx](artifacts/frames/852-transcribe-bytes-signature-frame.mdx) | Approved |
| Spec | [852-transcribe-bytes-signature-spec.mdx](artifacts/specs/852-transcribe-bytes-signature-spec.mdx) | Present |
| Plan | [852-transcribe-bytes-signature-plan.mdx](artifacts/plans/852-transcribe-bytes-signature-plan.mdx) | Present |
| Implementation | 1 commit on `feat/852-transcribe-bytes-signature` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2897 passed, 48 pre-existing skipped) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats tests/core/hub tests/integration` — all green
- [ ] `uv run pyright` — 0 errors
- [ ] Voice note round-trip via Telegram adapter still transcribes correctly (no tempfile spilled to disk)
- [ ] `rg "Path|_mime_from_suffix" src/lyra/nats/nats_stt_client.py` — 0 matches

Closes #852

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`