### PR TITLE
refactor(nats): move TTS constants to roxabi-contracts (ADR-059)

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/__init__.py
@@ -10,6 +10,10 @@ from roxabi_contracts.voice.builders import (
     build_stt_response,
     build_tts_response,
 )
+from roxabi_contracts.voice.constants import (
+    AGENT_TTS_FIELDS,
+    TTS_CONFIG_FIELDS,
+)
 from roxabi_contracts.voice.models import (
     SttRequest,
     SttResponse,
@@ -24,7 +28,9 @@ from roxabi_contracts.voice.subjects import (
 )
 
 __all__ = [
+    "AGENT_TTS_FIELDS",
     "SUBJECTS",
+    "TTS_CONFIG_FIELDS",
     "SttRequest",
     "SttResponse",
     "TtsRequest",

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/constants.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/constants.py
@@ -1,0 +1,33 @@
+"""TTS field constants shared across the hub/adapter boundary."""
+
+# Hub side — serialised by NatsTtsClient.synthesize()
+TTS_CONFIG_FIELDS: tuple[str, ...] = (
+    "engine",
+    "accent",
+    "personality",
+    "speed",
+    "emotion",
+    "exaggeration",
+    "cfg_weight",
+    "segment_gap",
+    "crossfade",
+    "chunk_size",
+)
+
+# Adapter side — deserialised by TtsAdapterStandalone.handle()
+AGENT_TTS_FIELDS: tuple[str, ...] = (
+    "engine",
+    "voice",
+    "language",
+    "accent",
+    "personality",
+    "speed",
+    "emotion",
+    "exaggeration",
+    "cfg_weight",
+    "segment_gap",
+    "crossfade",
+    "chunk_size",
+    "default_language",
+    "languages",
+)

--- a/packages/roxabi-contracts/tests/test_voice_constants.py
+++ b/packages/roxabi-contracts/tests/test_voice_constants.py
@@ -1,0 +1,44 @@
+"""Smoke tests for TTS field constants in roxabi_contracts.voice.constants."""
+
+from __future__ import annotations
+
+from roxabi_contracts.voice.constants import AGENT_TTS_FIELDS, TTS_CONFIG_FIELDS
+
+
+class TestShape:
+    def test_config_fields_is_tuple_of_strings(self) -> None:
+        assert isinstance(TTS_CONFIG_FIELDS, tuple)
+        assert TTS_CONFIG_FIELDS
+        assert all(isinstance(f, str) for f in TTS_CONFIG_FIELDS)
+
+    def test_agent_fields_is_tuple_of_strings(self) -> None:
+        assert isinstance(AGENT_TTS_FIELDS, tuple)
+        assert AGENT_TTS_FIELDS
+        assert all(isinstance(f, str) for f in AGENT_TTS_FIELDS)
+
+    def test_no_duplicate_fields_within_each_tuple(self) -> None:
+        assert len(TTS_CONFIG_FIELDS) == len(set(TTS_CONFIG_FIELDS))
+        assert len(AGENT_TTS_FIELDS) == len(set(AGENT_TTS_FIELDS))
+
+
+class TestBoundaryContract:
+    def test_engine_is_in_both_tuples(self) -> None:
+        # engine is the routing key between hub and adapter — must exist
+        # on both sides of the boundary.
+        assert "engine" in TTS_CONFIG_FIELDS
+        assert "engine" in AGENT_TTS_FIELDS
+
+    def test_hub_subset_is_carried_in_agent(self) -> None:
+        # Every field the hub sends must be receivable on the adapter side.
+        # (voice and language are passed as explicit kwargs, hence absent
+        # from the hub tuple but present on the adapter side.)
+        hub_shared = set(TTS_CONFIG_FIELDS)
+        agent_shared = set(AGENT_TTS_FIELDS)
+        assert hub_shared.issubset(agent_shared)
+
+    def test_agent_only_fields_are_kwargs_or_defaults(self) -> None:
+        # Fields on the adapter that are not in the hub tuple must be ones
+        # the adapter reads from defaults or explicit kwargs — document the
+        # known set so accidental additions fail this test and force a review.
+        agent_only = set(AGENT_TTS_FIELDS) - set(TTS_CONFIG_FIELDS)
+        assert agent_only == {"voice", "language", "default_language", "languages"}

--- a/packages/roxabi-nats/src/roxabi_nats/_tts_constants.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_tts_constants.py
@@ -1,10 +1,8 @@
 """Backward-compat shim — constants live in roxabi_contracts.voice.constants."""
 
 from roxabi_contracts.voice.constants import (
-    AGENT_TTS_FIELDS as _AGENT_TTS_FIELDS,
+    AGENT_TTS_FIELDS as _AGENT_TTS_FIELDS,  # noqa: F401  # pyright: ignore[reportUnusedImport]
 )
 from roxabi_contracts.voice.constants import (
-    TTS_CONFIG_FIELDS as _TTS_CONFIG_FIELDS,
+    TTS_CONFIG_FIELDS as _TTS_CONFIG_FIELDS,  # noqa: F401  # pyright: ignore[reportUnusedImport]
 )
-
-__all__ = ["_AGENT_TTS_FIELDS", "_TTS_CONFIG_FIELDS"]

--- a/packages/roxabi-nats/src/roxabi_nats/_tts_constants.py
+++ b/packages/roxabi-nats/src/roxabi_nats/_tts_constants.py
@@ -1,44 +1,10 @@
-"""Shared TTS field constants for the NATS request/response boundary.
+"""Backward-compat shim — constants live in roxabi_contracts.voice.constants."""
 
-Two separate tuples because each side of the boundary has different needs:
-- ``_TTS_CONFIG_FIELDS`` — fields NatsTtsClient serializes from AgentTTSConfig
-  into the outgoing request. voice/language are passed as explicit keyword
-  arguments to synthesize(); default_language/languages are not forwarded.
-- ``_AGENT_TTS_FIELDS`` — fields TtsAdapterStandalone reads back from the
-  request payload into a lightweight _NatsTtsConfig stand-in.
-
-Both are defined here so that additions to AgentTTSConfig only require a
-single-file update.
-"""
-
-# Hub side — serialised by NatsTtsClient.synthesize()
-_TTS_CONFIG_FIELDS: tuple[str, ...] = (
-    "engine",
-    "accent",
-    "personality",
-    "speed",
-    "emotion",
-    "exaggeration",
-    "cfg_weight",
-    "segment_gap",
-    "crossfade",
-    "chunk_size",
+from roxabi_contracts.voice.constants import (
+    AGENT_TTS_FIELDS as _AGENT_TTS_FIELDS,
+)
+from roxabi_contracts.voice.constants import (
+    TTS_CONFIG_FIELDS as _TTS_CONFIG_FIELDS,
 )
 
-# Adapter side — deserialised by TtsAdapterStandalone.handle()
-_AGENT_TTS_FIELDS: tuple[str, ...] = (
-    "engine",
-    "voice",
-    "language",
-    "accent",
-    "personality",
-    "speed",
-    "emotion",
-    "exaggeration",
-    "cfg_weight",
-    "segment_gap",
-    "crossfade",
-    "chunk_size",
-    "default_language",
-    "languages",
-)
+__all__ = ["_AGENT_TTS_FIELDS", "_TTS_CONFIG_FIELDS"]

--- a/packages/roxabi-nats/tests/test_tts_constants.py
+++ b/packages/roxabi-nats/tests/test_tts_constants.py
@@ -42,3 +42,16 @@ class TestBoundaryContract:
         # known set so accidental additions fail this test and force a review.
         agent_only = set(_AGENT_TTS_FIELDS) - set(_TTS_CONFIG_FIELDS)
         assert agent_only == {"voice", "language", "default_language", "languages"}
+
+
+class TestShimDelegation:
+    def test_shim_delegates_to_contracts_not_inline_copy(self) -> None:
+        # The shim must re-export the canonical objects from roxabi_contracts,
+        # not define its own copies.  Identity (is) guarantees delegation.
+        from roxabi_contracts.voice.constants import (
+            AGENT_TTS_FIELDS,
+            TTS_CONFIG_FIELDS,
+        )
+
+        assert _TTS_CONFIG_FIELDS is TTS_CONFIG_FIELDS
+        assert _AGENT_TTS_FIELDS is AGENT_TTS_FIELDS

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -29,7 +29,7 @@ from roxabi_contracts.voice import (
     per_worker_tts,
     validate_worker_id,
 )
-from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS
+from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS as _TTS_CONFIG_FIELDS
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 if TYPE_CHECKING:

--- a/src/lyra/nats/nats_tts_client.py
+++ b/src/lyra/nats/nats_tts_client.py
@@ -29,7 +29,7 @@ from roxabi_contracts.voice import (
     per_worker_tts,
     validate_worker_id,
 )
-from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS as _TTS_CONFIG_FIELDS
+from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
 if TYPE_CHECKING:
@@ -235,7 +235,7 @@ class NatsTtsClient:
         }
         if agent_tts is not None:
             # voice/language use caller-override semantics (see below); excluded here
-            for field in _TTS_CONFIG_FIELDS:
+            for field in TTS_CONFIG_FIELDS:
                 val = getattr(agent_tts, field, None)
                 if val is not None:
                     req_kwargs[field] = val

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -10,9 +10,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.core.agent.agent_config import AgentTTSConfig
-from lyra.nats.nats_tts_client import _TTS_CONFIG_FIELDS, NatsTtsClient
+from lyra.nats.nats_tts_client import NatsTtsClient
 from lyra.nats.worker_registry import WorkerStats
 from lyra.tts import TtsUnavailableError
+from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS
 
 
 def _inject_fresh_worker(
@@ -177,7 +178,7 @@ class TestCircuitBreaker:
         # contract_version is always stamped (ADR-044)
         assert request_dict["contract_version"] == "1"
         # All unset fields (None) must be absent from the NATS payload
-        none_fields = [f for f in _TTS_CONFIG_FIELDS if f not in ("engine", "speed")]
+        none_fields = [f for f in TTS_CONFIG_FIELDS if f not in ("engine", "speed")]
         assert all(f not in request_dict for f in none_fields)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Moves `_TTS_CONFIG_FIELDS` / `_AGENT_TTS_FIELDS` from `roxabi-nats._tts_constants` into `roxabi_contracts.voice.constants` as public `TTS_CONFIG_FIELDS` / `AGENT_TTS_FIELDS`
- `roxabi-nats._tts_constants` becomes a backward-compat re-export shim; all existing consumers keep working without changes
- `lyra/nats/nats_tts_client.py` now imports directly from `roxabi_contracts.voice.constants`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #960: refactor(nats): move _tts_constants.py out of roxabi-nats to roxabi-contracts | Open |
| Implementation | 1 commit on `feat/960-move-tts-constants-to-roxabi-contracts` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (42 passing) | Passed |

## Test Plan
- [ ] `uv run pytest packages/roxabi-nats/tests/test_tts_constants.py tests/nats/test_nats_tts_client.py` — 42 tests pass
- [ ] Import `from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS, AGENT_TTS_FIELDS` works
- [ ] `from roxabi_nats._tts_constants import _TTS_CONFIG_FIELDS, _AGENT_TTS_FIELDS` still works (shim)

Closes #960

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`