### PR TITLE
feat(render-events): add Run{Started,Finished,Error} lifecycle events

### DIFF
--- a/artifacts/specs/1096-render-event-v2-agui-modeling-spec.mdx
+++ b/artifacts/specs/1096-render-event-v2-agui-modeling-spec.mdx
@@ -331,7 +331,7 @@ These are tested at every slice merge, not just at epic close:
 
 1. **Hexagonal boundary preserved.** Every new event type lives in `core/messaging/render_events.py`. No platform imports leak in. Verified by `import-linter`.
 2. **All event classes are `frozen=True`.** Per `render_events.py:8-15` immutability contract.
-3. **No silent event drop.** `StreamingSession.dispatch` raises `TypeError` on unknown event types. No fall-through `pass` allowed.
+3. **No silent event drop.** `StreamingSession.dispatch` fails loudly on unknown event types — either via an explicit `raise TypeError(...)`, or via `typing.assert_never(event)` (which raises `AssertionError` at runtime AND surfaces a pyright compile error when the union widens without updating dispatch). No fall-through `pass` allowed.
 4. **Per-event schema constant.** Every new event type has its own `SCHEMA_VERSION_*` constant; the event's `schema_version` field defaults to that constant. (Same pattern as `render_events.py:22-23`.)
 5. **Coexistence is the default.** Within a slice, v1 paths must keep working. v1 deletion only in Slice 5.
 
@@ -339,7 +339,7 @@ These are tested at every slice merge, not just at epic close:
 
 6. **Dual emission during coexistence.** Within slices 2-4, StreamProcessor emits BOTH the v1 event and the new v2 events for the same source `LlmEvent`. Doubles wire traffic temporarily; gives ironclad parity test ground truth (v2 receivers compared against v1 baseline edit-in-place output, byte-for-byte). Slice 5 removes v1 emission and the dual-write path.
 
-7. **`runId` == `trace_id` verbatim.** Simplest mapping, aligned with existing observability. No fresh UUID, no `metadata.trace_id` indirection. Re-visit only if interrupt+resume becomes a concrete requirement (out of scope for this epic).
+7. **`runId` == `trace_id` verbatim (when set).** Simplest mapping, aligned with existing observability. No fresh UUID, no `metadata.trace_id` indirection. **Edge case (clarified 2026-05-07 from #1109 review):** when `TraceContext.get_trace_id()` returns falsy (`None` from missing context, or empty string from a misconfigured caller), StreamProcessor falls back to `f"synthetic-{uuid4()}"` so the `run_id` field is always non-empty on the wire. Slice 2+ consumers that compare `run_id` across events MAY see a `synthetic-*` prefix when the trace context is unset; treat that as a valid identifier, not an error. Re-visit only if interrupt+resume becomes a concrete requirement (out of scope for this epic).
 
 8. **`message_id` per text block.** New id per `TextStart` (not per turn). Supports interleaved `text → tool → text` patterns natural to agentic flows and matches AG-UI's modeling. Slice 3 sub-analysis (`artifacts/analyses/NNN-toolcall-streaming-cli-instrumentation.mdx`) must capture Claude CLI text-block boundary semantics (U2) and confirm; if CLI emits a single block per turn, the per-block id collapses harmlessly to per-turn behavior.
 

--- a/artifacts/specs/1096-render-event-v2-agui-modeling-spec.mdx
+++ b/artifacts/specs/1096-render-event-v2-agui-modeling-spec.mdx
@@ -308,6 +308,8 @@ Each slice that adds new event types adds new constants; existing constants stay
 
 **Coordinated deploy rule:** any slice that introduces new event types requires `lyra_hub` + `lyra_telegram` + `lyra_discord` to be deployed together. Receivers reject (loud-fail per `_version_check.check_schema_version`) any payload with a newer schema_version than their compiled-in floor.
 
+**Slice 1 deploy ordering (added 2026-05-07 from #1109 review):** Slice 1 (#1098) moved the canonical NATS terminal signal off `text`/`done=True` onto `run_finished` / `run_error`. A new adapter connected to an old hub (which never emits `run_finished`) still terminates correctly via the unconditional `stream_end` sentinel published by `nats_channel_proxy.py`, but loses the previous fast-path. Therefore: **deploy `lyra_hub` before `lyra_telegram`/`lyra_discord` for Slice 1+**. The reverse ordering is safe but degrades adapter latency to one extra NATS round-trip per turn. Old adapter + new hub is unaffected — old adapters continue using the old `is_terminal` fast-path on `text`/`done=True`.
+
 ## Success Criteria
 
 Umbrella-level. Each `- [ ]` is binary pass/fail at the **end of the epic** (after Slice 5 merges).

--- a/src/lyra/adapters/nats/nats_stream_decoder.py
+++ b/src/lyra/adapters/nats/nats_stream_decoder.py
@@ -85,11 +85,10 @@ async def decode_stream_events(
         if event_type == "stream_error":
             break
         payload = chunk.get("payload", {})
-        is_done = chunk.get("done", False)
         event = _codec.decode(event_type, payload, counter=counter)
         if event is not None:
             yield event
-        if NatsRenderEventCodec.is_terminal(event_type, is_done):
+        if NatsRenderEventCodec.is_terminal(event_type):
             break
 
 

--- a/src/lyra/adapters/shared/_shared_streaming_emitter.py
+++ b/src/lyra/adapters/shared/_shared_streaming_emitter.py
@@ -18,7 +18,14 @@ from lyra.adapters.shared._shared_streaming_state import (
     StreamState,
     classify_stream_error,
 )
-from lyra.core.messaging import RenderEvent, TextRenderEvent, ToolSummaryRenderEvent
+from lyra.core.messaging import (
+    RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
+    TextRenderEvent,
+    ToolSummaryRenderEvent,
+)
 from lyra.core.messaging.message import GENERIC_ERROR_REPLY, OutboundMessage
 from lyra.core.messaging.tool_recap_format import format_tool_lines
 
@@ -111,7 +118,7 @@ class StreamingSession:
         if self._outbound is not None and fallback_message_id is not None:
             self._outbound.metadata["reply_message_id"] = fallback_message_id
 
-    async def _run_event_loop(
+    async def _run_event_loop(  # noqa: C901 — full v1+v2 dispatch ladder lands in Slice 2 (#1099)
         self,
         events: AsyncIterator[RenderEvent],
         placeholder_obj: Any,
@@ -119,6 +126,17 @@ class StreamingSession:
         """Iterate over events, updating the placeholder with debounced edits."""
         try:
             async for event in events:
+                if isinstance(
+                    event,
+                    RunStartedRenderEvent
+                    | RunFinishedRenderEvent
+                    | RunErrorRenderEvent,
+                ):
+                    # Slice 1 (#1098): Run lifecycle events are pure additive
+                    # surface — adapters initially ignore (no UX). Future slices
+                    # may render banners or expose run_id in observability.
+                    continue
+
                 if isinstance(event, ToolSummaryRenderEvent):
                     self._st.had_tool_events = True
                     header = "🔧 Done ✅" if event.is_complete else "🔧 Working…"

--- a/src/lyra/adapters/shared/_shared_streaming_emitter.py
+++ b/src/lyra/adapters/shared/_shared_streaming_emitter.py
@@ -11,7 +11,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, assert_never
 
 from lyra.adapters.shared._shared_streaming_state import (
     STREAMING_EDIT_INTERVAL,
@@ -107,6 +107,10 @@ class StreamingSession:
         """Drain remaining events, accumulate text, send via fallback callback."""
         parts: list[str] = []
         async for event in events:
+            # Slice 1 (#1098): only TextRenderEvent contributes to the fallback
+            # text — Run lifecycle events are silently skipped here. Slice 2
+            # (#1099) must extend this branch when TextDeltaRenderEvent lands
+            # so delta text is not lost on fallback.
             if isinstance(event, TextRenderEvent):
                 parts.append(event.text)
         fallback_text = "".join(parts) or self._cb.placeholder_text
@@ -167,7 +171,7 @@ class StreamingSession:
                                 log.debug("Tool summary edit skipped: %s", edit_exc)
                             self._st.last_tool_edit = now
 
-                else:  # TextRenderEvent
+                elif isinstance(event, TextRenderEvent):  # pyright: ignore[reportUnnecessaryIsInstance]
                     if event.is_final:
                         self._st.on_final_text(event)
                     else:
@@ -187,6 +191,11 @@ class StreamingSession:
                                     "Intermediate text edit skipped: %s", edit_exc
                                 )
                             self._st.last_intermediate_edit = now
+                else:
+                    # Cross-slice invariant 3: no silent event drop. When Slice 2
+                    # (#1099) extends RenderEvent with TextStart/Delta/End, pyright
+                    # will fail this assert_never until the dispatch is updated.
+                    assert_never(event)
 
         except Exception as exc:
             self._st.stream_error = exc

--- a/src/lyra/core/messaging/__init__.py
+++ b/src/lyra/core/messaging/__init__.py
@@ -10,7 +10,14 @@ from .message import (
     SessionUpdateFn,
     TelegramMeta,
 )
-from .render_events import RenderEvent, TextRenderEvent, ToolSummaryRenderEvent
+from .render_events import (
+    RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
+    TextRenderEvent,
+    ToolSummaryRenderEvent,
+)
 
 __all__ = [
     "Bus",
@@ -22,6 +29,9 @@ __all__ = [
     "OutboundMessage",
     "PlatformMeta",
     "RenderEvent",
+    "RunErrorRenderEvent",
+    "RunFinishedRenderEvent",
+    "RunStartedRenderEvent",
     "SessionUpdateFn",
     "TelegramMeta",
     "TextRenderEvent",

--- a/src/lyra/core/messaging/render_events.py
+++ b/src/lyra/core/messaging/render_events.py
@@ -18,9 +18,13 @@ accumulator reference with an already-emitted event.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 SCHEMA_VERSION_TEXT_RENDER_EVENT = 1
 SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT = 1
+SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT = 1
+SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT = 1
+SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT = 1
 
 
 @dataclass(frozen=True)
@@ -102,12 +106,68 @@ class ToolSummaryRenderEvent:
     schema_version: int = 1
 
 
+@dataclass(frozen=True)
+class RunStartedRenderEvent:
+    """Run lifecycle: stream begin. ``run_id`` mirrors the per-turn ``trace_id``.
+
+    Slice 1 of #1096 — additive surface. Adapters initially ignore (no UX).
+    Future slices may render a banner or expose the run_id in observability.
+    """
+
+    run_id: str
+    schema_version: int = SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT
+
+
+@dataclass(frozen=True)
+class RunFinishedRenderEvent:
+    """Run lifecycle: clean stream end (no exception).
+
+    ``outcome=success`` is the normal terminal state. ``outcome=interrupt``
+    is reserved for future cancellation paths and is not emitted in Slice 1.
+    """
+
+    run_id: str
+    outcome: Literal["success", "interrupt"] = "success"
+    schema_version: int = SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT
+
+
+@dataclass(frozen=True)
+class RunErrorRenderEvent:
+    """Run lifecycle: stream terminated by an exception in StreamProcessor.
+
+    Soft errors (``ResultLlmEvent.is_error=True`` without an exception) emit
+    ``RunFinishedRenderEvent(outcome="success")`` instead — the LLM run still
+    completed, the model just returned an error response. This event is for
+    infrastructure-level failures.
+
+    ``code`` is reserved for a future taxonomy (carry-over from #1097 review);
+    Slice 1 always passes ``None``.
+    """
+
+    run_id: str
+    message: str
+    code: str | None = None
+    schema_version: int = SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT
+
+
 # Union type exported for type annotations and ``isinstance`` checks.
-RenderEvent = TextRenderEvent | ToolSummaryRenderEvent
+RenderEvent = (
+    TextRenderEvent
+    | ToolSummaryRenderEvent
+    | RunStartedRenderEvent
+    | RunFinishedRenderEvent
+    | RunErrorRenderEvent
+)
 
 __all__ = [
     "FileEditSummary",
     "RenderEvent",
+    "RunErrorRenderEvent",
+    "RunFinishedRenderEvent",
+    "RunStartedRenderEvent",
+    "SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT",
+    "SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT",
+    "SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT",
     "SCHEMA_VERSION_TEXT_RENDER_EVENT",
     "SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT",
     "SilentCounts",

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -29,11 +29,15 @@ from lyra.core.messaging.metrics import emit_received_total
 from lyra.core.messaging.render_events import (
     FileEditSummary,
     RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
     SilentCounts,
     TextRenderEvent,
     ToolSummaryRenderEvent,
 )
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
+from lyra.core.trace import TraceContext
 from roxabi_contracts.errors import KNOWN_CODES
 
 
@@ -109,57 +113,68 @@ class StreamProcessor:
             turn end.
         """
         self._mark_consumed()
+        run_id = TraceContext.get_trace_id() or f"synthetic-{TraceContext.generate()}"
+        yield RunStartedRenderEvent(run_id=run_id)
         _result_received = False
-        async for event in events:
-            if isinstance(event, TextLlmEvent):
-                self._pending_text += event.text
+        try:
+            async for event in events:
+                if isinstance(event, TextLlmEvent):
+                    self._pending_text += event.text
 
-            elif isinstance(event, ToolUseLlmEvent):
-                async for render_event in self._handle_tool_event(event):
-                    yield render_event
+                elif isinstance(event, ToolUseLlmEvent):
+                    async for render_event in self._handle_tool_event(event):
+                        yield render_event
 
-            else:  # ResultLlmEvent
-                _result_received = True
+                else:  # ResultLlmEvent
+                    _result_received = True
+                    if self._has_any_tool_events():
+                        yield self._emit_snapshot(is_complete=True)
+                    # On error with no streamed text, surface the structured WorkerError
+                    # message (P1 path) or the legacy error_text shim (P2 transitional).
+                    if event.is_error and not self._pending_text:
+                        we = _extract_worker_error(event)
+                        if we is not None:
+                            meta = KNOWN_CODES.get(we.code)
+                            domain = meta.domain if meta else we.code.split(".")[0]
+                            emit_received_total(code=we.code, domain=domain)
+                            error_text = we.message
+                        else:
+                            # P2 transitional: fall back to legacy error_text shim.
+                            error_text = event.error_text or ""
+                        final_text = error_text
+                    else:
+                        final_text = self._pending_text
+                    yield TextRenderEvent(
+                        text=final_text,
+                        is_final=True,
+                        is_error=event.is_error,  # #392: propagate error state
+                    )
+
+            # Stream ended without ResultLlmEvent (truncation or upstream error)
+            if not _result_received:
                 if self._has_any_tool_events():
                     yield self._emit_snapshot(is_complete=True)
-                # On error with no streamed text, surface the structured WorkerError
-                # message (P1 path) or the legacy error_text shim (P2 transitional).
-                if event.is_error and not self._pending_text:
-                    we = _extract_worker_error(event)
-                    if we is not None:
-                        meta = KNOWN_CODES.get(we.code)
-                        domain = meta.domain if meta else we.code.split(".")[0]
-                        emit_received_total(code=we.code, domain=domain)
-                        error_text = we.message
-                    else:
-                        # P2 transitional: fall back to legacy error_text shim.
-                        error_text = event.error_text or ""
-                    final_text = error_text
-                else:
-                    final_text = self._pending_text
-                yield TextRenderEvent(
-                    text=final_text,
-                    is_final=True,
-                    is_error=event.is_error,  # #392: propagate error state
-                )
-
-        # Stream ended without ResultLlmEvent (truncation or upstream error)
-        if not _result_received:
-            if self._has_any_tool_events():
-                yield self._emit_snapshot(is_complete=True)
-            if self._pending_text:
-                yield TextRenderEvent(text=self._pending_text, is_final=False)
-            elif not self._has_any_tool_events():
-                # No text, no tools, no result — backend died before producing
-                # anything (e.g. auth failure, crash).  Emit an error event so
-                # the adapter replaces the "…" placeholder instead of leaving
-                # it stuck forever.
-                _upstream_error = getattr(events, "error", None)
-                yield TextRenderEvent(
-                    text=str(_upstream_error) if _upstream_error else "",
-                    is_final=True,
-                    is_error=True,
-                )
+                if self._pending_text:
+                    yield TextRenderEvent(text=self._pending_text, is_final=False)
+                elif not self._has_any_tool_events():
+                    # No text, no tools, no result — backend died before producing
+                    # anything (e.g. auth failure, crash).  Emit an error event so
+                    # the adapter replaces the "…" placeholder instead of leaving
+                    # it stuck forever.
+                    _upstream_error = getattr(events, "error", None)
+                    yield TextRenderEvent(
+                        text=str(_upstream_error) if _upstream_error else "",
+                        is_final=True,
+                        is_error=True,
+                    )
+        except Exception as exc:
+            # Slice 1 (#1098): infrastructure-level exception during stream
+            # processing. Surface a RunErrorRenderEvent then re-raise so the
+            # adapter's existing exception handler (sets stream_error and
+            # falls through to classify_stream_error) keeps working.
+            yield RunErrorRenderEvent(run_id=run_id, message=str(exc), code=None)
+            raise
+        yield RunFinishedRenderEvent(run_id=run_id, outcome="success")
 
     async def _handle_tool_event(
         self, event: ToolUseLlmEvent

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -172,8 +172,22 @@ class StreamProcessor:
             # processing. Surface a RunErrorRenderEvent then re-raise so the
             # adapter's existing exception handler (sets stream_error and
             # falls through to classify_stream_error) keeps working.
-            yield RunErrorRenderEvent(run_id=run_id, message=str(exc), code=None)
+            #
+            # message=type(exc).__name__ — never str(exc): exception strings can
+            # carry file paths, internal hostnames, auth-token fragments from
+            # httpx/aiohttp errors, DB connection strings, etc. RunErrorRenderEvent
+            # is published on the NATS bus where any subscriber can read it.
+            yield RunErrorRenderEvent(
+                run_id=run_id, message=type(exc).__name__, code=None
+            )
             raise
+        finally:
+            # Eagerly finalize the input iterator on both success and exception
+            # paths so generators holding resources (e.g. CLI subprocess pipes)
+            # release them deterministically rather than on GC.
+            _aclose = getattr(events, "aclose", None)
+            if _aclose is not None:
+                await _aclose()
         yield RunFinishedRenderEvent(run_id=run_id, outcome="success")
 
     async def _handle_tool_event(

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -8,6 +8,7 @@ change here — there is no way to silently drop it on the other side.
 from __future__ import annotations
 
 import json
+import logging
 
 from lyra.core.messaging.render_events import (
     SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT,
@@ -28,6 +29,8 @@ from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
 from roxabi_nats import TypeHintResolver
 from roxabi_nats._serialize import deserialize, serialize
 from roxabi_nats._version_check import check_schema_version
+
+log = logging.getLogger(__name__)
 
 
 class NatsRenderEventCodec:
@@ -71,8 +74,11 @@ class NatsRenderEventCodec:
             return "run_started", payload, False
         if isinstance(event, RunFinishedRenderEvent):
             return "run_finished", payload, True
-        # RunErrorRenderEvent
-        return "run_error", payload, True
+        if isinstance(event, RunErrorRenderEvent):  # pyright: ignore[reportUnnecessaryIsInstance]
+            return "run_error", payload, True
+        raise TypeError(  # pyright: ignore[reportUnreachable]
+            f"Unsupported RenderEvent subtype: {type(event)!r}"
+        )
 
     def decode(  # noqa: C901 — per-event-type version-check + decode; refactored when Slice 5 sunsets v1
         self,
@@ -168,10 +174,22 @@ class NatsRenderEventCodec:
                 RunErrorRenderEvent,
                 resolver=self._resolver,
             )
-        return None  # "stream_end" or unknown
+        if event_type == "stream_end":
+            return None
+        # Unknown event_type — surface via log + counter so partial-deploy
+        # mismatches are visible. Synthetic transport sentinels (stream_end /
+        # stream_error) are handled above.
+        log.warning(
+            "NatsRenderEventCodec: unknown event_type=%r; dropping chunk",
+            event_type,
+        )
+        if counter is not None:
+            key = f"unknown:{event_type}"
+            counter[key] = counter.get(key, 0) + 1
+        return None
 
     @staticmethod
-    def is_terminal(event_type: str, is_done: bool) -> bool:
+    def is_terminal(event_type: str) -> bool:
         """Return ``True`` when this chunk signals end-of-stream.
 
         Rules:
@@ -187,11 +205,9 @@ class NatsRenderEventCodec:
           still published unconditionally as a backward-compat safety net
           for receivers that pre-date Slice 1.
         """
-        if event_type in (
+        return event_type in (
             "stream_end",
             "stream_error",
             "run_finished",
             "run_error",
-        ):
-            return True
-        return False
+        )

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -10,10 +10,16 @@ from __future__ import annotations
 import json
 
 from lyra.core.messaging.render_events import (
+    SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT,
+    SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT,
+    SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT,
     SCHEMA_VERSION_TEXT_RENDER_EVENT,
     SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT,
     FileEditSummary,
     RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
     SilentCounts,
     TextRenderEvent,
     ToolSummaryRenderEvent,
@@ -32,13 +38,16 @@ class NatsRenderEventCodec:
         {
             "stream_id": str,
             "seq":        int,
-            "event_type": "text" | "tool_summary" | "stream_end",
+            "event_type": "text" | "tool_summary"
+                          | "run_started" | "run_finished" | "run_error"
+                          | "stream_end",
             "payload":    dict,   # serialized event fields
             "done":       bool,
         }
 
     ``"stream_end"`` is a synthetic terminal sentinel emitted by
-    ``NatsChannelProxy``; ``decode()`` returns ``None`` for it.
+    ``NatsChannelProxy``; ``decode()`` returns ``None`` for it. The
+    ``run_*`` types were added by Slice 1 of #1096 (#1098).
     """
 
     def __init__(self, *, resolver: TypeHintResolver = TYPE_REGISTRY_RESOLVER) -> None:
@@ -48,16 +57,24 @@ class NatsRenderEventCodec:
     def encode(event: RenderEvent) -> tuple[str, dict, bool]:
         """Return ``(event_type, payload_dict, is_done)`` for *event*.
 
-        ``is_done`` is ``True`` for a final ``TextRenderEvent`` (``is_final``)
-        or a complete ``ToolSummaryRenderEvent`` (``is_complete``).
+        ``is_done`` is ``True`` for a final ``TextRenderEvent`` (``is_final``),
+        a complete ``ToolSummaryRenderEvent`` (``is_complete``), or any of the
+        terminal Run lifecycle events (``RunFinishedRenderEvent``,
+        ``RunErrorRenderEvent``). ``RunStartedRenderEvent`` is not terminal.
         """
         payload: dict = json.loads(serialize(event).decode("utf-8"))
         if isinstance(event, TextRenderEvent):
             return "text", payload, event.is_final
-        # ToolSummaryRenderEvent
-        return "tool_summary", payload, event.is_complete
+        if isinstance(event, ToolSummaryRenderEvent):
+            return "tool_summary", payload, event.is_complete
+        if isinstance(event, RunStartedRenderEvent):
+            return "run_started", payload, False
+        if isinstance(event, RunFinishedRenderEvent):
+            return "run_finished", payload, True
+        # RunErrorRenderEvent
+        return "run_error", payload, True
 
-    def decode(
+    def decode(  # noqa: C901 — per-event-type version-check + decode; refactored when Slice 5 sunsets v1
         self,
         event_type: str,
         payload: dict,
@@ -112,6 +129,45 @@ class NatsRenderEventCodec:
                 ),
                 is_complete=payload.get("is_complete", False),
             )
+        if event_type == "run_started":
+            if not check_schema_version(
+                payload,
+                envelope_name="RunStartedRenderEvent",
+                expected=SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                RunStartedRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "run_finished":
+            if not check_schema_version(
+                payload,
+                envelope_name="RunFinishedRenderEvent",
+                expected=SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                RunFinishedRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "run_error":
+            if not check_schema_version(
+                payload,
+                envelope_name="RunErrorRenderEvent",
+                expected=SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                RunErrorRenderEvent,
+                resolver=self._resolver,
+            )
         return None  # "stream_end" or unknown
 
     @staticmethod
@@ -120,14 +176,22 @@ class NatsRenderEventCodec:
 
         Rules:
 
-        * ``"stream_end"`` — always terminal (explicit sentinel from hub).
-        * ``"tool_summary"`` — never terminal; the final ``TextRenderEvent``
-          follows unconditionally.
-        * All other types (including ``"text"``) — terminal when ``is_done``
-          is ``True``.
+        * ``"stream_end"`` / ``"stream_error"`` — always terminal (explicit
+          sentinels from hub / transport).
+        * ``"run_finished"`` / ``"run_error"`` — always terminal (Slice 1 of
+          #1096 moved the canonical run terminator off ``text``/``done`` so
+          adapters always see Run lifecycle events before the loop exits).
+        * ``"tool_summary"`` — never terminal; subsequent events follow.
+        * ``"text"`` — never terminal; ``run_finished``/``run_error``
+          arrives after the final ``TextRenderEvent``. ``stream_end`` is
+          still published unconditionally as a backward-compat safety net
+          for receivers that pre-date Slice 1.
         """
-        if event_type in ("stream_end", "stream_error"):
+        if event_type in (
+            "stream_end",
+            "stream_error",
+            "run_finished",
+            "run_error",
+        ):
             return True
-        if event_type == "tool_summary":
-            return False
-        return is_done
+        return False

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -832,13 +832,25 @@ async def test_version_mismatch_counter_flows_from_listener() -> None:
             "done": False,
         }
     )
-    # Chunk 2: v1 payload → should decode and be yielded; is_final=True → terminal
+    # Chunk 2: v1 payload → should decode and be yielded.
     await q.put(
         {
             "stream_id": stream_id,
             "seq": 1,
             "event_type": "text",
             "payload": {"schema_version": 1, "text": "good", "is_final": True},
+            "done": True,
+        }
+    )
+    # Chunk 3: terminal sentinel — Slice 1 of #1096 moved the canonical
+    # run terminator off ``text``/``done`` so adapters see lifecycle events
+    # before the loop exits. ``stream_end`` always arrives from the proxy.
+    await q.put(
+        {
+            "stream_id": stream_id,
+            "seq": 2,
+            "event_type": "stream_end",
+            "payload": {},
             "done": True,
         }
     )

--- a/tests/core/test_render_events.py
+++ b/tests/core/test_render_events.py
@@ -227,6 +227,12 @@ class TestRenderEventUnion:
         assert set(_mod.__all__) == {
             "FileEditSummary",
             "RenderEvent",
+            "RunErrorRenderEvent",
+            "RunFinishedRenderEvent",
+            "RunStartedRenderEvent",
+            "SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT",
+            "SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT",
+            "SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT",
             "SCHEMA_VERSION_TEXT_RENDER_EVENT",
             "SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT",
             "SilentCounts",

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -8,11 +8,33 @@ from typing import AsyncIterator
 
 from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
 from lyra.core.messaging.render_events import (
+    RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
     TextRenderEvent,
     ToolSummaryRenderEvent,
 )
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
 from lyra.core.processors.stream_processor import StreamProcessor
+from lyra.core.trace import TraceContext
+
+_RUN_LIFECYCLE_TYPES = (
+    RunStartedRenderEvent,
+    RunFinishedRenderEvent,
+    RunErrorRenderEvent,
+)
+
+
+def strip_run_lifecycle(events: list[RenderEvent]) -> list[RenderEvent]:
+    """Drop ``Run{Started,Finished,Error}RenderEvent`` from a result list.
+
+    Slice 1 of #1096 added unconditional Run lifecycle bookends to every
+    ``StreamProcessor.process()`` invocation. Tests that focus on text/tool
+    payload count and ordering use this helper to keep their original
+    assertions intact; lifecycle-specific tests live in ``TestRunLifecycle``.
+    """
+    return [e for e in events if not isinstance(e, _RUN_LIFECYCLE_TYPES)]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -61,7 +83,7 @@ class TestStreamProcessor:
         )
 
         # Act
-        result = await collect(processor.process(events))
+        result = strip_run_lifecycle(await collect(processor.process(events)))
 
         # Assert
         assert len(result) == 1
@@ -94,7 +116,7 @@ class TestStreamProcessor:
         )
 
         # Act
-        result = await collect(processor.process(events))
+        result = strip_run_lifecycle(await collect(processor.process(events)))
 
         # Assert — 3 events: intermediate text, final summary, final text
         # Mid-turn ToolSummaryRenderEvent is suppressed when intermediate text
@@ -123,7 +145,7 @@ class TestStreamProcessor:
         )
 
         # Act
-        result = await collect(processor.process(events))
+        result = strip_run_lifecycle(await collect(processor.process(events)))
 
         # Assert — 3 events: mid-turn summary, final summary, text
         # show_intermediate=False keeps text accumulated until ResultLlmEvent.
@@ -662,7 +684,9 @@ class TestStreamProcessor:
         processor = StreamProcessor(cfg())
 
         # Act
-        result = await collect(processor.process(async_events()))
+        result = strip_run_lifecycle(
+            await collect(processor.process(async_events()))
+        )
 
         # Assert — backend produced nothing: emit an error so the "…"
         # placeholder is replaced instead of staying stuck.
@@ -719,3 +743,139 @@ class TestStreamProcessor:
                         assert not (name or "").startswith(f), (
                             f"{source_path}: forbidden import '{name}'"
                         )
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 of #1096 — Run lifecycle events (#1098)
+# ---------------------------------------------------------------------------
+
+
+class TestRunLifecycle:
+    """RunStarted/RunFinished/RunError emission contract (#1098)."""
+
+    async def test_emission_order_text_only(self) -> None:
+        """Text-only turn emits RunStarted first and RunFinished last."""
+        processor = StreamProcessor(cfg())
+        events = async_events(
+            TextLlmEvent(text="hello"),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+
+        assert isinstance(result[0], RunStartedRenderEvent)
+        assert isinstance(result[-1], RunFinishedRenderEvent)
+        assert result[-1].outcome == "success"
+        # The text event is sandwiched between the lifecycle bookends.
+        assert any(isinstance(e, TextRenderEvent) for e in result[1:-1])
+
+    async def test_emission_order_with_tool(self) -> None:
+        """Tool-using turn keeps lifecycle bookends around tool/text events."""
+        processor = StreamProcessor(cfg(), show_intermediate=False)
+        events = async_events(
+            ToolUseLlmEvent(
+                tool_name="Edit", tool_id="t1", input={"path": "src/foo.py"}
+            ),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+
+        assert isinstance(result[0], RunStartedRenderEvent)
+        assert isinstance(result[-1], RunFinishedRenderEvent)
+        # Mid-turn payload: at least one ToolSummaryRenderEvent and one TextRenderEvent.
+        middle = result[1:-1]
+        assert any(isinstance(e, ToolSummaryRenderEvent) for e in middle)
+        assert any(isinstance(e, TextRenderEvent) for e in middle)
+
+    async def test_run_id_matches_trace_id(self) -> None:
+        """RunStarted/RunFinished both carry run_id == TraceContext.trace_id."""
+        token = TraceContext.set_trace_id("abc-123")
+        try:
+            processor = StreamProcessor(cfg())
+            events = async_events(
+                TextLlmEvent(text="x"),
+                ResultLlmEvent(is_error=False, duration_ms=1),
+            )
+            result = await collect(processor.process(events))
+        finally:
+            TraceContext.reset_trace_id(token)
+
+        started = next(e for e in result if isinstance(e, RunStartedRenderEvent))
+        finished = next(e for e in result if isinstance(e, RunFinishedRenderEvent))
+        assert started.run_id == "abc-123"
+        assert finished.run_id == "abc-123"
+
+    async def test_run_id_synthetic_when_trace_unset(self) -> None:
+        """No active TraceContext → synthetic prefix; both bookends carry it."""
+        # No set_trace_id call — TraceContext.get_trace_id() returns None.
+        processor = StreamProcessor(cfg())
+        events = async_events(
+            TextLlmEvent(text="x"),
+            ResultLlmEvent(is_error=False, duration_ms=1),
+        )
+        result = await collect(processor.process(events))
+
+        started = next(e for e in result if isinstance(e, RunStartedRenderEvent))
+        finished = next(e for e in result if isinstance(e, RunFinishedRenderEvent))
+        assert started.run_id.startswith("synthetic-")
+        assert started.run_id == finished.run_id
+
+    async def test_run_error_on_input_exception(self) -> None:
+        """Exception while iterating LlmEvent stream → RunError + re-raise."""
+
+        class _Boom(RuntimeError):
+            pass
+
+        async def _raising_events():
+            yield TextLlmEvent(text="partial")
+            raise _Boom("input died")
+
+        processor = StreamProcessor(cfg())
+        seen: list[RenderEvent] = []
+        with __import__("pytest").raises(_Boom):
+            async for ev in processor.process(_raising_events()):
+                seen.append(ev)
+
+        # Order: RunStarted → ... → RunError (immediately before re-raise).
+        assert isinstance(seen[0], RunStartedRenderEvent)
+        assert isinstance(seen[-1], RunErrorRenderEvent)
+        assert seen[-1].message == "input died"
+        assert seen[-1].code is None
+        assert seen[-1].run_id == seen[0].run_id
+        # No RunFinished must be emitted on the error path.
+        assert not any(isinstance(e, RunFinishedRenderEvent) for e in seen)
+
+    async def test_soft_error_emits_finished_not_error(self) -> None:
+        """ResultLlmEvent.is_error=True (soft error) → RunFinished, not RunError."""
+        processor = StreamProcessor(cfg())
+        events = async_events(
+            ResultLlmEvent(is_error=True, duration_ms=10, error_text="model error"),
+        )
+
+        result = await collect(processor.process(events))
+
+        assert isinstance(result[-1], RunFinishedRenderEvent)
+        assert result[-1].outcome == "success"
+        assert not any(isinstance(e, RunErrorRenderEvent) for e in result)
+        # The soft error still surfaces via TextRenderEvent.is_error=True.
+        text_events = [e for e in result if isinstance(e, TextRenderEvent)]
+        assert any(e.is_error for e in text_events)
+
+    def test_schema_versions(self) -> None:
+        """Each new event type carries its own SCHEMA_VERSION_* constant."""
+        from lyra.core.messaging.render_events import (
+            SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT,
+            SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT,
+            SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT,
+        )
+
+        assert RunStartedRenderEvent(run_id="x").schema_version == (
+            SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT
+        )
+        assert RunFinishedRenderEvent(run_id="x").schema_version == (
+            SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT
+        )
+        assert RunErrorRenderEvent(run_id="x", message="m").schema_version == (
+            SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT
+        )

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -808,7 +808,11 @@ class TestRunLifecycle:
 
     async def test_run_id_synthetic_when_trace_unset(self) -> None:
         """No active TraceContext → synthetic prefix; both bookends carry it."""
-        # No set_trace_id call — TraceContext.get_trace_id() returns None.
+        # Sanity: prior test must have cleaned up. ContextVar has no "unset"
+        # token, so a missing try/finally elsewhere would leak in here.
+        assert TraceContext.get_trace_id() is None, (
+            "test leaked trace_id from a prior test — see test_run_id_matches_trace_id"
+        )
         processor = StreamProcessor(cfg())
         events = async_events(
             TextLlmEvent(text="x"),
@@ -821,6 +825,27 @@ class TestRunLifecycle:
         assert started.run_id.startswith("synthetic-")
         assert started.run_id == finished.run_id
 
+    async def test_run_id_empty_trace_id_falls_back_to_synthetic(self) -> None:
+        """Empty-string trace_id is falsy → synthetic fallback kicks in.
+
+        Documents current `or` semantics in StreamProcessor.process. If the
+        invariant should hold for empty strings too (run_id == ""), tighten
+        the source to `is None` and update this test.
+        """
+        token = TraceContext.set_trace_id("")
+        try:
+            processor = StreamProcessor(cfg())
+            events = async_events(
+                TextLlmEvent(text="x"),
+                ResultLlmEvent(is_error=False, duration_ms=1),
+            )
+            result = await collect(processor.process(events))
+        finally:
+            TraceContext.reset_trace_id(token)
+
+        started = next(e for e in result if isinstance(e, RunStartedRenderEvent))
+        assert started.run_id.startswith("synthetic-")
+
     async def test_run_error_on_input_exception(self) -> None:
         """Exception while iterating LlmEvent stream → RunError + re-raise."""
 
@@ -829,7 +854,7 @@ class TestRunLifecycle:
 
         async def _raising_events():
             yield TextLlmEvent(text="partial")
-            raise _Boom("input died")
+            raise _Boom("input died — this string MUST NOT reach the wire")
 
         processor = StreamProcessor(cfg())
         seen: list[RenderEvent] = []
@@ -840,11 +865,47 @@ class TestRunLifecycle:
         # Order: RunStarted → ... → RunError (immediately before re-raise).
         assert isinstance(seen[0], RunStartedRenderEvent)
         assert isinstance(seen[-1], RunErrorRenderEvent)
-        assert seen[-1].message == "input died"
+        # message carries the exception class name, NOT str(exc) — str(exc)
+        # can leak file paths, hostnames, auth tokens onto the wire.
+        assert seen[-1].message == "_Boom"
+        assert "input died" not in seen[-1].message
         assert seen[-1].code is None
         assert seen[-1].run_id == seen[0].run_id
-        # No RunFinished must be emitted on the error path.
-        assert not any(isinstance(e, RunFinishedRenderEvent) for e in seen)
+        # Position-aware: no RunFinished must appear before RunError, and
+        # exactly two lifecycle events should be present (started + error).
+        error_idx = next(
+            i for i, e in enumerate(seen) if isinstance(e, RunErrorRenderEvent)
+        )
+        assert not any(
+            isinstance(seen[i], RunFinishedRenderEvent) for i in range(error_idx)
+        )
+        lifecycle = [
+            e
+            for e in seen
+            if isinstance(
+                e,
+                (
+                    RunStartedRenderEvent,
+                    RunFinishedRenderEvent,
+                    RunErrorRenderEvent,
+                ),
+            )
+        ]
+        assert len(lifecycle) == 2  # exactly RunStarted + RunError
+
+    async def test_emission_order_empty_stream(self) -> None:
+        """Zero-event input still emits RunStarted + RunFinished bookends.
+
+        Confirms the `if not _result_received` branch flows through the success
+        path and does NOT trigger RunError (no exception raised). Pairs with
+        the pre-existing `test_empty_stream` which strips lifecycle events.
+        """
+        processor = StreamProcessor(cfg())
+        result = await collect(processor.process(async_events()))
+
+        assert isinstance(result[0], RunStartedRenderEvent)
+        assert isinstance(result[-1], RunFinishedRenderEvent)
+        assert not any(isinstance(e, RunErrorRenderEvent) for e in result)
 
     async def test_soft_error_emits_finished_not_error(self) -> None:
         """ResultLlmEvent.is_error=True (soft error) → RunFinished, not RunError."""

--- a/tests/nats/test_nats_channel_proxy.py
+++ b/tests/nats/test_nats_channel_proxy.py
@@ -484,8 +484,7 @@ def test_is_terminal_stream_error():
     """stream_error event type is always terminal regardless of done flag."""
     from lyra.nats.render_event_codec import NatsRenderEventCodec
 
-    assert NatsRenderEventCodec.is_terminal("stream_error", True) is True
-    assert NatsRenderEventCodec.is_terminal("stream_error", False) is True
+    assert NatsRenderEventCodec.is_terminal("stream_error") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -7,6 +7,7 @@ src/lyra/bootstrap/bootstrap_stores.py  # 305 lines — #957 idx_sql DDL validat
 src/lyra/core/cli/cli_pool.py  # 327 lines — #1008 resume_direct() method added for hub-side session resolution
 src/lyra/agents/simple_agent.py  # 309 lines — #1008 cli_nats_driver wiring for NATS-mode resume + link_lyra_session
 src/lyra/bootstrap/standalone/adapter_standalone.py  # 303 lines — #1016 WorkerError startup version log
-src/lyra/core/processors/stream_processor.py  # 305 lines — #1016 WorkerError extractor + emit_received_total wiring
+src/lyra/core/processors/stream_processor.py  # 322 lines — #1016 WorkerError extractor + #1098 Run lifecycle emission (Slice 2 of #1096 will refactor _handle_text_event)
+src/lyra/adapters/shared/_shared_streaming_emitter.py  # 315 lines — #1098 Run lifecycle skip branch (Slice 2 of #1096 lands the full v1+v2 isinstance ladder)
 src/lyra/llm/drivers/nats_driver.py  # 364 lines — #1016 WorkerError population on transport.* failures (P3 will refactor with NatsDriverBase)
 src/lyra/adapters/clipool/clipool_worker.py  # 334 lines — #1016 WorkerError population + exception classifier


### PR DESCRIPTION
## Summary
- Slice 1 of #1096 (RenderEvent v2 — AG-UI modeling): pure additive surface that adds 3 new RenderEvent types with per-event SCHEMA_VERSION_* constants. StreamProcessor emits them as RunStarted (begin) / RunFinished (success) / RunError (exception); adapters dispatch but ignore — zero UX change.
- `run_id` is wired to `TraceContext.get_trace_id()` with a `synthetic-…` fallback when no trace context is active.
- NATS codec gains 3 new wire event types with version-checked decode; terminal logic now keys off Run*/stream_end so lifecycle events always reach the adapter before the decode loop exits.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1098: feat(render-events): add Run{Started,Finished,Error} lifecycle events | Open |
| Implementation | 1 commit on `feat/1098-add-run-lifecycle-events` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (7 new) | Passed |

## Test Plan
- [x] `uv run pytest tests/core/test_stream_processor.py` — 32 passed (includes 7 new TestRunLifecycle cases)
- [x] `uv run pytest tests/core/test_render_events.py tests/adapters/test_nats_outbound_listener.py tests/nats/test_nats_channel_proxy.py` — 121 passed
- [x] `uv run ruff check . && uv run pyright` — clean
- [x] `uv run lint-imports` — 7 contracts kept, hexagonal boundary preserved

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`