### PR TITLE
refactor(core): add ThreadStoreProtocol, break Discord adapter → ThreadStore direct coupling (ADR-059 V5)

### DIFF
--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from lyra.adapters.shared._shared_streaming import PlatformCallbacks
     from lyra.adapters.shared.outbound_listener import OutboundListener
     from lyra.core.messaging.bus import Bus
+    from lyra.core.stores.thread_store_protocol import ThreadStoreProtocol
     from lyra.infrastructure.stores.turn_store import TurnStore
 
 from lyra.adapters.discord import discord_audio  # noqa: I001
@@ -48,7 +49,6 @@ from lyra.core.messaging.message import (
     OutboundMessage,
 )
 from lyra.core.messaging.messages import MessageManager
-from lyra.core.stores.thread_store_protocol import ThreadStoreProtocol
 
 log = logging.getLogger(__name__)
 

--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -48,7 +48,7 @@ from lyra.core.messaging.message import (
     OutboundMessage,
 )
 from lyra.core.messaging.messages import MessageManager
-from lyra.infrastructure.stores.thread_store import ThreadStore
+from lyra.core.stores.thread_store_protocol import ThreadStoreProtocol
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         msg_manager: MessageManager | None = None,
         auto_thread: bool = True,
         thread_hot_hours: int = 36,
-        thread_store: ThreadStore | None = None,
+        thread_store: ThreadStoreProtocol | None = None,
         watch_channels: frozenset[int] = frozenset(),
         turn_store: "TurnStore | None" = None,
     ) -> None:
@@ -96,7 +96,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         self._bot_user: Any = None  # set on on_ready; None until login
         self._mention_re: re.Pattern[str] | None = None  # compiled on on_ready
         self._owned_threads: set[int] = set()  # populated from ThreadStore on on_ready
-        self._thread_store: ThreadStore | None = thread_store
+        self._thread_store: ThreadStoreProtocol | None = thread_store
         self._turn_store: "TurnStore | None" = turn_store
         self._watch_channels: frozenset[int] = watch_channels
         self._thread_sessions: dict[str, tuple[str, str]] = {}

--- a/src/lyra/adapters/discord/discord_threads.py
+++ b/src/lyra/adapters/discord/discord_threads.py
@@ -10,13 +10,13 @@ from lyra.core.messaging.message import DiscordMeta
 
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage
-    from lyra.infrastructure.stores.thread_store import ThreadStore
+    from lyra.core.stores.thread_store_protocol import ThreadStoreProtocol
 
 log = logging.getLogger(__name__)
 
 
 async def persist_thread_claim(
-    thread_store: "ThreadStore",
+    thread_store: "ThreadStoreProtocol",
     thread_id: int,
     bot_id: str,
     channel_id: int,
@@ -42,7 +42,7 @@ async def persist_thread_claim(
 
 
 async def persist_thread_session(  # noqa: PLR0913 — each arg is a distinct required dependency
-    thread_store: "ThreadStore",
+    thread_store: "ThreadStoreProtocol",
     msg: "InboundMessage",
     session_id: str,
     pool_id: str,
@@ -86,7 +86,7 @@ async def persist_thread_session(  # noqa: PLR0913 — each arg is a distinct re
 
 
 async def restore_hot_threads(
-    thread_store: "ThreadStore",
+    thread_store: "ThreadStoreProtocol",
     bot_id: str,
     hot_hours: int,
 ) -> set[int]:
@@ -109,7 +109,7 @@ async def restore_hot_threads(
 
 
 async def retrieve_thread_session(
-    thread_store: "ThreadStore",
+    thread_store: "ThreadStoreProtocol",
     thread_id: str,
     bot_id: str,
     cache: dict[str, tuple[str, str]],

--- a/src/lyra/core/stores/__init__.py
+++ b/src/lyra/core/stores/__init__.py
@@ -5,7 +5,9 @@ This package re-exports only protocol-safe symbols for backward compatibility.
 """
 
 from .agent_store_protocol import AgentStoreProtocol
+from .thread_store_protocol import ThreadStoreProtocol
 
 __all__ = [
     "AgentStoreProtocol",
+    "ThreadStoreProtocol",
 ]

--- a/src/lyra/core/stores/thread_store_protocol.py
+++ b/src/lyra/core/stores/thread_store_protocol.py
@@ -1,0 +1,41 @@
+"""ThreadStoreProtocol — structural protocol for Discord thread persistence.
+
+Decouples the Discord adapter from the concrete SQLite ThreadStore (ADR-059 V5).
+Implementations live in lyra.infrastructure.stores; this protocol lives in core.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ThreadStoreProtocol(Protocol):
+    """Structural protocol for Discord thread ownership and session persistence."""
+
+    async def close(self) -> None: ...
+
+    async def get_thread_ids(
+        self,
+        bot_id: str,
+        active_since: datetime | None = None,
+    ) -> list[str]: ...
+
+    async def is_owned(self, thread_id: str, bot_id: str) -> bool: ...
+
+    async def get_session(
+        self, thread_id: str, bot_id: str
+    ) -> tuple[str | None, str | None]: ...
+
+    async def claim(
+        self,
+        thread_id: str,
+        bot_id: str,
+        channel_id: str,
+        guild_id: str | None = None,
+    ) -> None: ...
+
+    async def update_session(
+        self, thread_id: str, bot_id: str, session_id: str, pool_id: str
+    ) -> None: ...

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -390,3 +390,153 @@ class TestPersistThreadClaimFailurePath:
 
         # Assert — message still reaches the inbound bus
         inbound_bus.put.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for retrieve_thread_session
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveThreadSession:
+    """retrieve_thread_session — cache hit/miss, LRU promotion, eviction."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_cached_value(self) -> None:
+        """Cache hit: returns value without calling get_session."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import retrieve_thread_session
+
+        store = AsyncMock()
+        cache: dict[str, tuple[str, str]] = {"123": ("sess-a", "pool-a")}
+
+        result = await retrieve_thread_session(store, "123", "bot1", cache)
+
+        assert result == ("sess-a", "pool-a")
+        store.get_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_promotes_key_to_end(self) -> None:
+        """Cache hit moves the accessed key to end (LRU promotion)."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import retrieve_thread_session
+
+        store = AsyncMock()
+        cache: dict[str, tuple[str, str]] = {
+            "1": ("s1", "p1"),
+            "2": ("s2", "p2"),
+            "3": ("s3", "p3"),
+        }
+
+        await retrieve_thread_session(store, "1", "bot1", cache)
+
+        # "1" should now be at the end (most recently used)
+        assert list(cache.keys())[-1] == "1"
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_store_and_warms_cache(self) -> None:
+        """Cache miss: calls get_session and warms the cache on a hit."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import retrieve_thread_session
+
+        store = AsyncMock()
+        store.get_session.return_value = ("sess-b", "pool-b")
+        cache: dict[str, tuple[str, str]] = {}
+
+        result = await retrieve_thread_session(store, "456", "bot1", cache)
+
+        assert result == ("sess-b", "pool-b")
+        store.get_session.assert_awaited_once_with(thread_id="456", bot_id="bot1")
+        assert cache["456"] == ("sess-b", "pool-b")
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_none_result_does_not_populate_cache(self) -> None:
+        """Cache miss with (None, None) from store: cache stays empty."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import retrieve_thread_session
+
+        store = AsyncMock()
+        store.get_session.return_value = (None, None)
+        cache: dict[str, tuple[str, str]] = {}
+
+        result = await retrieve_thread_session(store, "789", "bot1", cache)
+
+        assert result == (None, None)
+        assert "789" not in cache
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_evicts_oldest_when_full(self) -> None:
+        """Cache at 500 entries: miss with a store hit evicts the oldest key."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import retrieve_thread_session
+
+        store = AsyncMock()
+        store.get_session.return_value = ("sess-new", "pool-new")
+        cache: dict[str, tuple[str, str]] = {str(i): ("s", "p") for i in range(500)}
+        oldest_key = "0"
+
+        await retrieve_thread_session(store, "999", "bot1", cache)
+
+        assert oldest_key not in cache
+        assert "999" in cache
+        assert len(cache) == 500
+
+
+# ---------------------------------------------------------------------------
+# Tests for restore_hot_threads
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreHotThreads:
+    """restore_hot_threads — str→int conversion, empty path, window calculation."""
+
+    @pytest.mark.asyncio
+    async def test_returns_set_of_int_thread_ids(self) -> None:
+        """store returns string IDs → result is a set of ints."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import restore_hot_threads
+
+        store = AsyncMock()
+        store.get_thread_ids.return_value = ["123", "456", "789"]
+
+        result = await restore_hot_threads(store, "bot1", hot_hours=36)
+
+        assert result == {123, 456, 789}
+
+    @pytest.mark.asyncio
+    async def test_empty_store_returns_empty_set(self) -> None:
+        """store returns no thread IDs → empty set."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import restore_hot_threads
+
+        store = AsyncMock()
+        store.get_thread_ids.return_value = []
+
+        result = await restore_hot_threads(store, "bot1", hot_hours=36)
+
+        assert result == set()
+
+    @pytest.mark.asyncio
+    async def test_passes_active_since_datetime_to_store(self) -> None:
+        """get_thread_ids is called with a non-None active_since datetime."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import restore_hot_threads
+
+        store = AsyncMock()
+        store.get_thread_ids.return_value = []
+
+        await restore_hot_threads(store, "bot1", hot_hours=24)
+
+        call_kwargs = store.get_thread_ids.call_args
+        assert call_kwargs is not None
+        active_since = call_kwargs.kwargs.get(
+            "active_since"
+        ) or call_kwargs.args[1]
+        assert active_since is not None

--- a/tests/core/test_thread_store_protocol.py
+++ b/tests/core/test_thread_store_protocol.py
@@ -1,0 +1,26 @@
+"""Protocol conformance test — ThreadStore satisfies ThreadStoreProtocol.
+
+Guards against silent drift: if ThreadStore drops or renames any of the
+6 methods required by the protocol, this test fails at import time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lyra.core.stores.thread_store_protocol import ThreadStoreProtocol
+
+
+def test_thread_store_isinstance_check(tmp_path: pytest.TempPathFactory) -> None:
+    """ThreadStore satisfies ThreadStoreProtocol (runtime_checkable check)."""
+    from lyra.infrastructure.stores.thread_store import ThreadStore
+
+    store = ThreadStore(db_path=tmp_path / "discord.db")  # type: ignore[arg-type]
+    assert isinstance(store, ThreadStoreProtocol)
+
+
+def test_thread_store_protocol_exported_from_package() -> None:
+    """ThreadStoreProtocol is importable from lyra.core.stores."""
+    from lyra.core.stores import ThreadStoreProtocol as _TSP
+
+    assert _TSP is ThreadStoreProtocol


### PR DESCRIPTION
## Summary
- Add `ThreadStoreProtocol` to `lyra.core.stores` — structural protocol exposing the 6 methods the Discord adapter needs (`close`, `get_thread_ids`, `is_owned`, `get_session`, `claim`, `update_session`)
- `DiscordAdapter` and `discord_threads` now depend on the protocol; concrete `ThreadStore` (SQLite) stays in the bootstrap layer where it belongs

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #959: refactor(core): add ThreadStoreProtocol | Open |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 1 commit on `feat/959-threadstore-protocol` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2858 passed) | Passed |

## Test Plan
- [ ] Discord adapter boots and connects to ThreadStore via injected protocol (no import change at runtime)
- [ ] `isinstance(ThreadStore(...), ThreadStoreProtocol)` returns `True` (`runtime_checkable`)
- [ ] Swapping in a test double that satisfies `ThreadStoreProtocol` works without touching the adapter

Closes #959

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`