### PR TITLE
docs(deploy-lib): clarify HUB_SERVICE semantics for single-service projects

### DIFF
--- a/docs/QUADLET-ADOPTION.md
+++ b/docs/QUADLET-ADOPTION.md
@@ -145,6 +145,22 @@ source "$LIB_PATH"
 
 LIB must be installed before the first deploy (`make quadlet-install-deploy-lib` in the lyra checkout).
 
+### HUB_SERVICE semantics
+
+`HUB_SERVICE` exists to solve the hub→adapters ordering problem: restart the hub first, gate
+on it reaching `active`, then restart the adapters. It is meaningful **only for multi-service
+projects** (like Lyra: hub + telegram + discord + clipool).
+
+**Single-service projects must leave `HUB_SERVICE` unset.** Setting it with an empty
+`ADAPTER_SERVICES` triggers the full 60s readiness polling loop before the lib does nothing —
+wasted time with no sequencing benefit. When both are unset the lib restarts all services
+as a flat group.
+
+| Project shape | `HUB_SERVICE` | `ADAPTER_SERVICES` |
+|---|---|---|
+| 1 service (e.g. imageCLI `imagecli-gen`) | _(unset)_ | _(unset)_ |
+| Multi-service hub+adapters (e.g. Lyra) | `lyra-hub` | `lyra-telegram lyra-discord lyra-clipool` |
+
 ### Full example — imageCLI (1 service, NATS-using)
 
 ```sh
@@ -164,8 +180,8 @@ PROJECT_DIR="$HOME/projects/imageCLI"
 PROJECT_BRANCH="staging"
 IMAGE="localhost/imagecli-gen:latest"
 DOCKERFILE="Dockerfile"
-HUB_SERVICE="imagecli-gen"
-ADAPTER_SERVICES=""            # single service: no adapters
+# HUB_SERVICE / ADAPTER_SERVICES: leave unset for single-service projects.
+# Setting HUB_SERVICE without adapters triggers a pointless 60s readiness poll.
 ENV_FILES_DIR="$HOME/.imagecli/env"
 ENV_FILES="gen"
 LOG_FILE="$HOME/.local/state/imagecli/logs/deploy.log"

--- a/scripts/deploy-lib.sh
+++ b/scripts/deploy-lib.sh
@@ -13,8 +13,13 @@
 #                      not contain colons. Empty lines are skipped.
 #   IMAGE            — OCI image, e.g. "localhost/lyra:latest"
 #   DOCKERFILE       — path relative to PROJECT_DIR, default "Dockerfile"
-#   HUB_SERVICE      — primary service to start first and gate the rest on (optional)
-#   ADAPTER_SERVICES — space-separated services restarted after HUB_SERVICE is active
+#   HUB_SERVICE      — hub service restarted first; lib waits up to 60s for it to reach
+#                      active before restarting ADAPTER_SERVICES. Only set for multi-service
+#                      projects that require hub→adapter ordering. Single-service projects
+#                      must leave this unset (no adapters to sequence; the 60s readiness
+#                      poll is wasted work). When unset, all services restart as a flat group.
+#   ADAPTER_SERVICES — space-separated adapter services restarted after HUB_SERVICE is
+#                      active. Leave empty (or unset) when HUB_SERVICE is unset.
 #   ENV_FILES_DIR    — directory holding per-role env files, e.g. "$HOME/.lyra/env"
 #   ENV_FILES        — space-separated list of <role> names expected under ENV_FILES_DIR
 #                      (script verifies "<role>.env" exists with mode 0600)


### PR DESCRIPTION
## Summary
- Add semantics table + callout in `QUADLET-ADOPTION.md` §5: `HUB_SERVICE` is for multi-service hub→adapter ordering only; single-service projects must leave it unset
- Fix imageCLI deploy script example: remove `HUB_SERVICE="imagecli-gen"` assignment (anti-pattern — triggers pointless 60s readiness poll with no adapters to sequence), replace with explanatory comment
- Tighten `deploy-lib.sh` header comment to state the multi-service-only constraint and flat-group fallback

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #915: refactor(deploy-lib): clarify HUB_SERVICE semantics for single-service projects | Open |
| Implementation | 1 commit on `feat/915-deploy-lib-hub-service-semantics` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Review imageCLI deploy example: `HUB_SERVICE` and `ADAPTER_SERVICES` are absent, comment explains why
- [ ] Review semantics table in §5: single-service vs multi-service rows are clear
- [ ] Review `deploy-lib.sh` header: new comment captures the multi-service-only constraint and flat-group fallback

Closes #915

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`