### PR TITLE
fix(trace): add bare token redaction to TelegramTokenFilter

### DIFF
--- a/docs/architecture/testing-conventions.md
+++ b/docs/architecture/testing-conventions.md
@@ -64,7 +64,7 @@ The `dev-core:tester` agent flags missing negative tests as `issue:` (≥90% con
 - Import + call real source functions — never mock the module under test
 - `unittest.mock.patch('module.Symbol')` / `mocker.patch(...)` — patch at the import site of the dependency, never patch the module under test itself
 - Integration tests (real modules wired) > unit tests with heavy mocks
-- Verify coverage: `uv run pytest --coverage <file>` (substitute your project's test command) — 0% → wrong mocking
+- Verify coverage: `uv run pytest --cov=src/<module> <test_path>` (substitute your project's test command) — 0% → wrong mocking
 
 ---
 

--- a/src/lyra/core/trace.py
+++ b/src/lyra/core/trace.py
@@ -113,20 +113,24 @@ class TelegramTokenFilter(logging.Filter):
     never appear in persisted logs, crash reports, or log-shipping
     pipelines.
 
-    Matches ``bot<digits>:<alphanumeric-with-hyphens-underscores>`` and
-    replaces the token segment with ``<REDACTED>``. Always returns
-    ``True`` — the record is never suppressed. Defensive: never raises.
+    Matches both the URL-embedded form (``bot<digits>:<secret>``) and the
+    bare form (``<digits>:<secret>`` from config dumps or exception reprs)
+    and replaces them with ``<REDACTED>``. Always returns ``True`` — the
+    record is never suppressed. Defensive: never raises.
     """
 
-    # Bot tokens: 1234567890:AAEhBP0av28...Z (numeric id, colon, ~35 char secret)
+    # URL-embedded: /bot1234567890:AAEhBP0av28...Z/method
     _TOKEN_RE = re.compile(r"bot(\d+):[A-Za-z0-9_-]+")
     _REDACTED_SUB = r"bot\1:<REDACTED>"
+    # Bare token: 1234567890:AAEhBP0av28...Z (config dumps, exception reprs)
+    _BARE_TOKEN_RE = re.compile(r"\b(\d{8,12}:[A-Za-z0-9_-]{30,50})\b")
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
             # Format the message once (% args interpolation) then redact.
             msg = record.getMessage()
             redacted = self._TOKEN_RE.sub(self._REDACTED_SUB, msg)
+            redacted = self._BARE_TOKEN_RE.sub("<REDACTED>", redacted)
             if redacted != msg:
                 record.msg = redacted
                 record.args = None

--- a/src/lyra/core/trace.py
+++ b/src/lyra/core/trace.py
@@ -119,11 +119,17 @@ class TelegramTokenFilter(logging.Filter):
     record is never suppressed. Defensive: never raises.
     """
 
-    # URL-embedded: /bot1234567890:AAEhBP0av28...Z/method
+    # URL-embedded: /bot<id>:<secret>/method (httpx always emits full-length secrets)
     _TOKEN_RE = re.compile(r"bot(\d+):[A-Za-z0-9_-]+")
     _REDACTED_SUB = r"bot\1:<REDACTED>"
     # Bare token: 1234567890:AAEhBP0av28...Z (config dumps, exception reprs)
-    _BARE_TOKEN_RE = re.compile(r"\b(\d{8,12}:[A-Za-z0-9_-]{30,50})\b")
+    # Lookbehind/lookahead instead of \b: \b breaks after trailing '-' (non-\w).
+    # No upper bound: avoids silently missing tokens with secrets > 50 chars.
+    # _REDACTED_SUB must stay < 30 chars so a partially-redacted URL-form token
+    # (bot<id>:<REDACTED>) is not re-matched by this pattern.
+    _BARE_TOKEN_RE = re.compile(
+        r"(?<!\w)(\d{8,12}:[A-Za-z0-9_-]{30,})(?![A-Za-z0-9_-])"
+    )
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -450,6 +450,7 @@ class TestTelegramTokenFilter:
         )
         filt.filter(record)
         assert "BBFfiQCzx1yABCDefGHijKLmnoPQRstUVwx" not in record.getMessage()
+        assert "<REDACTED>" in record.getMessage()
 
     def test_bare_token_not_over_matched_by_short_secret(self) -> None:
         """Secrets shorter than 30 chars are not bot tokens — must not be redacted."""
@@ -459,6 +460,17 @@ class TestTelegramTokenFilter:
         record = self._make_record("ratio=12345678:short")
         filt.filter(record)
         assert record.getMessage() == "ratio=12345678:short"
+
+    def test_bare_token_not_matched_when_id_too_short(self) -> None:
+        """IDs shorter than 8 digits do not match the digit-count floor."""
+        from lyra.core.trace import TelegramTokenFilter
+
+        filt = TelegramTokenFilter()
+        record = self._make_record(
+            "id=1234567:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        )
+        filt.filter(record)
+        assert record.getMessage() == "id=1234567:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
     def test_url_token_already_redacted_before_bare_pass(self) -> None:
         """URL pattern runs first; bare pass must not double-redact."""
@@ -474,3 +486,4 @@ class TestTelegramTokenFilter:
         msg = record.getMessage()
         assert "AAGg_wDfJ7896yPdf-L10CEVHbiuShA38Sw" not in msg
         assert msg.count("<REDACTED>") == 1
+        assert "bot8500388193:<REDACTED>" in msg

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -445,7 +445,8 @@ class TestTelegramTokenFilter:
 
         filt = TelegramTokenFilter()
         record = self._make_record(
-            "TelegramError: invalid token 9876543210:BBFfiQCzx1yABCDefGHijKLmnoPQRstUVwx"
+            "TelegramError: invalid token "
+            "9876543210:BBFfiQCzx1yABCDefGHijKLmnoPQRstUVwx"
         )
         filt.filter(record)
         assert "BBFfiQCzx1yABCDefGHijKLmnoPQRstUVwx" not in record.getMessage()
@@ -460,15 +461,16 @@ class TestTelegramTokenFilter:
         assert record.getMessage() == "ratio=12345678:short"
 
     def test_url_token_already_redacted_before_bare_pass(self) -> None:
-        """URL-embedded token is handled by _TOKEN_RE; bare pass must not double-redact."""
+        """URL pattern runs first; bare pass must not double-redact."""
         from lyra.core.trace import TelegramTokenFilter
 
         filt = TelegramTokenFilter()
-        url = "https://api.telegram.org/bot8500388193:AAGg_wDfJ7896yPdf-L10CEVHbiuShA38Sw/sendMessage"
+        url = (
+            "https://api.telegram.org/"
+            "bot8500388193:AAGg_wDfJ7896yPdf-L10CEVHbiuShA38Sw/sendMessage"
+        )
         record = self._make_record(f"POST {url}")
         filt.filter(record)
         msg = record.getMessage()
         assert "AAGg_wDfJ7896yPdf-L10CEVHbiuShA38Sw" not in msg
-        # Bot id preserved from URL pattern; bare pass sees bot8500388193:<REDACTED> which
-        # no longer matches the bare pattern (it starts with 'bot'), so no double-redact.
         assert msg.count("<REDACTED>") == 1

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -428,3 +428,47 @@ class TestTelegramTokenFilter:
         filt = TelegramTokenFilter()
         record = self._make_record("anything")
         assert filt.filter(record) is True
+
+    def test_redacts_bare_token_in_config_dump(self) -> None:
+        from lyra.core.trace import TelegramTokenFilter
+
+        filt = TelegramTokenFilter()
+        record = self._make_record(
+            "token=123456789:AAEhBP0av28xYzAbCdEfGhIjKlMnOpQrStU"
+        )
+        filt.filter(record)
+        assert "AAEhBP0av28xYzAbCdEfGhIjKlMnOpQrStU" not in record.getMessage()
+        assert "<REDACTED>" in record.getMessage()
+
+    def test_redacts_bare_token_in_exception_repr(self) -> None:
+        from lyra.core.trace import TelegramTokenFilter
+
+        filt = TelegramTokenFilter()
+        record = self._make_record(
+            "TelegramError: invalid token 9876543210:BBFfiQCzx1yABCDefGHijKLmnoPQRstUVwx"
+        )
+        filt.filter(record)
+        assert "BBFfiQCzx1yABCDefGHijKLmnoPQRstUVwx" not in record.getMessage()
+
+    def test_bare_token_not_over_matched_by_short_secret(self) -> None:
+        """Secrets shorter than 30 chars are not bot tokens — must not be redacted."""
+        from lyra.core.trace import TelegramTokenFilter
+
+        filt = TelegramTokenFilter()
+        record = self._make_record("ratio=12345678:short")
+        filt.filter(record)
+        assert record.getMessage() == "ratio=12345678:short"
+
+    def test_url_token_already_redacted_before_bare_pass(self) -> None:
+        """URL-embedded token is handled by _TOKEN_RE; bare pass must not double-redact."""
+        from lyra.core.trace import TelegramTokenFilter
+
+        filt = TelegramTokenFilter()
+        url = "https://api.telegram.org/bot8500388193:AAGg_wDfJ7896yPdf-L10CEVHbiuShA38Sw/sendMessage"
+        record = self._make_record(f"POST {url}")
+        filt.filter(record)
+        msg = record.getMessage()
+        assert "AAGg_wDfJ7896yPdf-L10CEVHbiuShA38Sw" not in msg
+        # Bot id preserved from URL pattern; bare pass sees bot8500388193:<REDACTED> which
+        # no longer matches the bare pattern (it starts with 'bot'), so no double-redact.
+        assert msg.count("<REDACTED>") == 1


### PR DESCRIPTION
## Summary
- Adds `_BARE_TOKEN_RE` to `TelegramTokenFilter` to catch tokens logged without the `bot` URL prefix (config dumps, exception reprs, direct token variable logs)
- Both URL-embedded (`bot<id>:<secret>`) and bare (`<id>:<secret>`) forms are now redacted; URL pattern runs first to preserve the bot ID, bare pass cleans up any remaining standalone tokens

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1028: fix(trace): TelegramTokenFilter misses bare token format (no bot prefix) | Open |
| Implementation | 2 commits on `fix/1028-telegram-token-filter-bare-format` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5 new) | Passed |

## Test Plan
- [ ] `uv run pytest tests/core/test_trace.py::TestTelegramTokenFilter -v` — all 9 pass
- [ ] Bare token in config dump string is redacted
- [ ] Bare token in exception repr is redacted
- [ ] Short secrets (`<30 chars`) are not over-matched
- [ ] URL-embedded token still produces exactly one `<REDACTED>` (no double-redact)

Closes #1028

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`