### PR TITLE
refactor(bootstrap): typed Secrets registry replaces _read_secret(name)

### DIFF
--- a/src/lyra/bootstrap/infra/health.py
+++ b/src/lyra/bootstrap/infra/health.py
@@ -60,23 +60,9 @@ def _probe_nats(nc: Any | None) -> str | None:
         return "unreachable"
 
 
-def _read_secret(name: str) -> str:
-    """Read a secret from $LYRA_VAULT_DIR/secrets/{name}. Returns '' if missing."""
-    vault_dir = Path(
-        os.environ.get("LYRA_VAULT_DIR", str(Path.home() / ".lyra"))
-    ).resolve()
-    path = vault_dir / "secrets" / name
-    try:
-        return path.read_text().strip()
-    except FileNotFoundError:
-        return ""
-    except OSError as exc:
-        log.warning("Could not read secret %r: %s", name, exc)
-        return ""
-
 
 def create_health_app(  # noqa: C901 — optional sections (nats/reaper/circuits)
-    hub: Hub, nc: Any | None = None
+    hub: Hub, nc: Any | None = None, secrets: Secrets | None = None
 ) -> FastAPI:
     """Create a root FastAPI app with /health endpoint for hub monitoring.
 
@@ -88,6 +74,7 @@ def create_health_app(  # noqa: C901 — optional sections (nats/reaper/circuits
     ``status`` of ``ok``/``degraded``. When ``NATS_URL`` is unset both
     fields are omitted.
     """
+    _secrets = secrets or Secrets()
     app = FastAPI(title="Lyra Hub")
 
     @app.get("/health")
@@ -96,7 +83,7 @@ def create_health_app(  # noqa: C901 — optional sections (nats/reaper/circuits
 
     @app.get("/health/detail")
     async def health_detail(authorization: str = Header(default="")) -> dict:
-        health_secret = _read_secret("health_secret")
+        health_secret = _secrets.health_secret
         expected = f"Bearer {health_secret}"
         # Encode both sides to bytes: hmac.compare_digest requires matching
         # types; passing mixed str/bytes raises TypeError (becomes a 500)

--- a/src/lyra/bootstrap/infra/health.py
+++ b/src/lyra/bootstrap/infra/health.py
@@ -6,6 +6,7 @@ import hmac
 import logging
 import os
 import time
+from functools import cached_property
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,27 @@ from fastapi import FastAPI, Header, HTTPException
 from lyra.core.hub import Hub
 
 log = logging.getLogger(__name__)
+
+
+class Secrets:
+    def __init__(self, vault_dir: Path | None = None) -> None:
+        self._vault_dir = vault_dir or Path(
+            os.environ.get("LYRA_VAULT_DIR", str(Path.home() / ".lyra"))
+        ).resolve()
+
+    def _read(self, name: str) -> str:
+        path = self._vault_dir / "secrets" / name
+        try:
+            return path.read_text().strip()
+        except FileNotFoundError:
+            return ""
+        except OSError as exc:
+            log.warning("Could not read secret %r: %s", name, exc)
+            return ""
+
+    @cached_property
+    def health_secret(self) -> str:
+        return self._read("health_secret")
 
 
 def _probe_nats(nc: Any | None) -> str | None:

--- a/tests/test_health_endpoint_config.py
+++ b/tests/test_health_endpoint_config.py
@@ -11,6 +11,7 @@ import time
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from lyra.bootstrap.infra.health import Secrets, create_health_app
 from lyra.core.hub import Hub
 from tests.conftest import AUTH_HEADERS, HEALTH_SECRET
 
@@ -22,20 +23,14 @@ from tests.conftest import AUTH_HEADERS, HEALTH_SECRET
 class TestConfigEndpoint:
     """GET /config endpoint auth and 404 behavior."""
 
-    async def test_config_returns_404_when_no_anthropic_agent(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_config_returns_404_when_no_anthropic_agent(self) -> None:
         """No agent registered → 404."""
         # Arrange
-        import lyra.bootstrap.infra.health as health_mod
+        from unittest.mock import Mock
 
-        monkeypatch.setattr(
-            health_mod, "_read_secret", lambda name: "test-config-secret"
-        )
-        from lyra.bootstrap.infra.health import create_health_app
-
+        mock_secrets = Mock(spec=Secrets, health_secret="test-config-secret")
         test_hub = Hub()
-        app = create_health_app(test_hub)
+        app = create_health_app(test_hub, secrets=mock_secrets)
         transport = ASGITransport(app=app)
 
         # Act
@@ -57,17 +52,17 @@ class TestHealthReaperFields:
     """#317 SC-11: /health/detail includes reaper_alive and reaper_last_sweep_age."""
 
     @pytest.fixture(autouse=True)
-    def set_health_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import lyra.bootstrap.infra.health as health_mod
+    def mock_secrets(self) -> Secrets:
+        from unittest.mock import Mock
 
-        monkeypatch.setattr(health_mod, "_read_secret", lambda name: HEALTH_SECRET)
+        return Mock(spec=Secrets, health_secret=HEALTH_SECRET)
 
-    async def test_reaper_fields_absent_when_no_cli_pool(self, hub: Hub) -> None:
+    async def test_reaper_fields_absent_when_no_cli_pool(
+        self, hub: Hub, mock_secrets: Secrets
+    ) -> None:
         """No cli_pool → reaper keys omitted entirely from response."""
-        from lyra.bootstrap.infra.health import create_health_app
-
         assert hub.cli_pool is None
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=mock_secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -76,11 +71,12 @@ class TestHealthReaperFields:
         assert "reaper_alive" not in data
         assert "reaper_last_sweep_age" not in data
 
-    async def test_reaper_fields_with_live_cli_pool(self, hub: Hub) -> None:
+    async def test_reaper_fields_with_live_cli_pool(
+        self, hub: Hub, mock_secrets: Secrets
+    ) -> None:
         """cli_pool with active reaper → reaper_alive=True."""
         from unittest.mock import MagicMock
 
-        from lyra.bootstrap.infra.health import create_health_app
         from lyra.core.cli.cli_pool import CliPool
 
         cli_pool = CliPool()
@@ -91,7 +87,7 @@ class TestHealthReaperFields:
         cli_pool._last_sweep_at = time.monotonic() - 30  # 30s ago
         hub.cli_pool = cli_pool
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=mock_secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -101,11 +97,12 @@ class TestHealthReaperFields:
         assert data["reaper_last_sweep_age"] is not None
         assert 25 <= data["reaper_last_sweep_age"] <= 35
 
-    async def test_reaper_fields_before_first_sweep(self, hub: Hub) -> None:
+    async def test_reaper_fields_before_first_sweep(
+        self, hub: Hub, mock_secrets: Secrets
+    ) -> None:
         """cli_pool started but no sweep yet → reaper_alive=True, age=None."""
         from unittest.mock import MagicMock
 
-        from lyra.bootstrap.infra.health import create_health_app
         from lyra.core.cli.cli_pool import CliPool
 
         cli_pool = CliPool()
@@ -115,7 +112,7 @@ class TestHealthReaperFields:
         cli_pool._last_sweep_at = None
         hub.cli_pool = cli_pool
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=mock_secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)

--- a/tests/test_health_endpoint_config.py
+++ b/tests/test_health_endpoint_config.py
@@ -7,6 +7,7 @@ Classes: TestConfigEndpoint, TestHealthReaperFields.
 from __future__ import annotations
 
 import time
+from unittest.mock import Mock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -26,8 +27,6 @@ class TestConfigEndpoint:
     async def test_config_returns_404_when_no_anthropic_agent(self) -> None:
         """No agent registered → 404."""
         # Arrange
-        from unittest.mock import Mock
-
         mock_secrets = Mock(spec=Secrets, health_secret="test-config-secret")
         test_hub = Hub()
         app = create_health_app(test_hub, secrets=mock_secrets)
@@ -53,8 +52,6 @@ class TestHealthReaperFields:
 
     @pytest.fixture(autouse=True)
     def mock_secrets(self) -> Secrets:
-        from unittest.mock import Mock
-
         return Mock(spec=Secrets, health_secret=HEALTH_SECRET)
 
     async def test_reaper_fields_absent_when_no_cli_pool(

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
+from unittest.mock import Mock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from lyra.bootstrap.infra.health import Secrets
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.hub import Hub
@@ -100,16 +102,14 @@ class TestHealthUnauthenticated:
 
 class TestHealthEndpoint:
     @pytest.fixture(autouse=True)
-    def set_health_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import lyra.bootstrap.infra.health as health_mod
-
-        monkeypatch.setattr(health_mod, "_read_secret", lambda name: HEALTH_SECRET)
+    def set_health_secret(self) -> None:
+        self.secrets = Mock(spec=Secrets, health_secret=HEALTH_SECRET)
 
     async def test_health_returns_json(self, hub: Hub) -> None:
         """SC-2: /health/detail returns JSON with expected keys."""
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -146,7 +146,7 @@ class TestHealthEndpoint:
         await push_to_hub(hub, msg)
         await yield_once()  # let feeder task move message to staging
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -184,7 +184,7 @@ class TestHealthEndpoint:
         )
         await hub.inbound_bus.put(Platform.TELEGRAM, msg)
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -197,7 +197,7 @@ class TestHealthEndpoint:
         """SC-2: uptime_s is a positive number."""
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -211,7 +211,7 @@ class TestHealthEndpoint:
         """SC-2: last_message_age_s is null when no messages have been processed."""
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -225,7 +225,7 @@ class TestHealthEndpoint:
 
         hub._outbound_router._last_processed_at = time.monotonic()
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -238,7 +238,7 @@ class TestHealthEndpoint:
         """SC-2: circuits shows state for all registered circuits."""
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -261,7 +261,7 @@ class TestHealthEndpoint:
         for _ in range(5):
             cb.record_failure()
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -280,10 +280,8 @@ class TestNatsHealthProbe:
     """#449: /health/detail surfaces NATS status only when NATS is configured."""
 
     @pytest.fixture(autouse=True)
-    def set_health_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import lyra.bootstrap.infra.health as health_mod
-
-        monkeypatch.setattr(health_mod, "_read_secret", lambda name: HEALTH_SECRET)
+    def set_health_secret(self) -> None:
+        self.secrets = Mock(spec=Secrets, health_secret=HEALTH_SECRET)
 
     async def test_nats_field_absent_when_url_unset(
         self, hub: Hub, monkeypatch: pytest.MonkeyPatch
@@ -292,7 +290,8 @@ class TestNatsHealthProbe:
         monkeypatch.delenv("NATS_URL", raising=False)
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)  # nc omitted — mirrors unified mode
+        # nc omitted — mirrors unified mode
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -315,7 +314,7 @@ class TestNatsHealthProbe:
 
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub, nc=nc)
+        app = create_health_app(hub, nc=nc, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -337,7 +336,7 @@ class TestNatsHealthProbe:
 
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub, nc=nc)
+        app = create_health_app(hub, nc=nc, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -353,7 +352,7 @@ class TestNatsHealthProbe:
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=self.secrets)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health/detail", headers=AUTH_HEADERS)
@@ -380,7 +379,7 @@ class TestNatsHealthProbe:
 
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub, nc=nc)
+        app = create_health_app(hub, nc=nc, secrets=self.secrets)
         transport = ASGITransport(app=app)
 
         with caplog.at_level(_logging.DEBUG, logger="lyra.bootstrap.infra.health"):

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -47,7 +47,7 @@ class TestHealthUnauthenticated:
         assert resp.json() == {"ok": True}
 
     async def test_wrong_token_returns_ok_only(
-        self, hub: Hub, monkeypatch: pytest.MonkeyPatch
+        self, hub: Hub
     ) -> None:
         """#207: Wrong Bearer token still returns minimal response."""
         from lyra.bootstrap.infra.health import create_health_app
@@ -81,7 +81,7 @@ class TestHealthUnauthenticated:
         assert resp.json() == {"ok": True}
 
     async def test_empty_secret_env_returns_ok_only(
-        self, hub: Hub, monkeypatch: pytest.MonkeyPatch
+        self, hub: Hub
     ) -> None:
         """#207: LYRA_HEALTH_SECRET='' still returns minimal response."""
         from lyra.bootstrap.infra.health import create_health_app

--- a/tests/test_health_endpoint_status.py
+++ b/tests/test_health_endpoint_status.py
@@ -32,13 +32,12 @@ from tests.core.conftest import push_to_hub
 
 class TestHealthUnauthenticated:
     async def test_no_token_returns_ok_only(
-        self, hub: Hub, monkeypatch: pytest.MonkeyPatch
+        self, hub: Hub
     ) -> None:
         """#207: Unauthenticated /health returns only {"ok": true}."""
-        monkeypatch.delenv("LYRA_HEALTH_SECRET", raising=False)
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=Mock(spec=Secrets, health_secret=""))
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health")
@@ -64,13 +63,12 @@ class TestHealthUnauthenticated:
         assert data == {"ok": True}
 
     async def test_no_secret_configured_returns_ok_only(
-        self, hub: Hub, monkeypatch: pytest.MonkeyPatch
+        self, hub: Hub
     ) -> None:
-        """#207: When LYRA_HEALTH_SECRET is unset, always minimal."""
-        monkeypatch.delenv("LYRA_HEALTH_SECRET", raising=False)
+        """#207: When no secret is configured, always minimal."""
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=Mock(spec=Secrets, health_secret=""))
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get(
@@ -83,10 +81,10 @@ class TestHealthUnauthenticated:
     async def test_empty_secret_env_returns_ok_only(
         self, hub: Hub
     ) -> None:
-        """#207: LYRA_HEALTH_SECRET='' still returns minimal response."""
+        """#207: Empty health_secret still returns minimal response."""
         from lyra.bootstrap.infra.health import create_health_app
 
-        app = create_health_app(hub)
+        app = create_health_app(hub, secrets=Mock(spec=Secrets, health_secret=""))
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get("/health", headers={"authorization": "Bearer "})

--- a/tests/test_read_secret.py
+++ b/tests/test_read_secret.py
@@ -72,13 +72,17 @@ class TestSecrets:
             secret_file.chmod(0o644)
 
     def test_health_secret_cached_property(self, tmp_path: Path) -> None:
-        """health_secret cached_property reads from secrets/health_secret."""
+        """health_secret cached_property reads once and caches the result."""
+        from unittest.mock import patch
+
         vault_dir = self._setup_secrets_dir(tmp_path)
         (vault_dir / "secrets" / "health_secret").write_text("my-health-token\n")
 
         secrets = Secrets(vault_dir=vault_dir)
-        result = secrets.health_secret
+        with patch.object(secrets, "_read", wraps=secrets._read) as spy:
+            first = secrets.health_secret
+            second = secrets.health_secret
 
-        assert result == "my-health-token"
-        # Second access returns same value (cached_property)
-        assert secrets.health_secret == "my-health-token"
+        assert first == "my-health-token"
+        assert second == "my-health-token"
+        assert spy.call_count == 1

--- a/tests/test_read_secret.py
+++ b/tests/test_read_secret.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from lyra.bootstrap.infra.health import Secrets
 
 
@@ -49,16 +51,22 @@ class TestSecrets:
 
         assert result == ""
 
-    def test_permission_error_returns_empty_string(self, tmp_path: Path) -> None:
+    def test_permission_error_returns_empty_string(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """PermissionError (OSError) returns empty string instead of propagating."""
+        import logging
+
         vault_dir = self._setup_secrets_dir(tmp_path)
         secret_file = vault_dir / "secrets" / "locked_secret"
         secret_file.write_text("private")
         secret_file.chmod(0o000)
 
         try:
-            result = Secrets(vault_dir=vault_dir)._read("locked_secret")
+            with caplog.at_level(logging.WARNING, logger="lyra.bootstrap.infra.health"):
+                result = Secrets(vault_dir=vault_dir)._read("locked_secret")
             assert result == ""
+            assert "Could not read secret" in caplog.text
         finally:
             # Restore permissions so tmp_path cleanup works
             secret_file.chmod(0o644)

--- a/tests/test_read_secret.py
+++ b/tests/test_read_secret.py
@@ -1,79 +1,76 @@
-"""Tests for lyra.bootstrap.infra.health._read_secret."""
+"""Tests for lyra.bootstrap.infra.health.Secrets."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
-from lyra.bootstrap.infra.health import _read_secret
+from lyra.bootstrap.infra.health import Secrets
 
 
-class TestReadSecret:
-    def _setup_secrets_dir(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> Path:
-        """Set up ~/.lyra/secrets/ structure under tmp_path."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        secrets_dir = tmp_path / ".lyra" / "secrets"
+class TestSecrets:
+    def _setup_secrets_dir(self, tmp_path: Path) -> Path:
+        """Create tmp_path/secrets/ and return tmp_path as vault_dir."""
+        secrets_dir = tmp_path / "secrets"
         secrets_dir.mkdir(parents=True, exist_ok=True)
-        return secrets_dir
+        return tmp_path
 
-    def test_file_exists_returns_stripped_content(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_file_exists_returns_stripped_content(self, tmp_path: Path) -> None:
         """File with content returns the stripped string."""
-        secrets_dir = self._setup_secrets_dir(tmp_path, monkeypatch)
-        (secrets_dir / "my_secret").write_text("supersecret")
+        vault_dir = self._setup_secrets_dir(tmp_path)
+        (vault_dir / "secrets" / "my_secret").write_text("supersecret")
 
-        result = _read_secret("my_secret")
+        result = Secrets(vault_dir=vault_dir)._read("my_secret")
 
         assert result == "supersecret"
 
-    def test_trailing_whitespace_and_newline_stripped(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_trailing_whitespace_and_newline_stripped(self, tmp_path: Path) -> None:
         """Trailing whitespace and newlines are stripped."""
-        secrets_dir = self._setup_secrets_dir(tmp_path, monkeypatch)
-        (secrets_dir / "token").write_text("  my-token\n  ")
+        vault_dir = self._setup_secrets_dir(tmp_path)
+        (vault_dir / "secrets" / "token").write_text("  my-token\n  ")
 
-        result = _read_secret("token")
+        result = Secrets(vault_dir=vault_dir)._read("token")
 
         assert result == "my-token"
 
-    def test_missing_file_returns_empty_string(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_file_returns_empty_string(self, tmp_path: Path) -> None:
         """Missing secret file returns empty string (no exception)."""
-        self._setup_secrets_dir(tmp_path, monkeypatch)
+        vault_dir = self._setup_secrets_dir(tmp_path)
 
-        result = _read_secret("nonexistent")
+        result = Secrets(vault_dir=vault_dir)._read("nonexistent")
 
         assert result == ""
 
-    def test_empty_file_returns_empty_string(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_empty_file_returns_empty_string(self, tmp_path: Path) -> None:
         """Empty secret file returns empty string."""
-        secrets_dir = self._setup_secrets_dir(tmp_path, monkeypatch)
-        (secrets_dir / "empty_secret").write_text("")
+        vault_dir = self._setup_secrets_dir(tmp_path)
+        (vault_dir / "secrets" / "empty_secret").write_text("")
 
-        result = _read_secret("empty_secret")
+        result = Secrets(vault_dir=vault_dir)._read("empty_secret")
 
         assert result == ""
 
-    def test_permission_error_returns_empty_string(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_permission_error_returns_empty_string(self, tmp_path: Path) -> None:
         """PermissionError (OSError) returns empty string instead of propagating."""
-        secrets_dir = self._setup_secrets_dir(tmp_path, monkeypatch)
-        secret_file = secrets_dir / "locked_secret"
+        vault_dir = self._setup_secrets_dir(tmp_path)
+        secret_file = vault_dir / "secrets" / "locked_secret"
         secret_file.write_text("private")
         secret_file.chmod(0o000)
 
         try:
-            result = _read_secret("locked_secret")
+            result = Secrets(vault_dir=vault_dir)._read("locked_secret")
             assert result == ""
         finally:
             # Restore permissions so tmp_path cleanup works
             secret_file.chmod(0o644)
+
+    def test_health_secret_cached_property(self, tmp_path: Path) -> None:
+        """health_secret cached_property reads from secrets/health_secret."""
+        vault_dir = self._setup_secrets_dir(tmp_path)
+        (vault_dir / "secrets" / "health_secret").write_text("my-health-token\n")
+
+        secrets = Secrets(vault_dir=vault_dir)
+        result = secrets.health_secret
+
+        assert result == "my-health-token"
+        # Second access returns same value (cached_property)
+        assert secrets.health_secret == "my-health-token"


### PR DESCRIPTION
## Summary
- Replace stringly-typed `_read_secret(name: str)` with a `Secrets` class whose `@cached_property` fields enumerate known secrets by name — path traversal structurally impossible
- Migrate three test files from `monkeypatch.setattr` on the deleted function to `Secrets` instance injection via the new optional `secrets=` parameter on `create_health_app`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #854: refactor(bootstrap): typed Secrets registry replaces _read_secret(name) | Open |
| Analysis | — | Absent (F-lite, skipped) |
| Spec | [854-typed-secrets-registry-spec.mdx](artifacts/specs/854-typed-secrets-registry-spec.mdx) | Present |
| Implementation | 5 commits on `feat/854-typed-secrets-registry` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3054 passed) | Passed |

## Test Plan
- [ ] `grep -r '_read_secret' src/` returns no matches
- [ ] `uv run pyright` → 0 errors
- [ ] `uv run pytest tests/test_read_secret.py tests/test_health_endpoint_config.py tests/test_health_endpoint_status.py -v` → all green
- [ ] `/health/detail` with correct Bearer token returns 200 (no runtime regression)
- [ ] Adding a future secret = adding a `@cached_property` to `Secrets`, no string arg at callsite

Closes #854

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`