### PR TITLE
feat(clipool): extract CliPool into dedicated NATS container (ADR-054)

### DIFF
--- a/artifacts/analyses/941-extract-clipool-dedicated-container-nats-consensus.mdx
+++ b/artifacts/analyses/941-extract-clipool-dedicated-container-nats-consensus.mdx
@@ -1,0 +1,100 @@
+---
+title: "CliPool NATS Extraction — Deferred Findings Expert Consensus"
+issue: 941
+status: consensus-reached
+date: 2026-04-27
+panel: architect, security-auditor, devops
+confidence: high
+---
+
+## Problem
+
+PR #946 (issue #941) received 9 deferred review findings after 7 blocking issues were already fixed.
+The panel must decide which of the 9 deferred findings to fix before merge vs. genuinely defer to a
+follow-up issue.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | arch soundness, maintainability, scalability |
+| security-auditor | security, attack surface, compliance |
+| devops | ops impact, deploy safety, infra cost, monitoring |
+
+## Consensus ρ
+
+**Fix before merge:** S6, S14, S15 (3/3 unanimous)
+**Defer:** S2, S3, S5, S7, S13, S18/S19/S20 (majority 2/3 or unanimous)
+
+### Rationale
+
+**S6 — `await queue.put(msg)` in NATS callback (blocking)**
+All 3 agents flagged this as a hard blocker. `NatsDriverBase._stream_gen` creates a bounded
+`asyncio.Queue(maxsize=512)` and subscribes an `_on_msg` coroutine that does `await queue.put(msg)`.
+NATS-py calls this coroutine on its dispatch loop. When the queue is full, the `await` suspends
+the entire dispatch loop — heartbeats stall, keep-alives freeze, the hub marks the worker dead,
+and systemd recycles the container. This is a deterministic failure path under sustained load.
+Fix: `queue.put_nowait(msg)` with drop-and-log on `QueueFull`.
+
+**S14 — Missing `TimeoutStopSec` in `lyra-clipool.container`**
+All 3 agents agreed. The worker calls `nc.drain(timeout=60)` then `nc.close()`. Systemd default
+is 90s. That leaves only 30s for SIGTERM propagation, Python teardown, and NATS flush — not
+enough margin. Fix: `TimeoutStopSec=120` in `[Service]`. Zero risk, one-line change.
+
+**S15 — `EnvironmentFile=` without `-` prefix**
+All 3 agents agreed. On a fresh install or new fleet node where `~/.lyra/env/clipool.env` has not
+been created, the container unit fails to start with a cryptic systemd error instead of the clearer
+"missing env var" message. Fix: `EnvironmentFile=-%h/.lyra/env/clipool.env`. One-character change,
+preserves idempotent deploy semantics.
+
+### Trade-offs
+
+- **S6 put_nowait drop vs unbounded queue**: put_nowait drops messages under backpressure (observable
+  via logs) but keeps the event loop alive. Unbounded queue avoids drops but risks OOM under sustained
+  load. Drop-and-log is the correct ops choice.
+- **S14 TimeoutStopSec vs reducing drain timeout**: Reducing drain from 60s would risk torn sessions.
+  Raising the systemd wall clock is the conservative, zero-risk option.
+- **S15 `-` prefix vs mandatory provisioning script**: `-` keeps the unit idempotent and self-contained.
+  A mandatory pre-create script is fragile and inconsistent with other lyra Quadlet units.
+
+## Alternatives (Deferred)
+
+| Finding | Proposed fix | Deferred because |
+|---------|-------------|------------------|
+| S2 (is_alive stale) | Add `not self._nc.is_closed` guard | C=62; reconnect race requires nats-py internals audit; architect (1/3) only |
+| S3 (stream_gen no cleanup) | `finally: await sub.unsubscribe()` | Already fixed in prior commit; architect (1/3) only |
+| S5 (no node_id heartbeat) | Add `node_id` field | Not a current deployment concern; 0/3 |
+| S7 (magic 512 constant) | Extract `_QUEUE_MAXSIZE = 512` | Cosmetic; architect (1/3) only |
+| S13 (_make_chunk params) | Keyword-only after text | API ergonomics; no ops impact; 0/3 |
+| S18/S19/S20 (worker_id type) | `isinstance(worker_id, str)` guard | int 0 not a real production path; security-auditor (1/3) only |
+
+## Dissent
+
+**S7 (architect):** Architect recommended extracting the 512 magic number as `_QUEUE_MAXSIZE` as
+part of the S6 fix since the edit touches adjacent code. Devops and security-auditor consider it
+cosmetic and out of scope. Majority (2/3) prevails — S7 deferred.
+
+**S2, S3 (architect):** Architect flagged both for fix-now. Security-auditor and devops both
+deferred. Majority (2/3) prevails.
+
+**S18/S19/S20 (security-auditor):** Security-auditor flagged the `worker_id` falsy guard as a type
+safety issue (int 0 case). Architect and devops both consider the int 0 path non-existent in
+production. Majority (2/3) prevails — deferred.
+
+## Implementation Notes
+
+S6: In `packages/roxabi-nats/src/roxabi_nats/driver_base.py`, `_stream_gen._on_msg`:
+```python
+try:
+    queue.put_nowait(msg)
+except asyncio.QueueFull:
+    log.warning("nats_driver_base: _stream_gen inbox queue full, dropping chunk on %s", subject)
+```
+
+S14 + S15: In `deploy/quadlet/lyra-clipool.container`:
+- `EnvironmentFile=-%h/.lyra/env/clipool.env`
+- `TimeoutStopSec=120` under `[Service]`
+
+## Next
+
+Follow-up issue for deferred findings (S2, S3, S7, S18/S19/S20) → roxabi-nats hardening ticket.

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -92,10 +92,11 @@ authorization {
     }
     {
       nkey: "UDUMMYCLIPOOLWORKER"
+      # TODO(941): replace with real nkey from ~/.lyra/nkeys/clipool-worker.seed -> public
       # clipool-worker
       permissions: {
         publish:   { allow: ["lyra.clipool.heartbeat"] }
-        subscribe: { allow: ["lyra.clipool.cmd", "lyra.clipool.control", "_INBOX.>"] }
+        subscribe: { allow: ["lyra.clipool.cmd", "lyra.clipool.control"] }
         allow_responses: true
       }
     }

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -18,8 +18,8 @@ authorization {
       nkey: "UDUMMYHUB"
       # hub
       permissions: {
-        publish:   { allow: ["lyra.outbound.telegram.>","lyra.outbound.discord.>","lyra.voice.tts.request","lyra.voice.stt.request","lyra.llm.request"] }
-        subscribe: { allow: ["lyra.inbound.telegram.>","lyra.inbound.discord.>","lyra.voice.tts.heartbeat","lyra.voice.stt.heartbeat","lyra.llm.health.*","lyra.system.ready","_INBOX.>"] }
+        publish:   { allow: ["lyra.outbound.telegram.>","lyra.outbound.discord.>","lyra.voice.tts.request","lyra.voice.stt.request","lyra.llm.request","lyra.clipool.cmd","lyra.clipool.control"] }
+        subscribe: { allow: ["lyra.inbound.telegram.>","lyra.inbound.discord.>","lyra.voice.tts.heartbeat","lyra.voice.stt.heartbeat","lyra.llm.health.*","lyra.system.ready","lyra.clipool.heartbeat","_INBOX.>"] }
         allow_responses: true
       }
     }
@@ -87,6 +87,15 @@ authorization {
       permissions: {
         publish:   { allow: ["lyra.llm.health.*"] }
         subscribe: { allow: ["lyra.llm.request"] }
+        allow_responses: true
+      }
+    }
+    {
+      nkey: "UDUMMYCLIPOOLWORKER"
+      # clipool-worker
+      permissions: {
+        publish:   { allow: ["lyra.clipool.heartbeat"] }
+        subscribe: { allow: ["lyra.clipool.cmd", "lyra.clipool.control", "_INBOX.>"] }
         allow_responses: true
       }
     }

--- a/deploy/quadlet/clipool.env.example
+++ b/deploy/quadlet/clipool.env.example
@@ -4,8 +4,8 @@
 # NATS_URL is set inline in lyra-clipool.container
 # NATS_NKEY_SEED_PATH is injected via Podman secret
 
-# Working directory for claude subprocesses
-LYRA_CLAUDE_CWD=/home/lyra/projects
+# Working directory for claude subprocesses — overridden inline in lyra-clipool.container
+# LYRA_CLAUDE_CWD=/home/lyra/projects
 
 # Optional: override log level
 # LYRA_LOG_LEVEL=INFO

--- a/deploy/quadlet/clipool.env.example
+++ b/deploy/quadlet/clipool.env.example
@@ -1,0 +1,11 @@
+# clipool.env — environment for lyra-clipool container
+# Copy to ~/.lyra/env/clipool.env and fill in values
+
+# NATS_URL is set inline in lyra-clipool.container
+# NATS_NKEY_SEED_PATH is injected via Podman secret
+
+# Working directory for claude subprocesses
+LYRA_CLAUDE_CWD=/home/lyra/projects
+
+# Optional: override log level
+# LYRA_LOG_LEVEL=INFO

--- a/deploy/quadlet/lyra-clipool.container
+++ b/deploy/quadlet/lyra-clipool.container
@@ -1,0 +1,49 @@
+[Unit]
+Description=Lyra CliPool Worker
+After=lyra-nats.service
+# No Requires= — clipool connects directly to NATS; hub restarts must not cascade
+
+[Container]
+Image=ghcr.io/roxabi/lyra:staging
+Label=io.containers.autoupdate=registry
+ContainerName=lyra-clipool
+Network=roxabi.network
+NoNewPrivileges=true
+ReadOnly=true
+DropCapability=all
+UserNS=keep-id:uid=1500,gid=1500
+EnvironmentFile=%h/.lyra/env/clipool.env
+Environment=NATS_URL=nats://lyra-nats:4222
+Secret=lyra-nkey-clipool-worker,type=mount,target=clipool-worker.seed,mode=0400,uid=1500,gid=1500
+Environment=NATS_NKEY_SEED_PATH=/run/secrets/clipool-worker.seed
+# ~/.claude/ mounts (moved from lyra-hub.container — see issue #941)
+# rw: CLI writes tokens + project memory at runtime
+# ro: config/skills read at startup
+# z: shared SELinux label
+Volume=%h/.claude/.credentials.json:/home/lyra/.claude/.credentials.json:z
+Volume=%h/.claude/settings.json:/home/lyra/.claude/settings.json:ro,z
+Volume=%h/.claude/settings.local.json:/home/lyra/.claude/settings.local.json:ro,z
+Volume=%h/.claude/CLAUDE.md:/home/lyra/.claude/CLAUDE.md:ro,z
+Volume=%h/.claude/projects:/home/lyra/.claude/projects:z
+Volume=%h/.claude/plugins:/home/lyra/.claude/plugins:ro,z
+Volume=%h/.claude/skills:/home/lyra/.claude/skills:ro,z
+Volume=%h/.claude/shared:/home/lyra/.claude/shared:ro,z
+Volume=%h/.claude/.git:/home/lyra/.claude/.git:ro,z
+Volume=%h/.claude.json:/home/lyra/.claude.json:z
+# Workspace — mirrors host ~/projects so claude subprocess picks up per-project CLAUDE.md
+Volume=%h/projects:/home/lyra/projects:z
+Environment=LYRA_CLAUDE_CWD=/home/lyra/projects
+Exec=lyra adapter clipool
+
+[Service]
+Restart=on-failure
+RestartSec=5
+CPUQuota=400%
+ExecStartPre=/bin/bash -c 'test -e %h/.claude.json || echo "{}" > %h/.claude.json'
+ExecStartPre=/bin/bash -c 'test -e %h/.claude/.credentials.json || echo "{}" > %h/.claude/.credentials.json'
+ExecStartPre=/bin/bash -c 'test -e %h/.claude/settings.json || echo "{}" > %h/.claude/settings.json'
+ExecStartPre=/bin/bash -c 'test -e %h/.claude/settings.local.json || echo "{}" > %h/.claude/settings.local.json'
+ExecStartPre=/bin/bash -c 'test -e %h/.claude/CLAUDE.md || touch %h/.claude/CLAUDE.md'
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/lyra-clipool.container
+++ b/deploy/quadlet/lyra-clipool.container
@@ -12,7 +12,7 @@ NoNewPrivileges=true
 ReadOnly=true
 DropCapability=all
 UserNS=keep-id:uid=1500,gid=1500
-EnvironmentFile=%h/.lyra/env/clipool.env
+EnvironmentFile=-%h/.lyra/env/clipool.env
 Environment=NATS_URL=nats://lyra-nats:4222
 Secret=lyra-nkey-clipool-worker,type=mount,target=clipool-worker.seed,mode=0400,uid=1500,gid=1500
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/clipool-worker.seed
@@ -38,6 +38,7 @@ Exec=lyra adapter clipool
 [Service]
 Restart=on-failure
 RestartSec=5
+TimeoutStopSec=120
 CPUQuota=400%
 ExecStartPre=/bin/bash -c 'test -e %h/.claude.json || echo "{}" > %h/.claude.json'
 ExecStartPre=/bin/bash -c 'test -e %h/.claude/.credentials.json || echo "{}" > %h/.claude/.credentials.json'

--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -36,29 +36,7 @@ Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 # either fail with loop-device errors or are silently downgraded to empty named
 # volumes (IsADirectoryError at read time). Inline Volume= does a direct bind.
 Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
-# claude CLI — selective mounts (not the whole ~/.claude dir).
-# Only config, credentials, memory, and skills are shared — ephemeral state
-# (sessions, tasks, teams, history, telemetry, cache) stays host-only.
-# UserNS=keep-id maps UID 1500 → host UID 1000 (mickael).
-#   rw  — CLI writes tokens + project memory at runtime
-#   ro  — config/skills read at startup, no container writes
-#   z   — shared SELinux label so host CLI retains access
-Volume=%h/.claude/.credentials.json:/home/lyra/.claude/.credentials.json:z
-Volume=%h/.claude/settings.json:/home/lyra/.claude/settings.json:ro,z
-Volume=%h/.claude/settings.local.json:/home/lyra/.claude/settings.local.json:ro,z
-Volume=%h/.claude/CLAUDE.md:/home/lyra/.claude/CLAUDE.md:ro,z
-Volume=%h/.claude/projects:/home/lyra/.claude/projects:z
-Volume=%h/.claude/plugins:/home/lyra/.claude/plugins:ro,z
-Volume=%h/.claude/skills:/home/lyra/.claude/skills:ro,z
-Volume=%h/.claude/shared:/home/lyra/.claude/shared:ro,z
-Volume=%h/.claude/.git:/home/lyra/.claude/.git:ro,z
-Volume=%h/.claude.json:/home/lyra/.claude.json:z
-# Workspace — mirrors host ~/projects so claude subprocess picks up
-# ~/projects/CLAUDE.md (project index) and per-project instructions.
-# This is the default cwd for agent claude processes (config.toml [defaults]).
-Volume=%h/projects:/home/lyra/projects:z
-# Default cwd for claude subprocesses — ~/projects (not /app).
-Environment=LYRA_CLAUDE_CWD=/home/lyra/projects
+# ~/.claude/ mounts moved to lyra-clipool.container (issue #941 — security boundary)
 # Health endpoint — probed by lyra-monitor via host loopback (localhost:8443).
 # Bind to 0.0.0.0 inside container so PublishPort forwarding reaches uvicorn;
 # host exposure is restricted to 127.0.0.1 by PublishPort below.
@@ -75,11 +53,6 @@ RestartSec=5
 CPUQuota=200%
 # Pre-create single-file bind-mount sources if absent — prevents Podman from
 # auto-creating them as directories (IsADirectoryError at read time).
-ExecStartPre=/bin/bash -c 'test -e %h/.claude.json || echo "{}" > %h/.claude.json'
-ExecStartPre=/bin/bash -c 'test -e %h/.claude/.credentials.json || echo "{}" > %h/.claude/.credentials.json'
-ExecStartPre=/bin/bash -c 'test -e %h/.claude/settings.json || echo "{}" > %h/.claude/settings.json'
-ExecStartPre=/bin/bash -c 'test -e %h/.claude/settings.local.json || echo "{}" > %h/.claude/settings.local.json'
-ExecStartPre=/bin/bash -c 'test -e %h/.claude/CLAUDE.md || touch %h/.claude/CLAUDE.md'
 
 [Install]
 WantedBy=default.target

--- a/docs/architecture/container-split.md
+++ b/docs/architecture/container-split.md
@@ -2,7 +2,15 @@
 
 ## Overview
 
-3 containers communicating over NATS.
+5 containers communicating over NATS.
+
+| Container | Process | Role |
+|---|---|---|
+| `lyra-hub` | `lyra hub` | Hub process, NATS-connected |
+| `lyra-telegram` | `lyra adapter telegram` | Telegram platform adapter |
+| `lyra-discord` | `lyra adapter discord` | Discord platform adapter |
+| `lyra-clipool` | `lyra adapter clipool` | CliPool NATS worker (claude-cli subprocess pool) |
+| `lyra-nats` | nats-server | NATS message broker |
 
 ```
 ┌──────────────┐  NATS inbound   ┌─────────────┐  NATS cmd    ┌──────────────┐
@@ -153,18 +161,27 @@ resumes it rather than starting fresh.
 
 Adapter mounts are per-file inline binds (not the full `lyra-data.volume`) — adapters never touch `auth.db` or `message_index.db`.
 
+> **Credential boundary:** `~/.claude/` (Claude session files + credentials) is mounted exclusively in `lyra-clipool`. The Hub no longer requires access to Claude credentials — it only sends UUIDs over NATS and receives streaming events back.
+
 ---
 
 ## NATS Topics
 
-| Topic | Direction | Purpose |
+| Subject | Direction | Semantics |
 |---|---|---|
 | `lyra.inbound.telegram.<bot_id>` | Adapter → Hub | Telegram messages |
 | `lyra.inbound.discord.<bot_id>` | Adapter → Hub | Discord messages |
 | `lyra.outbound.telegram.<bot_id>` | Hub → Adapter | Responses to Telegram |
 | `lyra.outbound.discord.<bot_id>` | Hub → Adapter | Responses to Discord |
-| `lyra.clipool.cmd.<pool_id>` | Hub → CliPool | Submit turn + resume UUID *(new)* |
-| `lyra.clipool.reply.<pool_id>` | CliPool → Hub | Streaming events + session_id *(new)* |
+| `lyra.clipool.cmd` | Hub → CliPool | Send a claude-cli command; reply-to is ephemeral inbox |
+| `lyra.clipool.control` | Hub → CliPool | Control operations (reset/resume_and_reset/switch_cwd) |
+| `lyra.clipool.heartbeat` | CliPool → Hub | Worker liveness every 30s |
+
+**CliPool subject design notes:**
+
+- All CliPool subjects are **flat** (not per-pool-id) — `pool_id` is routed via payload
+- Reply-to for `lyra.clipool.cmd` is an **ephemeral inbox** (`_INBOX.<random>`) — streaming chunks arrive on the inbox, not a fixed subject
+- Workers subscribe to `lyra.clipool.cmd` with queue group `clipool-workers` for future multi-instance scaling
 
 ---
 

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-contracts"
-version = "0.2.0"
+version = "0.3.0"
 description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/roxabi-contracts/src/roxabi_contracts/cli/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/cli/__init__.py
@@ -1,0 +1,17 @@
+"""roxabi_contracts.cli — CliPool NATS contract models (ADR-054)."""
+
+from .models import (
+    CliChunkEvent,
+    CliCmdPayload,
+    CliControlAck,
+    CliControlCmd,
+    CliHeartbeat,
+)
+
+__all__ = [
+    "CliCmdPayload",
+    "CliChunkEvent",
+    "CliControlAck",
+    "CliControlCmd",
+    "CliHeartbeat",
+]

--- a/packages/roxabi-contracts/src/roxabi_contracts/cli/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/cli/models.py
@@ -1,0 +1,62 @@
+"""CliPool NATS contract models — hub ↔ clipool-worker (ADR-054)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from roxabi_contracts.envelope import ContractEnvelope
+
+__all__ = [
+    "CliCmdPayload",
+    "CliChunkEvent",
+    "CliControlAck",
+    "CliControlCmd",
+    "CliHeartbeat",
+]
+
+
+class CliCmdPayload(ContractEnvelope):
+    """Hub -> clipool: run a claude-cli command."""
+
+    pool_id: str
+    lyra_session_id: str
+    text: str
+    model_cfg: dict
+    system_prompt: str
+    resume_session_id: str | None = None
+    stream: bool = True
+
+
+class CliChunkEvent(ContractEnvelope):
+    """Clipool -> hub: one streaming chunk or terminal event."""
+
+    pool_id: str
+    event_type: Literal["text", "tool_use", "session_id", "result", "error"]
+    text: str | None = None
+    session_id: str | None = None
+    is_error: bool = False
+    done: bool = False
+
+
+class CliControlCmd(ContractEnvelope):
+    """Hub -> clipool: control operation (reset, resume, cwd switch)."""
+
+    pool_id: str
+    op: Literal["reset", "resume_and_reset", "switch_cwd"]
+    session_id: str | None = None
+    cwd: str | None = None
+
+
+class CliControlAck(ContractEnvelope):
+    """Clipool -> hub: reply to CliControlCmd."""
+
+    pool_id: str
+    ok: bool
+    resumed: bool | None = None
+
+
+class CliHeartbeat(ContractEnvelope):
+    """Clipool -> hub: periodic heartbeat."""
+
+    worker_id: str
+    pool_count: int

--- a/packages/roxabi-contracts/tests/test_cli_models.py
+++ b/packages/roxabi-contracts/tests/test_cli_models.py
@@ -1,0 +1,366 @@
+"""Tests for roxabi_contracts.cli.models — RED phase (T5).
+
+Import will fail until T6 ships the implementation. Tests are syntactically
+valid and structurally complete per the cli/ domain spec (issue #941).
+
+All five models extend ContractEnvelope (contract_version, trace_id,
+issued_at) with extra="ignore" forward-compat.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from roxabi_contracts.cli.models import (
+    CliChunkEvent,
+    CliCmdPayload,
+    CliControlAck,
+    CliControlCmd,
+    CliHeartbeat,
+)
+
+_ENVELOPE: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "tst-trace-cli",
+    "issued_at": datetime(2026, 4, 26, tzinfo=timezone.utc),
+}
+
+
+# ---------------------------------------------------------------------------
+# CliCmdPayload
+# ---------------------------------------------------------------------------
+
+
+def test_cli_cmd_payload_roundtrip() -> None:
+    """Build a CliCmdPayload with all required fields, validate, check fields."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "pool_id": "pool-1",
+        "lyra_session_id": "sess-abc",
+        "text": "summarise this",
+        "model_cfg": {"model": "claude-opus-4-5"},
+        "system_prompt": "You are a helpful assistant.",
+    }
+
+    # Act
+    inst = CliCmdPayload.model_validate(payload)
+    parsed = CliCmdPayload.model_validate_json(inst.model_dump_json())
+
+    # Assert
+    assert parsed == inst
+    assert parsed.pool_id == "pool-1"
+    assert parsed.lyra_session_id == "sess-abc"
+    assert parsed.text == "summarise this"
+    assert parsed.model_cfg == {"model": "claude-opus-4-5"}
+    assert parsed.system_prompt == "You are a helpful assistant."
+
+
+def test_cli_cmd_payload_defaults() -> None:
+    """stream defaults to True; resume_session_id defaults to None."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "pool_id": "pool-2",
+        "lyra_session_id": "sess-xyz",
+        "text": "hello",
+        "model_cfg": {},
+        "system_prompt": "sys",
+    }
+
+    # Act
+    inst = CliCmdPayload.model_validate(payload)
+
+    # Assert
+    assert inst.stream is True
+    assert inst.resume_session_id is None
+
+
+def test_cli_cmd_payload_resume_session_id_accepted() -> None:
+    """resume_session_id is accepted when provided."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "pool_id": "pool-3",
+        "lyra_session_id": "sess-res",
+        "text": "continue",
+        "model_cfg": {},
+        "system_prompt": "sys",
+        "resume_session_id": "prev-session-42",
+    }
+
+    # Act
+    inst = CliCmdPayload.model_validate(payload)
+
+    # Assert
+    assert inst.resume_session_id == "prev-session-42"
+
+
+def test_cli_cmd_payload_stream_false_accepted() -> None:
+    """stream=False overrides the default."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "pool_id": "pool-4",
+        "lyra_session_id": "sess-s",
+        "text": "batch",
+        "model_cfg": {},
+        "system_prompt": "sys",
+        "stream": False,
+    }
+
+    # Act
+    inst = CliCmdPayload.model_validate(payload)
+
+    # Assert
+    assert inst.stream is False
+
+
+def test_cli_cmd_payload_extra_ignore() -> None:
+    """Extra fields are silently ignored (ContractEnvelope model_config)."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "pool_id": "pool-5",
+        "lyra_session_id": "sess-extra",
+        "text": "hi",
+        "model_cfg": {},
+        "system_prompt": "sys",
+        "unknown_future_field": "should_be_ignored",
+    }
+
+    # Act — must not raise
+    inst = CliCmdPayload.model_validate(payload)
+
+    # Assert
+    assert inst.pool_id == "pool-5"
+    assert not hasattr(inst, "unknown_future_field")
+
+
+# ---------------------------------------------------------------------------
+# CliChunkEvent
+# ---------------------------------------------------------------------------
+
+
+def test_cli_chunk_event_text_type() -> None:
+    """event_type='text' is a valid Literal."""
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-1", "event_type": "text", "text": "hello"}
+
+    # Act
+    inst = CliChunkEvent.model_validate(payload)
+
+    # Assert
+    assert inst.event_type == "text"
+    assert inst.text == "hello"
+
+
+def test_cli_chunk_event_result_type() -> None:
+    """event_type='result' is a valid Literal."""
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-1", "event_type": "result", "done": True}
+
+    # Act
+    inst = CliChunkEvent.model_validate(payload)
+
+    # Assert
+    assert inst.event_type == "result"
+    assert inst.done is True
+
+
+def test_cli_chunk_event_invalid_type() -> None:
+    """event_type='unknown' raises ValidationError."""
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-1", "event_type": "unknown"}
+
+    # Act / Assert
+    with pytest.raises(ValidationError):
+        CliChunkEvent.model_validate(payload)
+
+
+def test_cli_chunk_event_literals() -> None:
+    """All five event_type literals are individually valid."""
+    # Arrange
+    valid_types = ["text", "tool_use", "session_id", "result", "error"]
+
+    for event_type in valid_types:
+        payload = {**_ENVELOPE, "pool_id": "pool-1", "event_type": event_type}
+
+        # Act
+        inst = CliChunkEvent.model_validate(payload)
+
+        # Assert
+        assert inst.event_type == event_type
+
+
+def test_cli_chunk_event_defaults() -> None:
+    """is_error defaults to False; done defaults to False; optional fields default to None."""  # noqa: E501
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-1", "event_type": "text"}
+
+    # Act
+    inst = CliChunkEvent.model_validate(payload)
+
+    # Assert
+    assert inst.is_error is False
+    assert inst.done is False
+    assert inst.text is None
+    assert inst.session_id is None
+
+
+def test_cli_chunk_event_session_id_type() -> None:
+    """event_type='session_id' carries session_id field."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "pool_id": "pool-1",
+        "event_type": "session_id",
+        "session_id": "sess-new-99",
+    }
+
+    # Act
+    inst = CliChunkEvent.model_validate(payload)
+
+    # Assert
+    assert inst.session_id == "sess-new-99"
+
+
+# ---------------------------------------------------------------------------
+# CliControlCmd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", ["reset", "resume_and_reset", "switch_cwd"])
+def test_cli_control_cmd_ops(op: str) -> None:
+    """op='reset'/'resume_and_reset'/'switch_cwd' are all valid Literals."""
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-ctrl", "op": op}
+
+    # Act
+    inst = CliControlCmd.model_validate(payload)
+
+    # Assert
+    assert inst.op == op
+    assert inst.pool_id == "pool-ctrl"
+
+
+def test_cli_control_cmd_invalid_op() -> None:
+    """op='invalid' raises ValidationError."""
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-ctrl", "op": "invalid"}
+
+    # Act / Assert
+    with pytest.raises(ValidationError):
+        CliControlCmd.model_validate(payload)
+
+
+def test_cli_control_cmd_optional_fields() -> None:
+    """session_id and cwd are None by default; accepted when provided."""
+    # Arrange
+    payload_minimal = {**_ENVELOPE, "pool_id": "pool-ctrl", "op": "reset"}
+    payload_full = {
+        **_ENVELOPE,
+        "pool_id": "pool-ctrl",
+        "op": "switch_cwd",
+        "cwd": "/tmp/workspace",
+        "session_id": "sess-42",
+    }
+
+    # Act
+    inst_min = CliControlCmd.model_validate(payload_minimal)
+    inst_full = CliControlCmd.model_validate(payload_full)
+
+    # Assert
+    assert inst_min.session_id is None
+    assert inst_min.cwd is None
+    assert inst_full.cwd == "/tmp/workspace"
+    assert inst_full.session_id == "sess-42"
+
+
+# ---------------------------------------------------------------------------
+# CliControlAck
+# ---------------------------------------------------------------------------
+
+
+def test_cli_control_ack_fields() -> None:
+    """ok=True/False accepted; resumed is optional."""
+    # Arrange
+    payload_ok = {**_ENVELOPE, "pool_id": "pool-ack", "ok": True}
+    payload_nok = {**_ENVELOPE, "pool_id": "pool-ack", "ok": False, "resumed": False}
+    payload_resumed = {**_ENVELOPE, "pool_id": "pool-ack", "ok": True, "resumed": True}
+
+    # Act
+    inst_ok = CliControlAck.model_validate(payload_ok)
+    inst_nok = CliControlAck.model_validate(payload_nok)
+    inst_resumed = CliControlAck.model_validate(payload_resumed)
+
+    # Assert
+    assert inst_ok.ok is True
+    assert inst_ok.resumed is None
+    assert inst_nok.ok is False
+    assert inst_nok.resumed is False
+    assert inst_resumed.resumed is True
+
+
+def test_cli_control_ack_roundtrip() -> None:
+    """CliControlAck round-trips cleanly through JSON."""
+    # Arrange
+    payload = {**_ENVELOPE, "pool_id": "pool-ack", "ok": True, "resumed": True}
+
+    # Act
+    inst = CliControlAck.model_validate(payload)
+    parsed = CliControlAck.model_validate_json(inst.model_dump_json())
+
+    # Assert
+    assert parsed == inst
+
+
+# ---------------------------------------------------------------------------
+# CliHeartbeat
+# ---------------------------------------------------------------------------
+
+
+def test_cli_heartbeat_fields() -> None:
+    """worker_id and pool_count are present and correctly typed."""
+    # Arrange
+    payload = {
+        **_ENVELOPE,
+        "worker_id": "worker-001",
+        "pool_count": 3,
+    }
+
+    # Act
+    inst = CliHeartbeat.model_validate(payload)
+
+    # Assert
+    assert inst.worker_id == "worker-001"
+    assert inst.pool_count == 3
+
+
+def test_cli_heartbeat_roundtrip() -> None:
+    """CliHeartbeat round-trips cleanly through JSON."""
+    # Arrange
+    payload = {**_ENVELOPE, "worker_id": "worker-002", "pool_count": 0}
+
+    # Act
+    inst = CliHeartbeat.model_validate(payload)
+    parsed = CliHeartbeat.model_validate_json(inst.model_dump_json())
+
+    # Assert
+    assert parsed == inst
+
+
+def test_cli_heartbeat_pool_count_zero() -> None:
+    """pool_count=0 is valid (idle worker)."""
+    # Arrange
+    payload = {**_ENVELOPE, "worker_id": "worker-idle", "pool_count": 0}
+
+    # Act
+    inst = CliHeartbeat.model_validate(payload)
+
+    # Assert
+    assert inst.pool_count == 0

--- a/packages/roxabi-nats/pyproject.toml
+++ b/packages/roxabi-nats/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-nats"
-version = "0.2.0"
+version = "0.3.0"
 description = "NATS transport SDK for Lyra and Roxabi plugin ecosystem"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/roxabi-nats/src/roxabi_nats/__init__.py
+++ b/packages/roxabi-nats/src/roxabi_nats/__init__.py
@@ -12,10 +12,12 @@ may change without notice — external consumers MUST NOT import them.
 from ._serialize import _TypeHintResolver as TypeHintResolver
 from .adapter_base import CONTRACT_VERSION, NatsAdapterBase
 from .connect import nats_connect
+from .driver_base import NatsDriverBase
 
 __all__ = [
     "CONTRACT_VERSION",
     "NatsAdapterBase",
+    "NatsDriverBase",
     "TypeHintResolver",
     "nats_connect",
 ]

--- a/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
@@ -120,6 +120,28 @@ class NatsAdapterBase(ABC):
         await stop.wait()
         await self._shutdown()
 
+    async def run_embedded(self, nc: NATS, stop: asyncio.Event | None = None) -> None:
+        """Run using an already-connected NATS client (for unified/embedded mode).
+
+        Unlike ``run()``, this method does not create a new NATS connection and
+        does not call ``_shutdown()`` (which would drain/close the shared connection).
+        The caller is responsible for managing the NATS connection lifecycle.
+        """
+        self._nc = nc
+        self._started_at = time.monotonic()
+        await nc.subscribe(self.subject, queue=self.queue_group, cb=self._dispatch)
+        for extra in self._extra_subjects():
+            await nc.subscribe(extra, cb=self._dispatch)
+        if self._heartbeat_subject:
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        if stop is None:
+            stop = asyncio.Event()
+        await stop.wait()
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._heartbeat_task
+
     @abstractmethod
     async def handle(self, msg, payload: dict) -> None: ...
 

--- a/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
@@ -129,18 +129,26 @@ class NatsAdapterBase(ABC):
         """
         self._nc = nc
         self._started_at = time.monotonic()
-        await nc.subscribe(self.subject, queue=self.queue_group, cb=self._dispatch)
+        cmd_sub = await nc.subscribe(
+            self.subject, queue=self.queue_group, cb=self._dispatch
+        )
+        subs = [cmd_sub]
         for extra in self._extra_subjects():
-            await nc.subscribe(extra, cb=self._dispatch)
+            subs.append(await nc.subscribe(extra, cb=self._dispatch))
         if self._heartbeat_subject:
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         if stop is None:
             stop = asyncio.Event()
-        await stop.wait()
-        if self._heartbeat_task is not None:
-            self._heartbeat_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._heartbeat_task
+        try:
+            await stop.wait()
+        finally:
+            if self._heartbeat_task is not None:
+                self._heartbeat_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._heartbeat_task
+            for sub in subs:
+                with contextlib.suppress(Exception):
+                    await sub.unsubscribe()
 
     @abstractmethod
     async def handle(self, msg, payload: dict) -> None: ...

--- a/packages/roxabi-nats/src/roxabi_nats/driver_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/driver_base.py
@@ -1,0 +1,125 @@
+"""NatsDriverBase — reusable hub-side NATS request-dispatch base.
+
+Provides:
+- Heartbeat subscription and worker-freshness tracking
+- Ephemeral-inbox streaming (_stream_gen)
+- Simple request-reply (_request)
+
+Subclass this to build hub-side drivers (e.g. CliNatsDriver, NatsLlmDriver).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+    from nats.aio.subscription import Subscription
+
+__all__ = ["NatsDriverBase"]
+log = logging.getLogger(__name__)
+
+
+class NatsDriverBase:
+    HB_TTL: float = 30.0
+    # Subclasses set this to the heartbeat subject they subscribe to.
+    # NatsDriverBase uses it in start()/stop() only if set.
+    HB_SUBJECT: str = ""
+
+    def __init__(self, nc: "NATS", *, timeout: float = 120.0) -> None:
+        self._nc = nc
+        self._timeout = timeout
+        self._worker_freshness: dict[str, float] = {}
+        self._hb_sub: "Subscription | None" = None
+
+    async def start(self) -> None:
+        """Subscribe to HB_SUBJECT. Idempotent."""
+        if self._hb_sub is None and self.HB_SUBJECT:
+            self._hb_sub = await self._nc.subscribe(
+                self.HB_SUBJECT, cb=self._on_heartbeat
+            )
+
+    async def stop(self) -> None:
+        """Unsubscribe from HB_SUBJECT. Idempotent."""
+        if self._hb_sub is not None:
+            try:
+                await self._hb_sub.unsubscribe()
+            except Exception:
+                log.debug(
+                    "NatsDriverBase: error unsubscribing heartbeat", exc_info=True
+                )
+            finally:
+                self._hb_sub = None
+
+    async def _on_heartbeat(self, msg: Any) -> None:
+        try:
+            data = json.loads(msg.data)
+            worker_id = data.get("worker_id")
+            if not worker_id:
+                log.warning("nats_driver_base: heartbeat missing worker_id, ignoring")
+                return
+            self._worker_freshness[worker_id] = time.monotonic()
+        except Exception:
+            log.debug("nats_driver_base: heartbeat parse error", exc_info=True)
+
+    def _any_worker_alive(self) -> bool:
+        now = time.monotonic()
+        self._worker_freshness = {
+            k: v
+            for k, v in self._worker_freshness.items()
+            if now - v <= self.HB_TTL * 2
+        }
+        return any(now - ts <= self.HB_TTL for ts in self._worker_freshness.values())
+
+    def is_alive(self, worker_id: str) -> bool:
+        del worker_id
+        return self._nc.is_connected and self._any_worker_alive()
+
+    async def _stream_gen(
+        self, subject: str, payload_dict: dict, *, timeout: float | None = None
+    ) -> AsyncIterator[dict]:
+        """Publish to subject with ephemeral inbox reply, yield raw dict chunks."""
+        timeout = timeout if timeout is not None else self._timeout
+        inbox = self._nc.new_inbox()
+        queue: asyncio.Queue = asyncio.Queue(maxsize=512)
+
+        async def _on_msg(msg: Any) -> None:
+            await queue.put(msg)
+
+        sub = await self._nc.subscribe(inbox, cb=_on_msg)
+        payload = json.dumps(payload_dict, ensure_ascii=False).encode("utf-8")
+        try:
+            await self._nc.publish(subject, payload, reply=inbox)
+            while True:
+                try:
+                    msg = await asyncio.wait_for(queue.get(), timeout=timeout)
+                except TimeoutError:
+                    log.warning("nats_driver_base: _stream_gen timeout on %s", subject)
+                    return
+                try:
+                    chunk: dict = json.loads(msg.data)
+                except Exception:
+                    log.debug("nats_driver_base: chunk parse error", exc_info=True)
+                    continue
+                yield chunk
+                if chunk.get("done", False):
+                    return
+        finally:
+            try:
+                await sub.unsubscribe()
+            except Exception:
+                log.debug("nats_driver_base: error unsubscribing inbox", exc_info=True)
+
+    async def _request(
+        self, subject: str, payload_dict: dict, *, timeout: float | None = None
+    ) -> dict:
+        """Simple request-reply, returns parsed JSON dict."""
+        timeout = timeout if timeout is not None else self._timeout
+        payload = json.dumps(payload_dict, ensure_ascii=False).encode("utf-8")
+        reply = await self._nc.request(subject, payload, timeout=timeout)
+        return json.loads(reply.data)

--- a/packages/roxabi-nats/src/roxabi_nats/driver_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/driver_base.py
@@ -89,7 +89,14 @@ class NatsDriverBase:
         queue: asyncio.Queue = asyncio.Queue(maxsize=512)
 
         async def _on_msg(msg: Any) -> None:
-            await queue.put(msg)
+            try:
+                queue.put_nowait(msg)
+            except asyncio.QueueFull:
+                log.warning(
+                    "nats_driver_base: _stream_gen inbox queue full,"
+                    " dropping chunk on %s",
+                    subject,
+                )
 
         sub = await self._nc.subscribe(inbox, cb=_on_msg)
         payload = json.dumps(payload_dict, ensure_ascii=False).encode("utf-8")

--- a/packages/roxabi-nats/src/roxabi_nats/driver_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/driver_base.py
@@ -76,8 +76,8 @@ class NatsDriverBase:
         }
         return any(now - ts <= self.HB_TTL for ts in self._worker_freshness.values())
 
-    def is_alive(self, worker_id: str) -> bool:
-        del worker_id
+    def is_alive(self, pool_id: str) -> bool:
+        del pool_id
         return self._nc.is_connected and self._any_worker_alive()
 
     async def _stream_gen(

--- a/packages/roxabi-nats/tests/test_driver_base.py
+++ b/packages/roxabi-nats/tests/test_driver_base.py
@@ -1,0 +1,649 @@
+"""RED-phase tests for NatsDriverBase (issue #941).
+
+NatsDriverBase does not exist yet — all tests are expected to fail with
+ImportError until the implementation is in place (T2).
+
+Covers:
+- _stream_gen: yields chunks, stops on done=True, terminates on timeout
+- is_alive: threshold behaviour (within/outside HB_TTL)
+- _on_heartbeat: updates _worker_freshness from JSON msg
+- _any_worker_alive: prunes stale entries older than HB_TTL*2
+- _request: publishes via nc.request(), returns parsed JSON dict
+- start: subscribes to HB_SUBJECT pattern exactly once (idempotent)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from roxabi_nats.driver_base import NatsDriverBase  # ImportError expected (RED)
+
+# ---------------------------------------------------------------------------
+# Concrete subclass — minimal stub for testing
+# ---------------------------------------------------------------------------
+
+HB_SUBJECT = "lyra.clipool.heartbeat.*"
+
+
+class _ConcreteDriver(NatsDriverBase):
+    HB_SUBJECT: str = HB_SUBJECT
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_nc(*, is_connected: bool = True) -> MagicMock:
+    """Return a MagicMock NATS client with async stubs attached."""
+    nc = MagicMock()
+    nc.is_connected = is_connected
+    nc.new_inbox = MagicMock(return_value="_INBOX.test123")
+    nc.subscribe = AsyncMock()
+    nc.publish = AsyncMock()
+    nc.request = AsyncMock()
+    return nc
+
+
+def _make_msg(data: dict) -> MagicMock:
+    """Return a mock NATS message whose .data is the JSON-encoded dict."""
+    msg = MagicMock()
+    msg.data = json.dumps(data).encode("utf-8")
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# T_stream — _stream_gen
+# ---------------------------------------------------------------------------
+
+
+class TestStreamGen:
+    """_stream_gen yields raw dict chunks until done=True."""
+
+    @pytest.mark.asyncio
+    async def test_stream_gen_yields_chunks(self) -> None:
+        """Chunks without done=True are yielded in order."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=5.0)
+
+        chunks = [
+            {"text": "hello", "done": False},
+            {"text": " world", "done": False},
+            {"text": "", "done": True},
+        ]
+
+        # Capture the subscription callback so we can push messages into the queue.
+        captured_cb = None
+
+        async def _fake_subscribe(inbox: str, *, cb) -> MagicMock:
+            nonlocal captured_cb
+            captured_cb = cb
+            sub = MagicMock()
+            sub.unsubscribe = AsyncMock()
+            return sub
+
+        nc.subscribe = AsyncMock(side_effect=_fake_subscribe)
+
+        async def _inject_chunks(gen: AsyncIterator) -> list[dict]:
+            """Advance the generator while feeding messages through the callback."""
+            results: list[dict] = []
+            # Kick the generator to run until it awaits the first queue.get()
+            async for chunk in gen:
+                results.append(chunk)
+            return results
+
+        # We need to push messages after the generator subscribes.
+        # Use a task to inject them concurrently.
+        collected: list[dict] = []
+
+        async def _run() -> None:
+            nonlocal collected
+            gen = driver._stream_gen("lyra.clipool.exec", {"cmd": "echo hi"})
+
+            # Consume the generator in a task; inject chunks from this coroutine.
+            async def _consume() -> None:
+                nonlocal collected
+                async for chunk in gen:
+                    collected.append(chunk)
+
+            task = asyncio.create_task(_consume())
+            # Give the generator a moment to subscribe and await queue.get()
+            await asyncio.sleep(0)
+            assert captured_cb is not None, "subscribe callback was never captured"
+            for chunk_dict in chunks:
+                msg = _make_msg(chunk_dict)
+                await captured_cb(msg)
+            await task
+
+        await _run()
+
+        # Assert — only chunks before done=True (exclusive) should be yielded,
+        # or the generator may include the done chunk depending on impl.
+        # We assert that the non-done chunks all arrived.
+        texts = [c.get("text") for c in collected]
+        assert "hello" in texts
+        assert " world" in texts
+
+    @pytest.mark.asyncio
+    async def test_stream_gen_stops_on_done(self) -> None:
+        """Generator terminates when a chunk with done=True arrives."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=5.0)
+
+        captured_cb = None
+
+        async def _fake_subscribe(inbox: str, *, cb) -> MagicMock:
+            nonlocal captured_cb
+            captured_cb = cb
+            sub = MagicMock()
+            sub.unsubscribe = AsyncMock()
+            return sub
+
+        nc.subscribe = AsyncMock(side_effect=_fake_subscribe)
+
+        collected: list[dict] = []
+
+        async def _run() -> None:
+            gen = driver._stream_gen("lyra.clipool.exec", {"cmd": "ls"})
+
+            async def _consume() -> None:
+                async for chunk in gen:
+                    collected.append(chunk)
+
+            task = asyncio.create_task(_consume())
+            await asyncio.sleep(0)
+            assert captured_cb is not None
+
+            # Push a done=True chunk immediately — generator must stop.
+            await captured_cb(_make_msg({"done": True}))
+            await task
+
+        await _run()
+
+        # Assert — generator returned without yielding extra items after done
+        # (collected may include the done chunk or not depending on impl,
+        # but the task must have finished cleanly).
+        # The key invariant is that the generator did NOT block forever.
+        assert True  # reaching here proves the generator exited
+
+    @pytest.mark.asyncio
+    async def test_stream_gen_timeout(self) -> None:
+        """Generator terminates (yields nothing extra) when queue.get times out."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=0.05)
+
+        sub_mock = MagicMock()
+        sub_mock.unsubscribe = AsyncMock()
+        nc.subscribe = AsyncMock(return_value=sub_mock)
+
+        collected: list[dict] = []
+
+        # Act — no messages pushed; queue.get will time out after timeout seconds.
+        async def _run() -> None:
+            async for chunk in driver._stream_gen("lyra.clipool.exec", {"cmd": "ls"}):
+                collected.append(chunk)
+
+        await _run()
+
+        # Assert — generator exited cleanly (timeout path), no infinite hang.
+        # The unsubscribe finaliser must have been called.
+        sub_mock.unsubscribe.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# T_is_alive — is_alive threshold
+# ---------------------------------------------------------------------------
+
+
+class TestIsAlive:
+    """is_alive returns True only when connected + fresh heartbeat exists."""
+
+    def test_is_alive_true_within_threshold(self) -> None:
+        """is_alive returns True when nc.is_connected and freshness within HB_TTL."""
+        # Arrange
+        nc = _make_mock_nc(is_connected=True)
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        worker_id = "worker-a"
+        # Set freshness to just now (well within HB_TTL=30s)
+        driver._worker_freshness[worker_id] = time.monotonic()
+
+        # Act
+        result = driver.is_alive(worker_id)
+
+        # Assert
+        assert result is True
+
+    def test_is_alive_false_when_entry_older_than_ttl(self) -> None:
+        """is_alive returns False when the heartbeat is older than HB_TTL."""
+        # Arrange
+        nc = _make_mock_nc(is_connected=True)
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        worker_id = "worker-b"
+        # Set freshness to HB_TTL + 1 seconds in the past → stale
+        driver._worker_freshness[worker_id] = time.monotonic() - (driver.HB_TTL + 1.0)
+
+        # Act
+        result = driver.is_alive(worker_id)
+
+        # Assert
+        assert result is False
+
+    def test_is_alive_false_when_not_connected(self) -> None:
+        """is_alive returns False when nc.is_connected is False, regardless of freshness."""  # noqa: E501
+        # Arrange
+        nc = _make_mock_nc(is_connected=False)
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        worker_id = "worker-c"
+        driver._worker_freshness[worker_id] = time.monotonic()
+
+        # Act
+        result = driver.is_alive(worker_id)
+
+        # Assert
+        assert result is False
+
+    def test_is_alive_false_when_no_workers(self) -> None:
+        """is_alive returns False when _worker_freshness is empty."""
+        # Arrange
+        nc = _make_mock_nc(is_connected=True)
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        # Act
+        result = driver.is_alive("any-worker")
+
+        # Assert
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# T_on_heartbeat — freshness update
+# ---------------------------------------------------------------------------
+
+
+class TestOnHeartbeat:
+    """_on_heartbeat extracts worker_id from JSON and updates _worker_freshness."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_sub_updates_freshness(self) -> None:
+        """_on_heartbeat stores time.monotonic() keyed by worker_id."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        msg = _make_msg({"worker_id": "worker-x", "ts": 1234567890.0})
+
+        # Act
+        before = time.monotonic()
+        await driver._on_heartbeat(msg)
+        after = time.monotonic()
+
+        # Assert
+        assert "worker-x" in driver._worker_freshness
+        ts = driver._worker_freshness["worker-x"]
+        assert before <= ts <= after
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_missing_worker_id_does_not_update(self) -> None:
+        """_on_heartbeat ignores messages with no worker_id field."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        msg = _make_msg({"ts": 123.0})  # no worker_id
+
+        # Act
+        await driver._on_heartbeat(msg)
+
+        # Assert
+        assert driver._worker_freshness == {}
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_invalid_json_does_not_raise(self) -> None:
+        """_on_heartbeat silently ignores non-JSON payloads."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        msg = MagicMock()
+        msg.data = b"not json at all"
+
+        # Act / Assert — must not raise
+        await driver._on_heartbeat(msg)
+        assert driver._worker_freshness == {}
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_updates_existing_entry(self) -> None:
+        """A second heartbeat for the same worker_id overwrites the previous timestamp."""  # noqa: E501
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        driver._worker_freshness["worker-y"] = time.monotonic() - 10.0
+
+        msg = _make_msg({"worker_id": "worker-y"})
+
+        # Act
+        await driver._on_heartbeat(msg)
+
+        # Assert — timestamp was refreshed (newer than 10s ago)
+        ts = driver._worker_freshness["worker-y"]
+        assert time.monotonic() - ts < 1.0
+
+
+# ---------------------------------------------------------------------------
+# T_any_worker_alive — prune stale entries
+# ---------------------------------------------------------------------------
+
+
+class TestAnyWorkerAlive:
+    """_any_worker_alive prunes entries older than HB_TTL*2 and checks recency."""
+
+    def test_any_worker_alive_fresh_entry_returns_true(self) -> None:
+        """Returns True when at least one entry is within HB_TTL."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        driver._worker_freshness["fresh"] = time.monotonic()
+
+        # Act
+        result = driver._any_worker_alive()
+
+        # Assert
+        assert result is True
+
+    def test_any_worker_alive_stale_entry_returns_false(self) -> None:
+        """Returns False when the only entry is older than HB_TTL."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        driver._worker_freshness["stale"] = time.monotonic() - (driver.HB_TTL + 5.0)
+
+        # Act
+        result = driver._any_worker_alive()
+
+        # Assert
+        assert result is False
+
+    def test_any_worker_alive_prunes_stale(self) -> None:
+        """Entries older than HB_TTL*2 are evicted from _worker_freshness."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        very_stale_ts = time.monotonic() - (driver.HB_TTL * 2 + 1.0)
+        driver._worker_freshness["very-stale"] = very_stale_ts
+
+        # Act
+        driver._any_worker_alive()
+
+        # Assert — entry evicted
+        assert "very-stale" not in driver._worker_freshness
+
+    def test_any_worker_alive_keeps_within_double_ttl(self) -> None:
+        """Entries within HB_TTL*2 (but outside HB_TTL) are kept but not counted as alive."""  # noqa: E501
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        # Between HB_TTL and HB_TTL*2 → kept but stale (not alive)
+        between_ts = time.monotonic() - (driver.HB_TTL + 1.0)
+        driver._worker_freshness["between"] = between_ts
+
+        # Act
+        result = driver._any_worker_alive()
+
+        # Assert — not counted as alive, but also not yet evicted
+        assert result is False
+        assert "between" in driver._worker_freshness
+
+    def test_any_worker_alive_empty_freshness_returns_false(self) -> None:
+        """Returns False when no workers are registered."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        # Act
+        result = driver._any_worker_alive()
+
+        # Assert
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# T_request — simple request-reply
+# ---------------------------------------------------------------------------
+
+
+class TestRequest:
+    """_request dispatches via nc.request() and returns parsed JSON."""
+
+    @pytest.mark.asyncio
+    async def test_request_returns_parsed_json(self) -> None:
+        """_request publishes to nc.request and returns the parsed reply dict."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        reply_data = {"status": "ok", "result": "pong"}
+        mock_reply = MagicMock()
+        mock_reply.data = json.dumps(reply_data).encode("utf-8")
+        nc.request = AsyncMock(return_value=mock_reply)
+
+        # Act
+        result = await driver._request("lyra.clipool.ping", {"msg": "ping"})
+
+        # Assert
+        assert result == reply_data
+        nc.request.assert_awaited_once()
+        call_args = nc.request.call_args
+        assert call_args.args[0] == "lyra.clipool.ping"
+
+    @pytest.mark.asyncio
+    async def test_request_sends_json_encoded_payload(self) -> None:
+        """_request JSON-encodes the payload_dict and passes it to nc.request."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        payload = {"key": "value", "num": 42}
+        mock_reply = MagicMock()
+        mock_reply.data = b'{"ok": true}'
+        nc.request = AsyncMock(return_value=mock_reply)
+
+        # Act
+        await driver._request("lyra.clipool.exec", payload)
+
+        # Assert — the bytes sent are valid JSON matching the payload
+        sent_bytes: bytes = nc.request.call_args.args[1]
+        sent_dict = json.loads(sent_bytes)
+        assert sent_dict == payload
+
+    @pytest.mark.asyncio
+    async def test_request_uses_instance_timeout_by_default(self) -> None:
+        """_request uses self._timeout when no explicit timeout is given."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=42.0)
+
+        mock_reply = MagicMock()
+        mock_reply.data = b"{}"
+        nc.request = AsyncMock(return_value=mock_reply)
+
+        # Act
+        await driver._request("lyra.clipool.exec", {})
+
+        # Assert
+        call_kwargs = nc.request.call_args.kwargs
+        assert call_kwargs.get("timeout") == 42.0
+
+    @pytest.mark.asyncio
+    async def test_request_allows_custom_timeout(self) -> None:
+        """_request accepts an explicit timeout kwarg that overrides self._timeout."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        mock_reply = MagicMock()
+        mock_reply.data = b"{}"
+        nc.request = AsyncMock(return_value=mock_reply)
+
+        # Act
+        await driver._request("lyra.clipool.exec", {}, timeout=5.0)
+
+        # Assert
+        call_kwargs = nc.request.call_args.kwargs
+        assert call_kwargs.get("timeout") == 5.0
+
+
+# ---------------------------------------------------------------------------
+# T_start — idempotent subscribe
+# ---------------------------------------------------------------------------
+
+
+class TestStart:
+    """start() subscribes to the heartbeat pattern exactly once, regardless of calls."""
+
+    @pytest.mark.asyncio
+    async def test_start_subscribes_once(self) -> None:
+        """Calling start() twice only creates one subscription."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        sub_mock = MagicMock()
+        nc.subscribe = AsyncMock(return_value=sub_mock)
+
+        # Act
+        await driver.start()
+        await driver.start()
+
+        # Assert — subscribe called only once despite two start() calls
+        nc.subscribe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_subscribes_to_hb_subject(self) -> None:
+        """start() subscribes to the class-level HB_SUBJECT pattern."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        sub_mock = MagicMock()
+        nc.subscribe = AsyncMock(return_value=sub_mock)
+
+        # Act
+        await driver.start()
+
+        # Assert
+        call_args = nc.subscribe.call_args
+        subscribed_subject = call_args.args[0]
+        assert subscribed_subject == HB_SUBJECT
+
+    @pytest.mark.asyncio
+    async def test_start_stores_subscription(self) -> None:
+        """start() stores the subscription object for later stop() calls."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        sub_mock = MagicMock()
+        nc.subscribe = AsyncMock(return_value=sub_mock)
+
+        # Act
+        await driver.start()
+
+        # Assert — _hb_sub is set
+        assert driver._hb_sub is not None
+
+    @pytest.mark.asyncio
+    async def test_stop_unsubscribes(self) -> None:
+        """stop() calls unsubscribe() on the stored subscription."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+
+        sub_mock = MagicMock()
+        sub_mock.unsubscribe = AsyncMock()
+        nc.subscribe = AsyncMock(return_value=sub_mock)
+
+        await driver.start()
+
+        # Act
+        await driver.stop()
+
+        # Assert
+        sub_mock.unsubscribe.assert_awaited_once()
+        assert driver._hb_sub is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self) -> None:
+        """Calling stop() twice does not raise even when _hb_sub is None."""
+        # Arrange
+        nc = _make_mock_nc()
+        driver = _ConcreteDriver(nc, timeout=30.0)
+        # _hb_sub is None — never started
+
+        # Act / Assert — must not raise
+        await driver.stop()
+        await driver.stop()
+
+
+# ---------------------------------------------------------------------------
+# T_construction — basic initialisation checks
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """NatsDriverBase stores nc and timeout; initialises freshness dict and hb_sub."""
+
+    def test_stores_nc_and_timeout(self) -> None:
+        """Constructor stores nc and timeout on the instance."""
+        # Arrange
+        nc = _make_mock_nc()
+
+        # Act
+        driver = _ConcreteDriver(nc, timeout=45.0)
+
+        # Assert
+        assert driver._nc is nc
+        assert driver._timeout == 45.0
+
+    def test_default_timeout(self) -> None:
+        """Default timeout is 120.0 seconds."""
+        # Arrange
+        nc = _make_mock_nc()
+
+        # Act
+        driver = _ConcreteDriver(nc)
+
+        # Assert
+        assert driver._timeout == 120.0
+
+    def test_initial_freshness_is_empty(self) -> None:
+        """_worker_freshness starts as an empty dict."""
+        # Arrange
+        nc = _make_mock_nc()
+
+        # Act
+        driver = _ConcreteDriver(nc)
+
+        # Assert
+        assert driver._worker_freshness == {}
+
+    def test_hb_sub_is_none_initially(self) -> None:
+        """_hb_sub is None before start() is called."""
+        # Arrange
+        nc = _make_mock_nc()
+
+        # Act
+        driver = _ConcreteDriver(nc)
+
+        # Assert
+        assert driver._hb_sub is None
+
+    def test_hb_ttl_class_constant(self) -> None:
+        """HB_TTL class constant is 30.0."""
+        # Arrange / Act / Assert
+        assert _ConcreteDriver.HB_TTL == 30.0

--- a/packages/roxabi-nats/tests/test_driver_base.py
+++ b/packages/roxabi-nats/tests/test_driver_base.py
@@ -168,11 +168,12 @@ class TestStreamGen:
 
         await _run()
 
-        # Assert — generator returned without yielding extra items after done
-        # (collected may include the done chunk or not depending on impl,
-        # but the task must have finished cleanly).
-        # The key invariant is that the generator did NOT block forever.
-        assert True  # reaching here proves the generator exited
+        # Assert — _stream_gen yields the done=True chunk (yield before done check).
+        # The generator must have exited after yielding it.
+        assert len(collected) == 1
+        assert collected[0].get("done") is True
+        # Find the sub_mock from the captured callback's closure to verify unsubscribe.
+        # (unsubscribe is called in the finally block of _stream_gen)
 
     @pytest.mark.asyncio
     async def test_stream_gen_timeout(self) -> None:
@@ -195,6 +196,8 @@ class TestStreamGen:
         await _run()
 
         # Assert — generator exited cleanly (timeout path), no infinite hang.
+        # No chunks were yielded (nothing was pushed before timeout).
+        assert collected == []
         # The unsubscribe finaliser must have been called.
         sub_mock.unsubscribe.assert_awaited()
 

--- a/src/lyra/adapters/clipool/__init__.py
+++ b/src/lyra/adapters/clipool/__init__.py
@@ -1,0 +1,5 @@
+"""lyra.adapters.clipool — CliPool NATS worker adapter."""
+
+from .clipool_worker import CliPoolNatsWorker
+
+__all__ = ["CliPoolNatsWorker"]

--- a/src/lyra/adapters/clipool/clipool_worker.py
+++ b/src/lyra/adapters/clipool/clipool_worker.py
@@ -1,0 +1,260 @@
+"""CliPoolNatsWorker — NATS worker adapter for CliPool (ADR-054).
+
+Subscribes to ``lyra.clipool.cmd`` (queue group ``clipool-workers``) and
+``lyra.clipool.control``.  Routes inbound messages to _handle_cmd or
+_handle_control based on subject.  Streams CLI output back to the caller
+via NATS request-reply inbox.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from lyra.core.agent.agent_config import ModelConfig
+from lyra.core.cli.cli_pool import CliPool
+from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
+from roxabi_contracts.cli.models import (
+    CliChunkEvent,
+    CliCmdPayload,
+    CliControlAck,
+    CliControlCmd,
+)
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_nats.adapter_base import NatsAdapterBase
+
+log = logging.getLogger(__name__)
+
+_CMD_SUBJECT = "lyra.clipool.cmd"
+_CONTROL_SUBJECT = "lyra.clipool.control"
+_HEARTBEAT_SUBJECT = "lyra.clipool.heartbeat"
+_QUEUE_GROUP = "clipool-workers"
+_ENVELOPE_NAME = "CliCmdPayload"
+_SCHEMA_VERSION = 1
+_HEARTBEAT_INTERVAL = 30.0
+
+
+def _make_chunk(pool_id: str, **kwargs: Any) -> bytes:
+    """Serialise a CliChunkEvent to JSON bytes for NATS publish."""
+    import uuid
+    from datetime import datetime, timezone
+
+    event = CliChunkEvent(
+        contract_version=CONTRACT_VERSION,
+        trace_id=str(uuid.uuid4()),
+        issued_at=datetime.now(timezone.utc),
+        pool_id=pool_id,
+        **kwargs,
+    )
+    return event.model_dump_json().encode()
+
+
+def _make_ack(pool_id: str, **kwargs: Any) -> bytes:
+    """Serialise a CliControlAck to JSON bytes for NATS publish."""
+    import uuid
+    from datetime import datetime, timezone
+
+    ack = CliControlAck(
+        contract_version=CONTRACT_VERSION,
+        trace_id=str(uuid.uuid4()),
+        issued_at=datetime.now(timezone.utc),
+        pool_id=pool_id,
+        **kwargs,
+    )
+    return ack.model_dump_json().encode()
+
+
+class CliPoolNatsWorker(NatsAdapterBase):
+    """NATS worker adapter that exposes CliPool over request-reply subjects.
+
+    Routing:
+      - ``lyra.clipool.cmd``     (queue group) → _handle_cmd
+      - ``lyra.clipool.control`` (broadcast)   → _handle_control
+
+    The caller sends a JSON envelope (CliCmdPayload / CliControlCmd) and
+    provides a reply-to inbox.  Streaming chunks are published to that inbox
+    as CliChunkEvent messages.  A terminal chunk with ``done=True`` signals
+    end-of-turn.
+    """
+
+    def __init__(self, pool: CliPool, *, timeout: float = 30.0) -> None:
+        super().__init__(
+            subject=_CMD_SUBJECT,
+            queue_group=_QUEUE_GROUP,
+            envelope_name=_ENVELOPE_NAME,
+            schema_version=_SCHEMA_VERSION,
+            timeout=timeout,
+            heartbeat_subject=_HEARTBEAT_SUBJECT,
+            heartbeat_interval=_HEARTBEAT_INTERVAL,
+        )
+        self._pool = pool
+
+    # ------------------------------------------------------------------
+    # NatsAdapterBase overrides
+    # ------------------------------------------------------------------
+
+    def _extra_subjects(self) -> list[str]:
+        return [_CONTROL_SUBJECT]
+
+    async def handle(self, msg: Any, payload: dict) -> None:
+        if msg.subject == _CONTROL_SUBJECT:
+            await self._handle_control(msg, payload)
+        else:
+            await self._handle_cmd(msg, payload)
+
+    def heartbeat_payload(self) -> dict:
+        base = super().heartbeat_payload()
+        base["pool_count"] = len(self._pool._entries)
+        return base
+
+    # ------------------------------------------------------------------
+    # Command handler (streaming + non-streaming)
+    # ------------------------------------------------------------------
+
+    async def _handle_cmd(self, msg: Any, payload: dict) -> None:
+        try:
+            cmd = CliCmdPayload.model_validate(payload)
+        except Exception:
+            log.exception("clipool_worker: failed to parse CliCmdPayload")
+            return
+
+        model_cfg = ModelConfig.model_validate(cmd.model_cfg)
+
+        if cmd.stream:
+            await self._handle_cmd_streaming(msg, cmd, model_cfg)
+        else:
+            await self._handle_cmd_blocking(msg, cmd, model_cfg)
+
+    async def _handle_cmd_streaming(
+        self, msg: Any, cmd: CliCmdPayload, model_cfg: ModelConfig
+    ) -> None:
+        try:
+            iterator = await self._pool.send_streaming(
+                cmd.pool_id,
+                cmd.text,
+                model_cfg,
+                cmd.system_prompt,
+            )
+        except Exception:
+            log.exception(
+                "clipool_worker: send_streaming failed for pool_id=%r", cmd.pool_id
+            )
+            if msg.reply and self._nc:
+                await self._nc.publish(
+                    msg.reply,
+                    _make_chunk(
+                        cmd.pool_id,
+                        event_type="error",
+                        is_error=True,
+                        done=True,
+                    ),
+                )
+            return
+
+        async for event in iterator:
+            if isinstance(event, TextLlmEvent):
+                chunk = _make_chunk(
+                    cmd.pool_id,
+                    event_type="text",
+                    text=event.text,
+                    done=False,
+                )
+                await self.reply(msg, chunk)
+            elif isinstance(event, ResultLlmEvent):
+                chunk = _make_chunk(
+                    cmd.pool_id,
+                    event_type="result",
+                    is_error=event.is_error,
+                    done=True,
+                )
+                await self.reply(msg, chunk)
+            # ToolUseLlmEvent — skip; tool use is internal to claude CLI
+
+    async def _handle_cmd_blocking(
+        self, msg: Any, cmd: CliCmdPayload, model_cfg: ModelConfig
+    ) -> None:
+        try:
+            result = await self._pool.send(
+                cmd.pool_id,
+                cmd.text,
+                model_cfg,
+                cmd.system_prompt,
+            )
+        except Exception:
+            log.exception("clipool_worker: send failed for pool_id=%r", cmd.pool_id)
+            await self.reply(
+                msg,
+                _make_chunk(
+                    cmd.pool_id,
+                    event_type="error",
+                    is_error=True,
+                    done=True,
+                ),
+            )
+            return
+
+        chunk = _make_chunk(
+            cmd.pool_id,
+            event_type="result",
+            is_error=bool(result.error),
+            session_id=result.session_id or None,
+            done=True,
+        )
+        await self.reply(msg, chunk)
+
+    # ------------------------------------------------------------------
+    # Control handler (reset / resume_and_reset / switch_cwd)
+    # ------------------------------------------------------------------
+
+    async def _handle_control(self, msg: Any, payload: dict) -> None:
+        try:
+            cmd = CliControlCmd.model_validate(payload)
+        except Exception:
+            log.exception("clipool_worker: failed to parse CliControlCmd")
+            return
+
+        try:
+            ack_bytes = await self._dispatch_control(cmd)
+        except Exception:
+            log.exception(
+                "clipool_worker: control op %r failed for pool_id=%r",
+                cmd.op,
+                cmd.pool_id,
+            )
+            ack_bytes = _make_ack(cmd.pool_id, ok=False)
+
+        await self.reply(msg, ack_bytes)
+
+    async def _dispatch_control(self, cmd: CliControlCmd) -> bytes:
+        if cmd.op == "reset":
+            await self._pool.reset(cmd.pool_id)
+            return _make_ack(cmd.pool_id, ok=True)
+
+        if cmd.op == "resume_and_reset":
+            if not cmd.session_id:
+                log.warning(
+                    "clipool_worker: resume_and_reset missing session_id"
+                    " for pool_id=%r",
+                    cmd.pool_id,
+                )
+                return _make_ack(cmd.pool_id, ok=False)
+            resumed = await self._pool.resume_and_reset(cmd.pool_id, cmd.session_id)
+            return _make_ack(cmd.pool_id, ok=True, resumed=resumed)
+
+        if cmd.op == "switch_cwd":
+            if not cmd.cwd:
+                log.warning(
+                    "clipool_worker: switch_cwd missing cwd for pool_id=%r",
+                    cmd.pool_id,
+                )
+                return _make_ack(cmd.pool_id, ok=False)
+            await self._pool.switch_cwd(cmd.pool_id, Path(cmd.cwd))
+            return _make_ack(cmd.pool_id, ok=True)
+
+        log.warning(
+            "clipool_worker: unknown control op %r for pool_id=%r",
+            cmd.op,
+            cmd.pool_id,
+        )
+        return _make_ack(cmd.pool_id, ok=False)

--- a/src/lyra/adapters/clipool/clipool_worker.py
+++ b/src/lyra/adapters/clipool/clipool_worker.py
@@ -169,7 +169,13 @@ class CliPoolNatsWorker(NatsAdapterBase):
                     done=True,
                 )
                 await self.reply(msg, chunk)
+                return
             # ToolUseLlmEvent — skip; tool use is internal to claude CLI
+        # Iterator exhausted without a ResultLlmEvent — send synthetic terminal chunk.
+        await self.reply(
+            msg,
+            _make_chunk(cmd.pool_id, event_type="result", done=True),
+        )
 
     async def _handle_cmd_blocking(
         self, msg: Any, cmd: CliCmdPayload, model_cfg: ModelConfig

--- a/src/lyra/adapters/clipool/clipool_worker.py
+++ b/src/lyra/adapters/clipool/clipool_worker.py
@@ -9,6 +9,7 @@ via NATS request-reply inbox.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -117,6 +118,9 @@ class CliPoolNatsWorker(NatsAdapterBase):
             cmd = CliCmdPayload.model_validate(payload)
         except Exception:
             log.exception("clipool_worker: failed to parse CliCmdPayload")
+            await self.reply(
+                msg, _make_chunk("", event_type="error", is_error=True, done=True)
+            )
             return
 
         model_cfg = ModelConfig.model_validate(cmd.model_cfg)
@@ -218,6 +222,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
             cmd = CliControlCmd.model_validate(payload)
         except Exception:
             log.exception("clipool_worker: failed to parse CliControlCmd")
+            await self.reply(msg, _make_ack("", ok=False))
             return
 
         try:
@@ -255,7 +260,21 @@ class CliPoolNatsWorker(NatsAdapterBase):
                     cmd.pool_id,
                 )
                 return _make_ack(cmd.pool_id, ok=False)
-            await self._pool.switch_cwd(cmd.pool_id, Path(cmd.cwd))
+            base_dir = Path(
+                os.environ.get("LYRA_CLAUDE_CWD", str(Path.home() / "projects"))
+            ).resolve()
+            try:
+                resolved = Path(cmd.cwd).resolve()
+                resolved.relative_to(base_dir)  # raises ValueError if outside
+            except ValueError:
+                log.warning(
+                    "clipool_worker: switch_cwd path %r escapes base %r for pool_id=%r",
+                    cmd.cwd,
+                    str(base_dir),
+                    cmd.pool_id,
+                )
+                return _make_ack(cmd.pool_id, ok=False)
+            await self._pool.switch_cwd(cmd.pool_id, resolved)
             return _make_ack(cmd.pool_id, ok=True)
 
         log.warning(

--- a/src/lyra/bootstrap/factory/agent_factory.py
+++ b/src/lyra/bootstrap/factory/agent_factory.py
@@ -19,6 +19,7 @@ from lyra.stt import STTProtocol
 from lyra.tts import TtsProtocol
 
 if TYPE_CHECKING:
+    from lyra.llm.drivers.cli_nats import CliNatsDriver  # noqa: F401
     from lyra.llm.drivers.nats_driver import NatsLlmDriver
 
 log = logging.getLogger(__name__)
@@ -44,18 +45,30 @@ def _build_shared_base_providers(
     llm_cfg: LlmConfig,
     *,
     nats_llm_driver: "NatsLlmDriver | None" = None,
+    cli_nats_driver: "CliNatsDriver | None" = None,
 ) -> dict[str, LlmProvider]:
     """Build ``{backend: base LlmProvider}`` reusable across all agents.
 
-    ``claude-cli`` (ClaudeCliDriver), ``nats`` (Retry -> NatsLlmDriver, only
-    when ``nats_llm_driver`` is provided). Callers layer decorators per agent
-    via ``_build_per_agent_registry``.
+    ``claude-cli`` (ClaudeCliDriver or CliNatsDriver), ``nats`` (Retry ->
+    NatsLlmDriver, only when ``nats_llm_driver`` is provided). Callers layer
+    decorators per agent via ``_build_per_agent_registry``.
+
+    ``cli_nats_driver`` takes precedence over ``cli_pool`` for the
+    ``claude-cli`` backend when both are provided.
     """
     from lyra.llm.decorators import CircuitBreakerDecorator, RetryDecorator
 
     providers: dict[str, LlmProvider] = {}
 
-    if cli_pool is not None:
+    if cli_nats_driver is not None:
+        cli_cb = circuit_registry.get("claude-cli")
+        base: LlmProvider = cli_nats_driver
+        if cli_cb is not None:
+            providers["claude-cli"] = CircuitBreakerDecorator(base, cli_cb)
+        else:
+            providers["claude-cli"] = base
+        log.info("Shared base: built claude-cli driver via NATS (decorated)")
+    elif cli_pool is not None:
         from lyra.llm.drivers.cli import ClaudeCliDriver
 
         cli_driver: LlmProvider = ClaudeCliDriver(cli_pool)
@@ -64,7 +77,7 @@ def _build_shared_base_providers(
             providers["claude-cli"] = CircuitBreakerDecorator(cli_driver, cli_cb)
         else:
             providers["claude-cli"] = cli_driver
-        log.info("Shared base: built claude-cli driver (decorated)")
+        log.info("Shared base: built claude-cli driver (in-process, decorated)")
 
     if nats_llm_driver is not None:
         providers["nats"] = RetryDecorator(
@@ -96,7 +109,7 @@ def _build_per_agent_registry(
 def _build_provider_registry(
     circuit_registry: CircuitRegistry,
     cli_pool: CliPool | None,
-    llm_cfg: LlmConfig | None = None,  # None → LlmConfig() (defaults)
+    llm_cfg: LlmConfig | None = None,  # None -> LlmConfig() (defaults)
 ) -> ProviderRegistry:
     """Build and return a ProviderRegistry with all configured drivers.
 
@@ -106,12 +119,12 @@ def _build_provider_registry(
     agent.
     """
     shared = _build_shared_base_providers(
-        circuit_registry, cli_pool, llm_cfg or LlmConfig()
+        circuit_registry, cli_pool, llm_cfg or LlmConfig(), cli_nats_driver=None
     )
     return _build_per_agent_registry(shared)
 
 
-def _create_agent(  # noqa: PLR0913 — factory with optional overrides for each agent dependency
+def _create_agent(  # noqa: PLR0913 -- factory with optional overrides for each agent dependency
     config: Agent,
     cli_pool: CliPool | None,
     circuit_registry: CircuitRegistry | None = None,
@@ -135,7 +148,7 @@ def _create_agent(  # noqa: PLR0913 — factory with optional overrides for each
             except KeyError as exc:
                 raise RuntimeError(
                     "backend='nats' registered but NatsLlmDriver missing from"
-                    " registry — is NATS_URL set and driver started?"
+                    " registry -- is NATS_URL set and driver started?"
                 ) from exc
         elif provider_registry is not None:
             provider = provider_registry.get("claude-cli")
@@ -170,25 +183,30 @@ def _resolve_agents(  # noqa: PLR0913
     agent_store: AgentStore | None = None,
     llm_cfg: LlmConfig | None = None,
     nats_llm_driver: "NatsLlmDriver | None" = None,
+    cli_nats_driver: "CliNatsDriver | None" = None,
 ) -> dict[str, AgentBase]:
     """Create all uniquely named agents referenced by bot configs.
 
     Builds the shared driver layer once (``_build_shared_base_providers``),
     then layers a per-agent ``ProviderRegistry`` on top so that each agent's
-    settings are respected independently — without reconstructing the underlying
+    settings are respected independently -- without reconstructing the underlying
     SDK client or circuit breaker for every agent.
 
     Accepts pre-loaded agent configs to avoid duplicate I/O.
     Returns a dict mapping agent_name to AgentBase instance.
 
-    ``nats_llm_driver`` — if provided (NATS_URL set), registers the shared
+    ``nats_llm_driver`` -- if provided (NATS_URL set), registers the shared
     ``NatsLlmDriver`` as the ``"nats"`` backend. Must be started first.
+
+    ``cli_nats_driver`` -- if provided, used as the ``claude-cli`` backend
+    instead of an in-process ``CliPool``. Takes precedence over ``cli_pool``.
     """
     shared_providers = _build_shared_base_providers(
         circuit_registry,
         cli_pool,
         llm_cfg or LlmConfig(),
         nats_llm_driver=nats_llm_driver,
+        cli_nats_driver=cli_nats_driver,
     )
 
     agents: dict[str, AgentBase] = {}

--- a/src/lyra/bootstrap/factory/hub_builder.py
+++ b/src/lyra/bootstrap/factory/hub_builder.py
@@ -153,7 +153,9 @@ def register_agents(  # noqa: PLR0913 — registration requires all deps
     tts_service: TtsProtocol | None,
     agent_store: AgentStore | None,
     raw_config: dict,
-    nats_llm_driver: NatsLlmDriver | None,
+    nats_llm_driver: "NatsLlmDriver | None",
+    *,
+    cli_nats_driver: "CliNatsDriver | None" = None,
 ) -> None:
     """Resolve agents from configs and register them on the hub."""
     llm_cfg = _load_llm_config(raw_config)
@@ -167,6 +169,7 @@ def register_agents(  # noqa: PLR0913 — registration requires all deps
         agent_store=agent_store,
         llm_cfg=llm_cfg,
         nats_llm_driver=nats_llm_driver,
+        cli_nats_driver=cli_nats_driver,
     )
     for ag in all_agents.values():
         hub.register_agent(ag)

--- a/src/lyra/bootstrap/factory/hub_builder.py
+++ b/src/lyra/bootstrap/factory/hub_builder.py
@@ -39,9 +39,19 @@ if TYPE_CHECKING:
     from lyra.core.messaging.messages import MessageManager
     from lyra.infrastructure.stores.pairing import PairingManager
     from lyra.infrastructure.stores.prefs_store import PrefsStore
+    from lyra.llm.drivers.cli_nats import CliNatsDriver
     from lyra.llm.drivers.nats_driver import NatsLlmDriver
 
 log = logging.getLogger(__name__)
+
+
+async def build_cli_nats_driver(nc: NATS, *, timeout: float = 120.0) -> "CliNatsDriver":
+    """Build and start a CliNatsDriver connected to the clipool worker."""
+    from lyra.llm.drivers.cli_nats import CliNatsDriver
+
+    driver = CliNatsDriver(nc, timeout=timeout)
+    await driver.start()
+    return driver
 
 
 def build_inbound_bus(

--- a/src/lyra/bootstrap/factory/unified.py
+++ b/src/lyra/bootstrap/factory/unified.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 
+from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
 from lyra.bootstrap.bootstrap_stores import open_stores
 from lyra.bootstrap.factory.agent_factory import _resolve_agents, _resolve_bot_agent_map
 from lyra.bootstrap.factory.config import (
@@ -24,7 +25,7 @@ from lyra.bootstrap.factory.config import (
     _load_pairing_config,
     _load_pool_config,
 )
-from lyra.bootstrap.factory.hub_builder import build_cli_pool
+from lyra.bootstrap.factory.hub_builder import build_cli_nats_driver
 from lyra.bootstrap.infra.embedded_nats import ensure_nats
 from lyra.bootstrap.infra.lockfile import acquire_lockfile, release_lockfile
 from lyra.bootstrap.lifecycle.bootstrap_lifecycle import run_lifecycle
@@ -36,6 +37,7 @@ from lyra.bootstrap.wiring.bootstrap_wiring import (
 from lyra.config import load_multibot_config
 from lyra.core.agent import Agent
 from lyra.core.agent.agent_loader import agent_row_to_config
+from lyra.core.cli.cli_pool import CliPool
 from lyra.core.config import HubConfig
 from lyra.core.hub import Hub
 from lyra.core.hub.event_bus import PipelineEventBus
@@ -57,6 +59,7 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
     nc, embedded, _ = await ensure_nats(os.environ.get("NATS_URL"))
     acquire_lockfile()
     nats_llm_driver = None
+    cli_nats_driver = None
     cli_pool = None
     try:
         inbound_bus_cfg = _load_inbound_bus_config(raw_config)
@@ -216,16 +219,28 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
             audit_sink = JetStreamAuditSink()
             await audit_sink.provision(nc)
 
-            cli_pool = await build_cli_pool(
-                raw_config, agent_configs, audit_sink=audit_sink
+            # Build CliNatsDriver (hub-side) and spawn CliPoolNatsWorker (worker-side)
+            # as an embedded asyncio task for unified mode.
+            cli_nats_driver = await build_cli_nats_driver(nc)
+            cli_pool = CliPool(
+                idle_ttl=cli_pool_cfg.idle_ttl,
+                default_timeout=cli_pool_cfg.default_timeout,
+                reaper_interval=cli_pool_cfg.reaper_interval,
+                kill_timeout=cli_pool_cfg.kill_timeout,
+                read_buffer_bytes=cli_pool_cfg.read_buffer_bytes,
+                stdin_drain_timeout=cli_pool_cfg.stdin_drain_timeout,
+                max_idle_retries=cli_pool_cfg.max_idle_retries,
+                intermediate_timeout=cli_pool_cfg.intermediate_timeout,
+                audit_sink=audit_sink,
             )
-            if cli_pool is not None:
-                cli_pool.set_turn_store(stores.turn)
-            hub.cli_pool = cli_pool
+            await cli_pool.start()
+            cli_pool.set_turn_store(stores.turn)
+            worker = CliPoolNatsWorker(cli_pool, timeout=cli_pool_cfg.default_timeout)
+            hub.cli_pool = None  # hub no longer holds CliPool directly
 
             all_agents = _resolve_agents(
                 agent_configs,
-                cli_pool,
+                None,
                 circuit_registry,
                 msg_manager,
                 stt_service,
@@ -233,6 +248,7 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
                 agent_store=stores.agent,
                 llm_cfg=llm_cfg,
                 nats_llm_driver=nats_llm_driver,
+                cli_nats_driver=cli_nats_driver,
             )
             for ag in all_agents.values():
                 hub.register_agent(ag)
@@ -265,6 +281,10 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
                 nats_client=nc,
             )
 
+            clipool_worker_task = asyncio.create_task(
+                worker.run_embedded(nc), name="clipool-worker"
+            )
+
             await run_lifecycle(
                 hub,
                 tg_adapters,
@@ -272,14 +292,19 @@ async def _bootstrap_unified(  # noqa: C901, PLR0915
                 dc_adapters,
                 dc_dispatchers,
                 pm,
-                cli_pool,
+                None,
                 _stop,
                 nc=nc,
             )
 
+            clipool_worker_task.cancel()
+            await asyncio.gather(clipool_worker_task, return_exceptions=True)
+
     finally:
         if nats_llm_driver is not None:
             await nats_llm_driver.stop()
+        if cli_nats_driver is not None:
+            await cli_nats_driver.stop()
         # Flush in-flight audit emit tasks before closing NATS (audit uses JetStream).
         if cli_pool is not None:
             await cli_pool.drain_audit_tasks()

--- a/src/lyra/bootstrap/standalone/clipool_standalone.py
+++ b/src/lyra/bootstrap/standalone/clipool_standalone.py
@@ -38,4 +38,8 @@ async def _bootstrap_clipool_standalone(raw_config: dict) -> None:
 
     worker = CliPoolNatsWorker(cli_pool, timeout=cli_pool_cfg.default_timeout)
     log.info("clipool: starting CliPoolNatsWorker on lyra.clipool.cmd")
-    await worker.run(nats_url)
+    try:
+        await worker.run(nats_url)
+    finally:
+        await cli_pool.drain_audit_tasks()
+        await cli_pool.stop()

--- a/src/lyra/bootstrap/standalone/clipool_standalone.py
+++ b/src/lyra/bootstrap/standalone/clipool_standalone.py
@@ -1,0 +1,41 @@
+"""Bootstrap standalone CliPool NATS worker."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+from lyra.bootstrap.factory.config import _load_cli_pool_config
+from lyra.core.cli.cli_pool import CliPool
+from roxabi_nats.connect import scrub_nats_url
+
+log = logging.getLogger(__name__)
+
+
+async def _bootstrap_clipool_standalone(raw_config: dict) -> None:
+    """Wire a standalone CliPoolNatsWorker connected to NATS."""
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        sys.exit("NATS_URL is required for standalone clipool mode.")
+
+    cli_pool_cfg = _load_cli_pool_config(raw_config)
+
+    log.info("clipool: will connect to NATS at %s", scrub_nats_url(nats_url))
+
+    cli_pool = CliPool(
+        idle_ttl=cli_pool_cfg.idle_ttl,
+        default_timeout=cli_pool_cfg.default_timeout,
+        reaper_interval=cli_pool_cfg.reaper_interval,
+        kill_timeout=cli_pool_cfg.kill_timeout,
+        read_buffer_bytes=cli_pool_cfg.read_buffer_bytes,
+        stdin_drain_timeout=cli_pool_cfg.stdin_drain_timeout,
+        max_idle_retries=cli_pool_cfg.max_idle_retries,
+        intermediate_timeout=cli_pool_cfg.intermediate_timeout,
+    )
+    await cli_pool.start()
+
+    worker = CliPoolNatsWorker(cli_pool, timeout=cli_pool_cfg.default_timeout)
+    log.info("clipool: starting CliPoolNatsWorker on lyra.clipool.cmd")
+    await worker.run(nats_url)

--- a/src/lyra/bootstrap/standalone/hub_standalone.py
+++ b/src/lyra/bootstrap/standalone/hub_standalone.py
@@ -13,7 +13,7 @@ from lyra.bootstrap.bootstrap_stores import open_stores
 from lyra.bootstrap.factory.agent_factory import _resolve_bot_agent_map
 from lyra.bootstrap.factory.config import MessageIndexConfig
 from lyra.bootstrap.factory.hub_builder import (
-    build_cli_pool,
+    build_cli_nats_driver,
     build_hub,
     build_inbound_bus,
     register_agents,
@@ -150,17 +150,13 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
         audit_sink = JetStreamAuditSink()
         await audit_sink.provision(nc)
 
-        cli_pool = await build_cli_pool(
-            raw_config, agent_configs, audit_sink=audit_sink
-        )
-        if cli_pool is not None:
-            cli_pool.set_turn_store(stores.turn)
-        hub.cli_pool = cli_pool
+        cli_nats_driver = await build_cli_nats_driver(nc)
+        hub.cli_pool = None  # CliPool now runs in lyra-clipool container
 
         register_agents(
             hub,
             agent_configs,
-            cli_pool,
+            None,
             circuit_registry,
             msg_manager,
             stt_service,
@@ -168,6 +164,7 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
             stores.agent,
             raw_config,
             nats_llm_driver,
+            cli_nats_driver=cli_nats_driver,
         )
 
         # Wire each (platform, bot_id) to a NatsChannelProxy + OutboundDispatcher
@@ -248,13 +245,9 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — startup wiring
             dispatchers=dispatchers,
             proxies=proxies,
             pm=pm,
-            cli_pool=cli_pool,
+            cli_nats_driver=cli_nats_driver,
             nats_llm_driver=nats_llm_driver,
         )
-
-    # Flush in-flight audit emit tasks before closing NATS (audit uses JetStream).
-    if cli_pool is not None:
-        await cli_pool.drain_audit_tasks()
 
     # Close NATS connection after stores context exits
     try:

--- a/src/lyra/bootstrap/standalone/hub_standalone_helpers.py
+++ b/src/lyra/bootstrap/standalone/hub_standalone_helpers.py
@@ -17,10 +17,11 @@ from lyra.infrastructure.stores.pairing import PairingManager, set_pairing_manag
 
 if TYPE_CHECKING:
     from lyra.core.agent import Agent
-    from lyra.core.cli.cli_pool import CliPool
     from lyra.core.hub.hub import Hub
     from lyra.infrastructure.stores.agent_store import AgentStore
     from lyra.infrastructure.stores.auth_store import AuthStore
+    from lyra.llm.drivers.cli_nats import CliNatsDriver
+    from lyra.llm.drivers.nats_driver import NatsLlmDriver
 
 log = logging.getLogger(__name__)
 
@@ -77,8 +78,8 @@ async def shutdown_hub_runtime(  # noqa: PLR0913 — unavoidable wiring surface
     dispatchers,
     proxies,
     pm: PairingManager | None,
-    cli_pool: CliPool | None,
-    nats_llm_driver,
+    cli_nats_driver: "CliNatsDriver | None",
+    nats_llm_driver: "NatsLlmDriver | None",
 ) -> None:
     """Run the post-cancellation teardown sequence for hub_standalone."""
     await readiness_sub.unsubscribe()
@@ -88,12 +89,8 @@ async def shutdown_hub_runtime(  # noqa: PLR0913 — unavoidable wiring surface
         await proxy.publish_stream_errors("hub_shutdown")
     if pm is not None:
         await pm.close()
-    if cli_pool is not None:
-        await cli_pool.drain(timeout=60.0)
-        active_ids = cli_pool.get_active_pool_ids()
-        if active_ids:
-            await hub.notify_shutdown_inflight(active_ids)
-        await cli_pool.stop()
+    if cli_nats_driver is not None:
+        await cli_nats_driver.stop()
     if nats_llm_driver is not None:
         await nats_llm_driver.stop()
     await hub.shutdown()

--- a/src/lyra/cli.py
+++ b/src/lyra/cli.py
@@ -118,6 +118,16 @@ def _adapter_discord() -> None:
     _run_adapter("discord")
 
 
+@adapter_app.command("clipool")
+def _adapter_clipool() -> None:
+    """Start the standalone CliPool NATS worker."""
+    from lyra.bootstrap.standalone.clipool_standalone import (
+        _bootstrap_clipool_standalone,
+    )
+
+    _boot(_bootstrap_clipool_standalone)
+
+
 def _run_adapter(platform: str) -> None:
     from lyra.bootstrap.standalone.adapter_standalone import (
         _bootstrap_adapter_standalone,

--- a/src/lyra/llm/drivers/__init__.py
+++ b/src/lyra/llm/drivers/__init__.py
@@ -1,0 +1,3 @@
+from lyra.llm.drivers.cli_nats import CliNatsDriver
+
+__all__ = ["CliNatsDriver"]

--- a/src/lyra/llm/drivers/cli_nats.py
+++ b/src/lyra/llm/drivers/cli_nats.py
@@ -136,9 +136,9 @@ class CliNatsDriver(NatsDriverBase):
         payload = self._build_control_payload(pool_id, "switch_cwd", cwd=str(cwd))
         await self._request(self.SUBJECT_CONTROL, payload)
 
-    def is_alive(self, worker_id: str) -> bool:
+    def is_alive(self, pool_id: str) -> bool:
         """Return True when NATS is connected and a clipool worker is fresh."""
-        del worker_id
+        del pool_id
         return self._nc.is_connected and self._any_worker_alive()
 
     def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:

--- a/src/lyra/llm/drivers/cli_nats.py
+++ b/src/lyra/llm/drivers/cli_nats.py
@@ -136,11 +136,6 @@ class CliNatsDriver(NatsDriverBase):
         payload = self._build_control_payload(pool_id, "switch_cwd", cwd=str(cwd))
         await self._request(self.SUBJECT_CONTROL, payload)
 
-    def is_alive(self, pool_id: str) -> bool:
-        """Return True when NATS is connected and a clipool worker is fresh."""
-        del pool_id
-        return self._nc.is_connected and self._any_worker_alive()
-
     def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
         """No-op on the NATS side — session linkage is carried in each payload."""
         log.debug(

--- a/src/lyra/llm/drivers/cli_nats.py
+++ b/src/lyra/llm/drivers/cli_nats.py
@@ -1,0 +1,189 @@
+"""CliNatsDriver — hub-side LlmProvider dispatching claude-cli over NATS."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from lyra.core.messaging.events import LlmEvent, ResultLlmEvent, TextLlmEvent
+from lyra.llm.base import LlmResult
+from roxabi_contracts.cli.models import CliCmdPayload, CliControlCmd
+from roxabi_nats.driver_base import NatsDriverBase
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+
+    from lyra.core.agent.agent_config import ModelConfig
+
+__all__ = ["CliNatsDriver"]
+log = logging.getLogger(__name__)
+
+
+class CliNatsDriver(NatsDriverBase):
+    """LlmProvider over NATS — hub sends to CliPoolNatsWorker."""
+
+    SUBJECT_CMD = "lyra.clipool.cmd"
+    SUBJECT_CONTROL = "lyra.clipool.control"
+    HB_SUBJECT = "lyra.clipool.heartbeat"
+    capabilities: dict[str, Any] = {"streaming": True, "auth": "nats"}
+
+    def __init__(self, nc: "NATS", *, timeout: float = 120.0) -> None:
+        super().__init__(nc, timeout=timeout)
+
+    # ── LlmProvider protocol ──────────────────────────────────────────────
+
+    async def stream(
+        self,
+        pool_id: str,
+        text: str,
+        model_cfg: "ModelConfig",
+        system_prompt: str,
+        *,
+        messages: list[dict] | None = None,
+    ) -> AsyncIterator[LlmEvent]:
+        """Return an async generator of LlmEvents for a streaming clipool request."""
+        return self._stream_gen_llm(pool_id, text, model_cfg, system_prompt)
+
+    async def _stream_gen_llm(
+        self,
+        pool_id: str,
+        text: str,
+        model_cfg: "ModelConfig",
+        system_prompt: str,
+    ) -> AsyncIterator[LlmEvent]:
+        """Async generator: yield LlmEvents from the clipool worker via NATS inbox."""
+        payload = self._build_cmd_payload(
+            pool_id, text, model_cfg, system_prompt, stream=True
+        )
+        async for chunk in self._stream_gen(self.SUBJECT_CMD, payload):
+            event_type = chunk.get("event_type", "text")
+            if event_type == "text":
+                t = chunk.get("text") or ""
+                if t:
+                    yield TextLlmEvent(text=t)
+            elif event_type == "result":
+                yield ResultLlmEvent(
+                    is_error=bool(chunk.get("is_error", False)),
+                    duration_ms=int(chunk.get("duration_ms", 0)),
+                )
+                return
+            if chunk.get("done", False):
+                # Defensive: worker set done=True on a non-result chunk.
+                log.warning(
+                    "cli_nats: worker sent done=True on event_type=%r [pool:%s]",
+                    event_type,
+                    pool_id,
+                )
+                yield ResultLlmEvent(is_error=False, duration_ms=0)
+                return
+
+    async def complete(
+        self,
+        pool_id: str,
+        text: str,
+        model_cfg: "ModelConfig",
+        system_prompt: str,
+        *,
+        messages: list[dict] | None = None,
+    ) -> LlmResult:
+        """Dispatch a single-turn completion to clipool over NATS request-reply."""
+        payload = self._build_cmd_payload(
+            pool_id, text, model_cfg, system_prompt, stream=False
+        )
+        try:
+            reply = await self._request(self.SUBJECT_CMD, payload)
+        except Exception as exc:
+            log.warning(
+                "cli_nats: complete() transport error [pool:%s]: %s: %s",
+                pool_id,
+                type(exc).__name__,
+                exc,
+            )
+            return LlmResult(error=f"NATS transport error: {exc}", retryable=True)
+
+        error = reply.get("error", "")
+        if error:
+            return LlmResult(
+                error=error,
+                retryable=bool(reply.get("retryable", True)),
+            )
+        return LlmResult(
+            result=reply.get("text") or reply.get("result", ""),
+            session_id=reply.get("session_id", ""),
+        )
+
+    # ── CliPool-compatible control methods ────────────────────────────────
+
+    async def reset(self, pool_id: str) -> None:
+        """Send reset control command to clipool worker."""
+        payload = self._build_control_payload(pool_id, "reset")
+        await self._request(self.SUBJECT_CONTROL, payload)
+
+    async def resume_and_reset(self, pool_id: str, session_id: str) -> bool:
+        """Ask clipool worker to resume a prior session then reset."""
+        payload = self._build_control_payload(
+            pool_id, "resume_and_reset", session_id=session_id
+        )
+        reply = await self._request(self.SUBJECT_CONTROL, payload)
+        return bool(reply.get("resumed", False))
+
+    async def switch_cwd(self, pool_id: str, cwd: Path) -> None:
+        """Ask clipool worker to switch the working directory."""
+        payload = self._build_control_payload(pool_id, "switch_cwd", cwd=str(cwd))
+        await self._request(self.SUBJECT_CONTROL, payload)
+
+    def is_alive(self, worker_id: str) -> bool:
+        """Return True when NATS is connected and a clipool worker is fresh."""
+        del worker_id
+        return self._nc.is_connected and self._any_worker_alive()
+
+    def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
+        """No-op on the NATS side — session linkage is carried in each payload."""
+        log.debug(
+            "cli_nats: link pool_id=%s → lyra_session=%s", pool_id, lyra_session_id
+        )
+
+    # ── Payload builders ──────────────────────────────────────────────────
+
+    def _build_cmd_payload(
+        self,
+        pool_id: str,
+        text: str,
+        model_cfg: "ModelConfig",
+        system_prompt: str,
+        *,
+        stream: bool,
+    ) -> dict:
+        return CliCmdPayload(
+            contract_version="1",
+            trace_id=str(uuid4()),
+            issued_at=datetime.now(timezone.utc),
+            pool_id=pool_id,
+            lyra_session_id=pool_id,
+            text=text,
+            model_cfg=model_cfg.model_dump(exclude={"api_key"}),
+            system_prompt=system_prompt,
+            stream=stream,
+        ).model_dump(mode="json")
+
+    def _build_control_payload(
+        self,
+        pool_id: str,
+        op: str,
+        *,
+        session_id: str | None = None,
+        cwd: str | None = None,
+    ) -> dict:
+        return CliControlCmd(
+            contract_version="1",
+            trace_id=str(uuid4()),
+            issued_at=datetime.now(timezone.utc),
+            pool_id=pool_id,
+            op=op,  # type: ignore[arg-type]
+            session_id=session_id,
+            cwd=cwd,
+        ).model_dump(mode="json")

--- a/tests/adapters/test_clipool_worker.py
+++ b/tests/adapters/test_clipool_worker.py
@@ -189,6 +189,32 @@ async def test_handle_cmd_nonstream_calls_pool_send() -> None:
     assert publish_subject == "_INBOX.reply"
 
 
+async def test_handle_cmd_send_streaming_exception_publishes_error() -> None:
+    """When pool.send_streaming raises, worker publishes error chunk via _nc.publish."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    pool.send_streaming = AsyncMock(side_effect=RuntimeError("boom"))
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+    msg = _make_nats_msg(subject="lyra.clipool.cmd", reply="_INBOX.test.1")
+    payload = _cmd_payload(stream=True)
+
+    # Act
+    await worker._handle_cmd(msg, payload)
+
+    # Assert — error published directly via _nc.publish (not self.reply)
+    nc.publish.assert_awaited_once()
+    call_args = nc.publish.call_args
+    subject = call_args.args[0]
+    data = json.loads(call_args.args[1])
+    assert subject == "_INBOX.test.1"
+    assert data["is_error"] is True
+    assert data["done"] is True
+
+
 async def test_handle_cmd_publishes_done_chunk_after_stream() -> None:
     """Streaming path publishes a terminal 'done' chunk after iterating events."""
     from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
@@ -219,6 +245,50 @@ async def test_handle_cmd_publishes_done_chunk_after_stream() -> None:
 # ---------------------------------------------------------------------------
 # _handle_control — reset
 # ---------------------------------------------------------------------------
+
+
+async def test_handle_control_parse_failure_replies_error_ack() -> None:
+    """Malformed CliControlCmd payload: worker replies ok=False (does not hang)."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+    msg = _make_nats_msg(subject="lyra.clipool.control", reply="_INBOX.test.ctrl")
+    bad_payload = {"op": "invalid_op_not_in_literal"}  # will fail validation
+
+    # Act
+    await worker._handle_control(msg, bad_payload)
+
+    # Assert — worker replies with ok=False rather than hanging
+    nc.publish.assert_awaited_once()
+    call_args = nc.publish.call_args
+    data = json.loads(call_args.args[1])
+    assert data["ok"] is False
+
+
+async def test_handle_control_dispatch_exception_replies_ok_false() -> None:
+    """When pool.reset raises, _handle_control catches and replies ok=False."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    pool.reset = AsyncMock(side_effect=RuntimeError("pool reset exploded"))
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+    msg = _make_nats_msg(subject="lyra.clipool.control", reply="_INBOX.test.ctrl2")
+    payload = _control_payload(op="reset")
+
+    # Act
+    await worker._handle_control(msg, payload)
+
+    # Assert
+    nc.publish.assert_awaited_once()
+    data = json.loads(nc.publish.call_args.args[1])
+    assert data["ok"] is False
 
 
 async def test_handle_control_reset() -> None:

--- a/tests/adapters/test_clipool_worker.py
+++ b/tests/adapters/test_clipool_worker.py
@@ -16,6 +16,8 @@ import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from lyra.core.cli.cli_pool import CliPool, CliResult
 from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
 
@@ -283,11 +285,12 @@ async def test_handle_control_resume_and_reset() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_handle_control_switch_cwd() -> None:
+async def test_handle_control_switch_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
     """op='switch_cwd': pool.switch_cwd() called with pool_id and cwd."""
     from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
 
-    # Arrange
+    # Arrange — allow /tmp as the base so /tmp/workspace passes the guard
+    monkeypatch.setenv("LYRA_CLAUDE_CWD", "/tmp")
     pool = _make_pool()
     worker = CliPoolNatsWorker(pool)
     nc = AsyncMock()

--- a/tests/adapters/test_clipool_worker.py
+++ b/tests/adapters/test_clipool_worker.py
@@ -1,0 +1,387 @@
+"""Tests for CliPoolNatsWorker — RED phase (T9).
+
+CliPoolNatsWorker does not exist yet; these tests will fail until T10 lands.
+
+Coverage targets:
+- handle() routing by msg.subject
+- _handle_cmd(): stream=True path (send_streaming) and stream=False path (send)
+- _handle_control(): reset, resume_and_reset, switch_cwd ops
+- heartbeat_payload() pool_count extension
+- _extra_subjects() contract
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from lyra.core.cli.cli_pool import CliPool, CliResult
+from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_nats_msg(subject: str = "lyra.clipool.cmd", reply: str = "_INBOX.test"):
+    msg = MagicMock()
+    msg.subject = subject
+    msg.reply = reply
+    return msg
+
+
+async def _make_event_iter(events):
+    for e in events:
+        yield e
+
+
+def _cmd_payload(**overrides) -> dict:
+    """Build a minimal CliCmdPayload dict with required envelope fields."""
+    base = {
+        "contract_version": "1",
+        "trace_id": "trace-001",
+        "issued_at": datetime.now(timezone.utc).isoformat(),
+        "pool_id": "pool-1",
+        "lyra_session_id": "sess-1",
+        "text": "hello",
+        "model_cfg": {},
+        "system_prompt": "",
+        "stream": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _control_payload(**overrides) -> dict:
+    """Build a minimal CliControlCmd dict with required envelope fields."""
+    base = {
+        "contract_version": "1",
+        "trace_id": "trace-002",
+        "issued_at": datetime.now(timezone.utc).isoformat(),
+        "pool_id": "pool-1",
+        "op": "reset",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_pool() -> MagicMock:
+    pool = MagicMock(spec=CliPool)
+    pool._entries = {}
+    pool.send_streaming = AsyncMock()
+    pool.send = AsyncMock()
+    pool.reset = AsyncMock()
+    pool.resume_and_reset = AsyncMock(return_value=True)
+    pool.switch_cwd = AsyncMock()
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# _extra_subjects
+# ---------------------------------------------------------------------------
+
+
+def test_extra_subjects_includes_control() -> None:
+    """_extra_subjects() returns exactly ['lyra.clipool.control']."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+
+    # Act
+    worker = CliPoolNatsWorker(pool)
+
+    # Assert
+    assert worker._extra_subjects() == ["lyra.clipool.control"]
+
+
+# ---------------------------------------------------------------------------
+# handle() routing
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_routes_control_by_subject() -> None:
+    """msg.subject == 'lyra.clipool.control' -> _handle_control; else -> _handle_cmd."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    worker = CliPoolNatsWorker(pool)
+
+    control_msg = _make_nats_msg(subject="lyra.clipool.control")
+    cmd_msg = _make_nats_msg(subject="lyra.clipool.cmd")
+
+    with (
+        patch.object(worker, "_handle_control", new_callable=AsyncMock) as mock_ctrl,
+        patch.object(worker, "_handle_cmd", new_callable=AsyncMock) as mock_cmd,
+    ):
+        # Act — control subject
+        await worker.handle(control_msg, _control_payload())
+        # Act — default subject
+        await worker.handle(cmd_msg, _cmd_payload())
+
+    # Assert
+    mock_ctrl.assert_awaited_once()
+    mock_cmd.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_cmd — streaming path
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_cmd_stream_calls_pool_send_streaming() -> None:
+    """stream=True: send_streaming() called, chunks published to msg.reply."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    text_event = TextLlmEvent(text="hello")
+    result_event = ResultLlmEvent(is_error=False, duration_ms=0)
+    pool.send_streaming.return_value = _make_event_iter([text_event, result_event])
+
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="lyra.clipool.cmd", reply="_INBOX.reply")
+    payload = _cmd_payload(stream=True)
+
+    # Act
+    await worker._handle_cmd(msg, payload)
+
+    # Assert — pool.send_streaming was called
+    pool.send_streaming.assert_called_once()
+    # Assert — at least one publish to msg.reply
+    assert nc.publish.call_count >= 1
+    call_subjects = [call.args[0] for call in nc.publish.call_args_list]
+    assert all(s == "_INBOX.reply" for s in call_subjects)
+
+
+async def test_handle_cmd_nonstream_calls_pool_send() -> None:
+    """stream=False: pool.send() called, single reply published to msg.reply."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    pool.send.return_value = CliResult(result="answer", session_id="sid", error="")
+
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="lyra.clipool.cmd", reply="_INBOX.reply")
+    payload = _cmd_payload(stream=False)
+
+    # Act
+    await worker._handle_cmd(msg, payload)
+
+    # Assert — pool.send used, not send_streaming
+    pool.send.assert_called_once()
+    pool.send_streaming.assert_not_called()
+
+    # Assert — single reply published
+    nc.publish.assert_called_once()
+    publish_subject = nc.publish.call_args.args[0]
+    assert publish_subject == "_INBOX.reply"
+
+
+async def test_handle_cmd_publishes_done_chunk_after_stream() -> None:
+    """Streaming path publishes a terminal 'done' chunk after iterating events."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    text_event = TextLlmEvent(text="chunk1")
+    pool.send_streaming.return_value = _make_event_iter([text_event])
+
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="lyra.clipool.cmd", reply="_INBOX.reply")
+
+    # Act
+    await worker._handle_cmd(msg, _cmd_payload(stream=True))
+
+    # Assert — final publish carries done=True
+    published_payloads = [
+        json.loads(call.args[1].decode())
+        for call in nc.publish.call_args_list
+        if len(call.args) > 1
+    ]
+    assert any(p.get("done") is True for p in published_payloads)
+
+
+# ---------------------------------------------------------------------------
+# _handle_control — reset
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_control_reset() -> None:
+    """op='reset': pool.reset() called; CliControlAck(ok=True) published."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="lyra.clipool.control", reply="_INBOX.ctrl")
+    payload = _control_payload(op="reset", pool_id="pool-x")
+
+    # Act
+    await worker._handle_control(msg, payload)
+
+    # Assert — pool.reset called with pool_id
+    pool.reset.assert_awaited_once_with("pool-x")
+
+    # Assert — reply published with ok=True
+    nc.publish.assert_called_once()
+    reply_body = json.loads(nc.publish.call_args.args[1].decode())
+    assert reply_body["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# _handle_control — resume_and_reset
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_control_resume_and_reset() -> None:
+    """op='resume_and_reset': pool.resume_and_reset(pool_id, session_id) called."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    pool.resume_and_reset.return_value = True
+
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="lyra.clipool.control", reply="_INBOX.ctrl")
+    payload = _control_payload(
+        op="resume_and_reset", pool_id="pool-y", session_id="sid-42"
+    )
+
+    # Act
+    await worker._handle_control(msg, payload)
+
+    # Assert — correct call signature
+    pool.resume_and_reset.assert_awaited_once_with("pool-y", "sid-42")
+
+    # Assert — reply published with ok=True (pool returned True)
+    nc.publish.assert_called_once()
+    reply_body = json.loads(nc.publish.call_args.args[1].decode())
+    assert reply_body["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# _handle_control — switch_cwd
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_control_switch_cwd() -> None:
+    """op='switch_cwd': pool.switch_cwd() called with pool_id and cwd."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="lyra.clipool.control", reply="_INBOX.ctrl")
+    payload = _control_payload(op="switch_cwd", pool_id="pool-z", cwd="/tmp/workspace")
+
+    # Act
+    await worker._handle_control(msg, payload)
+
+    # Assert — pool.switch_cwd called
+    pool.switch_cwd.assert_awaited_once()
+    call_args = pool.switch_cwd.call_args
+    # First positional arg is pool_id; second (or kwarg cwd) is the path
+    assert call_args.args[0] == "pool-z" or call_args.kwargs.get("pool_id") == "pool-z"
+
+    # Assert — ACK published
+    nc.publish.assert_called_once()
+    reply_body = json.loads(nc.publish.call_args.args[1].decode())
+    assert reply_body["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# heartbeat_payload
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_payload_has_pool_count() -> None:
+    """heartbeat_payload() includes pool_count == len(pool._entries)."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    pool._entries = {"a": MagicMock(), "b": MagicMock()}
+
+    worker = CliPoolNatsWorker(pool)
+    # Seed _started_at so uptime calculation does not fail
+    import time
+
+    worker._started_at = time.monotonic()
+
+    # Act
+    payload = worker.heartbeat_payload()
+
+    # Assert
+    assert payload["pool_count"] == 2
+
+
+def test_heartbeat_payload_empty_pool() -> None:
+    """heartbeat_payload() with empty pool gives pool_count == 0."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange
+    pool = _make_pool()
+    pool._entries = {}
+
+    worker = CliPoolNatsWorker(pool)
+    import time
+
+    worker._started_at = time.monotonic()
+
+    # Act
+    payload = worker.heartbeat_payload()
+
+    # Assert
+    assert payload["pool_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Constructor wiring
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_passes_correct_subject_and_queue_group() -> None:
+    """Constructor sets subject='lyra.clipool.cmd' and queue_group='clipool-workers'."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange / Act
+    pool = _make_pool()
+    worker = CliPoolNatsWorker(pool)
+
+    # Assert
+    assert worker.subject == "lyra.clipool.cmd"
+    assert worker.queue_group == "clipool-workers"
+
+
+def test_constructor_custom_timeout() -> None:
+    """Constructor accepts custom timeout kwarg."""
+    from lyra.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    # Arrange / Act
+    pool = _make_pool()
+    worker = CliPoolNatsWorker(pool, timeout=60.0)  # noqa: E501
+
+    # Assert
+    assert worker.timeout == 60.0

--- a/tests/bootstrap/test_audit_bootstrap_wiring.py
+++ b/tests/bootstrap/test_audit_bootstrap_wiring.py
@@ -54,15 +54,14 @@ class TestBuildCliPoolAuditSinkWiring:
 
 class TestJetStreamAuditSinkBootstrapIntegration:
     async def test_provision_is_called_before_cli_pool_in_standalone(self) -> None:
-        """provision() must be called before build_cli_pool in hub_standalone."""
+        """provision() must be called before build_cli_nats_driver in hub_standalone."""
         call_order: list[str] = []
 
-        async def _fake_provision(nc: object) -> None:
+        async def _fake_provision(*_: object) -> None:
             call_order.append("provision")
 
-        async def _fake_build_cli_pool(*args: object, **kwargs: object) -> None:
-            call_order.append("build_cli_pool")
-            return None
+        async def _fake_build_cli_nats_driver(*_: object) -> None:  # type: ignore[misc]
+            call_order.append("build_cli_nats_driver")
 
         with patch(
             "lyra.bootstrap.standalone.hub_standalone.JetStreamAuditSink"
@@ -72,8 +71,8 @@ class TestJetStreamAuditSinkBootstrapIntegration:
             MockSink.return_value = mock_sink
 
             with patch(
-                "lyra.bootstrap.standalone.hub_standalone.build_cli_pool",
-                side_effect=_fake_build_cli_pool,
+                "lyra.bootstrap.standalone.hub_standalone.build_cli_nats_driver",
+                side_effect=_fake_build_cli_nats_driver,
             ):
                 # Import the module — both symbols are referenced at module level
                 import lyra.bootstrap.standalone.hub_standalone as hub_mod
@@ -81,9 +80,10 @@ class TestJetStreamAuditSinkBootstrapIntegration:
                 # Verify structural presence — imported at module level
                 assert hasattr(hub_mod, "JetStreamAuditSink")
 
-        # If both were called, provision must precede build_cli_pool
-        if "provision" in call_order and "build_cli_pool" in call_order:
-            assert call_order.index("provision") < call_order.index("build_cli_pool")
+        # If both were called, provision must precede build_cli_nats_driver
+        _key = "build_cli_nats_driver"
+        if "provision" in call_order and _key in call_order:
+            assert call_order.index("provision") < call_order.index(_key)
 
     async def test_audit_sink_skip_permissions_event_fields(self) -> None:
         """A spawn with skip_permissions=True emits event with that field True."""

--- a/tests/bootstrap/test_unified_clipool.py
+++ b/tests/bootstrap/test_unified_clipool.py
@@ -1,0 +1,127 @@
+"""RED-phase tests for unified.py CliPool → CliNatsDriver wiring (T22).
+
+These tests verify the *post-T22* contract:
+  - build_cli_pool is NOT called from unified.py
+  - build_cli_nats_driver IS called during startup
+  - CliPoolNatsWorker IS instantiated
+  - asyncio.create_task is called with the worker coroutine
+
+All tests will fail RED until T22 ships.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+
+class TestUnifiedNoBuildCliPool:
+    def test_unified_no_direct_cli_pool_in_bootstrap(self) -> None:
+        """After T22, unified.py must not import or call build_cli_pool."""
+        # Arrange
+        import lyra.bootstrap.factory.unified as unified_mod
+
+        importlib.reload(unified_mod)
+        source = inspect.getsource(unified_mod)
+
+        # Assert — after T22 this call is replaced by CliNatsDriver wiring
+        assert "build_cli_pool" not in source, (
+            "unified.py still calls build_cli_pool — "
+            "T22 should replace this with CliNatsDriver + CliPoolNatsWorker"
+        )
+
+
+class TestUnifiedCliNatsDriverWired:
+    def test_unified_imports_build_cli_nats_driver(self) -> None:
+        """After T22, unified.py must import build_cli_nats_driver."""
+        # Arrange
+        import lyra.bootstrap.factory.unified as unified_mod
+
+        importlib.reload(unified_mod)
+        source = inspect.getsource(unified_mod)
+
+        # Assert
+        assert "build_cli_nats_driver" in source, (
+            "unified.py does not reference build_cli_nats_driver — "
+            "T22 should add CliNatsDriver wiring"
+        )
+
+    def test_unified_imports_clipool_nats_worker(self) -> None:
+        """After T22, unified.py must reference CliPoolNatsWorker."""
+        # Arrange
+        import lyra.bootstrap.factory.unified as unified_mod
+
+        importlib.reload(unified_mod)
+        source = inspect.getsource(unified_mod)
+
+        # Assert
+        assert "CliPoolNatsWorker" in source, (
+            "unified.py does not reference CliPoolNatsWorker — "
+            "T22 should spawn it as an asyncio task"
+        )
+
+
+class TestUnifiedCliPoolNatsWorkerInstantiated:
+    @pytest.mark.asyncio
+    async def test_unified_spawns_clipool_worker_task(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After T22, _bootstrap_unified must instantiate CliPoolNatsWorker."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import lyra.bootstrap.factory.unified as unified_mod
+
+        # Track whether CliPoolNatsWorker was ever instantiated
+        instantiated: list[object] = []
+
+        try:
+            import lyra.adapters.clipool.clipool_worker as _clipool_worker_mod
+
+            _ = _clipool_worker_mod.CliPoolNatsWorker
+        except (ImportError, AttributeError):
+            pytest.skip("CliPoolNatsWorker not importable — dependency missing")
+
+        worker_mock = MagicMock()
+        worker_mock.run = AsyncMock()
+        worker_mock.run_embedded = AsyncMock()
+
+        def track_instantiation(*args, **kwargs):
+            inst = MagicMock()
+            inst.run = AsyncMock()
+            inst.run_embedded = AsyncMock()
+            instantiated.append(inst)
+            return inst
+
+        # Patch at the module boundary where unified.py resolves the class
+        with patch.object(
+            unified_mod,
+            "CliPoolNatsWorker",
+            side_effect=track_instantiation,
+            create=True,
+        ):
+            # We do NOT call _bootstrap_unified (too heavy) —
+            # instead verify the source contract via inspection.
+            source = inspect.getsource(unified_mod)
+
+        # Assert — post-T22 the class is referenced in source
+        assert "CliPoolNatsWorker" in source, (
+            "CliPoolNatsWorker never referenced in unified.py — T22 must add it"
+        )
+
+
+class TestUnifiedWorkerTaskCreated:
+    def test_unified_uses_create_task_for_worker(self) -> None:
+        """After T22, unified.py must use asyncio.create_task for the worker."""
+        # Arrange
+        import lyra.bootstrap.factory.unified as unified_mod
+
+        importlib.reload(unified_mod)
+        source = inspect.getsource(unified_mod)
+
+        # Assert — T22 must wire the worker via create_task so it runs concurrently
+        assert "create_task" in source, (
+            "unified.py does not call asyncio.create_task — "
+            "T22 should schedule CliPoolNatsWorker via asyncio.create_task"
+        )

--- a/tests/llm/drivers/test_cli_nats_driver.py
+++ b/tests/llm/drivers/test_cli_nats_driver.py
@@ -185,6 +185,35 @@ class TestStream:
         assert result_events[0].is_error is False
 
     @pytest.mark.asyncio
+    async def test_stream_yields_synthetic_result_on_done_non_result_chunk(
+        self,
+    ) -> None:
+        """done=True on a text chunk: text event + synthetic ResultLlmEvent emitted."""
+        # Arrange
+        driver = _make_driver()
+        chunks = [{"event_type": "text", "text": "hello", "done": True}]
+        events = []
+
+        async def _mock_stream_gen(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> AsyncIterator[dict]:
+            for c in chunks:
+                yield c
+
+        # Act
+        with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+            async for ev in await driver.stream(
+                "pool-1", "hi", _make_model_cfg(), "sys"
+            ):
+                events.append(ev)
+
+        # Assert
+        assert len(events) == 2
+        assert isinstance(events[0], TextLlmEvent)
+        assert isinstance(events[1], ResultLlmEvent)
+        assert events[1].is_error is False
+
+    @pytest.mark.asyncio
     async def test_stream_calls_stream_gen_with_subject_cmd(self) -> None:
         """stream() delegates to _stream_gen using SUBJECT_CMD."""
         # Arrange
@@ -234,6 +263,47 @@ class TestComplete:
         assert isinstance(result, LlmResult)
         assert result.ok is True
         assert result.result == "answer"
+
+    @pytest.mark.asyncio
+    async def test_complete_transport_exception_returns_retryable_error(
+        self,
+    ) -> None:
+        """Transport exception from _request → LlmResult(retryable=True)."""
+        # Arrange
+        driver = _make_driver()
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            raise Exception("NATS connection lost")
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            result = await driver.complete("pool-1", "hello", _make_model_cfg(), "sys")
+
+        # Assert
+        assert result.ok is False
+        assert "NATS" in result.error
+        assert result.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_complete_worker_error_retryable_false(self) -> None:
+        """Worker reply with error + retryable=False → LlmResult.retryable is False."""
+        # Arrange
+        driver = _make_driver()
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            return {"error": "quota exhausted", "retryable": False}
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            result = await driver.complete("pool-1", "hello", _make_model_cfg(), "sys")
+
+        # Assert
+        assert result.ok is False
+        assert result.retryable is False
 
     @pytest.mark.asyncio
     async def test_complete_on_error(self) -> None:

--- a/tests/llm/drivers/test_cli_nats_driver.py
+++ b/tests/llm/drivers/test_cli_nats_driver.py
@@ -1,0 +1,470 @@
+"""RED-phase tests for CliNatsDriver (issue #941).
+
+CliNatsDriver does not exist yet — all tests are expected to fail with
+ImportError until the implementation lands in T15.
+
+Covers:
+- stream(): yields TextLlmEvent per text chunk, terminates on result chunk
+- stream(): propagates is_error from result chunk
+- complete(): returns LlmResult on success
+- complete(): returns LlmResult with error on worker error
+- reset(): dispatches control op with correct payload
+- resume_and_reset(): returns ack["resumed"]
+- switch_cwd(): dispatches control op with cwd as string
+- is_alive(): checks nc.is_connected + _any_worker_alive
+- link_lyra_session(): callable without raising
+- Class-level constants: HB_SUBJECT, SUBJECT_CMD, SUBJECT_CONTROL
+
+AAA structure throughout.
+asyncio_mode = "auto" is configured project-wide in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lyra.core.agent.agent_config import ModelConfig
+from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
+from lyra.llm.base import LlmResult
+
+# RED phase — ImportError expected until T15 lands
+from lyra.llm.drivers.cli_nats import CliNatsDriver  # type: ignore[import]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_nc(*, is_connected: bool = True) -> MagicMock:
+    nc = MagicMock()
+    nc.is_connected = is_connected
+    nc.new_inbox = MagicMock(return_value="_INBOX.clipool.test")
+    nc.subscribe = AsyncMock()
+    nc.publish = AsyncMock()
+    nc.request = AsyncMock()
+    return nc
+
+
+def _make_driver(nc: MagicMock | None = None, timeout: float = 5.0) -> CliNatsDriver:
+    if nc is None:
+        nc = _make_nc()
+    return CliNatsDriver(nc=nc, timeout=timeout)
+
+
+def _make_model_cfg() -> ModelConfig:
+    return ModelConfig(backend="cli-nats", model="claude-cli")
+
+
+def _make_reply(data: dict) -> MagicMock:
+    msg = MagicMock()
+    msg.data = json.dumps(data).encode("utf-8")
+    return msg
+
+
+async def _collect_stream(driver: CliNatsDriver, mock_chunks: list[dict]) -> list:
+    """Drive driver.stream() by patching the lower-level _stream_gen."""
+
+    async def _mock_stream_gen(
+        subject: str, payload_dict: dict, *, timeout: float | None = None
+    ) -> AsyncIterator[dict]:
+        for chunk in mock_chunks:
+            yield chunk
+
+    events = []
+    with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+        async for event in await driver.stream(
+            "pool-1", "hello", _make_model_cfg(), "You are helpful."
+        ):
+            events.append(event)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Class-level subject constants are correct."""
+
+    def test_hb_subject_set(self) -> None:
+        # Arrange / Act / Assert
+        assert CliNatsDriver.HB_SUBJECT == "lyra.clipool.heartbeat"
+
+    def test_subject_cmd(self) -> None:
+        assert CliNatsDriver.SUBJECT_CMD == "lyra.clipool.cmd"
+
+    def test_subject_control(self) -> None:
+        assert CliNatsDriver.SUBJECT_CONTROL == "lyra.clipool.control"
+
+
+# ---------------------------------------------------------------------------
+# stream()
+# ---------------------------------------------------------------------------
+
+
+class TestStream:
+    """stream() parses dict chunks from _stream_gen into LlmEvents."""
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_text_events(self) -> None:
+        """Text chunks are converted to TextLlmEvent."""
+        # Arrange
+        driver = _make_driver()
+        chunks = [
+            {"event_type": "text", "text": "hello", "done": False},
+            {"event_type": "result", "is_error": False, "done": True},
+        ]
+
+        # Act
+        events = await _collect_stream(driver, chunks)
+
+        # Assert
+        text_events = [e for e in events if isinstance(e, TextLlmEvent)]
+        assert len(text_events) == 1
+        assert text_events[0].text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_stream_terminates_on_result(self) -> None:
+        """stream() stops and yields ResultLlmEvent when event_type='result'."""
+        # Arrange
+        driver = _make_driver()
+        chunks = [
+            {"event_type": "text", "text": "part1", "done": False},
+            {"event_type": "result", "is_error": False, "done": True},
+            # This extra chunk must never be reached
+            {"event_type": "text", "text": "unreachable", "done": False},
+        ]
+
+        # Act
+        events = await _collect_stream(driver, chunks)
+
+        # Assert — ResultLlmEvent is last; no events after it
+        assert isinstance(events[-1], ResultLlmEvent)
+        texts = [e.text for e in events if isinstance(e, TextLlmEvent)]
+        assert "unreachable" not in texts
+
+    @pytest.mark.asyncio
+    async def test_stream_result_is_error(self) -> None:
+        """is_error=True on the result chunk propagates to ResultLlmEvent."""
+        # Arrange
+        driver = _make_driver()
+        chunks = [
+            {"event_type": "result", "is_error": True, "done": True},
+        ]
+
+        # Act
+        events = await _collect_stream(driver, chunks)
+
+        # Assert
+        result_events = [e for e in events if isinstance(e, ResultLlmEvent)]
+        assert len(result_events) == 1
+        assert result_events[0].is_error is True
+
+    @pytest.mark.asyncio
+    async def test_stream_result_not_error_by_default(self) -> None:
+        """is_error=False on the result chunk yields ResultLlmEvent(is_error=False)."""
+        # Arrange
+        driver = _make_driver()
+        chunks = [
+            {"event_type": "result", "is_error": False, "done": True},
+        ]
+
+        # Act
+        events = await _collect_stream(driver, chunks)
+
+        # Assert
+        result_events = [e for e in events if isinstance(e, ResultLlmEvent)]
+        assert len(result_events) == 1
+        assert result_events[0].is_error is False
+
+    @pytest.mark.asyncio
+    async def test_stream_calls_stream_gen_with_subject_cmd(self) -> None:
+        """stream() delegates to _stream_gen using SUBJECT_CMD."""
+        # Arrange
+        driver = _make_driver()
+        called_subjects: list[str] = []
+
+        async def _spy_stream_gen(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> AsyncIterator[dict]:
+            called_subjects.append(subject)
+            yield {"event_type": "result", "is_error": False, "done": True}
+
+        # Act
+        with patch.object(driver, "_stream_gen", new=_spy_stream_gen):
+            async for _ in await driver.stream("p1", "hi", _make_model_cfg(), "sys"):
+                pass
+
+        # Assert
+        assert len(called_subjects) == 1
+        assert called_subjects[0] == CliNatsDriver.SUBJECT_CMD
+
+
+# ---------------------------------------------------------------------------
+# complete()
+# ---------------------------------------------------------------------------
+
+
+class TestComplete:
+    """complete() wraps _request and returns an LlmResult."""
+
+    @pytest.mark.asyncio
+    async def test_complete_returns_llm_result(self) -> None:
+        """Successful reply is mapped to LlmResult with result text."""
+        # Arrange
+        nc = _make_nc()
+        driver = _make_driver(nc)
+        nc.request = AsyncMock(
+            return_value=_make_reply(
+                {"result": "answer", "session_id": "sid-1", "error": ""}
+            )
+        )
+
+        # Act
+        result = await driver.complete("pool-1", "query", _make_model_cfg(), "sys")
+
+        # Assert
+        assert isinstance(result, LlmResult)
+        assert result.ok is True
+        assert result.result == "answer"
+
+    @pytest.mark.asyncio
+    async def test_complete_on_error(self) -> None:
+        """Worker error in reply yields LlmResult with ok=False."""
+        # Arrange
+        nc = _make_nc()
+        driver = _make_driver(nc)
+        nc.request = AsyncMock(
+            return_value=_make_reply(
+                {"result": "", "session_id": "", "error": "timeout"}
+            )
+        )
+
+        # Act
+        result = await driver.complete("pool-1", "query", _make_model_cfg(), "sys")
+
+        # Assert
+        assert result.ok is False
+        assert result.error != ""
+
+
+# ---------------------------------------------------------------------------
+# reset()
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    """reset() dispatches a control message with op='reset'."""
+
+    @pytest.mark.asyncio
+    async def test_reset_publishes_control_cmd(self) -> None:
+        """reset() calls _request on SUBJECT_CONTROL with op='reset' and pool_id."""
+        # Arrange
+        driver = _make_driver()
+        captured: list[tuple[str, dict]] = []
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            captured.append((subject, payload_dict))
+            return {"ok": True}
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            await driver.reset("pool-42")
+
+        # Assert
+        assert len(captured) == 1
+        subject, payload = captured[0]
+        assert subject == CliNatsDriver.SUBJECT_CONTROL
+        assert payload.get("op") == "reset"
+        assert payload.get("pool_id") == "pool-42"
+
+
+# ---------------------------------------------------------------------------
+# resume_and_reset()
+# ---------------------------------------------------------------------------
+
+
+class TestResumeAndReset:
+    """resume_and_reset() returns the value of ack['resumed']."""
+
+    @pytest.mark.asyncio
+    async def test_resume_and_reset_returns_ack_true(self) -> None:
+        """Returns True when ack['resumed'] is True."""
+        # Arrange
+        driver = _make_driver()
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            return {"ok": True, "resumed": True}
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            result = await driver.resume_and_reset("pool-1", "sess-abc")
+
+        # Assert
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_resume_and_reset_returns_ack_false(self) -> None:
+        """Returns False when ack['resumed'] is False."""
+        # Arrange
+        driver = _make_driver()
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            return {"ok": True, "resumed": False}
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            result = await driver.resume_and_reset("pool-1", "sess-abc")
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_resume_and_reset_sends_correct_payload(self) -> None:
+        """resume_and_reset() sends op=resume_and_reset with pool_id and session_id."""
+        # Arrange
+        driver = _make_driver()
+        captured: list[tuple[str, dict]] = []
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            captured.append((subject, payload_dict))
+            return {"ok": True, "resumed": True}
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            await driver.resume_and_reset("pool-1", "sess-xyz")
+
+        # Assert
+        subject, payload = captured[0]
+        assert subject == CliNatsDriver.SUBJECT_CONTROL
+        assert payload.get("op") == "resume_and_reset"
+        assert payload.get("pool_id") == "pool-1"
+        assert payload.get("session_id") == "sess-xyz"
+
+
+# ---------------------------------------------------------------------------
+# switch_cwd()
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchCwd:
+    """switch_cwd() sends cwd as a string via SUBJECT_CONTROL."""
+
+    @pytest.mark.asyncio
+    async def test_switch_cwd_sends_cwd(self) -> None:
+        """switch_cwd() dispatches op='switch_cwd' with cwd as a string."""
+        # Arrange
+        driver = _make_driver()
+        captured: list[tuple[str, dict]] = []
+        cwd = Path("/home/user/project")
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            captured.append((subject, payload_dict))
+            return {"ok": True}
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            await driver.switch_cwd("pool-1", cwd)
+
+        # Assert
+        subject, payload = captured[0]
+        assert subject == CliNatsDriver.SUBJECT_CONTROL
+        assert payload.get("op") == "switch_cwd"
+        assert payload.get("cwd") == str(cwd)
+        assert isinstance(payload.get("cwd"), str)
+
+
+# ---------------------------------------------------------------------------
+# is_alive()
+# ---------------------------------------------------------------------------
+
+
+class TestIsAlive:
+    """is_alive() checks nc.is_connected and _any_worker_alive."""
+
+    def test_is_alive_uses_freshness_threshold(self) -> None:
+        """is_alive() returns True when connected and a fresh worker exists."""
+        # Arrange
+        nc = _make_nc(is_connected=True)
+        driver = _make_driver(nc)
+        # Inject a fresh heartbeat
+        driver._worker_freshness["worker-a"] = time.monotonic()
+
+        # Act
+        result = driver.is_alive("pool-1")
+
+        # Assert
+        assert result is True
+
+    def test_is_alive_false_when_worker_stale(self) -> None:
+        """is_alive() returns False when the worker heartbeat is older than HB_TTL."""
+        # Arrange
+        nc = _make_nc(is_connected=True)
+        driver = _make_driver(nc)
+        driver._worker_freshness["worker-b"] = time.monotonic() - (driver.HB_TTL + 5.0)
+
+        # Act
+        result = driver.is_alive("pool-1")
+
+        # Assert
+        assert result is False
+
+    def test_is_alive_false_when_disconnected(self) -> None:
+        """is_alive() returns False when nc.is_connected is False."""
+        # Arrange
+        nc = _make_nc(is_connected=False)
+        driver = _make_driver(nc)
+        # Even with a fresh worker, disconnected NATS → not alive
+        driver._worker_freshness["worker-c"] = time.monotonic()
+
+        # Act
+        result = driver.is_alive("pool-1")
+
+        # Assert
+        assert result is False
+
+    def test_is_alive_false_when_no_workers(self) -> None:
+        """is_alive() returns False when no workers have sent heartbeats."""
+        # Arrange
+        nc = _make_nc(is_connected=True)
+        driver = _make_driver(nc)
+
+        # Act
+        result = driver.is_alive("pool-1")
+
+        # Assert
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# link_lyra_session()
+# ---------------------------------------------------------------------------
+
+
+class TestLinkLyraSession:
+    """link_lyra_session() is callable without raising."""
+
+    def test_link_lyra_session_does_not_raise(self) -> None:
+        """link_lyra_session() is a no-op or state mutation — must not raise."""
+        # Arrange
+        driver = _make_driver()
+
+        # Act / Assert
+        driver.link_lyra_session("pool-1", "lyra-session-abc")

--- a/tests/nats/test_hub_standalone.py
+++ b/tests/nats/test_hub_standalone.py
@@ -77,20 +77,22 @@ class TestLockfileLifecycle:
     def test_lockfile_blocks_second_instance(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """_acquire_lockfile exits when the lockfile holds a live PID."""
-        # Arrange — write our own PID (we are alive)
+        """_acquire_lockfile exits when the lockfile holds a live foreign PID."""
+        # Use parent PID — alive but not os.getpid(), so it hits the "already
+        # running" branch rather than the container-restart overwrite path
+        # (added in fix(lockfile): handle stale PID-1 lock on container OOM-kill).
+        live_foreign_pid = os.getppid()
         monkeypatch.setenv("LYRA_VAULT_DIR", str(tmp_path))
         lockfile = tmp_path.resolve() / "hub.lock"
-        lockfile.write_text(str(os.getpid()))
+        lockfile.write_text(str(live_foreign_pid))
 
         # Act / Assert — should sys.exit because PID is alive
         with pytest.raises(SystemExit) as exc_info:
             _acquire_lockfile()
 
         assert exc_info.value.code is not None
-        # Message should mention the PID and lockfile path
         message = str(exc_info.value.code)
-        assert str(os.getpid()) in message or "already running" in message
+        assert str(live_foreign_pid) in message or "already running" in message
 
     def test_lockfile_overwrites_stale_pid(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -3,3 +3,4 @@
 # Format: <path>  # <lines> lines — <issue> <description>
 src/lyra/core/pool/pool.py  # 326 lines — #858 backward-compat param overrides
 src/lyra/core/commands/command_router.py  # 303 lines — #858 backward-compat param overrides
+src/lyra/bootstrap/factory/unified.py  # 320 lines — #941 CliPool NATS extraction adds worker task wiring

--- a/uv.lock
+++ b/uv.lock
@@ -1294,7 +1294,7 @@ wheels = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/roxabi-contracts" }
 dependencies = [
     { name = "pydantic" },
@@ -1318,7 +1318,7 @@ provides-extras = ["testing"]
 
 [[package]]
 name = "roxabi-nats"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/roxabi-nats" }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary

- Extracts `CliPool` (Claude Code subprocess pool) out of `lyra-hub` into a new **`lyra-clipool`** container, connected over NATS request-reply (`lyra.clipool.cmd / .control / .heartbeat`)
- Adds `NatsDriverBase` to `roxabi-nats` (hub-side heartbeat tracking + stream/request helpers) and `CliCmdPayload / CliChunkEvent / CliControlCmd / CliControlAck / CliHeartbeat` models to `roxabi-contracts/cli/`
- Replaces in-process `ClaudeCliDriver` with `CliNatsDriver` in the hub; `CliPoolNatsWorker` runs in the new container
- Moves all `~/.claude/` volume mounts and `LYRA_CLAUDE_CWD` from `lyra-hub.container` to `lyra-clipool.container` (security boundary enforced at process level)
- Unified single-process mode (`lyra start`) embeds `CliPoolNatsWorker` as a background asyncio task via `run_embedded(nc)`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #941: Extract CliPool into dedicated container with NATS protocol | Open |
| Analysis | [941-extract-clipool-dedicated-container-nats-analysis.mdx](artifacts/analyses/941-extract-clipool-dedicated-container-nats-analysis.mdx) | Present |
| Spec | [941-extract-clipool-dedicated-container-nats-spec.mdx](artifacts/specs/941-extract-clipool-dedicated-container-nats-spec.mdx) | Present |
| Implementation | 12 commits on `feat/941-extract-clipool-dedicated-container-nats` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3176 passed, +1015 new test lines) | Passed |

## Test Plan

- [ ] `uv run pytest` passes (3176 passed, 0 failed)
- [ ] `uv run pyright` reports 0 errors
- [ ] `lyra adapter clipool` starts the worker process and subscribes to NATS subjects
- [ ] `lyra hub` boots without CliPool; `is_alive()` returns True once clipool heartbeats arrive
- [ ] `lyra start` (unified) embeds the clipool worker as a background task alongside the hub
- [ ] `lyra-clipool.container` Quadlet unit starts in Podman and registers with NATS using `clipool-worker` nkey
- [ ] `lyra-hub.container` no longer mounts `~/.claude/` (verify with `podman inspect lyra-hub`)
- [ ] Streaming and blocking CLI requests work end-to-end through the NATS boundary
- [ ] Control ops (`reset`, `resume_and_reset`, `switch_cwd`) round-trip correctly

Closes #941

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`