### PR TITLE
fix(quadlet): bind-mount ~/.claude.json into lyra-hub

### DIFF
--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -37,7 +37,10 @@ Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 # claude CLI credentials — host ~/.claude is bind-mounted read-write so the
 # CLI can refresh tokens. UserNS=keep-id maps UID 1500 → host UID 1000 (mickael).
+# ~/.claude.json is a separate top-level config file the CLI looks up outside
+# of ~/.claude/ — must be bind-mounted inline (same pattern as config.toml).
 Volume=%h/.claude:/home/lyra/.claude:z
+Volume=%h/.claude.json:/home/lyra/.claude.json:z
 # Health endpoint — probed by lyra-monitor via host loopback (localhost:8443).
 # Bind to 0.0.0.0 inside container so PublishPort forwarding reaches uvicorn;
 # host exposure is restricted to 127.0.0.1 by PublishPort below.


### PR DESCRIPTION
## Summary
- Add inline \`Volume=%h/.claude.json:/home/lyra/.claude.json:z\` to lyra-hub.container
- Required because the Claude CLI stores top-level config at \`~/.claude.json\` outside \`~/.claude/\`
- Uses same pattern as config.toml (inline Volume=, not .volume unit)

## Test plan
- [ ] Deploy to M₁ and verify hub container starts cleanly
- [ ] Confirm CLI inside container reads expected settings