### PR TITLE
fix(deploy): export XDG_RUNTIME_DIR in quadlet-install-verify.sh + nats/setup.sh

### DIFF
--- a/deploy/nats/setup.sh
+++ b/deploy/nats/setup.sh
@@ -21,6 +21,11 @@
 # To rotate keys: sudo rm -f /etc/nats/nkeys/auth.conf && rm -rf ~/.lyra/nkeys && make nats-setup
 
 set -euo pipefail
+# Required when invoked via `make remote` (SSH non-interactive shell): without
+# it, `systemctl --user` fails to locate the dbus session ("Failed to connect
+# to bus: No such file or directory"). Provision.sh sets this consistently;
+# the deploy scripts must too.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 
 [[ $EUID -eq 0 ]] && { echo "[!] Do not run as root — use: make nats-setup"; exit 1; }
 

--- a/deploy/quadlet-install-verify.sh
+++ b/deploy/quadlet-install-verify.sh
@@ -10,6 +10,11 @@
 #
 # Exits non-zero if any unit fails to reach `active`.
 set -euo pipefail
+# Required when invoked via `make remote` (SSH non-interactive shell): without
+# it, `systemctl --user` fails to locate the dbus session ("Failed to connect
+# to bus: No such file or directory"). Provision.sh sets this consistently;
+# the deploy scripts must too.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 
 # Units derived from .container files.  Quadlet maps <name>.container → <name>.service.
 UNITS=(


### PR DESCRIPTION
## Summary

- Same root cause as #1111 (PR #1115): SSH non-interactive shells do not inherit `XDG_RUNTIME_DIR`; `systemctl --user` fails with "Failed to connect to bus: No such file or directory"
- Adds `export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"` near the top of the two affected files, mirroring the fix pattern in `deploy/scripts/rotate-gh-key.sh`
- `deploy/provision.sh` already handles this per-call via `sudo -u … XDG_RUNTIME_DIR=…` — not touched

## Files changed

| File | Calls fixed | Lines added |
|---|---|---|
| `deploy/quadlet-install-verify.sh` | 5 `systemctl --user` calls (lines 25, 30, 32, 35, 49) | +5 |
| `deploy/nats/setup.sh` | 1 `systemctl --user` call (line 105) | +5 |

## Test plan

- [ ] `bash -n` passes on both files (verified locally)
- [ ] `make quadlet-install` on M₁ via SSH (`make remote ...`) no longer errors on dbus socket

Closes #1122
Refs #1111 #1115