### PR TITLE
fix(security): add audit logging for skip_permissions bypass

### DIFF
--- a/src/lyra/core/cli/cli_protocol.py
+++ b/src/lyra/core/cli/cli_protocol.py
@@ -76,6 +76,9 @@ def build_cmd(
     if model_config.streaming:
         cmd.append("--include-partial-messages")
     if model_config.skip_permissions:
+        log.warning(
+            "SECURITY: --dangerously-skip-permissions enabled for CLI subprocess"
+        )
         cmd.append("--dangerously-skip-permissions")
     if model_config.tools:
         cmd.extend(["--allowedTools", ",".join(model_config.tools)])

--- a/tests/core/test_cli_build_cmd_audit.py
+++ b/tests/core/test_cli_build_cmd_audit.py
@@ -1,0 +1,63 @@
+"""Audit logging tests for build_cmd() skip_permissions bypass."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lyra.core.agent.agent_config import ModelConfig
+from lyra.core.cli.cli_protocol import build_cmd
+
+
+class TestBuildCmdSkipPermissionsAudit:
+    """build_cmd() must emit a WARNING when skip_permissions is True."""
+
+    def test_warning_logged_when_skip_permissions_true(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARNING emitted at lyra.core.cli.cli_protocol when skip_permissions=True."""
+        model_config = ModelConfig(skip_permissions=True)
+
+        with caplog.at_level(logging.WARNING, logger="lyra.core.cli.cli_protocol"):
+            cmd, prompt_file = build_cmd(model_config)
+
+        assert prompt_file is None
+        assert "--dangerously-skip-permissions" in cmd
+        assert any(
+            "SECURITY" in record.message
+            and "dangerously-skip-permissions" in record.message
+            for record in caplog.records
+        ), "Expected SECURITY warning for skip_permissions bypass"
+        assert any(
+            record.levelno == logging.WARNING for record in caplog.records
+        )
+
+    def test_no_warning_when_skip_permissions_false(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No WARNING is emitted when skip_permissions=False."""
+        model_config = ModelConfig(skip_permissions=False)
+
+        with caplog.at_level(logging.WARNING, logger="lyra.core.cli.cli_protocol"):
+            cmd, prompt_file = build_cmd(model_config)
+
+        assert prompt_file is None
+        assert "--dangerously-skip-permissions" not in cmd
+        assert not any(
+            "dangerously-skip-permissions" in record.message
+            for record in caplog.records
+        )
+
+    def test_warning_exact_message(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Warning message matches expected audit string exactly."""
+        model_config = ModelConfig(skip_permissions=True)
+
+        with caplog.at_level(logging.WARNING, logger="lyra.core.cli.cli_protocol"):
+            build_cmd(model_config)
+
+        messages = [r.message for r in caplog.records]
+        assert (
+            "SECURITY: --dangerously-skip-permissions enabled for CLI subprocess"
+            in messages
+        )


### PR DESCRIPTION
## Summary
- Add WARNING-level log when `--dangerously-skip-permissions` is activated in CLI subprocess
- Single activation point confirmed (grep verified no other sites)
- Addresses P1 #12 from quality audit

## Test plan
- [x] 3 new unit tests: warning emitted, correct level, no warning when flag off
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)