### PR TITLE
fix(scripts): apply B7 pushd/popd discipline to build_image (follow-up to #910)

### DIFF
--- a/scripts/deploy-lib.sh
+++ b/scripts/deploy-lib.sh
@@ -178,7 +178,8 @@ build_image() {
     local dockerfile="${DOCKERFILE:-Dockerfile}"
     local digest_dir="$HOME/.${PROJECT}"
 
-    cd "$PROJECT_DIR"
+    pushd "$PROJECT_DIR" > /dev/null
+    trap 'popd > /dev/null 2>&1 || true' RETURN
 
     log "Tagging current image as rollback..."
     podman tag "${IMAGE}" "${IMAGE%:*}:rollback" 2>/dev/null \


### PR DESCRIPTION
## Summary
One-line correctness fix missed by PR #910 merge. Re-review flagged a bare `cd "$PROJECT_DIR"` in `build_image` that mutates the caller's `$PWD` — same anti-pattern that B7 fixed in `check_repo`. Applied the same `pushd`/`popd` + `RETURN` trap for consistency.

## Why it matters
`build_image` currently leaves the shell in `$PROJECT_DIR` after it returns. Lyra's happy path doesn't hit this (subsequent ops use absolute paths), but downstream callers of the shared lib can't assume side-effect-free PWD semantics.

## Test Plan
- [x] `bash -n scripts/deploy-lib.sh` passes
- [x] Lyra deploy path uses absolute paths after `build_image` — no regression expected
- [ ] Verify on M₁ next deploy cycle

Context: #910 re-review iteration 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)