### PR TITLE
refactor(core): ThreadSession dataclass for get_session() return

### DIFF
--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 import discord
 
+from lyra.core.stores.thread_store_protocol import ThreadSession
+
 if TYPE_CHECKING:
     from lyra.adapters.shared._shared_streaming import PlatformCallbacks
     from lyra.adapters.shared.outbound_listener import OutboundListener
@@ -99,7 +101,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         self._thread_store: ThreadStoreProtocol | None = thread_store
         self._turn_store: "TurnStore | None" = turn_store
         self._watch_channels: frozenset[int] = watch_channels
-        self._thread_sessions: dict[str, tuple[str, str]] = {}
+        self._thread_sessions: dict[str, ThreadSession] = {}
         self._vsm: VoiceSessionManager = VoiceSessionManager()
         self._outbound_listener: "OutboundListener | None" = None
         # Injectable identity resolver for slash command trust (set by wiring layer).

--- a/src/lyra/adapters/discord/discord_inbound.py
+++ b/src/lyra/adapters/discord/discord_inbound.py
@@ -157,15 +157,15 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
     # Retrieve stored session for existing owned threads (read-side fix).
     # New auto-threads have no prior session; skip get_session() for those.
     _stored_session_id: str | None = None
-    _stored_pool_id: str | None = None
     if _in_owned_thread and adapter._thread_store is not None:
         try:
-            _stored_session_id, _stored_pool_id = await retrieve_thread_session(
+            _ts_result = await retrieve_thread_session(
                 adapter._thread_store,
                 thread_id=str(message.channel.id),
                 bot_id=adapter._bot_id,
                 cache=adapter._thread_sessions,
             )
+            _stored_session_id = _ts_result.session_id
         except Exception:
             log.exception(
                 "ThreadStore: failed to retrieve session for thread_id=%s",

--- a/src/lyra/adapters/discord/discord_inbound.py
+++ b/src/lyra/adapters/discord/discord_inbound.py
@@ -165,6 +165,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:  # no
                 bot_id=adapter._bot_id,
                 cache=adapter._thread_sessions,
             )
+            # pool_id not consumed here; session routing uses session_id only
             _stored_session_id = _ts_result.session_id
         except Exception:
             log.exception(

--- a/src/lyra/adapters/discord/discord_threads.py
+++ b/src/lyra/adapters/discord/discord_threads.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from lyra.core.messaging.message import DiscordMeta
+from lyra.core.stores.thread_store_protocol import ThreadSession
 
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage
@@ -47,7 +48,7 @@ async def persist_thread_session(  # noqa: PLR0913 — each arg is a distinct re
     session_id: str,
     pool_id: str,
     bot_id: str,
-    cache: dict[str, tuple[str, str]],
+    cache: dict[str, ThreadSession],
 ) -> None:
     """Persist session_id and pool_id for a thread after a successful turn."""
     if not isinstance(msg.platform_meta, DiscordMeta):
@@ -72,7 +73,7 @@ async def persist_thread_session(  # noqa: PLR0913 — each arg is a distinct re
             )
         _key = str(thread_id)
         cache.pop(_key, None)
-        cache[_key] = (session_id, pool_id)
+        cache[_key] = ThreadSession(session_id=session_id, pool_id=pool_id)
         log.debug(
             "ThreadStore: persisted session_id=%s pool_id=%s for thread_id=%s",
             session_id,
@@ -112,8 +113,8 @@ async def retrieve_thread_session(
     thread_store: "ThreadStoreProtocol",
     thread_id: str,
     bot_id: str,
-    cache: dict[str, tuple[str, str]],
-) -> tuple[str | None, str | None]:
+    cache: dict[str, ThreadSession],
+) -> ThreadSession:
     """Look up session_id and pool_id for an owned thread.
 
     Checks the in-memory *cache* first; on a miss, queries ThreadStore and
@@ -124,19 +125,16 @@ async def retrieve_thread_session(
         cache[thread_id] = cache.pop(thread_id)
         return cached
 
-    stored_session_id, stored_pool_id = await thread_store.get_session(
-        thread_id=thread_id,
-        bot_id=bot_id,
-    )
-    if stored_session_id is not None and stored_pool_id is not None:
+    ts = await thread_store.get_session(thread_id=thread_id, bot_id=bot_id)
+    if ts.session_id is not None and ts.pool_id is not None:
         if len(cache) >= 500:
             _oldest = next(iter(cache))
             del cache[_oldest]
-        cache[thread_id] = (stored_session_id, stored_pool_id)
+        cache[thread_id] = ts
         log.debug(
             "ThreadStore: retrieved session_id=%s pool_id=%s for thread_id=%s",
-            stored_session_id,
-            stored_pool_id,
+            ts.session_id,
+            ts.pool_id,
             thread_id,
         )
-    return stored_session_id, stored_pool_id
+    return ts

--- a/src/lyra/adapters/discord/discord_threads.py
+++ b/src/lyra/adapters/discord/discord_threads.py
@@ -126,7 +126,7 @@ async def retrieve_thread_session(
         return cached
 
     ts = await thread_store.get_session(thread_id=thread_id, bot_id=bot_id)
-    if ts.session_id is not None and ts.pool_id is not None:
+    if ts.is_resolved:
         if len(cache) >= 500:
             _oldest = next(iter(cache))
             del cache[_oldest]

--- a/src/lyra/core/stores/thread_store_protocol.py
+++ b/src/lyra/core/stores/thread_store_protocol.py
@@ -16,6 +16,10 @@ class ThreadSession:
     session_id: str | None
     pool_id: str | None
 
+    @property
+    def is_resolved(self) -> bool:
+        return self.session_id is not None and self.pool_id is not None
+
 
 @runtime_checkable
 class ThreadStoreProtocol(Protocol):

--- a/src/lyra/core/stores/thread_store_protocol.py
+++ b/src/lyra/core/stores/thread_store_protocol.py
@@ -6,8 +6,15 @@ Implementations live in lyra.infrastructure.stores; this protocol lives in core.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class ThreadSession:
+    session_id: str | None
+    pool_id: str | None
 
 
 @runtime_checkable
@@ -26,7 +33,7 @@ class ThreadStoreProtocol(Protocol):
 
     async def get_session(
         self, thread_id: str, bot_id: str
-    ) -> tuple[str | None, str | None]: ...
+    ) -> ThreadSession: ...
 
     async def claim(
         self,

--- a/src/lyra/infrastructure/stores/thread_store.py
+++ b/src/lyra/infrastructure/stores/thread_store.py
@@ -107,7 +107,10 @@ class ThreadStore(SqliteStore):
     async def get_session(
         self, thread_id: str, bot_id: str
     ) -> ThreadSession:
-        """Return ThreadSession for (thread_id, bot_id), or null-session."""
+        """Return ThreadSession for (thread_id, bot_id).
+
+        Returns an unresolved ThreadSession (is_resolved=False) if not found.
+        """
         db = self._require_db()
         async with db.execute(
             "SELECT session_id, pool_id FROM discord_threads "

--- a/src/lyra/infrastructure/stores/thread_store.py
+++ b/src/lyra/infrastructure/stores/thread_store.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+from lyra.core.stores.thread_store_protocol import ThreadSession
 from lyra.infrastructure.stores.sqlite_base import SqliteStore
 
 log = logging.getLogger(__name__)
@@ -105,8 +106,8 @@ class ThreadStore(SqliteStore):
 
     async def get_session(
         self, thread_id: str, bot_id: str
-    ) -> tuple[str | None, str | None]:
-        """Return (session_id, pool_id) for (thread_id, bot_id), or (None, None)."""
+    ) -> ThreadSession:
+        """Return ThreadSession for (thread_id, bot_id), or null-session."""
         db = self._require_db()
         async with db.execute(
             "SELECT session_id, pool_id FROM discord_threads "
@@ -115,8 +116,8 @@ class ThreadStore(SqliteStore):
         ) as cur:
             row = await cur.fetchone()
         if row is None:
-            return None, None
-        return row[0], row[1]
+            return ThreadSession(session_id=None, pool_id=None)
+        return ThreadSession(session_id=row[0], pool_id=row[1])
 
     # ------------------------------------------------------------------
     # Writes

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -300,8 +300,6 @@ class TestPersistThreadSessionEviction:
         # Oldest key ("0") must have been evicted
         assert "0" not in cache
         # New entry must be present with the correct value
-        from lyra.core.stores.thread_store_protocol import ThreadSession
-
         assert "9999" in cache
         assert cache["9999"] == ThreadSession("new-sess", "new-pool")
 
@@ -497,6 +495,25 @@ class TestRetrieveThreadSession:
         assert oldest_key not in cache
         assert "999" in cache
         assert len(cache) == 500
+        assert cache["999"] == ThreadSession("sess-new", "pool-new")
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_partial_result_does_not_populate_cache(self) -> None:
+        """Partial ThreadSession (session_id set, pool_id=None): cache stays empty."""
+        from unittest.mock import AsyncMock
+
+        from lyra.adapters.discord.discord_threads import retrieve_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
+
+        store = AsyncMock()
+        store.get_session.return_value = ThreadSession("sess-x", None)
+        cache: dict[str, ThreadSession] = {}
+
+        result = await retrieve_thread_session(store, "101", "bot1", cache)
+
+        assert result.session_id == "sess-x"
+        assert result.pool_id is None
+        assert "101" not in cache
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -273,9 +273,12 @@ class TestPersistThreadSessionEviction:
         from unittest.mock import AsyncMock, MagicMock
 
         from lyra.adapters.discord.discord_threads import persist_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
         # Arrange — cache pre-filled to the limit (500 entries)
-        cache: dict[str, tuple[str, str]] = {str(i): ("s", "p") for i in range(500)}
+        cache: dict[str, ThreadSession] = {
+            str(i): ThreadSession("s", "p") for i in range(500)
+        }
 
         mock_store = MagicMock()
         mock_store.update_session = AsyncMock()
@@ -297,8 +300,10 @@ class TestPersistThreadSessionEviction:
         # Oldest key ("0") must have been evicted
         assert "0" not in cache
         # New entry must be present with the correct value
+        from lyra.core.stores.thread_store_protocol import ThreadSession
+
         assert "9999" in cache
-        assert cache["9999"] == ("new-sess", "new-pool")
+        assert cache["9999"] == ThreadSession("new-sess", "new-pool")
 
     @pytest.mark.asyncio
     async def test_persist_thread_session_returns_early_for_non_discord_meta(
@@ -309,8 +314,9 @@ class TestPersistThreadSessionEviction:
 
         from lyra.adapters.discord.discord_threads import persist_thread_session
         from lyra.core.messaging.message import TelegramMeta
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
-        cache: dict[str, tuple[str, str]] = {}
+        cache: dict[str, ThreadSession] = {}
         mock_store = MagicMock()
         mock_store.update_session = AsyncMock()
 
@@ -406,13 +412,14 @@ class TestRetrieveThreadSession:
         from unittest.mock import AsyncMock
 
         from lyra.adapters.discord.discord_threads import retrieve_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
         store = AsyncMock()
-        cache: dict[str, tuple[str, str]] = {"123": ("sess-a", "pool-a")}
+        cache: dict[str, ThreadSession] = {"123": ThreadSession("sess-a", "pool-a")}
 
         result = await retrieve_thread_session(store, "123", "bot1", cache)
 
-        assert result == ("sess-a", "pool-a")
+        assert result == ThreadSession("sess-a", "pool-a")
         store.get_session.assert_not_called()
 
     @pytest.mark.asyncio
@@ -421,12 +428,13 @@ class TestRetrieveThreadSession:
         from unittest.mock import AsyncMock
 
         from lyra.adapters.discord.discord_threads import retrieve_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
         store = AsyncMock()
-        cache: dict[str, tuple[str, str]] = {
-            "1": ("s1", "p1"),
-            "2": ("s2", "p2"),
-            "3": ("s3", "p3"),
+        cache: dict[str, ThreadSession] = {
+            "1": ThreadSession("s1", "p1"),
+            "2": ThreadSession("s2", "p2"),
+            "3": ThreadSession("s3", "p3"),
         }
 
         await retrieve_thread_session(store, "1", "bot1", cache)
@@ -440,16 +448,17 @@ class TestRetrieveThreadSession:
         from unittest.mock import AsyncMock
 
         from lyra.adapters.discord.discord_threads import retrieve_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
         store = AsyncMock()
-        store.get_session.return_value = ("sess-b", "pool-b")
-        cache: dict[str, tuple[str, str]] = {}
+        store.get_session.return_value = ThreadSession("sess-b", "pool-b")
+        cache: dict[str, ThreadSession] = {}
 
         result = await retrieve_thread_session(store, "456", "bot1", cache)
 
-        assert result == ("sess-b", "pool-b")
+        assert result == ThreadSession("sess-b", "pool-b")
         store.get_session.assert_awaited_once_with(thread_id="456", bot_id="bot1")
-        assert cache["456"] == ("sess-b", "pool-b")
+        assert cache["456"] == ThreadSession("sess-b", "pool-b")
 
     @pytest.mark.asyncio
     async def test_cache_miss_none_result_does_not_populate_cache(self) -> None:
@@ -457,14 +466,15 @@ class TestRetrieveThreadSession:
         from unittest.mock import AsyncMock
 
         from lyra.adapters.discord.discord_threads import retrieve_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
         store = AsyncMock()
-        store.get_session.return_value = (None, None)
-        cache: dict[str, tuple[str, str]] = {}
+        store.get_session.return_value = ThreadSession(None, None)
+        cache: dict[str, ThreadSession] = {}
 
         result = await retrieve_thread_session(store, "789", "bot1", cache)
 
-        assert result == (None, None)
+        assert result == ThreadSession(None, None)
         assert "789" not in cache
 
     @pytest.mark.asyncio
@@ -473,10 +483,13 @@ class TestRetrieveThreadSession:
         from unittest.mock import AsyncMock
 
         from lyra.adapters.discord.discord_threads import retrieve_thread_session
+        from lyra.core.stores.thread_store_protocol import ThreadSession
 
         store = AsyncMock()
-        store.get_session.return_value = ("sess-new", "pool-new")
-        cache: dict[str, tuple[str, str]] = {str(i): ("s", "p") for i in range(500)}
+        store.get_session.return_value = ThreadSession("sess-new", "pool-new")
+        cache: dict[str, ThreadSession] = {
+            str(i): ThreadSession("s", "p") for i in range(500)
+        }
         oldest_key = "0"
 
         await retrieve_thread_session(store, "999", "bot1", cache)


### PR DESCRIPTION
## Summary

- Introduce `ThreadSession(frozen=True)` dataclass in `thread_store_protocol.py` to replace the opaque `tuple[str | None, str | None]` returned by `get_session()`
- Named fields (`.session_id`, `.pool_id`) make call sites self-documenting and prevent silent positional breakage when a third field is added (e.g. `agent_name`)
- Update `ThreadStore.get_session()`, `retrieve_thread_session()`, `persist_thread_session()`, `DiscordAdapter._thread_sessions` cache, and `discord_inbound.py` unpack site to use the new type

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #985: refactor(core): replace get_session() opaque tuple with ThreadSession dataclass | Open |
| Implementation | 1 commit on `feat/985-threadsession-dataclass` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (6 updated) | Passed |

## Test Plan

- [ ] All existing `test_discord_threads.py` tests pass with `ThreadSession` mock return values
- [ ] `ThreadStore.get_session()` returns `ThreadSession` with correct fields on DB hit and null-session on miss
- [ ] `retrieve_thread_session` warms cache with `ThreadSession` objects and promotes on LRU hit

Closes #985

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`