### PR TITLE
refactor(nats): make PLATFORM_META_ALLOWLIST injectable in sanitize_platform_meta

### DIFF
--- a/packages/roxabi-nats/src/roxabi_nats/_sanitize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_sanitize.py
@@ -40,11 +40,15 @@ def _cap_value(val: str | int | bool) -> str | int | bool:
     return val
 
 
-def sanitize_platform_meta(meta: dict[str, Any]) -> dict[str, Any]:
+def sanitize_platform_meta(
+    meta: dict[str, Any],
+    *,
+    allowlist: frozenset[str] | None = None,
+) -> dict[str, Any]:
     """Filter platform_meta to allowlisted keys and safe scalar values.
 
     Strips:
-    - Keys not in PLATFORM_META_ALLOWLIST
+    - Keys not in the allowlist (defaults to ``PLATFORM_META_ALLOWLIST``)
     - Keys with leading underscore (internal-only, e.g. _session_update_fn)
     - Values that are not scalar (``str | int | bool``) — avoids the
       ``str({deep dict})`` memory-amplification path since the only
@@ -55,15 +59,19 @@ def sanitize_platform_meta(meta: dict[str, Any]) -> dict[str, Any]:
 
     Stripped keys and dropped values are logged at DEBUG (key names only,
     never value content — avoids log-amplification from crafted messages).
+
+    Pass ``allowlist`` to inject a platform-specific set instead of the
+    hardcoded default (e.g. sourced from roxabi-contracts at call time).
     """
+    active_allowlist = allowlist if allowlist is not None else PLATFORM_META_ALLOWLIST
     stripped = [
-        k for k in meta if k not in PLATFORM_META_ALLOWLIST or k.startswith("_")
+        k for k in meta if k not in active_allowlist or k.startswith("_")
     ]
     if stripped:
         log.debug("platform_meta: stripped keys %s", stripped)
     result: dict[str, Any] = {}
     for k, v in meta.items():
-        if k not in PLATFORM_META_ALLOWLIST or k.startswith("_"):
+        if k not in active_allowlist or k.startswith("_"):
             continue
         if not isinstance(v, (str, int, bool)):
             log.debug(

--- a/packages/roxabi-nats/src/roxabi_nats/_sanitize.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_sanitize.py
@@ -63,6 +63,7 @@ def sanitize_platform_meta(
     Pass ``allowlist`` to inject a platform-specific set instead of the
     hardcoded default (e.g. sourced from roxabi-contracts at call time).
     """
+    # empty frozenset is valid (block-all); only None falls back to default
     active_allowlist = allowlist if allowlist is not None else PLATFORM_META_ALLOWLIST
     stripped = [
         k for k in meta if k not in active_allowlist or k.startswith("_")

--- a/packages/roxabi-nats/tests/test_sanitize.py
+++ b/packages/roxabi-nats/tests/test_sanitize.py
@@ -102,10 +102,13 @@ class TestEmptyAndAllowlistShape:
 
 class TestInjectableAllowlist:
     def test_custom_allowlist_used_when_provided(self) -> None:
-        custom = frozenset({"custom_field", "other_field"})
-        meta = {"custom_field": "keep", "guild_id": "strip", "other_field": 1}
+        # "custom_only" is NOT on PLATFORM_META_ALLOWLIST — proves the custom set is
+        # active. "guild_id" IS on PLATFORM_META_ALLOWLIST — proves the default is not.
+        custom = frozenset({"custom_only", "other_field"})
+        meta = {"custom_only": "keep", "guild_id": "default-only", "other_field": 1}
         result = sanitize_platform_meta(meta, allowlist=custom)
-        assert result == {"custom_field": "keep", "other_field": 1}
+        assert result == {"custom_only": "keep", "other_field": 1}
+        assert "guild_id" not in result
 
     def test_default_allowlist_used_when_none(self) -> None:
         meta = {"guild_id": "123", "unknown": "x"}
@@ -116,7 +119,15 @@ class TestInjectableAllowlist:
         assert sanitize_platform_meta(meta, allowlist=frozenset()) == {}
 
     def test_underscore_keys_still_stripped_with_custom_allowlist(self) -> None:
-        custom = frozenset({"custom_field"})
+        # "_custom_field" IS in custom — the only operative filter is the underscore
+        # guard; if that guard were removed the key would pass through.
+        custom = frozenset({"custom_field", "_custom_field"})
         meta = {"custom_field": "ok", "_custom_field": "injected"}
         result = sanitize_platform_meta(meta, allowlist=custom)
         assert result == {"custom_field": "ok"}
+        assert "_custom_field" not in result
+
+    def test_non_scalar_dropped_with_custom_allowlist(self) -> None:
+        custom = frozenset({"custom_field"})
+        meta = {"custom_field": [1, 2, 3]}
+        assert sanitize_platform_meta(meta, allowlist=custom) == {}

--- a/packages/roxabi-nats/tests/test_sanitize.py
+++ b/packages/roxabi-nats/tests/test_sanitize.py
@@ -98,3 +98,25 @@ class TestEmptyAndAllowlistShape:
 
     def test_allowlist_is_immutable(self) -> None:
         assert isinstance(PLATFORM_META_ALLOWLIST, frozenset)
+
+
+class TestInjectableAllowlist:
+    def test_custom_allowlist_used_when_provided(self) -> None:
+        custom = frozenset({"custom_field", "other_field"})
+        meta = {"custom_field": "keep", "guild_id": "strip", "other_field": 1}
+        result = sanitize_platform_meta(meta, allowlist=custom)
+        assert result == {"custom_field": "keep", "other_field": 1}
+
+    def test_default_allowlist_used_when_none(self) -> None:
+        meta = {"guild_id": "123", "unknown": "x"}
+        assert sanitize_platform_meta(meta, allowlist=None) == {"guild_id": "123"}
+
+    def test_empty_custom_allowlist_strips_everything(self) -> None:
+        meta = {"guild_id": "123", "chat_id": 42}
+        assert sanitize_platform_meta(meta, allowlist=frozenset()) == {}
+
+    def test_underscore_keys_still_stripped_with_custom_allowlist(self) -> None:
+        custom = frozenset({"custom_field"})
+        meta = {"custom_field": "ok", "_custom_field": "injected"}
+        result = sanitize_platform_meta(meta, allowlist=custom)
+        assert result == {"custom_field": "ok"}


### PR DESCRIPTION
## Summary
- Add optional keyword-only `allowlist` parameter to `sanitize_platform_meta` so callers can inject a platform-specific set instead of relying on the hardcoded default
- Default behaviour is unchanged — `None` falls back to `PLATFORM_META_ALLOWLIST`, preserving full backward compatibility
- Add `TestInjectableAllowlist` class (4 tests) covering custom allowlist, `None` fallback, empty allowlist, and underscore-strip invariant

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #961: refactor(nats): make PLATFORM_META_ALLOWLIST injectable in _sanitize.py (ADR-059 shared V3) | Open |
| Implementation | 1 commit on `feat/961-platform-meta-allowlist-injectable` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new) | Passed |

## Test Plan
- [ ] `cd packages/roxabi-nats && uv run pytest tests/test_sanitize.py -v` — 18 tests pass
- [ ] Existing callers unaffected (signature is backward compatible via keyword-only optional param)
- [ ] Inject a custom `frozenset` and verify only those keys survive

Closes #961

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`