### PR TITLE
fix(clipool): inject CLAUDE_CODE_OAUTH_TOKEN via Podman secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,13 @@ quadlet-secrets-install:  ## (re)create Podman secrets from ~/.lyra/nkeys/*
 		echo "SKIP: ~/.lyra/gh-app.pem not found — lyra-gh-pem secret not created."; \
 		echo "      Copy the GitHub App PEM to ~/.lyra/gh-app.pem then re-run."; \
 	fi
+	@if [ -f "$(HOME)/.lyra/claude-oauth.tok" ]; then \
+		tr -d '\n' < "$(HOME)/.lyra/claude-oauth.tok" | podman secret create --replace lyra-claude-oauth -; \
+		echo "lyra-claude-oauth secret created from ~/.lyra/claude-oauth.tok"; \
+	else \
+		echo "SKIP: ~/.lyra/claude-oauth.tok not found — lyra-claude-oauth secret not created."; \
+		echo "      Generate with: claude setup-token > ~/.lyra/claude-oauth.tok && chmod 600 ~/.lyra/claude-oauth.tok"; \
+	fi
 	@echo "Podman secrets installed. Verify: podman secret ls"
 
 # ── Deploy + remote ──────────────────────────────────────────────────────────

--- a/artifacts/analyses/1105-claude-oauth-injection-consensus.mdx
+++ b/artifacts/analyses/1105-claude-oauth-injection-consensus.mdx
@@ -119,6 +119,7 @@ mode=$(stat -c '%a' "$TOKEN_PATH")
 
 ## Next
 
-- `/fix` to apply the hygiene items in PR #1106 (chmod+shred, forwarding test, accepted-risk comment)
-- Defer ADR-070 + Podman verification preflight to a follow-up issue (allows merging the current PR after hygiene fixes; verification can land before the prod cutover)
+- `/fix` to apply the hygiene items in PR #1106 (chmod+shred, forwarding test, accepted-risk comment) — **applied**
+- ADR-070 — **landed in this PR** (`docs/architecture/adr/070-clipool-claude-oauth-token-mechanism.mdx`)
+- Podman verification preflight tracked in #1108 — must run before next prod cutover; ADR-070 is amended in place when outcome is known
 - Open backlog issue: "evaluate Anthropic SDK migration to remove CLI auth layer" (Theme C, no current trigger)

--- a/artifacts/analyses/1105-claude-oauth-injection-consensus.mdx
+++ b/artifacts/analyses/1105-claude-oauth-injection-consensus.mdx
@@ -1,0 +1,124 @@
+---
+title: "Claude Code OAuth token injection — long-term direction (Expert Consensus)"
+issue: 1105
+status: consensus-reached
+date: 2026-05-07
+panel: architect, devops, security-auditor
+confidence: medium
+---
+
+## Problem
+
+PR #1106 injects `CLAUDE_CODE_OAUTH_TOKEN` (1-year Claude Code setup-token, account-scoped) into `lyra-clipool` via Podman secret `type=env`, replacing the broken interactive-OAuth refresh path (anthropics/claude-code#50743) for headless `claude` CLI subprocesses. Code review surfaced 11+ findings clustering into four themes; this consensus addresses the long-term shape rather than mechanical fixes.
+
+**Themes from review:**
+
+- **A — Delivery mechanism:** `type=env` (current) vs `type=mount + Python read-and-inject` (matches existing repo convention, ADR-054)
+- **B — Subprocess env exposure:** `claude` CLI accepts auth ONLY via env or `credentials.json` — token leaks into `/proc/<claude-pid>/environ` regardless of upstream delivery
+- **C — Bigger architectural alternative:** migrate from `claude` CLI subprocess to direct Anthropic SDK, eliminating the entire CLI-auth surface
+- **D — Operational hygiene:** trailing-newline strip, Makefile gap, ANTHROPIC_API_KEY guard (all auto-applied), chmod+shred, forwarding test, Podman version verification
+
+## Panel
+
+| α | Focus |
+|---|-------|
+| **architect** | pattern coherence, maintainability, scope boundaries |
+| **devops** | operational reliability, real Podman behavior, deploy/rotation surface |
+| **security-auditor** | attack surface, threat modeling, blast-radius bounding |
+
+## Consensus ρ
+
+**Hybrid path: keep `type=env` as the default, with a documented escape hatch to `type=mount + Python-side read-and-inject` if Podman bug #28075 is unfixed in Ubuntu 26.04's apt-distributed podman 5.x.**
+
+Long-term direction:
+
+1. **Phase 1 (this PR + small follow-ups):**
+   - **Verify** podman patch level on M₁ before next merge: install the secret, trigger `Restart=on-failure`, confirm `CLAUDE_CODE_OAUTH_TOKEN` survives the restart. If it does → keep `type=env`. If it reverts to the literal secret name → switch to `type=mount`.
+   - **ADR-070** documents the `type=env` exception (reason: `claude` CLI accepts no `--token-file` flag), threat-model scope (single-tenant M₁), and the `type=mount` fallback path.
+   - **Apply** secret-hygiene items: `chmod 600` + `shred -u` on token file in `provision.sh` and `rotate-claude-oauth.sh`; forwarding unit test asserting `CLAUDE_CODE_OAUTH_TOKEN` propagates AND `ANTHROPIC_API_KEY` is excluded.
+   - **Defer:** `# Acceptance` block on `rotate-claude-oauth.sh` (no measurement yet); split `_SAFE_ENV_KEYS` (cosmetic, single-token); `Volume=%h/.claude` cleanup (separate issue, requires verifying nothing else writes there).
+
+2. **Phase 2 (separate frame/spec, when triggered):**
+   - **SDK migration** (Theme C) is the architecturally cleaner long-term direction but is a substantial refactor: it eliminates `--resume` session continuity, the MCP subprocess bridge, and the tool-use protocol that the CLI provides. Track as a backlog item; revisit when CLI auth pain compounds or when MCP/session features become available natively in the SDK.
+
+### Rationale
+
+**Why hybrid (not pure type=env or pure type=mount):**
+
+- `type=env` is *necessary* for Anthropic CLI compatibility — there is no `--token-file` flag, and any "mount" path still requires injecting the value into the subprocess env in `_spawn()`. The architect noted: mount-then-read achieves *identical* `/proc/<claude-pid>/environ` exposure with more indirection.
+- BUT `type=env` has known Podman reliability bugs (containers/podman#28075 — env var loses target= mapping after `Restart=on-failure`; #23788 — value visible in `podman inspect`). The unit declares `Restart=on-failure` + `StartLimitBurst=5`, so #28075 is not theoretical. Devops correctly flagged this as a *blocking* operational concern — silent auth failure after every restart would be production-breaking.
+- The verification preflight resolves the disagreement empirically: if the bug is fixed in M₁'s podman, keep the simpler design; if not, pay the indirection cost in `_spawn()` for reliability.
+
+**Why defer SDK migration:**
+
+- Migrating from `claude` CLI subprocess to `anthropic.messages.create` removes the auth problem entirely but eliminates `--resume` session semantics, the MCP bridge, and tool-use protocol features that lyra-clipool currently relies on. Out of scope for this PR — needs its own frame + spec.
+
+### Trade-offs
+
+1. **Mechanism flexibility vs simplicity** — the hybrid keeps two possible delivery paths (env vs mount-then-read), which is more code surface than committing to one. Mitigated by ADR-070 making the choice explicit and by the verification preflight being a one-time check.
+2. **Subscription billing preservation vs API key simplicity** — `CLAUDE_CODE_OAUTH_TOKEN` preserves Pro/Max subscription billing, which is the user's primary cost constraint. `ANTHROPIC_API_KEY` would simplify auth (no expiry, no Podman bugs) but reroutes to Console pay-per-token, an unacceptable cost shift. The `_SAFE_ENV_KEYS` guard comment is load-bearing.
+3. **1-year TTL with no revocation API** — dominant residual risk regardless of mechanism. A stolen token = up to 1y exposure window with no programmatic mitigation. Accepted; rotation script provides manual mitigation if compromise is suspected.
+
+## Alternatives
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| Pure `type=env` (status quo PR) | architect, security-auditor | Devops blocking concern (#28075) is verifiable and credible — must verify before claiming the simpler design is safe |
+| Pure `type=mount` + Python read-inject | devops | Architect: mount-then-read does not reduce subprocess `/proc/environ` exposure; security: marginal improvement on single-tenant. Pay the cost only if #28075 forces it. |
+| `ANTHROPIC_API_KEY` | (implicit fallback) | Reroutes billing to Console pay-per-token (auth precedence #3 > #5); silent cost shift; explicitly guarded against in code |
+| `apiKeyHelper` script + secret manager | (Anthropic docs) | Vault/1Password infra not present; over-engineering for single-machine prod with annual rotation |
+| `hidepid=2` on container `/proc` | (security defense-in-depth) | Breaks `podman exec` introspection valuable for ops; single-tenant scope makes the `/proc/environ` window already-bounded |
+| SDK migration to direct API | architect, devops, security-auditor (all Theme C) | Eliminates `--resume`, MCP bridge, tool-use protocol — too large for this PR; defer to dedicated frame/spec |
+
+## Dissent
+
+**Devops dissent → reconciled via verification preflight.**
+
+Devops recommended `type=mount` outright. Architect + security-auditor recommended `type=env` (status quo). Reconciliation: devops's blocking concern is *empirically verifiable* against M₁'s actual podman patch level. Hybrid path keeps both options open and resolves the disagreement with a runtime check rather than a theoretical decision. All three panelists endorse the hybrid as a proper extension of their individual recommendations.
+
+## Implementation Notes
+
+**Verification preflight (must run before next merge or before next prod deployment):**
+
+```bash
+# On M₁:
+podman version | grep -E '^Version'                    # Confirm 5.x patch level
+podman secret create test-env-restart -                # paste a literal value
+# In a throwaway test unit with: Secret=test-env-restart,type=env,target=TEST_VAR + Restart=on-failure
+# Trigger restart, then:
+podman exec <container> printenv TEST_VAR             # Should print the original value
+# If it prints "test-env-restart" instead → bug is unfixed → switch to type=mount
+podman secret rm test-env-restart
+```
+
+**If verification passes (current PR is good as merged):**
+- Add ADR-070 documenting the type=env exception
+- Apply hygiene items (chmod+shred, forwarding test, /proc/environ accepted-risk doc)
+- Done.
+
+**If verification fails (#28075 unfixed):**
+- Change `lyra-clipool.container`: `Secret=lyra-claude-oauth,type=mount,target=claude-oauth.tok,mode=0400,uid=1500,gid=1500`
+- Update `cli_pool_worker._spawn`: read `/run/secrets/claude-oauth.tok` once at module load (or on first spawn), inject into the subprocess `env` dict at spawn time
+- Update ADR-070 to document the mount path as the chosen mechanism
+
+**Token file lifecycle (apply regardless of mechanism):**
+
+In `provision.sh` and `rotate-claude-oauth.sh`, after `podman secret create` succeeds:
+
+```bash
+# Wipe the source file — token now lives only in podman's encrypted store.
+shred -u "$TOKEN_PATH" 2>/dev/null || rm -f "$TOKEN_PATH"
+```
+
+Pre-create check for input file mode:
+
+```bash
+mode=$(stat -c '%a' "$TOKEN_PATH")
+[[ "$mode" == "600" ]] || { warn "Token file mode is $mode; expected 600. chmod 600 first."; exit 1; }
+```
+
+## Next
+
+- `/fix` to apply the hygiene items in PR #1106 (chmod+shred, forwarding test, accepted-risk comment)
+- Defer ADR-070 + Podman verification preflight to a follow-up issue (allows merging the current PR after hygiene fixes; verification can land before the prod cutover)
+- Open backlog issue: "evaluate Anthropic SDK migration to remove CLI auth layer" (Theme C, no current trigger)

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -434,12 +434,17 @@ else
   else
     [[ "$CLAUDE_OAUTH_TOKEN_PATH" =~ $TOKEN_PATH_RE ]] || error "Invalid CLAUDE_OAUTH_TOKEN_PATH: $CLAUDE_OAUTH_TOKEN_PATH"
     [[ -f "$CLAUDE_OAUTH_TOKEN_PATH" ]] || error "Token file not found: $CLAUDE_OAUTH_TOKEN_PATH"
+    token_mode=$(stat -c '%a' "$CLAUDE_OAUTH_TOKEN_PATH")
+    [[ "$token_mode" == "600" ]] || error "Token file must be mode 0600 (got $token_mode): $CLAUDE_OAUTH_TOKEN_PATH"
     # Pipe via `tr -d '\n'` so a trailing newline (common from `cmd > file`)
     # cannot leak into the secret value and silently break auth at runtime.
     sudo -u "$ADMIN_USER" XDG_RUNTIME_DIR="/run/user/$ADMIN_UID" bash -c \
       "tr -d '\n' < \"$CLAUDE_OAUTH_TOKEN_PATH\" | podman secret create lyra-claude-oauth -" \
       || error "Failed to create podman secret lyra-claude-oauth"
     info "Podman secret 'lyra-claude-oauth' created from $CLAUDE_OAUTH_TOKEN_PATH."
+    # Wipe source file — the token now lives only in podman's encrypted store.
+    shred -u "$CLAUDE_OAUTH_TOKEN_PATH" 2>/dev/null || rm -f "$CLAUDE_OAUTH_TOKEN_PATH"
+    info "Token source file shredded: $CLAUDE_OAUTH_TOKEN_PATH"
   fi
 fi
 

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -410,6 +410,37 @@ else
   fi
 fi
 
+# ── Lyra Claude Code OAuth token (Podman secret) ────────────────────────────
+#
+# The `claude` subprocess in lyra-clipool uses a 1-year OAuth setup-token
+# (auth precedence #5) instead of the interactive-OAuth credentials file
+# (#6), because the latter's auto-refresh is broken in non-TTY subprocess
+# contexts (anthropics/claude-code#50743). Bootstrap the token by running
+# `claude setup-token` interactively on a workstation, then re-run this
+# script with CLAUDE_OAUTH_TOKEN_PATH=/abs/path/to/token-file (single line,
+# no newline).
+
+section "Lyra Claude Code OAuth token (Podman secret)"
+CLAUDE_OAUTH_TOKEN_PATH="${CLAUDE_OAUTH_TOKEN_PATH:-}"
+TOKEN_PATH_RE='^[A-Za-z0-9._/-]+$'  # path validation — reject shell metachars (env-driven via curl|bash)
+if sudo -u "$ADMIN_USER" XDG_RUNTIME_DIR="/run/user/$ADMIN_UID" \
+     podman secret inspect lyra-claude-oauth &>/dev/null; then
+  info "Podman secret 'lyra-claude-oauth' already present, skipping."
+else
+  if [[ -z "$CLAUDE_OAUTH_TOKEN_PATH" ]]; then
+    warn "CLAUDE_OAUTH_TOKEN_PATH not set — skipping lyra-claude-oauth bootstrap."
+    warn "  Generate the token: claude setup-token > /tmp/claude-oauth.tok"
+    warn "  Re-run with: CLAUDE_OAUTH_TOKEN_PATH=/tmp/claude-oauth.tok $0"
+  else
+    [[ "$CLAUDE_OAUTH_TOKEN_PATH" =~ $TOKEN_PATH_RE ]] || error "Invalid CLAUDE_OAUTH_TOKEN_PATH: $CLAUDE_OAUTH_TOKEN_PATH"
+    [[ -f "$CLAUDE_OAUTH_TOKEN_PATH" ]] || error "Token file not found: $CLAUDE_OAUTH_TOKEN_PATH"
+    sudo -u "$ADMIN_USER" XDG_RUNTIME_DIR="/run/user/$ADMIN_UID" \
+      podman secret create lyra-claude-oauth "$CLAUDE_OAUTH_TOKEN_PATH" \
+      || error "Failed to create podman secret lyra-claude-oauth"
+    info "Podman secret 'lyra-claude-oauth' created from $CLAUDE_OAUTH_TOKEN_PATH."
+  fi
+fi
+
 # ── Dev tools ────────────────────────────────────────────────────────────────
 
 section "uv (Python package manager)"

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -429,13 +429,15 @@ if sudo -u "$ADMIN_USER" XDG_RUNTIME_DIR="/run/user/$ADMIN_UID" \
 else
   if [[ -z "$CLAUDE_OAUTH_TOKEN_PATH" ]]; then
     warn "CLAUDE_OAUTH_TOKEN_PATH not set — skipping lyra-claude-oauth bootstrap."
-    warn "  Generate the token: claude setup-token > /tmp/claude-oauth.tok"
-    warn "  Re-run with: CLAUDE_OAUTH_TOKEN_PATH=/tmp/claude-oauth.tok $0"
+    warn "  Generate the token: install -m 0600 /dev/null ~/.lyra/claude-oauth.tok && claude setup-token > ~/.lyra/claude-oauth.tok"
+    warn "  Re-run with: CLAUDE_OAUTH_TOKEN_PATH=~/.lyra/claude-oauth.tok $0"
   else
     [[ "$CLAUDE_OAUTH_TOKEN_PATH" =~ $TOKEN_PATH_RE ]] || error "Invalid CLAUDE_OAUTH_TOKEN_PATH: $CLAUDE_OAUTH_TOKEN_PATH"
     [[ -f "$CLAUDE_OAUTH_TOKEN_PATH" ]] || error "Token file not found: $CLAUDE_OAUTH_TOKEN_PATH"
-    sudo -u "$ADMIN_USER" XDG_RUNTIME_DIR="/run/user/$ADMIN_UID" \
-      podman secret create lyra-claude-oauth "$CLAUDE_OAUTH_TOKEN_PATH" \
+    # Pipe via `tr -d '\n'` so a trailing newline (common from `cmd > file`)
+    # cannot leak into the secret value and silently break auth at runtime.
+    sudo -u "$ADMIN_USER" XDG_RUNTIME_DIR="/run/user/$ADMIN_UID" bash -c \
+      "tr -d '\n' < \"$CLAUDE_OAUTH_TOKEN_PATH\" | podman secret create lyra-claude-oauth -" \
       || error "Failed to create podman secret lyra-claude-oauth"
     info "Podman secret 'lyra-claude-oauth' created from $CLAUDE_OAUTH_TOKEN_PATH."
   fi

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -434,6 +434,8 @@ else
   else
     [[ "$CLAUDE_OAUTH_TOKEN_PATH" =~ $TOKEN_PATH_RE ]] || error "Invalid CLAUDE_OAUTH_TOKEN_PATH: $CLAUDE_OAUTH_TOKEN_PATH"
     [[ -f "$CLAUDE_OAUTH_TOKEN_PATH" ]] || error "Token file not found: $CLAUDE_OAUTH_TOKEN_PATH"
+    # Auto-fix mode (operator's `>` redirect may inherit umask 0644); then assert.
+    chmod 600 "$CLAUDE_OAUTH_TOKEN_PATH"
     token_mode=$(stat -c '%a' "$CLAUDE_OAUTH_TOKEN_PATH")
     [[ "$token_mode" == "600" ]] || error "Token file must be mode 0600 (got $token_mode): $CLAUDE_OAUTH_TOKEN_PATH"
     # Pipe via `tr -d '\n'` so a trailing newline (common from `cmd > file`)
@@ -442,9 +444,10 @@ else
       "tr -d '\n' < \"$CLAUDE_OAUTH_TOKEN_PATH\" | podman secret create lyra-claude-oauth -" \
       || error "Failed to create podman secret lyra-claude-oauth"
     info "Podman secret 'lyra-claude-oauth' created from $CLAUDE_OAUTH_TOKEN_PATH."
-    # Wipe source file — the token now lives only in podman's encrypted store.
-    shred -u "$CLAUDE_OAUTH_TOKEN_PATH" 2>/dev/null || rm -f "$CLAUDE_OAUTH_TOKEN_PATH"
-    info "Token source file shredded: $CLAUDE_OAUTH_TOKEN_PATH"
+    # Wipe source file — best-effort. shred is a no-op on CoW filesystems
+    # (btrfs, tmpfs, ZFS); rely on encrypted home for at-rest protection.
+    shred -u "$CLAUDE_OAUTH_TOKEN_PATH" || rm -f "$CLAUDE_OAUTH_TOKEN_PATH"
+    info "Token source file removed: $CLAUDE_OAUTH_TOKEN_PATH"
   fi
 fi
 

--- a/deploy/quadlet/lyra-clipool.container
+++ b/deploy/quadlet/lyra-clipool.container
@@ -25,6 +25,10 @@ DropCapability=all
 Environment=NATS_URL=nats://lyra-nats:4222
 Secret=lyra-nkey-clipool-worker,type=mount,target=clipool-worker.seed,mode=0400,uid=1500,gid=1500
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/clipool-worker.seed
+# Claude Code auth — 1-year setup-token bypasses the broken OAuth refresh
+# path in non-TTY subprocess contexts (anthropics/claude-code#50743).
+# Bootstrap: `claude setup-token | podman secret create lyra-claude-oauth -`
+Secret=lyra-claude-oauth,type=env,target=CLAUDE_CODE_OAUTH_TOKEN
 # ~/.claude/ — directory mount (not file mounts) so Syncthing's atomic renames
 # (unlink old inode → rename new) remain transparent to the container.
 # Single-file bind-mounts bind the inode at mount time; after an atomic replace

--- a/deploy/scripts/rotate-claude-oauth.sh
+++ b/deploy/scripts/rotate-claude-oauth.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Lyra Claude Code OAuth token rotation — replaces the lyra-claude-oauth Podman
+# secret and restarts lyra-clipool so the new env var is picked up.
+#
+# Why a clipool restart: Podman Secret=type=env binds the secret value to the
+# container's environment at start time. Unlike type=mount (file backed by
+# tmpfs that the container re-reads), env vars are immutable for the lifetime
+# of the container — `secret create --replace` alone has no effect on a
+# running clipool.
+#
+# WARNING: in-flight `claude` subprocesses spawned by clipool are killed on
+# restart. Active conversations lose their --resume session id and the user
+# sees a brief stall while clipool re-spawns. Schedule rotations during low
+# traffic. The 1-year setup-token TTL means this is at most an annual event.
+#
+# Usage: rotate-claude-oauth.sh /abs/path/to/new-token-file
+# Token format: single line, no trailing newline. Generate with
+#   `claude setup-token > /tmp/claude-oauth.tok` on an interactive workstation.
+set -euo pipefail
+export LC_ALL=C
+
+NEW_TOKEN="${1:-}"
+TOKEN_PATH_RE='^[A-Za-z0-9._/-]+$'
+[[ -n "$NEW_TOKEN" ]] || { echo "usage: $0 /path/to/new-token-file" >&2; exit 2; }
+[[ "$NEW_TOKEN" =~ $TOKEN_PATH_RE ]] || { echo "Invalid token path: $NEW_TOKEN" >&2; exit 2; }
+[[ -f "$NEW_TOKEN" ]] || { echo "Token file not found: $NEW_TOKEN" >&2; exit 2; }
+
+# Tolerate first-time creation: rm only if exists.
+if podman secret inspect lyra-claude-oauth &>/dev/null; then
+  podman secret rm lyra-claude-oauth
+fi
+podman secret create lyra-claude-oauth "$NEW_TOKEN"
+systemctl --user restart lyra-clipool.service
+
+# Gate on clipool Up — env vars are picked up at container start, so once the
+# container reports Up the new token is in effect. Bound the wait at 30s
+# (60×0.5s) — clipool has heavier startup than the gh-helper sidecar.
+for _ in $(seq 60); do
+  if podman ps --filter name=lyra-clipool --format '{{.Status}}' \
+       | grep -q '^Up '; then
+    echo "lyra-clipool restarted, secret rotated."
+    exit 0
+  fi
+  sleep 0.5
+done
+echo "rotation did not complete within 30s" >&2
+exit 1

--- a/deploy/scripts/rotate-claude-oauth.sh
+++ b/deploy/scripts/rotate-claude-oauth.sh
@@ -18,12 +18,18 @@
 #   `claude setup-token > /tmp/claude-oauth.tok` on an interactive workstation.
 set -euo pipefail
 export LC_ALL=C
+# Required when invoked via `make remote` (SSH non-interactive shell): without
+# it, `systemctl --user` fails to locate the dbus session ("Failed to connect
+# to bus: No such file or directory"). Provision.sh sets this consistently;
+# the rotate scripts must too.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 
 NEW_TOKEN="${1:-}"
 TOKEN_PATH_RE='^[A-Za-z0-9._/-]+$'
 [[ -n "$NEW_TOKEN" ]] || { echo "usage: $0 /path/to/new-token-file" >&2; exit 2; }
 [[ "$NEW_TOKEN" =~ $TOKEN_PATH_RE ]] || { echo "Invalid token path: $NEW_TOKEN" >&2; exit 2; }
 [[ -f "$NEW_TOKEN" ]] || { echo "Token file not found: $NEW_TOKEN" >&2; exit 2; }
+chmod 600 "$NEW_TOKEN"
 token_mode=$(stat -c '%a' "$NEW_TOKEN")
 [[ "$token_mode" == "600" ]] || { echo "Token file must be mode 0600 (got $token_mode): $NEW_TOKEN" >&2; exit 2; }
 
@@ -34,8 +40,9 @@ fi
 # Pipe via `tr -d '\n'` so a trailing newline (common from `cmd > file`) cannot
 # leak into the secret value and silently break auth at runtime.
 tr -d '\n' < "$NEW_TOKEN" | podman secret create lyra-claude-oauth -
-# Wipe source file — the token now lives only in podman's encrypted store.
-shred -u "$NEW_TOKEN" 2>/dev/null || rm -f "$NEW_TOKEN"
+# Wipe source file — best-effort. shred is a no-op on CoW filesystems
+# (btrfs, tmpfs, ZFS); rely on encrypted home for at-rest protection.
+shred -u "$NEW_TOKEN" || rm -f "$NEW_TOKEN"
 systemctl --user restart lyra-clipool.service
 
 # Gate on clipool Up — env vars are picked up at container start, so once the

--- a/deploy/scripts/rotate-claude-oauth.sh
+++ b/deploy/scripts/rotate-claude-oauth.sh
@@ -29,7 +29,9 @@ TOKEN_PATH_RE='^[A-Za-z0-9._/-]+$'
 if podman secret inspect lyra-claude-oauth &>/dev/null; then
   podman secret rm lyra-claude-oauth
 fi
-podman secret create lyra-claude-oauth "$NEW_TOKEN"
+# Pipe via `tr -d '\n'` so a trailing newline (common from `cmd > file`) cannot
+# leak into the secret value and silently break auth at runtime.
+tr -d '\n' < "$NEW_TOKEN" | podman secret create lyra-claude-oauth -
 systemctl --user restart lyra-clipool.service
 
 # Gate on clipool Up — env vars are picked up at container start, so once the

--- a/deploy/scripts/rotate-claude-oauth.sh
+++ b/deploy/scripts/rotate-claude-oauth.sh
@@ -24,6 +24,8 @@ TOKEN_PATH_RE='^[A-Za-z0-9._/-]+$'
 [[ -n "$NEW_TOKEN" ]] || { echo "usage: $0 /path/to/new-token-file" >&2; exit 2; }
 [[ "$NEW_TOKEN" =~ $TOKEN_PATH_RE ]] || { echo "Invalid token path: $NEW_TOKEN" >&2; exit 2; }
 [[ -f "$NEW_TOKEN" ]] || { echo "Token file not found: $NEW_TOKEN" >&2; exit 2; }
+token_mode=$(stat -c '%a' "$NEW_TOKEN")
+[[ "$token_mode" == "600" ]] || { echo "Token file must be mode 0600 (got $token_mode): $NEW_TOKEN" >&2; exit 2; }
 
 # Tolerate first-time creation: rm only if exists.
 if podman secret inspect lyra-claude-oauth &>/dev/null; then
@@ -32,6 +34,8 @@ fi
 # Pipe via `tr -d '\n'` so a trailing newline (common from `cmd > file`) cannot
 # leak into the secret value and silently break auth at runtime.
 tr -d '\n' < "$NEW_TOKEN" | podman secret create lyra-claude-oauth -
+# Wipe source file — the token now lives only in podman's encrypted store.
+shred -u "$NEW_TOKEN" 2>/dev/null || rm -f "$NEW_TOKEN"
 systemctl --user restart lyra-clipool.service
 
 # Gate on clipool Up — env vars are picked up at container start, so once the

--- a/docs/architecture/adr/070-clipool-claude-oauth-token-mechanism.mdx
+++ b/docs/architecture/adr/070-clipool-claude-oauth-token-mechanism.mdx
@@ -1,0 +1,107 @@
+---
+title: "ADR-070: CLI pool Claude OAuth token injection mechanism"
+description: Documents the type=env Podman secret exception for CLAUDE_CODE_OAUTH_TOKEN injection into lyra-clipool, the threat-model scope that bounds it, and the type=mount fallback if Podman bug #28075 forces a switch.
+---
+
+## Status
+
+Accepted (2026-05-07)
+
+Related: ADR-054 (Quadlet credential-store, established `type=mount` Podman secret pattern).
+Issue: #1105 (this ADR's implementation), #1108 (Podman version verification preflight).
+
+## Context
+
+The `claude` CLI subprocess spawned by `lyra-clipool` requires authentication to call Anthropic. Three upstream constraints frame the choice:
+
+1. **OAuth refresh broken in headless subprocess contexts** ([anthropics/claude-code#50743](https://github.com/anthropics/claude-code/issues/50743), closed-as-duplicate, no fix planned). The `accessToken` in `~/.claude/.credentials.json` expires every ~6–8h; the CLI does not auto-refresh in non-TTY invocations. Cloudflare WAF additionally blocks the OAuth refresh endpoint from headless Linux ([#47754](https://github.com/anthropics/claude-code/issues/47754)). Production lyra-clipool fails with `401 authentication_error` every ~6–8h until interactive re-login.
+
+2. **Auth precedence chain in Claude Code** ([docs](https://code.claude.com/docs/en/authentication)):
+   1. Bedrock/Vertex/Foundry env
+   2. `ANTHROPIC_AUTH_TOKEN`
+   3. `ANTHROPIC_API_KEY` ← Console pay-per-token billing
+   4. `apiKeyHelper`
+   5. **`CLAUDE_CODE_OAUTH_TOKEN`** — 1-year setup-token, preserves Pro/Max subscription billing
+   6. Interactive OAuth (`~/.claude/.credentials.json`) — broken, see #1
+
+3. **The `claude` CLI accepts auth ONLY via env or `credentials.json`**. There is no `--token-file` flag. Whatever delivery mechanism Lyra uses ultimately must inject the token into the subprocess environment.
+
+ADR-054 established `type=mount` as the standard Podman secret delivery pattern for Lyra (NATS nkeys, GitHub App PEM). All existing secrets follow this convention.
+
+## Decisions
+
+### 1. Use `Secret=…,type=env,target=CLAUDE_CODE_OAUTH_TOKEN`
+
+`lyra-clipool.container` declares:
+
+```ini
+Secret=lyra-claude-oauth,type=env,target=CLAUDE_CODE_OAUTH_TOKEN
+```
+
+This injects the secret value directly as an environment variable in the container. The Python forwarder in `cli_pool_worker._spawn` passes it through `_SAFE_ENV_KEYS` allowlist to the spawned `claude` subprocess.
+
+**Rationale for `type=env` over `type=mount`:** the `claude` CLI must receive the token in its environment regardless of upstream delivery — there is no `--token-file` flag. Using `type=mount` would require Python to read `/run/secrets/claude-oauth.tok` and inject the contents into `env` at spawn time, achieving identical `/proc/<claude-pid>/environ` exposure with one extra syscall and a parent-process token lifecycle to manage. The architect's analysis on the consensus panel (`artifacts/analyses/1105-claude-oauth-injection-consensus.mdx`) concluded: "mount-then-read achieves *identical* exposure with more indirection. No benefit."
+
+### 2. Threat-model scope that bounds the residual exposure
+
+`type=env` carries known exposure risks that are accepted in our deployment:
+
+- **Token visible in `/proc/1/environ` of clipool**: bounded by single-tenant container (no co-tenant processes today). `DropCapability=all`, `ReadOnly=true`, and `UserNS=keep-id` confine the blast radius.
+- **`podman inspect` may expose value** ([containers/podman#23788](https://github.com/containers/podman/issues/23788), claimed fixed in PR #23959 — version unverified on M₁). Only readable by users with access to the Podman socket (= the daemon user).
+- **Token also in `/proc/<claude-pid>/environ` of every subprocess**: intrinsic to env-based auth; identical exposure regardless of upstream delivery mechanism.
+
+`hidepid=2` on the container's `/proc` mount is intentionally NOT set per `lyra-clipool.container:65-70` — it would break `podman exec` introspection valuable for ops, and the single-tenant scope makes the `/proc/environ` window already-bounded.
+
+### 3. ANTHROPIC_API_KEY explicitly excluded from `_SAFE_ENV_KEYS`
+
+`src/lyra/core/cli/cli_pool_worker.py` carries a load-bearing comment forbidding the addition of `ANTHROPIC_API_KEY` to the allowlist. Forwarding it would override Pro/Max subscription billing and silently route inference to Console pay-per-token (precedence #3 > #5). The constraint is enforced by the unit test `tests/core/test_cli_pool_process.py::TestCliPoolSpawnEnv::test_anthropic_api_key_not_forwarded`.
+
+### 4. Bootstrap and rotation — manual, annual
+
+- Bootstrap (1×): `claude setup-token > ~/.lyra/claude-oauth.tok` on an interactive workstation, then `make quadlet-secrets-install` (or `CLAUDE_OAUTH_TOKEN_PATH=… deploy/provision.sh`) creates the Podman secret. The provision path validates 0600 mode, strips trailing newlines, and shreds the source file after secret creation.
+- Rotation: `deploy/scripts/rotate-claude-oauth.sh /path/to/new.tok` — same pattern, plus `systemctl --user restart lyra-clipool.service` to pick up the new env var binding.
+- TTL: 1 year. No upstream programmatic revocation API ([anthropics/claude-code#34198](https://github.com/anthropics/claude-code/issues/34198) open). Stolen token = up to 1y exposure window.
+
+## Fallback path: `type=mount` if Podman bug #28075 forces it
+
+[containers/podman#28075](https://github.com/containers/podman/issues/28075) is a confirmed bug in Podman 5.7.1: `--secret name,type=env,target=X` loses the `target=` mapping after `Restart=on-failure` triggers a restart. The unit declares `Restart=on-failure` + `StartLimitBurst=5` (`lyra-clipool.container:9-10`), making it directly susceptible. Fix status in Ubuntu 26.04's apt podman 5.x is unverified.
+
+**Verification preflight** (#1108):
+
+```bash
+# On M₁:
+podman version | grep -E '^Version'
+echo 'TEST_VALUE_42' > /tmp/test-restart-tok && chmod 600 /tmp/test-restart-tok
+podman secret create test-env-restart-1105 /tmp/test-restart-tok
+# In a throwaway test unit with Secret=...,type=env,target=TEST_VAR + Restart=on-failure:
+# force a restart, then:
+podman exec <test-container> printenv TEST_VAR  # MUST print "TEST_VALUE_42"
+# If it prints "test-env-restart-1105" → bug unfixed → switch to type=mount
+podman secret rm test-env-restart-1105 && shred -u /tmp/test-restart-tok
+```
+
+**If the bug is unfixed on M₁**, switch to:
+
+```ini
+Secret=lyra-claude-oauth,type=mount,target=claude-oauth.tok,mode=0400,uid=1500,gid=1500
+```
+
+And update `cli_pool_worker._spawn` to read `/run/secrets/claude-oauth.tok` once at spawn time, inject the contents into the subprocess `env` dict, then drop the value from the parent dict. This restores parity with the rest of the repo's `type=mount` convention at the cost of a 1-file Python change.
+
+This ADR is amended in place when the preflight outcome is known.
+
+## Alternatives rejected
+
+| Alternative | Reason |
+|---|---|
+| `ANTHROPIC_API_KEY` (Console) | Reroutes billing to Console pay-per-token; silent cost shift unacceptable |
+| `apiKeyHelper` script + secret manager | Vault/1Password infra not present; over-engineering for single-machine prod with annual rotation |
+| `hidepid=2` on container `/proc` | Breaks `podman exec` introspection valuable for ops; single-tenant scope makes the `/proc/environ` window already-bounded |
+| Anthropic SDK direct API migration | Eliminates `--resume`, MCP bridge, tool-use protocol — out of scope; backlog item if CLI auth pain compounds |
+| Pure `type=mount` (without env injection in `_spawn`) | Impossible: `claude` CLI accepts no `--token-file` flag |
+
+## Consequences
+
+- One `type=env` secret in the repo, asymmetric with the otherwise-uniform `type=mount` convention. Documented here.
+- A Podman version regression on M₁ (revert to a build affected by #28075) would silently break clipool auth on every restart. Mitigation: #1108 verification preflight; long-term fallback to `type=mount` if reproducible.
+- The `_SAFE_ENV_KEYS` allowlist now mixes locale + auth concerns. If a second auth env var lands (e.g. MCP), revisit the split that was deferred in #1105 review.

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -70,6 +70,7 @@
     "066-unified-worker-error-envelope-nats-reply-contracts",
     "067-blobstore-abstraction-flat-fs-content-addressed",
     "068-selinux-z-label-quadlet-bind-volume-policy",
-    "069-provision-warn-subid-overlap-defensive-posture"
+    "069-provision-warn-subid-overlap-defensive-posture",
+    "070-clipool-claude-oauth-token-mechanism"
   ]
 }

--- a/src/lyra/core/cli/cli_pool_worker.py
+++ b/src/lyra/core/cli/cli_pool_worker.py
@@ -34,12 +34,16 @@ __all__ = ["_ProcessEntry", "CliPoolWorkerMixin", "_LYRA_ROOT"]
 log = logging.getLogger(__name__)
 
 # Explicit env allowlist — only forward safe vars to the claude subprocess.
+# CLAUDE_CODE_OAUTH_TOKEN: 1-year setup-token (auth precedence #5) bypasses the
+# broken interactive-OAuth refresh path on headless subprocess invocations
+# (anthropics/claude-code#50743). Injected via Podman secret in prod (ADR-054).
 _SAFE_ENV_KEYS = {
     "PATH",
     "LANG",
     "LC_ALL",
     "LC_CTYPE",
     "TMPDIR",
+    "CLAUDE_CODE_OAUTH_TOKEN",
 }
 
 

--- a/src/lyra/core/cli/cli_pool_worker.py
+++ b/src/lyra/core/cli/cli_pool_worker.py
@@ -37,6 +37,9 @@ log = logging.getLogger(__name__)
 # CLAUDE_CODE_OAUTH_TOKEN: 1-year setup-token (auth precedence #5) bypasses the
 # broken interactive-OAuth refresh path on headless subprocess invocations
 # (anthropics/claude-code#50743). Injected via Podman secret in prod (ADR-054).
+# The token reaches /proc/<claude-pid>/environ — accepted residual risk per
+# the single-tenant container threat model (DropCapability=all, ReadOnly=true,
+# UserNS=keep-id; claude CLI accepts auth ONLY via env, no file alternative).
 #
 # DO NOT add ANTHROPIC_API_KEY here. Forwarding it overrides Pro/Max
 # subscription billing and silently routes inference to Console pay-per-token

--- a/src/lyra/core/cli/cli_pool_worker.py
+++ b/src/lyra/core/cli/cli_pool_worker.py
@@ -37,6 +37,10 @@ log = logging.getLogger(__name__)
 # CLAUDE_CODE_OAUTH_TOKEN: 1-year setup-token (auth precedence #5) bypasses the
 # broken interactive-OAuth refresh path on headless subprocess invocations
 # (anthropics/claude-code#50743). Injected via Podman secret in prod (ADR-054).
+#
+# DO NOT add ANTHROPIC_API_KEY here. Forwarding it overrides Pro/Max
+# subscription billing and silently routes inference to Console pay-per-token
+# (auth precedence #3 > #5). Use CLAUDE_CODE_OAUTH_TOKEN exclusively.
 _SAFE_ENV_KEYS = {
     "PATH",
     "LANG",

--- a/tests/core/test_cli_pool_process.py
+++ b/tests/core/test_cli_pool_process.py
@@ -415,7 +415,7 @@ class TestCliPoolSpawnEnv:
     async def test_oauth_token_forwarded_to_subprocess(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test-value")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "FAKE-OAUTH-TOKEN-FOR-TESTING")
         proc = make_fake_proc([INIT_LINE, ASSISTANT_LINE, RESULT_LINE])
         spawn_mock = AsyncMock(return_value=proc)
         pool = CliPool()
@@ -424,7 +424,7 @@ class TestCliPoolSpawnEnv:
             await pool.send("pool-1", "hello", DEFAULT_MODEL)
 
         env_kwarg = spawn_mock.call_args.kwargs["env"]
-        assert env_kwarg["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-test-value"
+        assert env_kwarg["CLAUDE_CODE_OAUTH_TOKEN"] == "FAKE-OAUTH-TOKEN-FOR-TESTING"
 
     async def test_anthropic_api_key_not_forwarded(
         self, monkeypatch: pytest.MonkeyPatch
@@ -432,7 +432,7 @@ class TestCliPoolSpawnEnv:
         # Setting ANTHROPIC_API_KEY in the parent env must NOT reach the
         # subprocess — forwarding it would override Pro/Max subscription
         # billing and silently route to Console pay-per-token.
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-leak-canary")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "FAKE-API-KEY-LEAK-CANARY")
         proc = make_fake_proc([INIT_LINE, ASSISTANT_LINE, RESULT_LINE])
         spawn_mock = AsyncMock(return_value=proc)
         pool = CliPool()
@@ -442,3 +442,32 @@ class TestCliPoolSpawnEnv:
 
         env_kwarg = spawn_mock.call_args.kwargs["env"]
         assert "ANTHROPIC_API_KEY" not in env_kwarg
+
+    async def test_env_is_closed_allowlist(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Closed-world contract: only _SAFE_ENV_KEYS members + HOME may reach
+        # the subprocess. Catches "forward everything" regressions that the
+        # positive token test alone would not (the positive test passes even
+        # if `env = os.environ.copy()`).
+        monkeypatch.setenv("UNSAFE_LEAK_VAR", "should-not-propagate")
+        monkeypatch.setenv("ANOTHER_LEAK", "also-blocked")
+        proc = make_fake_proc([INIT_LINE, ASSISTANT_LINE, RESULT_LINE])
+        spawn_mock = AsyncMock(return_value=proc)
+        pool = CliPool()
+
+        with patch(_PATCH_TARGET, new=spawn_mock):
+            await pool.send("pool-1", "hello", DEFAULT_MODEL)
+
+        env_kwarg = spawn_mock.call_args.kwargs["env"]
+        allowed = {
+            "PATH",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "TMPDIR",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "HOME",  # injected unconditionally at spawn (¬from os.environ)
+        }
+        leaked = set(env_kwarg.keys()) - allowed
+        assert not leaked, f"unexpected env vars leaked to subprocess: {leaked}"

--- a/tests/core/test_cli_pool_process.py
+++ b/tests/core/test_cli_pool_process.py
@@ -395,3 +395,50 @@ class TestCliPoolIsAlive:
         )
         pool._entries["test-pool"] = entry
         assert pool.is_alive("test-pool") is False
+
+
+# ---------------------------------------------------------------------------
+# TestCliPoolSpawnEnv — env allowlist forwarding contract (#1105)
+# ---------------------------------------------------------------------------
+
+
+class TestCliPoolSpawnEnv:
+    """Locks the CliPool _SAFE_ENV_KEYS contract for the claude subprocess.
+
+    Without this test, a refactor that drops or renames CLAUDE_CODE_OAUTH_TOKEN
+    from the allowlist would silently break headless auth in prod (the symptom
+    is a 401 from the claude CLI, hours after deploy). Equally, accidentally
+    forwarding ANTHROPIC_API_KEY would silently switch billing to Console
+    pay-per-token (auth precedence #3 > #5).
+    """
+
+    async def test_oauth_token_forwarded_to_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test-value")
+        proc = make_fake_proc([INIT_LINE, ASSISTANT_LINE, RESULT_LINE])
+        spawn_mock = AsyncMock(return_value=proc)
+        pool = CliPool()
+
+        with patch(_PATCH_TARGET, new=spawn_mock):
+            await pool.send("pool-1", "hello", DEFAULT_MODEL)
+
+        env_kwarg = spawn_mock.call_args.kwargs["env"]
+        assert env_kwarg["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-test-value"
+
+    async def test_anthropic_api_key_not_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Setting ANTHROPIC_API_KEY in the parent env must NOT reach the
+        # subprocess — forwarding it would override Pro/Max subscription
+        # billing and silently route to Console pay-per-token.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-leak-canary")
+        proc = make_fake_proc([INIT_LINE, ASSISTANT_LINE, RESULT_LINE])
+        spawn_mock = AsyncMock(return_value=proc)
+        pool = CliPool()
+
+        with patch(_PATCH_TARGET, new=spawn_mock):
+            await pool.send("pool-1", "hello", DEFAULT_MODEL)
+
+        env_kwarg = spawn_mock.call_args.kwargs["env"]
+        assert "ANTHROPIC_API_KEY" not in env_kwarg


### PR DESCRIPTION
## Summary
- Inject `CLAUDE_CODE_OAUTH_TOKEN` (1-year `claude setup-token`) via Podman secret to bypass the broken interactive-OAuth refresh in headless subprocess contexts ([anthropics/claude-code#50743](https://github.com/anthropics/claude-code/issues/50743), closed-as-duplicate, no fix planned).
- Auth precedence #5 (`CLAUDE_CODE_OAUTH_TOKEN`) takes precedence over interactive OAuth #6 (`~/.claude/.credentials.json`), so the broken refresh path is sidestepped entirely. Subscription billing (Pro/Max) preserved vs `ANTHROPIC_API_KEY` which routes to Console pay-per-token.
- Pattern mirrors existing `lyra-gh-pem` Podman secret flow (ADR-054); uses `Secret=type=env` for env-var injection.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1105 — `fix(clipool): inject CLAUDE_CODE_OAUTH_TOKEN via Podman secret to bypass broken OAuth refresh` | OPEN |
| Implementation | 1 commit on `fix/1105-inject-claude-oauth-token` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3097 passed, 0 new — mechanical config change) | Passed |

## Files

| File | Change |
|---|---|
| `src/lyra/core/cli/cli_pool_worker.py` | Add `CLAUDE_CODE_OAUTH_TOKEN` to `_SAFE_ENV_KEYS` allowlist |
| `deploy/quadlet/lyra-clipool.container` | `Secret=lyra-claude-oauth,type=env,target=CLAUDE_CODE_OAUTH_TOKEN` |
| `deploy/provision.sh` | Bootstrap block mirroring `lyra-gh-pem`; reads token from `CLAUDE_OAUTH_TOKEN_PATH` env |
| `deploy/scripts/rotate-claude-oauth.sh` | New rotation script — `secret rm` + `secret create` + `systemctl restart lyra-clipool` (30s gate) |

## Test Plan
- [ ] On M₁: `claude setup-token > /tmp/oauth.tok` (interactive), then `CLAUDE_OAUTH_TOKEN_PATH=/tmp/oauth.tok deploy/provision.sh` creates the secret idempotently
- [ ] `podman secret ls | grep lyra-claude-oauth` → present
- [ ] After Quadlet reload + clipool restart: `podman exec lyra-clipool env | grep CLAUDE_CODE_OAUTH_TOKEN` shows non-empty value
- [ ] Send a message via Telegram → `claude` subprocess succeeds with no 401 in logs
- [ ] Wait 24h with no interactive re-login → daemon still responds
- [ ] Rotation: `deploy/scripts/rotate-claude-oauth.sh /tmp/new.tok` completes within 30s and clipool serves traffic again

## Out of Scope (separate cleanup)
- Removing the now-unused `Volume=%h/.claude:/home/lyra/.claude:z` mount and the `ExecStartPre touch .credentials.json` lines from the Quadlet — deferred until verified that nothing else writes there (MCP, plugins, settings).
- No programmatic token revocation API exists upstream ([anthropics/claude-code#34198](https://github.com/anthropics/claude-code/issues/34198)). Leaked-token mitigation = wait 1y or contact support.

Closes #1105

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`