### PR TITLE
feat(quadlet): big-bang NATS consolidation — roxabi.network, merged auth.conf, drop :4223

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ define require_machine1
 	@[ -n "$(DEPLOY_DIR)" ] || { echo "Error: DEPLOY_DIR not set in .env"; exit 1; }
 endef
 
-.PHONY: build push lyra telegram discord monitor register quadlet-install quadlet-install-deploy-lib quadlet-upgrade-lib quadlet-secrets-install quadlet-authconf-merged deploy remote update nats-setup nats-deploy test test-integration voice-smoke lint typecheck format gen-conf
+.PHONY: build push lyra telegram discord monitor register quadlet-preflight quadlet-install quadlet-install-deploy-lib quadlet-upgrade-lib quadlet-secrets-install quadlet-authconf-merged deploy remote update nats-setup nats-deploy test test-integration voice-smoke lint typecheck format gen-conf
 
 # ── Container image build + transfer ─────────────────────────────────────────
 
@@ -147,7 +147,16 @@ register:
 
 DEPLOY_LIB_INSTALL_DIR := $(HOME)/.local/lib/roxabi
 
-quadlet-install:  ## install Quadlet units to ~/.config/containers/systemd/ + reload
+quadlet-preflight:  ## advisory pre-flight checks before Quadlet install (non-blocking)
+	@_unprivport=$$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null || echo 1024); \
+	if [ "$${_unprivport}" -gt 4222 ]; then \
+		echo "WARNING: net.ipv4.ip_unprivileged_port_start=$${_unprivport} (>4222)."; \
+		echo "         Rootless :4222 binding will fail silently."; \
+		echo "         Fix: sudo sysctl -w net.ipv4.ip_unprivileged_port_start=4222"; \
+		echo "         (or persist in /etc/sysctl.d/99-rootless-ports.conf)"; \
+	fi
+
+quadlet-install: quadlet-preflight  ## install Quadlet units to ~/.config/containers/systemd/ + reload
 	@mkdir -p "$(QUADLET_DIR)"
 	@rm -f "$(QUADLET_DIR)"/lyra*.{network,volume,container} "$(QUADLET_DIR)/nats.container" \
 	       "$(QUADLET_DIR)/roxabi.network" "$(QUADLET_DIR)/lyra-nats.container"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ define require_machine1
 	@[ -n "$(DEPLOY_DIR)" ] || { echo "Error: DEPLOY_DIR not set in .env"; exit 1; }
 endef
 
-.PHONY: build push lyra telegram discord monitor register quadlet-install quadlet-install-deploy-lib quadlet-upgrade-lib quadlet-secrets-install deploy remote update nats-setup nats-deploy test test-integration voice-smoke lint typecheck format gen-conf
+.PHONY: build push lyra telegram discord monitor register quadlet-install quadlet-install-deploy-lib quadlet-upgrade-lib quadlet-secrets-install quadlet-authconf-merged deploy remote update nats-setup nats-deploy test test-integration voice-smoke lint typecheck format gen-conf
 
 # ── Container image build + transfer ─────────────────────────────────────────
 
@@ -149,11 +149,12 @@ DEPLOY_LIB_INSTALL_DIR := $(HOME)/.local/lib/roxabi
 
 quadlet-install:  ## install Quadlet units to ~/.config/containers/systemd/ + reload
 	@mkdir -p "$(QUADLET_DIR)"
-	@rm -f "$(QUADLET_DIR)"/lyra*.{network,volume,container} "$(QUADLET_DIR)/nats.container"
-	@cp deploy/quadlet/lyra.network                    "$(QUADLET_DIR)/lyra.network"
+	@rm -f "$(QUADLET_DIR)"/lyra*.{network,volume,container} "$(QUADLET_DIR)/nats.container" \
+	       "$(QUADLET_DIR)/roxabi.network" "$(QUADLET_DIR)/lyra-nats.container"
+	@cp deploy/quadlet/roxabi.network                  "$(QUADLET_DIR)/roxabi.network"
 	@cp deploy/quadlet/lyra-data.volume                "$(QUADLET_DIR)/lyra-data.volume"
 	@cp deploy/quadlet/lyra-logs.volume                "$(QUADLET_DIR)/lyra-logs.volume"
-	@cp deploy/quadlet/nats.container                  "$(QUADLET_DIR)/nats.container"
+	@cp deploy/quadlet/lyra-nats.container             "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/lyra-hub.container              "$(QUADLET_DIR)/lyra-hub.container"
 	@cp deploy/quadlet/lyra-telegram.container         "$(QUADLET_DIR)/lyra-telegram.container"
 	@cp deploy/quadlet/lyra-discord.container          "$(QUADLET_DIR)/lyra-discord.container"
@@ -165,6 +166,9 @@ quadlet-install:  ## install Quadlet units to ~/.config/containers/systemd/ + re
 		echo "Hint: deploy-lib.sh not found at $(DEPLOY_LIB_INSTALL_DIR)/"; \
 		echo "      Run 'make quadlet-install-deploy-lib' to install the shared deploy library."; \
 	fi
+
+quadlet-authconf-merged:  ## render merged auth.conf (lyra + voicecli identities) → ~/.lyra/nkeys/auth.conf
+	@./deploy/nats/gen-nkeys.sh --emit-merged-authconf
 
 quadlet-install-deploy-lib:  ## install scripts/deploy-lib.sh to ~/.local/lib/roxabi/ with pinned commit
 	@mkdir -p "$(DEPLOY_LIB_INSTALL_DIR)"

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -20,6 +20,7 @@
 #        sudo ./deploy/nats/gen-nkeys.sh --regen-authconf   # re-render auth.conf from EXISTING seeds (no key rotation)
 #             ./deploy/nats/gen-nkeys.sh --template-only    # write auth.conf skeleton to stdout (no root needed)
 #             ./deploy/nats/gen-nkeys.sh --validate-supervisor   # verify each owner==lyra identity has its seed wired into a supervisor conf or quadlet container
+#             ./deploy/nats/gen-nkeys.sh --emit-merged-authconf  # write merged auth.conf (lyra + voicecli identities) to ~/.lyra/nkeys/auth.conf (no root needed)
 #
 # Idempotent — skips if auth.conf already exists. Delete auth.conf + seeds dir to regenerate.
 # Override seeds location: SEEDS_DIR=/custom/path sudo ./gen-nkeys.sh
@@ -155,16 +156,18 @@ REGENERATE=false
 REGEN_AUTHCONF=false
 AUTO_YES=false
 VALIDATE_SUPERVISOR=false
+EMIT_MERGED_AUTHCONF=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --show)                SHOW_ONLY=true;           shift ;;
-    --fix-perms)           FIX_PERMS=true;           shift ;;
-    --template-only)       TEMPLATE_ONLY=true;       shift ;;
-    --regenerate)          REGENERATE=true;           shift ;;
-    --regen-authconf)      REGEN_AUTHCONF=true;      shift ;;
-    --yes)                 AUTO_YES=true;             shift ;;
-    --validate-supervisor) VALIDATE_SUPERVISOR=true;  shift ;;
+    --show)                  SHOW_ONLY=true;             shift ;;
+    --fix-perms)             FIX_PERMS=true;             shift ;;
+    --template-only)         TEMPLATE_ONLY=true;         shift ;;
+    --regenerate)            REGENERATE=true;             shift ;;
+    --regen-authconf)        REGEN_AUTHCONF=true;        shift ;;
+    --yes)                   AUTO_YES=true;               shift ;;
+    --validate-supervisor)   VALIDATE_SUPERVISOR=true;    shift ;;
+    --emit-merged-authconf)  EMIT_MERGED_AUTHCONF=true;  shift ;;
     *) error "Unknown option: $1" ;;
   esac
 done
@@ -348,6 +351,74 @@ if [ "${REGEN_AUTHCONF}" = true ]; then
 
   info "auth.conf re-rendered from ${#IDENTITIES[@]} existing seeds."
   info "Next: sudo systemctl reload nats.service"
+  exit 0
+fi
+
+# ── emit-merged-authconf mode: write merged lyra+voicecli auth.conf ──────────
+# Purpose: produce a single auth.conf covering all 5 live identities:
+#   hub, telegram-adapter, discord-adapter (lyra seeds → ~/.lyra/nkeys/)
+#   voice-tts, voice-stt                   (voicecli seeds → ~/.voicecli/nkeys/)
+# Retired identities (tts-adapter, stt-adapter) are excluded.
+# No root required — writes to user-owned ~/.lyra/nkeys/auth.conf.
+# Seeds must already exist (run gen-nkeys.sh once, then relocate voice seeds per
+# ADR-055 D4: cp ~/.lyra/nkeys/voice-*.seed ~/.voicecli/nkeys/).
+if [ "${EMIT_MERGED_AUTHCONF}" = true ]; then
+  NK_BIN=$(command -v nk || echo "")
+  [ -n "${NK_BIN}" ] || error "nk not found on \$PATH — run gen-nkeys.sh without flags first (it will install nk)"
+
+  VOICECLI_SEEDS_DIR="${HOME}/.voicecli/nkeys"
+  MERGED_AUTH_CONF="${SEEDS_DIR}/auth.conf"
+
+  # Live identities for merged auth.conf
+  MERGED_LYRA_IDENTITIES=("hub" "telegram-adapter" "discord-adapter")
+  MERGED_VOICE_IDENTITIES=("voice-tts" "voice-stt")
+
+  declare -A MERGED_PUBKEYS
+
+  # Derive lyra identity pubkeys from ~/.lyra/nkeys/
+  for name in "${MERGED_LYRA_IDENTITIES[@]}"; do
+    seed_file="${SEEDS_DIR}/${name}.seed"
+    [ -f "${seed_file}" ] \
+      || error "Missing lyra seed: ${seed_file} — run gen-nkeys.sh without flags first"
+    pubkey=$("${NK_BIN}" -inkey "${seed_file}" -pubout 2>/dev/null) \
+      || error "Failed to derive pubkey from ${seed_file}"
+    MERGED_PUBKEYS[$name]="${pubkey}"
+    info "Derived pubkey: ${name} (from ${seed_file})"
+  done
+
+  # Derive voicecli identity pubkeys from ~/.voicecli/nkeys/
+  for name in "${MERGED_VOICE_IDENTITIES[@]}"; do
+    # Map identity name to seed filename: voice-tts → voice-tts.seed
+    seed_file="${VOICECLI_SEEDS_DIR}/${name}.seed"
+    [ -f "${seed_file}" ] \
+      || error "Missing voicecli seed: ${seed_file} — run: mkdir -p ~/.voicecli/nkeys && cp ~/.lyra/nkeys/${name}.seed ~/.voicecli/nkeys/"
+    pubkey=$("${NK_BIN}" -inkey "${seed_file}" -pubout 2>/dev/null) \
+      || error "Failed to derive pubkey from ${seed_file}"
+    MERGED_PUBKEYS[$name]="${pubkey}"
+    info "Derived pubkey: ${name} (from ${seed_file})"
+  done
+
+  # Build IDENTITIES subset for render_auth_conf (must be in IDENTITIES from acl-matrix)
+  IDENTITIES=("${MERGED_LYRA_IDENTITIES[@]}" "${MERGED_VOICE_IDENTITIES[@]}")
+
+  # Backup existing merged auth.conf if present
+  if [ -f "${MERGED_AUTH_CONF}" ]; then
+    BACKUP_MERGED="${MERGED_AUTH_CONF}.bak.$(date +%Y%m%d-%H%M%S)"
+    cp -a "${MERGED_AUTH_CONF}" "${BACKUP_MERGED}"
+    info "Backed up existing auth.conf → ${BACKUP_MERGED}"
+  fi
+
+  # Render and write atomically (temp + rename)
+  TMP_MERGED=$(mktemp)
+  trap 'rm -f "${TMP_MERGED}"' EXIT
+  render_auth_conf MERGED_PUBKEYS > "${TMP_MERGED}"
+  mkdir -p "${SEEDS_DIR}"
+  mv "${TMP_MERGED}" "${MERGED_AUTH_CONF}"
+  chmod 0600 "${MERGED_AUTH_CONF}"
+
+  info "Merged auth.conf written → ${MERGED_AUTH_CONF}"
+  info "Identities: ${IDENTITIES[*]}"
+  info "Next: make quadlet-secrets-install  # uploads as Podman secret lyra-nats-auth"
   exit 0
 fi
 

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -5,8 +5,9 @@
 # auth.conf (public keys) → /etc/nats/nkeys/ owned by root:nats,  0640 — read by nats-server
 #
 # Creates 10 user nkey seeds: hub, telegram-adapter, discord-adapter,
-#                              tts-adapter, stt-adapter, voice-tts, voice-stt,
-#                              llm-worker, image-worker, monitor
+#                              tts-adapter [retired: ADR-051; kept for audit_matrix_inbox_drift only],
+#                              stt-adapter [retired: ADR-051; kept for audit_matrix_inbox_drift only],
+#                              voice-tts, voice-stt, llm-worker, image-worker, monitor
 #
 # ACL matrix (identities + publish/subscribe allow-lists) is sourced from
 # deploy/nats/acl-matrix.json — do not edit inline; update the JSON instead.
@@ -104,6 +105,8 @@ load_matrix() {
 # Args: name pubkey
 emit_user() {
   local name="$1" pubkey="$2"
+  [ -z "${pubkey:-}" ] \
+    && error "BUG: render_auth_conf invoked for identity '${name}' with no pubkey"
   cat <<USER
     {
       nkey: "${pubkey}"
@@ -405,6 +408,7 @@ if [ "${EMIT_MERGED_AUTHCONF}" = true ]; then
   if [ -f "${MERGED_AUTH_CONF}" ]; then
     BACKUP_MERGED="${MERGED_AUTH_CONF}.bak.$(date +%Y%m%d-%H%M%S)"
     cp -a "${MERGED_AUTH_CONF}" "${BACKUP_MERGED}"
+    chmod 0600 "${BACKUP_MERGED}"
     info "Backed up existing auth.conf → ${BACKUP_MERGED}"
   fi
 

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -1,13 +1,13 @@
 # NATS Server — Lyra by Roxabi (container)
-# Used by: deploy/quadlet/nats.container
+# Used by: deploy/quadlet/lyra-nats.container
 # Differences from nats.conf:
-#   - Listens on 0.0.0.0 — hub container connects via lyra.network
+#   - Listens on 0.0.0.0 — hub container connects via roxabi.network
 #   - No TLS — internal container network, no external exposure
 #   - Monitoring: disabled (same as nats.conf — re-enable in Slice A3)
 #   - No pid_file — not applicable inside a container
 
 # Bind to all interfaces so hub/adapter containers can reach NATS via
-# the lyra bridge network (nats://lyra-nats:4222).
+# the roxabi bridge network (nats://lyra-nats:4222).
 port: 4222
 
 # ── nkey auth ──────────────────────────────────────────────────────────────

--- a/deploy/nats/setup.sh
+++ b/deploy/nats/setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# DEPRECATED — host NATS retired by big-bang consolidation (see docs/ops/bigbang-nats-consolidation.md).
+# Kept for rollback reference only. Do NOT run on a post-cutover system.
+#
 # Lyra by Roxabi — NATS setup (install + configure + start)
 #
 # Usage: cd ~/projects/lyra && make nats-setup

--- a/deploy/quadlet/lyra-discord.container
+++ b/deploy/quadlet/lyra-discord.container
@@ -12,7 +12,7 @@ StartLimitBurst=5
 # (CI tag-by-SHA strategy).
 Image=localhost/lyra:latest
 ContainerName=lyra-discord
-Network=lyra.network
+Network=roxabi.network
 # Hardening — defense in depth (see issue #652).
 NoNewPrivileges=true
 ReadOnly=true

--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -11,7 +11,7 @@ StartLimitBurst=5
 # are pinned by digest directly.
 Image=localhost/lyra:latest
 ContainerName=lyra-hub
-Network=lyra.network
+Network=roxabi.network
 # Hardening — defense in depth (see issue #652).
 NoNewPrivileges=true
 ReadOnly=true

--- a/deploy/quadlet/lyra-nats.container
+++ b/deploy/quadlet/lyra-nats.container
@@ -6,14 +6,13 @@ Description=Lyra NATS server
 # Tag 2.10.29-alpine resolved via Docker Hub registry API (see issue #652).
 Image=docker.io/library/nats:2.10.29-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
 ContainerName=lyra-nats
-Network=lyra.network
+Network=roxabi.network
 # Hardening — defense in depth (see issue #652).
 NoNewPrivileges=true
 ReadOnly=true
 DropCapability=all
-# Host 4223 → container 4222: runs alongside supervisord NATS (4222) during
-# parallel testing. Switch to 4222:4222 once supervisord NATS is retired.
-PublishPort=127.0.0.1:4223:4222
+# Sole NATS on the host — host nats.service is retired (big-bang consolidation).
+PublishPort=127.0.0.1:4222:4222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
 # ADR-054 Decision 5 (revised): file-based credentials delivered as Podman secrets
 # (type=mount, tmpfs-backed). Replaces single-file .volume wrappers which failed

--- a/deploy/quadlet/lyra-telegram.container
+++ b/deploy/quadlet/lyra-telegram.container
@@ -12,7 +12,7 @@ StartLimitBurst=5
 # (CI tag-by-SHA strategy).
 Image=localhost/lyra:latest
 ContainerName=lyra-telegram
-Network=lyra.network
+Network=roxabi.network
 # Hardening — defense in depth (see issue #652).
 NoNewPrivileges=true
 ReadOnly=true

--- a/deploy/quadlet/roxabi.network
+++ b/deploy/quadlet/roxabi.network
@@ -1,9 +1,9 @@
 [Unit]
-Description=Lyra container bridge network
+Description=Shared Roxabi container bridge network (lyra + voicecli)
 
 [Network]
 Driver=bridge
 # No Internal=true — the hub needs outbound internet (Anthropic API, Telegram).
 # Isolation is achieved via: nkey auth (NATS rejects unauthenticated clients) +
-# PublishPort=127.0.0.1:4223:4222 (NATS port is localhost-only, no LAN exposure).
-Label=app=lyra
+# PublishPort=127.0.0.1:4222:4222 (NATS port is localhost-only, no LAN exposure).
+Label=app=roxabi

--- a/docs/ops/bigbang-nats-consolidation.md
+++ b/docs/ops/bigbang-nats-consolidation.md
@@ -163,6 +163,31 @@ systemctl --user list-units 'lyra-*' 'voicecli-*'
 sudo systemctl status nats.service    # inactive (disabled)
 ```
 
+## Rollback (if NATS fails at T+0:06)
+
+Bots are already stopped at this point — rollback is purely recovery; no user-visible regression beyond the cutover window.
+
+```bash
+# 1. Stop any partially-started Quadlet units
+systemctl --user stop 'lyra-*' 'voicecli-*'
+
+# 2. Restore old nats.container from git
+git show HEAD~1:deploy/quadlet/nats.container > /tmp/nats.container
+cp /tmp/nats.container ~/.config/containers/systemd/nats.container
+systemctl --user daemon-reload
+
+# 3. Re-enable host NATS
+sudo systemctl enable --now nats.service
+
+# 4. Revert both PRs on M₁ (lyra + voiceCLI repos)
+#    In each repo: git revert HEAD && make quadlet-install
+git revert HEAD   # lyra
+make quadlet-install
+
+# 5. Restart bots via old Quadlet units
+systemctl --user start lyra-hub.service lyra-telegram.service lyra-discord.service
+```
+
 ## References
 
 - [ADR-055 — Quadlet ecosystem conventions](../architecture/adr/055-quadlet-ecosystem-conventions.mdx) — original staged plan; this doc collapses Phases 3+4 and drops TLS inside `roxabi.network`


### PR DESCRIPTION
## Summary

- Rename `deploy/quadlet/lyra.network` → `roxabi.network` (`Label=app=roxabi`); shared with voicecli
- Rename `nats.container` → `lyra-nats.container`; `PublishPort` 4223 → 4222 (sole NATS on host, host `nats.service` retired)
- `Network=lyra.network` → `Network=roxabi.network` on hub, telegram, discord containers
- `gen-nkeys.sh --emit-merged-authconf`: writes merged auth.conf for 5 live identities (`hub`, `telegram-adapter`, `discord-adapter`, `voice-tts`, `voice-stt`); lyra seeds from `~/.lyra/nkeys/`, voicecli seeds from `~/.voicecli/nkeys/` (ADR-055 D4); atomic write + timestamped backup
- `Makefile`: new `quadlet-authconf-merged` target; `quadlet-install` updated for renamed files + cleans up stale `nats.container`/`roxabi.network` on install
- `nats-container.conf`: update inline network-reference comments

Required before big-bang cutover (see `docs/ops/bigbang-nats-consolidation.md`).

## Test plan

- [ ] **Pre-window on M₁** (runbook §"Pre-window"):
  - [ ] `git pull --ff-only origin staging`
  - [ ] Relocate voicecli seeds: `cp ~/.lyra/nkeys/voice-{tts,stt}.seed ~/.voicecli/nkeys/`
  - [ ] `make quadlet-authconf-merged` — verify `~/.lyra/nkeys/auth.conf` contains exactly hub, telegram-adapter, discord-adapter, voice-tts, voice-stt blocks
  - [ ] `make quadlet-secrets-install` — verify `podman secret ls` shows `lyra-nats-auth`
- [ ] **Dry-run install** (M₁, pre-cutover):
  - [ ] `make -n quadlet-install` — confirm no reference to `nats.container` or `lyra.network`
- [ ] **Cutover** (runbook §"Cutover sequence"):
  - [ ] `make quadlet-install` — confirm `roxabi.network` + `lyra-nats.container` deployed
  - [ ] `systemctl --user start lyra-nats.service` → `ss -tlnp | grep ':4222'` shows podman/rootlessport
  - [ ] Start hub + adapters + voicecli workers; check all Active
  - [ ] Smoke: Telegram `/ping` → reply; Discord `/ping` → reply; voice note → transcript reply
- [ ] **Post-cutover**: `podman network ls` shows `roxabi.network` only (no `lyra.network`, no `voicecli.network`)