### PR TITLE
feat(nats): add status/created_at lifecycle fields to acl-matrix identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Check ACL matrix spec drift
         run: bash scripts/check-acl-matrix-spec.sh
 
+      - name: Check ACL matrix lifecycle fields
+        run: bash scripts/check-acl-matrix-retired.sh
+
       - name: Check request-reply flows
         run: bash scripts/check-request-reply-flows.sh
 

--- a/artifacts/analyses/1001-acl-matrix-review-findings-consensus.mdx
+++ b/artifacts/analyses/1001-acl-matrix-review-findings-consensus.mdx
@@ -1,0 +1,75 @@
+---
+title: "#1001 acl-matrix review findings — Expert Consensus"
+issue: 1001
+status: consensus-reached
+date: 2026-04-29
+panel: architect, devops, product-lead
+confidence: high
+---
+
+## Problem
+
+Four remaining code-review findings for #1001 (acl-matrix.json lifecycle fields) required a long-term decision: whether to apply structural changes or lighter-weight annotations, and whether to reorder CI steps or accept current ordering.
+
+## Panel
+
+| Agent | Focus |
+|---|---|
+| architect | arch soundness, maintainability, future-proofing |
+| devops | ops impact, CI reliability, bash idioms |
+| product-lead | operator UX, docs quality, runbook usability |
+
+## Consensus
+
+### F3 — `retired_at` format-check short-circuit (unanimous B, avg 87%)
+
+**Decision:** Add a comment clarifying the intent of the `-z "$retired"` guard — no structural refactor.
+
+**Rationale:** Both line 21 and line 22 use the same `[[ -z "$x" || "$x" =~ $RE ]]` idiom; rewriting only line 22 to an if/fi block would break visual symmetry with line 21 and add 3 lines for zero behavioral change. A comment is the minimum-cost fix.
+
+**Rejected (A):** Structural refactor introduces diff noise, breaks symmetry, adds indentation for no runtime benefit.
+
+---
+
+### F4 — CI step ordering (unanimous B, avg 86%)
+
+**Decision:** Leave current order — "Check ACL matrix spec drift" before "Check ACL matrix lifecycle fields".
+
+**Rationale:** The current order follows a coherent data-flow narrative: spec table correctness → lifecycle field validity → flow references → authconf drift. Swapping produces no measurable diagnostic improvement (both steps fail independently with clear step names in the CI log). "More fundamental" is not user-observable in a flat CI log.
+
+**Rejected (A):** No runtime benefit; would break an implicit ordering rationale and generate a noise commit.
+
+---
+
+### F5 — jq O(n) forks in `check-acl-matrix-retired.sh` (unanimous B, avg 92%)
+
+**Decision:** Accept the current approach (3–5 jq calls per identity). Revisit only if the matrix grows beyond ~100 identities or the script enters a hot path.
+
+**Rationale:** At ≤20 identities the overhead is 50–200ms, unmeasurable against the pytest bottleneck in the same CI job. The current pattern (one jq call per field per identity) maps directly to error messages and is easy to audit. A single-pass jq refactor would embed complex conditional validation in jq syntax, increasing cognitive surface for ops maintainers.
+
+**Rejected (A):** Premature optimization. Identity counts are bounded by human decisions and grow slowly.
+
+---
+
+### F6 — Runbook annotation (unanimous A, avg 90%)
+
+**Decision:** Add an inline one-liner comment at each `check-acl-matrix-retired.sh` call site in the runbook, explaining it validates all identities (not just the one being retired/added).
+
+**Rationale:** Runbooks are read top-to-bottom under operational pressure. An inline comment at the call site eliminates the most common misread ("this only checks the identity I just touched") without requiring the reader to scroll to the CI checks table. Cross-references are appropriate for architecture docs, not for procedural steps.
+
+**Rejected (B):** Cross-reference requires navigation during a time-sensitive operation; the table is excellent reference material but not a substitute for inline context at the call site.
+
+## Dissent
+
+None — unanimous on all four findings.
+
+## Implementation Notes
+
+- F3: add `# -z guard intentional: empty already caught above` on line 22
+- F4: no change to ci.yml
+- F5: no change to check-acl-matrix-retired.sh
+- F6: add inline annotation at both call sites in nats-identity-retirement.md (retire step 3, add-identity step 2)
+
+## Next
+
+These decisions feed directly into the active `/fix` pipeline for PR #1011.

--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -14,13 +14,13 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 ## ACL Matrix
 
 <!-- acl-matrix:begin -->
-| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | image-worker | clipool-worker | monitor |
+| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | image-worker | monitor | clipool-worker |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — |
 | `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — |
 | `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — |
 | `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — |
-| `lyra.system.ready` [^ready] | SUB | PUB | PUB | PUB | PUB | — | — | PUB | — |
+| `lyra.system.ready` [^ready] | SUB | PUB | PUB | PUB | PUB | — | — | — | PUB |
 | `lyra.voice.tts.request` | PUB | — | — | SUB | — | — | — | — | — |
 | `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — |
 | `lyra.voice.stt.request` | PUB | — | — | — | SUB | — | — | — | — |
@@ -29,17 +29,17 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 | `lyra.llm.health.*` [^health] | SUB | — | — | — | — | PUB | — | — | — |
 | `lyra.image.generate.request` | PUB | — | — | — | — | — | SUB | — | — |
 | `lyra.image.heartbeat` | SUB | — | — | — | — | — | PUB | — | — |
-| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | SUB | — |
-| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | PUB | — |
+| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | SUB |
+| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | PUB |
 | `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — |
-| `lyra.monitor.>` [^monitor] | — | — | — | — | — | — | — | — | PUB+SUB |
-| `_inbox.hub.>` [^inbox] | SUB | — | — | PUB | PUB | PUB | PUB | PUB | — |
+| `lyra.monitor.>` [^monitor] | — | — | — | — | — | — | — | PUB+SUB | — |
+| `_inbox.hub.>` [^inbox] | SUB | — | — | PUB | PUB | PUB | PUB | — | PUB |
 | `_inbox.telegram-adapter.>` [^inbox] | — | SUB | — | — | — | — | — | — | — |
 | `_inbox.discord-adapter.>` [^inbox] | — | — | SUB | — | — | — | — | — | — |
 | `_inbox.voice-tts.>` [^inbox] | — | — | — | SUB | — | — | — | — | — |
 | `_inbox.voice-stt.>` [^inbox] | — | — | — | — | SUB | — | — | — | — |
 | `_inbox.image-worker.>` [^inbox] | — | — | — | — | — | — | SUB | — | — |
-| `_inbox.clipool-worker.>` [^inbox] | — | — | — | — | — | — | — | SUB | — |
+| `_inbox.clipool-worker.>` [^inbox] | — | — | — | — | — | — | — | — | SUB |
 <!-- acl-matrix:end -->
 
 [^ready]: `lyra.system.ready` — adapters and workers publish once on startup; hub subscribes to track liveness.

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -9,6 +9,8 @@
   ],
   "identities": {
     "hub": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "lyra",
       "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image/clipool workers. Inbox normalized to lowercase _inbox.hub.> (ADR-051 + postmortem Fix 1).",
       "notes": "Stream provisioning is a deploy-time admin operation — hub does not create/update streams at runtime. $JS.API.STREAM.CREATE/UPDATE.LYRA_AUDIT are intentionally absent from publish ACLs.",
@@ -36,6 +38,8 @@
       ]
     },
     "telegram-adapter": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "lyra",
       "description": "Telegram bot adapter — inbox normalized to _inbox.telegram-adapter.> (ADR-051 + postmortem Fix 1).",
       "allow_responses": false,
@@ -50,6 +54,8 @@
       ]
     },
     "discord-adapter": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "lyra",
       "description": "Discord bot adapter — inbox normalized to _inbox.discord-adapter.> (ADR-051 + postmortem Fix 1).",
       "allow_responses": false,
@@ -64,6 +70,8 @@
       ]
     },
     "voice-tts": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "voicecli",
       "description": "voicecli nats-serve TTS worker on Machine 1 (#689). Inbox normalized to _inbox.voice-tts.> (ADR-051 + postmortem Fix 1; voicecli confirmed lowercase 2026-04-28). Inbox grant derived from request_reply_flows (Fix 3 / #992).",
       "allow_responses": true,
@@ -78,6 +86,8 @@
       ]
     },
     "voice-stt": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "voicecli",
       "description": "voicecli nats-serve STT worker on Machine 1 (#689). Inbox normalized to _inbox.voice-stt.> (ADR-051 + postmortem Fix 1; voicecli confirmed lowercase 2026-04-28). Inbox grant derived from request_reply_flows (Fix 3 / #992).",
       "allow_responses": true,
@@ -92,6 +102,8 @@
       ]
     },
     "llm-worker": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "reserved",
       "description": "Reserved LLM worker identity — publishes health status, subscribes to LLM request queue. Inbox grant derived from request_reply_flows (Fix 3 / #992).",
       "allow_responses": true,
@@ -103,6 +115,8 @@
       ]
     },
     "image-worker": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "imagecli",
       "description": "imagecli nats-serve satellite (ADR-050, imageCLI#50 + #754). Inbox normalized to _inbox.image-worker.> (ADR-051 + postmortem Fix 1). Inbox grant derived from request_reply_flows (Fix 3 / #992).",
       "allow_responses": true,
@@ -115,6 +129,8 @@
       ]
     },
     "monitor": {
+      "status": "active",
+      "created_at": "2026-04-21",
       "owner": "reserved",
       "description": "Monitoring identity — full pub+sub on lyra.monitor.> namespace.",
       "allow_responses": false,
@@ -126,6 +142,8 @@
       ]
     },
     "clipool-worker": {
+      "status": "active",
+      "created_at": "2026-04-27",
       "owner": "lyra",
       "description": "CliPool NATS worker — receives claude subprocess dispatch commands from hub, publishes heartbeat and reply-path responses. Inbox normalized to _inbox.clipool-worker.> (ADR-051 + postmortem Fix 1). Inbox grant derived from request_reply_flows (Fix 3 / #992).",
       "allow_responses": true,

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -97,6 +97,14 @@ load_matrix() {
         || error "acl-matrix.json: identity '${name}' missing field '${field}'"
     done
 
+    for lc_field in status created_at; do
+      local has_lc
+      has_lc=$(jq -r --arg n "${name}" --arg f "${lc_field}" \
+        'if .identities[$n] | has($f) then "yes" else "no" end' "${MATRIX_JSON}")
+      [ "${has_lc}" = "yes" ] \
+        || error "acl-matrix.json: identity '${name}' missing field '${lc_field}'"
+    done
+
     local o
     o=$(jq -r --arg n "${name}" '.identities[$n].owner' "${MATRIX_JSON}")
     echo " ${valid_owners} " | grep -qw "${o}" \
@@ -110,7 +118,7 @@ load_matrix() {
     ALLOW_RESPONSES[$name]=$(jq -r --arg n "${name}" \
       'if (.identities[$n] | has("allow_responses")) then .identities[$n].allow_responses else true end' \
       "${MATRIX_JSON}")
-  done < <(jq -r '.identities | keys_unsorted[]' "${MATRIX_JSON}")
+  done < <(jq -r '.identities | to_entries[] | select(.value.status != "retired") | .key' "${MATRIX_JSON}")
 
   # Assert no duplicate (requester, responder) pairs in request_reply_flows.
   # subject is advisory only — derivation is per-pair, not per-subject; two entries with

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -664,31 +664,15 @@ mkdir -p "${AUTH_DIR}"
 chown root:nats "${AUTH_DIR}"
 chmod 750 "${AUTH_DIR}"
 
-# ── generate nkey pairs (T1.5: extended to 7; generate_nkey defined earlier) ──
+# ── generate nkey pairs + write auth.conf ────────────────────────────────────
 
 info "Generating nkey pairs in ${SEEDS_DIR}/ ..."
-HUB_PUB=$(generate_nkey "hub")
-TELEGRAM_PUB=$(generate_nkey "telegram-adapter")
-DISCORD_PUB=$(generate_nkey "discord-adapter")
-VOICE_TTS_PUB=$(generate_nkey "voice-tts")
-VOICE_STT_PUB=$(generate_nkey "voice-stt")
-WORKER_PUB=$(generate_nkey "llm-worker")
-IMAGE_WORKER_PUB=$(generate_nkey "image-worker")
-MONITOR_PUB=$(generate_nkey "monitor")
-CLIPOOL_PUB=$(generate_nkey "clipool-worker")
+declare -A PUBKEYS
+for name in "${IDENTITIES[@]}"; do
+  PUBKEYS[$name]=$(generate_nkey "${name}")
+done
 
-# ── write auth.conf via render_auth_conf (T1.6) ───────────────────────────────
-declare -A PUBKEYS=(
-  [hub]="${HUB_PUB}"
-  [telegram-adapter]="${TELEGRAM_PUB}"
-  [discord-adapter]="${DISCORD_PUB}"
-  [voice-tts]="${VOICE_TTS_PUB}"
-  [voice-stt]="${VOICE_STT_PUB}"
-  [llm-worker]="${WORKER_PUB}"
-  [image-worker]="${IMAGE_WORKER_PUB}"
-  [monitor]="${MONITOR_PUB}"
-  [clipool-worker]="${CLIPOOL_PUB}"
-)
+# ── write auth.conf via render_auth_conf ──────────────────────────────────────
 render_auth_conf PUBKEYS > "${AUTH_CONF}"
 
 chown root:nats "${AUTH_CONF}"

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -247,6 +247,15 @@ done
 [ -n "${MATRIX_JSON_OVERRIDE}" ] && MATRIX_JSON="${MATRIX_JSON_OVERRIDE}"
 load_matrix
 
+# ── warn for retired identities with seeds on disk ───────────────────────────
+while IFS= read -r name; do
+  _status=$(jq -r --arg n "${name}" '.identities[$n].status' "${MATRIX_JSON}")
+  if [ "${_status}" = "retired" ]; then
+    seed_file="${SEEDS_DIR}/${name}.seed"
+    [ -f "${seed_file}" ] && warn "Retired identity '${name}' has a seed on disk: ${seed_file} — consider shredding it"
+  fi
+done < <(jq -r '.identities | keys_unsorted[]' "${MATRIX_JSON}")
+
 # ── validate-supervisor mode — no root required ────────────────────────────────
 if $VALIDATE_SUPERVISOR; then
   validate_supervisor

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -306,9 +306,15 @@ if [ "${EMIT_MERGED_AUTHCONF}" = true ]; then
   VOICECLI_SEEDS_DIR="${HOME}/.voicecli/nkeys"
   MERGED_AUTH_CONF="${SEEDS_DIR}/auth.conf"
 
-  # Live identities for merged auth.conf
-  MERGED_LYRA_IDENTITIES=("hub" "telegram-adapter" "discord-adapter" "clipool-worker")
-  MERGED_VOICE_IDENTITIES=("voice-tts" "voice-stt")
+  # Live identities for merged auth.conf — derived from IDENTITIES[] by owner
+  MERGED_LYRA_IDENTITIES=()
+  MERGED_VOICE_IDENTITIES=()
+  for name in "${IDENTITIES[@]}"; do
+    case "${OWNER[$name]}" in
+      lyra)     MERGED_LYRA_IDENTITIES+=("${name}") ;;
+      voicecli) MERGED_VOICE_IDENTITIES+=("${name}") ;;
+    esac
+  done
 
   declare -A MERGED_PUBKEYS
 

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -251,12 +251,6 @@ done
 [ -n "${MATRIX_JSON_OVERRIDE}" ] && MATRIX_JSON="${MATRIX_JSON_OVERRIDE}"
 load_matrix
 
-# ── warn for retired identities with seeds on disk ───────────────────────────
-while IFS= read -r name; do
-  seed_file="${SEEDS_DIR}/${name}.seed"
-  [ -f "${seed_file}" ] && warn "Retired identity '${name}' has a seed on disk: ${seed_file} — consider shredding it"
-done < <(jq -r '.identities | to_entries[] | select(.value.status == "retired") | .key' "${MATRIX_JSON}")
-
 # ── validate-supervisor mode — no root required ────────────────────────────────
 if $VALIDATE_SUPERVISOR; then
   validate_supervisor
@@ -442,6 +436,13 @@ if [ "${FIX_PERMS}" = true ]; then
   apply_permissions
   exit 0
 fi
+
+# ── warn for retired identities with seeds on disk ───────────────────────────
+# Runs only for filesystem-mutating modes (regen-authconf, regenerate, default).
+while IFS= read -r name; do
+  seed_file="${SEEDS_DIR}/${name}.seed"
+  [ -f "${seed_file}" ] && warn "Retired identity '${name}' has a seed on disk: ${seed_file} — consider shredding it"
+done < <(jq -r '.identities | to_entries[] | select(.value.status == "retired") | .key' "${MATRIX_JSON}")
 
 # ── regen-authconf mode: re-render auth.conf from existing seeds ──────────────
 # Purpose: upgrade a live auth.conf to the current IDENTITIES + ACL matrix

--- a/deploy/nats/gen-nkeys.sh
+++ b/deploy/nats/gen-nkeys.sh
@@ -4,9 +4,8 @@
 # Seeds (private keys) → ~/.lyra/nkeys/     owned by LYRA_USER, 0600 — no system access needed
 # auth.conf (public keys) → /etc/nats/nkeys/ owned by root:nats,  0640 — read by nats-server
 #
-# Creates 9 user nkey seeds: hub, telegram-adapter, discord-adapter,
-#                             voice-tts, voice-stt, llm-worker, image-worker, monitor, clipool-worker
-# Retired: tts-adapter, stt-adapter (removed in #690; entries purged from matrix per postmortem Phase 1).
+# Creates user nkey seeds for all active identities in deploy/nats/acl-matrix.json.
+# Retired identities are excluded; see docs/ops/nats-identity-retirement.md.
 #
 # ACL matrix (identities + publish/subscribe allow-lists) is sourced from
 # deploy/nats/acl-matrix.json — do not edit inline; update the JSON instead.
@@ -104,6 +103,11 @@ load_matrix() {
       [ "${has_lc}" = "yes" ] \
         || error "acl-matrix.json: identity '${name}' missing field '${lc_field}'"
     done
+
+    local st
+    st=$(jq -r --arg n "${name}" '.identities[$n].status' "${MATRIX_JSON}")
+    jq -e --arg n "${name}" '.identities[$n].status | IN("active","retired")' "${MATRIX_JSON}" > /dev/null \
+      || error "acl-matrix.json: identity '${name}' has invalid status '${st}' (expected active|retired)"
 
     local o
     o=$(jq -r --arg n "${name}" '.identities[$n].owner' "${MATRIX_JSON}")
@@ -249,12 +253,9 @@ load_matrix
 
 # ── warn for retired identities with seeds on disk ───────────────────────────
 while IFS= read -r name; do
-  _status=$(jq -r --arg n "${name}" '.identities[$n].status' "${MATRIX_JSON}")
-  if [ "${_status}" = "retired" ]; then
-    seed_file="${SEEDS_DIR}/${name}.seed"
-    [ -f "${seed_file}" ] && warn "Retired identity '${name}' has a seed on disk: ${seed_file} — consider shredding it"
-  fi
-done < <(jq -r '.identities | keys_unsorted[]' "${MATRIX_JSON}")
+  seed_file="${SEEDS_DIR}/${name}.seed"
+  [ -f "${seed_file}" ] && warn "Retired identity '${name}' has a seed on disk: ${seed_file} — consider shredding it"
+done < <(jq -r '.identities | to_entries[] | select(.value.status == "retired") | .key' "${MATRIX_JSON}")
 
 # ── validate-supervisor mode — no root required ────────────────────────────────
 if $VALIDATE_SUPERVISOR; then

--- a/docs/ops/nats-identity-retirement.md
+++ b/docs/ops/nats-identity-retirement.md
@@ -28,7 +28,7 @@ If the identity appears as `requester` or `responder` in any flow entry, remove 
 **3. Validate lifecycle fields.**
 
 ```bash
-bash scripts/check-acl-matrix-retired.sh
+bash scripts/check-acl-matrix-retired.sh  # validates status, created_at, retired_at on ALL identities
 ```
 
 Expected output: `ok — acl-matrix lifecycle fields valid`
@@ -106,7 +106,7 @@ If the identity participates in request-reply, add the corresponding entry to `r
 **2. Validate and regenerate.**
 
 ```bash
-bash scripts/check-acl-matrix-retired.sh
+bash scripts/check-acl-matrix-retired.sh  # validates status, created_at on ALL identities (not just the new one)
 bash scripts/check-acl-matrix-spec.sh --update
 sudo ./deploy/nats/gen-nkeys.sh --regen-authconf
 ```

--- a/docs/ops/nats-identity-retirement.md
+++ b/docs/ops/nats-identity-retirement.md
@@ -1,0 +1,154 @@
+# NATS Identity Retirement Runbook
+
+## Overview
+
+Each identity in `deploy/nats/acl-matrix.json` carries `status`, `created_at`, and (when retired) `retired_at`. These fields create an audit trail: you can see when each credential was provisioned, when it was decommissioned, and why — without silently discarding entries. A retired identity remains in the file for history but is excluded from `auth.conf` generation and from CI spec table rendering.
+
+---
+
+## Retiring an identity
+
+**1. Update `acl-matrix.json`.**
+
+Set `"status": "retired"` and add `"retired_at"` on the identity being decommissioned:
+
+```json
+"old-worker": {
+  "status": "retired",
+  "created_at": "2026-01-10",
+  "retired_at": "2026-04-28",
+  ...
+}
+```
+
+**2. Remove from `request_reply_flows`.**
+
+If the identity appears as `requester` or `responder` in any flow entry, remove those entries. A retired identity in `request_reply_flows` is a CI error.
+
+**3. Validate lifecycle fields.**
+
+```bash
+bash scripts/check-acl-matrix-retired.sh
+```
+
+Expected output: `ok — acl-matrix lifecycle fields valid`
+
+**4. Refresh the ACL spec table.**
+
+```bash
+bash scripts/check-acl-matrix-spec.sh --update
+```
+
+This rewrites the sentinel-bracketed table in `artifacts/specs/706-per-role-nkeys-acls-spec.mdx` to reflect the current active identity set.
+
+**5. Regenerate `auth.conf`.**
+
+`gen-nkeys.sh` skips retired identities when rendering `auth.conf`. The retired identity's public key is no longer present in any permissions block after this step.
+
+```bash
+sudo ./deploy/nats/gen-nkeys.sh --regen-authconf
+```
+
+**6. Commit.**
+
+```bash
+git add deploy/nats/acl-matrix.json artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+git commit -m "chore(nats): retire <name> identity"
+```
+
+**7. Reload NATS.**
+
+```bash
+sudo systemctl reload nats
+# or, if systemd is not managing NATS directly:
+nats-server --signal reload
+```
+
+**8. Verify the retired identity is rejected.**
+
+Attempt to connect with the retired seed and confirm NATS returns an auth error. Any active services should be unaffected; check their logs for unexpected reconnect errors:
+
+```bash
+journalctl --user -u lyra-hub --since "2 min ago" | grep -i "auth\|error\|nats"
+journalctl --user -u lyra-telegram --since "2 min ago" | grep -i "auth\|error\|nats"
+```
+
+**9. Seed file decision.**
+
+The seed file at `~/.lyra/nkeys/<name>.seed` remains on disk. NATS rejects the credential regardless once `auth.conf` is reloaded. Once you have confirmed the identity is fully offline and no rollback is needed, you may shred the file:
+
+```bash
+shred -u ~/.lyra/nkeys/<name>.seed
+```
+
+This is optional — the file is inert after step 7.
+
+---
+
+## Adding a new identity
+
+**1. Add the entry to `acl-matrix.json`** with `"status": "active"` and today's date as `"created_at"`:
+
+```json
+"new-worker": {
+  "status": "active",
+  "created_at": "2026-04-28",
+  "owner": "<project>",
+  "description": "...",
+  "allow_responses": false,
+  "publish": [...],
+  "subscribe": [...]
+}
+```
+
+If the identity participates in request-reply, add the corresponding entry to `request_reply_flows`.
+
+**2. Validate and regenerate.**
+
+```bash
+bash scripts/check-acl-matrix-retired.sh
+bash scripts/check-acl-matrix-spec.sh --update
+sudo ./deploy/nats/gen-nkeys.sh --regen-authconf
+```
+
+`gen-nkeys.sh` creates `~/.lyra/nkeys/<name>.seed` if absent, derives the public key, and re-renders `auth.conf`.
+
+**3. Commit and reload.**
+
+```bash
+git add deploy/nats/acl-matrix.json artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+git commit -m "feat(nats): add <name> identity"
+sudo systemctl reload nats
+```
+
+---
+
+## CI checks — what `check-acl-matrix-retired.sh` validates
+
+The script iterates every identity in `acl-matrix.json` and asserts:
+
+| Check | Applies to |
+|---|---|
+| `status` field is present | all identities |
+| `created_at` field is present and matches `YYYY-MM-DD` | all identities |
+| `retired_at` field is present and matches `YYYY-MM-DD` | retired identities only |
+| identity does not appear in `request_reply_flows` | retired identities only |
+
+Exit 0 on success; exit 1 with per-error messages on failure. The check runs in CI on every push that touches `acl-matrix.json`.
+
+---
+
+## Future
+
+A `--retire <name>` subcommand for `gen-nkeys.sh` is planned. It will automate steps 1–7 above (update JSON, remove flows, validate, update spec, regen auth.conf, commit). Until it ships, follow this runbook manually.
+
+---
+
+## Cross-references
+
+- [`deploy/nats/acl-matrix.json`](../../deploy/nats/acl-matrix.json) — identity registry
+- [`deploy/nats/gen-nkeys.sh`](../../deploy/nats/gen-nkeys.sh) — seed generation and auth.conf rendering
+- [`scripts/check-acl-matrix-retired.sh`](../../scripts/check-acl-matrix-retired.sh) — lifecycle field validator
+- [`scripts/check-acl-matrix-spec.sh`](../../scripts/check-acl-matrix-spec.sh) — spec table sync checker
+- [nkey Rotation Runbook](nkey-rotation.md) — for suspected seed compromise (different scenario)
+- [ADR-046](../architecture/adr/046-nkey-provisioning-declarative-authconf.mdx) — declarative provisioning invariants

--- a/scripts/check-acl-matrix-retired.sh
+++ b/scripts/check-acl-matrix-retired.sh
@@ -19,7 +19,7 @@ while IFS= read -r name; do
   if [ "$status" = "retired" ]; then
     retired=$(jq -r --arg n "$name" '.identities[$n].retired_at // empty' "$JSON")
     [ -n "$retired" ] || { echo "ERROR: '$name' is retired but missing retired_at"; errors=$((errors + 1)); }
-    [[ -z "$retired" || "$retired" =~ $DATE_RE ]] || { echo "ERROR: '$name' retired_at invalid format: $retired (expected YYYY-MM-DD)"; errors=$((errors + 1)); }
+    [[ -z "$retired" || "$retired" =~ $DATE_RE ]] || { echo "ERROR: '$name' retired_at invalid format: $retired (expected YYYY-MM-DD)"; errors=$((errors + 1)); }  # -z guard intentional: empty already caught above
     in_flows=$(jq -r --arg n "$name" \
       '[.request_reply_flows[]? | select(.requester==$n or .responder==$n)] | length' "$JSON")
     [ "$in_flows" = "0" ] || { echo "ERROR: '$name' is retired but still referenced in request_reply_flows"; errors=$((errors + 1)); }

--- a/scripts/check-acl-matrix-retired.sh
+++ b/scripts/check-acl-matrix-retired.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# check-acl-matrix-retired.sh — validate lifecycle fields on all acl-matrix.json identities.
+# Exit 0 → all valid. Exit 1 → one or more errors printed to stdout.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JSON="${REPO_ROOT}/deploy/nats/acl-matrix.json"
+DATE_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+errors=0
+
+while IFS= read -r name; do
+  status=$(jq -r --arg n "$name" '.identities[$n].status // empty' "$JSON")
+  created=$(jq -r --arg n "$name" '.identities[$n].created_at // empty' "$JSON")
+
+  [ -n "$status" ]  || { echo "ERROR: '$name' missing status";     ((errors++)); }
+  [ -n "$created" ] || { echo "ERROR: '$name' missing created_at"; ((errors++)); }
+  [[ -z "$created" || "$created" =~ $DATE_RE ]] || { echo "ERROR: '$name' created_at invalid format: $created (expected YYYY-MM-DD)"; ((errors++)); }
+
+  if [ "$status" = "retired" ]; then
+    retired=$(jq -r --arg n "$name" '.identities[$n].retired_at // empty' "$JSON")
+    [ -n "$retired" ] || { echo "ERROR: '$name' is retired but missing retired_at"; ((errors++)); }
+    [[ -z "$retired" || "$retired" =~ $DATE_RE ]] || { echo "ERROR: '$name' retired_at invalid format: $retired (expected YYYY-MM-DD)"; ((errors++)); }
+    in_flows=$(jq -r --arg n "$name" \
+      '[.request_reply_flows[]? | select(.requester==$n or .responder==$n)] | length' "$JSON")
+    [ "$in_flows" = "0" ] || { echo "ERROR: '$name' is retired but still referenced in request_reply_flows"; ((errors++)); }
+  fi
+done < <(jq -r '.identities | keys_unsorted[]' "$JSON")
+
+if [ "$errors" -eq 0 ]; then
+  echo "ok — acl-matrix lifecycle fields valid"
+else
+  exit 1
+fi

--- a/scripts/check-acl-matrix-retired.sh
+++ b/scripts/check-acl-matrix-retired.sh
@@ -12,17 +12,17 @@ while IFS= read -r name; do
   status=$(jq -r --arg n "$name" '.identities[$n].status // empty' "$JSON")
   created=$(jq -r --arg n "$name" '.identities[$n].created_at // empty' "$JSON")
 
-  [ -n "$status" ]  || { echo "ERROR: '$name' missing status";     ((errors++)); }
-  [ -n "$created" ] || { echo "ERROR: '$name' missing created_at"; ((errors++)); }
-  [[ -z "$created" || "$created" =~ $DATE_RE ]] || { echo "ERROR: '$name' created_at invalid format: $created (expected YYYY-MM-DD)"; ((errors++)); }
+  [ -n "$status" ]  || { echo "ERROR: '$name' missing status";     errors=$((errors + 1)); }
+  [ -n "$created" ] || { echo "ERROR: '$name' missing created_at"; errors=$((errors + 1)); }
+  [[ -z "$created" || "$created" =~ $DATE_RE ]] || { echo "ERROR: '$name' created_at invalid format: $created (expected YYYY-MM-DD)"; errors=$((errors + 1)); }
 
   if [ "$status" = "retired" ]; then
     retired=$(jq -r --arg n "$name" '.identities[$n].retired_at // empty' "$JSON")
-    [ -n "$retired" ] || { echo "ERROR: '$name' is retired but missing retired_at"; ((errors++)); }
-    [[ -z "$retired" || "$retired" =~ $DATE_RE ]] || { echo "ERROR: '$name' retired_at invalid format: $retired (expected YYYY-MM-DD)"; ((errors++)); }
+    [ -n "$retired" ] || { echo "ERROR: '$name' is retired but missing retired_at"; errors=$((errors + 1)); }
+    [[ -z "$retired" || "$retired" =~ $DATE_RE ]] || { echo "ERROR: '$name' retired_at invalid format: $retired (expected YYYY-MM-DD)"; errors=$((errors + 1)); }
     in_flows=$(jq -r --arg n "$name" \
       '[.request_reply_flows[]? | select(.requester==$n or .responder==$n)] | length' "$JSON")
-    [ "$in_flows" = "0" ] || { echo "ERROR: '$name' is retired but still referenced in request_reply_flows"; ((errors++)); }
+    [ "$in_flows" = "0" ] || { echo "ERROR: '$name' is retired but still referenced in request_reply_flows"; errors=$((errors + 1)); }
   fi
 done < <(jq -r '.identities | keys_unsorted[]' "$JSON")
 

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -21,6 +21,9 @@
 
 set -euo pipefail
 
+UPDATE=false
+[[ "${1:-}" == "--update" ]] && UPDATE=true
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 JSON="${REPO_ROOT}/deploy/nats/acl-matrix.json"
 SPEC="${REPO_ROOT}/artifacts/specs/706-per-role-nkeys-acls-spec.mdx"
@@ -171,6 +174,17 @@ awk '/<!-- acl-matrix:begin -->/{found=1; next} /<!-- acl-matrix:end -->/{found=
   "$SPEC" > "$SPEC_BLOCK"
 
 render_table > "$RENDERED"
+
+if [ "${UPDATE}" = true ]; then
+  awk '
+    /<!-- acl-matrix:begin -->/ { print; found=1; next }
+    /<!-- acl-matrix:end -->/ { found=0; while ((getline line < RENDERED) > 0) print line; print; next }
+    !found { print }
+  ' RENDERED="$RENDERED" "$SPEC" > "${NATS_TMPDIR}/spec_updated.txt"
+  cp "${NATS_TMPDIR}/spec_updated.txt" "$SPEC"
+  echo "Updated sentinel block in $SPEC"
+  exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # Diff — exit 0 on match, 1 on drift

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -38,7 +38,7 @@ EFFECTIVE_JSON=$(jq '
 # Identity column order — all active identities (updated: retired tts-adapter/sst-adapter
 # removed, voice-tts/voice-stt/image-worker/clipool-worker added per postmortem Fix 1+2)
 # ---------------------------------------------------------------------------
-IDENTITIES=(hub telegram-adapter discord-adapter voice-tts voice-stt llm-worker image-worker clipool-worker monitor)
+mapfile -t IDENTITIES < <(jq -r '.identities | to_entries[] | select(.value.status == "active") | .key' "$JSON")
 
 # ---------------------------------------------------------------------------
 # Subject rows — "display_label|json_pub_subject|json_sub_subject"

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -176,6 +176,10 @@ awk '/<!-- acl-matrix:begin -->/{found=1; next} /<!-- acl-matrix:end -->/{found=
 render_table > "$RENDERED"
 
 if [ "${UPDATE}" = true ]; then
+  if [ "${CI:-}" = "true" ]; then
+    echo "::error::--update is a local-only flag and must not be passed in CI (changes would be lost at runner teardown)"
+    exit 1
+  fi
   awk '
     /<!-- acl-matrix:begin -->/ { print; found=1; next }
     /<!-- acl-matrix:end -->/ { found=0; while ((getline line < RENDERED) > 0) print line; print; next }


### PR DESCRIPTION
## Summary

- Add `status` (active|retired) and `created_at` lifecycle fields to all 9 identities in `deploy/nats/acl-matrix.json`, enabling tooling-enforced retirement with full audit trail
- `gen-nkeys.sh` now filters out retired identities from key generation and `auth.conf` rendering; replaces hardcoded key-gen block with `IDENTITIES[]` loop; fixes `--emit-merged-authconf` to derive lists by owner; warns when a retired identity has a seed on disk
- New `scripts/check-acl-matrix-retired.sh` validates `status`, `created_at`, `retired_at` format, and rejects retired identities still referenced in `request_reply_flows`
- `scripts/check-acl-matrix-spec.sh` now derives its `IDENTITIES` column list from active JSON entries (no hardcoded array) and gains a `--update` flag to auto-regenerate the sentinel block in `706-per-role-nkeys-acls-spec.mdx`
- New `docs/ops/nats-identity-retirement.md` runbook covers the full retirement procedure

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1001: acl-matrix.json: add status active\|retired field to identities | Open |
| Frame | [1001-acl-matrix-status-field-frame.mdx](artifacts/frames/1001-acl-matrix-status-field-frame.mdx) | Present |
| Spec | [1001-acl-matrix-status-field-spec.mdx](artifacts/specs/1001-acl-matrix-status-field-spec.mdx) | Present |
| Plan | [1001-acl-matrix-status-field-plan.mdx](artifacts/plans/1001-acl-matrix-status-field-plan.mdx) | Present |
| Implementation | 8 commits on `feat/1001-acl-matrix-status-field` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3236 pass) | Passed |

## Test Plan

- [ ] `bash scripts/check-acl-matrix-retired.sh` → `ok — acl-matrix lifecycle fields valid`
- [ ] `bash scripts/check-acl-matrix-spec.sh` → exit 0 (no drift)
- [ ] `bash deploy/nats/gen-nkeys.sh --template-only` → 9 active identity `permissions` blocks, no retired identity present
- [ ] Set an identity to `"status": "retired"` without `"retired_at"` → `check-acl-matrix-retired.sh` exits 1
- [ ] Set an identity to `"status": "retired"` with `"retired_at": "28-04-2026"` (wrong format) → exits 1
- [ ] `bash scripts/check-acl-matrix-spec.sh --update` → rewrites sentinel block, subsequent run exits 0

Closes #1001

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`