### PR TITLE
feat(deploy): JetStream persistent volume + store_dir config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ quadlet-install: quadlet-preflight  ## install Quadlet units to ~/.config/contai
 	@cp deploy/quadlet/roxabi.network                  "$(QUADLET_DIR)/roxabi.network"
 	@cp deploy/quadlet/lyra-data.volume                "$(QUADLET_DIR)/lyra-data.volume"
 	@cp deploy/quadlet/lyra-jetstream.volume           "$(QUADLET_DIR)/lyra-jetstream.volume"
+	@mkdir -p "$(HOME)/.lyra/jetstream"
 	@cp deploy/quadlet/lyra-nats.container             "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/lyra-hub.container              "$(QUADLET_DIR)/lyra-hub.container"
 	@cp deploy/quadlet/lyra-telegram.container         "$(QUADLET_DIR)/lyra-telegram.container"

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ quadlet-install: quadlet-preflight  ## install Quadlet units to ~/.config/contai
 	@cp deploy/quadlet/roxabi.network                  "$(QUADLET_DIR)/roxabi.network"
 	@cp deploy/quadlet/lyra-data.volume                "$(QUADLET_DIR)/lyra-data.volume"
 	@cp deploy/quadlet/lyra-jetstream.volume           "$(QUADLET_DIR)/lyra-jetstream.volume"
-	@mkdir -p "$(HOME)/.lyra/jetstream"
+	@install -d -m 0700 "$(HOME)/.lyra/jetstream"
 	@cp deploy/quadlet/lyra-nats.container             "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/lyra-hub.container              "$(QUADLET_DIR)/lyra-hub.container"
 	@cp deploy/quadlet/lyra-telegram.container         "$(QUADLET_DIR)/lyra-telegram.container"

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ quadlet-install: quadlet-preflight  ## install Quadlet units to ~/.config/contai
 	@cp deploy/quadlet/lyra-data.volume                "$(QUADLET_DIR)/lyra-data.volume"
 	@cp deploy/quadlet/lyra-jetstream.volume           "$(QUADLET_DIR)/lyra-jetstream.volume"
 	@install -d -m 0700 "$(HOME)/.lyra/jetstream"
+	@chmod 0700 "$(HOME)/.lyra/jetstream"
 	@cp deploy/quadlet/lyra-nats.container             "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/lyra-hub.container              "$(QUADLET_DIR)/lyra-hub.container"
 	@cp deploy/quadlet/lyra-telegram.container         "$(QUADLET_DIR)/lyra-telegram.container"

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ quadlet-install: quadlet-preflight  ## install Quadlet units to ~/.config/contai
 	       "$(QUADLET_DIR)/roxabi.network" "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/roxabi.network                  "$(QUADLET_DIR)/roxabi.network"
 	@cp deploy/quadlet/lyra-data.volume                "$(QUADLET_DIR)/lyra-data.volume"
+	@cp deploy/quadlet/lyra-jetstream.volume           "$(QUADLET_DIR)/lyra-jetstream.volume"
 	@cp deploy/quadlet/lyra-nats.container             "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/lyra-hub.container              "$(QUADLET_DIR)/lyra-hub.container"
 	@cp deploy/quadlet/lyra-telegram.container         "$(QUADLET_DIR)/lyra-telegram.container"

--- a/artifacts/analyses/1055-jetstream-volume-findings-consensus.mdx
+++ b/artifacts/analyses/1055-jetstream-volume-findings-consensus.mdx
@@ -1,0 +1,119 @@
+---
+title: "JetStream Volume Review Findings — Expert Consensus"
+issue: 1055
+status: consensus-reached
+date: 2026-05-04
+panel: architect, security-auditor, devops
+confidence: high
+---
+
+## Problem
+
+PR #1062 introduced the JetStream persistent volume (lyra-jetstream.volume, bind-mount
+`~/.lyra/jetstream` → `/var/lib/nats/jetstream`). A multi-domain code review raised 4
+actionable findings. This consensus determines the best long-term solution for each and
+the minimal fix for the current PR.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | arch soundness, structural correctness, reference-impl portability |
+| security-auditor | attack surface, data confidentiality, defense-in-depth |
+| devops | ops impact, deploy sequencing, day-2, migration risk |
+
+## Consensus
+
+### F1 — noexec,nosuid on jetstream volume mount
+
+**ρ: (a) Add `noexec,nosuid` to `Options=bind` in `lyra-jetstream.volume` — unanimous.**
+
+`ReadOnly=true` on the container applies to the rootfs, not volume mounts. NATS never
+executes binaries from its store dir (only reads/writes WAL + stream data). Adding
+`noexec,nosuid` is a zero-cost defense-in-depth layer orthogonal to `DropCapability=all`
+and `NoNewPrivileges=true`. Change: `Options=bind,noexec,nosuid`.
+
+### F2 — Directory permissions at creation
+
+**ρ: (a) Replace `mkdir -p` with `install -d -m 0700` in `quadlet-install` — unanimous.**
+
+`mkdir -p` inherits the shell umask (0755 on Ubuntu). JetStream store contains serialized
+KV payloads (`lyra-turns`, `lyra-msg-index`) — conversation content constitutes PII.
+`install -d -m 0700` is atomic and idempotent. `ExecStartPre=chmod` is rejected (wrong
+layer, TOCTOU window, silent on restart skip).
+
+### F3 — SELinux `:z` label on `~/.lyra/jetstream` subdirectory
+
+**Long-term ρ: (a) Move jetstream dir to `~/.lyra/nats/jetstream/` — 2/3 majority
+(architect #1, security-auditor #1, devops #3).**
+
+The parent-child bind-mount overlap (`lyra-data.volume` mounts `~/.lyra`; `lyra-jetstream.volume`
+mounts `~/.lyra/jetstream`) creates a structural defect: `:z` relabels the jetstream inode
+while the parent mount has no label, causing AVC denials on SELinux hosts. Moving to a
+disjoint path eliminates the overlap entirely and is SELinux-safe by construction.
+
+**For this PR (prereq, no migration):** (b) document AppArmor-only assumption in the
+volume unit and link a follow-up issue for the path migration.
+
+Rationale for deferral: #1062 is Phase 1 of #1049. Introducing a prod data migration
+(`stop → mkdir → mv → quadlet-install → start`) in a prereq PR risks silent data loss
+if the migration step is missed. The structural fix should ship as an independent
+S-tier issue with an explicit migration runbook.
+
+Dissent recorded: devops ranked (c) drop-`:z` highest for this PR, accepting (b) only
+if a follow-up issue is linked. ADR-068 (`docs/architecture/adr/068-selinux-z-label-quadlet-bind-volume-policy.mdx`)
+documents the SELinux label policy decision (written during consensus, main repo staging branch).
+
+### F4 — Restart instruction missing `quadlet-secrets-install` ordering
+
+**ρ: (a) Add `make quadlet-secrets-install` as explicit prerequisite before any
+"restart lyra-nats" instruction — unanimous.**
+
+Without the secret, NATS fails to start with an opaque Podman mount error, not an auth
+error. `full-deploy` and `nats-regen-authconf` already sequence correctly; the gap is in
+manual runbook paths. Add with "skip if secrets already installed" note to avoid confusion
+during normal deploys where secrets are current.
+
+## Alternatives
+
+| Option | Finding | Rejected because |
+|--------|---------|------------------|
+| (b) host-level noexec doc | F1 | Unenforceable; does not apply to volume unit |
+| (c) accept as-is | F1 | ReadOnly=true + capability drops are orthogonal to VFS mount exec restriction |
+| (b) ExecStartPre=chmod | F2 | Wrong layer; TOCTOU window; runs as container user, not host user |
+| (c) accept 0755 | F2 | PII exposure; single-user assumption has known expiry (voiceCLI joining roxabi.network Phase 4) |
+| (c) drop :z | F3 | Silently breaks SELinux hosts; cargo-cult removal of a label that has a correct use case |
+| (b) document AppArmor-only (long-term) | F3 | Enshrines constraint in docs rather than fixing the structural overlap |
+| (b) quadlet-install echo only | F4 | Gap is in manual restart paths, not in quadlet-install flow |
+
+## Dissent
+
+- **F3:** devops ranked (c) drop-`:z` #1 for this PR; accepts (b) if follow-up issue is created.
+  Devops concern: "dead defensive config is a maintenance liability." Majority holds: the label
+  has a correct use case on SELinux hosts; the right fix is structural path separation, not
+  removal of a valid mechanism.
+
+## Implementation Notes
+
+### For PR #1062 (immediate)
+
+1. **F1:** `Options=bind,noexec,nosuid` in `deploy/quadlet/lyra-jetstream.volume`
+2. **F2:** `install -d -m 0700 "$(HOME)/.lyra/jetstream"` in `Makefile` `quadlet-install`
+   (replacing `mkdir -p "$(HOME)/.lyra/jetstream"`)
+3. **F3:** Add `[Unit]` comment to `lyra-jetstream.volume`: "AppArmor host (Ubuntu 26.04).
+   On SELinux hosts, relocate Device= to a path disjoint from ~/.lyra — see follow-up issue."
+4. **F4:** Expand `docs/CONFIGURATION.md` JetStream setup block to include
+   `make quadlet-secrets-install` before restart, with "skip if already installed" note.
+
+### Follow-up issue (S-tier, post Phase 1)
+
+- Move `Device=%h/.lyra/jetstream` → `Device=%h/.lyra/nats/jetstream` in `lyra-jetstream.volume`
+- Update `quadlet-install` mkdir target to match
+- Production migration runbook: `systemctl --user stop lyra-nats && mkdir -p ~/.lyra/nats/jetstream && mv ~/.lyra/jetstream/* ~/.lyra/nats/jetstream/ && make quadlet-install && systemctl --user start lyra-nats && nats kv ls` (verify `lyra-state` bucket present)
+- Migration is idempotent if `~/.lyra/jetstream/` is absent (first install, no data to migrate)
+- Reference: ADR-068 (`docs/architecture/adr/068-selinux-z-label-quadlet-bind-volume-policy.mdx`)
+
+## Next
+
+Apply F1, F2, F3 (partial), F4 to PR #1062 via 1b1 decisions. Create follow-up issue
+for F3 structural path migration.

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -25,7 +25,7 @@ max_payload:     52428800 # 50 MB — supports audio, images, video over NATS
 # ── JetStream ──────────────────────────────────────────────────────────────
 # Persistent storage via lyra-jetstream.volume → /var/lib/nats/jetstream (see #1055).
 # Replaces the -js CLI flag which enabled JetStream without durable storage.
-# Host path: ~/.lyra/jetstream — init with: mkdir -p ~/.lyra/jetstream
+# Host path: ~/.lyra/jetstream — created at mode 0700 by make quadlet-install
 # Production (uid 1500): podman unshare chown 1500:1500 ~/.lyra/jetstream
 jetstream {
   store_dir: "/var/lib/nats/jetstream"

--- a/deploy/nats/nats-container.conf
+++ b/deploy/nats/nats-container.conf
@@ -22,6 +22,15 @@ include "nkeys/auth.conf"
 max_connections: 25       # hub + adapters + clipool + voice workers + headroom
 max_payload:     52428800 # 50 MB — supports audio, images, video over NATS
 
+# ── JetStream ──────────────────────────────────────────────────────────────
+# Persistent storage via lyra-jetstream.volume → /var/lib/nats/jetstream (see #1055).
+# Replaces the -js CLI flag which enabled JetStream without durable storage.
+# Host path: ~/.lyra/jetstream — init with: mkdir -p ~/.lyra/jetstream
+# Production (uid 1500): podman unshare chown 1500:1500 ~/.lyra/jetstream
+jetstream {
+  store_dir: "/var/lib/nats/jetstream"
+}
+
 # ── Monitoring ─────────────────────────────────────────────────────────────
 # Binds to 0.0.0.0 inside the container (no http: directive = all interfaces).
 # Readable by all roxabi.network peers — endpoint is read-only, trusted network.

--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -38,8 +38,9 @@ max_payload:     52428800 # 50MB — supports large audio, images, video over NA
 
 # ── JetStream ───────────────────────────────────────────────────────────────
 # Required for the KV readiness probe (hub.ready in lyra-state bucket).
-# Container installs enable JetStream via the -js CLI flag in lyra-nats.container;
-# this stanza covers bare systemd installs (install.sh path).
+# Both host (systemd) and container (Quadlet) installs use this stanza.
+# Container: lyra-jetstream.volume bind-mounts ~/.lyra/jetstream → /var/lib/nats/jetstream.
+# The -js CLI flag was removed in #1055; store_dir config is now the sole activation path.
 jetstream {
   store_dir: "/var/lib/nats/jetstream"
 }

--- a/deploy/quadlet/lyra-jetstream.volume
+++ b/deploy/quadlet/lyra-jetstream.volume
@@ -1,0 +1,11 @@
+[Unit]
+Description=Lyra JetStream persistent storage — bind-mount %h/.lyra/jetstream into the NATS container
+# Provides durable backing for JetStream streams and KV buckets (lyra-turns, lyra-msg-index).
+# Host directory must exist before first start: mkdir -p ~/.lyra/jetstream
+# On production (uid 1500): podman unshare chown 1500:1500 ~/.lyra/jetstream
+
+[Volume]
+Type=none
+Device=%h/.lyra/jetstream
+Options=bind
+Label=app=lyra

--- a/deploy/quadlet/lyra-jetstream.volume
+++ b/deploy/quadlet/lyra-jetstream.volume
@@ -1,11 +1,15 @@
 [Unit]
 Description=Lyra JetStream persistent storage — bind-mount %h/.lyra/jetstream into the NATS container
 # Provides durable backing for JetStream streams and KV buckets (lyra-turns, lyra-msg-index).
-# Host directory must exist before first start: mkdir -p ~/.lyra/jetstream
+# quadlet-install creates this directory automatically (install -d -m 0700).
 # On production (uid 1500): podman unshare chown 1500:1500 ~/.lyra/jetstream
+# SELinux note: AppArmor host (Ubuntu 26.04). On SELinux hosts, relocate Device= to a
+# path disjoint from ~/.lyra (e.g. ~/.lyra/nats/jetstream) — see follow-up issue.
 
 [Volume]
 Type=none
 Device=%h/.lyra/jetstream
-Options=bind
+# noexec,nosuid: NATS never executes from the store dir; restrict blast radius of any
+# write primitive inside the container (defense-in-depth alongside ReadOnly=true).
+Options=bind,noexec,nosuid
 Label=app=lyra

--- a/deploy/quadlet/lyra-jetstream.volume
+++ b/deploy/quadlet/lyra-jetstream.volume
@@ -11,5 +11,5 @@ Type=none
 Device=%h/.lyra/jetstream
 # noexec,nosuid: NATS never executes from the store dir; restrict blast radius of any
 # write primitive inside the container (defense-in-depth alongside ReadOnly=true).
-Options=bind,noexec,nosuid
+Options=bind,noexec,nosuid,nodev
 Label=app=lyra

--- a/deploy/quadlet/lyra-nats.container
+++ b/deploy/quadlet/lyra-nats.container
@@ -18,7 +18,7 @@ PublishPort=4222:4222
 # HTTP monitoring — localhost only, consumed by lyra-monitor check_nats_varz().
 PublishPort=127.0.0.1:8222:8222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
-Volume=lyra-jetstream.volume:/var/lib/nats/jetstream:z
+Volume=lyra-jetstream.volume:/var/lib/nats/jetstream:z  # writable exception to ReadOnly=true — JetStream persistence (rootfs flag only in Podman)
 # ADR-054 Decision 5 (revised): file-based credentials delivered as Podman secrets
 # (type=mount, tmpfs-backed). Replaces single-file .volume wrappers which failed
 # with "loop device setup" in Podman 5.x. Bootstrap: `make quadlet-secrets-install`.

--- a/deploy/quadlet/lyra-nats.container
+++ b/deploy/quadlet/lyra-nats.container
@@ -18,11 +18,12 @@ PublishPort=4222:4222
 # HTTP monitoring — localhost only, consumed by lyra-monitor check_nats_varz().
 PublishPort=127.0.0.1:8222:8222
 Volume=%h/projects/lyra/deploy/nats/nats-container.conf:/etc/nats/nats.conf:ro,z
+Volume=lyra-jetstream.volume:/var/lib/nats/jetstream:z
 # ADR-054 Decision 5 (revised): file-based credentials delivered as Podman secrets
 # (type=mount, tmpfs-backed). Replaces single-file .volume wrappers which failed
 # with "loop device setup" in Podman 5.x. Bootstrap: `make quadlet-secrets-install`.
 Secret=lyra-nats-auth,type=mount,target=/etc/nats/nkeys/auth.conf,mode=0444
-Exec=nats-server -js -c /etc/nats/nats.conf
+Exec=nats-server -c /etc/nats/nats.conf
 
 [Service]
 Restart=always

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -383,6 +383,8 @@ systemctl --user restart lyra-nats
 
 **Dev (no fixed uid mapping):** `make quadlet-install` is sufficient — omit the `podman unshare chown` step.
 
+**Upgrade:** after `make quadlet-install`, run `systemctl --user daemon-reload && systemctl --user restart lyra-nats` to pick up unit file changes.
+
 ### Voice (STT/TTS)
 
 | Variable | Default | Description |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -364,6 +364,24 @@ health_secret = ""                            # optional health endpoint auth
 |----------|---------|-------------|
 | `NATS_URL` | `nats://localhost:4222` | NATS server URL (required for standalone hub) |
 
+#### JetStream persistent storage
+
+JetStream is enabled via the config file stanza in `deploy/nats/nats-container.conf` (the `-js` CLI flag was removed in #1055). Storage is backed by a Quadlet bind-mount volume:
+
+| Unit | Host path | Container path |
+|------|-----------|----------------|
+| `lyra-jetstream.volume` | `~/.lyra/jetstream` | `/var/lib/nats/jetstream` |
+
+**First-time setup (production, uid 1500):**
+
+```bash
+mkdir -p ~/.lyra/jetstream
+podman unshare chown 1500:1500 ~/.lyra/jetstream
+make quadlet-install
+```
+
+After `make quadlet-install`, restart NATS: `systemctl --user restart lyra-nats`.
+
 ### Voice (STT/TTS)
 
 | Variable | Default | Description |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -375,12 +375,13 @@ JetStream is enabled via the config file stanza in `deploy/nats/nats-container.c
 **First-time setup (production, uid 1500):**
 
 ```bash
-mkdir -p ~/.lyra/jetstream
+make quadlet-install                          # creates ~/.lyra/jetstream at mode 0700
 podman unshare chown 1500:1500 ~/.lyra/jetstream
-make quadlet-install
+make quadlet-secrets-install                  # skip if secrets already installed
+systemctl --user restart lyra-nats
 ```
 
-After `make quadlet-install`, restart NATS: `systemctl --user restart lyra-nats`.
+**Dev (no fixed uid mapping):** `make quadlet-install` is sufficient — omit the `podman unshare chown` step.
 
 ### Voice (STT/TTS)
 

--- a/docs/architecture/adr/065-nats-kv-readiness-probe.mdx
+++ b/docs/architecture/adr/065-nats-kv-readiness-probe.mdx
@@ -74,7 +74,7 @@ Bucket provisioning ownership: the hub is the sole creator of the `lyra-state` b
 When deploying this change, the following order must be respected:
 
 1. **Enable JetStream on NATS.** Both container and systemd installs use the `jetstream { store_dir: ... }` stanza in the NATS config. Container installs: the stanza is in `nats-container.conf`, backed by the `lyra-jetstream.volume` bind-mount (`~/.lyra/jetstream` → `/var/lib/nats/jetstream`). The `-js` CLI flag was removed in #1055. Systemd installs: the stanza is in `nats.conf`.
-2. **Regen auth.conf.** Run `sudo ./deploy/nats/gen-nkeys.sh --regen-authconf` to add the `$KV.lyra-state.>` subscribe grants and voice-client identity to the production ACL.
+2. **Regen auth.conf.** Run `make nats-regen-authconf` to add the `$KV.lyra-state.>` subscribe grants and voice-client identity to the production ACL.
 3. **Reload NATS.** `make quadlet-secrets-install && podman kill -s HUP lyra-nats` (container) or `systemctl reload nats-server` (systemd).
 4. **Deploy code.** `make deploy` — hub wires `announce_hub_ready()` on startup; adapters call `wait_for_hub()` instead of the legacy probe.
 

--- a/docs/architecture/adr/065-nats-kv-readiness-probe.mdx
+++ b/docs/architecture/adr/065-nats-kv-readiness-probe.mdx
@@ -73,7 +73,7 @@ Bucket provisioning ownership: the hub is the sole creator of the `lyra-state` b
 
 When deploying this change, the following order must be respected:
 
-1. **Enable JetStream on NATS.** Container installs: ensure `Exec=nats-server -js -c /etc/nats/nats.conf` in `lyra-nats.container`. Systemd installs: the `jetstream { store_dir: ... }` stanza in `nats.conf` activates it.
+1. **Enable JetStream on NATS.** Both container and systemd installs use the `jetstream { store_dir: ... }` stanza in the NATS config. Container installs: the stanza is in `nats-container.conf`, backed by the `lyra-jetstream.volume` bind-mount (`~/.lyra/jetstream` → `/var/lib/nats/jetstream`). The `-js` CLI flag was removed in #1055. Systemd installs: the stanza is in `nats.conf`.
 2. **Regen auth.conf.** Run `sudo ./deploy/nats/gen-nkeys.sh --regen-authconf` to add the `$KV.lyra-state.>` subscribe grants and voice-client identity to the production ACL.
 3. **Reload NATS.** `make quadlet-secrets-install && podman kill -s HUP lyra-nats` (container) or `systemctl reload nats-server` (systemd).
 4. **Deploy code.** `make deploy` — hub wires `announce_hub_ready()` on startup; adapters call `wait_for_hub()` instead of the legacy probe.


### PR DESCRIPTION
## Summary

- Add `lyra-jetstream.volume` Quadlet unit — bind-mounts `~/.lyra/jetstream` → `/var/lib/nats/jetstream` inside the NATS container, providing durable storage for JetStream streams and KV buckets
- Add `jetstream { store_dir }` stanza to `nats-container.conf` and drop the `-js` CLI flag from `lyra-nats.container` (JetStream is now enabled via config, not the flag)
- Update `Makefile` `quadlet-install` to copy the new volume unit, and document the first-time prod setup in `docs/CONFIGURATION.md`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1055: JetStream persistent volume + store_dir config (NATS KV prereq) | Open |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 1 commit on `feat/1055-jetstream-persistent-volume` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new — config/deploy only) | Passed |

## Test Plan

- [ ] `make quadlet-install` on prod copies `lyra-jetstream.volume` to `~/.config/containers/systemd/`
- [ ] After `mkdir -p ~/.lyra/jetstream && podman unshare chown 1500:1500 ~/.lyra/jetstream && systemctl --user restart lyra-nats`, KV bucket `lyra-state` survives `podman restart lyra-nats`
- [ ] `~/.lyra/jetstream/jetstream/$G/streams/KV_lyra-state/` exists post-restart
- [ ] `make remote logs | grep "announce_hub_ready"` shows no regression in readiness probe timing
- [ ] `nats-server -v` inside container confirms JetStream enabled without `-js` flag

Closes #1055

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`