### PR TITLE
fix(contracts): post-merge consensus fixes — jobs domain (#1045 follow-up)

### DIFF
--- a/artifacts/analyses/1045-jobs-contracts-review-consensus.mdx
+++ b/artifacts/analyses/1045-jobs-contracts-review-consensus.mdx
@@ -1,0 +1,102 @@
+---
+title: "jobs contracts review findings — Expert Consensus"
+issue: 1045
+status: consensus-reached
+date: 2026-05-05
+panel: architect, security-auditor, backend-dev
+confidence: high
+---
+
+## Problem
+
+PR #1071 final review produced 11 open findings (0 blockers, 7 suggestions, 2 informational, 2 praise)
+across `_nats_utils.py`, `jobs/models.py`, `jobs/subjects.py`, `tests/test_jobs_models.py`, and
+`jobs/fixtures.py`. Panel resolves the long-term fix strategy for each finding before `/fix` applies them.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | arch soundness, maintainability, ADR compliance, evolvability |
+| security-auditor | input validation design, injection surface, trust boundaries |
+| backend-dev | Python/Pydantic v2 patterns, API design, test coverage |
+
+## Consensus
+
+| F | Finding | Decision | Vote |
+|---|---------|----------|------|
+| F1 | `validate_nats_subject` calls `validate_job_token` on post-split segments | Extract `_validate_subject_segment` using `_SAFE_WORKER_ID_RE` (no dots) | Unanimous |
+| F2 | Empty `_Subjects` dataclass | Populate with `Literal`-typed prefix fields: `submit_prefix`, `result_prefix`, `progress_prefix` | 2-1 |
+| F3 | `validate_nats_subject("")` raises with job-token error message | Explicit empty-string guard at top: `if not subject: raise ValueError(...)` | Unanimous |
+| F4 | Missing `parent_job_id` bad-token test | Add to existing `test_job_envelope_rejects_bad_token` parametrize | Unanimous |
+| F5 | Missing `reply_to` multi-segment tests (`_INBOX..abc`, `_INBOX.abc.`) | Add to existing `test_job_envelope_rejects_bad_token` parametrize (with comment marking `validate_nats_subject` semantics) | 2-1 |
+| F6 | Missing `success` + `data=None` test | Add `pytest.param({"status": "success"}, False, id="success-no-data")` to `test_job_result_invariant` | Unanimous |
+| F7 | Missing `step=""` rejection test | Add parametrize case | Unanimous |
+| F8 | `reply_to` no prefix restriction | Document trust assumption in `_validate_reply_to`: closed internal NATS cluster, all publishers trusted | Unanimous |
+| F9 | `_validate_job_id` duplicated in JobResult + JobProgress | Accept duplication — flat composition per ADR-049; 3-line body; independent evolvability | 2-1 |
+| F10 | Test docstring inverts SC-10/SC-11 | Fix docstring | Unanimous |
+| F11 | `_ENV` private symbol imported in tests | Rename `_ENV` → `ENV_BASE` in fixtures.py + all importers | Unanimous |
+
+## Rationale
+
+### F1 — separate segment validator
+
+`validate_job_token` regex `[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*` allows dots (for job namespacing).
+Split segments structurally cannot contain dots — correctness by coincidence, not by contract.
+Any future relaxation of `validate_job_token` silently widens subject validation with no type-check
+signal. `_validate_subject_segment` with `_SAFE_WORKER_ID_RE` makes the constraint explicit and removes
+the cross-function dependency.
+
+### F2 — populate _Subjects
+
+Voice/image/llm pattern: `SUBJECTS` holds static Literal-typed fields enabling pyright-checked access
+and grep-discovery. Jobs subjects are partially dynamic (parameterized by `job_name`/`job_id`) but the
+static prefix halves are Literal constants. `submit_prefix: Literal["lyra.jobs"] = "lyra.jobs"` etc.
+preserve the cross-domain pattern while acknowledging that complete subjects require the helper functions.
+Security's concern (dead surface) is resolved by populating rather than removing.
+
+### F8 — trust documentation
+
+Restricting `reply_to` to `_INBOX.`/`_R_.` prefixes would break legitimate patterns:
+JetStream-managed reply subjects (`$JS.ACK.*`), custom routing in test harnesses, any future transport
+that uses named reply queues. The `validate_nats_subject` call already blocks wildcards. The correct
+enforcement point is NATS ACL (ADR-062/064). Document the closed-cluster trust assumption inline.
+
+### F9 — flat composition preserved
+
+`_validate_job_id` is 3 lines in each of `JobResult` and `JobProgress`. ADR-049 specifies independent
+envelope evolvability — `JobResult.job_id` and `JobProgress.job_id` may diverge in a future schema
+version (structured composite IDs, versioned UUIDs). A `_JobIdMixin` locks both to the same validation
+rule before that divergence is needed. 3-line duplication is below the threshold of architectural value.
+Revisit at ≥3 duplications.
+
+## Alternatives
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| F2 — remove `_Subjects` entirely | security-auditor | Breaks cross-domain pattern; empty body is the problem, not the symbol |
+| F5 — dedicated test block for multi-segment | architect | `reply_to` overrides belong with other `reply_to` overrides; comment marks the semantic distinction |
+| F8 — prefix allowlist `_INBOX.`/`_R_.` | security-auditor (conditional) | Brittle; breaks JetStream reply subjects; correct enforcement is ACL layer |
+| F9 — `_JobIdMixin(ContractEnvelope)` | backend-dev | Premature; ADR-049 flat composition; 3-line body; pre-locks independent evolvability |
+
+## Dissent
+
+- **F2:** security-auditor accepts populate; notes prefix fields diverge from `voice.SUBJECTS.tts_request`
+  ergonomics (full subject vs prefix). Document this divergence in `subjects.py` docstring.
+- **F5:** architect accepts existing parametrize block; requires a comment marking multi-segment cases as
+  testing `validate_nats_subject` segment-splitting semantics (not field-token validation).
+- **F9:** backend-dev accepts flat composition; records that at ≥3 `_validate_job_id` copies a mixin
+  should be revisited regardless of ADR-049.
+
+## Implementation Notes
+
+Apply in this order to avoid conflicts:
+1. `_nats_utils.py`: add `_validate_subject_segment` + `_SAFE_SUBJECT_SEGMENT_RE`; update `validate_nats_subject` to use it; add empty-string guard (F1 + F3)
+2. `jobs/subjects.py`: populate `_Subjects` with prefix Literal fields (F2)
+3. `jobs/models.py`: add trust assumption comment to `_validate_reply_to` (F8)
+4. `jobs/fixtures.py`: rename `_ENV` → `ENV_BASE` (F11)
+5. `tests/test_jobs_models.py`: all test additions (F4, F5, F6, F7, F10, F11-import-update)
+
+## Next
+
+`/fix #1071` — apply consensus decisions above.

--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -109,6 +109,38 @@ from roxabi_contracts.voice.fixtures import silence_wav_16khz, sample_transcript
 `scipy` is declared in `[project.optional-dependencies].testing` and is
 only pulled when a consumer requests the `[testing]` extra.
 
+## Jobs domain
+
+Generic job-dispatch contract used to route work items across Lyra workers. Import surface:
+
+```python
+from roxabi_contracts.jobs import JobEnvelope, JobResult, JobProgress, jobs_submit
+```
+
+### Subjects
+
+| Subject | Model | Transport | Purpose |
+|---|---|---|---|
+| `lyra.jobs.<job_name>` | `JobEnvelope` | JetStream durable | Submit a job |
+| `lyra.results.<job_id>` | `JobResult` | Core NATS reply | Job completion reply |
+| `lyra.progress.<job_id>` | `JobProgress` | Core NATS pub/sub | Streaming progress (best-effort) |
+
+Subject strings are produced by the helpers `jobs_submit(job_name)`, `jobs_result(job_id)`, and `jobs_progress(job_id)`. Each helper validates its argument via `validate_job_token` (rejects empty strings and NATS wildcard characters).
+
+### Models
+
+All three models subclass `ContractEnvelope` and inherit `ConfigDict(extra="ignore")`.
+
+| Model | Purpose |
+|---|---|
+| `JobEnvelope` | Job submission; carries `job_id`, `job_name`, `payload`, `reply_to`, and optional `parent_job_id` / `composite_depth` |
+| `JobResult` | Completion reply; `status` is `"success"` or `"error"`; on error carries a `WorkerError` |
+| `JobProgress` | Progress event; carries `step`, optional `pct` (0–100), and optional `detail` dict |
+
+### Invariants
+
+`composite_depth` is validated 0–3 (raises `ValueError` outside that range). `JobResult` `status` and `error` are mutually exclusive: `status="error"` requires a `WorkerError`; `status="success"` must not carry one.
+
 ## Test doubles
 
 `roxabi_contracts.voice.testing` provides in-process replacements for a real

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-contracts"
-version = "0.3.0"
+version = "0.4.0"
 description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
@@ -11,7 +11,6 @@ from importlib.metadata import PackageNotFoundError, version
 
 from .audit import SecurityEvent
 from .envelope import CONTRACT_VERSION, ContractEnvelope
-from .jobs import JobEnvelope, JobProgress, JobResult
 
 try:
     __version__: str = version("roxabi-contracts")
@@ -21,9 +20,6 @@ except PackageNotFoundError:
 __all__ = [
     "CONTRACT_VERSION",
     "ContractEnvelope",
-    "JobEnvelope",
-    "JobProgress",
-    "JobResult",
     "SecurityEvent",
     "__version__",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
@@ -11,10 +11,19 @@ from importlib.metadata import PackageNotFoundError, version
 
 from .audit import SecurityEvent
 from .envelope import CONTRACT_VERSION, ContractEnvelope
+from .jobs import JobEnvelope, JobProgress, JobResult
 
 try:
     __version__: str = version("roxabi-contracts")
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
-__all__ = ["CONTRACT_VERSION", "ContractEnvelope", "SecurityEvent", "__version__"]
+__all__ = [
+    "CONTRACT_VERSION",
+    "ContractEnvelope",
+    "JobEnvelope",
+    "JobProgress",
+    "JobResult",
+    "SecurityEvent",
+    "__version__",
+]

--- a/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
@@ -31,3 +31,16 @@ def validate_worker_id(worker_id: str) -> None:
             "NATS wildcard / subtree characters (. * >) are rejected to "
             "prevent subject injection"
         )
+
+
+_SAFE_JOB_TOKEN_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def validate_job_token(token: str) -> None:
+    """Validate a job_name or job_id for NATS subject safety.
+    Dots allowed (namespacing: vault.add-from-url); * and > rejected."""
+    if not _SAFE_JOB_TOKEN_RE.fullmatch(token):
+        raise ValueError(
+            f"job token must match [A-Za-z0-9._-]+ (got {token!r}); "
+            "NATS wildcard characters (* >) and spaces are rejected"
+        )

--- a/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
@@ -33,14 +33,23 @@ def validate_worker_id(worker_id: str) -> None:
         )
 
 
-_SAFE_JOB_TOKEN_RE = re.compile(r"[A-Za-z0-9._-]+")
+_SAFE_JOB_TOKEN_RE = re.compile(r"[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*")
 
 
 def validate_job_token(token: str) -> None:
     """Validate a job_name or job_id for NATS subject safety.
-    Dots allowed (namespacing: vault.add-from-url); * and > rejected."""
+    Dots allowed for namespacing (vault.add-from-url) but leading/trailing/
+    consecutive dots are rejected; * and > rejected."""
     if not _SAFE_JOB_TOKEN_RE.fullmatch(token):
         raise ValueError(
-            f"job token must match [A-Za-z0-9._-]+ (got {token!r}); "
-            "NATS wildcard characters (* >) and spaces are rejected"
+            f"job token must match [A-Za-z0-9_-]+([.][A-Za-z0-9_-]+)* (got {token!r}); "
+            "NATS wildcard characters (* >) and dot-boundary violations are rejected"
         )
+
+
+def validate_nats_subject(subject: str) -> None:
+    """Validate a full multi-segment NATS subject (e.g. _INBOX.abc123).
+    Splits on '.' and validates each segment; rejects empty segments,
+    * and > in any position."""
+    for segment in subject.split("."):
+        validate_job_token(segment)

--- a/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
@@ -47,9 +47,24 @@ def validate_job_token(token: str) -> None:
         )
 
 
+# Subject *segments* (post-split) must not contain dots; use _SAFE_WORKER_ID_RE
+# rather than _SAFE_JOB_TOKEN_RE to keep the two validation paths independent.
+_SAFE_SUBJECT_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]+")
+
+
+def _validate_subject_segment(segment: str) -> None:
+    if not _SAFE_SUBJECT_SEGMENT_RE.fullmatch(segment):
+        raise ValueError(
+            f"NATS subject segment must match [A-Za-z0-9_-]+ (got {segment!r}); "
+            "dots, wildcards (* >) and empty segments are rejected"
+        )
+
+
 def validate_nats_subject(subject: str) -> None:
     """Validate a full multi-segment NATS subject (e.g. _INBOX.abc123).
-    Splits on '.' and validates each segment; rejects empty segments,
-    * and > in any position."""
+    Splits on '.' and validates each segment via _validate_subject_segment
+    (no dots allowed per segment); rejects empty segments and wildcards."""
+    if not subject:
+        raise ValueError("NATS subject must not be empty")
     for segment in subject.split("."):
-        validate_job_token(segment)
+        _validate_subject_segment(segment)

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/__init__.py
@@ -1,0 +1,23 @@
+"""Jobs-domain NATS contract surface.
+
+Public API: three envelope models + SUBJECTS namespace + subject helpers.
+fixtures submodule is test-only — import explicitly as
+``from roxabi_contracts.jobs.fixtures import ...``.
+"""
+from roxabi_contracts.jobs.models import JobEnvelope, JobProgress, JobResult
+from roxabi_contracts.jobs.subjects import (
+    SUBJECTS,
+    jobs_progress,
+    jobs_result,
+    jobs_submit,
+)
+
+__all__ = [
+    "JobEnvelope",
+    "JobProgress",
+    "JobResult",
+    "SUBJECTS",
+    "jobs_progress",
+    "jobs_result",
+    "jobs_submit",
+]

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/__init__.py
@@ -4,6 +4,7 @@ Public API: three envelope models + SUBJECTS namespace + subject helpers.
 fixtures submodule is test-only — import explicitly as
 ``from roxabi_contracts.jobs.fixtures import ...``.
 """
+
 from roxabi_contracts.jobs.models import JobEnvelope, JobProgress, JobResult
 from roxabi_contracts.jobs.subjects import (
     SUBJECTS,

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
@@ -1,0 +1,37 @@
+"""Test fixtures for roxabi_contracts.jobs. Pure dicts — no NATS imports."""
+from datetime import datetime, timezone
+
+_ENV: dict = {
+    "contract_version": "1",
+    "trace_id": "tst-jobs-trace",
+    "issued_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
+}
+
+sample_job_envelope: dict = {
+    **_ENV,
+    "job_id": "job-uuid-1234",
+    "job_name": "vault.add-from-url",
+    "payload": {"url": "https://example.com"},
+    "reply_to": "_INBOX.abc123",
+}
+
+sample_job_result_ok: dict = {
+    **_ENV,
+    "job_id": "job-uuid-1234",
+    "status": "success",
+    "data": {"stored": True},
+}
+
+sample_job_result_err: dict = {
+    **_ENV,
+    "job_id": "job-uuid-1234",
+    "status": "error",
+    "error": {"code": "worker.crash", "message": "scraper failed", "retryable": True},
+}
+
+sample_job_progress: dict = {
+    **_ENV,
+    "job_id": "job-uuid-1234",
+    "step": "fetching",
+    "pct": 25.0,
+}

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
@@ -1,4 +1,5 @@
 """Test fixtures for roxabi_contracts.jobs. Pure dicts — no NATS imports."""
+
 from datetime import datetime, timezone
 
 _ENV: dict = {

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
@@ -3,14 +3,14 @@
 from datetime import datetime, timezone
 from typing import Any
 
-_ENV: dict[str, Any] = {
+ENV_BASE: dict[str, Any] = {
     "contract_version": "1",
     "trace_id": "tst-jobs-trace",
     "issued_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
 }
 
 sample_job_envelope: dict[str, Any] = {
-    **_ENV,
+    **ENV_BASE,
     "job_id": "job-uuid-1234",
     "job_name": "vault.add-from-url",
     "payload": {"url": "https://example.com"},
@@ -18,21 +18,21 @@ sample_job_envelope: dict[str, Any] = {
 }
 
 sample_job_result_ok: dict[str, Any] = {
-    **_ENV,
+    **ENV_BASE,
     "job_id": "job-uuid-1234",
     "status": "success",
     "data": {"stored": True},
 }
 
 sample_job_result_err: dict[str, Any] = {
-    **_ENV,
+    **ENV_BASE,
     "job_id": "job-uuid-1234",
     "status": "error",
     "error": {"code": "worker.crash", "message": "scraper failed", "retryable": True},
 }
 
 sample_job_progress: dict[str, Any] = {
-    **_ENV,
+    **ENV_BASE,
     "job_id": "job-uuid-1234",
     "step": "fetching",
     "pct": 25.0,

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/fixtures.py
@@ -1,14 +1,15 @@
 """Test fixtures for roxabi_contracts.jobs. Pure dicts — no NATS imports."""
 
 from datetime import datetime, timezone
+from typing import Any
 
-_ENV: dict = {
+_ENV: dict[str, Any] = {
     "contract_version": "1",
     "trace_id": "tst-jobs-trace",
     "issued_at": datetime(2026, 5, 4, tzinfo=timezone.utc),
 }
 
-sample_job_envelope: dict = {
+sample_job_envelope: dict[str, Any] = {
     **_ENV,
     "job_id": "job-uuid-1234",
     "job_name": "vault.add-from-url",
@@ -16,21 +17,21 @@ sample_job_envelope: dict = {
     "reply_to": "_INBOX.abc123",
 }
 
-sample_job_result_ok: dict = {
+sample_job_result_ok: dict[str, Any] = {
     **_ENV,
     "job_id": "job-uuid-1234",
     "status": "success",
     "data": {"stored": True},
 }
 
-sample_job_result_err: dict = {
+sample_job_result_err: dict[str, Any] = {
     **_ENV,
     "job_id": "job-uuid-1234",
     "status": "error",
     "error": {"code": "worker.crash", "message": "scraper failed", "retryable": True},
 }
 
-sample_job_progress: dict = {
+sample_job_progress: dict[str, Any] = {
     **_ENV,
     "job_id": "job-uuid-1234",
     "step": "fetching",

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -37,6 +37,10 @@ class JobEnvelope(ContractEnvelope):
     @field_validator("reply_to")
     @classmethod
     def _validate_reply_to(cls, v: str) -> str:
+        # Trust boundary: all JobEnvelope publishers are internal trusted services
+        # on a private NATS cluster (ADR-062/064). No prefix restriction is applied
+        # here; enforcement is at the ACL layer. If the cluster topology ever allows
+        # untrusted publishers, restrict reply_to to _INBOX.* / _R_.* prefixes.
         validate_nats_subject(v)
         return v
 

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -7,6 +7,7 @@ plus ConfigDict(extra="ignore") for forward-compat.
 Validators for composite_depth and JobResult status/error mutex are in
 models.py but added in the GREEN phase (T7).
 """
+
 from __future__ import annotations
 
 from typing import Annotated, Any, Literal, Self
@@ -21,6 +22,7 @@ __all__ = ["JobEnvelope", "JobResult", "JobProgress"]
 
 class JobEnvelope(ContractEnvelope):
     """Job submission envelope. Canonical subject: lyra.jobs.<job_name>."""
+
     job_id: Annotated[str, StringConstraints(min_length=1)]
     job_name: Annotated[str, StringConstraints(min_length=1)]
     payload: dict[str, Any]
@@ -38,6 +40,7 @@ class JobEnvelope(ContractEnvelope):
 
 class JobResult(ContractEnvelope):
     """Job reply envelope. Sent to reply_to subject on completion."""
+
     job_id: Annotated[str, StringConstraints(min_length=1)]
     status: Literal["success", "error"]
     data: dict[str, Any] | None = None
@@ -56,6 +59,7 @@ class JobResult(ContractEnvelope):
 
 class JobProgress(ContractEnvelope):
     """Job progress event. Published to lyra.progress.<job_id> (best-effort)."""
+
     job_id: Annotated[str, StringConstraints(min_length=1)]
     step: Annotated[str, StringConstraints(min_length=1)]
     pct: float | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -1,0 +1,45 @@
+"""Jobs-domain NATS contract models.
+
+Pure Pydantic. No NATS imports. No transport logic. Every model subclasses
+ContractEnvelope, which provides (contract_version, trace_id, issued_at)
+plus ConfigDict(extra="ignore") for forward-compat.
+
+Validators for composite_depth and JobResult status/error mutex are in
+models.py but added in the GREEN phase (T7).
+"""
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import StringConstraints
+
+from roxabi_contracts.envelope import ContractEnvelope
+from roxabi_contracts.errors import WorkerError
+
+__all__ = ["JobEnvelope", "JobResult", "JobProgress"]
+
+
+class JobEnvelope(ContractEnvelope):
+    """Job submission envelope. Canonical subject: lyra.jobs.<job_name>."""
+    job_id: Annotated[str, StringConstraints(min_length=1)]
+    job_name: Annotated[str, StringConstraints(min_length=1)]
+    payload: dict[str, Any]
+    reply_to: Annotated[str, StringConstraints(min_length=1)]
+    parent_job_id: str | None = None
+    composite_depth: int = 0
+
+
+class JobResult(ContractEnvelope):
+    """Job reply envelope. Sent to reply_to subject on completion."""
+    job_id: Annotated[str, StringConstraints(min_length=1)]
+    status: Literal["success", "error"]
+    data: dict[str, Any] | None = None
+    error: WorkerError | None = None
+
+
+class JobProgress(ContractEnvelope):
+    """Job progress event. Published to lyra.progress.<job_id> (best-effort)."""
+    job_id: Annotated[str, StringConstraints(min_length=1)]
+    step: Annotated[str, StringConstraints(min_length=1)]
+    pct: float | None = None
+    detail: dict[str, Any] | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -21,10 +21,10 @@ __all__ = ["JobEnvelope", "JobResult", "JobProgress"]
 class JobEnvelope(ContractEnvelope):
     """Job submission envelope. Canonical subject: lyra.jobs.<job_name>."""
 
-    job_id: Annotated[str, StringConstraints(min_length=1)]
-    job_name: Annotated[str, StringConstraints(min_length=1)]
+    job_id: str
+    job_name: str
     payload: dict[str, Any]
-    reply_to: Annotated[str, StringConstraints(min_length=1)]
+    reply_to: str
     parent_job_id: str | None = None
     composite_depth: Annotated[int, Field(ge=0, le=3)] = 0
 
@@ -34,11 +34,18 @@ class JobEnvelope(ContractEnvelope):
         validate_job_token(v)
         return v
 
+    @field_validator("parent_job_id")
+    @classmethod
+    def _validate_parent_job_id(cls, v: str | None) -> str | None:
+        if v is not None:
+            validate_job_token(v)
+        return v
+
 
 class JobResult(ContractEnvelope):
     """Job reply envelope. Sent to reply_to subject on completion."""
 
-    job_id: Annotated[str, StringConstraints(min_length=1)]
+    job_id: str
     status: Literal["success", "error"]
     data: dict[str, Any] | None = None
     error: WorkerError | None = None
@@ -63,7 +70,7 @@ class JobResult(ContractEnvelope):
 class JobProgress(ContractEnvelope):
     """Job progress event. Published to lyra.progress.<job_id> (best-effort)."""
 
-    job_id: Annotated[str, StringConstraints(min_length=1)]
+    job_id: str
     step: Annotated[str, StringConstraints(min_length=1)]
     pct: Annotated[float, Field(ge=0.0, le=100.0)] | None = None
     detail: dict[str, Any] | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StringConstraints, field_validator, model_validator
 
-from roxabi_contracts._nats_utils import validate_job_token
+from roxabi_contracts._nats_utils import validate_job_token, validate_nats_subject
 from roxabi_contracts.envelope import ContractEnvelope
 from roxabi_contracts.errors import WorkerError
 
@@ -28,10 +28,16 @@ class JobEnvelope(ContractEnvelope):
     parent_job_id: str | None = None
     composite_depth: Annotated[int, Field(ge=0, le=3)] = 0
 
-    @field_validator("job_id", "job_name", "reply_to")
+    @field_validator("job_id", "job_name")
     @classmethod
-    def _validate_nats_tokens(cls, v: str) -> str:
+    def _validate_job_tokens(cls, v: str) -> str:
         validate_job_token(v)
+        return v
+
+    @field_validator("reply_to")
+    @classmethod
+    def _validate_reply_to(cls, v: str) -> str:
+        validate_nats_subject(v)
         return v
 
     @field_validator("parent_job_id")
@@ -72,7 +78,7 @@ class JobProgress(ContractEnvelope):
 
     job_id: str
     step: Annotated[str, StringConstraints(min_length=1)]
-    pct: Annotated[float, Field(ge=0.0, le=100.0)] | None = None
+    pct: Annotated[float | None, Field(ge=0.0, le=100.0)] = None
     detail: dict[str, Any] | None = None
 
     @field_validator("job_id")

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -9,9 +9,9 @@ models.py but added in the GREEN phase (T7).
 """
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import StringConstraints
+from pydantic import StringConstraints, field_validator, model_validator
 
 from roxabi_contracts.envelope import ContractEnvelope
 from roxabi_contracts.errors import WorkerError
@@ -28,6 +28,13 @@ class JobEnvelope(ContractEnvelope):
     parent_job_id: str | None = None
     composite_depth: int = 0
 
+    @field_validator("composite_depth")
+    @classmethod
+    def _validate_depth(cls, v: int) -> int:
+        if not (0 <= v <= 3):
+            raise ValueError(f"composite_depth must be 0–3, got {v}")
+        return v
+
 
 class JobResult(ContractEnvelope):
     """Job reply envelope. Sent to reply_to subject on completion."""
@@ -35,6 +42,16 @@ class JobResult(ContractEnvelope):
     status: Literal["success", "error"]
     data: dict[str, Any] | None = None
     error: WorkerError | None = None
+
+    @model_validator(mode="after")
+    def _enforce_status_invariant(self) -> Self:
+        if self.status == "error" and self.error is None:
+            raise ValueError("JobResult with status='error' must carry a WorkerError")
+        if self.status == "success" and self.error is not None:
+            raise ValueError(
+                "JobResult with status='success' must not carry a WorkerError"
+            )
+        return self
 
 
 class JobProgress(ContractEnvelope):

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -3,17 +3,15 @@
 Pure Pydantic. No NATS imports. No transport logic. Every model subclasses
 ContractEnvelope, which provides (contract_version, trace_id, issued_at)
 plus ConfigDict(extra="ignore") for forward-compat.
-
-Validators for composite_depth and JobResult status/error mutex are in
-models.py but added in the GREEN phase (T7).
 """
 
 from __future__ import annotations
 
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import StringConstraints, field_validator, model_validator
+from pydantic import Field, StringConstraints, field_validator, model_validator
 
+from roxabi_contracts._nats_utils import validate_job_token
 from roxabi_contracts.envelope import ContractEnvelope
 from roxabi_contracts.errors import WorkerError
 
@@ -28,13 +26,12 @@ class JobEnvelope(ContractEnvelope):
     payload: dict[str, Any]
     reply_to: Annotated[str, StringConstraints(min_length=1)]
     parent_job_id: str | None = None
-    composite_depth: int = 0
+    composite_depth: Annotated[int, Field(ge=0, le=3)] = 0
 
-    @field_validator("composite_depth")
+    @field_validator("job_id", "job_name", "reply_to")
     @classmethod
-    def _validate_depth(cls, v: int) -> int:
-        if not (0 <= v <= 3):
-            raise ValueError(f"composite_depth must be 0–3, got {v}")
+    def _validate_nats_tokens(cls, v: str) -> str:
+        validate_job_token(v)
         return v
 
 
@@ -45,6 +42,12 @@ class JobResult(ContractEnvelope):
     status: Literal["success", "error"]
     data: dict[str, Any] | None = None
     error: WorkerError | None = None
+
+    @field_validator("job_id")
+    @classmethod
+    def _validate_job_id(cls, v: str) -> str:
+        validate_job_token(v)
+        return v
 
     @model_validator(mode="after")
     def _enforce_status_invariant(self) -> Self:
@@ -62,5 +65,11 @@ class JobProgress(ContractEnvelope):
 
     job_id: Annotated[str, StringConstraints(min_length=1)]
     step: Annotated[str, StringConstraints(min_length=1)]
-    pct: float | None = None
+    pct: Annotated[float, Field(ge=0.0, le=100.0)] | None = None
     detail: dict[str, Any] | None = None
+
+    @field_validator("job_id")
+    @classmethod
+    def _validate_job_id(cls, v: str) -> str:
+        validate_job_token(v)
+        return v

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
@@ -1,0 +1,43 @@
+"""Jobs-domain NATS subject strings and helpers."""
+from dataclasses import dataclass
+
+from roxabi_contracts._nats_utils import validate_job_token
+
+__all__ = [
+    "SUBJECTS",
+    "jobs_submit",
+    "jobs_result",
+    "jobs_progress",
+    "validate_job_token",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class _Subjects:
+    """Frozen namespace for jobs-domain subjects.
+
+    Empty at v0.4.0; callers use helpers.
+    """
+
+    pass
+
+
+SUBJECTS = _Subjects()
+
+
+def jobs_submit(job_name: str) -> str:
+    """Submit subject: lyra.jobs.<job_name>."""
+    validate_job_token(job_name)
+    return f"lyra.jobs.{job_name}"
+
+
+def jobs_result(job_id: str) -> str:
+    """Result subject: lyra.results.<job_id>."""
+    validate_job_token(job_id)
+    return f"lyra.results.{job_id}"
+
+
+def jobs_progress(job_id: str) -> str:
+    """Progress subject: lyra.progress.<job_id>."""
+    validate_job_token(job_id)
+    return f"lyra.progress.{job_id}"

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
@@ -1,4 +1,5 @@
 """Jobs-domain NATS subject strings and helpers."""
+
 from dataclasses import dataclass
 
 from roxabi_contracts._nats_utils import validate_job_token

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
@@ -1,6 +1,7 @@
 """Jobs-domain NATS subject strings and helpers."""
 
 from dataclasses import dataclass
+from typing import Literal
 
 from roxabi_contracts._nats_utils import validate_job_token
 
@@ -14,12 +15,17 @@ __all__ = [
 
 @dataclass(frozen=True, slots=True)
 class _Subjects:
-    """Frozen namespace for jobs-domain subjects.
+    """Frozen namespace for jobs-domain subject prefixes.
 
-    Empty at v0.4.0; callers use helpers.
+    Holds the static prefix halves of each subject family. The dynamic
+    suffix (job_name or job_id) is appended by the helper functions below.
+    Diverges from voice/image/llm where SUBJECTS holds complete Literal
+    subjects — jobs subjects are always parameterised.
     """
 
-    pass
+    submit_prefix: Literal["lyra.jobs"] = "lyra.jobs"
+    result_prefix: Literal["lyra.results"] = "lyra.results"
+    progress_prefix: Literal["lyra.progress"] = "lyra.progress"
 
 
 SUBJECTS = _Subjects()

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
@@ -9,7 +9,6 @@ __all__ = [
     "jobs_submit",
     "jobs_result",
     "jobs_progress",
-    "validate_job_token",
 ]
 
 

--- a/packages/roxabi-contracts/tests/test_jobs_models.py
+++ b/packages/roxabi-contracts/tests/test_jobs_models.py
@@ -261,9 +261,12 @@ def test_job_envelope_accepts_inbox_reply_to() -> None:
         pytest.param(jobs_progress, "bad*token", id="progress-asterisk"),
         pytest.param(jobs_progress, "bad>token", id="progress-greater-than"),
         pytest.param(jobs_progress, "", id="progress-empty-string"),
+        pytest.param(jobs_submit, ".leading-dot", id="submit-leading-dot"),
+        pytest.param(jobs_submit, "a..b", id="submit-consecutive-dots"),
+        pytest.param(jobs_submit, "trailing.", id="submit-trailing-dot"),
     ],
 )
 def test_subjects_rejects_bad_tokens(helper: Any, bad_token: str) -> None:
-    """Subject helpers raise ValueError for NATS wildcards (* >) and empty strings."""
+    """Subject helpers raise ValueError for wildcards, empty strings, dot boundaries."""
     with pytest.raises(ValueError):
         helper(bad_token)

--- a/packages/roxabi-contracts/tests/test_jobs_models.py
+++ b/packages/roxabi-contracts/tests/test_jobs_models.py
@@ -1,13 +1,7 @@
-"""RED-phase tests for roxabi_contracts.jobs domain models and subjects.
+"""Tests for roxabi_contracts.jobs domain models and subjects.
 
 Covers SC-10 (model roundtrip, extra-ignore, composite_depth boundary,
 JobResult status/error mutex) and SC-11 (subject helpers).
-
-test_roundtrip and test_extra_ignore → PASS immediately (no validators needed).
-test_subjects → PASS immediately (helpers already enforce bad tokens).
-test_composite_depth_boundary[depth-4] and [depth--1] → FAIL until T7.
-test_job_result_invariant[error-no-WorkerError] and [success-with-error]
-→ FAIL until T7.
 """
 
 from __future__ import annotations
@@ -72,7 +66,7 @@ def test_roundtrip(model: type[BaseModel], payload: dict[str, Any]) -> None:
     ],
 )
 def test_composite_depth_boundary(depth: int, should_raise: bool) -> None:
-    """composite_depth in [0..3] is valid; 4 or -1 raise ValidationError (RED until T7)."""  # noqa: E501
+    """composite_depth in [0..3] is valid; 4 or -1 raise ValidationError."""
     # Arrange
     payload: dict[str, Any] = {
         **sample_job_envelope,
@@ -80,11 +74,9 @@ def test_composite_depth_boundary(depth: int, should_raise: bool) -> None:
     }
 
     if should_raise:
-        # Act / Assert — expected RED until T7 adds the validator
         with pytest.raises(ValidationError):
             JobEnvelope.model_validate(payload)
     else:
-        # Act / Assert — must pass right now
         inst = JobEnvelope.model_validate(payload)
         assert inst.composite_depth == depth
 
@@ -122,7 +114,7 @@ _WORKER_ERROR = WorkerError(code="worker.crash", message="scraper failed")
     ],
 )
 def test_job_result_invariant(kwargs: dict[str, Any], should_raise: bool) -> None:
-    """status/error mutex: error=None on status=error raises; WorkerError on success raises (RED until T7)."""  # noqa: E501
+    """status/error mutex: error=None on error raises; WorkerError on success raises."""
     # Arrange
     from roxabi_contracts.jobs.fixtures import _ENV
 
@@ -133,11 +125,9 @@ def test_job_result_invariant(kwargs: dict[str, Any], should_raise: bool) -> Non
     }
 
     if should_raise:
-        # Act / Assert — expected RED until T7 adds the validator
         with pytest.raises(ValidationError):
             JobResult.model_validate(payload)
     else:
-        # Act / Assert — must pass right now
         inst = JobResult.model_validate(payload)
         assert inst.status == kwargs["status"]
 
@@ -198,19 +188,18 @@ def test_subjects_jobs_progress() -> None:
 
 
 @pytest.mark.parametrize(
-    "bad_token",
+    ("helper", "bad_token"),
     [
-        pytest.param("bad*token", id="asterisk"),
-        pytest.param("bad>token", id="greater-than"),
+        pytest.param(jobs_submit, "bad*token", id="submit-asterisk"),
+        pytest.param(jobs_submit, "bad>token", id="submit-greater-than"),
+        pytest.param(jobs_submit, "", id="submit-empty-string"),
+        pytest.param(jobs_result, "bad*token", id="result-asterisk"),
+        pytest.param(jobs_result, "bad>token", id="result-greater-than"),
+        pytest.param(jobs_progress, "bad*token", id="progress-asterisk"),
+        pytest.param(jobs_progress, "bad>token", id="progress-greater-than"),
     ],
 )
-def test_subjects_rejects_bad_tokens(bad_token: str) -> None:
-    """jobs_submit raises ValueError for NATS wildcard characters (* and >)."""
+def test_subjects_rejects_bad_tokens(helper: Any, bad_token: str) -> None:
+    """Subject helpers raise ValueError for NATS wildcards (* >) and empty strings."""
     with pytest.raises(ValueError):
-        jobs_submit(bad_token)
-
-
-def test_subjects_dots_allowed() -> None:
-    """Dots in job_name are permitted (e.g. 'vault.add-from-url')."""
-    subject = jobs_submit("vault.add-from-url")
-    assert subject == "lyra.jobs.vault.add-from-url"
+        helper(bad_token)

--- a/packages/roxabi-contracts/tests/test_jobs_models.py
+++ b/packages/roxabi-contracts/tests/test_jobs_models.py
@@ -1,7 +1,8 @@
 """Tests for roxabi_contracts.jobs domain models and subjects.
 
-Covers SC-10 (model roundtrip, extra-ignore, composite_depth boundary,
-JobResult status/error mutex) and SC-11 (subject helpers).
+Covers SC-10 (round-trip JSON for all three models), SC-11 (valid construction,
+composite_depth boundary, JobResult status/error invariant, extra-field ignore),
+plus subject validation (beyond spec).
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from roxabi_contracts.jobs import (
     jobs_submit,
 )
 from roxabi_contracts.jobs.fixtures import (
-    _ENV,
+    ENV_BASE,
     sample_job_envelope,
     sample_job_progress,
     sample_job_result_err,
@@ -87,7 +88,7 @@ def test_composite_depth_boundary(depth: int, should_raise: bool) -> None:
 # ---------------------------------------------------------------------------
 
 _WORKER_ERROR = WorkerError(code="worker.crash", message="scraper failed")
-_RESULT_BASE: dict[str, Any] = {**_ENV, "job_id": "job-uuid-1234"}
+_RESULT_BASE: dict[str, Any] = {**ENV_BASE, "job_id": "job-uuid-1234"}
 
 
 @pytest.mark.parametrize(
@@ -112,6 +113,11 @@ _RESULT_BASE: dict[str, Any] = {**_ENV, "job_id": "job-uuid-1234"}
             {"status": "error", "error": _WORKER_ERROR},
             False,
             id="error-with-WorkerError",
+        ),
+        pytest.param(
+            {"status": "success"},
+            False,
+            id="success-no-data",
         ),
     ],
 )
@@ -173,10 +179,15 @@ def test_extra_ignore(model: type[BaseModel], payload: dict[str, Any]) -> None:
         pytest.param({"job_id": "bad*id"}, id="envelope-job_id-wildcard"),
         pytest.param({"job_name": "bad>name"}, id="envelope-job_name-wildcard"),
         pytest.param({"reply_to": "bad*inbox"}, id="envelope-reply_to-wildcard"),
+        pytest.param({"parent_job_id": "bad*id"}, id="envelope-parent_job_id-wildcard"),
+        pytest.param({"parent_job_id": "bad>id"}, id="envelope-parent_job_id-gt"),
+        # validate_nats_subject segment-splitting semantics on reply_to
+        pytest.param({"reply_to": "_INBOX..abc"}, id="reply_to-consecutive-dots"),
+        pytest.param({"reply_to": "_INBOX.abc."}, id="reply_to-trailing-dot"),
     ],
 )
 def test_job_envelope_rejects_bad_token(overrides: dict[str, Any]) -> None:
-    """field_validators on job_id/job_name/reply_to reject NATS wildcards."""
+    """field_validators on job_id/job_name/reply_to/parent_job_id reject wildcards."""
     with pytest.raises(ValidationError):
         JobEnvelope.model_validate({**sample_job_envelope, **overrides})
 
@@ -192,6 +203,12 @@ def test_job_progress_rejects_bad_job_id() -> None:
     """field_validator on job_id raises ValidationError for NATS wildcard characters."""
     with pytest.raises(ValidationError):
         JobProgress.model_validate({**sample_job_progress, "job_id": "bad*id"})
+
+
+def test_job_progress_rejects_empty_step() -> None:
+    """StringConstraints(min_length=1) on step rejects empty string."""
+    with pytest.raises(ValidationError):
+        JobProgress.model_validate({**sample_job_progress, "step": ""})
 
 
 # ---------------------------------------------------------------------------

--- a/packages/roxabi-contracts/tests/test_jobs_models.py
+++ b/packages/roxabi-contracts/tests/test_jobs_models.py
@@ -1,0 +1,216 @@
+"""RED-phase tests for roxabi_contracts.jobs domain models and subjects.
+
+Covers SC-10 (model roundtrip, extra-ignore, composite_depth boundary,
+JobResult status/error mutex) and SC-11 (subject helpers).
+
+test_roundtrip and test_extra_ignore → PASS immediately (no validators needed).
+test_subjects → PASS immediately (helpers already enforce bad tokens).
+test_composite_depth_boundary[depth-4] and [depth--1] → FAIL until T7.
+test_job_result_invariant[error-no-WorkerError] and [success-with-error]
+→ FAIL until T7.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from roxabi_contracts.errors import WorkerError
+from roxabi_contracts.jobs import (
+    JobEnvelope,
+    JobProgress,
+    JobResult,
+    jobs_progress,
+    jobs_result,
+    jobs_submit,
+)
+from roxabi_contracts.jobs.fixtures import (
+    sample_job_envelope,
+    sample_job_progress,
+    sample_job_result_err,
+    sample_job_result_ok,
+)
+
+# ---------------------------------------------------------------------------
+# test_roundtrip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        pytest.param(JobEnvelope, sample_job_envelope, id="JobEnvelope"),
+        pytest.param(JobResult, sample_job_result_ok, id="JobResult-success"),
+        pytest.param(JobResult, sample_job_result_err, id="JobResult-error"),
+        pytest.param(JobProgress, sample_job_progress, id="JobProgress"),
+    ],
+)
+def test_roundtrip(model: type[BaseModel], payload: dict[str, Any]) -> None:
+    """model_validate → model_dump_json → model_validate_json yields equal instance."""
+    # Arrange / Act
+    inst = model.model_validate(payload)
+    restored = model.model_validate_json(inst.model_dump_json())
+
+    # Assert
+    assert restored == inst
+
+
+# ---------------------------------------------------------------------------
+# test_composite_depth_boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("depth", "should_raise"),
+    [
+        pytest.param(0, False, id="depth-0-valid"),
+        pytest.param(3, False, id="depth-3-valid"),
+        pytest.param(4, True, id="depth-4-invalid"),
+        pytest.param(-1, True, id="depth--1-invalid"),
+    ],
+)
+def test_composite_depth_boundary(depth: int, should_raise: bool) -> None:
+    """composite_depth in [0..3] is valid; 4 or -1 raise ValidationError (RED until T7)."""  # noqa: E501
+    # Arrange
+    payload: dict[str, Any] = {
+        **sample_job_envelope,
+        "composite_depth": depth,
+    }
+
+    if should_raise:
+        # Act / Assert — expected RED until T7 adds the validator
+        with pytest.raises(ValidationError):
+            JobEnvelope.model_validate(payload)
+    else:
+        # Act / Assert — must pass right now
+        inst = JobEnvelope.model_validate(payload)
+        assert inst.composite_depth == depth
+
+
+# ---------------------------------------------------------------------------
+# test_job_result_invariant
+# ---------------------------------------------------------------------------
+
+_WORKER_ERROR = WorkerError(code="worker.crash", message="scraper failed")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "should_raise"),
+    [
+        pytest.param(
+            {"status": "error", "error": None},
+            True,
+            id="error-no-WorkerError",
+        ),
+        pytest.param(
+            {"status": "success", "error": _WORKER_ERROR},
+            True,
+            id="success-with-error",
+        ),
+        pytest.param(
+            {"status": "success", "data": {"x": 1}},
+            False,
+            id="success-with-data",
+        ),
+        pytest.param(
+            {"status": "error", "error": _WORKER_ERROR},
+            False,
+            id="error-with-WorkerError",
+        ),
+    ],
+)
+def test_job_result_invariant(kwargs: dict[str, Any], should_raise: bool) -> None:
+    """status/error mutex: error=None on status=error raises; WorkerError on success raises (RED until T7)."""  # noqa: E501
+    # Arrange
+    from roxabi_contracts.jobs.fixtures import _ENV
+
+    payload: dict[str, Any] = {
+        **_ENV,
+        "job_id": "job-uuid-1234",
+        **kwargs,
+    }
+
+    if should_raise:
+        # Act / Assert — expected RED until T7 adds the validator
+        with pytest.raises(ValidationError):
+            JobResult.model_validate(payload)
+    else:
+        # Act / Assert — must pass right now
+        inst = JobResult.model_validate(payload)
+        assert inst.status == kwargs["status"]
+
+
+# ---------------------------------------------------------------------------
+# test_extra_ignore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        pytest.param(
+            JobEnvelope,
+            {**sample_job_envelope, "unknown_field": "surprise"},
+            id="JobEnvelope-extra",
+        ),
+        pytest.param(
+            JobResult,
+            {**sample_job_result_ok, "unknown_field": "surprise"},
+            id="JobResult-extra",
+        ),
+        pytest.param(
+            JobProgress,
+            {**sample_job_progress, "unknown_field": "surprise"},
+            id="JobProgress-extra",
+        ),
+    ],
+)
+def test_extra_ignore(model: type[BaseModel], payload: dict[str, Any]) -> None:
+    """Unknown fields are silently ignored (extra='ignore') and absent from output."""
+    # Arrange / Act
+    inst = model.model_validate(payload)
+    dumped = inst.model_dump()
+
+    # Assert
+    assert "unknown_field" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# test_subjects
+# ---------------------------------------------------------------------------
+
+
+def test_subjects_jobs_submit() -> None:
+    """jobs_submit produces lyra.jobs.<job_name>."""
+    assert jobs_submit("vault.add-from-url") == "lyra.jobs.vault.add-from-url"
+
+
+def test_subjects_jobs_result() -> None:
+    """jobs_result produces lyra.results.<job_id>."""
+    assert jobs_result("job-uuid-1234") == "lyra.results.job-uuid-1234"
+
+
+def test_subjects_jobs_progress() -> None:
+    """jobs_progress produces lyra.progress.<job_id>."""
+    assert jobs_progress("job-uuid-1234") == "lyra.progress.job-uuid-1234"
+
+
+@pytest.mark.parametrize(
+    "bad_token",
+    [
+        pytest.param("bad*token", id="asterisk"),
+        pytest.param("bad>token", id="greater-than"),
+    ],
+)
+def test_subjects_rejects_bad_tokens(bad_token: str) -> None:
+    """jobs_submit raises ValueError for NATS wildcard characters (* and >)."""
+    with pytest.raises(ValueError):
+        jobs_submit(bad_token)
+
+
+def test_subjects_dots_allowed() -> None:
+    """Dots in job_name are permitted (e.g. 'vault.add-from-url')."""
+    subject = jobs_submit("vault.add-from-url")
+    assert subject == "lyra.jobs.vault.add-from-url"

--- a/packages/roxabi-contracts/tests/test_jobs_models.py
+++ b/packages/roxabi-contracts/tests/test_jobs_models.py
@@ -21,6 +21,7 @@ from roxabi_contracts.jobs import (
     jobs_submit,
 )
 from roxabi_contracts.jobs.fixtures import (
+    _ENV,
     sample_job_envelope,
     sample_job_progress,
     sample_job_result_err,
@@ -86,6 +87,7 @@ def test_composite_depth_boundary(depth: int, should_raise: bool) -> None:
 # ---------------------------------------------------------------------------
 
 _WORKER_ERROR = WorkerError(code="worker.crash", message="scraper failed")
+_RESULT_BASE: dict[str, Any] = {**_ENV, "job_id": "job-uuid-1234"}
 
 
 @pytest.mark.parametrize(
@@ -115,14 +117,7 @@ _WORKER_ERROR = WorkerError(code="worker.crash", message="scraper failed")
 )
 def test_job_result_invariant(kwargs: dict[str, Any], should_raise: bool) -> None:
     """status/error mutex: error=None on error raises; WorkerError on success raises."""
-    # Arrange
-    from roxabi_contracts.jobs.fixtures import _ENV
-
-    payload: dict[str, Any] = {
-        **_ENV,
-        "job_id": "job-uuid-1234",
-        **kwargs,
-    }
+    payload: dict[str, Any] = {**_RESULT_BASE, **kwargs}
 
     if should_raise:
         with pytest.raises(ValidationError):
@@ -168,6 +163,65 @@ def test_extra_ignore(model: type[BaseModel], payload: dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# test_model_rejects_bad_job_token (B1 — model-level field_validator coverage)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("overrides",),
+    [
+        pytest.param({"job_id": "bad*id"}, id="envelope-job_id-wildcard"),
+        pytest.param({"job_name": "bad>name"}, id="envelope-job_name-wildcard"),
+        pytest.param({"reply_to": "bad*inbox"}, id="envelope-reply_to-wildcard"),
+    ],
+)
+def test_job_envelope_rejects_bad_token(overrides: dict[str, Any]) -> None:
+    """field_validators on job_id/job_name/reply_to reject NATS wildcards."""
+    with pytest.raises(ValidationError):
+        JobEnvelope.model_validate({**sample_job_envelope, **overrides})
+
+
+def test_job_result_rejects_bad_job_id() -> None:
+    """field_validator on job_id raises ValidationError for wildcard characters."""
+    payload = {**_RESULT_BASE, "job_id": "bad*id", "status": "success"}
+    with pytest.raises(ValidationError):
+        JobResult.model_validate(payload)
+
+
+def test_job_progress_rejects_bad_job_id() -> None:
+    """field_validator on job_id raises ValidationError for NATS wildcard characters."""
+    with pytest.raises(ValidationError):
+        JobProgress.model_validate({**sample_job_progress, "job_id": "bad*id"})
+
+
+# ---------------------------------------------------------------------------
+# test_job_progress_pct_boundary (B5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("pct", "should_raise"),
+    [
+        pytest.param(0.0, False, id="pct-0-valid"),
+        pytest.param(100.0, False, id="pct-100-valid"),
+        pytest.param(-0.1, True, id="pct-negative-invalid"),
+        pytest.param(100.1, True, id="pct-over-100-invalid"),
+        pytest.param(None, False, id="pct-none-valid"),
+    ],
+)
+def test_job_progress_pct_boundary(pct: float | None, should_raise: bool) -> None:
+    """pct in [0.0..100.0] is valid; outside that range raises ValidationError."""
+    payload: dict[str, Any] = {**sample_job_progress, "pct": pct}
+
+    if should_raise:
+        with pytest.raises(ValidationError):
+            JobProgress.model_validate(payload)
+    else:
+        inst = JobProgress.model_validate(payload)
+        assert inst.pct == pct
+
+
+# ---------------------------------------------------------------------------
 # test_subjects
 # ---------------------------------------------------------------------------
 
@@ -187,6 +241,14 @@ def test_subjects_jobs_progress() -> None:
     assert jobs_progress("job-uuid-1234") == "lyra.progress.job-uuid-1234"
 
 
+def test_job_envelope_accepts_inbox_reply_to() -> None:
+    """_INBOX.nonce subjects are valid reply_to values (underscore in charset)."""
+    inst = JobEnvelope.model_validate(
+        {**sample_job_envelope, "reply_to": "_INBOX.abc123"}
+    )
+    assert inst.reply_to == "_INBOX.abc123"
+
+
 @pytest.mark.parametrize(
     ("helper", "bad_token"),
     [
@@ -195,8 +257,10 @@ def test_subjects_jobs_progress() -> None:
         pytest.param(jobs_submit, "", id="submit-empty-string"),
         pytest.param(jobs_result, "bad*token", id="result-asterisk"),
         pytest.param(jobs_result, "bad>token", id="result-greater-than"),
+        pytest.param(jobs_result, "", id="result-empty-string"),
         pytest.param(jobs_progress, "bad*token", id="progress-asterisk"),
         pytest.param(jobs_progress, "bad>token", id="progress-greater-than"),
+        pytest.param(jobs_progress, "", id="progress-empty-string"),
     ],
 )
 def test_subjects_rejects_bad_tokens(helper: Any, bad_token: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1292,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/roxabi-contracts" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Carries 3 commits that landed after PR #1071 squash-merged (06:28 UTC); pushed at 09:00–09:34 UTC
- All changes are consensus-resolved (3-agent panel: architect + security-auditor + backend-dev)

## Changes

**`_nats_utils.py`**
- Extract `_validate_subject_segment` (no dots, `_SAFE_SUBJECT_SEGMENT_RE`) — decouples subject-segment validation from job-token validation; removes correctness-by-coincidence coupling
- Explicit empty-string guard in `validate_nats_subject` with subject-level error message
- Tighten `validate_job_token` regex: `[A-Za-z0-9._-]+` → `[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*` (rejects leading/trailing/consecutive dots)

**`jobs/subjects.py`**
- Populate `_Subjects` with `Literal`-typed prefix fields (`submit_prefix`, `result_prefix`, `progress_prefix`) — matches voice/image/llm cross-domain pattern

**`jobs/models.py`**
- Trust assumption documented on `_validate_reply_to` (closed cluster, ADR-062/064)

**`jobs/fixtures.py`**
- Rename `_ENV` → `ENV_BASE` (public test fixture — removes convention-violating private-symbol import)

**`tests/test_jobs_models.py`**
- `parent_job_id` wildcard-rejection cases
- `reply_to` multi-segment cases (`_INBOX..abc`, `_INBOX.abc.`) testing `validate_nats_subject` semantics
- `success+data=None` invariant path
- `step=""` rejection test
- Fix SC-10/SC-11 docstring attribution
- 47/47 passing

## Consensus artifact

`artifacts/analyses/1045-jobs-contracts-review-consensus.mdx`

Closes follow-up to #1045

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`