### PR TITLE
fix(deploy): validate LYRA_USER + use printf in nats/setup.sh (#1125)

### DIFF
--- a/deploy/nats/setup.sh
+++ b/deploy/nats/setup.sh
@@ -184,8 +184,9 @@ section "Done"
 LYRA_USER="${SUDO_USER:-$(id -un)}"
 # Security: validate LYRA_USER before any use — SUDO_USER is attacker-controllable
 # (sudo -E / env_keep). Reject anything that doesn't look like a valid Unix username.
-[[ "$LYRA_USER" =~ ^[a-z_][a-z0-9_-]*$ ]] \
-  || { echo "[!] Invalid LYRA_USER: $LYRA_USER"; exit 1; }
+# Regex matches deploy/provision.sh USER_RE — 32-char POSIX cap.
+[[ "$LYRA_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] \
+  || error "Invalid LYRA_USER: $LYRA_USER"
 LYRA_HOME=$(getent passwd "$LYRA_USER" | cut -d: -f6)
 ENV_FILE="${LYRA_DIR}/.env"
 HUB_SEED="${LYRA_HOME}/.lyra/nkeys/hub.seed"

--- a/deploy/nats/setup.sh
+++ b/deploy/nats/setup.sh
@@ -182,6 +182,10 @@ section "Done"
 
 # ── 10. Wire NATS env vars into .env ─────────────────────────────────────
 LYRA_USER="${SUDO_USER:-$(id -un)}"
+# Security: validate LYRA_USER before any use — SUDO_USER is attacker-controllable
+# (sudo -E / env_keep). Reject anything that doesn't look like a valid Unix username.
+[[ "$LYRA_USER" =~ ^[a-z_][a-z0-9_-]*$ ]] \
+  || { echo "[!] Invalid LYRA_USER: $LYRA_USER"; exit 1; }
 LYRA_HOME=$(getent passwd "$LYRA_USER" | cut -d: -f6)
 ENV_FILE="${LYRA_DIR}/.env"
 HUB_SEED="${LYRA_HOME}/.lyra/nkeys/hub.seed"
@@ -191,21 +195,21 @@ if [ -f "${ENV_FILE}" ]; then
   if grep -q "^NATS_URL=" "${ENV_FILE}"; then
     info ".env already has NATS_URL — not overwriting."
   else
-    echo "NATS_URL=tls://127.0.0.1:4222" >> "${ENV_FILE}"
+    printf 'NATS_URL=tls://127.0.0.1:4222\n' >> "${ENV_FILE}"
     info "NATS_URL=tls://127.0.0.1:4222 added to .env."
   fi
   # NATS_NKEY_SEED_PATH — nkey authentication
   if grep -q "^NATS_NKEY_SEED_PATH=" "${ENV_FILE}"; then
     info ".env already has NATS_NKEY_SEED_PATH — not overwriting."
   else
-    echo "NATS_NKEY_SEED_PATH=${HUB_SEED}" >> "${ENV_FILE}"
+    printf 'NATS_NKEY_SEED_PATH=%s\n' "${HUB_SEED}" >> "${ENV_FILE}"
     info "NATS_NKEY_SEED_PATH=${HUB_SEED} added to .env."
   fi
   # NATS_CA_CERT — CA certificate for TLS verification
   if grep -q "^NATS_CA_CERT=" "${ENV_FILE}"; then
     info ".env already has NATS_CA_CERT — not overwriting."
   else
-    echo "NATS_CA_CERT=${NATS_CA}" >> "${ENV_FILE}"
+    printf 'NATS_CA_CERT=%s\n' "${NATS_CA}" >> "${ENV_FILE}"
     info "NATS_CA_CERT=${NATS_CA} added to .env."
   fi
 else


### PR DESCRIPTION
## Summary

Security fix for shell variable injection via `SUDO_USER` in `deploy/nats/setup.sh`.

- **Validate at entry:** `LYRA_USER` is now checked against `^[a-z_][a-z0-9_-]*$` immediately after assignment; script exits 1 on mismatch (fail-closed).
- **Eliminate injection sink:** all `.env` appends that carry user-derived paths switch from `echo` to `printf 'KEY=%s\n'`, closing the newline-injection vector even if validation were bypassed.

## Security note

`SUDO_USER` is attacker-controllable when the script is invoked via `sudo -E` or a sudoers `env_keep` rule. A payload like `$'foo\nNATS_NKEY_SEED_PATH=/attacker/path'` would have injected an extra line into `.env`. The validation check is placed before `LYRA_HOME`, `HUB_SEED`, and all other derivations — nothing downstream runs with an untrusted username.

## Test plan

- [ ] `bash -n deploy/nats/setup.sh` passes (syntax OK)
- [ ] `SUDO_USER=$'foo\nNATS_NKEY_SEED_PATH=/attacker/path' <validation snippet>` → exits 1, prints `[!] Invalid LYRA_USER`
- [ ] `SUDO_USER='; touch /tmp/pwned' <validation snippet>` → exits 1
- [ ] `SUDO_USER=mickael <validation snippet>` → passes through

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)