### PR TITLE
fix(security): add TrustedCallback validation for metadata-transported callables

### DIFF
--- a/src/lyra/adapters/discord/discord_inbound.py
+++ b/src/lyra/adapters/discord/discord_inbound.py
@@ -18,6 +18,7 @@ from lyra.adapters.discord.discord_threads import (
 )
 from lyra.adapters.shared._shared import AUDIO_MIME_TYPES, push_to_hub_guarded
 from lyra.core.auth.trust import TrustLevel
+from lyra.core.messaging.callbacks import TrustedCallback
 from lyra.core.messaging.message import InboundMessage, Platform
 
 if TYPE_CHECKING:
@@ -216,7 +217,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
         ) -> None:
             await _dm_ts.start_session(session_id, pool_id)
 
-        _meta_updates["_session_update_fn"] = _dm_session_update_fn
+        _meta_updates["_session_update_fn"] = TrustedCallback(_dm_session_update_fn)
     elif _has_thread_id and adapter._thread_store is not None:
         _ts = adapter._thread_store
         _bid, _cache = adapter._bot_id, adapter._thread_sessions
@@ -226,7 +227,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
         ) -> None:
             await persist_thread_session(_ts, msg, session_id, pool_id, _bid, _cache)
 
-        _meta_updates["_session_update_fn"] = _session_update_fn
+        _meta_updates["_session_update_fn"] = TrustedCallback(_session_update_fn)
     if _meta_updates:
         hub_msg = dataclasses.replace(
             hub_msg,

--- a/src/lyra/adapters/telegram/telegram_inbound.py
+++ b/src/lyra/adapters/telegram/telegram_inbound.py
@@ -12,6 +12,7 @@ from lyra.adapters.telegram.telegram_audio import _download_audio
 from lyra.adapters.telegram.telegram_formatting import _make_send_kwargs
 from lyra.adapters.telegram.telegram_normalize import _make_scope_id, normalize_audio
 from lyra.core.auth.trust import TrustLevel
+from lyra.core.messaging.callbacks import TrustedCallback
 from lyra.core.messaging.message import InboundMessage, Platform
 
 if TYPE_CHECKING:
@@ -91,7 +92,7 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
         ) -> None:
             await _ts.start_session(session_id, pool_id)
 
-        _meta_updates["_session_update_fn"] = _tg_session_update_fn
+        _meta_updates["_session_update_fn"] = TrustedCallback(_tg_session_update_fn)
     if _meta_updates:
         hub_msg = dataclasses.replace(
             hub_msg,

--- a/src/lyra/core/hub/middleware/middleware_submit.py
+++ b/src/lyra/core/hub/middleware/middleware_submit.py
@@ -8,9 +8,8 @@ resume via three paths, and returns ``SUBMIT_TO_POOL``.
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
-from typing import cast
 
+from ...messaging.callbacks import unwrap_callback
 from ...messaging.message import (
     InboundMessage,
     Platform,
@@ -82,12 +81,9 @@ class SubmitToPoolMiddleware:
 
         pool = ctx.pool
         # Register session persistence callback once.
-        _update_fn = msg.platform_meta.get("_session_update_fn")
-        if callable(_update_fn) and not pool.has_session_update_fn():
-            _typed_update_fn = cast(
-                "Callable[[InboundMessage, str, str], Awaitable[None]]", _update_fn
-            )
-            pool.register_session_callbacks(update_fn=_typed_update_fn)
+        _update_cb = unwrap_callback(msg.platform_meta, "_session_update_fn")
+        if _update_cb is not None and not pool.has_session_update_fn():
+            pool.register_session_callbacks(update_fn=_update_cb.fn)
 
         try:
             status = await resolve_context(msg, pool, pool.pool_id, ctx)

--- a/src/lyra/core/hub/outbound/_dispatch.py
+++ b/src/lyra/core/hub/outbound/_dispatch.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 import time
 from typing import TYPE_CHECKING
 
 from ...circuit_breaker import CircuitBreaker
+from ...messaging.callbacks import unwrap_callback
 from ...messaging.message import RoutingContext
 from .outbound_errors import (
     _CIRCUIT_NOTIFY_DEBOUNCE,
@@ -90,11 +90,9 @@ async def dispatch_outbound_item(  # noqa: C901, PLR0913, PLR0915
         _cb_out = payload if kind == "send" else outbound
         if _cb_out is not None:
             _cb_out.metadata["reply_message_id"] = None
-            _cb = _cb_out.metadata.pop("_on_dispatched", None)
-            if callable(_cb):
-                _cb_result = _cb(_cb_out)
-                if inspect.isawaitable(_cb_result):
-                    await _cb_result
+            _cb = unwrap_callback(_cb_out.metadata, "_on_dispatched", pop=True)
+            if _cb is not None:
+                await _cb(_cb_out)
         # Fix 3: notify user once per chat per debounce window
         scope_key = msg.scope_id or msg.id
         now = time.monotonic()
@@ -167,11 +165,9 @@ async def dispatch_outbound_item(  # noqa: C901, PLR0913, PLR0915
     # "send" → payload is the OutboundMessage; else → outbound.
     _out = payload if kind == "send" else outbound
     if _out is not None:
-        _dispatched = _out.metadata.pop("_on_dispatched", None)
-        if callable(_dispatched):
-            _dispatched_result = _dispatched(_out)
-            if inspect.isawaitable(_dispatched_result):
-                await _dispatched_result
+        _dispatched = unwrap_callback(_out.metadata, "_on_dispatched", pop=True)
+        if _dispatched is not None:
+            await _dispatched(_out)
 
     if _last_exc is not None:
         exc = _last_exc

--- a/src/lyra/core/hub/outbound/outbound_router.py
+++ b/src/lyra/core/hub/outbound/outbound_router.py
@@ -159,7 +159,7 @@ class OutboundRouter:
             outbound = response
         else:
             outbound = response.to_outbound()
-            _cb = unwrap_callback(response.metadata, "_on_dispatched")
+            _cb = unwrap_callback(response.metadata, "_on_dispatched", pop=True)
             if _cb is not None:
                 outbound.metadata["_on_dispatched"] = _cb
         if outbound.routing is None and msg.routing is not None:

--- a/src/lyra/core/hub/outbound/outbound_router.py
+++ b/src/lyra/core/hub/outbound/outbound_router.py
@@ -12,12 +12,12 @@ TtsDispatch (outbound_tts.py); audio/attachment logic in AudioDispatch
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 import time
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
+from ...messaging.callbacks import unwrap_callback
 from ...messaging.message import InboundMessage, OutboundMessage, Platform, Response
 from .outbound_audio import AudioDispatch
 from .outbound_streaming import StreamingDispatch
@@ -159,7 +159,7 @@ class OutboundRouter:
             outbound = response
         else:
             outbound = response.to_outbound()
-            _cb = response.metadata.get("_on_dispatched")
+            _cb = unwrap_callback(response.metadata, "_on_dispatched")
             if _cb is not None:
                 outbound.metadata["_on_dispatched"] = _cb
         if outbound.routing is None and msg.routing is not None:
@@ -167,11 +167,9 @@ class OutboundRouter:
 
         async def _fallback_and_notify(adapter: "ChannelAdapter") -> None:
             await adapter.send(msg, outbound)
-            _dispatched = outbound.metadata.pop("_on_dispatched", None)
-            if callable(_dispatched):
-                _result = _dispatched(outbound)
-                if inspect.isawaitable(_result):
-                    await _result
+            _dispatched = unwrap_callback(outbound.metadata, "_on_dispatched", pop=True)
+            if _dispatched is not None:
+                await _dispatched(outbound)
 
         await self._route_outbound(
             msg,

--- a/src/lyra/core/hub/outbound/outbound_streaming.py
+++ b/src/lyra/core/hub/outbound/outbound_streaming.py
@@ -7,12 +7,12 @@ the fallback text-accumulation path used when an adapter lacks ``send_streaming`
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 import time
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING
 
+from ...messaging.callbacks import unwrap_callback
 from ...messaging.message import InboundMessage, OutboundMessage, Platform
 from ...messaging.render_events import TextRenderEvent
 
@@ -123,11 +123,9 @@ class StreamingDispatch:
                     msg.id,
                 )
         if outbound is not None:
-            _dispatched = outbound.metadata.pop("_on_dispatched", None)
-            if callable(_dispatched):
-                _result = _dispatched(outbound)
-                if inspect.isawaitable(_result):
-                    await _result
+            _dispatched = unwrap_callback(outbound.metadata, "_on_dispatched", pop=True)
+            if _dispatched is not None:
+                await _dispatched(outbound)
         stamp = time.monotonic()
 
         # Voice: synthesize TTS after text collected (fallback path)

--- a/src/lyra/core/messaging/callbacks.py
+++ b/src/lyra/core/messaging/callbacks.py
@@ -1,0 +1,54 @@
+"""Trusted callback wrapper for metadata-transported callables.
+
+Callbacks passed through message metadata dicts (platform_meta,
+OutboundMessage.metadata) are wrapped in TrustedCallback at the producer site
+and unwrapped at the consumer site. Raw callables found in metadata are
+rejected — prevents code execution if an attacker controls the metadata source.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class TrustedCallback[T]:
+    """Wraps a callable to mark it as originating from trusted internal code."""
+
+    __slots__ = ("fn",)
+
+    def __init__(self, fn: Callable[..., T | Awaitable[T]]) -> None:
+        self.fn = fn
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> T:
+        result = self.fn(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result  # type: ignore[return-value]
+
+
+def unwrap_callback(
+    metadata: dict[str, Any],
+    key: str,
+    *,
+    pop: bool = False,
+) -> TrustedCallback[Any] | None:
+    """Extract and validate a TrustedCallback from a metadata dict.
+
+    Returns None (and logs a warning) if the value exists but is not a TrustedCallback.
+    """
+    value = metadata.pop(key, None) if pop else metadata.get(key)
+    if value is None:
+        return None
+    if isinstance(value, TrustedCallback):
+        return value
+    log.warning(
+        "Rejected untrusted callback in metadata key %r: %s",
+        key,
+        type(value).__qualname__,
+    )
+    return None

--- a/src/lyra/core/pool/pool_processor_exec.py
+++ b/src/lyra/core/pool/pool_processor_exec.py
@@ -10,13 +10,16 @@ import collections.abc
 import importlib
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from ..agent import AgentBase
     from ..messaging.message import InboundMessage
     from .pool import Pool
 
+from collections.abc import Callable
+
+from ..messaging.callbacks import TrustedCallback
 from ..messaging.message import GENERIC_ERROR_REPLY, OutboundMessage, Response
 from .pool_processor_streaming import (
     build_streaming_capture,
@@ -201,7 +204,9 @@ async def process_one(  # noqa: C901, PLR0915 — session-id update adds branche
             _content_parts,
         )
         pool._inflight_stream_outbound = _outbound
-        _outbound.metadata["_on_dispatched"] = _log_callback
+        _outbound.metadata["_on_dispatched"] = TrustedCallback(
+            cast("Callable[..., object]", _log_callback)
+        )
 
         try:
             await pool._ctx.dispatch_streaming(_original_msg, result, _outbound)
@@ -251,7 +256,7 @@ async def process_one(  # noqa: C901, PLR0915 — session-id update adds branche
                     role="assistant",
                 )
 
-            result.metadata["_on_dispatched"] = _log_turn
+            result.metadata["_on_dispatched"] = TrustedCallback(_log_turn)
         await pool._ctx.dispatch_response(_original_msg, result)
         await pool._observer.session_update_async(_original_msg)
 

--- a/src/lyra/core/pool/pool_processor_exec.py
+++ b/src/lyra/core/pool/pool_processor_exec.py
@@ -10,14 +10,12 @@ import collections.abc
 import importlib
 import logging
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..agent import AgentBase
     from ..messaging.message import InboundMessage
     from .pool import Pool
-
-from collections.abc import Callable
 
 from ..messaging.callbacks import TrustedCallback
 from ..messaging.message import GENERIC_ERROR_REPLY, OutboundMessage, Response
@@ -204,9 +202,7 @@ async def process_one(  # noqa: C901, PLR0915 — session-id update adds branche
             _content_parts,
         )
         pool._inflight_stream_outbound = _outbound
-        _outbound.metadata["_on_dispatched"] = TrustedCallback(
-            cast("Callable[..., object]", _log_callback)
-        )
+        _outbound.metadata["_on_dispatched"] = TrustedCallback(_log_callback)
 
         try:
             await pool._ctx.dispatch_streaming(_original_msg, result, _outbound)

--- a/src/lyra/core/pool/pool_processor_streaming.py
+++ b/src/lyra/core/pool/pool_processor_streaming.py
@@ -10,6 +10,8 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from ..messaging.message import InboundMessage
     from .pool import Pool
 
@@ -60,7 +62,7 @@ def build_streaming_turn_logger(  # noqa: PLR0913 — internal helper, params bu
     platform: str,
     user_id: str,
     content_parts: list[str],
-) -> tuple[OutboundMessage, object]:
+) -> tuple[OutboundMessage, Callable[[OutboundMessage], Awaitable[None]]]:
     """Build OutboundMessage with turn-logging callback for streaming responses.
 
     Returns:

--- a/tests/core/test_outbound_dispatcher_coverage.py
+++ b/tests/core/test_outbound_dispatcher_coverage.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from lyra.core.circuit_breaker import CircuitBreaker
 from lyra.core.hub.outbound.outbound_dispatcher import OutboundDispatcher
 from lyra.core.hub.outbound.outbound_errors import _SCOPE_REAP_THRESHOLD
+from lyra.core.messaging.callbacks import TrustedCallback
 from lyra.core.messaging.message import InboundMessage, OutboundMessage, RoutingContext
 from lyra.core.messaging.render_events import TextRenderEvent
 from tests.conftest import TIMEOUT_IO
@@ -125,7 +126,7 @@ class TestOnDispatchedCallback:
             msg = make_dispatcher_msg()
             out = OutboundMessage.from_text("hi")
             called: list[OutboundMessage] = []
-            out.metadata["_on_dispatched"] = called.append
+            out.metadata["_on_dispatched"] = TrustedCallback(called.append)
 
             dispatcher.enqueue(msg, out)
             await asyncio.sleep(0.05)
@@ -151,7 +152,7 @@ class TestOnDispatchedCallback:
             msg = make_dispatcher_msg()
             out = OutboundMessage.from_text("hi")
             called: list[OutboundMessage] = []
-            out.metadata["_on_dispatched"] = called.append
+            out.metadata["_on_dispatched"] = TrustedCallback(called.append)
 
             dispatcher.enqueue(msg, out)
             await asyncio.sleep(0.05)

--- a/tests/core/test_trusted_callbacks.py
+++ b/tests/core/test_trusted_callbacks.py
@@ -1,0 +1,129 @@
+"""Tests for TrustedCallback and unwrap_callback (security fix #924)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lyra.core.messaging.callbacks import TrustedCallback, unwrap_callback
+
+# ---------------------------------------------------------------------------
+# TrustedCallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trusted_callback_wraps_sync() -> None:
+    called_with: list[object] = []
+
+    def _sync(x: int) -> int:
+        called_with.append(x)
+        return x * 2
+
+    cb: TrustedCallback[int] = TrustedCallback(_sync)
+    result = await cb(7)
+
+    assert result == 14
+    assert called_with == [7]
+
+
+@pytest.mark.asyncio
+async def test_trusted_callback_wraps_async() -> None:
+    called_with: list[object] = []
+
+    async def _async(x: int) -> int:
+        called_with.append(x)
+        return x + 1
+
+    cb: TrustedCallback[int] = TrustedCallback(_async)
+    result = await cb(3)
+
+    assert result == 4
+    assert called_with == [3]
+
+
+@pytest.mark.asyncio
+async def test_trusted_callback_passes_kwargs() -> None:
+    async def _fn(*, name: str) -> str:
+        return f"hello {name}"
+
+    cb: TrustedCallback[str] = TrustedCallback(_fn)
+    result = await cb(name="world")
+
+    assert result == "hello world"
+
+
+def test_trusted_callback_stores_fn() -> None:
+    def _fn() -> None:
+        pass
+
+    cb = TrustedCallback(_fn)
+    assert cb.fn is _fn
+
+
+# ---------------------------------------------------------------------------
+# unwrap_callback
+# ---------------------------------------------------------------------------
+
+
+def test_unwrap_returns_trusted_callback() -> None:
+    def _fn() -> None:
+        pass
+
+    cb = TrustedCallback(_fn)
+    meta = {"_on_dispatched": cb}
+
+    result = unwrap_callback(meta, "_on_dispatched")
+
+    assert result is cb
+    assert "_on_dispatched" in meta  # not popped
+
+
+def test_unwrap_pop_removes_key() -> None:
+    def _fn() -> None:
+        pass
+
+    cb = TrustedCallback(_fn)
+    meta = {"_on_dispatched": cb}
+
+    result = unwrap_callback(meta, "_on_dispatched", pop=True)
+
+    assert result is cb
+    assert "_on_dispatched" not in meta
+
+
+def test_unwrap_returns_none_for_missing_key() -> None:
+    meta: dict[str, object] = {}
+    result = unwrap_callback(meta, "_on_dispatched")
+    assert result is None
+
+
+def test_unwrap_rejects_raw_callable_and_logs(caplog: pytest.LogCaptureFixture) -> None:
+    def _raw() -> None:
+        pass
+
+    meta: dict[str, object] = {"_on_dispatched": _raw}
+
+    with caplog.at_level(logging.WARNING, logger="lyra.core.messaging.callbacks"):
+        result = unwrap_callback(meta, "_on_dispatched")
+
+    assert result is None
+    assert any("Rejected untrusted callback" in r.message for r in caplog.records)
+    assert any("_on_dispatched" in r.message for r in caplog.records)
+
+
+def test_unwrap_rejects_lambda_and_logs(caplog: pytest.LogCaptureFixture) -> None:
+    meta: dict[str, object] = {"_session_update_fn": lambda: None}
+
+    with caplog.at_level(logging.WARNING, logger="lyra.core.messaging.callbacks"):
+        result = unwrap_callback(meta, "_session_update_fn")
+
+    assert result is None
+    assert caplog.records
+
+
+def test_unwrap_pop_missing_key_does_not_raise() -> None:
+    meta: dict[str, object] = {}
+    result = unwrap_callback(meta, "_on_dispatched", pop=True)
+    assert result is None

--- a/tests/core/test_trusted_callbacks.py
+++ b/tests/core/test_trusted_callbacks.py
@@ -120,10 +120,58 @@ def test_unwrap_rejects_lambda_and_logs(caplog: pytest.LogCaptureFixture) -> Non
         result = unwrap_callback(meta, "_session_update_fn")
 
     assert result is None
-    assert caplog.records
+    assert any("Rejected untrusted callback" in r.message for r in caplog.records)
+    assert any("_session_update_fn" in r.message for r in caplog.records)
 
 
 def test_unwrap_pop_missing_key_does_not_raise() -> None:
     meta: dict[str, object] = {}
     result = unwrap_callback(meta, "_on_dispatched", pop=True)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_trusted_callback_propagates_sync_exception() -> None:
+    def _raise() -> None:
+        raise RuntimeError("boom")
+
+    cb = TrustedCallback(_raise)
+    with pytest.raises(RuntimeError, match="boom"):
+        await cb()
+
+
+@pytest.mark.asyncio
+async def test_trusted_callback_propagates_async_exception() -> None:
+    async def _raise() -> None:
+        raise RuntimeError("async boom")
+
+    cb = TrustedCallback(_raise)
+    with pytest.raises(RuntimeError, match="async boom"):
+        await cb()
+
+
+def test_unwrap_rejects_non_callable_value_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    meta: dict[str, object] = {"_on_dispatched": 42}
+
+    with caplog.at_level(logging.WARNING, logger="lyra.core.messaging.callbacks"):
+        result = unwrap_callback(meta, "_on_dispatched")
+
+    assert result is None
+    assert any("Rejected untrusted callback" in r.message for r in caplog.records)
+
+
+def test_unwrap_pop_removes_key_even_on_rejection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def _raw() -> None:
+        pass
+
+    meta: dict[str, object] = {"_on_dispatched": _raw}
+
+    with caplog.at_level(logging.WARNING, logger="lyra.core.messaging.callbacks"):
+        result = unwrap_callback(meta, "_on_dispatched", pop=True)
+
+    assert result is None
+    assert "_on_dispatched" not in meta


### PR DESCRIPTION
## Summary

- Introduces `TrustedCallback` wrapper class in `core/messaging/callbacks.py` — producers wrap callables at injection site, consumers validate via `isinstance` before execution
- Wraps `_session_update_fn` (Telegram adapter → middleware_submit) and `_on_dispatched` (pool_processor → outbound dispatch) at all producer/consumer sites
- Raw callables in metadata are now logged and rejected, preventing code execution if an attacker controls the metadata source
- Removes `inspect.isawaitable` dance at consumer sites — `TrustedCallback.__call__` handles both sync and async uniformly

Closes #924

## Files changed

| File | Change |
|------|--------|
| `core/messaging/callbacks.py` | New — `TrustedCallback`, `unwrap_callback` |
| `adapters/telegram/telegram_inbound.py` | Wrap `_session_update_fn` |
| `core/pool/pool_processor_exec.py` | Wrap `_on_dispatched` |
| `core/hub/middleware/middleware_submit.py` | Validate via `unwrap_callback` |
| `core/hub/outbound/_dispatch.py` | Validate via `unwrap_callback` |
| `core/hub/outbound/outbound_streaming.py` | Validate via `unwrap_callback` |
| `core/hub/outbound/outbound_router.py` | Validate via `unwrap_callback` |
| `tests/core/test_trusted_callbacks.py` | 10 unit tests |
| `tests/core/test_outbound_dispatcher_coverage.py` | Updated for TrustedCallback |

## Test plan

- [x] 10 unit tests for TrustedCallback + unwrap_callback (sync, async, kwargs, pop, reject raw, reject lambda)
- [x] 69 existing dispatch tests pass
- [x] All pre-commit hooks pass (lint, typecheck, import-layers, file-length, folder-size)
- [ ] Manual: verify Telegram session persistence still works
- [ ] Manual: verify outbound message delivery + turn logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)