### PR TITLE
chore(provision): warn on re-run if existing subuid range overlaps other users

### DIFF
--- a/artifacts/analyses/876-provision-warn-subuid-overlap-consensus.mdx
+++ b/artifacts/analyses/876-provision-warn-subuid-overlap-consensus.mdx
@@ -1,0 +1,76 @@
+---
+title: "provision.sh warn_subid_overlap — Long-Term Defensive Posture Consensus"
+issue: 876
+status: consensus-reached
+date: 2026-05-05
+panel: architect, devops, security-auditor
+confidence: high
+---
+
+## Problem
+
+Three review findings (F2, F5, F6) on PR #1072 remained after auto-apply. Panel was asked for long-term recommendations on all three pending findings in the context of `warn_subid_overlap` and `assert_no_subid_overlap` in `deploy/provision.sh`.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | Arch soundness, contract parity, maintainability |
+| devops | Ops observability, curl\|bash run visibility, idempotency |
+| security-auditor | Defense-in-depth, path traversal, privilege boundary |
+
+## Consensus ρ
+
+Apply all three fixes:
+
+**F2** — Split the combined missing/unreadable guard in `warn_subid_overlap`:
+```bash
+[[ ! -e "$file" ]] && return 0
+[[ ! -r "$file" ]] && { warn "Cannot read $file (check permissions) — skipping overlap check"; return 0; }
+```
+
+**F5** — Add allowlist guard at function entry in `warn_subid_overlap`:
+```bash
+[[ "$file" == /etc/subuid || "$file" == /etc/subgid ]] \
+  || { warn "warn_subid_overlap: unexpected file path '$file' — skipping"; return 0; }
+```
+
+**F6** — Add blank line between `warn_subid_overlap` and `assert_no_subid_overlap`.
+
+**Contract rule to document:** Advisory-path functions (`warn_*`) must distinguish missing (silent return 0) from unreadable (warn + return 0). This mirrors the hard-path (`assert_*`) pattern: missing = skip, unreadable = abort.
+
+### Rationale
+
+All three experts converged on the same solutions without debate:
+- F2: Missing vs unreadable distinction is an observability fix, not a security fix — the devops and arch perspectives both identified this as the right long-term posture for a `curl | bash` provisioner where operator signal matters
+- F5: Allowlist (not regex) because the permitted set is exactly two paths; exact match detects future drift loudly
+- F6: Blank line is unconditionally correct; security-auditor additionally recommends `shfmt` in CI as a systemic fix
+
+### Trade-offs
+
+- F2 warn on unreadable adds noise on permission-hardened hosts — accepted cost; advisory, not hard failure
+- F5 whitelist must be updated if distros relocate subid files — acceptable visible maintenance cost
+- F6 blank line: consider adding `shfmt` to the CI lint gate to prevent recurrence of shell style issues
+
+## Alternatives
+
+| Option | Proposed by | Rejected because |
+|--------|-------------|------------------|
+| F2: hard error on unreadable | — | Contradicts `warn_subid_overlap`'s advisory contract; `assert_no_subid_overlap` owns the abort path |
+| F2: silent skip with comment (status quo) | security-auditor (initial review) | Hides permission regressions in curl\|bash runs permanently |
+| F5: regex path guard (`^/etc/`) | — | Too broad; allows `/etc/passwd`, `/etc/shadow` to reach awk |
+| F5: no guard (status quo) | — | Implicit contract; breaks as script accumulates callers over time |
+| Shared file-access helper | architect | Over-engineering for single-file bash provisioner; bash lacks structured return types |
+
+## Dissent
+
+None — unanimous.
+
+## Implementation Notes
+
+Apply in order: F2 → F5 → F6 (ascending blast radius). All changes are local to `warn_subid_overlap`; no callers change. ADR-069 documents the contract rule for future reviewers.
+
+## Next
+
+- Apply F2/F5/F6 in PR #1072 → re-review → merge to staging
+- Follow-up (low priority): add `shfmt` to CI lint gate for shell files

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -131,7 +131,8 @@ warn_subid_overlap() {
   local start count
   read -r start count < <(awk -F: -v u="$ADMIN_USER" '$1 == u {print $2, $3; exit}' "$file")
   [[ -z "$start" ]] && return 0
-  local end=$(( start + count ))
+  [[ -z "$count" || ! "$count" =~ ^[0-9]+$ ]] && { warn "malformed subid entry for $ADMIN_USER in $file — skipping overlap check"; return 0; }
+  local end; end=$(( start + count ))
   local hit
   hit=$(awk -F: -v u="$ADMIN_USER" -v s="$start" -v e="$end" \
     '$1 != u && $2 + $3 > s && $2 < e { print $1 ": " $2 "-" $2+$3-1 }' "$file")
@@ -145,8 +146,8 @@ assert_no_subid_overlap() {
   [[ ! -e "$file" ]] && return 0
   [[ -e "$file" && ! -r "$file" ]] && error "Cannot read $file (check permissions)."
   local hit
-  hit=$(awk -F: -v s="$start" -v e="$end" \
-    '$2 + $3 > s && $2 < e { print "overlap with " $1 ": " $2 "-" $2+$3-1 }' "$file")
+  hit=$(awk -F: -v u="$ADMIN_USER" -v s="$start" -v e="$end" \
+    '$1 != u && $2 + $3 > s && $2 < e { print "overlap with " $1 ": " $2 "-" $2+$3-1 }' "$file")
   if [[ -n "$hit" ]]; then
     while IFS= read -r line; do warn "  $line"; done <<< "$hit"
     error "subid overlap detected in $file — see warnings above"

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -127,7 +127,11 @@ next_free_subid_start() {
 # real failures. Revisit when AGENT_USER subuid provisioning is added (#876).
 warn_subid_overlap() {
   local file="$1"
-  [[ ! -e "$file" || ! -r "$file" ]] && return 0
+  # Advisory-only: missing = silent, unreadable = warn + skip (mirrors assert_no_subid_overlap hard path).
+  [[ "$file" == /etc/subuid || "$file" == /etc/subgid ]] \
+    || { warn "warn_subid_overlap: unexpected file path '$file' — skipping"; return 0; }
+  [[ ! -e "$file" ]] && return 0
+  [[ ! -r "$file" ]] && { warn "Cannot read $file (check permissions) — skipping overlap check"; return 0; }
   local start count
   read -r start count < <(awk -F: -v u="$ADMIN_USER" '$1 == u {print $2, $3; exit}' "$file")
   [[ -z "$start" ]] && return 0
@@ -141,6 +145,7 @@ warn_subid_overlap() {
     while IFS= read -r line; do warn "  $line"; done <<< "$hit"
   fi
 }
+
 assert_no_subid_overlap() {
   local file="$1" start="$2" end="$3"
   [[ ! -e "$file" ]] && return 0

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -122,6 +122,24 @@ next_free_subid_start() {
 # HWM gives the highest ending point but misses non-contiguous gaps: a manually
 # edited entry with start < HWM but start+count > HWM would go undetected and
 # the new allocation would alias an existing range. Scan every interval.
+# Warn-only variant used on re-runs when the range already exists. Idempotency
+# is preserved (no fail-fast); the downstream `podman info` smoke test surfaces
+# real failures. Revisit when AGENT_USER subuid provisioning is added (#876).
+warn_subid_overlap() {
+  local file="$1"
+  [[ ! -e "$file" || ! -r "$file" ]] && return 0
+  local start count
+  read -r start count < <(awk -F: -v u="$ADMIN_USER" '$1 == u {print $2, $3; exit}' "$file")
+  [[ -z "$start" ]] && return 0
+  local end=$(( start + count ))
+  local hit
+  hit=$(awk -F: -v u="$ADMIN_USER" -v s="$start" -v e="$end" \
+    '$1 != u && $2 + $3 > s && $2 < e { print $1 ": " $2 "-" $2+$3-1 }' "$file")
+  if [[ -n "$hit" ]]; then
+    warn "subuid range for $ADMIN_USER in $file overlaps with:"
+    while IFS= read -r line; do warn "  $line"; done <<< "$hit"
+  fi
+}
 assert_no_subid_overlap() {
   local file="$1" start="$2" end="$3"
   [[ ! -e "$file" ]] && return 0
@@ -180,6 +198,8 @@ if ! has_sufficient_subids /etc/subuid || ! has_sufficient_subids /etc/subgid; t
   fi
   info "subuid/subgid added for $ADMIN_USER (≥65536 IDs)."
 else
+  warn_subid_overlap /etc/subuid
+  warn_subid_overlap /etc/subgid
   info "subuid/subgid already configured for $ADMIN_USER (≥65536 IDs)."
 fi
 

--- a/docs/architecture/adr/069-provision-warn-subid-overlap-defensive-posture.mdx
+++ b/docs/architecture/adr/069-provision-warn-subid-overlap-defensive-posture.mdx
@@ -1,0 +1,116 @@
+---
+title: "ADR-069: Defensive posture for warn_subid_overlap in provision.sh"
+description: Defines how warn_subid_overlap handles unreadable files, unvalidated path arguments, and formatting; aligns its contract with assert_no_subid_overlap.
+---
+
+## Status
+
+Accepted
+
+## Context
+
+`deploy/provision.sh` contains two functions that inspect `/etc/subuid` and `/etc/subgid`
+to prevent silent UID namespace aliasing during rootless Podman provisioning:
+
+- `assert_no_subid_overlap` — hard path: aborts provisioning on overlap or unreadable file
+- `warn_subid_overlap` — soft path: advisory warnings only, no exit
+
+Three review findings (F2, F5, F6) exposed inconsistencies in `warn_subid_overlap`'s
+defensive posture relative to `assert_no_subid_overlap`, and one whitespace gap.
+
+**F2.** `warn_subid_overlap` treats missing files and unreadable-but-present files
+identically (`[[ ! -e "$file" || ! -r "$file" ]] && return 0`). A missing file is normal
+(fresh install). An unreadable file that exists silently suppresses the entire overlap
+warning, which is the only advisory check for pre-existing range conflicts on hosts with
+LDAP or multi-user rootless containers.
+
+**F5.** `$file` is passed by callers as a hardcoded literal (`/etc/subuid`,
+`/etc/subgid`) but the function has no guard. A provisioning script that evolves
+(new distros, abstracted callers, copy-paste reuse) can easily pass an unexpected path.
+In a `curl | bash` execution context, a misdirected `awk -F:` scan of an arbitrary file
+is a low-severity but real correctness risk.
+
+**F6.** No blank line between `warn_subid_overlap` and `assert_no_subid_overlap`,
+reducing readability.
+
+**Scope:** These are bash-layer decisions in a provisioning script, not application
+architecture. No ADR would normally be warranted for whitespace. This record exists
+because F2 and F5 together establish a durable contract rule (advisory-path functions
+must still fail loudly on unreadable inputs, not silently degrade) that reviewers and
+future editors need to understand.
+
+## Options Considered
+
+### Option A: Silent skip on unreadable (status quo for F2) + no path guard (status quo for F5)
+
+- **Pros:** Minimal code; provisioning continues without noise on permission-hardened hosts.
+- **Cons:** Silently drops the entire advisory overlap check when the file is unreadable.
+  Operator has no signal that the check was skipped. Inconsistent with `assert_no_subid_overlap`
+  which hard-errors on the same condition. Unvalidated path grows as a latent risk.
+
+### Option B: Emit `warn` on unreadable + whitelist path guard (recommended)
+
+- **Pros:** Preserves advisory contract (no abort), but the operator sees a warning that the
+  check was skipped and why. Path whitelist makes the allowed input set explicit and catches
+  copy-paste drift early. Symmetric contract with `assert_no_subid_overlap` (both distinguish
+  missing vs unreadable; they differ only in severity: `warn` vs `error`).
+- **Cons:** Two additional lines of bash. Whitelist is exact (`/etc/subuid` | `/etc/subgid`)
+  so any future distro that moves the files requires an update to the guard.
+
+### Option C: Extract shared file-access helper returning a structured result
+
+- **Pros:** Eliminates all future drift between the two functions; single place to update
+  if paths change.
+- **Cons:** Over-engineering for a single-file bash provisioner. Bash has no structured
+  return types; a helper would use global variables or stdout parsing, both of which
+  increase complexity and testing surface. Not warranted at this scope.
+
+## Decision
+
+Apply Option B.
+
+**F2 fix:** Replace the combined missing/unreadable guard in `warn_subid_overlap` with
+two separate checks — missing returns silently, unreadable emits `warn` and returns:
+
+```bash
+[[ ! -e "$file" ]] && return 0
+[[ ! -r "$file" ]] && { warn "Cannot read $file (check permissions) — skipping overlap check"; return 0; }
+```
+
+**F5 fix:** Add a whitelist guard as the first line of `warn_subid_overlap`
+(and defensively of `assert_no_subid_overlap`):
+
+```bash
+[[ "$file" == /etc/subuid || "$file" == /etc/subgid ]] \
+  || { warn "warn_subid_overlap: unexpected file path '$file' — skipping"; return 0; }
+```
+
+For `assert_no_subid_overlap` the equivalent guard uses `error` instead of `warn/return 0`
+because that function is on the abort path.
+
+**F6 fix:** Add a blank line between the two function definitions.
+
+**Contract rule (document in code comment):** Advisory-path functions (`warn_*`) must
+still distinguish missing vs unreadable inputs. Missing = normal/silent. Unreadable = warn
+and skip. This mirrors the hard-path (`assert_*`) pattern of missing = skip, unreadable = abort.
+
+## Consequences
+
+### Positive
+
+- Operator learns when an overlap check was skipped due to permissions, not just when an
+  overlap was found. Reduces silent failure surface in `curl | bash` provisioning runs.
+- Path whitelist makes future callers explicit about which files are supported.
+- Contract parity between `warn_subid_overlap` and `assert_no_subid_overlap` reduces
+  cognitive load for reviewers who must reason about both functions together.
+
+### Negative
+
+- The whitelist guard must be updated if a future distro relocates subid files (e.g.,
+  Ubuntu with alternative NSS backends). This is an expected, visible maintenance cost.
+
+### Neutral
+
+- No change to provisioning outcome on the happy path (both files present and readable).
+- `warn_subid_overlap` remains a no-exit function; the `warn` on unreadable does not
+  abort provisioning.

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -67,6 +67,9 @@
     "063-thread-store-teardown-bootstrap-ownership",
     "064-nats-acl-request-reply-flows-derivation",
     "065-nats-kv-readiness-probe",
-    "066-unified-worker-error-envelope-nats-reply-contracts"
+    "066-unified-worker-error-envelope-nats-reply-contracts",
+    "067-blobstore-abstraction-flat-fs-content-addressed",
+    "068-selinux-z-label-quadlet-bind-volume-policy",
+    "069-provision-warn-subid-overlap-defensive-posture"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `warn_subid_overlap()` helper that scans `/etc/subuid` and `/etc/subgid` for ranges belonging to other users that overlap the admin user's existing allocation
- Call it in the idempotent re-run path (the `else` branch of `has_sufficient_subids`) so operators are warned on repeat runs without breaking idempotency

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #876: chore(provision): warn on re-run if existing subuid range overlaps other users | Open |
| Analysis | Absent | — |
| Spec | Absent | — |
| Implementation | 1 commit on `feat/876-provision-warn-subuid-overlap` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Re-run `provision.sh` on a host where two users share `100000:65536` — confirm warning is emitted and script continues (no error)
- [ ] Re-run on a host with no overlaps — confirm no warning, info line only
- [ ] Run on a fresh host (no subuid entries) — no warning, allocation proceeds normally via the `if` branch

Closes #876

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`