### PR TITLE
refactor(hub): remove deprecated individual params from Hub.__init__

### DIFF
--- a/artifacts/analyses/quality-audit/AUDIT-SUMMARY.md
+++ b/artifacts/analyses/quality-audit/AUDIT-SUMMARY.md
@@ -89,9 +89,7 @@
 
 ### Code Smells - God Classes / Long Parameters
 
-9. **Hub.__init__ has 21 parameters** (`core/hub/hub.py:74-96`)
-   - Critical maintainability issue
-   - **Effort:** 4 hours (extract HubConfig dataclass)
+9. ~~**Hub.__init__ has 21 parameters**~~ — **FIXED** by #933 (removed 12 deprecated individual params; all callers migrated to `config=HubConfig(...)`)
 
 10. **Pool has 13 constructor parameters** (`core/pool/pool.py:32`)
     - Extract PoolConfig dataclass
@@ -312,7 +310,7 @@
 |---|--------|--------|--------|
 | 7 | Complete ADR-048 migration (core stores -> infrastructure) | 4h | Medium |
 | 8 | Add integration tests for SimpleAgent | 6h | High |
-| 9 | Extract HubConfig dataclass | 4h | Medium |
+| ~~9~~ | ~~Extract HubConfig dataclass~~ | ~~4h~~ | ~~Medium~~ | ✅ #933 |
 | 10 | Fix flaky test patterns (sleep -> events) | 4h | Medium |
 | 11 | Add pool eviction synchronization | 2h | Medium |
 | 12 | Wrap blocking DNS in `asyncio.to_thread` | 1h | Medium |

--- a/src/lyra/bootstrap/factory/unified.py
+++ b/src/lyra/bootstrap/factory/unified.py
@@ -36,6 +36,7 @@ from lyra.config import load_multibot_config
 from lyra.core.agent import Agent
 from lyra.core.agent.agent_loader import agent_row_to_config
 from lyra.core.cli.cli_pool import CliPool
+from lyra.core.config import HubConfig
 from lyra.core.hub import Hub
 from lyra.core.hub.event_bus import PipelineEventBus
 from lyra.core.messaging.message import InboundMessage
@@ -178,26 +179,30 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
             event_bus_cfg = _load_event_bus_config(raw_config)
             event_bus = PipelineEventBus(maxsize=event_bus_cfg.queue_maxsize)
 
+            hub_config = HubConfig(
+                rate_limit=hub_cfg.rate_limit,
+                rate_window=hub_cfg.rate_window,
+                pool_ttl=hub_cfg.pool_ttl,
+                debounce_ms=debouncer_cfg.default_debounce_ms,
+                cancel_on_new_message=debouncer_cfg.cancel_on_new_message,
+                turn_timeout=cli_pool_cfg.turn_timeout,
+                safe_dispatch_timeout=pool_cfg.safe_dispatch_timeout,
+                staging_maxsize=inbound_bus_cfg.staging_maxsize,
+                platform_queue_maxsize=inbound_bus_cfg.platform_queue_maxsize,
+                queue_depth_threshold=inbound_bus_cfg.queue_depth_threshold,
+                max_merged_chars=debouncer_cfg.max_merged_chars,
+            )
+
             hub = Hub(
                 circuit_registry=circuit_registry,
                 msg_manager=msg_manager,
                 pairing_manager=pm,
                 stt=stt_service,
                 tts=tts_service,
-                debounce_ms=debouncer_cfg.default_debounce_ms,
-                cancel_on_new_message=debouncer_cfg.cancel_on_new_message,
                 prefs_store=stores.prefs,
-                turn_timeout=cli_pool_cfg.turn_timeout,
-                pool_ttl=hub_cfg.pool_ttl,
-                rate_limit=hub_cfg.rate_limit,
-                rate_window=hub_cfg.rate_window,
-                safe_dispatch_timeout=pool_cfg.safe_dispatch_timeout,
-                staging_maxsize=inbound_bus_cfg.staging_maxsize,
-                platform_queue_maxsize=inbound_bus_cfg.platform_queue_maxsize,
-                queue_depth_threshold=inbound_bus_cfg.queue_depth_threshold,
-                max_merged_chars=debouncer_cfg.max_merged_chars,
                 event_bus=event_bus,
                 inbound_bus=inbound_bus,
+                config=hub_config,
             )
             hub.set_turn_store(stores.turn)
             hub.set_message_index(stores.message_index)

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -60,16 +60,7 @@ class Hub(
 ):
     """Central hub: Bus + OutboundDispatchers + adapter registry + pools."""
 
-    # Class-level defaults; production values come from [hub] in config.toml.
     BUS_SIZE = 100
-    RATE_LIMIT = 20
-    RATE_WINDOW = 60
-    POOL_TTL: float = 604800.0  # 7 days
-    SAFE_DISPATCH_TIMEOUT: float = 10.0  # [pool] safe_dispatch_timeout
-    STAGING_MAXSIZE = 500  # [inbound_bus] staging_maxsize
-    PLATFORM_QUEUE_MAXSIZE = 100  # [inbound_bus] platform_queue_maxsize
-    QUEUE_DEPTH_THRESHOLD = 100  # [inbound_bus] queue_depth_threshold
-    MAX_MERGED_CHARS = 4096  # [debouncer] max_merged_chars
 
     def __init__(  # noqa: PLR0913
         self,
@@ -82,66 +73,8 @@ class Hub(
         event_bus: "PipelineEventBus | None" = None,
         inbound_bus: "Bus[InboundMessage] | None" = None,
         config: HubConfig | None = None,
-        # Backward-compat: individual params override config (deprecated)
-        rate_limit: int | None = None,
-        rate_window: int | None = None,
-        pool_ttl: float | None = None,
-        debounce_ms: int | None = None,
-        cancel_on_new_message: bool | None = None,
-        turn_timeout: float | None = None,
-        safe_dispatch_timeout: float | None = None,
-        staging_maxsize: int | None = None,
-        platform_queue_maxsize: int | None = None,
-        queue_depth_threshold: int | None = None,
-        max_merged_chars: int | None = None,
-        max_pools: int | None = None,
     ) -> None:
-        base_cfg: HubConfig = config if config is not None else HubConfig()
-        # Merge backward-compat overrides
-        cfg = HubConfig(
-            rate_limit=rate_limit if rate_limit is not None else base_cfg.rate_limit,
-            rate_window=rate_window
-            if rate_window is not None
-            else base_cfg.rate_window,
-            pool_ttl=pool_ttl if pool_ttl is not None else base_cfg.pool_ttl,
-            debounce_ms=debounce_ms
-            if debounce_ms is not None
-            else base_cfg.debounce_ms,
-            cancel_on_new_message=(
-                cancel_on_new_message
-                if cancel_on_new_message is not None
-                else base_cfg.cancel_on_new_message
-            ),
-            turn_timeout=turn_timeout
-            if turn_timeout is not None
-            else base_cfg.turn_timeout,
-            safe_dispatch_timeout=(
-                safe_dispatch_timeout
-                if safe_dispatch_timeout is not None
-                else base_cfg.safe_dispatch_timeout
-            ),
-            staging_maxsize=(
-                staging_maxsize
-                if staging_maxsize is not None
-                else base_cfg.staging_maxsize
-            ),
-            platform_queue_maxsize=(
-                platform_queue_maxsize
-                if platform_queue_maxsize is not None
-                else base_cfg.platform_queue_maxsize
-            ),
-            queue_depth_threshold=(
-                queue_depth_threshold
-                if queue_depth_threshold is not None
-                else base_cfg.queue_depth_threshold
-            ),
-            max_merged_chars=(
-                max_merged_chars
-                if max_merged_chars is not None
-                else base_cfg.max_merged_chars
-            ),
-            max_pools=max_pools if max_pools is not None else base_cfg.max_pools,
-        )
+        cfg = config if config is not None else HubConfig()
         if cfg.max_pools <= 0:
             raise ValueError(f"max_pools must be > 0, got {cfg.max_pools}")
         self._platform_queue_maxsize = cfg.platform_queue_maxsize

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -9,6 +9,7 @@ import pytest
 
 from lyra.core import Agent, AgentBase, Hub, Pool
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
+from lyra.core.config import HubConfig
 from lyra.core.messaging.message import InboundMessage, Response
 from lyra.core.messaging.render_events import RenderEvent
 from tests.core.conftest import make_inbound_message
@@ -28,7 +29,7 @@ class TestPoolTTLEviction:
 
     def test_stale_idle_pool_evicted(self) -> None:
         """An idle pool past TTL is removed on next get_or_create_pool call."""
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         pool = hub.get_or_create_pool("p1", "agent")
         pool._last_active -= 120
         self._force_eviction_eligible(hub)
@@ -38,7 +39,7 @@ class TestPoolTTLEviction:
 
     def test_active_pool_not_evicted(self) -> None:
         """A pool with a running task is never evicted, even past TTL."""
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         pool = hub.get_or_create_pool("p1", "agent")
         pool._last_active -= 120
         pool._current_task = MagicMock()
@@ -49,7 +50,7 @@ class TestPoolTTLEviction:
 
     def test_fresh_pool_not_evicted(self) -> None:
         """A recently active idle pool is kept."""
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         hub.get_or_create_pool("p1", "agent")
         self._force_eviction_eligible(hub)
         hub.get_or_create_pool("p2", "agent")
@@ -58,11 +59,11 @@ class TestPoolTTLEviction:
     def test_pool_ttl_default(self) -> None:
         """Default POOL_TTL is 604800s (7 days) and passes through to _pool_ttl."""
         hub = Hub()
-        assert hub._pool_ttl == Hub.POOL_TTL
+        assert hub._pool_ttl == HubConfig().pool_ttl
 
     def test_done_task_pool_evicted(self) -> None:
         """A pool whose task finished (done()=True) is evicted when stale."""
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         pool = hub.get_or_create_pool("p1", "agent")
         pool._last_active -= 120
         pool._current_task = MagicMock()
@@ -73,7 +74,7 @@ class TestPoolTTLEviction:
 
     def test_multiple_stale_pools_all_evicted(self) -> None:
         """Multiple stale idle pools are evicted in a single pass."""
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         p1 = hub.get_or_create_pool("p1", "agent")
         hub.get_or_create_pool("p2", "agent")
         p3 = hub.get_or_create_pool("p3", "agent")
@@ -88,7 +89,7 @@ class TestPoolTTLEviction:
 
     def test_eviction_throttled(self) -> None:
         """Eviction scan is throttled — skipped if less than TTL/10 elapsed."""
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         pool = hub.get_or_create_pool("p1", "agent")
         pool._last_active -= 120
         # Don't reset throttle — second call is within TTL/10
@@ -99,7 +100,7 @@ class TestPoolTTLEviction:
         """Pool.submit() updates last_active timestamp."""
         import time
 
-        hub = Hub(pool_ttl=60)
+        hub = Hub(config=HubConfig(pool_ttl=60))
         pool = hub.get_or_create_pool("p1", "agent")
         pool._last_active -= 50  # nearly stale
         t0 = time.monotonic()
@@ -184,7 +185,7 @@ class TestHubEvictFlushTask:
     @pytest.mark.asyncio
     async def test_evict_stale_pool_creates_flush_task(self) -> None:
         """Evicting a pool that has at least one message must schedule a flush task."""
-        hub = Hub(pool_ttl=1)
+        hub = Hub(config=HubConfig(pool_ttl=1))
         mock_mm = AsyncMock()
         object.__setattr__(hub, "_memory", mock_mm)
 

--- a/tests/core/test_hub_scope.py
+++ b/tests/core/test_hub_scope.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from lyra.core import Hub
 from lyra.core.auth.trust import TrustLevel
+from lyra.core.config import HubConfig
 from lyra.core.messaging.message import InboundMessage, Platform
 from tests.core.conftest import make_inbound_message
 
@@ -50,7 +51,7 @@ class TestCrossScopeRateLimit:
 
     def test_rate_limit_spans_scopes(self) -> None:
         # Arrange — two different scopes for the same user_id
-        hub = Hub(rate_limit=5, rate_window=60)
+        hub = Hub(config=HubConfig(rate_limit=5, rate_window=60))
 
         def make_scoped_message(scope_id: str) -> InboundMessage:
             return InboundMessage(
@@ -178,7 +179,7 @@ class TestRateTimestampsCleanup:
         timestamp — the new one — confirming the stale entry was removed."""
         import unittest.mock
 
-        hub = Hub(rate_window=1)
+        hub = Hub(config=HubConfig(rate_window=1))
         msg = make_inbound_message(platform="telegram", user_id="alice")
 
         # First call — inserts a timestamp for alice's user key

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -10,6 +10,7 @@ import dataclasses
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from lyra.core.config import HubConfig
 from lyra.core.hub.middleware import (
     MiddlewarePipeline,
     PipelineContext,
@@ -112,7 +113,7 @@ class TestRateLimit:
 
     async def test_rate_limited_drops(self) -> None:
         mw = RateLimitMiddleware()
-        hub = _make_hub(rate_limit=1, rate_window=60)
+        hub = _make_hub(config=HubConfig(rate_limit=1, rate_window=60))
         ctx = PipelineContext(hub=hub)
         msg = make_inbound_message()
 

--- a/tests/core/test_pool_manager.py
+++ b/tests/core/test_pool_manager.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lyra.core.cli.cli_pool import CliPool, _ProcessEntry
+from lyra.core.config import HubConfig
 from lyra.core.hub import Hub
 from lyra.core.messaging.message import Platform
 from lyra.core.pool import Pool
@@ -54,9 +55,11 @@ def _make_hub(
     cancel_on_new_message: bool = False,
 ) -> Hub:
     hub = Hub(
-        pool_ttl=pool_ttl,
-        debounce_ms=debounce_ms,
-        cancel_on_new_message=cancel_on_new_message,
+        config=HubConfig(
+            pool_ttl=pool_ttl,
+            debounce_ms=debounce_ms,
+            cancel_on_new_message=cancel_on_new_message,
+        ),
     )
     hub.inbound_bus.register(Platform.TELEGRAM, maxsize=10)
     return hub
@@ -504,12 +507,12 @@ class TestMaxPoolsValidation:
 
     def test_zero_max_pools_raises_valueerror(self):
         with pytest.raises(ValueError, match="max_pools must be > 0"):
-            Hub(max_pools=0)
+            Hub(config=HubConfig(max_pools=0))
 
     def test_negative_max_pools_raises_valueerror(self):
         with pytest.raises(ValueError, match="max_pools must be > 0"):
-            Hub(max_pools=-1)
+            Hub(config=HubConfig(max_pools=-1))
 
     def test_positive_max_pools_works(self):
-        hub = Hub(max_pools=100)
+        hub = Hub(config=HubConfig(max_pools=100))
         assert hub._max_pools == 100

--- a/tests/integration/test_message_pipeline.py
+++ b/tests/integration/test_message_pipeline.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 
 import pytest
 
+from lyra.core.config import HubConfig
 from lyra.core.hub.middleware import build_default_pipeline
 from lyra.core.hub.pipeline.message_pipeline import Action
 from lyra.core.messaging.message import Platform
@@ -128,7 +129,7 @@ class TestMessagePipelineTraces:
         steps_first: list[dict[str, Any]] = []
         steps_second: list[dict[str, Any]] = []
 
-        hub = _make_hub(rate_limit=1, rate_window=60)
+        hub = _make_hub(config=HubConfig(rate_limit=1, rate_window=60))
         msg = make_inbound_message()
 
         pipeline1 = build_default_pipeline(


### PR DESCRIPTION
## Summary

- Remove 12 backward-compat individual params from `Hub.__init__` (pool_ttl, rate_limit, rate_window, debounce_ms, cancel_on_new_message, turn_timeout, safe_dispatch_timeout, staging_maxsize, platform_queue_maxsize, queue_depth_threshold, max_merged_chars, max_pools)
- Migrate `unified.py` to build `HubConfig(...)` and pass `config=` (matching `hub_builder.py` pattern)
- Migrate all test callers: `Hub(pool_ttl=60)` → `Hub(config=HubConfig(pool_ttl=60))`
- Remove 55-line backward-compat merge block and duplicated class-level constants
- Mark audit P1 #9 as fixed

## Test plan

- [x] All 2753 tests pass (0 failures)
- [x] Lint, typecheck, import-layers, file-length gates pass
- [x] Pre-push hooks (trufflehog, license) pass

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)