### PR TITLE
fix(nats): CI lint, drift detection, and ops improvements (closes #951, #952, #953, #954)

### DIFF
--- a/src/lyra/adapters/clipool/clipool_worker.py
+++ b/src/lyra/adapters/clipool/clipool_worker.py
@@ -13,6 +13,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from pydantic import ValidationError
+
 from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.cli.cli_pool import CliPool
 from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
@@ -123,7 +125,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
     async def _handle_cmd(self, msg: Any, payload: dict) -> None:
         try:
             cmd = CliCmdPayload.model_validate(payload)
-        except Exception:
+        except ValidationError:
             log.exception("clipool_worker: failed to parse CliCmdPayload")
             await self.reply(
                 msg, _make_chunk("", event_type="error", is_error=True, done=True)
@@ -147,7 +149,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
                 model_cfg,
                 cmd.system_prompt,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 - external boundary: catch all to ensure error reply
             log.exception(
                 "clipool_worker: send_streaming failed for pool_id=%r", cmd.pool_id
             )
@@ -198,7 +200,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
                 model_cfg,
                 cmd.system_prompt,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 - external boundary: catch all to ensure error reply
             log.exception("clipool_worker: send failed for pool_id=%r", cmd.pool_id)
             await self.reply(
                 msg,
@@ -227,14 +229,14 @@ class CliPoolNatsWorker(NatsAdapterBase):
     async def _handle_control(self, msg: Any, payload: dict) -> None:
         try:
             cmd = CliControlCmd.model_validate(payload)
-        except Exception:
+        except ValidationError:
             log.exception("clipool_worker: failed to parse CliControlCmd")
             await self.reply(msg, _make_ack("", ok=False))
             return
 
         try:
             ack_bytes = await self._dispatch_control(cmd)
-        except Exception:
+        except Exception:  # noqa: BLE001 - external boundary: catch all to ensure error ack
             log.exception(
                 "clipool_worker: control op %r failed for pool_id=%r",
                 cmd.op,

--- a/src/lyra/bootstrap/factory/wiring_helpers.py
+++ b/src/lyra/bootstrap/factory/wiring_helpers.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -137,7 +136,7 @@ async def _init_bot_auths_and_agents(
     try:
         tg_multi_cfg, dc_multi_cfg = load_multibot_config(raw_config)
     except ValueError as exc:
-        sys.exit(str(exc))
+        raise SystemExit(str(exc))
 
     tg_bot_auths, dc_bot_auths = _build_bot_auths(
         raw_config,
@@ -153,7 +152,7 @@ async def _init_bot_auths_and_agents(
     )
 
     if not tg_bot_auths and not dc_bot_auths:
-        sys.exit(
+        raise SystemExit(
             "No adapters configured — add at least one"
             " [[telegram.bots]] or [[discord.bots]] entry with"
             " a matching [[auth.telegram_bots]] or"
@@ -177,7 +176,7 @@ async def _init_bot_auths_and_agents(
         else:
             log.error("Agent %r not found in DB — skipping", n)
     if not agent_configs:
-        sys.exit(
+        raise SystemExit(
             "No agent configs could be loaded — run"
             " 'lyra agent init' to seed the agents table"
         )

--- a/src/lyra/core/pool/pool.py
+++ b/src/lyra/core/pool/pool.py
@@ -253,12 +253,13 @@ class Pool:
             if self._on_resume_fn is not None:
                 try:
                     await self._on_resume_fn(session_id)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     log.exception(
                         "[pool:%s] resume count increment failed for %r",
                         self.pool_id,
                         session_id,
                     )
+                    accepted = False
         return accepted
 
     def _msg(self, key: str, fallback: str) -> str:
@@ -276,7 +277,7 @@ class Pool:
                 await self._observer._turn_store.start_session(
                     self.session_id, self.pool_id
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.exception("[pool:%s] start_session failed", self.pool_id)
         self._observer.reset_session_persisted()
         if self._session_reset_fn is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,7 +370,7 @@ def patch_all(
         stores_mod, "CredentialStore", lambda **kwargs: _fake_cred_store
     )
     monkeypatch.setattr(
-        unified_mod,
+        wiring_helpers_mod,
         "agent_row_to_config",
         lambda row, **kw: Agent(
             name=row.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 import lyra.__main__ as main_mod
 import lyra.bootstrap.bootstrap_stores as stores_mod
+import lyra.bootstrap.factory.agent_factory as agent_factory_mod
 import lyra.bootstrap.factory.unified as unified_mod
 import lyra.bootstrap.factory.wiring_helpers as wiring_helpers_mod
 import lyra.bootstrap.wiring.bootstrap_wiring as wiring_mod
@@ -309,7 +310,7 @@ def patch_all(
             super().__init__(**kwargs)
             captured.append(self)
 
-    monkeypatch.setattr(unified_mod, "Hub", CapturingHub)
+    monkeypatch.setattr(wiring_helpers_mod, "Hub", CapturingHub)
 
     class CapturingDcAdapter(_FakeDcAdapter):
         def __init__(self, **kwargs: object) -> None:
@@ -405,7 +406,7 @@ def patch_auth_config_test(monkeypatch: pytest.MonkeyPatch) -> None:
     _fake_agent_store.set_bot_agent = AsyncMock()
     monkeypatch.setattr(stores_mod, "AgentStore", lambda **kwargs: _fake_agent_store)
     monkeypatch.setattr(
-        unified_mod,
+        agent_factory_mod,
         "_resolve_bot_agent_map",
         AsyncMock(return_value={("telegram", "main"): "lyra_default"}),
     )

--- a/tests/nats/test_hub_standalone.py
+++ b/tests/nats/test_hub_standalone.py
@@ -4,7 +4,7 @@ Covers:
 - NATS_URL guard (SystemExit when env var missing)
 - Lockfile lifecycle (acquire / release / stale PID / live PID block)
 - Health endpoint basic response (no NATS required)
-- inbox_prefix kwarg passed to nats_connect (ADR-051, #715)
+- identity_name kwarg passed to nats_connect (ADR-051, #715)
 """
 
 from __future__ import annotations
@@ -388,15 +388,15 @@ class TestStandaloneHubPipeline:
 
 
 # ---------------------------------------------------------------------------
-# T4 — hub_standalone passes inbox_prefix to nats_connect (ADR-051, #715)
+# T4 — hub_standalone passes identity_name to nats_connect (ADR-051, #715)
 # ---------------------------------------------------------------------------
 
 
-class TestHubStandaloneInboxPrefix:
-    async def test_bootstrap_hub_standalone_passes_inbox_prefix(
+class TestHubStandaloneIdentityName:
+    async def test_bootstrap_hub_standalone_passes_identity_name(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Bootstrap calls nats_connect with inbox_prefix='_INBOX.hub' (ADR-051)."""
+        """Bootstrap calls nats_connect with identity_name='hub' (ADR-051)."""
         # Arrange
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         raw_config = _test_config()
@@ -436,34 +436,34 @@ class TestHubStandaloneInboxPrefix:
             with pytest.raises(SystemExit, match="test-sentinel"):
                 await _bootstrap_hub_standalone(raw_config)
 
-        # Assert — nats_connect called once with the hub inbox prefix
+        # Assert — nats_connect called once with the hub identity_name
         mock_nats_connect.assert_awaited_once()
         call_kwargs = mock_nats_connect.call_args.kwargs
-        assert call_kwargs.get("inbox_prefix") == "_INBOX.hub", (
-            f"Expected inbox_prefix='_INBOX.hub', got {call_kwargs!r}"
+        assert call_kwargs.get("identity_name") == "hub", (
+            f"Expected identity_name='hub', got {call_kwargs!r}"
         )
 
 
 # ---------------------------------------------------------------------------
-# T10b — adapter_standalone passes platform inbox_prefix (ADR-051, #715)
+# T10b — adapter_standalone passes platform identity_name (ADR-051, #715)
 # ---------------------------------------------------------------------------
 
 
-class TestAdapterStandaloneInboxPrefix:
+class TestAdapterStandaloneIdentityName:
     @pytest.mark.parametrize(
-        ("platform", "expected_prefix"),
+        ("platform", "expected_identity"),
         [
-            ("telegram", "_INBOX.telegram-adapter"),
-            ("discord", "_INBOX.discord-adapter"),
+            ("telegram", "telegram-adapter"),
+            ("discord", "discord-adapter"),
         ],
     )
-    async def test_bootstrap_adapter_standalone_passes_platform_inbox_prefix(
+    async def test_bootstrap_adapter_standalone_passes_platform_identity_name(
         self,
         monkeypatch: pytest.MonkeyPatch,
         platform: str,
-        expected_prefix: str,
+        expected_identity: str,
     ) -> None:
-        """Adapter bootstrap passes per-platform inbox_prefix (ADR-051)."""
+        """Adapter bootstrap passes per-platform identity_name (ADR-051)."""
         # Arrange
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         raw_config = _test_config()
@@ -499,11 +499,11 @@ class TestAdapterStandaloneInboxPrefix:
             with pytest.raises(SystemExit, match="test-sentinel"):
                 await _bootstrap_adapter_standalone(raw_config, platform)
 
-        # Assert — nats_connect called with platform-derived inbox prefix
+        # Assert — nats_connect called with platform-derived identity_name
         mock_nats_connect.assert_awaited_once()
         call_kwargs = mock_nats_connect.call_args.kwargs
-        assert call_kwargs.get("inbox_prefix") == expected_prefix, (
-            f"platform={platform!r}: expected inbox_prefix={expected_prefix!r},"
+        assert call_kwargs.get("identity_name") == expected_identity, (
+            f"platform={platform!r}: expected identity_name={expected_identity!r},"
             f" got {call_kwargs!r}"
         )
 

--- a/tests/test_main_auth.py
+++ b/tests/test_main_auth.py
@@ -9,7 +9,7 @@ import pytest
 
 import lyra.__main__ as main_mod
 import lyra.bootstrap.factory.agent_factory as agent_factory_mod
-import lyra.bootstrap.factory.unified as unified_mod
+import lyra.bootstrap.factory.wiring_helpers as wiring_helpers_mod
 from lyra.core.agent import Agent
 from lyra.core.agent.agent_config import ModelConfig
 from tests.conftest import patch_auth_config_test
@@ -109,7 +109,7 @@ class TestAuthConfig:
         )
         # Sentinel: if we reach agent_row_to_config, auth validation passed.
         monkeypatch.setattr(
-            unified_mod,
+            wiring_helpers_mod,
             "agent_row_to_config",
             lambda row, **kw: (_ for _ in ()).throw(SystemExit("past_auth")),
         )


### PR DESCRIPTION
## Summary
- Fix gen-nkeys.sh reload hint to use `nats-server --signal reload` instead of systemctl
- Add Makefile target `nats-regen-authconf` that git-pulls first
- Add CI drift detection between acl-matrix.json and auth.conf
- Add CI lint for raw `_INBOX.{name}` string construction

## Issues
- Closes #951 — correct reload hint
- Closes #952 — CI drift detection
- Closes #953 — Makefile target
- Closes #954 — inbox_prefix lint

## Remaining (ops actions)
- #948 — Run gen-nkeys.sh on M₁ to converge auth.conf (ops, not code)
- #955 — Automate post-merge auth.conf regen (depends on #948)

🤖 Generated with [Claude Code](https://claude.com/claude-code)