### PR TITLE
fix(nats): add stop() lifecycle to voice clients

### DIFF
--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -102,6 +102,13 @@ class NatsImageClient:
                 SUBJECTS.image_heartbeat, cb=self._on_heartbeat
             )
 
+    async def stop(self) -> None:
+        """Unsubscribe from heartbeat subject. Idempotent."""
+        if self._hb_sub is not None:
+            await self._hb_sub.unsubscribe()
+            self._hb_sub = None
+            log.debug("NatsImageClient stopped")
+
     async def _on_heartbeat(self, msg) -> None:
         try:
             data = json.loads(msg.data)

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -107,6 +107,13 @@ class NatsSttClient:
                 SUBJECTS.stt_heartbeat, cb=self._on_heartbeat
             )
 
+    async def stop(self) -> None:
+        """Unsubscribe from heartbeat subject. Idempotent."""
+        if self._hb_sub is not None:
+            await self._hb_sub.unsubscribe()
+            self._hb_sub = None
+            log.debug("NatsSttClient stopped")
+
     def is_available(self) -> bool:
         """Check if any STT workers are registered via heartbeats."""
         return self._registry.any_alive()

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -94,6 +94,13 @@ class NatsTtsClient:
                 SUBJECTS.tts_heartbeat, cb=self._on_heartbeat
             )
 
+    async def stop(self) -> None:
+        """Unsubscribe from heartbeat subject. Idempotent."""
+        if self._hb_sub is not None:
+            await self._hb_sub.unsubscribe()
+            self._hb_sub = None
+            log.debug("NatsTtsClient stopped")
+
     def is_available(self) -> bool:
         """Check if any TTS workers are registered via heartbeats."""
         return self._registry.any_alive()

--- a/tests/nats/test_nats_image_client.py
+++ b/tests/nats/test_nats_image_client.py
@@ -240,3 +240,45 @@ class TestNatsImageClient:
         with pytest.raises(ImageUnavailableError, match="adapter unreachable"):
             await client.generate(prompt="test", engine="flux2-klein")
         assert client._cb._failures == initial_failures + 1
+
+    @pytest.mark.asyncio
+    async def test_stop_calls_unsubscribe(self) -> None:
+        """stop() calls unsubscribe() on the active subscription."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsImageClient(nc=mock_nc)
+        await client.start()
+        await client.stop()
+        mock_sub.unsubscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_hb_sub_to_none(self) -> None:
+        """After stop(), _hb_sub is None."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsImageClient(nc=mock_nc)
+        await client.start()
+        assert client._hb_sub is not None
+        await client.stop()
+        assert client._hb_sub is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self) -> None:
+        """stop() called twice does not raise and only unsubscribes once."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsImageClient(nc=mock_nc)
+        await client.start()
+        await client.stop()
+        await client.stop()
+        mock_sub.unsubscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_safe(self) -> None:
+        """stop() before start() (hb_sub is None) does not raise."""
+        mock_nc = AsyncMock()
+        client = NatsImageClient(nc=mock_nc)
+        await client.stop()  # must not raise

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -865,3 +865,49 @@ class TestWalkRegistry:
             "TimeoutError" in record.message and record.levelname == "WARNING"
             for record in caplog.records
         )
+
+
+class TestSttClientStop:
+    """Tests for NatsSttClient.stop() lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_stop_calls_unsubscribe(self) -> None:
+        """stop() calls unsubscribe() on the active subscription."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsSttClient(nc=mock_nc)
+        await client.start()
+        await client.stop()
+        mock_sub.unsubscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_hb_sub_to_none(self) -> None:
+        """After stop(), _hb_sub is None."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsSttClient(nc=mock_nc)
+        await client.start()
+        assert client._hb_sub is not None
+        await client.stop()
+        assert client._hb_sub is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self) -> None:
+        """stop() called twice does not raise and only unsubscribes once."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsSttClient(nc=mock_nc)
+        await client.start()
+        await client.stop()
+        await client.stop()
+        mock_sub.unsubscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_safe(self) -> None:
+        """stop() before start() (hb_sub is None) does not raise."""
+        mock_nc = AsyncMock()
+        client = NatsSttClient(nc=mock_nc)
+        await client.stop()  # must not raise

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -721,3 +721,49 @@ class TestMalformedReply:
 
         assert isinstance(exc_info.value.__cause__, ValidationError)
         assert client._cb._failures == initial_failures + 1
+
+
+class TestTtsClientStop:
+    """Tests for NatsTtsClient.stop() lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_stop_calls_unsubscribe(self) -> None:
+        """stop() calls unsubscribe() on the active subscription."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsTtsClient(nc=mock_nc)
+        await client.start()
+        await client.stop()
+        mock_sub.unsubscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_hb_sub_to_none(self) -> None:
+        """After stop(), _hb_sub is None."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsTtsClient(nc=mock_nc)
+        await client.start()
+        assert client._hb_sub is not None
+        await client.stop()
+        assert client._hb_sub is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self) -> None:
+        """stop() called twice does not raise and only unsubscribes once."""
+        mock_nc = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_nc.subscribe = AsyncMock(return_value=mock_sub)
+        client = NatsTtsClient(nc=mock_nc)
+        await client.start()
+        await client.stop()
+        await client.stop()
+        mock_sub.unsubscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_safe(self) -> None:
+        """stop() before start() (hb_sub is None) does not raise."""
+        mock_nc = AsyncMock()
+        client = NatsTtsClient(nc=mock_nc)
+        await client.stop()  # must not raise


### PR DESCRIPTION
## Summary
- Add idempotent `async def stop()` to `NatsSttClient`, `NatsTtsClient`, `NatsImageClient`
- Unsubscribes heartbeat NATS subscriptions that were previously leaked
- Addresses P1 #8 from quality audit

## Test plan
- [x] 12 new unit tests (4 per client): unsubscribe called, `_hb_sub` nulled, idempotency, safe before `start()`
- [x] All pre-commit hooks pass (lint, typecheck, file-length, folder-size, import-layers, trufflehog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)