### PR TITLE
feat(audit): route skip_permissions=True spawns to dedicated NATS subject

### DIFF
--- a/artifacts/analyses/942-feat-audit-skip-permissions-nats-subject-consensus.mdx
+++ b/artifacts/analyses/942-feat-audit-skip-permissions-nats-subject-consensus.mdx
@@ -1,0 +1,61 @@
+---
+title: "PR #979 Q_1b1 Findings — Expert Consensus"
+issue: 942
+status: consensus-reached
+date: 2026-04-27
+panel: architect, backend-dev, product-lead
+confidence: high
+---
+
+## Problem
+
+4 remaining Q_1b1 review findings on PR #979 (feat(audit): skip_permissions subject routing). The 4 high-C blockers were already auto-applied. Should the remaining findings be applied in this PR?
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | arch soundness, maintainability, NATS subject namespace contract |
+| backend-dev | impl complexity, correctness, DRY |
+| product-lead | user/operator impact, P3-low cost/benefit |
+
+## Consensus ρ
+
+**Apply F1 + F2. Skip F3 + F4.**
+
+### Rationale
+
+**F1 (payload assertion, C:75%):** Unanimous Apply. Routing tests only assert subject; payload goes unchecked. `model_dump_json()` + encode is the primary data path — consumers read the payload, not just the subject. 2-line assertion per routing test closes a real regression gap on the exact new code path introduced in this PR.
+
+**F2 (shared prefix constant, C:75%):** 2-1 Apply (product-lead: defer). Architect and backend-dev: the test at line 182 already asserts `startswith("lyra.audit.security.")` — acknowledging the prefix relationship. The source should encode what the test already treats as an invariant. 3-line change, zero runtime cost, makes rename atomic.
+
+**F3 (rename _SUBJECT_NORMAL, C:70%):** Unanimous Skip. "normal" is established domain vocabulary in permission systems. The wire subject value (`lyra.audit.security.normal`) consumed by all NATS subscribers would not change — only the Python constant name. Rename churn > clarity gain on a P3-low PR.
+
+**F4 (AAA comments, C:65%):** Unanimous Skip. No project-wide AAA convention. Applying selectively creates inconsistency. Docstrings on each test already state intent. Stack.yml file_length gate makes comment padding a cost.
+
+### Trade-offs
+
+- F1 + F2 combined: ~10 lines added, closes two real maintainability gaps introduced by this PR
+- F3: cosmetic churn with active risk (external NATS consumers reference the string value; constant rename could mislead future authors about whether the subject string also changed)
+- F4: style-only, zero functional signal
+
+## Alternatives
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| Defer F2 to next modification | product-lead | Majority: the invariant is already tested; source should match |
+| Apply F3 | — | Unanimous skip: domain vocabulary, rename risk > benefit |
+| Apply F4 | — | Unanimous skip: no project convention, inconsistency worse than omission |
+
+## Dissent
+
+**F2:** product-lead preferred deferring on grounds of zero active risk with only 2 constants. Overruled by majority: encoding the prefix relationship in source is correct regardless of current risk level.
+
+## Implementation Notes
+
+- F1: `payload = js.publish.call_args[0][1]; assert json.loads(payload)["skip_permissions"] is True/False` in each routing test
+- F2: `_SUBJECT_PREFIX = "lyra.audit.security"` → `_SUBJECT_PRIVILEGED = f"{_SUBJECT_PREFIX}.privileged"` → `_SUBJECT_NORMAL = f"{_SUBJECT_PREFIX}.normal"`; `test_subjects_are_under_lyra_audit_wildcard` can assert against `_SUBJECT_PREFIX` directly
+
+## Next
+
+Apply F1 + F2 in the `/fix` 1b1 phase → push → re-run `/code-review`.

--- a/src/lyra/infrastructure/audit/jetstream_sink.py
+++ b/src/lyra/infrastructure/audit/jetstream_sink.py
@@ -14,8 +14,9 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 _security_log = logging.getLogger("lyra.security")
 
-_SUBJECT_PRIVILEGED = "lyra.audit.security.privileged"
-_SUBJECT_NORMAL = "lyra.audit.security.normal"
+_SUBJECT_PREFIX = "lyra.audit.security"
+_SUBJECT_PRIVILEGED = f"{_SUBJECT_PREFIX}.privileged"
+_SUBJECT_NORMAL = f"{_SUBJECT_PREFIX}.normal"
 
 
 class JetStreamAuditSink:

--- a/src/lyra/infrastructure/audit/jetstream_sink.py
+++ b/src/lyra/infrastructure/audit/jetstream_sink.py
@@ -80,13 +80,16 @@ class JetStreamAuditSink:
         """Publish event; never raises — falls back to lyra.security logger on error."""
         json_str = event.model_dump_json()
         payload = json_str.encode()
+        subject = _SUBJECT_PRIVILEGED if event.skip_permissions else _SUBJECT_NORMAL
         try:
             if self._degraded or self._js is None:
-                _security_log.warning("%s", json_str)
+                _security_log.warning("AUDIT DEGRADED [%s]: %s", subject, json_str)
                 return
-            subject = _SUBJECT_PRIVILEGED if event.skip_permissions else _SUBJECT_NORMAL
             await self._js.publish(subject, payload)
         except Exception as exc:
             _security_log.warning(
-                "AUDIT: emit failed (%s) — %s", type(exc).__name__, json_str
+                "AUDIT: emit failed (%s) on subject %s — %s",
+                type(exc).__name__,
+                subject,
+                json_str,
             )

--- a/src/lyra/infrastructure/audit/jetstream_sink.py
+++ b/src/lyra/infrastructure/audit/jetstream_sink.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 _security_log = logging.getLogger("lyra.security")
 
-_SUBJECT = "lyra.audit.security"
+_SUBJECT_PRIVILEGED = "lyra.audit.security.privileged"
+_SUBJECT_NORMAL = "lyra.audit.security.normal"
 
 
 class JetStreamAuditSink:
@@ -83,7 +84,8 @@ class JetStreamAuditSink:
             if self._degraded or self._js is None:
                 _security_log.warning("%s", json_str)
                 return
-            await self._js.publish(_SUBJECT, payload)
+            subject = _SUBJECT_PRIVILEGED if event.skip_permissions else _SUBJECT_NORMAL
+            await self._js.publish(subject, payload)
         except Exception as exc:
             _security_log.warning(
                 "AUDIT: emit failed (%s) — %s", type(exc).__name__, json_str

--- a/tests/core/test_cli_spawn_audit.py
+++ b/tests/core/test_cli_spawn_audit.py
@@ -273,6 +273,9 @@ class TestJetStreamAuditSinkEmit:
         assert all(r.name == "lyra.security" for r in security_records)
         import json
 
-        payload = json.loads(security_records[0].getMessage())
+        # Message format: "AUDIT DEGRADED [<subject>]: <json>"
+        msg = security_records[0].getMessage()
+        json_str = msg.split(": ", 1)[1]
+        payload = json.loads(json_str)
         assert payload["pid"] == 2
         assert payload["skip_permissions"] is True

--- a/tests/core/test_jetstream_audit_provision.py
+++ b/tests/core/test_jetstream_audit_provision.py
@@ -14,6 +14,7 @@ import pytest
 
 from lyra.infrastructure.audit.jetstream_sink import (
     _SUBJECT_NORMAL,
+    _SUBJECT_PREFIX,
     _SUBJECT_PRIVILEGED,
     JetStreamAuditSink,
 )
@@ -153,6 +154,8 @@ class TestJetStreamAuditSinkSubjectRouting:
 
     async def test_emit_privileged_subject_when_skip_permissions_true(self) -> None:
         """emit() uses lyra.audit.security.privileged when skip_permissions=True."""
+        import json
+
         sink = JetStreamAuditSink()
         js = _make_js()
         js.publish = AsyncMock()
@@ -162,11 +165,14 @@ class TestJetStreamAuditSinkSubjectRouting:
         await sink.emit(event)  # type: ignore[arg-type]
 
         js.publish.assert_awaited_once()
-        subject = js.publish.call_args[0][0]
+        subject, payload = js.publish.call_args[0]
         assert subject == _SUBJECT_PRIVILEGED
+        assert json.loads(payload)["skip_permissions"] is True
 
     async def test_emit_normal_subject_when_skip_permissions_false(self) -> None:
         """emit() uses lyra.audit.security.normal when skip_permissions=False."""
+        import json
+
         sink = JetStreamAuditSink()
         js = _make_js()
         js.publish = AsyncMock()
@@ -176,13 +182,14 @@ class TestJetStreamAuditSinkSubjectRouting:
         await sink.emit(event)  # type: ignore[arg-type]
 
         js.publish.assert_awaited_once()
-        subject = js.publish.call_args[0][0]
+        subject, payload = js.publish.call_args[0]
         assert subject == _SUBJECT_NORMAL
+        assert json.loads(payload)["skip_permissions"] is False
 
     def test_subjects_are_under_lyra_audit_wildcard(self) -> None:
-        """Both subjects fall under lyra.audit.security.* (stream wildcard)."""
-        assert _SUBJECT_PRIVILEGED.startswith("lyra.audit.security.")
-        assert _SUBJECT_NORMAL.startswith("lyra.audit.security.")
+        """Both subjects fall under _SUBJECT_PREFIX.* (stream wildcard)."""
+        assert _SUBJECT_PRIVILEGED.startswith(f"{_SUBJECT_PREFIX}.")
+        assert _SUBJECT_NORMAL.startswith(f"{_SUBJECT_PREFIX}.")
 
     async def test_emit_degraded_sink_does_not_publish_privileged_event(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/core/test_jetstream_audit_provision.py
+++ b/tests/core/test_jetstream_audit_provision.py
@@ -1,13 +1,22 @@
-"""Tests for JetStreamAuditSink.provision() (#855) — S3 criteria."""
+"""Tests for JetStreamAuditSink.provision() (#855) — S3 criteria.
+
+Subject routing tests for #942 (skip_permissions split) are in
+TestJetStreamAuditSinkSubjectRouting at the bottom of this file.
+"""
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from lyra.infrastructure.audit.jetstream_sink import JetStreamAuditSink
+from lyra.infrastructure.audit.jetstream_sink import (
+    _SUBJECT_NORMAL,
+    _SUBJECT_PRIVILEGED,
+    JetStreamAuditSink,
+)
 
 
 def _make_nc(js: object | None = None) -> MagicMock:
@@ -117,3 +126,60 @@ class TestJetStreamAuditSinkProvision:
             await sink.provision(nc)
 
         assert sink._degraded  # type: ignore[attr-defined]
+
+
+def _make_event(*, skip_permissions: bool) -> object:
+    """Build a minimal SecurityEvent for emit() tests."""
+    from roxabi_contracts.audit import SecurityEvent
+    from roxabi_contracts.envelope import CONTRACT_VERSION
+
+    return SecurityEvent(
+        contract_version=CONTRACT_VERSION,
+        trace_id="t-test",
+        issued_at=datetime.now(UTC),
+        kind="cli.subprocess.spawned",
+        pool_id="p:1",
+        agent_name="bot",
+        skip_permissions=skip_permissions,
+        tools_restricted=False,
+        tools_allowlist=[],
+        model="claude-opus-4-6",
+        pid=999,
+    )
+
+
+class TestJetStreamAuditSinkSubjectRouting:
+    """#942 — skip_permissions routes to dedicated NATS subjects."""
+
+    async def test_emit_privileged_subject_when_skip_permissions_true(self) -> None:
+        """emit() uses lyra.audit.security.privileged when skip_permissions=True."""
+        sink = JetStreamAuditSink()
+        js = _make_js()
+        js.publish = AsyncMock()
+        sink._js = js  # type: ignore[attr-defined]
+
+        event = _make_event(skip_permissions=True)
+        await sink.emit(event)  # type: ignore[arg-type]
+
+        js.publish.assert_awaited_once()
+        subject = js.publish.call_args[0][0]
+        assert subject == _SUBJECT_PRIVILEGED
+
+    async def test_emit_normal_subject_when_skip_permissions_false(self) -> None:
+        """emit() uses lyra.audit.security.normal when skip_permissions=False."""
+        sink = JetStreamAuditSink()
+        js = _make_js()
+        js.publish = AsyncMock()
+        sink._js = js  # type: ignore[attr-defined]
+
+        event = _make_event(skip_permissions=False)
+        await sink.emit(event)  # type: ignore[arg-type]
+
+        js.publish.assert_awaited_once()
+        subject = js.publish.call_args[0][0]
+        assert subject == _SUBJECT_NORMAL
+
+    async def test_subjects_are_under_lyra_audit_wildcard(self) -> None:
+        """Both subjects fall under lyra.audit.security.* (stream wildcard)."""
+        assert _SUBJECT_PRIVILEGED.startswith("lyra.audit.security.")
+        assert _SUBJECT_NORMAL.startswith("lyra.audit.security.")

--- a/tests/core/test_jetstream_audit_provision.py
+++ b/tests/core/test_jetstream_audit_provision.py
@@ -179,7 +179,26 @@ class TestJetStreamAuditSinkSubjectRouting:
         subject = js.publish.call_args[0][0]
         assert subject == _SUBJECT_NORMAL
 
-    async def test_subjects_are_under_lyra_audit_wildcard(self) -> None:
+    def test_subjects_are_under_lyra_audit_wildcard(self) -> None:
         """Both subjects fall under lyra.audit.security.* (stream wildcard)."""
         assert _SUBJECT_PRIVILEGED.startswith("lyra.audit.security.")
         assert _SUBJECT_NORMAL.startswith("lyra.audit.security.")
+
+    async def test_emit_degraded_sink_does_not_publish_privileged_event(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Degraded sink logs (not publishes) privileged events; subject in message."""
+        sink = JetStreamAuditSink()
+        sink._degraded = True  # type: ignore[attr-defined]
+        js = _make_js()
+        js.publish = AsyncMock()
+        sink._js = js  # type: ignore[attr-defined]
+
+        event = _make_event(skip_permissions=True)
+        with caplog.at_level(logging.WARNING, logger="lyra.security"):
+            await sink.emit(event)  # type: ignore[arg-type]
+
+        js.publish.assert_not_awaited()
+        security_records = [r for r in caplog.records if r.name == "lyra.security"]
+        assert len(security_records) == 1
+        assert _SUBJECT_PRIVILEGED in security_records[0].message


### PR DESCRIPTION
## Summary
- Route `SecurityEvent` emissions to `lyra.audit.security.privileged` when `skip_permissions=True`, `lyra.audit.security.normal` otherwise
- Zero stream config change — both subjects fall under the existing `lyra.audit.>` wildcard; consumers can now subscribe to the privileged subject directly for tiered SIEM alerting

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #942: feat(audit): route skip_permissions=True spawns to dedicated NATS subject | Open |
| Implementation | 1 commit on `feat/942-audit-skip-permissions-nats-subject` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/core/test_jetstream_audit_provision.py -v` — 9 tests pass
- [ ] Emit a privileged event in dev: verify message lands on `lyra.audit.security.privileged`
- [ ] Emit a normal event: verify `lyra.audit.security.normal`
- [ ] Confirm `LYRA_AUDIT` stream still captures both via `lyra.audit.>` wildcard

Closes #942

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`