### PR TITLE
fix(deploy): export XDG_RUNTIME_DIR in rotate-gh-key.sh for SSH non-interactive

### DIFF
--- a/deploy/scripts/rotate-gh-key.sh
+++ b/deploy/scripts/rotate-gh-key.sh
@@ -19,6 +19,11 @@
 # (Podman 5.7.0): 0.58s.
 set -euo pipefail
 export LC_ALL=C
+# Required when invoked via `make remote` (SSH non-interactive shell): without
+# it, `systemctl --user` fails to locate the dbus session ("Failed to connect
+# to bus: No such file or directory"). Provision.sh sets this consistently;
+# the rotate scripts must too.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 
 NEW_PEM="${1:-}"
 PEM_RE='^[A-Za-z0-9._/-]+$'


### PR DESCRIPTION
## Summary

- `rotate-gh-key.sh` was missing `export XDG_RUNTIME_DIR` — without it, `systemctl --user restart lyra-gh-helper.service` (and `podman secret create`) fail with "Failed to connect to bus: No such file or directory" when invoked over SSH non-interactive (e.g. `make remote …`)
- Sister-script `rotate-claude-oauth.sh` received this fix in #1106 (iter-2 finding F13); this PR mirrors the identical export + comment block at the equivalent location
- No other changes

## Diff (1 hunk)

```diff
+# Required when invoked via `make remote` (SSH non-interactive shell): without
+# it, `systemctl --user` fails to locate the dbus session ("Failed to connect
+# to bus: No such file or directory"). Provision.sh sets this consistently;
+# the rotate scripts must too.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
```

Placement: after `export LC_ALL=C`, before argument parsing — identical to `rotate-claude-oauth.sh`.

## Test plan

- [ ] `bash -n deploy/scripts/rotate-gh-key.sh` — passes (verified locally)
- [ ] `shellcheck` — not installed locally; CI will catch any issues
- [ ] Manual: invoke `make remote rotate-gh-key PEM=…` over SSH non-interactive and confirm no dbus error

Closes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)