### PR TITLE
refactor(logging): stdout-only — remove RotatingFileHandler + lyra-logs volume (#999)

### DIFF
--- a/deploy/quadlet/hub.env.example
+++ b/deploy/quadlet/hub.env.example
@@ -8,6 +8,9 @@
 #
 # NATS_URL and NATS_NKEY_SEED_PATH are set inline in lyra-hub.container.
 
+# Optional: override log level
+# LYRA_LOG_LEVEL=INFO
+
 # Secret token for the /health endpoint (any random string; keep private)
 LYRA_HEALTH_SECRET=
 

--- a/deploy/quadlet/lyra-clipool.container
+++ b/deploy/quadlet/lyra-clipool.container
@@ -13,8 +13,6 @@ ReadOnly=true
 DropCapability=all
 UserNS=keep-id:uid=1500,gid=1500
 Environment=NATS_URL=nats://lyra-nats:4222
-Volume=lyra-logs.volume:/home/lyra/.local/state/lyra/logs:z
-Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 Secret=lyra-nkey-clipool-worker,type=mount,target=clipool-worker.seed,mode=0400,uid=1500,gid=1500
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/clipool-worker.seed
 # ~/.claude/ — directory mount (not file mounts) so Syncthing's atomic renames

--- a/deploy/quadlet/lyra-discord.container
+++ b/deploy/quadlet/lyra-discord.container
@@ -28,8 +28,6 @@ Environment=NATS_URL=nats://lyra-nats:4222
 Secret=lyra-nkey-discord-adapter,type=mount,target=discord-adapter.seed,mode=0400,uid=1500,gid=1500
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/discord-adapter.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:z
-Volume=lyra-logs.volume:/home/lyra/.local/state/lyra/logs:z
-Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 # Inline single-file bind mount — see rationale in lyra-hub.container.
 Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 Exec=lyra adapter discord

--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -22,7 +22,7 @@ DropCapability=all
 UserNS=keep-id:uid=1500,gid=1500
 EnvironmentFile=%h/.lyra/env/hub.env
 # hub.env contains only hub-scoped vars (LYRA_HEALTH_SECRET,
-# LYRA_LOG_DIR, ROXABI_VAULT_DIR). Adapter tokens (Telegram, Discord, TTS/STT)
+# ROXABI_VAULT_DIR). Adapter tokens (Telegram, Discord, TTS/STT)
 # are excluded — hub does not need them. See deploy/quadlet/hub.env.example.
 # NATS_URL is overridden inline below; cutover = update .env.hub directly.
 Environment=NATS_URL=nats://lyra-nats:4222
@@ -30,8 +30,6 @@ Environment=NATS_URL=nats://lyra-nats:4222
 Secret=lyra-nkey-hub,type=mount,target=hub.seed,mode=0400,uid=1500,gid=1500
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/hub.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:z
-Volume=lyra-logs.volume:/home/lyra/.local/state/lyra/logs:z
-Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 # Inline single-file bind mount — Quadlet .volume units wrapping a single file
 # either fail with loop-device errors or are silently downgraded to empty named
 # volumes (IsADirectoryError at read time). Inline Volume= does a direct bind.

--- a/deploy/quadlet/lyra-logs.volume
+++ b/deploy/quadlet/lyra-logs.volume
@@ -1,5 +1,0 @@
-[Unit]
-Description=Lyra logs volume (rotating file handlers, rw for hub + adapters)
-
-[Volume]
-Label=app=lyra

--- a/deploy/quadlet/lyra-telegram.container
+++ b/deploy/quadlet/lyra-telegram.container
@@ -28,8 +28,6 @@ Environment=NATS_URL=nats://lyra-nats:4222
 Secret=lyra-nkey-telegram-adapter,type=mount,target=telegram-adapter.seed,mode=0400,uid=1500,gid=1500
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/telegram-adapter.seed
 Volume=lyra-data.volume:/home/lyra/.lyra:z
-Volume=lyra-logs.volume:/home/lyra/.local/state/lyra/logs:z
-Environment=LYRA_LOG_DIR=/home/lyra/.local/state/lyra/logs
 # Inline single-file bind mount — see rationale in lyra-hub.container.
 Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 Exec=lyra adapter telegram

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -342,7 +342,6 @@ health_secret = ""                            # optional health endpoint auth
 | `LYRA_VAULT_DIR` | `~/.lyra` | Store directory for all databases |
 | `LYRA_MESSAGES_CONFIG` | bundled | Path to custom `messages.toml` |
 | `LYRA_DB` | — | Override database path (test only) |
-| `LYRA_LOG_DIR` | — | Log directory override |
 
 ### Telegram
 

--- a/docs/DEPLOYMENT-quadlet.md
+++ b/docs/DEPLOYMENT-quadlet.md
@@ -34,7 +34,6 @@ systemd --user (linger enabled)
 
 Volumes
 ├── lyra-data           → /home/lyra/.lyra            (hub rw, adapters ro)
-├── lyra-logs           → /home/lyra/.local/state/lyra/logs  (all rw)
 ├── lyra-config         → config.toml bind mount       (ro)
 └── Podman secrets
                         → /run/secrets/*.seed          (each container ro)

--- a/docs/PROD-MIGRATION-STRATEGY.md
+++ b/docs/PROD-MIGRATION-STRATEGY.md
@@ -99,7 +99,7 @@ One or both may not run simultaneously, or INTEL_PORT is overridden. **Verify on
 
 | Project | Container name(s) | Image | Network | Port(s) | Volume(s) | NATS |
 |---|---|---|---|---|---|---|
-| `lyra` | `lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-nats` | `localhost/lyra:latest` | `lyra.network` (or shared `roxabi.network`) | 8443 (hub health) | `lyra-data`, `lyra-logs`, `lyra-config`, `lyra-nkey-*` | via `lyra-nats` container (shared or per-project — ADR TBD) |
+| `lyra` | `lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-nats` | `localhost/lyra:latest` | `lyra.network` (or shared `roxabi.network`) | 8443 (hub health) | `lyra-data`, `lyra-config`, `lyra-nkey-*` | via `lyra-nats` container (shared or per-project — ADR TBD) |
 | `voiceCLI` | `voicecli-tts`, `voicecli-stt` | `localhost/voicecli:latest` | TBD (own or shared) | GPU device passthrough | `voicecli-data`, `voicecli-nkey-*` | shared NATS (post-Phase 4) |
 | `imageCLI` | `imagecli-gen` | `localhost/imagecli:latest` | TBD | GPU device passthrough | `imagecli-data` | unknown; investigate |
 | `llmCLI` | `llmcli-serve` | `localhost/llmcli:latest` | TBD | TBD | `llmcli-data` | unknown; investigate |

--- a/src/lyra/__main__.py
+++ b/src/lyra/__main__.py
@@ -9,9 +9,6 @@ import asyncio
 import logging
 import os
 import sys
-from datetime import datetime, timezone
-from logging.handlers import RotatingFileHandler
-from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -21,7 +18,7 @@ from lyra.bootstrap.factory.config import (
     _load_raw_config,
 )
 from lyra.bootstrap.factory.unified import _bootstrap_unified
-from lyra.core.trace import JsonFormatter, TelegramTokenFilter, TraceIdFilter
+from lyra.core.trace import TelegramTokenFilter, TraceIdFilter
 from lyra.errors import KeyringError, MissingCredentialsError
 
 log = logging.getLogger(__name__)
@@ -47,42 +44,19 @@ async def _main(*, _stop: asyncio.Event | None = None) -> None:
 
 
 def _setup_logging(log_config: LoggingConfig | None = None) -> None:
-    """Configure logging: console + rotating file in ~/.local/state/lyra/logs/.
+    """Configure logging: stdout console handler only.
 
     Uses explicit handler construction (not ``basicConfig``) to guarantee
-    formatter and filter attachment.  When ``log_config.json_file`` is True
-    the file handler emits JSONL; console always stays plaintext.
+    formatter and filter attachment.
     """
     fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
     if log_config is None:
         log_config = LoggingConfig()
 
-    _default_log = str(Path.home() / ".local" / "state" / "lyra" / "logs")
-    log_dir = Path(os.environ.get("LYRA_LOG_DIR", _default_log)).resolve()
-    if os.environ.get("LYRA_LOG_DIR"):
-        log.debug("LYRA_LOG_DIR resolved to %s", log_dir)
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    log_file = log_dir / f"{stamp}_lyra.log"
-
     trace_filter = TraceIdFilter()
     # Redact Telegram bot tokens — httpx logs full request URLs (incl. token)
-    # at INFO. Must run on every handler so both console and file output are
-    # covered. Attached BEFORE formatting.
+    # at INFO. Attached BEFORE formatting.
     telegram_token_filter = TelegramTokenFilter()
-
-    file_handler = RotatingFileHandler(
-        log_file,
-        maxBytes=10 * 1024 * 1024,
-        backupCount=5,  # 10 MB per file, 5 backups
-    )
-    if log_config.json_file:
-        file_handler.setFormatter(JsonFormatter())
-    else:
-        file_handler.setFormatter(logging.Formatter(fmt))
-    file_handler.addFilter(trace_filter)
-    file_handler.addFilter(telegram_token_filter)
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logging.Formatter(fmt))
@@ -96,10 +70,7 @@ def _setup_logging(log_config: LoggingConfig | None = None) -> None:
     root.setLevel(level)
     root.addFilter(trace_filter)
     root.addFilter(telegram_token_filter)
-    root.addHandler(file_handler)
     root.addHandler(console_handler)
-
-    logging.getLogger(__name__).info("Logging to %s", log_file)
 
 
 def main() -> None:

--- a/src/lyra/__main__.py
+++ b/src/lyra/__main__.py
@@ -13,7 +13,6 @@ import sys
 from dotenv import load_dotenv
 
 from lyra.bootstrap.factory.config import (
-    LoggingConfig,
     _load_logging_config,
     _load_raw_config,
 )
@@ -43,15 +42,13 @@ async def _main(*, _stop: asyncio.Event | None = None) -> None:
         sys.exit(str(exc))
 
 
-def _setup_logging(log_config: LoggingConfig | None = None) -> None:
+def _setup_logging(level: str = "INFO") -> None:
     """Configure logging: stdout console handler only.
 
     Uses explicit handler construction (not ``basicConfig``) to guarantee
     formatter and filter attachment.
     """
     fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
-    if log_config is None:
-        log_config = LoggingConfig()
 
     trace_filter = TraceIdFilter()
     # Redact Telegram bot tokens — httpx logs full request URLs (incl. token)
@@ -66,8 +63,8 @@ def _setup_logging(log_config: LoggingConfig | None = None) -> None:
     root = logging.getLogger()
     if root.handlers:
         return  # already configured — avoid duplicate handlers
-    level = getattr(logging, log_config.level.upper(), logging.INFO)
-    root.setLevel(level)
+    level_int = getattr(logging, level.upper(), logging.INFO)
+    root.setLevel(level_int)
     root.addFilter(trace_filter)
     root.addFilter(telegram_token_filter)
     root.addHandler(console_handler)
@@ -75,8 +72,7 @@ def _setup_logging(log_config: LoggingConfig | None = None) -> None:
 
 def main() -> None:
     raw_config = _load_raw_config()
-    log_config = _load_logging_config(raw_config)
-    _setup_logging(log_config)
+    _setup_logging(_load_logging_config(raw_config).level)
     asyncio.run(_main())
 
 

--- a/src/lyra/bootstrap/factory/config.py
+++ b/src/lyra/bootstrap/factory/config.py
@@ -92,7 +92,6 @@ class LoggingConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    json_file: bool = True
     level: str = "info"
 
 

--- a/src/lyra/cli.py
+++ b/src/lyra/cli.py
@@ -91,7 +91,7 @@ def _boot(coro_factory) -> None:
     from lyra.bootstrap.factory.config import _load_logging_config, _load_raw_config
 
     raw_config = _load_raw_config()
-    _setup_logging(_load_logging_config(raw_config))
+    _setup_logging(_load_logging_config(raw_config).level)
     asyncio.run(coro_factory(raw_config))
 
 

--- a/src/lyra/core/trace.py
+++ b/src/lyra/core/trace.py
@@ -1,4 +1,4 @@
-"""Per-request trace context, log filter, and JSON formatter (#270).
+"""Per-request trace context, log filter, and token redaction (#270).
 
 Provides:
 - ``TraceContext`` — three ``contextvars.ContextVar`` instances (trace_id, pool_id,
@@ -9,14 +9,11 @@ Provides:
   tokens from log messages. ``httpx``'s default ``INFO`` log for every
   request includes the full URL, which for Telegram looks like
   ``POST https://api.telegram.org/bot<TOKEN>/sendMessage`` — the token is
-  a credential and must not reach disk.
-- ``JsonFormatter`` — emits one JSON object per line from an explicit field
-  allowlist. No ``LogRecord.__dict__`` dump.
+  a credential and must not appear in log output.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import uuid
@@ -138,49 +135,3 @@ class TelegramTokenFilter(logging.Filter):
         return True
 
 
-class JsonFormatter(logging.Formatter):
-    """Emit one JSON object per line with fields: timestamp, level, logger,
-    message, trace_id, pool_id, agent_name, exception, stack_info.
-
-    Fields whose value is empty string are omitted from the output to keep
-    JSON clean (e.g. ``trace_id`` is absent for startup log lines).
-    """
-
-    def format(self, record: logging.LogRecord) -> str:
-        # Ensure the message is fully interpolated.
-        record.message = record.getMessage()
-        if record.exc_info and not record.exc_text:
-            record.exc_text = self.formatException(record.exc_info)
-
-        obj: dict[str, object] = {
-            "timestamp": self.formatTime(record, self.datefmt),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.message,
-        }
-
-        # Exception and stack_info as separate fields (not in message).
-        if record.exc_text:
-            obj["exception"] = record.exc_text
-
-        if record.stack_info:
-            obj["stack_info"] = self.formatStack(record.stack_info)
-
-        # Add context var fields only when non-empty.
-        trace_id = getattr(record, "trace_id", "")
-        if trace_id:
-            obj["trace_id"] = trace_id
-
-        pool_id = getattr(record, "pool_id", "")
-        if pool_id:
-            obj["pool_id"] = pool_id
-
-        agent_name = getattr(record, "agent_name", "")
-        if agent_name:
-            obj["agent_name"] = agent_name
-
-        event = getattr(record, "event", None)
-        if event:
-            obj["event"] = event
-
-        return json.dumps(obj, ensure_ascii=False)

--- a/src/lyra/monitoring/__main__.py
+++ b/src/lyra/monitoring/__main__.py
@@ -11,9 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
-from logging.handlers import RotatingFileHandler
-from pathlib import Path
 
 from .checks import run_checks
 from .config import load_monitoring_config
@@ -23,26 +20,13 @@ log = logging.getLogger("lyra.monitoring")
 
 
 def _setup_monitor_logging() -> None:
-    """Configure logging to ~/.local/state/lyra/logs/monitor.log."""
+    """Configure logging to stdout."""
     fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
-
-    _default_log = str(Path.home() / ".local" / "state" / "lyra" / "logs")
-    log_dir = Path(os.environ.get("LYRA_LOG_DIR", _default_log)).resolve()
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    log_file = log_dir / "monitor.log"
-
-    file_handler = RotatingFileHandler(
-        log_file,
-        maxBytes=5 * 1024 * 1024,
-        backupCount=3,
-    )
-    file_handler.setFormatter(logging.Formatter(fmt))
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logging.Formatter(fmt))
 
-    logging.basicConfig(level=logging.INFO, handlers=[file_handler, console_handler])
+    logging.basicConfig(level=logging.INFO, handlers=[console_handler])
 
 
 async def _run() -> int:

--- a/src/lyra/monitoring/__main__.py
+++ b/src/lyra/monitoring/__main__.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from lyra.core.trace import TelegramTokenFilter, TraceIdFilter
+
 from .checks import run_checks
 from .config import load_monitoring_config
 from .escalation import escalate_to_llm, send_telegram_alert, send_telegram_raw_alert
@@ -20,13 +22,23 @@ log = logging.getLogger("lyra.monitoring")
 
 
 def _setup_monitor_logging() -> None:
-    """Configure logging to stdout."""
+    """Configure logging to stdout with token redaction."""
     fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logging.Formatter(fmt))
+    trace_filter = TraceIdFilter()
+    telegram_filter = TelegramTokenFilter()
+    console_handler.addFilter(trace_filter)
+    console_handler.addFilter(telegram_filter)
 
-    logging.basicConfig(level=logging.INFO, handlers=[console_handler])
+    root = logging.getLogger()
+    if root.handlers:
+        return
+    root.setLevel(logging.INFO)
+    root.addFilter(trace_filter)
+    root.addFilter(telegram_filter)
+    root.addHandler(console_handler)
 
 
 async def _run() -> int:

--- a/tests/core/test_json_formatter.py
+++ b/tests/core/test_json_formatter.py
@@ -1,228 +1,45 @@
-"""Unit tests for JsonFormatter and LoggingConfig (#270)."""
+"""Unit tests for LoggingConfig and _setup_logging wiring (#270)."""
 
 from __future__ import annotations
 
-import json
 import logging
-import logging.handlers
-from contextvars import copy_context
 
 from lyra.bootstrap.factory.config import LoggingConfig, _load_logging_config
-from lyra.core.trace import JsonFormatter, TraceContext, TraceIdFilter
-
-# ──────────────────────────────────────────────────────────────────────
-# JsonFormatter
-# ──────────────────────────────────────────────────────────────────────
-
-
-class TestJsonFormatter:
-    def _make_record(self, msg: str = "test message", **kwargs) -> logging.LogRecord:
-        record = logging.LogRecord(
-            name="lyra.core.hub",
-            level=logging.INFO,
-            pathname="hub.py",
-            lineno=42,
-            msg=msg,
-            args=kwargs.get("args", ()),
-            exc_info=None,
-        )
-        # Simulate TraceIdFilter having run
-        record.trace_id = kwargs.get("trace_id", "")  # type: ignore[attr-defined]
-        record.pool_id = kwargs.get("pool_id", "")  # type: ignore[attr-defined]
-        return record
-
-    def test_output_is_valid_json(self) -> None:
-        fmt = JsonFormatter()
-        record = self._make_record()
-        line = fmt.format(record)
-        obj = json.loads(line)
-        assert isinstance(obj, dict)
-
-    def test_allowlist_fields_present(self) -> None:
-        fmt = JsonFormatter()
-        record = self._make_record(trace_id="abc-123", pool_id="tg:main:chat:1")
-        obj = json.loads(fmt.format(record))
-        assert obj["level"] == "INFO"
-        assert obj["logger"] == "lyra.core.hub"
-        assert obj["message"] == "test message"
-        assert obj["trace_id"] == "abc-123"
-        assert obj["pool_id"] == "tg:main:chat:1"
-        assert "timestamp" in obj
-
-    def test_empty_trace_id_omitted(self) -> None:
-        """Fields with empty string value are omitted from JSON."""
-        fmt = JsonFormatter()
-        record = self._make_record()
-        obj = json.loads(fmt.format(record))
-        assert "trace_id" not in obj
-        assert "pool_id" not in obj
-
-    def test_no_internal_logrecord_fields(self) -> None:
-        """Internal fields like pathname, threadName must NOT appear."""
-        fmt = JsonFormatter()
-        record = self._make_record(trace_id="t1")
-        obj = json.loads(fmt.format(record))
-        forbidden = ("pathname", "threadName", "processName", "lineno")
-        for key in forbidden:
-            assert key not in obj
-
-    def test_message_interpolation(self) -> None:
-        """Format args should be interpolated into the message."""
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="hello %s count=%d",
-            args=("world", 42),
-            exc_info=None,
-        )
-        record.trace_id = ""  # type: ignore[attr-defined]
-        record.pool_id = ""  # type: ignore[attr-defined]
-        fmt = JsonFormatter()
-        obj = json.loads(fmt.format(record))
-        assert obj["message"] == "hello world count=42"
-
-    def test_exception_in_separate_field(self) -> None:
-        """Exception text should be in a separate 'exception' field."""
-        try:
-            raise ValueError("boom")
-        except ValueError:
-            import sys
-
-            exc_info = sys.exc_info()
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.ERROR,
-            pathname="",
-            lineno=0,
-            msg="something failed",
-            args=(),
-            exc_info=exc_info,
-        )
-        record.trace_id = ""  # type: ignore[attr-defined]
-        record.pool_id = ""  # type: ignore[attr-defined]
-        fmt = JsonFormatter()
-        obj = json.loads(fmt.format(record))
-        assert obj["message"] == "something failed"
-        assert "ValueError: boom" in obj["exception"]
-
-    def test_one_line_per_record(self) -> None:
-        """Each formatted record must be a single line (JSONL)."""
-        fmt = JsonFormatter()
-        record = self._make_record()
-        line = fmt.format(record)
-        assert "\n" not in line
-
-    def test_one_line_per_record_with_exception(self) -> None:
-        """JSONL invariant holds even with multi-line exception tracebacks."""
-        try:
-            raise RuntimeError("multi\nline\nerror")
-        except RuntimeError:
-            import sys
-
-            exc_info = sys.exc_info()
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.ERROR,
-            pathname="",
-            lineno=0,
-            msg="fail",
-            args=(),
-            exc_info=exc_info,
-        )
-        record.trace_id = ""  # type: ignore[attr-defined]
-        record.pool_id = ""  # type: ignore[attr-defined]
-        fmt = JsonFormatter()
-        line = fmt.format(record)
-        assert "\n" not in line
-        obj = json.loads(line)
-        assert "exception" in obj
-
-    def test_non_ascii_message(self) -> None:
-        """Non-ASCII messages are preserved (ensure_ascii=False)."""
-        fmt = JsonFormatter()
-        record = self._make_record(msg="Привет мир 🌍")
-        obj = json.loads(fmt.format(record))
-        assert obj["message"] == "Привет мир 🌍"
-
-    def test_integration_with_filter(self) -> None:
-        """TraceIdFilter + JsonFormatter work together end-to-end."""
-        f = TraceIdFilter()
-        fmt = JsonFormatter()
-        record = logging.LogRecord(
-            name="lyra.test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="integrated test",
-            args=(),
-            exc_info=None,
-        )
-
-        def _inner():
-            TraceContext.set_trace_id("int-trace-1")
-            TraceContext.set_pool_id("tg:main:chat:99")
-            f.filter(record)
-            return fmt.format(record)
-
-        ctx = copy_context()
-        line = ctx.run(_inner)
-        obj = json.loads(line)
-        assert obj["trace_id"] == "int-trace-1"
-        assert obj["pool_id"] == "tg:main:chat:99"
-        assert obj["message"] == "integrated test"
-
+from lyra.core.trace import TraceIdFilter  # noqa: F401 (used in isinstance checks)
 
 # ──────────────────────────────────────────────────────────────────────
 # LoggingConfig
 # ──────────────────────────────────────────────────────────────────────
 
 
+class TestLoggingConfig:
+    def test_default_level_is_info(self) -> None:
+        cfg = LoggingConfig()
+        assert cfg.level == "info"
+
+    def test_override_level(self) -> None:
+        cfg = LoggingConfig(level="debug")
+        assert cfg.level == "debug"
+
+    def test_load_from_raw_config(self) -> None:
+        raw = {"logging": {"level": "debug"}}
+        cfg = _load_logging_config(raw)
+        assert cfg.level == "debug"
+
+    def test_load_from_empty_config(self) -> None:
+        cfg = _load_logging_config({})
+        assert cfg.level == "info"  # default
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _setup_logging
+# ──────────────────────────────────────────────────────────────────────
+
+
 class TestSetupLogging:
     """Tests for _setup_logging wiring (#270)."""
 
-    def test_json_file_true_uses_json_formatter(self, tmp_path, monkeypatch) -> None:
-        monkeypatch.setattr("lyra.__main__.Path.home", lambda: tmp_path)
-        import lyra.__main__ as main_mod
-
-        # Clear any existing root handlers
-        root = logging.getLogger()
-        original_handlers = root.handlers[:]
-        root.handlers.clear()
-        try:
-            main_mod._setup_logging(LoggingConfig(json_file=True))
-            file_handler = next(
-                h
-                for h in root.handlers
-                if isinstance(h, logging.handlers.RotatingFileHandler)
-            )
-            assert isinstance(file_handler.formatter, JsonFormatter)
-        finally:
-            root.handlers[:] = original_handlers
-
-    def test_json_file_false_uses_plain_formatter(self, tmp_path, monkeypatch) -> None:
-        monkeypatch.setattr("lyra.__main__.Path.home", lambda: tmp_path)
-        import lyra.__main__ as main_mod
-
-        root = logging.getLogger()
-        original_handlers = root.handlers[:]
-        root.handlers.clear()
-        try:
-            main_mod._setup_logging(LoggingConfig(json_file=False))
-            file_handler = next(
-                h
-                for h in root.handlers
-                if isinstance(h, logging.handlers.RotatingFileHandler)
-            )
-            assert not isinstance(file_handler.formatter, JsonFormatter)
-        finally:
-            root.handlers[:] = original_handlers
-
-    def test_trace_filter_attached_to_root(self, tmp_path, monkeypatch) -> None:
-        monkeypatch.setattr("lyra.__main__.Path.home", lambda: tmp_path)
+    def test_trace_filter_attached_to_root(self) -> None:
         import lyra.__main__ as main_mod
 
         root = logging.getLogger()
@@ -237,8 +54,7 @@ class TestSetupLogging:
             root.handlers[:] = original_handlers
             root.filters[:] = original_filters
 
-    def test_duplicate_call_does_not_add_handlers(self, tmp_path, monkeypatch) -> None:
-        monkeypatch.setattr("lyra.__main__.Path.home", lambda: tmp_path)
+    def test_duplicate_call_does_not_add_handlers(self) -> None:
         import lyra.__main__ as main_mod
 
         root = logging.getLogger()
@@ -252,21 +68,16 @@ class TestSetupLogging:
         finally:
             root.handlers[:] = original_handlers
 
+    def test_console_handler_only(self) -> None:
+        """After setup, only a StreamHandler is present (no file handler)."""
+        import lyra.__main__ as main_mod
 
-class TestLoggingConfig:
-    def test_default_json_file_true(self) -> None:
-        cfg = LoggingConfig()
-        assert cfg.json_file is True
-
-    def test_override_json_file_false(self) -> None:
-        cfg = LoggingConfig(json_file=False)
-        assert cfg.json_file is False
-
-    def test_load_from_raw_config(self) -> None:
-        raw = {"logging": {"json_file": False}}
-        cfg = _load_logging_config(raw)
-        assert cfg.json_file is False
-
-    def test_load_from_empty_config(self) -> None:
-        cfg = _load_logging_config({})
-        assert cfg.json_file is True  # default
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        root.handlers.clear()
+        try:
+            main_mod._setup_logging(LoggingConfig())
+            assert len(root.handlers) == 1
+            assert isinstance(root.handlers[0], logging.StreamHandler)
+        finally:
+            root.handlers[:] = original_handlers

--- a/tests/core/test_logging_setup.py
+++ b/tests/core/test_logging_setup.py
@@ -1,11 +1,14 @@
-"""Unit tests for LoggingConfig and _setup_logging wiring (#270)."""
+"""Unit tests for LoggingConfig and _setup_logging wiring (#999)."""
 
 from __future__ import annotations
 
 import logging
 
 from lyra.bootstrap.factory.config import LoggingConfig, _load_logging_config
-from lyra.core.trace import TraceIdFilter  # noqa: F401 (used in isinstance checks)
+from lyra.core.trace import (  # noqa: F401 (used in isinstance checks)
+    TelegramTokenFilter,
+    TraceIdFilter,
+)
 
 # ──────────────────────────────────────────────────────────────────────
 # LoggingConfig
@@ -37,7 +40,7 @@ class TestLoggingConfig:
 
 
 class TestSetupLogging:
-    """Tests for _setup_logging wiring (#270)."""
+    """Tests for _setup_logging wiring (#999)."""
 
     def test_trace_filter_attached_to_root(self) -> None:
         import lyra.__main__ as main_mod
@@ -48,7 +51,7 @@ class TestSetupLogging:
         root.handlers.clear()
         root.filters.clear()
         try:
-            main_mod._setup_logging(LoggingConfig())
+            main_mod._setup_logging()
             assert any(isinstance(f, TraceIdFilter) for f in root.filters)
         finally:
             root.handlers[:] = original_handlers
@@ -59,14 +62,34 @@ class TestSetupLogging:
 
         root = logging.getLogger()
         original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
         root.handlers.clear()
+        root.filters.clear()
         try:
-            main_mod._setup_logging(LoggingConfig())
+            main_mod._setup_logging()
             count_after_first = len(root.handlers)
-            main_mod._setup_logging(LoggingConfig())
+            main_mod._setup_logging()
             assert len(root.handlers) == count_after_first
         finally:
             root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+
+    def test_level_applied_to_root(self) -> None:
+        import lyra.__main__ as main_mod
+
+        root = logging.getLogger()
+        original_level = root.level
+        original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
+        root.handlers.clear()
+        root.filters.clear()
+        try:
+            main_mod._setup_logging(level="debug")
+            assert root.level == logging.DEBUG
+        finally:
+            root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+            root.setLevel(original_level)
 
     def test_console_handler_only(self) -> None:
         """After setup, only a StreamHandler is present (no file handler)."""
@@ -74,10 +97,16 @@ class TestSetupLogging:
 
         root = logging.getLogger()
         original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
         root.handlers.clear()
+        root.filters.clear()
         try:
-            main_mod._setup_logging(LoggingConfig())
+            main_mod._setup_logging()
             assert len(root.handlers) == 1
             assert isinstance(root.handlers[0], logging.StreamHandler)
+            handler_filters = root.handlers[0].filters
+            assert any(isinstance(f, TraceIdFilter) for f in handler_filters)
+            assert any(isinstance(f, TelegramTokenFilter) for f in handler_filters)
         finally:
             root.handlers[:] = original_handlers
+            root.filters[:] = original_filters

--- a/tests/core/test_monitor_logging.py
+++ b/tests/core/test_monitor_logging.py
@@ -1,0 +1,82 @@
+"""Tests for lyra.monitoring._setup_monitor_logging (#999)."""
+
+from __future__ import annotations
+
+import logging
+
+from lyra.core.trace import TelegramTokenFilter, TraceIdFilter
+
+
+class TestSetupMonitorLogging:
+    def test_root_level_is_info(self) -> None:
+        from lyra.monitoring.__main__ import _setup_monitor_logging
+
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
+        original_level = root.level
+        root.handlers.clear()
+        root.filters.clear()
+        try:
+            _setup_monitor_logging()
+            assert root.level == logging.INFO
+        finally:
+            root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+            root.setLevel(original_level)
+
+    def test_stream_handler_present(self) -> None:
+        from lyra.monitoring.__main__ import _setup_monitor_logging
+
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
+        original_level = root.level
+        root.handlers.clear()
+        root.filters.clear()
+        try:
+            _setup_monitor_logging()
+            assert len(root.handlers) == 1
+            assert isinstance(root.handlers[0], logging.StreamHandler)
+        finally:
+            root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+            root.setLevel(original_level)
+
+    def test_telegram_token_filter_attached(self) -> None:
+        from lyra.monitoring.__main__ import _setup_monitor_logging
+
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
+        original_level = root.level
+        root.handlers.clear()
+        root.filters.clear()
+        try:
+            _setup_monitor_logging()
+            handler_filters = root.handlers[0].filters
+            assert any(isinstance(f, TelegramTokenFilter) for f in handler_filters)
+            assert any(isinstance(f, TraceIdFilter) for f in handler_filters)
+        finally:
+            root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+            root.setLevel(original_level)
+
+    def test_idempotent_on_double_call(self) -> None:
+        from lyra.monitoring.__main__ import _setup_monitor_logging
+
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
+        original_level = root.level
+        root.handlers.clear()
+        root.filters.clear()
+        try:
+            _setup_monitor_logging()
+            count_after_first = len(root.handlers)
+            _setup_monitor_logging()
+            assert len(root.handlers) == count_after_first
+        finally:
+            root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+            root.setLevel(original_level)


### PR DESCRIPTION
## Summary
- Remove `RotatingFileHandler` from all lyra entry points (`__main__.py`, `monitoring/__main__.py`) — stdout only, journald is the persistent sink in prod
- Delete `lyra-logs` named volume and all `Volume=`/`Environment=LYRA_LOG_DIR=` lines from 4 Quadlet units
- Remove dead `LoggingConfig.json_file` field and `JsonFormatter` class (sole consumer was the file handler)
- Update docs: remove `lyra-logs` from `DEPLOYMENT-quadlet.md` and `PROD-MIGRATION-STRATEGY.md`
- Supersedes #998 (bind-mount approach) — correct fix is removing the handler, not changing mount type

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | #999: std: stdout-only logging — remove file handlers, set journald retention | Open |
| Frame | [999-stdout-only-logging-frame.mdx](artifacts/frames/999-stdout-only-logging-frame.mdx) | Approved |
| Spec | [999-stdout-only-logging-spec.mdx](artifacts/specs/999-stdout-only-logging-spec.mdx) | Approved |
| Implementation | 2 commits on `feat/999-stdout-only-logging` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (test_json_formatter.py updated: JsonFormatter tests replaced with LoggingConfig + stdout-only wiring tests) | Passed |

## Test Plan
- [ ] `uv run lyra hub` starts without error; logs appear on stdout only
- [ ] `uv run python -m lyra.monitoring` starts, logs stdout only
- [ ] `grep -r "RotatingFileHandler\|lyra-logs\|LYRA_LOG_DIR\|JsonFormatter\|json_file" src/lyra/ deploy/quadlet/ docs/` → no matches
- [ ] On M₁ after `systemctl --user daemon-reload`: all 4 containers start without volume errors

Closes #999

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`