### PR TITLE
refactor(core): remove platform_meta dict[str, Any] escape hatch (#853)

### DIFF
--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -203,14 +203,18 @@ def _decode_union(
     # Multiple non-None: str | bytes without b64 prefix → keep as str
     if str in non_none and isinstance(value, str):
         return value
-    # Dataclass candidate: try to reconstruct
+    # Dataclass candidate: select by field-overlap scoring.
+    # Empty dataclass (e.g. GenericMeta) matches empty dicts; non-empty
+    # dataclasses match when at least one field key appears in the payload.
     for candidate in non_none:
         if (
             dataclasses.is_dataclass(candidate)
             and isinstance(candidate, type)
             and isinstance(value, dict)
         ):
-            return _decode_dataclass(value, candidate, resolver)
+            hints = _get_hints(candidate, resolver)
+            if not hints or (set(hints) & set(value)):
+                return _decode_dataclass(value, candidate, resolver)
     return value
 
 

--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -4,7 +4,7 @@ Handles encoding/decoding of Lyra dataclasses to/from UTF-8 JSON bytes:
 - Enum  → .value (str/int)
 - datetime → .isoformat()
 - bytes → "b64:<base64>" prefixed string
-- callables stripped from dict fields (platform_meta)
+- callable fields skipped (session_update_fn, similar non-serializable fields)
 - nested dataclasses serialized recursively
 """
 
@@ -82,11 +82,6 @@ def deserialize_dict(
 # ---------------------------------------------------------------------------
 
 
-def _strip_callables(d: dict[str, Any]) -> dict[str, Any]:
-    """Remove callable values from a dict (used for platform_meta)."""
-    return {k: v for k, v in d.items() if not callable(v)}
-
-
 def _get_hints(dc_type: type, resolver: _TypeHintResolver) -> dict[str, Any]:
     """Get type hints for a dataclass, handling TYPE_CHECKING-only imports.
 
@@ -156,11 +151,9 @@ def _encode(obj: Any) -> Any:
         # obj is a dataclass instance (narrowed by is_dataclass + not type check)
         for f in dataclasses.fields(obj):
             value = getattr(obj, f.name)
-            encoded_value = _encode(value)
-            # Strip callables from dict fields (platform_meta pattern)
-            if isinstance(encoded_value, dict):
-                encoded_value = _strip_callables(encoded_value)
-            result[f.name] = encoded_value
+            if callable(value):
+                continue
+            result[f.name] = _encode(value)
         return result
 
     if isinstance(obj, Enum):

--- a/packages/roxabi-nats/src/roxabi_nats/_serialize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_serialize.py
@@ -180,6 +180,36 @@ def _encode(obj: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
+def _best_dataclass_candidate(
+    value: dict[str, Any],
+    non_none: list[Any],
+    resolver: _TypeHintResolver,
+) -> Any:
+    """Return the best-matching dataclass type for *value* among *non_none*.
+
+    Uses max field-key overlap; falls back to the first no-field dataclass
+    (e.g. GenericMeta) when no typed candidate has positive overlap.
+    """
+    best: Any = None
+    best_score: int = -1
+    fallback: Any = None
+    for candidate in non_none:
+        if not (dataclasses.is_dataclass(candidate) and isinstance(candidate, type)):
+            continue
+        hints = _get_hints(candidate, resolver)
+        if not hints:
+            if fallback is None:
+                fallback = candidate
+        else:
+            score = len(set(hints) & set(value))
+            if score > best_score:
+                best_score = score
+                best = candidate
+    if best is not None and best_score > 0:
+        return best
+    return fallback
+
+
 def _decode_union(
     value: Any, args: tuple[Any, ...], resolver: _TypeHintResolver
 ) -> Any:
@@ -187,27 +217,16 @@ def _decode_union(
     if value is None:
         return None
     non_none = [a for a in args if a is not type(None)]
-    # bytes: detect "b64:" prefix
     if bytes in non_none and isinstance(value, str) and value.startswith(_B64_PREFIX):
         return base64.b64decode(value[len(_B64_PREFIX) :])
-    # Single non-None candidate: decode as that type
     if len(non_none) == 1:
         return _decode(value, non_none[0], resolver)
-    # Multiple non-None: str | bytes without b64 prefix → keep as str
     if str in non_none and isinstance(value, str):
         return value
-    # Dataclass candidate: select by field-overlap scoring.
-    # Empty dataclass (e.g. GenericMeta) matches empty dicts; non-empty
-    # dataclasses match when at least one field key appears in the payload.
-    for candidate in non_none:
-        if (
-            dataclasses.is_dataclass(candidate)
-            and isinstance(candidate, type)
-            and isinstance(value, dict)
-        ):
-            hints = _get_hints(candidate, resolver)
-            if not hints or (set(hints) & set(value)):
-                return _decode_dataclass(value, candidate, resolver)
+    if isinstance(value, dict):
+        candidate = _best_dataclass_candidate(value, non_none, resolver)
+        if candidate is not None:
+            return _decode_dataclass(value, candidate, resolver)
     return value
 
 

--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -40,6 +40,7 @@ from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.auth.guard import BlockedGuard, GuardChain
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     OutboundAttachment,
     OutboundAudio,
@@ -129,9 +130,11 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
 
     def _cancel_typing_for(self, inbound: InboundMessage) -> None:
         """Cancel the typing indicator for the channel/thread of *inbound*."""
-        channel_id: int | None = inbound.platform_meta.get("channel_id")
-        thread_id: int | None = inbound.platform_meta.get("thread_id")
-        send_to_id = thread_id if thread_id is not None else channel_id
+        if not isinstance(inbound.platform_meta, DiscordMeta):
+            return
+        channel_id: int = inbound.platform_meta.channel_id
+        thread_id: int | None = inbound.platform_meta.thread_id
+        send_to_id = thread_id if thread_id is not None else (channel_id or None)
         if send_to_id is not None:
             self._cancel_typing(send_to_id)
 

--- a/src/lyra/adapters/discord/discord_audio.py
+++ b/src/lyra/adapters/discord/discord_audio.py
@@ -10,6 +10,7 @@ import discord
 from lyra.adapters.shared._shared import push_to_hub_guarded
 from lyra.core.audio_payload import AudioPayload
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     Platform,
     RoutingContext,
@@ -76,18 +77,18 @@ def normalize_audio(
     if is_guild_channel:
         scope_id = user_scoped(scope_id, user_id)
     timestamp = raw.created_at
-    platform_meta = {
-        "guild_id": raw.guild.id if raw.guild else None,
-        "channel_id": raw.channel.id,
-        "message_id": raw.id,
-    }
+    platform_meta = DiscordMeta(
+        guild_id=raw.guild.id if raw.guild else None,
+        channel_id=raw.channel.id,
+        message_id=raw.id,
+    )
     routing = RoutingContext(
         platform=Platform.DISCORD.value,
         bot_id=bot_id,
         scope_id=scope_id,
         thread_id=str(raw.channel.id) if is_thread else None,
         reply_to_message_id=str(raw.id),
-        platform_meta=dict(platform_meta),
+        platform_meta=platform_meta,
     )
     return InboundMessage(
         id=f"discord:{user_id}:{int(timestamp.timestamp())}:{raw.id}",

--- a/src/lyra/adapters/discord/discord_audio_outbound.py
+++ b/src/lyra/adapters/discord/discord_audio_outbound.py
@@ -21,6 +21,7 @@ from lyra.adapters.shared._shared import (
     truncate_caption,
 )
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     OutboundAttachment,
     OutboundAudio,
@@ -198,7 +199,13 @@ async def render_voice_stream(
             inbound.id,
         )
         return
-    guild_id = inbound.platform_meta.get("guild_id")
+    if not isinstance(inbound.platform_meta, DiscordMeta):
+        log.warning(
+            "render_voice_stream: platform_meta is not DiscordMeta for msg id=%s",
+            inbound.id,
+        )
+        return
+    guild_id: int | None = inbound.platform_meta.guild_id
     if guild_id is None:
         log.warning(
             "render_voice_stream: platform_meta missing 'guild_id' for msg id=%s",

--- a/src/lyra/adapters/discord/discord_formatting.py
+++ b/src/lyra/adapters/discord/discord_formatting.py
@@ -10,7 +10,12 @@ import discord
 from tabulate import tabulate
 
 from lyra.adapters.shared._shared import AUDIO_MIME_TYPES, chunk_text
-from lyra.core.messaging.message import Attachment, InboundMessage, Platform
+from lyra.core.messaging.message import (
+    Attachment,
+    DiscordMeta,
+    InboundMessage,
+    Platform,
+)
 
 log = logging.getLogger("lyra.adapters.discord")
 
@@ -114,12 +119,18 @@ def _validate_inbound(
     if inbound.platform != Platform.DISCORD.value:
         log.error("%s called with non-discord message id=%s", caller, inbound.id)
         return None
-    channel_id: int | None = inbound.platform_meta.get("channel_id")
-    if channel_id is None:
+    if not isinstance(inbound.platform_meta, DiscordMeta):
+        log.error(
+            "%s: platform_meta is not DiscordMeta for msg id=%s", caller, inbound.id
+        )
+        return None
+    channel_id: int = inbound.platform_meta.channel_id
+    if channel_id == 0:
         log.error(
             "%s: platform_meta missing 'channel_id' for msg id=%s", caller, inbound.id
         )
         return None
-    thread_id: int | None = inbound.platform_meta.get("thread_id")
-    message_id: int | None = inbound.platform_meta.get("message_id")
+    thread_id: int | None = inbound.platform_meta.thread_id
+    raw_msg_id = inbound.platform_meta.message_id
+    message_id: int | None = raw_msg_id if raw_msg_id != 0 else None
     return channel_id, thread_id, message_id

--- a/src/lyra/adapters/discord/discord_inbound.py
+++ b/src/lyra/adapters/discord/discord_inbound.py
@@ -19,7 +19,7 @@ from lyra.adapters.discord.discord_threads import (
 from lyra.adapters.shared._shared import AUDIO_MIME_TYPES, push_to_hub_guarded
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.callbacks import TrustedCallback
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import DiscordMeta, InboundMessage, Platform
 
 if TYPE_CHECKING:
     from lyra.adapters.discord import DiscordAdapter
@@ -185,10 +185,8 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
         log.exception("Failed to normalize discord message id=%s", message.id)
         return
 
-    # Inject stored session + persistence callback into platform_meta.
-    _meta_updates: dict[str, Any] = {}
-    if _stored_session_id is not None:
-        _meta_updates["thread_session_id"] = _stored_session_id
+    # Inject stored thread_session_id into typed DiscordMeta.
+    _stored_session: str | None = _stored_session_id
 
     # DM session wiring: inject prior session_id + persist callback for DMs.
     _dm_session_id: str | None = None
@@ -206,8 +204,19 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
                 "TurnStore.get_last_session failed for DM pool_id=%s", _pool_id
             )
     if _dm_session_id is not None:
-        _meta_updates["thread_session_id"] = _dm_session_id
-    _has_thread_id = hub_msg.platform_meta.get("thread_id") is not None
+        _stored_session = _dm_session_id
+    if _stored_session is not None and isinstance(hub_msg.platform_meta, DiscordMeta):
+        hub_msg = dataclasses.replace(
+            hub_msg,
+            platform_meta=dataclasses.replace(
+                hub_msg.platform_meta, thread_session_id=_stored_session
+            ),
+        )
+    _has_thread_id = (
+        isinstance(hub_msg.platform_meta, DiscordMeta)
+        and hub_msg.platform_meta.thread_id is not None
+    )
+    _meta_updates: dict[str, Any] = {}
     if _is_dm and adapter._turn_store is not None:
         # DM path takes priority over thread-session persistence
         _dm_ts = adapter._turn_store
@@ -231,7 +240,10 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
     if _meta_updates:
         hub_msg = dataclasses.replace(
             hub_msg,
-            platform_meta={**hub_msg.platform_meta, **_meta_updates},
+            platform_meta={  # type: ignore[arg-type]  # T2.3: replace with typed DiscordMeta fields
+                **dataclasses.asdict(hub_msg.platform_meta),
+                **_meta_updates,
+            },
         )
 
     log.info(

--- a/src/lyra/adapters/discord/discord_inbound.py
+++ b/src/lyra/adapters/discord/discord_inbound.py
@@ -18,7 +18,6 @@ from lyra.adapters.discord.discord_threads import (
 )
 from lyra.adapters.shared._shared import AUDIO_MIME_TYPES, push_to_hub_guarded
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.callbacks import TrustedCallback
 from lyra.core.messaging.message import DiscordMeta, InboundMessage, Platform
 
 if TYPE_CHECKING:
@@ -216,7 +215,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
         isinstance(hub_msg.platform_meta, DiscordMeta)
         and hub_msg.platform_meta.thread_id is not None
     )
-    _meta_updates: dict[str, Any] = {}
+    _dc_session_update_fn = None
     if _is_dm and adapter._turn_store is not None:
         # DM path takes priority over thread-session persistence
         _dm_ts = adapter._turn_store
@@ -226,25 +225,19 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
         ) -> None:
             await _dm_ts.start_session(session_id, pool_id)
 
-        _meta_updates["_session_update_fn"] = TrustedCallback(_dm_session_update_fn)
+        _dc_session_update_fn = _dm_session_update_fn
     elif _has_thread_id and adapter._thread_store is not None:
         _ts = adapter._thread_store
         _bid, _cache = adapter._bot_id, adapter._thread_sessions
 
-        async def _session_update_fn(
+        async def _dc_thread_session_update_fn(
             msg: InboundMessage, session_id: str, pool_id: str
         ) -> None:
             await persist_thread_session(_ts, msg, session_id, pool_id, _bid, _cache)
 
-        _meta_updates["_session_update_fn"] = TrustedCallback(_session_update_fn)
-    if _meta_updates:
-        hub_msg = dataclasses.replace(
-            hub_msg,
-            platform_meta={  # type: ignore[arg-type]  # T2.3: replace with typed DiscordMeta fields
-                **dataclasses.asdict(hub_msg.platform_meta),
-                **_meta_updates,
-            },
-        )
+        _dc_session_update_fn = _dc_thread_session_update_fn
+    if _dc_session_update_fn is not None:
+        hub_msg = dataclasses.replace(hub_msg, session_update_fn=_dc_session_update_fn)
 
     log.info(
         "message_received",

--- a/src/lyra/adapters/discord/discord_normalize.py
+++ b/src/lyra/adapters/discord/discord_normalize.py
@@ -11,6 +11,7 @@ import discord
 from lyra.adapters.discord.discord_formatting import extract_attachments
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     Platform,
     RoutingContext,
@@ -86,21 +87,21 @@ def normalize(  # noqa: PLR0913 — all kwargs are platform-specific routing con
         if _reference is not None and _reference.message_id is not None
         else None
     )
-    platform_meta = {
-        "guild_id": raw.guild.id if raw.guild else None,
-        "channel_id": resolved_channel_id,
+    platform_meta = DiscordMeta(
+        guild_id=raw.guild.id if raw.guild else None,
+        channel_id=resolved_channel_id,
         # INVARIANT: always original message id, never thread.id
-        "message_id": raw.id,
-        "thread_id": resolved_thread_id,
-        "channel_type": channel_type,
-    }
+        message_id=raw.id,
+        thread_id=resolved_thread_id,
+        channel_type=channel_type,
+    )
     routing = RoutingContext(
         platform=Platform.DISCORD.value,
         bot_id=adapter._bot_id,
         scope_id=scope_id,
         thread_id=(str(resolved_thread_id) if resolved_thread_id is not None else None),
         reply_to_message_id=str(raw.id),
-        platform_meta=dict(platform_meta),
+        platform_meta=platform_meta,
     )
     return InboundMessage(
         id=(f"discord:{user_id}:{int(timestamp.timestamp())}:{raw.id}"),

--- a/src/lyra/adapters/discord/discord_threads.py
+++ b/src/lyra/adapters/discord/discord_threads.py
@@ -6,6 +6,8 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
+from lyra.core.messaging.message import DiscordMeta
+
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage
     from lyra.infrastructure.stores.thread_store import ThreadStore
@@ -48,7 +50,9 @@ async def persist_thread_session(  # noqa: PLR0913 — each arg is a distinct re
     cache: dict[str, tuple[str, str]],
 ) -> None:
     """Persist session_id and pool_id for a thread after a successful turn."""
-    thread_id: int | None = msg.platform_meta.get("thread_id")
+    if not isinstance(msg.platform_meta, DiscordMeta):
+        return
+    thread_id: int | None = msg.platform_meta.thread_id
     if thread_id is None:
         return
     try:

--- a/src/lyra/adapters/shared/cli.py
+++ b/src/lyra/adapters/shared/cli.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime, timezone
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage
+from lyra.core.messaging.message import GenericMeta, InboundMessage
 
 
 class CLIAdapter:
@@ -43,5 +43,5 @@ class CLIAdapter:
             text_raw=text,
             timestamp=now,
             trust_level=TrustLevel.OWNER,
-            platform_meta={},
+            platform_meta=GenericMeta(),
         )

--- a/src/lyra/adapters/telegram/telegram_formatting.py
+++ b/src/lyra/adapters/telegram/telegram_formatting.py
@@ -86,6 +86,9 @@ def _validate_inbound(
         )
         return None
     chat_id: int = inbound.platform_meta.chat_id
+    if not chat_id:
+        log.error("%s: chat_id is 0 for msg id=%s", caller, inbound.id)
+        return None
     topic_id: int | None = inbound.platform_meta.topic_id
     message_id: int | None = inbound.platform_meta.message_id
     return chat_id, topic_id, message_id

--- a/src/lyra/adapters/telegram/telegram_formatting.py
+++ b/src/lyra/adapters/telegram/telegram_formatting.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from lyra.adapters.shared._shared import ATTACHMENT_EXTS_BASE, chunk_text
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 
 log = logging.getLogger("lyra.adapters.telegram")
 
@@ -80,12 +80,12 @@ def _validate_inbound(
     if inbound.platform != Platform.TELEGRAM.value:
         log.error("%s called with non-telegram message id=%s", caller, inbound.id)
         return None
-    chat_id: int | None = inbound.platform_meta.get("chat_id")
-    if chat_id is None:
+    if not isinstance(inbound.platform_meta, TelegramMeta):
         log.error(
             "%s: platform_meta missing 'chat_id' for msg id=%s", caller, inbound.id
         )
         return None
-    topic_id: int | None = inbound.platform_meta.get("topic_id")
-    message_id: int | None = inbound.platform_meta.get("message_id")
+    chat_id: int = inbound.platform_meta.chat_id
+    topic_id: int | None = inbound.platform_meta.topic_id
+    message_id: int | None = inbound.platform_meta.message_id
     return chat_id, topic_id, message_id

--- a/src/lyra/adapters/telegram/telegram_inbound.py
+++ b/src/lyra/adapters/telegram/telegram_inbound.py
@@ -13,7 +13,7 @@ from lyra.adapters.telegram.telegram_formatting import _make_send_kwargs
 from lyra.adapters.telegram.telegram_normalize import _make_scope_id, normalize_audio
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.callbacks import TrustedCallback
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 
 if TYPE_CHECKING:
     from lyra.adapters.telegram import TelegramAdapter
@@ -32,7 +32,8 @@ async def _push_to_hub(
     cases (e.g. to clean up a temp audio file). Always returns normally so
     aiogram receives HTTP 200.
     """
-    chat_id = hub_msg.platform_meta.get("chat_id")
+    _meta = hub_msg.platform_meta
+    chat_id = _meta.chat_id if isinstance(_meta, TelegramMeta) else None
 
     async def _send_bp(text: str) -> None:
         if chat_id is None:
@@ -66,7 +67,11 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
 
     # In group chats, only respond when directly mentioned.
     # In private chats, always respond.
-    if hub_msg.platform_meta.get("is_group") and not hub_msg.is_mention:
+    if (
+        isinstance(hub_msg.platform_meta, TelegramMeta)
+        and hub_msg.platform_meta.is_group
+        and not hub_msg.is_mention
+    ):
         return
 
     # Session wiring: inject prior session_id + persist callback.
@@ -96,7 +101,7 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
     if _meta_updates:
         hub_msg = dataclasses.replace(
             hub_msg,
-            platform_meta={**hub_msg.platform_meta, **_meta_updates},
+            platform_meta={**hub_msg.platform_meta, **_meta_updates},  # type: ignore[arg-type]  # T2.2: write site migration pending
         )
 
     log.info(

--- a/src/lyra/adapters/telegram/telegram_inbound.py
+++ b/src/lyra/adapters/telegram/telegram_inbound.py
@@ -95,6 +95,8 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
         ) -> None:
             await _ts.start_session(session_id, pool_id)
 
+        _session_update_fn = _tg_session_update_fn
+
     _replacements: dict[str, Any] = {}
     _is_tg_meta = isinstance(hub_msg.platform_meta, TelegramMeta)
     if _new_thread_session_id is not None and _is_tg_meta:

--- a/src/lyra/adapters/telegram/telegram_inbound.py
+++ b/src/lyra/adapters/telegram/telegram_inbound.py
@@ -12,7 +12,6 @@ from lyra.adapters.telegram.telegram_audio import _download_audio
 from lyra.adapters.telegram.telegram_formatting import _make_send_kwargs
 from lyra.adapters.telegram.telegram_normalize import _make_scope_id, normalize_audio
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.callbacks import TrustedCallback
 from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 
 if TYPE_CHECKING:
@@ -75,21 +74,20 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
         return
 
     # Session wiring: inject prior session_id + persist callback.
-    _meta_updates: dict[str, Any] = {}
+    _new_thread_session_id: str | None = None
+    _session_update_fn = None
     if adapter._turn_store is not None:
         from lyra.core.hub.hub_protocol import RoutingKey
-        from lyra.core.messaging.message import Platform
 
         _pool_id = RoutingKey(
             Platform.TELEGRAM, adapter._bot_id, hub_msg.scope_id
         ).to_pool_id()
         try:
-            _last_sid = await adapter._turn_store.get_last_session(_pool_id)
+            _new_thread_session_id = await adapter._turn_store.get_last_session(
+                _pool_id
+            )
         except Exception:
             log.exception("TurnStore.get_last_session failed for pool_id=%s", _pool_id)
-            _last_sid = None
-        if _last_sid is not None:
-            _meta_updates["thread_session_id"] = _last_sid
         _ts = adapter._turn_store
 
         async def _tg_session_update_fn(
@@ -97,12 +95,16 @@ async def handle_message(adapter: TelegramAdapter, msg: Any) -> None:
         ) -> None:
             await _ts.start_session(session_id, pool_id)
 
-        _meta_updates["_session_update_fn"] = TrustedCallback(_tg_session_update_fn)
-    if _meta_updates:
-        hub_msg = dataclasses.replace(
-            hub_msg,
-            platform_meta={**hub_msg.platform_meta, **_meta_updates},  # type: ignore[arg-type]  # T2.2: write site migration pending
+    _replacements: dict[str, Any] = {}
+    _is_tg_meta = isinstance(hub_msg.platform_meta, TelegramMeta)
+    if _new_thread_session_id is not None and _is_tg_meta:
+        _replacements["platform_meta"] = dataclasses.replace(
+            hub_msg.platform_meta, thread_session_id=_new_thread_session_id
         )
+    if _session_update_fn is not None:
+        _replacements["session_update_fn"] = _session_update_fn
+    if _replacements:
+        hub_msg = dataclasses.replace(hub_msg, **_replacements)
 
     log.info(
         "message_received",

--- a/src/lyra/adapters/telegram/telegram_normalize.py
+++ b/src/lyra/adapters/telegram/telegram_normalize.py
@@ -13,6 +13,7 @@ from lyra.core.messaging.message import (
     InboundMessage,
     Platform,
     RoutingContext,
+    TelegramMeta,
 )
 
 if TYPE_CHECKING:
@@ -105,21 +106,21 @@ def _build_routing(  # noqa: PLR0913 — groups related metadata fields
     message_id: int | None,
     scope_id: str,
     is_group: bool,
-) -> tuple[dict[str, Any], RoutingContext]:
-    """Build platform_meta dict and RoutingContext for a Telegram message."""
-    platform_meta: dict[str, Any] = {
-        "chat_id": chat_id,
-        "topic_id": topic_id,
-        "message_id": message_id,
-        "is_group": is_group,
-    }
+) -> tuple[TelegramMeta, RoutingContext]:
+    """Build TelegramMeta and RoutingContext for a Telegram message."""
+    platform_meta = TelegramMeta(
+        chat_id=chat_id,
+        topic_id=topic_id,
+        message_id=message_id,
+        is_group=is_group,
+    )
     routing = RoutingContext(
         platform=Platform.TELEGRAM.value,
         bot_id=adapter._bot_id,
         scope_id=scope_id,
         thread_id=str(topic_id) if topic_id is not None else None,
         reply_to_message_id=str(message_id) if message_id is not None else None,
-        platform_meta=dict(platform_meta),
+        platform_meta=platform_meta,
     )
     return platform_meta, routing
 

--- a/src/lyra/adapters/telegram/telegram_outbound.py
+++ b/src/lyra/adapters/telegram/telegram_outbound.py
@@ -16,6 +16,7 @@ from lyra.adapters.telegram.telegram_formatting import (
 from lyra.core.messaging.message import (
     InboundMessage,
     OutboundMessage,
+    TelegramMeta,
 )
 from lyra.core.messaging.render_events import ToolSummaryRenderEvent
 
@@ -129,7 +130,8 @@ async def send(
     keyboard = _render_buttons(outbound.buttons)
     last_idx = len(chunks) - 1
 
-    reply_to: int | None = original_msg.platform_meta.get("message_id")
+    _pm = original_msg.platform_meta
+    reply_to: int | None = _pm.message_id if isinstance(_pm, TelegramMeta) else None
     for i, chunk in enumerate(chunks):
         kwargs: dict = {
             "chat_id": chat_id,
@@ -193,7 +195,8 @@ def build_streaming_callbacks(  # noqa: C901 — one closure per platform op
         )
 
     chat_id, _, _ = meta
-    reply_to: int | None = original_msg.platform_meta.get("message_id")
+    _pm = original_msg.platform_meta
+    reply_to: int | None = _pm.message_id if isinstance(_pm, TelegramMeta) else None
     _placeholder_text = adapter._msg("stream_placeholder", "\u2026")
 
     async def _send_placeholder() -> tuple[Any, int]:

--- a/src/lyra/core/hub/middleware/middleware_stt.py
+++ b/src/lyra/core/hub/middleware/middleware_stt.py
@@ -17,7 +17,7 @@ import dataclasses
 import logging
 from typing import TYPE_CHECKING
 
-from ...messaging.message import InboundMessage, Response
+from ...messaging.message import InboundMessage, Response, TelegramMeta
 from ..pipeline.pipeline_types import _DROP, PipelineResult
 
 if TYPE_CHECKING:
@@ -43,9 +43,9 @@ def _build_stt_reply(
     reply: bool = True,
 ) -> InboundMessage:
     """Construct synthetic reply envelope for STT error/echo dispatch."""
-    meta = dict(msg.platform_meta)
-    if not reply:
-        meta.pop("message_id", None)
+    meta = msg.platform_meta
+    if not reply and isinstance(meta, TelegramMeta):
+        meta = dataclasses.replace(meta, message_id=None)
     return dataclasses.replace(
         msg,
         text="",

--- a/src/lyra/core/hub/middleware/middleware_submit.py
+++ b/src/lyra/core/hub/middleware/middleware_submit.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 
-from ...messaging.callbacks import unwrap_callback
 from ...messaging.message import (
     InboundMessage,
     Platform,
@@ -81,9 +80,8 @@ class SubmitToPoolMiddleware:
 
         pool = ctx.pool
         # Register session persistence callback once.
-        _update_cb = unwrap_callback(msg.platform_meta, "_session_update_fn")
-        if _update_cb is not None and not pool.has_session_update_fn():
-            pool.register_session_callbacks(update_fn=_update_cb.fn)
+        if msg.session_update_fn is not None and not pool.has_session_update_fn():
+            pool.register_session_callbacks(update_fn=msg.session_update_fn)
 
         try:
             status = await resolve_context(msg, pool, pool.pool_id, ctx)

--- a/src/lyra/core/hub/middleware/middleware_submit.py
+++ b/src/lyra/core/hub/middleware/middleware_submit.py
@@ -80,7 +80,11 @@ class SubmitToPoolMiddleware:
 
         pool = ctx.pool
         # Register session persistence callback once.
-        if msg.session_update_fn is not None and not pool.has_session_update_fn():
+        if (
+            msg.session_update_fn is not None
+            and callable(msg.session_update_fn)
+            and not pool.has_session_update_fn()
+        ):
             pool.register_session_callbacks(update_fn=msg.session_update_fn)
 
         try:

--- a/src/lyra/core/hub/middleware/path_validation.py
+++ b/src/lyra/core/hub/middleware/path_validation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from ...messaging.message import InboundMessage
+from ...messaging.message import DiscordMeta, InboundMessage, TelegramMeta
 from ...pool import Pool
 from ..pipeline.pipeline_types import ResumeStatus
 from .middleware import PipelineContext
@@ -110,7 +110,9 @@ async def _resume_path2(
 ) -> tuple[ResumeStatus | None, bool]:
     """Path 2: thread-session-resume. Returns (status|None, attempted)."""
     hub = ctx.hub
-    thread_session_id: str | None = getattr(msg.platform_meta, "thread_session_id", None)
+    thread_session_id: str | None = None
+    if isinstance(msg.platform_meta, (TelegramMeta, DiscordMeta)):
+        thread_session_id = msg.platform_meta.thread_session_id
     if thread_session_id is None:
         return None, False
 

--- a/src/lyra/core/hub/middleware/path_validation.py
+++ b/src/lyra/core/hub/middleware/path_validation.py
@@ -110,7 +110,7 @@ async def _resume_path2(
 ) -> tuple[ResumeStatus | None, bool]:
     """Path 2: thread-session-resume. Returns (status|None, attempted)."""
     hub = ctx.hub
-    thread_session_id: str | None = msg.platform_meta.get("thread_session_id")
+    thread_session_id: str | None = getattr(msg.platform_meta, "thread_session_id", None)
     if thread_session_id is None:
         return None, False
 

--- a/src/lyra/core/messaging/__init__.py
+++ b/src/lyra/core/messaging/__init__.py
@@ -1,16 +1,27 @@
 from .bus import Bus
 from .events import LlmEvent
 from .inbound_bus import LocalBus
-from .message import InboundMessage, OutboundMessage
+from .message import (
+    DiscordMeta,
+    GenericMeta,
+    InboundMessage,
+    OutboundMessage,
+    PlatformMeta,
+    TelegramMeta,
+)
 from .render_events import RenderEvent, TextRenderEvent, ToolSummaryRenderEvent
 
 __all__ = [
     "Bus",
+    "DiscordMeta",
+    "GenericMeta",
     "InboundMessage",
     "LlmEvent",
     "LocalBus",
     "OutboundMessage",
+    "PlatformMeta",
     "RenderEvent",
+    "TelegramMeta",
     "TextRenderEvent",
     "ToolSummaryRenderEvent",
 ]

--- a/src/lyra/core/messaging/__init__.py
+++ b/src/lyra/core/messaging/__init__.py
@@ -7,6 +7,7 @@ from .message import (
     InboundMessage,
     OutboundMessage,
     PlatformMeta,
+    SessionUpdateFn,
     TelegramMeta,
 )
 from .render_events import RenderEvent, TextRenderEvent, ToolSummaryRenderEvent
@@ -21,6 +22,7 @@ __all__ = [
     "OutboundMessage",
     "PlatformMeta",
     "RenderEvent",
+    "SessionUpdateFn",
     "TelegramMeta",
     "TextRenderEvent",
     "ToolSummaryRenderEvent",

--- a/src/lyra/core/messaging/message.py
+++ b/src/lyra/core/messaging/message.py
@@ -24,6 +24,33 @@ class Platform(str, Enum):
 
 
 @dataclass(frozen=True)
+class TelegramMeta:
+    chat_id: int = 0
+    message_id: int | None = None
+    topic_id: int | None = None
+    is_group: bool = False
+    thread_session_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscordMeta:
+    channel_id: int = 0
+    message_id: int = 0
+    guild_id: int | None = None
+    thread_id: int | None = None
+    channel_type: str | None = None
+    thread_session_id: str | None = None
+
+
+@dataclass(frozen=True)
+class GenericMeta:
+    pass
+
+
+PlatformMeta = TelegramMeta | DiscordMeta | GenericMeta
+
+
+@dataclass(frozen=True)
 class RoutingContext:
     """Immutable routing envelope carried from inbound to outbound.
 
@@ -40,7 +67,7 @@ class RoutingContext:
     # The inbound message ID to reply to. Reserved for future outbound
     # reply threading; not yet read by adapters (they use platform_meta).
     reply_to_message_id: str | None = None
-    platform_meta: dict = field(default_factory=dict)
+    platform_meta: PlatformMeta = field(default_factory=GenericMeta)
 
 
 @dataclass(frozen=True)
@@ -93,7 +120,7 @@ class InboundMessage:
     locale: str | None = None
     # Whisper-detected spoken language (e.g. "fr") — distinct from locale
     language: str | None = None
-    platform_meta: dict = field(default_factory=dict)
+    platform_meta: PlatformMeta = field(default_factory=GenericMeta)
     routing: RoutingContext | None = None
     command: CommandContext | None = None
     modality: Literal["text", "voice"] | None = None

--- a/src/lyra/core/messaging/message.py
+++ b/src/lyra/core/messaging/message.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -16,6 +17,10 @@ GENERIC_ERROR_REPLY = "Something went wrong. Please try again."
 
 SCHEMA_VERSION_INBOUND_MESSAGE = 1
 SCHEMA_VERSION_OUTBOUND_MESSAGE = 1
+
+# Callback type for persisting a session ID after a turn is created.
+# Called by middleware_submit when a new pool session begins.
+SessionUpdateFn = Callable[["InboundMessage", str, str], Awaitable[None]]
 
 
 class Platform(str, Enum):
@@ -130,6 +135,9 @@ class InboundMessage:
     # Audio payload — populated when modality == "voice" (#534).
     # Stripped to None by the STT pipeline stage after successful transcription.
     audio: AudioPayload | None = None
+    # Callback set by adapters to persist session ID after a turn starts (#853).
+    # Not serialized over NATS (callable cannot cross process boundary).
+    session_update_fn: SessionUpdateFn | None = field(default=None, repr=False)
 
 
 @dataclass

--- a/src/lyra/core/pool/pool_observer.py
+++ b/src/lyra/core/pool/pool_observer.py
@@ -164,7 +164,7 @@ class PoolObserver:
             message_id=msg.id,
         )
         # Index user turn for reply-to session routing (#341).
-        _msg_id = msg.platform_meta.get("message_id")
+        _msg_id = getattr(msg.platform_meta, "message_id", None)
         if _msg_id is not None:
             await self.index_turn_async(
                 str(_msg_id), session_id=session_id, role="user"

--- a/src/lyra/nats/nats_bus.py
+++ b/src/lyra/nats/nats_bus.py
@@ -17,10 +17,9 @@ Usage::
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import json
 import logging
-from typing import Any, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
@@ -33,7 +32,6 @@ from lyra.core.messaging.message import (
 )
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
 from roxabi_nats import TypeHintResolver
-from roxabi_nats._sanitize import sanitize_platform_meta
 from roxabi_nats._serialize import deserialize_dict, serialize
 from roxabi_nats._validate import validate_nats_token
 from roxabi_nats._version_check import check_schema_version
@@ -254,12 +252,6 @@ class NatsBus(Generic[T]):
 
         try:
             item = deserialize_dict(payload, self._item_type, resolver=self._resolver)
-            if hasattr(item, "platform_meta"):
-                _item: Any = item
-                item = dataclasses.replace(
-                    _item,
-                    platform_meta=sanitize_platform_meta(_item.platform_meta),
-                )
             self._staging.put_nowait(item)
         except asyncio.QueueFull:
             log.warning(

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -18,7 +18,7 @@ from lyra.adapters.discord import DiscordAdapter
 from lyra.adapters.telegram import TelegramAdapter
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
-from lyra.core.messaging.message import InboundMessage
+from lyra.core.messaging.message import DiscordMeta, GenericMeta, InboundMessage, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # Shared test helpers for adapter tests
@@ -39,12 +39,12 @@ def make_tg_msg(
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": chat_id,
-            "message_id": message_id,
-            "topic_id": topic_id,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=chat_id,
+            message_id=message_id,
+            topic_id=topic_id,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -61,13 +61,13 @@ def make_dc_msg(channel_id: int = 99, message_id: int = 55) -> InboundMessage:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "guild_id": 1,
-            "channel_id": channel_id,
-            "message_id": message_id,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=1,
+            channel_id=channel_id,
+            message_id=message_id,
+            thread_id=None,
+            channel_type="text",
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -111,13 +111,13 @@ def make_dc_inbound_msg(
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 111,
-            "channel_id": channel_id,
-            "message_id": message_id,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=111,
+            channel_id=channel_id,
+            message_id=message_id,
+            thread_id=None,
+            channel_type="text",
+        ),
     )
 
 
@@ -168,12 +168,12 @@ def make_tg_attach_msg(
         text_raw="hi",
         trust_level=TrustLevel.TRUSTED,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            **({"chat_id": chat_id} if not omit_chat_id else {}),
-            "message_id": message_id,
-            "topic_id": topic_id,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=chat_id if not omit_chat_id else 0,
+            message_id=message_id,
+            topic_id=topic_id,
+            is_group=False,
+        ),
     )
 
 
@@ -197,13 +197,13 @@ def make_dc_attach_msg(
         text_raw="hi",
         trust_level=TrustLevel.TRUSTED,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "guild_id": 1,
-            **({"channel_id": channel_id} if not omit_channel_id else {}),
-            "message_id": message_id,
-            "thread_id": thread_id,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=1,
+            channel_id=channel_id if not omit_channel_id else 0,
+            message_id=message_id,
+            thread_id=thread_id,
+            channel_type="text",
+        ),
     )
 
 
@@ -258,7 +258,7 @@ def _make_telegram_message() -> InboundMessage:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={"chat_id": 123, "message_id": 1},
+        platform_meta=TelegramMeta(chat_id=123, message_id=1),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -18,7 +18,7 @@ from lyra.adapters.discord import DiscordAdapter
 from lyra.adapters.telegram import TelegramAdapter
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
-from lyra.core.messaging.message import DiscordMeta, GenericMeta, InboundMessage, TelegramMeta
+from lyra.core.messaging.message import DiscordMeta, InboundMessage, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # Shared test helpers for adapter tests

--- a/tests/adapters/test_discord_edge.py
+++ b/tests/adapters/test_discord_edge.py
@@ -12,6 +12,7 @@ import pytest
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
+from lyra.core.messaging.message import DiscordMeta
 from lyra.core.messaging.messages import MessageManager
 
 from .conftest import attach_typing_cm
@@ -234,13 +235,13 @@ async def test_send_skips_when_discord_circuit_open() -> None:
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 111,
-            "channel_id": 333,
-            "message_id": 555,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=111,
+            channel_id=333,
+            message_id=555,
+            thread_id=None,
+            channel_type="text",
+        ),
     )
 
     # Act

--- a/tests/adapters/test_discord_normalize.py
+++ b/tests/adapters/test_discord_normalize.py
@@ -17,7 +17,7 @@ import pytest
 def test_normalize_builds_correct_discord_context() -> None:
     """normalize() on a discord message produces correct platform_meta."""
     from lyra.adapters.discord import DiscordAdapter  # ImportError expected in RED
-    from lyra.core.messaging.message import InboundMessage
+    from lyra.core.messaging.message import DiscordMeta, InboundMessage
 
     adapter = DiscordAdapter(
         bot_id="main",
@@ -41,10 +41,11 @@ def test_normalize_builds_correct_discord_context() -> None:
     assert isinstance(msg, InboundMessage)
     assert msg.platform == "discord"
     assert msg.scope_id == "channel:333"  # guild channels share one pool (#592)
-    assert msg.platform_meta["guild_id"] == 111
-    assert msg.platform_meta["channel_id"] == 333
-    assert msg.platform_meta["message_id"] == 555
-    assert msg.platform_meta["channel_type"] == "text"
+    assert isinstance(msg.platform_meta, DiscordMeta)
+    assert msg.platform_meta.guild_id == 111
+    assert msg.platform_meta.channel_id == 333
+    assert msg.platform_meta.message_id == 555
+    assert msg.platform_meta.channel_type == "text"
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +211,7 @@ def test_mention_prefix_stripped_nickname_variant() -> None:
 def test_normalize_dm_no_guild() -> None:
     """DM messages (guild=None) normalize with guild_id=None — no AttributeError."""
     from lyra.adapters.discord import DiscordAdapter
-    from lyra.core.messaging.message import InboundMessage
+    from lyra.core.messaging.message import DiscordMeta, InboundMessage
 
     adapter = DiscordAdapter(
         bot_id="main",
@@ -232,9 +233,10 @@ def test_normalize_dm_no_guild() -> None:
     msg = adapter.normalize(discord_msg)
 
     assert isinstance(msg, InboundMessage)
-    assert msg.platform_meta["guild_id"] is None
-    assert msg.platform_meta["channel_id"] == 333
-    assert msg.platform_meta["message_id"] == 555
+    assert isinstance(msg.platform_meta, DiscordMeta)
+    assert msg.platform_meta.guild_id is None
+    assert msg.platform_meta.channel_id == 333
+    assert msg.platform_meta.message_id == 555
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_discord_outbound.py
+++ b/tests/adapters/test_discord_outbound.py
@@ -10,7 +10,9 @@ import pytest
 
 from lyra.core.messaging.message import (
     Button,
+    DiscordMeta,
     OutboundMessage,
+    TelegramMeta,
 )
 
 from .conftest import attach_typing_cm, make_dc_inbound_msg
@@ -391,13 +393,13 @@ async def test_discord_fallback_sets_reply_message_id() -> None:
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 111,
-            "channel_id": 333,
-            "message_id": None,  # no reply-to → should_reply=False
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=111,
+            channel_id=333,
+            message_id=0,  # no reply-to → should_reply=False
+            thread_id=None,
+            channel_type="text",
+        ),
     )
 
     sent_mock = MagicMock()
@@ -453,7 +455,7 @@ async def test_build_streaming_noop_on_non_discord_msg() -> None:
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={"chat_id": 1, "message_id": 1},
+        platform_meta=TelegramMeta(chat_id=1, message_id=1),
     )
     outbound = OutboundMessage.from_text("hi")
 
@@ -664,13 +666,13 @@ async def test_send_thread_context_uses_channel_send() -> None:
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 111,
-            "channel_id": 333,
-            "message_id": 555,
-            "thread_id": 777,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=111,
+            channel_id=333,
+            message_id=555,
+            thread_id=777,
+            channel_type="text",
+        ),
     )
 
     outbound = OutboundMessage.from_text("reply in thread")
@@ -712,13 +714,13 @@ async def test_send_thread_context_with_view() -> None:
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 111,
-            "channel_id": 333,
-            "message_id": 555,
-            "thread_id": 777,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=111,
+            channel_id=333,
+            message_id=555,
+            thread_id=777,
+            channel_type="text",
+        ),
     )
 
     outbound = OutboundMessage(content=["pick one"], buttons=[Button("Yes", "yes")])
@@ -759,7 +761,7 @@ async def test_send_invalid_inbound_returns_early() -> None:
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={"chat_id": 1, "message_id": 1},
+        platform_meta=TelegramMeta(chat_id=1, message_id=1),
     )
 
     await adapter.send(tg_msg, OutboundMessage.from_text("hi"))

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -300,6 +300,30 @@ class TestPersistThreadSessionEviction:
         assert "9999" in cache
         assert cache["9999"] == ("new-sess", "new-pool")
 
+    @pytest.mark.asyncio
+    async def test_persist_thread_session_returns_early_for_non_discord_meta(
+        self,
+    ) -> None:
+        """Non-DiscordMeta platform_meta → early return, update_session not called."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from lyra.adapters.discord.discord_threads import persist_thread_session
+        from lyra.core.messaging.message import TelegramMeta
+
+        cache: dict[str, tuple[str, str]] = {}
+        mock_store = MagicMock()
+        mock_store.update_session = AsyncMock()
+
+        mock_msg = MagicMock()
+        mock_msg.platform_meta = TelegramMeta(chat_id=42)
+
+        await persist_thread_session(
+            mock_store, mock_msg, "sess", "pool", "bot1", cache
+        )
+
+        mock_store.update_session.assert_not_called()
+        assert cache == {}
+
 
 # ---------------------------------------------------------------------------
 # Finding G: persist_thread_claim failure path

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -67,7 +67,10 @@ class TestDiscordAutoThread:
         # Assert — inbound_bus.put was called and the InboundMessage has thread_id
         inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = inbound_bus.put.call_args[0]
-        assert hub_msg.platform_meta["thread_id"] == 9999
+        from lyra.core.messaging.message import DiscordMeta
+
+        assert isinstance(hub_msg.platform_meta, DiscordMeta)
+        assert hub_msg.platform_meta.thread_id == 9999
         assert hub_msg.scope_id == "thread:9999"
 
     @pytest.mark.asyncio
@@ -239,7 +242,10 @@ class TestDiscordAutoThread:
         inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = inbound_bus.put.call_args[0]
         assert hub_msg.scope_id == "thread:8888"
-        assert hub_msg.platform_meta["thread_id"] == 8888
+        from lyra.core.messaging.message import DiscordMeta
+
+        assert isinstance(hub_msg.platform_meta, DiscordMeta)
+        assert hub_msg.platform_meta.thread_id == 8888
         assert 8888 in adapter._owned_threads
 
     def test_discord_config_auto_thread_default_true(self) -> None:
@@ -274,8 +280,12 @@ class TestPersistThreadSessionEviction:
         mock_store = MagicMock()
         mock_store.update_session = AsyncMock()
 
+        from lyra.core.messaging.message import DiscordMeta
+
         mock_msg = MagicMock()
-        mock_msg.platform_meta = {"thread_id": 9999}
+        mock_msg.platform_meta = DiscordMeta(
+            guild_id=1, channel_id=1, message_id=1, channel_type="text", thread_id=9999
+        )
 
         # Act
         await persist_thread_session(

--- a/tests/adapters/test_discord_voice_streaming.py
+++ b/tests/adapters/test_discord_voice_streaming.py
@@ -18,7 +18,13 @@ from lyra.adapters.discord.voice.discord_voice import (
     VoiceSessionManager,
 )
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import DiscordMeta, GenericMeta, InboundMessage, OutboundAudioChunk, TelegramMeta
+from lyra.core.messaging.message import (
+    DiscordMeta,
+    GenericMeta,
+    InboundMessage,
+    OutboundAudioChunk,
+    TelegramMeta,
+)
 
 # ---------------------------------------------------------------------------
 # File-local helpers

--- a/tests/adapters/test_discord_voice_streaming.py
+++ b/tests/adapters/test_discord_voice_streaming.py
@@ -18,7 +18,7 @@ from lyra.adapters.discord.voice.discord_voice import (
     VoiceSessionManager,
 )
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, OutboundAudioChunk
+from lyra.core.messaging.message import DiscordMeta, GenericMeta, InboundMessage, OutboundAudioChunk, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # File-local helpers
@@ -60,19 +60,19 @@ def _make_voice_session(
 
 
 def _make_discord_inbound(
-    platform_meta: dict | None = None,
+    platform_meta: DiscordMeta | GenericMeta | None = None,
 ) -> InboundMessage:
     """Build a minimal discord InboundMessage for render_voice_stream tests."""
-    meta = (
+    meta: DiscordMeta | GenericMeta = (
         platform_meta
         if platform_meta is not None
-        else {
-            "guild_id": "1",
-            "channel_id": 333,
-            "message_id": 555,
-            "thread_id": None,
-            "channel_type": "text",
-        }
+        else DiscordMeta(
+            guild_id=1,
+            channel_id=333,
+            message_id=555,
+            thread_id=None,
+            channel_type="text",
+        )
     )
     return InboundMessage(
         id="msg-discord",
@@ -251,7 +251,7 @@ class TestRenderVoiceStream:
             inbound_bus=MagicMock(),
         )
         adapter._vsm.stream = AsyncMock()
-        inbound = _make_discord_inbound(platform_meta={"guild_id": "1"})
+        inbound = _make_discord_inbound(platform_meta=DiscordMeta(guild_id=1))
 
         async def chunks() -> AsyncIterator[OutboundAudioChunk]:
             yield _make_chunk()
@@ -286,7 +286,7 @@ class TestRenderVoiceStream:
             text="hello",
             text_raw="hello",
             timestamp=datetime.now(timezone.utc),
-            platform_meta={"chat_id": 42},
+            platform_meta=TelegramMeta(chat_id=42),
             trust_level=TrustLevel.TRUSTED,
         )
 
@@ -311,7 +311,7 @@ class TestRenderVoiceStream:
             inbound_bus=MagicMock(),
         )
         adapter._vsm.stream = AsyncMock()
-        inbound = _make_discord_inbound(platform_meta={})
+        inbound = _make_discord_inbound(platform_meta=GenericMeta())
 
         async def chunks() -> AsyncIterator[OutboundAudioChunk]:
             yield _make_chunk()

--- a/tests/adapters/test_discord_watch.py
+++ b/tests/adapters/test_discord_watch.py
@@ -102,7 +102,10 @@ class TestWatchChannels:
         create_thread_mock.assert_awaited_once()
         inbound_bus.put.assert_awaited_once()
         _platform_arg, hub_msg = inbound_bus.put.call_args[0]
-        assert hub_msg.platform_meta["thread_id"] == 8888
+        from lyra.core.messaging.message import DiscordMeta
+
+        assert isinstance(hub_msg.platform_meta, DiscordMeta)
+        assert hub_msg.platform_meta.thread_id == 8888
 
     @pytest.mark.asyncio
     async def test_non_watch_channel_still_filtered(self) -> None:

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 from roxabi_nats._serialize import serialize
 
 
@@ -28,12 +28,12 @@ def _make_tg_msg(msg_id: str = "msg-1") -> InboundMessage:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "message_id": 10,
-            "topic_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            message_id=10,
+            topic_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/adapters/test_outbound_listener_protocol.py
+++ b/tests/adapters/test_outbound_listener_protocol.py
@@ -24,7 +24,7 @@ from lyra.adapters.nats.nats_outbound_listener import NatsOutboundListener
 from lyra.adapters.shared.outbound_listener import OutboundListener
 from lyra.core.audio_payload import AudioPayload
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 
 # Module-level static structural check. mypy/pyright verify that
 # NatsOutboundListener (the class object) is assignable to
@@ -51,12 +51,12 @@ def _make_voice_message() -> InboundMessage:
         text="",
         text_raw="",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },  # noqa: E501
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
         modality="voice",
         audio=AudioPayload(

--- a/tests/adapters/test_render_attachment_discord.py
+++ b/tests/adapters/test_render_attachment_discord.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, OutboundAttachment
+from lyra.core.messaging.message import DiscordMeta, InboundMessage, OutboundAttachment
 
 from .conftest import (
     make_dc_attach_adapter,
@@ -170,13 +170,13 @@ class TestDiscordRenderAttachment:
             text_raw="hi",
             trust_level=TrustLevel.TRUSTED,
             timestamp=datetime.now(timezone.utc),
-            platform_meta={
-                "guild_id": 1,
-                "channel_id": 99,
-                "message_id": None,
-                "thread_id": None,
-                "channel_type": "text",
-            },
+            platform_meta=DiscordMeta(
+                guild_id=1,
+                channel_id=99,
+                message_id=0,
+                thread_id=None,
+                channel_type="text",
+            ),
         )
 
         with patch.object(adapter, "get_channel", return_value=channel):

--- a/tests/adapters/test_render_audio.py
+++ b/tests/adapters/test_render_audio.py
@@ -22,6 +22,7 @@ from aiogram.types import BufferedInputFile
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     OutboundAudio,
 )
@@ -200,13 +201,13 @@ async def test_dc_render_audio_no_reply_to_id_sends_normally() -> None:
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 1,
-            "channel_id": 99,
-            "message_id": None,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=1,
+            channel_id=99,
+            message_id=0,
+            thread_id=None,
+            channel_type="text",
+        ),
     )
 
     ref_msg = AsyncMock()
@@ -216,7 +217,7 @@ async def test_dc_render_audio_no_reply_to_id_sends_normally() -> None:
     with patch.object(adapter, "get_channel", return_value=channel):
         await adapter.render_audio(audio, inbound)
 
-    # message_id=None means no reply attempted, send directly
+    # message_id=0 means no reply attempted, send directly
     channel.send.assert_awaited_once()
 
 

--- a/tests/adapters/test_render_audio_stream.py
+++ b/tests/adapters/test_render_audio_stream.py
@@ -22,6 +22,7 @@ from aiogram.types import BufferedInputFile
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     OutboundAudioChunk,
 )
@@ -280,13 +281,13 @@ async def test_dc_stream_no_reply_target_sends_normally() -> None:
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={
-            "guild_id": 1,
-            "channel_id": 99,
-            "message_id": None,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=1,
+            channel_id=99,
+            message_id=0,
+            thread_id=None,
+            channel_type="text",
+        ),
     )
 
     ref_msg = AsyncMock()
@@ -296,5 +297,5 @@ async def test_dc_stream_no_reply_target_sends_normally() -> None:
     with patch.object(adapter, "get_channel", return_value=channel):
         await adapter.render_audio_stream(_single_chunk(), inbound)
 
-    # message_id=None means no reply attempted, send directly
+    # message_id=0 means no reply attempted, send directly
     channel.send.assert_awaited_once()

--- a/tests/adapters/test_streaming.py
+++ b/tests/adapters/test_streaming.py
@@ -8,7 +8,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import DiscordMeta, InboundMessage, OutboundMessage, TelegramMeta
+from lyra.core.messaging.message import (
+    DiscordMeta,
+    InboundMessage,
+    OutboundMessage,
+    TelegramMeta,
+)
 from lyra.core.messaging.render_events import TextRenderEvent, ToolSummaryRenderEvent
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_streaming.py
+++ b/tests/adapters/test_streaming.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, OutboundMessage
+from lyra.core.messaging.message import DiscordMeta, InboundMessage, OutboundMessage, TelegramMeta
 from lyra.core.messaging.render_events import TextRenderEvent, ToolSummaryRenderEvent
 
 # ---------------------------------------------------------------------------
@@ -28,12 +28,12 @@ def make_tg_message() -> InboundMessage:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -50,13 +50,13 @@ def make_dc_message() -> InboundMessage:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "guild_id": 1,
-            "channel_id": 100,
-            "message_id": 200,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=1,
+            channel_id=100,
+            message_id=200,
+            thread_id=None,
+            channel_type="text",
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/adapters/test_telegram_normalize_fields.py
+++ b/tests/adapters/test_telegram_normalize_fields.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lyra.core.messaging.message import InboundMessage
+from lyra.core.messaging.message import InboundMessage, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # T3 — _normalize() builds correct TelegramContext for private chat
@@ -46,10 +46,11 @@ def test_normalize_private_chat_context() -> None:
     assert msg.scope_id == "chat:123"
     assert msg.text == "hello"
     assert msg.user_id == "tg:user:42"
-    assert msg.platform_meta["chat_id"] == 123
-    assert msg.platform_meta["topic_id"] is None
-    assert msg.platform_meta["is_group"] is False
-    assert msg.platform_meta["message_id"] == 99
+    assert isinstance(msg.platform_meta, TelegramMeta)
+    assert msg.platform_meta.chat_id == 123
+    assert msg.platform_meta.topic_id is None
+    assert msg.platform_meta.is_group is False
+    assert msg.platform_meta.message_id == 99
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +170,8 @@ def test_normalize_captures_message_id() -> None:
 
     # Assert
     assert isinstance(msg, InboundMessage)
-    assert msg.platform_meta["message_id"] == 777
+    assert isinstance(msg.platform_meta, TelegramMeta)
+    assert msg.platform_meta.message_id == 777
 
 
 def test_normalize_message_id_none_when_absent() -> None:
@@ -201,7 +203,8 @@ def test_normalize_message_id_none_when_absent() -> None:
 
     # Assert
     assert isinstance(msg, InboundMessage)
-    assert msg.platform_meta["message_id"] is None
+    assert isinstance(msg.platform_meta, TelegramMeta)
+    assert msg.platform_meta.message_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -234,9 +237,10 @@ def test_normalize_captures_topic_and_message_id_for_forum() -> None:
 
     # Assert
     assert isinstance(msg, InboundMessage)
-    assert msg.platform_meta["topic_id"] == 99
-    assert msg.platform_meta["message_id"] == 777
-    assert msg.platform_meta["is_group"] is True
+    assert isinstance(msg.platform_meta, TelegramMeta)
+    assert msg.platform_meta.topic_id == 99
+    assert msg.platform_meta.message_id == 777
+    assert msg.platform_meta.is_group is True
     assert msg.scope_id == "chat:456:topic:99"  # groups/topics share pool (#592)
 
 

--- a/tests/adapters/test_telegram_outbound_send.py
+++ b/tests/adapters/test_telegram_outbound_send.py
@@ -15,8 +15,10 @@ import pytest
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (  # noqa: F401
+    DiscordMeta,
     InboundMessage,
     OutboundMessage,
+    TelegramMeta,
 )
 from lyra.core.messaging.render_events import ToolSummaryRenderEvent
 from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_message
@@ -54,12 +56,12 @@ async def test_send_calls_bot_send_message() -> None:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "topic_id": None,
-            "message_id": 99,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            topic_id=None,
+            message_id=99,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
     outbound = OutboundMessage.from_text("reply")
@@ -107,13 +109,13 @@ async def test_send_skips_when_platform_context_is_not_telegram(
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "guild_id": None,
-            "channel_id": 123,
-            "message_id": 456,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=None,
+            channel_id=123,
+            message_id=456,
+            thread_id=None,
+            channel_type="text",
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -157,12 +159,12 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "topic_id": None,
-            "message_id": 777,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            topic_id=None,
+            message_id=777,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
     outbound = OutboundMessage.from_text("reply")
@@ -223,12 +225,12 @@ async def test_send_always_delivers_regardless_of_circuit_state() -> None:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "topic_id": None,
-            "message_id": 1,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            topic_id=None,
+            message_id=1,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/adapters/test_telegram_outbound_send.py
+++ b/tests/adapters/test_telegram_outbound_send.py
@@ -259,13 +259,13 @@ def _make_discord_msg() -> InboundMessage:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "guild_id": 1,
-            "channel_id": 99,
-            "message_id": 55,
-            "thread_id": None,
-            "channel_type": "text",
-        },
+        platform_meta=DiscordMeta(
+            guild_id=1,
+            channel_id=99,
+            message_id=55,
+            thread_id=None,
+            channel_type="text",
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -315,12 +315,12 @@ async def test_streaming_send_placeholder_with_reply() -> None:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "message_id": 77,
-            "topic_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            message_id=77,
+            topic_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
     outbound = OutboundMessage.from_text("")
@@ -359,12 +359,12 @@ async def test_streaming_send_placeholder_no_reply() -> None:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "message_id": None,
-            "topic_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            message_id=None,
+            topic_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
     outbound = OutboundMessage.from_text("")
@@ -616,12 +616,12 @@ async def test_send_no_reply_to() -> None:
         text="hi",
         text_raw="hi",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "message_id": None,
-            "topic_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            message_id=None,
+            topic_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
     outbound = OutboundMessage.from_text("reply")

--- a/tests/adapters/test_telegram_typing.py
+++ b/tests/adapters/test_telegram_typing.py
@@ -122,7 +122,7 @@ async def test_send_cancels_typing_task() -> None:
     import asyncio
 
     from lyra.adapters.telegram import TelegramAdapter
-    from lyra.core.messaging.message import InboundMessage, OutboundMessage
+    from lyra.core.messaging.message import InboundMessage, OutboundMessage, TelegramMeta
 
     # Arrange
     bot = AsyncMock()
@@ -148,12 +148,12 @@ async def test_send_cancels_typing_task() -> None:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "topic_id": None,
-            "message_id": 99,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=123,
+            topic_id=None,
+            message_id=99,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
     outbound = OutboundMessage.from_text("reply")
@@ -186,7 +186,7 @@ async def test_send_streaming_cancels_typing_task_after_placeholder() -> None:
     import asyncio
 
     from lyra.adapters.telegram import TelegramAdapter
-    from lyra.core.messaging.message import InboundMessage
+    from lyra.core.messaging.message import InboundMessage, TelegramMeta
 
     # Arrange
     bot = AsyncMock()
@@ -212,12 +212,12 @@ async def test_send_streaming_cancels_typing_task_after_placeholder() -> None:
         text="stream this",
         text_raw="stream this",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 456,
-            "topic_id": None,
-            "message_id": 10,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=456,
+            topic_id=None,
+            message_id=10,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/adapters/test_telegram_typing.py
+++ b/tests/adapters/test_telegram_typing.py
@@ -122,7 +122,11 @@ async def test_send_cancels_typing_task() -> None:
     import asyncio
 
     from lyra.adapters.telegram import TelegramAdapter
-    from lyra.core.messaging.message import InboundMessage, OutboundMessage, TelegramMeta
+    from lyra.core.messaging.message import (
+        InboundMessage,
+        OutboundMessage,
+        TelegramMeta,
+    )
 
     # Arrange
     bot = AsyncMock()

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -14,6 +14,7 @@ from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
     Attachment,
     InboundMessage,
+    TelegramMeta,
 )
 from lyra.core.pool import Pool
 from lyra.llm.base import LlmResult
@@ -39,12 +40,7 @@ def make_audio_message(url: str) -> InboundMessage:
             Attachment(type="audio", url_or_path_or_bytes=url, mime_type="audio/ogg"),
         ],
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -61,12 +57,7 @@ def make_text_message(text: str = "hello") -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -19,6 +19,7 @@ from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
     InboundMessage,
     Response,
+    TelegramMeta,
 )
 from lyra.core.pool import Pool
 from lyra.llm.base import LlmResult
@@ -40,12 +41,7 @@ def make_inbound_message(text: str = "hello") -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -25,6 +25,7 @@ from lyra.core.config import PoolConfig, RouterConfig
 from lyra.core.hub import Hub
 from lyra.core.messaging.message import (
     Attachment,
+    DiscordMeta,
     InboundMessage,
     OutboundAttachment,
     OutboundAudio,
@@ -33,6 +34,7 @@ from lyra.core.messaging.message import (
     Platform,
     Response,
     RoutingContext,
+    TelegramMeta,
 )
 from lyra.core.messaging.render_events import RenderEvent
 from lyra.core.pool import Pool
@@ -176,12 +178,7 @@ def make_message(
         text=content,
         text_raw=content,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=TrustLevel.TRUSTED,
         is_admin=is_admin,
         command=cmd_ctx,
@@ -233,38 +230,29 @@ def make_inbound_message(  # noqa: PLR0913
     bot_id: str = "main",
     user_id: str = "alice",
     scope_id: str | None = None,
-    platform_meta: dict | None = None,
+    platform_meta=None,
     modality: str | None = None,
 ) -> InboundMessage:
     """Build a minimal InboundMessage for hub tests."""
+    from lyra.core.messaging.message import GenericMeta
+
     if platform == "telegram":
         _scope = scope_id if scope_id is not None else "chat:42"
         _meta = (
             platform_meta
             if platform_meta is not None
-            else {
-                "chat_id": 42,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            }
+            else TelegramMeta(chat_id=42)
         )
     elif platform == "discord":
         _scope = scope_id if scope_id is not None else "channel:333"
         _meta = (
             platform_meta
             if platform_meta is not None
-            else {
-                "guild_id": 111,
-                "channel_id": 333,
-                "message_id": 555,
-                "thread_id": None,
-                "channel_type": "text",
-            }
+            else DiscordMeta(channel_id=333, message_id=555, guild_id=111, channel_type="text")
         )
     else:
         _scope = scope_id if scope_id is not None else f"{platform}:default"
-        _meta = platform_meta or {}
+        _meta = platform_meta if platform_meta is not None else GenericMeta()
     kwargs: dict = dict(
         id="msg-1",
         platform=platform,
@@ -506,12 +494,7 @@ def make_dispatcher_msg() -> InboundMessage:
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 123,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=123),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -543,12 +526,7 @@ def make_debouncer_msg(
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 1,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=1),
         trust_level=TrustLevel.TRUSTED,
         attachments=attachments or [],
     )
@@ -631,12 +609,7 @@ def make_msg(text: str = "hello") -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 1,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=1),
         trust_level=TrustLevel.TRUSTED,
     )
 
@@ -783,7 +756,7 @@ def make_routing_inbound(routing: RoutingContext | None = None) -> InboundMessag
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
         trust_level=TrustLevel.TRUSTED,
-        platform_meta={"chat_id": 123},
+        platform_meta=TelegramMeta(chat_id=123),
         routing=routing,
     )
 
@@ -829,21 +802,10 @@ def make_pairing_message(  # noqa: PLR0913 — test factory with optional overri
     """Build a minimal InboundMessage for pairing tests."""
     if platform == Platform.DISCORD:
         scope = "channel:1"
-        meta = {
-            "guild_id": guild_id,
-            "channel_id": 1,
-            "message_id": 1,
-            "thread_id": None,
-            "channel_type": "text",
-        }
+        meta = DiscordMeta(channel_id=1, message_id=1, guild_id=guild_id, channel_type="text")
     else:
         scope = "chat:42"
-        meta = {
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": is_group,
-        }
+        meta = TelegramMeta(chat_id=42, is_group=is_group)
 
     return InboundMessage(
         id="msg-test-1",

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -238,17 +238,15 @@ def make_inbound_message(  # noqa: PLR0913
 
     if platform == "telegram":
         _scope = scope_id if scope_id is not None else "chat:42"
-        _meta = (
-            platform_meta
-            if platform_meta is not None
-            else TelegramMeta(chat_id=42)
-        )
+        _meta = platform_meta if platform_meta is not None else TelegramMeta(chat_id=42)
     elif platform == "discord":
         _scope = scope_id if scope_id is not None else "channel:333"
         _meta = (
             platform_meta
             if platform_meta is not None
-            else DiscordMeta(channel_id=333, message_id=555, guild_id=111, channel_type="text")
+            else DiscordMeta(
+                channel_id=333, message_id=555, guild_id=111, channel_type="text"
+            )
         )
     else:
         _scope = scope_id if scope_id is not None else f"{platform}:default"
@@ -802,7 +800,9 @@ def make_pairing_message(  # noqa: PLR0913 — test factory with optional overri
     """Build a minimal InboundMessage for pairing tests."""
     if platform == Platform.DISCORD:
         scope = "channel:1"
-        meta = DiscordMeta(channel_id=1, message_id=1, guild_id=guild_id, channel_type="text")
+        meta = DiscordMeta(
+            channel_id=1, message_id=1, guild_id=guild_id, channel_type="text"
+        )
     else:
         scope = "chat:42"
         meta = TelegramMeta(chat_id=42, is_group=is_group)

--- a/tests/core/hub/test_identity_resolver.py
+++ b/tests/core/hub/test_identity_resolver.py
@@ -11,7 +11,7 @@ from lyra.core.auth.authenticator import Authenticator
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.hub.hub_protocol import Binding, RoutingKey
 from lyra.core.hub.identity_resolver import IdentityResolver
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -39,7 +39,7 @@ def make_inbound(  # noqa: PLR0913
         text="hello",
         text_raw="hello",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={"chat_id": 42},
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=trust_level,
         is_admin=is_admin,
         roles=roles,

--- a/tests/core/hub/test_message_pipeline_stt.py
+++ b/tests/core/hub/test_message_pipeline_stt.py
@@ -397,3 +397,36 @@ class TestSttMiddleware:
         next_fn.assert_called_once_with(msg, ctx)
         assert result is _SENTINEL_RESULT
         hub.dispatch_response.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _build_stt_reply: platform_meta handling per meta type
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSttReply:
+    """Unit tests for the _build_stt_reply helper."""
+
+    def test_telegram_meta_reply_false_clears_message_id(self) -> None:
+        """TelegramMeta + reply=False → message_id set to None."""
+        from lyra.core.hub.middleware.middleware_stt import _build_stt_reply
+        from lyra.core.messaging.message import TelegramMeta
+
+        msg = make_text_message(
+            platform_meta=TelegramMeta(chat_id=1, message_id=5),
+        )
+        result = _build_stt_reply(msg, reply=False)
+
+        assert isinstance(result.platform_meta, TelegramMeta)
+        assert result.platform_meta.message_id is None
+
+    def test_discord_meta_reply_false_preserves_message_id(self) -> None:
+        """DiscordMeta + reply=False → platform_meta unchanged (no reply concept)."""
+        from lyra.core.hub.middleware.middleware_stt import _build_stt_reply
+        from lyra.core.messaging.message import DiscordMeta
+
+        meta = DiscordMeta(channel_id=10, message_id=5, guild_id=1, channel_type="text")
+        msg = make_text_message(platform_meta=meta)
+        result = _build_stt_reply(msg, reply=False)
+
+        assert result.platform_meta is meta  # unchanged, same object

--- a/tests/core/test_cli_build_cmd_audit.py
+++ b/tests/core/test_cli_build_cmd_audit.py
@@ -29,9 +29,7 @@ class TestBuildCmdSkipPermissionsAudit:
             and "dangerously-skip-permissions" in record.message
             for record in caplog.records
         ), "Expected SECURITY warning for skip_permissions bypass"
-        assert any(
-            record.levelno == logging.WARNING for record in caplog.records
-        )
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
 
     def test_no_warning_when_skip_permissions_false(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/core/test_command_router_circuit.py
+++ b/tests/core/test_command_router_circuit.py
@@ -24,7 +24,7 @@ from lyra.core.circuit_breaker import CircuitBreaker, CircuitRegistry
 from lyra.core.commands.command_loader import CommandLoader
 from lyra.core.commands.command_parser import CommandParser
 from lyra.core.commands.command_router import CommandConfig, CommandRouter
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,12 +69,7 @@ def make_circuit_msg(
         text="/circuit",
         text_raw="/circuit",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=TrustLevel.TRUSTED,
         is_admin=is_admin,
         command=_parser.parse("/circuit"),

--- a/tests/core/test_command_router_config.py
+++ b/tests/core/test_command_router_config.py
@@ -18,7 +18,7 @@ from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_loader import CommandLoader
 from lyra.core.commands.command_parser import CommandParser
 from lyra.core.commands.command_router import CommandRouter
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 from lyra.core.pool import Pool
 
 from .conftest import make_message, make_router
@@ -63,12 +63,7 @@ def make_config_msg(
         text=content,
         text_raw=content,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42),
         trust_level=TrustLevel.TRUSTED,
         is_admin=is_admin,
         command=_parser.parse(content),

--- a/tests/core/test_hub_scope.py
+++ b/tests/core/test_hub_scope.py
@@ -65,12 +65,12 @@ class TestCrossScopeRateLimit:
                 text="hello",
                 text_raw="hello",
                 timestamp=datetime.now(timezone.utc),
-                platform_meta={
-                    "chat_id": int(scope_id.split(":")[-1]),
-                    "topic_id": None,
-                    "message_id": None,
-                    "is_group": False,
-                },
+                platform_meta=TelegramMeta(
+                    chat_id=int(scope_id.split(":")[-1]),
+                    topic_id=None,
+                    message_id=None,
+                    is_group=False,
+                ),
                 trust_level=TrustLevel.TRUSTED,
             )
 
@@ -119,12 +119,12 @@ class TestScopeIsolatedPools:
             text="hello",
             text_raw="hello",
             timestamp=datetime.now(timezone.utc),
-            platform_meta={
-                "chat_id": 100,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            },
+            platform_meta=TelegramMeta(
+                chat_id=100,
+                topic_id=None,
+                message_id=None,
+                is_group=False,
+            ),
             trust_level=TrustLevel.TRUSTED,
         )
         msg_b = InboundMessage(
@@ -138,12 +138,12 @@ class TestScopeIsolatedPools:
             text="hello",
             text_raw="hello",
             timestamp=datetime.now(timezone.utc),
-            platform_meta={
-                "chat_id": 200,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            },
+            platform_meta=TelegramMeta(
+                chat_id=200,
+                topic_id=None,
+                message_id=None,
+                is_group=False,
+            ),
             trust_level=TrustLevel.TRUSTED,
         )
 

--- a/tests/core/test_hub_scope.py
+++ b/tests/core/test_hub_scope.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from lyra.core import Hub
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.config import HubConfig
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
 from tests.core.conftest import make_inbound_message
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_inbound_bus.py
+++ b/tests/core/test_inbound_bus.py
@@ -10,8 +10,10 @@ import pytest
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.inbound_bus import LocalBus
 from lyra.core.messaging.message import (
+    DiscordMeta,
     InboundMessage,
     Platform,
+    TelegramMeta,
 )
 from tests.conftest import TIMEOUT_FAST
 
@@ -19,16 +21,16 @@ from tests.conftest import TIMEOUT_FAST
 def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
     if platform == Platform.TELEGRAM:
         scope = "chat:123"
-        meta = {"chat_id": 123, "topic_id": None, "message_id": None, "is_group": False}
+        meta: TelegramMeta | DiscordMeta = TelegramMeta(chat_id=123, topic_id=None, message_id=None, is_group=False)
     else:
         scope = "channel:2"
-        meta = {
-            "guild_id": 1,
-            "channel_id": 2,
-            "message_id": 3,
-            "thread_id": None,
-            "channel_type": "text",
-        }
+        meta = DiscordMeta(
+            guild_id=1,
+            channel_id=2,
+            message_id=3,
+            thread_id=None,
+            channel_type="text",
+        )
     return InboundMessage(
         id="msg-1",
         platform=platform.value,

--- a/tests/core/test_inbound_bus.py
+++ b/tests/core/test_inbound_bus.py
@@ -21,7 +21,9 @@ from tests.conftest import TIMEOUT_FAST
 def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
     if platform == Platform.TELEGRAM:
         scope = "chat:123"
-        meta: TelegramMeta | DiscordMeta = TelegramMeta(chat_id=123, topic_id=None, message_id=None, is_group=False)
+        meta: TelegramMeta | DiscordMeta = TelegramMeta(
+            chat_id=123, topic_id=None, message_id=None, is_group=False
+        )
     else:
         scope = "channel:2"
         meta = DiscordMeta(

--- a/tests/core/test_link_command.py
+++ b/tests/core/test_link_command.py
@@ -10,7 +10,7 @@ import pytest
 
 from lyra.commands.identity.handlers import cmd_link, cmd_unlink
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage
+from lyra.core.messaging.message import InboundMessage, TelegramMeta
 from lyra.core.pool import Pool
 from lyra.infrastructure.stores.identity_alias_store import IdentityAliasStore
 
@@ -36,12 +36,12 @@ def _make_msg(
         text="",
         text_raw="",
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
         is_admin=is_admin,
     )

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -600,7 +600,12 @@ class TestResolveContextMiddleware:
 
         ctx = PipelineContext(hub=hub)
         _base = make_inbound_message(scope_id="chat:42")
-        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-1"))
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-1"
+            ),
+        )
 
         status = await resolve_context(msg, pool, pool.pool_id, ctx)
 
@@ -632,7 +637,12 @@ class TestResolveContextMiddleware:
 
         ctx = PipelineContext(hub=hub)
         _base = make_inbound_message(scope_id="chat:42")
-        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"))
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead"
+            ),
+        )
 
         status = await resolve_context(msg, pool, pool.pool_id, ctx)
 
@@ -736,7 +746,12 @@ class TestNotifySessionFallthroughMiddleware:
         hub._turn_store = cast(TurnStore, _FakeTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42")
-        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"))
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead"
+            ),
+        )
         ctx = PipelineContext(
             hub=hub,
             pool=pool,

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -600,8 +600,7 @@ class TestResolveContextMiddleware:
 
         ctx = PipelineContext(hub=hub)
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-1"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-1"))
 
         status = await resolve_context(msg, pool, pool.pool_id, ctx)
 
@@ -633,8 +632,7 @@ class TestResolveContextMiddleware:
 
         ctx = PipelineContext(hub=hub)
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"))
 
         status = await resolve_context(msg, pool, pool.pool_id, ctx)
 
@@ -738,8 +736,7 @@ class TestNotifySessionFallthroughMiddleware:
         hub._turn_store = cast(TurnStore, _FakeTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"))
         ctx = PipelineContext(
             hub=hub,
             pool=pool,

--- a/tests/core/test_pool_advanced.py
+++ b/tests/core/test_pool_advanced.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 from lyra.core.pool import Pool
 from tests.conftest import _drain
 from tests.core.conftest import make_msg
@@ -38,12 +38,12 @@ def _make_inbound(
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 1,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=1,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/core/test_pool_observer.py
+++ b/tests/core/test_pool_observer.py
@@ -9,10 +9,12 @@ Covers:
 
 from __future__ import annotations
 
+import dataclasses
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from lyra.core.messaging.message import TelegramMeta
 from lyra.core.pool.pool_observer import PoolObserver
 from tests.core.conftest import make_inbound_message
 
@@ -219,7 +221,11 @@ class TestMessageIndexPopulation:
         obs.register_message_index(mi)
 
         msg = make_inbound_message()
-        msg.platform_meta["message_id"] = 42  # Telegram int
+        assert isinstance(msg.platform_meta, TelegramMeta)
+        msg = dataclasses.replace(
+            msg,
+            platform_meta=dataclasses.replace(msg.platform_meta, message_id=42),
+        )
         await obs.append(msg, session_id=_SESSION_ID)
 
         mi.upsert.assert_called_once_with(_POOL_ID, "42", _SESSION_ID, "user")
@@ -229,7 +235,11 @@ class TestMessageIndexPopulation:
         """append() does not fail when no MessageIndex is registered."""
         obs = _make_observer()
         msg = make_inbound_message()
-        msg.platform_meta["message_id"] = 42
+        assert isinstance(msg.platform_meta, TelegramMeta)
+        msg = dataclasses.replace(
+            msg,
+            platform_meta=dataclasses.replace(msg.platform_meta, message_id=42),
+        )
         await obs.append(msg, session_id=_SESSION_ID)  # should not raise
 
     @pytest.mark.anyio
@@ -241,8 +251,12 @@ class TestMessageIndexPopulation:
         obs.register_message_index(mi)
 
         msg = make_inbound_message()
-        # No message_id in platform_meta
-        msg.platform_meta.pop("message_id", None)
+        assert isinstance(msg.platform_meta, TelegramMeta)
+        # Set message_id to None — observer should skip indexing
+        msg = dataclasses.replace(
+            msg,
+            platform_meta=dataclasses.replace(msg.platform_meta, message_id=None),
+        )
         await obs.append(msg, session_id=_SESSION_ID)
 
         mi.upsert.assert_not_called()

--- a/tests/core/test_routing_context_basics.py
+++ b/tests/core/test_routing_context_basics.py
@@ -15,6 +15,7 @@ from lyra.core.messaging.message import (
     OutboundMessage,
     Response,
     RoutingContext,
+    TelegramMeta,
 )
 
 from .conftest import _RC_DC, _RC_TG, make_routing_inbound
@@ -49,7 +50,7 @@ class TestRoutingContext:
             setattr(rc, "platform", "discord")
 
     def test_with_all_fields(self) -> None:
-        meta = {"chat_id": 123, "topic_id": 456}
+        meta = TelegramMeta(chat_id=123, topic_id=456)
         rc = RoutingContext(
             platform="telegram",
             bot_id="main",

--- a/tests/core/test_routing_context_basics.py
+++ b/tests/core/test_routing_context_basics.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from lyra.core.messaging.message import (
+    GenericMeta,
     OutboundMessage,
     Response,
     RoutingContext,
@@ -42,7 +43,7 @@ class TestRoutingContext:
         assert rc.scope_id == "chat:123"
         assert rc.thread_id is None
         assert rc.reply_to_message_id is None
-        assert rc.platform_meta == {}
+        assert rc.platform_meta == GenericMeta()
 
     def test_frozen(self) -> None:
         rc = RoutingContext(platform="telegram", bot_id="main", scope_id="chat:123")

--- a/tests/core/test_routing_context_integration.py
+++ b/tests/core/test_routing_context_integration.py
@@ -122,7 +122,6 @@ class TestTelegramNormalizeRouting:
 
         msg = adapter.normalize(raw)
         assert msg.routing is not None
-        assert msg.routing.platform_meta is not msg.platform_meta
         assert msg.routing.platform_meta == msg.platform_meta
 
 

--- a/tests/core/test_session_commands_bypass.py
+++ b/tests/core/test_session_commands_bypass.py
@@ -11,7 +11,7 @@ import pytest
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandParser
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 from lyra.core.pool import Pool
 from lyra.core.processors.processor_registry import BaseProcessor, registry
 from lyra.integrations.base import SessionTools
@@ -60,12 +60,12 @@ def _make_command_msg(text: str) -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
         command=cmd_ctx,
     )
@@ -83,12 +83,12 @@ def _make_plain_msg(text: str = "hello") -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
         command=None,
     )

--- a/tests/core/test_session_commands_post.py
+++ b/tests/core/test_session_commands_post.py
@@ -11,7 +11,7 @@ import pytest
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandParser
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 from lyra.core.pool import Pool
 from lyra.core.processors.processor_registry import registry
 from lyra.integrations.base import SessionTools
@@ -60,12 +60,12 @@ def _make_command_msg(text: str) -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
         command=cmd_ctx,
     )

--- a/tests/core/test_session_commands_pre.py
+++ b/tests/core/test_session_commands_pre.py
@@ -11,7 +11,7 @@ import pytest
 
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.commands.command_parser import CommandParser
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 from lyra.core.pool import Pool
 from lyra.core.processors.processor_registry import registry
 from lyra.integrations.base import SessionTools
@@ -60,12 +60,12 @@ def _make_command_msg(text: str) -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(
+            chat_id=42,
+            topic_id=None,
+            message_id=None,
+            is_group=False,
+        ),
         trust_level=TrustLevel.TRUSTED,
         command=cmd_ctx,
     )

--- a/tests/core/test_submit_middleware_context.py
+++ b/tests/core/test_submit_middleware_context.py
@@ -198,7 +198,7 @@ class TestReplyToResumePipeline:
         msg = dataclasses.replace(
             _base,
             reply_to_id="tg-msg-55",
-            platform_meta={**_base.platform_meta, "is_group": True},
+            platform_meta=dataclasses.replace(_base.platform_meta, is_group=True),
         )
         ctx = _make_ctx(hub)
 
@@ -362,8 +362,7 @@ class TestResolveContextResumeStatus:
         pool._session_resume_fn = _fake_resume
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-1"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-1"))
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -388,8 +387,10 @@ class TestResolveContextResumeStatus:
         pool._session_resume_fn = _fake_resume
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -427,8 +428,10 @@ class TestResolveContextResumeStatus:
         hub._turn_store = cast("TurnStore", _FakeTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -458,8 +461,10 @@ class TestResolveContextResumeStatus:
         pool._current_task = asyncio.create_task(_busy_task_never_completes.wait())
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-busy"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-busy"),
+        )
         ctx = _make_ctx(hub)
 
         try:
@@ -506,12 +511,12 @@ class TestResolveContextResumeStatus:
         _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
         # is_group in platform_meta no longer affects the pipeline path since #356
         # — included here only to document that it is now inert.
-        _meta = {
-            **_base.platform_meta,
-            "thread_session_id": "tss-dead",
-            "is_group": True,
-        }
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead", is_group=True
+            ),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -545,8 +550,10 @@ class TestResolveContextResumeStatus:
         hub._turn_store = cast("TurnStore", _FakeTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42:user:tg:user:alice")
-        _meta = {**_base.platform_meta, "is_group": True}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(_base.platform_meta, is_group=True),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -573,8 +580,10 @@ class TestResolveContextResumeStatus:
         hub._turn_store = cast("TurnStore", _WrongPoolTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-other"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-other"),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -589,8 +598,12 @@ class TestResolveContextResumeStatus:
         pool = hub.get_or_create_pool(pool_id, "lyra")
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-no-store"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-no-store"
+            ),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)

--- a/tests/core/test_submit_middleware_context.py
+++ b/tests/core/test_submit_middleware_context.py
@@ -362,7 +362,12 @@ class TestResolveContextResumeStatus:
         pool._session_resume_fn = _fake_resume
 
         _base = make_inbound_message(scope_id="chat:42")
-        msg = dataclasses.replace(_base, platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-1"))
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-1"
+            ),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -389,7 +394,9 @@ class TestResolveContextResumeStatus:
         _base = make_inbound_message(scope_id="chat:42")
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead"
+            ),
         )
         ctx = _make_ctx(hub)
 
@@ -430,7 +437,9 @@ class TestResolveContextResumeStatus:
         _base = make_inbound_message(scope_id="chat:42")
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-dead"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead"
+            ),
         )
         ctx = _make_ctx(hub)
 
@@ -463,7 +472,9 @@ class TestResolveContextResumeStatus:
         _base = make_inbound_message(scope_id="chat:42")
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-busy"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-busy"
+            ),
         )
         ctx = _make_ctx(hub)
 
@@ -582,7 +593,9 @@ class TestResolveContextResumeStatus:
         _base = make_inbound_message(scope_id="chat:42")
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="tss-other"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-other"
+            ),
         )
         ctx = _make_ctx(hub)
 
@@ -620,8 +633,12 @@ class TestResolveContextResumeStatus:
 
         _base = make_inbound_message(scope_id="chat:42")
         # Use pool's current session_id as the thread_session_id
-        _meta = {**_base.platform_meta, "thread_session_id": pool.session_id}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id=pool.session_id
+            ),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -678,8 +695,12 @@ class TestPath3DeadBackendGuard:
         hub._turn_store = cast("TurnStore", _FakeTurnStore())
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead"
+            ),
+        )
         ctx = _make_ctx(hub)
 
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -746,8 +767,12 @@ class TestNotifySessionFallthrough:
         hub._turn_store = cast("TurnStore", _FakeTurnStoreScope(pool_id))
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-dead"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-dead"
+            ),
+        )
 
         from lyra.core.hub.hub_protocol import RoutingKey
         from lyra.core.messaging.message import Platform
@@ -792,8 +817,12 @@ class TestNotifySessionFallthrough:
         hub._turn_store = cast("TurnStore", _FakeTurnStoreScope(pool_id))
 
         _base = make_inbound_message(scope_id="chat:42")
-        _meta = {**_base.platform_meta, "thread_session_id": "tss-live"}
-        msg = dataclasses.replace(_base, platform_meta=_meta)
+        msg = dataclasses.replace(
+            _base,
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="tss-live"
+            ),
+        )
 
         from lyra.core.hub.hub_protocol import RoutingKey
         from lyra.core.messaging.message import Platform

--- a/tests/fixtures/agent_harness.py
+++ b/tests/fixtures/agent_harness.py
@@ -18,7 +18,7 @@ from tests.conftest import _drain
 from lyra.agents.simple_agent import SimpleAgent
 from lyra.core.agent import Agent
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, Response
+from lyra.core.messaging.message import InboundMessage, Response, TelegramMeta
 from lyra.core.pool import Pool
 
 from .fake_drivers import FakeClaudeCliDriver, FakeStt, FakeTts
@@ -113,12 +113,12 @@ class AgentHarness:
             text_raw=text,
             trust_level=TrustLevel.TRUSTED,
             timestamp=datetime.now(timezone.utc),
-            platform_meta={
-                "chat_id": 1,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            },
+            platform_meta=TelegramMeta(
+                chat_id=1,
+                topic_id=None,
+                message_id=None,
+                is_group=False,
+            ),
         )
 
         if voice is not None:
@@ -173,12 +173,12 @@ class AgentHarness:
             trust_level=TrustLevel.TRUSTED,
             timestamp=datetime.now(timezone.utc),
             modality="voice",
-            platform_meta={
-                "chat_id": 1,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            },
+            platform_meta=TelegramMeta(
+                chat_id=1,
+                topic_id=None,
+                message_id=None,
+                is_group=False,
+            ),
         )
 
         self.pool.submit(msg)

--- a/tests/integration/test_session_dm_discord.py
+++ b/tests/integration/test_session_dm_discord.py
@@ -122,7 +122,12 @@ async def test_discord_dm_injects_thread_session_id() -> None:
     else:
         posted = mock_bus.put.call_args[0][1]
 
-    assert posted.platform_meta.get("thread_session_id") == "prior-session-id", (
+    from lyra.core.messaging.message import DiscordMeta
+
+    assert isinstance(posted.platform_meta, DiscordMeta), (
+        f"Expected DiscordMeta, got {posted.platform_meta!r}"
+    )
+    assert posted.platform_meta.thread_session_id == "prior-session-id", (
         f"Expected thread_session_id='prior-session-id', "
         f"got platform_meta={posted.platform_meta!r}"
     )

--- a/tests/integration/test_session_telegram.py
+++ b/tests/integration/test_session_telegram.py
@@ -146,7 +146,12 @@ async def test_telegram_private_injects_thread_session_id() -> None:
     else:
         posted = mock_bus.put.call_args[0][1]
 
-    assert posted.platform_meta.get("thread_session_id") == "prior-session-id", (
+    from lyra.core.messaging.message import TelegramMeta
+
+    assert isinstance(posted.platform_meta, TelegramMeta), (
+        f"Expected TelegramMeta, got {posted.platform_meta!r}"
+    )
+    assert posted.platform_meta.thread_session_id == "prior-session-id", (
         f"Expected thread_session_id='prior-session-id', "
         f"got platform_meta={posted.platform_meta!r}"
     )

--- a/tests/integration/test_voice_end_to_end.py
+++ b/tests/integration/test_voice_end_to_end.py
@@ -35,7 +35,7 @@ import pytest
 from lyra.core.audio_payload import AudioPayload
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.inbound_bus import LocalBus
-from lyra.core.messaging.message import InboundMessage
+from lyra.core.messaging.message import InboundMessage, TelegramMeta
 
 # ---------------------------------------------------------------------------
 # Helpers / stubs shared across this module
@@ -65,7 +65,7 @@ def _make_voice_message(  # noqa: PLR0913
         text="",
         text_raw="",
         timestamp=_NOW,
-        platform_meta={"chat_id": 99},
+        platform_meta=TelegramMeta(chat_id=99),
         trust_level=TrustLevel.PUBLIC,
         modality="voice",
         audio=AudioPayload(

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -340,7 +340,7 @@ class TestNatsBusRoundTrip:
             await subscriber.stop()
 
     async def test_callable_stripped_in_transit(self, nc: NATS) -> None:
-        """put() a message with _session_update_fn; get() on other side strips it."""
+        """put() a message with session_update_fn; get() on other side strips it."""
         # Arrange
         publisher = _make_bus(nc)
         subscriber = _make_bus(nc)
@@ -348,6 +348,11 @@ class TestNatsBusRoundTrip:
         publisher.register(Platform.TELEGRAM)
         subscriber.register(Platform.TELEGRAM)
         await subscriber.start()
+
+        async def _dummy_update(
+            _msg: InboundMessage, _session_id: str, _pool_id: str
+        ) -> None:
+            pass
 
         msg = InboundMessage(
             id="msg-fn",
@@ -362,14 +367,17 @@ class TestNatsBusRoundTrip:
             timestamp=datetime.now(timezone.utc),
             trust_level=TrustLevel.TRUSTED,
             platform_meta=TelegramMeta(chat_id=123),
+            session_update_fn=_dummy_update,
         )
+        assert msg.session_update_fn is not None  # callable is set before transit
 
         try:
             # Act
             await publisher.put(Platform.TELEGRAM, msg)
             received = await asyncio.wait_for(subscriber.get(), timeout=2.0)
 
-            # Assert — typed platform_meta fields preserved across NATS transit
+            # Assert — callable stripped; typed meta fields preserved
+            assert received.session_update_fn is None
             assert isinstance(received.platform_meta, TelegramMeta)
             assert received.platform_meta.chat_id == 123
         finally:

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -20,8 +20,10 @@ from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.bus import Bus
 from lyra.core.messaging.message import (
     Attachment,
+    DiscordMeta,
     InboundMessage,
     Platform,
+    TelegramMeta,
 )
 from lyra.nats.nats_bus import NatsBus
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
@@ -36,21 +38,10 @@ from tests.nats.conftest import requires_nats_server
 def _make_msg(platform: Platform = Platform.TELEGRAM) -> InboundMessage:
     if platform == Platform.TELEGRAM:
         scope = "chat:123"
-        meta: dict = {
-            "chat_id": 123,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        }
+        meta: TelegramMeta | DiscordMeta = TelegramMeta(chat_id=123)
     else:
         scope = "channel:2"
-        meta = {
-            "guild_id": 1,
-            "channel_id": 2,
-            "message_id": 3,
-            "thread_id": None,
-            "channel_type": "text",
-        }
+        meta = DiscordMeta(guild_id=1, channel_id=2, message_id=3, channel_type="text")
     return InboundMessage(
         id="msg-1",
         platform=platform.value,
@@ -78,7 +69,7 @@ def _make_bus(nc: NATS) -> NatsBus:
 
 class TestSerialize:
     def test_callable_stripped_from_platform_meta(self) -> None:
-        """Callables in platform_meta must be stripped during serialization."""
+        """Typed platform_meta survives serialize/deserialize round-trip (no callables)."""
         # Arrange
         msg = InboundMessage(
             id="msg-callable",
@@ -92,19 +83,19 @@ class TestSerialize:
             text_raw="hi",
             timestamp=datetime.now(timezone.utc),
             trust_level=TrustLevel.PUBLIC,
-            platform_meta={"_session_update_fn": lambda: None, "chat_id": 99},
+            platform_meta=TelegramMeta(chat_id=99),
         )
 
         # Act
         payload = serialize(msg)
         result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
-        # Assert
-        assert "_session_update_fn" not in result.platform_meta
-        assert result.platform_meta.get("chat_id") == 99
+        # Assert — typed fields survive the round-trip
+        assert isinstance(result.platform_meta, TelegramMeta)
+        assert result.platform_meta.chat_id == 99
 
     def test_non_callable_platform_meta_preserved(self) -> None:
-        """Non-callable values in platform_meta survive the round-trip intact."""
+        """Typed TelegramMeta fields survive the round-trip intact."""
         # Arrange
         msg = InboundMessage(
             id="msg-meta",
@@ -118,7 +109,7 @@ class TestSerialize:
             text_raw="hi",
             timestamp=datetime.now(timezone.utc),
             trust_level=TrustLevel.PUBLIC,
-            platform_meta={"chat_id": 42, "is_group": True, "label": "vip"},
+            platform_meta=TelegramMeta(chat_id=42, is_group=True),
         )
 
         # Act
@@ -126,9 +117,9 @@ class TestSerialize:
         result = deserialize(payload, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
 
         # Assert
-        assert result.platform_meta["chat_id"] == 42
-        assert result.platform_meta["is_group"] is True
-        assert result.platform_meta["label"] == "vip"
+        assert isinstance(result.platform_meta, TelegramMeta)
+        assert result.platform_meta.chat_id == 42
+        assert result.platform_meta.is_group is True
 
     def test_enum_roundtrip(self) -> None:
         """TrustLevel enum survives serialize → deserialize as the same enum member."""
@@ -208,7 +199,8 @@ class TestSerialize:
         assert isinstance(result.trust_level, TrustLevel)
         assert result.trust_level == TrustLevel.TRUSTED
         assert result.timestamp.tzinfo is not None
-        assert result.platform_meta["chat_id"] == 123
+        assert isinstance(result.platform_meta, TelegramMeta)
+        assert result.platform_meta.chat_id == 123
 
     def test_bytes_roundtrip(self) -> None:
         """bytes field (Attachment.url_or_path_or_bytes) survives as bytes."""
@@ -368,10 +360,7 @@ class TestNatsBusRoundTrip:
             text_raw="hello",
             timestamp=datetime.now(timezone.utc),
             trust_level=TrustLevel.TRUSTED,
-            platform_meta={
-                "_session_update_fn": lambda: "should not cross",
-                "chat_id": 123,
-            },
+            platform_meta=TelegramMeta(chat_id=123),
         )
 
         try:
@@ -379,9 +368,9 @@ class TestNatsBusRoundTrip:
             await publisher.put(Platform.TELEGRAM, msg)
             received = await asyncio.wait_for(subscriber.get(), timeout=2.0)
 
-            # Assert — callable gone, non-callable preserved
-            assert "_session_update_fn" not in received.platform_meta
-            assert received.platform_meta.get("chat_id") == 123
+            # Assert — typed platform_meta fields preserved across NATS transit
+            assert isinstance(received.platform_meta, TelegramMeta)
+            assert received.platform_meta.chat_id == 123
         finally:
             await subscriber.stop()
 

--- a/tests/nats/test_nats_bus.py
+++ b/tests/nats/test_nats_bus.py
@@ -69,7 +69,8 @@ def _make_bus(nc: NATS) -> NatsBus:
 
 class TestSerialize:
     def test_callable_stripped_from_platform_meta(self) -> None:
-        """Typed platform_meta survives serialize/deserialize round-trip (no callables)."""
+        """Typed platform_meta survives serialize/deserialize round-trip (no callables).
+        """
         # Arrange
         msg = InboundMessage(
             id="msg-callable",

--- a/tests/nats/test_nats_bus_multibot.py
+++ b/tests/nats/test_nats_bus_multibot.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from nats.aio.client import Client as NATS
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, Platform
+from lyra.core.messaging.message import DiscordMeta, InboundMessage, Platform, TelegramMeta
 from lyra.nats.nats_bus import NatsBus
 from tests.nats.conftest import requires_nats_server
 
@@ -29,21 +29,10 @@ def _make_msg(
 ) -> InboundMessage:
     if platform == Platform.TELEGRAM:
         scope = "chat:1"
-        meta: dict = {
-            "chat_id": 1,
-            "topic_id": None,
-            "message_id": None,
-            "is_group": False,
-        }
+        meta: TelegramMeta | DiscordMeta = TelegramMeta(chat_id=1)
     else:
         scope = "channel:2"
-        meta = {
-            "guild_id": 1,
-            "channel_id": 2,
-            "message_id": 3,
-            "thread_id": None,
-            "channel_type": "text",
-        }
+        meta = DiscordMeta(guild_id=1, channel_id=2, message_id=3, channel_type="text")
     return InboundMessage(
         id="msg-1",
         platform=platform.value,

--- a/tests/nats/test_nats_bus_multibot.py
+++ b/tests/nats/test_nats_bus_multibot.py
@@ -15,7 +15,12 @@ from datetime import datetime, timezone
 from nats.aio.client import Client as NATS
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import DiscordMeta, InboundMessage, Platform, TelegramMeta
+from lyra.core.messaging.message import (
+    DiscordMeta,
+    InboundMessage,
+    Platform,
+    TelegramMeta,
+)
 from lyra.nats.nats_bus import NatsBus
 from tests.nats.conftest import requires_nats_server
 

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -273,7 +273,9 @@ class TestScopeValidation:
         assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-1"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="sess-1"
+            ),
         )
 
         # Act
@@ -308,7 +310,9 @@ class TestScopeValidation:
         assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-live"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="sess-live"
+            ),
         )
 
         # Act
@@ -336,7 +340,9 @@ class TestScopeValidation:
         assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-ghost"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="sess-ghost"
+            ),
         )
 
         # Act
@@ -363,7 +369,9 @@ class TestScopeValidation:
         assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-any"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="sess-any"
+            ),
         )
 
         # Act
@@ -425,7 +433,9 @@ class TestScopeValidation:
         assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-cross"),
+            platform_meta=dataclasses.replace(
+                _base.platform_meta, thread_session_id="sess-cross"
+            ),
         )
 
         # Act

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -245,6 +245,63 @@ class TestNatsBusSanitization:
         assert item.platform_meta.chat_id == 123
         assert item.platform_meta.is_group is False
 
+    def test_discord_meta_round_trips(self) -> None:
+        """DiscordMeta round-trips cleanly; max-overlap decode picks DiscordMeta."""
+        from lyra.core.auth.trust import TrustLevel
+        from lyra.core.messaging.message import DiscordMeta, InboundMessage, Platform
+        from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+        from roxabi_nats._serialize import deserialize, serialize
+
+        msg = InboundMessage(
+            id="msg-dc",
+            platform=Platform.DISCORD.value,
+            bot_id="main",
+            scope_id="channel:99",
+            user_id="user:2",
+            user_name="Bob",
+            is_mention=True,
+            text="hi",
+            text_raw="hi",
+            trust_level=TrustLevel.PUBLIC,
+            platform_meta=DiscordMeta(
+                channel_id=99, message_id=42, guild_id=7, channel_type="text"
+            ),
+        )
+        raw = serialize(msg)
+        item = deserialize(raw, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
+        assert isinstance(item.platform_meta, DiscordMeta), (
+            f"Expected DiscordMeta, got {item.platform_meta!r}"
+        )
+        assert item.platform_meta.channel_id == 99
+        assert item.platform_meta.message_id == 42
+        assert item.platform_meta.guild_id == 7
+
+    def test_generic_meta_round_trips(self) -> None:
+        """GenericMeta (no fields) round-trips as GenericMeta, not TelegramMeta."""
+        from lyra.core.auth.trust import TrustLevel
+        from lyra.core.messaging.message import GenericMeta, InboundMessage, Platform
+        from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
+        from roxabi_nats._serialize import deserialize, serialize
+
+        msg = InboundMessage(
+            id="msg-gm",
+            platform=Platform.TELEGRAM.value,
+            bot_id="main",
+            scope_id="scope:1",
+            user_id="user:3",
+            user_name="Carol",
+            is_mention=False,
+            text="",
+            text_raw="",
+            trust_level=TrustLevel.PUBLIC,
+            platform_meta=GenericMeta(),
+        )
+        raw = serialize(msg)
+        item = deserialize(raw, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
+        assert isinstance(item.platform_meta, GenericMeta), (
+            f"Expected GenericMeta, got {item.platform_meta!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestScopeValidation — Path 2 scope-check in SubmitToPoolMiddleware

--- a/tests/nats/test_sanitize.py
+++ b/tests/nats/test_sanitize.py
@@ -20,6 +20,7 @@ import pytest
 from lyra.core.hub.middleware import PipelineContext
 from lyra.core.hub.middleware.path_validation import resolve_context
 from lyra.core.hub.pipeline.message_pipeline import ResumeStatus
+from lyra.core.messaging.message import TelegramMeta
 from roxabi_nats._sanitize import PLATFORM_META_ALLOWLIST, sanitize_platform_meta
 from tests.core.conftest import _make_hub, make_inbound_message
 
@@ -218,9 +219,10 @@ class TestNatsBusSanitization:
     """Verify sanitization fires inside the NatsBus handler closure."""
 
     def test_handler_sanitizes_platform_meta(self) -> None:
-        """NatsBus handler strips unknown keys via dataclasses.replace."""
+        """Typed TelegramMeta round-trips cleanly via serialize → deserialize."""
         from lyra.core.auth.trust import TrustLevel
-        from lyra.core.messaging.message import InboundMessage, Platform
+        from lyra.core.messaging.message import InboundMessage, Platform, TelegramMeta
+        from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
         from roxabi_nats._serialize import deserialize, serialize
 
         msg = InboundMessage(
@@ -234,22 +236,14 @@ class TestNatsBusSanitization:
             text="hello",
             text_raw="hello",
             trust_level=TrustLevel.PUBLIC,
-            platform_meta={
-                "chat_id": 123,
-                "is_group": False,
-                "evil_key": "should_vanish",
-            },
+            platform_meta=TelegramMeta(chat_id=123, is_group=False),
         )
-        # Simulate the handler: serialize → deserialize → sanitize
+        # Simulate the handler: serialize → deserialize with type registry
         raw = serialize(msg)
-        item = deserialize(raw, InboundMessage)
-        assert "evil_key" in item.platform_meta
-        cleaned = dataclasses.replace(
-            item,
-            platform_meta=sanitize_platform_meta(item.platform_meta),
-        )
-        assert "evil_key" not in cleaned.platform_meta
-        assert cleaned.platform_meta["chat_id"] == 123
+        item = deserialize(raw, InboundMessage, resolver=TYPE_REGISTRY_RESOLVER)
+        assert isinstance(item.platform_meta, TelegramMeta)
+        assert item.platform_meta.chat_id == 123
+        assert item.platform_meta.is_group is False
 
 
 # ---------------------------------------------------------------------------
@@ -276,8 +270,10 @@ class TestScopeValidation:
         ctx = PipelineContext(hub=hub)
 
         _base = make_inbound_message(scope_id="chat:99")
+        assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
-            _base, platform_meta={**_base.platform_meta, "thread_session_id": "sess-1"}
+            _base,
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-1"),
         )
 
         # Act
@@ -309,9 +305,10 @@ class TestScopeValidation:
         ctx = PipelineContext(hub=hub)
 
         _base = make_inbound_message(scope_id="chat:42")
+        assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta={**_base.platform_meta, "thread_session_id": "sess-live"},
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-live"),
         )
 
         # Act
@@ -336,9 +333,10 @@ class TestScopeValidation:
         ctx = PipelineContext(hub=hub)
 
         _base = make_inbound_message(scope_id="chat:42")
+        assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta={**_base.platform_meta, "thread_session_id": "sess-ghost"},
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-ghost"),
         )
 
         # Act
@@ -362,9 +360,10 @@ class TestScopeValidation:
         ctx = PipelineContext(hub=hub)
 
         _base = make_inbound_message(scope_id="chat:42")
+        assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta={**_base.platform_meta, "thread_session_id": "sess-any"},
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-any"),
         )
 
         # Act
@@ -392,7 +391,8 @@ class TestScopeValidation:
         ctx = PipelineContext(hub=hub)
 
         msg = make_inbound_message(scope_id="chat:42")
-        assert msg.platform_meta.get("thread_session_id") is None
+        assert isinstance(msg.platform_meta, TelegramMeta)
+        assert msg.platform_meta.thread_session_id is None
 
         # Act
         status = await resolve_context(msg, pool, pool_id, ctx)
@@ -422,9 +422,10 @@ class TestScopeValidation:
         ctx = PipelineContext(hub=hub)
 
         _base = make_inbound_message(scope_id="chat:42")
+        assert isinstance(_base.platform_meta, TelegramMeta)
         msg = dataclasses.replace(
             _base,
-            platform_meta={**_base.platform_meta, "thread_session_id": "sess-cross"},
+            platform_meta=dataclasses.replace(_base.platform_meta, thread_session_id="sess-cross"),
         )
 
         # Act

--- a/tests/nats/test_sanitize_single_entry.py
+++ b/tests/nats/test_sanitize_single_entry.py
@@ -40,10 +40,9 @@ from pathlib import Path
 # Key is the source file path relative to repo root.
 # Value is a short description of the architectural role.
 EXPECTED_CALL_SITES: dict[str, str] = {
-    # NatsBus._make_handler() sanitizes each inbound message as it arrives from
-    # the NATS wire.  This is the sole sanitization point for all hub-inbound
-    # paths (Slice 2, issue #534: compat shim deleted).
-    "src/lyra/nats/nats_bus.py": "NatsBus._make_handler — wire-boundary sanitization",
+    # Issue #853: platform_meta is now a typed PlatformMeta union (TelegramMeta |
+    # DiscordMeta | GenericMeta). Sanitization is no longer needed — the type
+    # system enforces valid structure at construction time. All call sites removed.
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -18,6 +18,7 @@ from lyra.core.hub import Hub
 from lyra.core.messaging.message import (
     InboundMessage,
     Platform,
+    TelegramMeta,
 )
 from tests.conftest import AUTH_HEADERS, HEALTH_SECRET, yield_once
 from tests.core.conftest import push_to_hub
@@ -139,12 +140,7 @@ class TestHealthEndpoint:
             text_raw="hello",
             timestamp=datetime.now(timezone.utc),
             scope_id="chat:123",
-            platform_meta={
-                "chat_id": 123,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            },
+            platform_meta=TelegramMeta(chat_id=123),
             trust_level=TrustLevel.TRUSTED,
         )
         await push_to_hub(hub, msg)
@@ -183,12 +179,7 @@ class TestHealthEndpoint:
             text_raw="hello",
             timestamp=datetime.now(timezone.utc),
             scope_id="chat:123",
-            platform_meta={
-                "chat_id": 123,
-                "topic_id": None,
-                "message_id": None,
-                "is_group": False,
-            },
+            platform_meta=TelegramMeta(chat_id=123),
             trust_level=TrustLevel.TRUSTED,
         )
         await hub.inbound_bus.put(Platform.TELEGRAM, msg)

--- a/tests/tts/test_voice_command.py
+++ b/tests/tts/test_voice_command.py
@@ -21,7 +21,7 @@ from lyra.agents.simple_agent import SimpleAgent
 from lyra.core.agent import Agent
 from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, OutboundAudio, Response
+from lyra.core.messaging.message import InboundMessage, OutboundAudio, Response, TelegramMeta
 from lyra.core.pool import Pool
 from lyra.core.runtime_config import RuntimeConfig
 from lyra.tts import TtsProtocol
@@ -43,12 +43,7 @@ def _make_message(text: str = "hello") -> InboundMessage:
         text=text,
         text_raw=text,
         timestamp=datetime.now(timezone.utc),
-        platform_meta={
-            "chat_id": 42,
-            "topic_id": None,
-            "message_id": 99,
-            "is_group": False,
-        },
+        platform_meta=TelegramMeta(chat_id=42, message_id=99),
         trust_level=TrustLevel.TRUSTED,
     )
 

--- a/tests/tts/test_voice_command.py
+++ b/tests/tts/test_voice_command.py
@@ -21,7 +21,12 @@ from lyra.agents.simple_agent import SimpleAgent
 from lyra.core.agent import Agent
 from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, OutboundAudio, Response, TelegramMeta
+from lyra.core.messaging.message import (
+    InboundMessage,
+    OutboundAudio,
+    Response,
+    TelegramMeta,
+)
 from lyra.core.pool import Pool
 from lyra.core.runtime_config import RuntimeConfig
 from lyra.tts import TtsProtocol


### PR DESCRIPTION
## Summary

- Replace \`platform_meta: dict[str, Any]\` on \`InboundMessage\` and \`RoutingContext\` with a typed \`PlatformMeta\` union (\`TelegramMeta | DiscordMeta | GenericMeta\`) — eliminates ~51 \`.get("key")\` call sites
- Add typed \`session_update_fn: SessionUpdateFn | None\` field on \`InboundMessage\`, removing \`_session_update_fn\` callable from the dict entirely (removes \`TrustedCallback\` wrapping on this path)
- Fix \`_decode_union\` in \`roxabi-nats\` to use field-overlap heuristic (prevents Discord payloads reconstructing as \`TelegramMeta\` after NATS round-trip)
- Add callable-field skip in \`_encode\` so \`session_update_fn\` is silently dropped during NATS serialization (consistent with existing behaviour)
- Remove \`sanitize_platform_meta\` call from \`nats_bus.py\` — typed union enforces the allowlist structurally

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #853: refactor(core): remove platform_meta dict[str, Any] escape hatch | Open |
| Spec | [853-remove-platform-meta-escape-hatch-spec.mdx](artifacts/specs/853-remove-platform-meta-escape-hatch-spec.mdx) | Present |
| Plan | [853-remove-platform-meta-escape-hatch-plan.mdx](artifacts/plans/853-remove-platform-meta-escape-hatch-plan.mdx) | Present |
| Implementation | 14 commits on \`feat/853-remove-platform-meta-escape-hatch\` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3048 passed, 48 skipped) | Passed |

## Test Plan

- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 3048 passed, 0 failures
- [x] `msg.platform_meta.chat_id` / `.channel_id` typed attribute access (no `.get()`)
- [x] `msg.session_update_fn` set by telegram + discord inbound adapters
- [x] `middleware_submit.py` reads `msg.session_update_fn` directly (no `unwrap_callback`)
- [x] NATS round-trip: `session_update_fn` serializes as absent → deserializes as `None`
- [x] `nats_bus.py` sanitize call removed; `cli.py` uses `GenericMeta()`

Closes #853

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`