### PR TITLE
feat(render-events): #1100 ToolCall{Start,Args,End,Result} streamed events

### DIFF
--- a/src/lyra/adapters/shared/_shared_streaming_emitter.py
+++ b/src/lyra/adapters/shared/_shared_streaming_emitter.py
@@ -90,6 +90,23 @@ class StreamingSession:
         self._outbound = outbound
         self._st = StreamState()
 
+    async def _on_toolcall_v2(
+        self,
+        event: ToolCallStartRenderEvent
+        | ToolCallArgsRenderEvent
+        | ToolCallEndRenderEvent
+        | ToolCallResultRenderEvent,
+    ) -> None:
+        """Per-platform override seam for Slice 3 (#1100) ToolCall* events.
+
+        Default no-op — parity is preserved by the v1 ``ToolSummaryRenderEvent``
+        dual-emit path that drives the existing summary-card UX. Platform
+        subclasses (Telegram, Discord) override this to render richer once they
+        migrate off v1 ToolSummary in Slice 5 (#1102). Discord's opt-in inline
+        args streaming (``LYRA_DISCORD_TOOLCALL_STREAM_ARGS``) hooks here.
+        """
+        return None
+
     async def _send_placeholder(self) -> tuple[Any, int | None] | None:
         """Send the placeholder and record reply_message_id on outbound.
 

--- a/src/lyra/adapters/shared/_shared_streaming_emitter.py
+++ b/src/lyra/adapters/shared/_shared_streaming_emitter.py
@@ -172,9 +172,11 @@ class StreamingSession:
                     # Slice 3 (#1100): ToolCall* lifecycle events. v1
                     # ``ToolSummaryRenderEvent`` is dual-emitted alongside, so
                     # the existing summary-card UX still drives the placeholder
-                    # edits below. Per-platform overrides may render richer
-                    # (e.g. Discord opt-in args streaming) by hooking into the
-                    # platform callbacks. Sunset planned in Slice 5 (#1102).
+                    # edits below. Per-platform overrides hook
+                    # ``_on_toolcall_v2`` to render richer once they migrate
+                    # off v1 ToolSummary in Slice 5 (#1102). Default is
+                    # no-op (parity).
+                    await self._on_toolcall_v2(event)
                     continue
 
                 if isinstance(event, ToolSummaryRenderEvent):

--- a/src/lyra/adapters/shared/_shared_streaming_emitter.py
+++ b/src/lyra/adapters/shared/_shared_streaming_emitter.py
@@ -24,6 +24,10 @@ from lyra.core.messaging import (
     RunFinishedRenderEvent,
     RunStartedRenderEvent,
     TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
     ToolSummaryRenderEvent,
 )
 from lyra.core.messaging.message import GENERIC_ERROR_REPLY, OutboundMessage
@@ -139,6 +143,21 @@ class StreamingSession:
                     # Slice 1 (#1098): Run lifecycle events are pure additive
                     # surface — adapters initially ignore (no UX). Future slices
                     # may render banners or expose run_id in observability.
+                    continue
+
+                if isinstance(
+                    event,
+                    ToolCallStartRenderEvent
+                    | ToolCallArgsRenderEvent
+                    | ToolCallEndRenderEvent
+                    | ToolCallResultRenderEvent,
+                ):
+                    # Slice 3 (#1100): ToolCall* lifecycle events. v1
+                    # ``ToolSummaryRenderEvent`` is dual-emitted alongside, so
+                    # the existing summary-card UX still drives the placeholder
+                    # edits below. Per-platform overrides may render richer
+                    # (e.g. Discord opt-in args streaming) by hooking into the
+                    # platform callbacks. Sunset planned in Slice 5 (#1102).
                     continue
 
                 if isinstance(event, ToolSummaryRenderEvent):

--- a/src/lyra/core/cli/cli_streaming_parser.py
+++ b/src/lyra/core/cli/cli_streaming_parser.py
@@ -84,6 +84,12 @@ class CliStreamingParser:
         # block. Text blocks and tool_use blocks without an index do not
         # participate in the args-streaming lifecycle.
         self._open_tool_blocks: dict[int, str] = {}
+        # Slice 3 dedupe (#1100 review): tool_ids for which a ToolUseLlmEvent
+        # has already been emitted. Both content_block_start and the post-hoc
+        # assistant-message path can announce the same tool_use; the second
+        # emission is silently dropped so downstream consumers see exactly one
+        # ToolUseLlmEvent per tool_id.
+        self._emitted_tool_use_ids: set[str] = set()
 
     def parse_line(self, line: str) -> deque[LlmEvent]:  # noqa: C901, PLR0912, PLR0915 — protocol event dispatch
         """Parse a JSON line, update state, and return events to yield.
@@ -146,11 +152,22 @@ class CliStreamingParser:
         elif msg_type == "assistant":
             blocks = data.get("message", {}).get("content", [])
             for b in blocks:
-                if b.get("type") == "tool_use":
+                if b.get("type") == _BLOCK_TYPE_TOOL_USE:
+                    tool_id = b.get("id", "")
+                    # Slice 3 dedupe (#1100 review): CLI emits the tool_use
+                    # block twice — once at content_block_start (input={}) and
+                    # again post-hoc here (input populated). Skip the post-hoc
+                    # duplicate when the streaming path already announced this
+                    # tool_id; the args dict is reconstructed from
+                    # ToolUseDeltaLlmEvent stream downstream.
+                    if tool_id and tool_id in self._emitted_tool_use_ids:
+                        continue
+                    if tool_id:
+                        self._emitted_tool_use_ids.add(tool_id)
                     self._pending.append(
                         ToolUseLlmEvent(
                             tool_name=b.get("name", ""),
-                            tool_id=b.get("id", ""),
+                            tool_id=tool_id,
                             input=b.get("input", {}),
                         )
                     )
@@ -165,13 +182,15 @@ class CliStreamingParser:
                     idx = event_data.get("index")
                     if isinstance(idx, int) and tool_id:
                         self._open_tool_blocks[idx] = tool_id
-                    self._pending.append(
-                        ToolUseLlmEvent(
-                            tool_name=cb.get("name", ""),
-                            tool_id=tool_id,
-                            input={},
+                    if tool_id and tool_id not in self._emitted_tool_use_ids:
+                        self._emitted_tool_use_ids.add(tool_id)
+                        self._pending.append(
+                            ToolUseLlmEvent(
+                                tool_name=cb.get("name", ""),
+                                tool_id=tool_id,
+                                input={},
+                            )
                         )
-                    )
             elif event_type == "content_block_delta":
                 delta = event_data.get("delta", {})
                 delta_type = delta.get("type", "")

--- a/src/lyra/core/cli/cli_streaming_parser.py
+++ b/src/lyra/core/cli/cli_streaming_parser.py
@@ -12,8 +12,22 @@ from collections import deque
 
 from roxabi_contracts.errors import KNOWN_CODES, WorkerError
 
-from ..messaging.events import LlmEvent, ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
+from ..messaging.events import (
+    LlmEvent,
+    ResultLlmEvent,
+    TextLlmEvent,
+    ToolResultLlmEvent,
+    ToolUseDeltaLlmEvent,
+    ToolUseEndLlmEvent,
+    ToolUseLlmEvent,
+)
 from ..messaging.metrics import emit_populated_total
+
+# Anthropic CLI NDJSON wire constants — kept here so the parser is the single
+# source of truth on what shapes upstream emits.
+_DELTA_INPUT_JSON = "input_json_delta"
+_BLOCK_TYPE_TOOL_USE = "tool_use"
+_BLOCK_TYPE_TOOL_RESULT = "tool_result"
 
 log = logging.getLogger(__name__)
 
@@ -64,6 +78,12 @@ class CliStreamingParser:
         self._had_text_delta = False
         self._done = False
         self._pending: deque[LlmEvent] = deque()
+        # Slice 3 (#1100): index → tool_id map for content_block_delta /
+        # content_block_stop correlation. Only populated when the CLI provides
+        # an `index` field on the content_block_start event for a tool_use
+        # block. Text blocks and tool_use blocks without an index do not
+        # participate in the args-streaming lifecycle.
+        self._open_tool_blocks: dict[int, str] = {}
 
     def parse_line(self, line: str) -> deque[LlmEvent]:  # noqa: C901, PLR0912, PLR0915 — protocol event dispatch
         """Parse a JSON line, update state, and return events to yield.
@@ -140,21 +160,72 @@ class CliStreamingParser:
             event_type = event_data.get("type", "")
             if event_type == "content_block_start":
                 cb = event_data.get("content_block", {})
-                if cb.get("type") == "tool_use":
+                if cb.get("type") == _BLOCK_TYPE_TOOL_USE:
+                    tool_id = cb.get("id", "")
+                    idx = event_data.get("index")
+                    if isinstance(idx, int) and tool_id:
+                        self._open_tool_blocks[idx] = tool_id
                     self._pending.append(
                         ToolUseLlmEvent(
                             tool_name=cb.get("name", ""),
-                            tool_id=cb.get("id", ""),
+                            tool_id=tool_id,
                             input={},
                         )
                     )
             elif event_type == "content_block_delta":
                 delta = event_data.get("delta", {})
-                if delta.get("type") == "text_delta":
+                delta_type = delta.get("type", "")
+                if delta_type == "text_delta":
                     text = delta.get("text", "")
                     if text:
                         self._had_text_delta = True
                         self._pending.append(TextLlmEvent(text=text))
+                elif delta_type == _DELTA_INPUT_JSON:
+                    idx = event_data.get("index")
+                    partial_json = delta.get("partial_json", "")
+                    if (
+                        isinstance(idx, int)
+                        and idx in self._open_tool_blocks
+                        and partial_json
+                    ):
+                        self._pending.append(
+                            ToolUseDeltaLlmEvent(
+                                tool_id=self._open_tool_blocks[idx],
+                                partial_json=partial_json,
+                            )
+                        )
+            elif event_type == "content_block_stop":
+                idx = event_data.get("index")
+                if isinstance(idx, int) and idx in self._open_tool_blocks:
+                    self._pending.append(
+                        ToolUseEndLlmEvent(tool_id=self._open_tool_blocks.pop(idx))
+                    )
+
+        elif msg_type == "user":
+            blocks = data.get("message", {}).get("content", [])
+            for b in blocks:
+                if b.get("type") != _BLOCK_TYPE_TOOL_RESULT:
+                    continue
+                content = b.get("content", "")
+                # Anthropic CLI may pack content as a list of typed blocks.
+                # Render text-only this slice; non-text blocks placeholder as
+                # `[{type}]` so non-renderable payloads never silently vanish.
+                if isinstance(content, list):
+                    parts = []
+                    for blk in content:
+                        if isinstance(blk, dict):
+                            if blk.get("type") == "text":
+                                parts.append(str(blk.get("text", "")))
+                            else:
+                                parts.append(f"[{blk.get('type', '?')}]")
+                    content = "".join(parts)
+                self._pending.append(
+                    ToolResultLlmEvent(
+                        tool_id=b.get("tool_use_id", ""),
+                        content=str(content),
+                        is_error=bool(b.get("is_error", False)),
+                    )
+                )
 
         elif msg_type == "result":
             sid = data.get("session_id", "")

--- a/src/lyra/core/messaging/__init__.py
+++ b/src/lyra/core/messaging/__init__.py
@@ -16,6 +16,10 @@ from .render_events import (
     RunFinishedRenderEvent,
     RunStartedRenderEvent,
     TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
     ToolSummaryRenderEvent,
 )
 
@@ -35,5 +39,9 @@ __all__ = [
     "SessionUpdateFn",
     "TelegramMeta",
     "TextRenderEvent",
+    "ToolCallArgsRenderEvent",
+    "ToolCallEndRenderEvent",
+    "ToolCallResultRenderEvent",
+    "ToolCallStartRenderEvent",
     "ToolSummaryRenderEvent",
 ]

--- a/src/lyra/core/messaging/events.py
+++ b/src/lyra/core/messaging/events.py
@@ -49,6 +49,46 @@ class ToolUseLlmEvent:
 
 
 @dataclass(frozen=True)
+class ToolUseDeltaLlmEvent:
+    """Tool-use input streaming chunk (partial JSON fragment).
+
+    Slice 3 of #1096. Emitted on Anthropic CLI ``content_block_delta`` events
+    whose ``delta.type == "input_json_delta"`` (per ADR-028
+    ``--include-partial-messages``). ``partial_json`` is only valid JSON when
+    concatenated with the rest of the deltas for the same ``tool_id``.
+    """
+
+    tool_id: str
+    partial_json: str
+
+
+@dataclass(frozen=True)
+class ToolUseEndLlmEvent:
+    """Tool-use content block end (input streaming complete).
+
+    Slice 3 of #1096. Emitted on Anthropic CLI ``content_block_stop`` events
+    that close a previously-opened ``tool_use`` block.
+    """
+
+    tool_id: str
+
+
+@dataclass(frozen=True)
+class ToolResultLlmEvent:
+    """Tool execution result, paired by ``tool_id`` with a prior ``ToolUseLlmEvent``.
+
+    Slice 3 of #1096. Emitted on Anthropic CLI user-message blocks of
+    ``type=tool_result``. ``content`` is rendered text-only this slice;
+    list-of-typed-blocks are concatenated with ``[{type}]`` placeholders for
+    non-text blocks (rich rendering deferred to a later slice).
+    """
+
+    tool_id: str
+    content: str
+    is_error: bool = False
+
+
+@dataclass(frozen=True)
 class ResultLlmEvent:
     """Final event in every stream — signals turn completion.
 
@@ -70,11 +110,21 @@ class ResultLlmEvent:
 
 
 # Union type exported for type annotations and ``isinstance`` checks.
-LlmEvent = TextLlmEvent | ToolUseLlmEvent | ResultLlmEvent
+LlmEvent = (
+    TextLlmEvent
+    | ToolUseLlmEvent
+    | ToolUseDeltaLlmEvent
+    | ToolUseEndLlmEvent
+    | ToolResultLlmEvent
+    | ResultLlmEvent
+)
 
 __all__ = [
     "LlmEvent",
     "ResultLlmEvent",
     "TextLlmEvent",
+    "ToolResultLlmEvent",
+    "ToolUseDeltaLlmEvent",
+    "ToolUseEndLlmEvent",
     "ToolUseLlmEvent",
 ]

--- a/src/lyra/core/messaging/render_events.py
+++ b/src/lyra/core/messaging/render_events.py
@@ -25,6 +25,10 @@ SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT = 1
 SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT = 1
 SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT = 1
 SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT = 1
+SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT = 1
+SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT = 1
+SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT = 1
+SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT = 1
 
 
 @dataclass(frozen=True)
@@ -150,6 +154,65 @@ class RunErrorRenderEvent:
     schema_version: int = SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT
 
 
+@dataclass(frozen=True)
+class ToolCallStartRenderEvent:
+    """Tool-call lifecycle: a single tool invocation begins.
+
+    Slice 3 of #1096. Streamed alternative to the post-hoc
+    ``ToolSummaryRenderEvent`` accumulator. ``tool_call_id`` is the cross-event
+    correlator — a verbatim pass-through of the CLI's ``content_block.id`` for
+    the corresponding ``tool_use`` block.
+    """
+
+    tool_call_id: str
+    tool_name: str
+    schema_version: int = SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT
+
+
+@dataclass(frozen=True)
+class ToolCallArgsRenderEvent:
+    """Tool-call lifecycle: a chunk of streamed tool input arguments.
+
+    ``delta`` is a *partial JSON fragment* (e.g. ``'{"foo": '``) — it is only
+    valid JSON when concatenated with the rest of the deltas for the same
+    ``tool_call_id``. Adapters that need parsed args wait for ``ToolCallEnd``
+    and reconstruct from accumulated deltas.
+    """
+
+    tool_call_id: str
+    delta: str
+    schema_version: int = SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT
+
+
+@dataclass(frozen=True)
+class ToolCallEndRenderEvent:
+    """Tool-call lifecycle: tool input streaming complete (no more args).
+
+    Emitted on the CLI's ``content_block_stop`` for the corresponding
+    ``tool_use`` block, OR synthesized by ``StreamProcessor`` at end-of-turn
+    for any ``tool_call_id`` that saw a ``Start`` but no matching ``stop``
+    (orphan recovery; logged at WARN level).
+    """
+
+    tool_call_id: str
+    schema_version: int = SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT
+
+
+@dataclass(frozen=True)
+class ToolCallResultRenderEvent:
+    """Tool-call lifecycle: the executed tool returned a result.
+
+    Emitted from the CLI's user-message ``tool_result`` block. ``content`` is
+    rendered text-only this slice — list-of-typed-blocks are concatenated with
+    placeholders for non-text content (rich rendering deferred).
+    """
+
+    tool_call_id: str
+    content: str
+    is_error: bool = False
+    schema_version: int = SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT
+
+
 # Union type exported for type annotations and ``isinstance`` checks.
 RenderEvent = (
     TextRenderEvent
@@ -157,6 +220,10 @@ RenderEvent = (
     | RunStartedRenderEvent
     | RunFinishedRenderEvent
     | RunErrorRenderEvent
+    | ToolCallStartRenderEvent
+    | ToolCallArgsRenderEvent
+    | ToolCallEndRenderEvent
+    | ToolCallResultRenderEvent
 )
 
 __all__ = [
@@ -169,8 +236,16 @@ __all__ = [
     "SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT",
     "SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT",
     "SCHEMA_VERSION_TEXT_RENDER_EVENT",
+    "SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT",
+    "SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT",
+    "SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT",
+    "SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT",
     "SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT",
     "SilentCounts",
     "TextRenderEvent",
+    "ToolCallArgsRenderEvent",
+    "ToolCallEndRenderEvent",
+    "ToolCallResultRenderEvent",
+    "ToolCallStartRenderEvent",
     "ToolSummaryRenderEvent",
 ]

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -20,8 +20,10 @@ Only stdlib and lyra-internal modules may be used.
 
 from __future__ import annotations
 
+import logging
 import time
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
+from typing import assert_never
 
 from lyra.core.messaging.error_extractor import _extract_worker_error
 from lyra.core.messaging.events import (
@@ -51,6 +53,49 @@ from lyra.core.messaging.render_events import (
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
 from lyra.core.trace import TraceContext
 from roxabi_contracts.errors import KNOWN_CODES
+
+log = logging.getLogger(__name__)
+
+# Slice 3 (#1100 review) — security boundary for ToolCallResultRenderEvent.
+# ``ToolResultLlmEvent.content`` carries raw tool output (file contents, shell
+# stdout, etc.). The output is published on the NATS bus where any subscriber
+# can read it. Mirror the ``RunErrorRenderEvent`` discipline:
+#  * for tools known to read sensitive payloads (Read/Bash/Edit/Write), replace
+#    content with a fixed redaction placeholder before encoding.
+#  * for everything else, truncate to MAX_CONTENT_BYTES with a ``[…truncated]``
+#    sentinel so a runaway tool output cannot exceed NATS message limits.
+_SENSITIVE_TOOL_NAMES_FOR_REDACTION: frozenset[str] = frozenset(
+    {"read", "bash", "edit", "write"}
+)
+_MAX_CONTENT_BYTES = 65_536
+_REDACTED_PLACEHOLDER = "[redacted — tool output suppressed for security]"
+_TRUNCATED_SENTINEL = "…[truncated]"
+
+
+def _sanitize_tool_result_content(content: str, tool_name: str | None) -> str:
+    """Apply secret-leak guard + size cap to ``ToolCallResultRenderEvent.content``.
+
+    Returns either:
+      * the redaction placeholder when the tool name matches a sensitive set
+        (file/shell I/O — file paths in errors, secrets in env, etc.), or
+      * the truncated content with a sentinel when length exceeds the NATS
+        message size budget, or
+      * the content unchanged.
+
+    ``tool_name`` is `None` when the parser receives a ``tool_result`` block
+    whose ``tool_use_id`` did not correlate with a prior ``ToolUseLlmEvent``
+    (orphan result). Treat orphans as sensitive — fail closed.
+    """
+    if tool_name is None or tool_name.lower() in _SENSITIVE_TOOL_NAMES_FOR_REDACTION:
+        return _REDACTED_PLACEHOLDER
+    encoded = content.encode("utf-8", errors="replace")
+    if len(encoded) <= _MAX_CONTENT_BYTES:
+        return content
+    sentinel_bytes = len(_TRUNCATED_SENTINEL.encode("utf-8"))
+    truncated = encoded[: _MAX_CONTENT_BYTES - sentinel_bytes].decode(
+        "utf-8", errors="ignore"
+    )
+    return f"{truncated}{_TRUNCATED_SENTINEL}"
 
 
 class StreamProcessor:
@@ -97,14 +142,17 @@ class StreamProcessor:
         self._pending_text: str = ""
 
         # --- Slice 3 (#1100) ToolCall* lifecycle state ---
-        # Dedupe: parser emits ``ToolUseLlmEvent`` from BOTH the streaming
-        # ``content_block_start`` path AND the post-hoc ``assistant``-message
-        # path. The second occurrence for the same ``tool_id`` is dropped.
-        self._seen_tool_ids: set[str] = set()
         # Open-call tracker for orphan ``ToolCallEnd`` synthesis. Populated on
         # ``ToolCallStart`` emission, cleared on ``ToolCallEnd``. Anything still
         # in the set at ``ResultLlmEvent`` time gets a synthesized end event.
+        # Dedupe of duplicate ``ToolUseLlmEvent``s lives in the parser
+        # (``cli_streaming_parser._emitted_tool_use_ids``) — wire-level
+        # artifacts of the Anthropic CLI stay below the application boundary.
         self._open_tool_call_ids: set[str] = set()
+        # tool_id → tool_name map populated on ``ToolUseLlmEvent`` so the
+        # ``_sanitize_tool_result_content`` boundary scrubber can decide whether
+        # to redact based on tool name (Read/Bash/Edit/Write are sensitive).
+        self._tool_id_to_name: dict[str, str] = {}
 
         # --- reuse guard ---
         self._consumed: bool = False
@@ -157,9 +205,12 @@ class StreamProcessor:
                     yield ToolCallEndRenderEvent(tool_call_id=event.tool_id)
 
                 elif isinstance(event, ToolResultLlmEvent):
+                    tool_name = self._tool_id_to_name.get(event.tool_id)
                     yield ToolCallResultRenderEvent(
                         tool_call_id=event.tool_id,
-                        content=event.content,
+                        content=_sanitize_tool_result_content(
+                            event.content, tool_name
+                        ),
                         is_error=event.is_error,
                     )
 
@@ -194,14 +245,12 @@ class StreamProcessor:
                     )
 
                 else:
-                    # Defensive: pyright's exhaustiveness on the LlmEvent union
-                    # makes this branch unreachable at type-check time. Kept as
-                    # a runtime guard against silent drop if the union widens
-                    # without dispatch update.
-                    raise TypeError(  # pyright: ignore[reportUnreachable]
-                        f"StreamProcessor.process: unhandled LlmEvent "
-                        f"{type(event).__name__}"
-                    )
+                    # Cross-slice invariant 3: no silent event drop. When the
+                    # ``LlmEvent`` union widens (e.g. Slice 4 reasoning events)
+                    # without updating this dispatch, ``assert_never`` surfaces
+                    # the gap at pyright time AND raises ``AssertionError`` at
+                    # runtime so a missing branch is never silently swallowed.
+                    assert_never(event)
 
             # Stream ended without ResultLlmEvent (truncation or upstream error)
             if not _result_received:
@@ -249,23 +298,19 @@ class StreamProcessor:
         """Handle a single ``ToolUseLlmEvent``, yielding any resulting ``RenderEvent``s.
 
         Slice 3 (#1100) emits ``ToolCallStartRenderEvent`` with cross-event
-        ``tool_call_id`` correlator. The parser emits ``ToolUseLlmEvent`` from
-        BOTH the streaming ``content_block_start`` path AND the post-hoc
-        ``assistant``-message path; we dedupe by ``tool_id`` so adapters see
-        exactly one ``ToolCallStart`` per call.
+        ``tool_call_id`` correlator. The parser already deduplicates the dual
+        emission of ``ToolUseLlmEvent`` (streaming + post-hoc paths), so this
+        handler sees each ``tool_id`` exactly once.
 
         Flushes pending text as an intermediate event when ``show_intermediate``
         is enabled, then accumulates the tool call (v1 ``ToolSummaryRenderEvent``
         dual-emit, kept until Slice 5).
         """
-        # Slice 3 dedupe: drop second emission for the same tool_id.
-        is_dupe = event.tool_id in self._seen_tool_ids
-        if not is_dupe:
-            self._seen_tool_ids.add(event.tool_id)
-            self._open_tool_call_ids.add(event.tool_id)
-            yield ToolCallStartRenderEvent(
-                tool_call_id=event.tool_id, tool_name=event.tool_name
-            )
+        self._open_tool_call_ids.add(event.tool_id)
+        self._tool_id_to_name[event.tool_id] = event.tool_name
+        yield ToolCallStartRenderEvent(
+            tool_call_id=event.tool_id, tool_name=event.tool_name
+        )
 
         # Flush any text accumulated before this tool call so adapters
         # can show inter-tool text progressively (show_intermediate gate).
@@ -287,26 +332,24 @@ class StreamProcessor:
 
     def _synth_orphan_tool_ends(
         self,
-    ) -> "list[ToolCallEndRenderEvent]":
+    ) -> Iterator[ToolCallEndRenderEvent]:
         """Synthesize ``ToolCallEndRenderEvent`` for any open tool_call_ids.
 
-        Called at ``ResultLlmEvent`` time (or at stream-end without result).
-        Tool calls that started but never received a ``content_block_stop``
-        leave adapters with a dangling open-call card; the synthesized end
-        closes it. WARN-logged once per orphan.
+        Called at ``ResultLlmEvent`` time. Tool calls that started but never
+        received a ``content_block_stop`` leave adapters with a dangling
+        open-call card; the synthesized end closes it. WARN-logged once per
+        orphan with a truncated id (last 6 chars) so cross-session correlation
+        of the full opaque tool_call_id is not exposed in shared log
+        aggregation (#1100 review S2).
         """
-        import logging
-
-        log = logging.getLogger(__name__)
-        events: list[ToolCallEndRenderEvent] = []
         for tid in sorted(self._open_tool_call_ids):
             log.warning(
-                "StreamProcessor: synthesizing orphan ToolCallEnd for tool_call_id=%s",
-                tid,
+                "StreamProcessor: synthesizing orphan ToolCallEnd for "
+                "tool_call_id=…%s",
+                tid[-6:],
             )
-            events.append(ToolCallEndRenderEvent(tool_call_id=tid))
+            yield ToolCallEndRenderEvent(tool_call_id=tid)
         self._open_tool_call_ids.clear()
-        return events
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -24,7 +24,15 @@ import time
 from collections.abc import AsyncGenerator, AsyncIterator
 
 from lyra.core.messaging.error_extractor import _extract_worker_error
-from lyra.core.messaging.events import LlmEvent, TextLlmEvent, ToolUseLlmEvent
+from lyra.core.messaging.events import (
+    LlmEvent,
+    ResultLlmEvent,
+    TextLlmEvent,
+    ToolResultLlmEvent,
+    ToolUseDeltaLlmEvent,
+    ToolUseEndLlmEvent,
+    ToolUseLlmEvent,
+)
 from lyra.core.messaging.metrics import emit_received_total
 from lyra.core.messaging.render_events import (
     FileEditSummary,
@@ -34,6 +42,10 @@ from lyra.core.messaging.render_events import (
     RunStartedRenderEvent,
     SilentCounts,
     TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
     ToolSummaryRenderEvent,
 )
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
@@ -84,6 +96,16 @@ class StreamProcessor:
         # --- pending text ---
         self._pending_text: str = ""
 
+        # --- Slice 3 (#1100) ToolCall* lifecycle state ---
+        # Dedupe: parser emits ``ToolUseLlmEvent`` from BOTH the streaming
+        # ``content_block_start`` path AND the post-hoc ``assistant``-message
+        # path. The second occurrence for the same ``tool_id`` is dropped.
+        self._seen_tool_ids: set[str] = set()
+        # Open-call tracker for orphan ``ToolCallEnd`` synthesis. Populated on
+        # ``ToolCallStart`` emission, cleared on ``ToolCallEnd``. Anything still
+        # in the set at ``ResultLlmEvent`` time gets a synthesized end event.
+        self._open_tool_call_ids: set[str] = set()
+
         # --- reuse guard ---
         self._consumed: bool = False
 
@@ -91,7 +113,7 @@ class StreamProcessor:
     # Public interface
     # ------------------------------------------------------------------
 
-    async def process(  # noqa: C901 — event-type dispatch + terminal fallbacks
+    async def process(  # noqa: C901, PLR0915 — event-type dispatch + terminal fallbacks
         self, events: AsyncIterator[LlmEvent]
     ) -> AsyncGenerator[RenderEvent, None]:
         """Process an async stream of ``LlmEvent`` objects.
@@ -125,8 +147,29 @@ class StreamProcessor:
                     async for render_event in self._handle_tool_event(event):
                         yield render_event
 
-                else:  # ResultLlmEvent
+                elif isinstance(event, ToolUseDeltaLlmEvent):
+                    yield ToolCallArgsRenderEvent(
+                        tool_call_id=event.tool_id, delta=event.partial_json
+                    )
+
+                elif isinstance(event, ToolUseEndLlmEvent):
+                    self._open_tool_call_ids.discard(event.tool_id)
+                    yield ToolCallEndRenderEvent(tool_call_id=event.tool_id)
+
+                elif isinstance(event, ToolResultLlmEvent):
+                    yield ToolCallResultRenderEvent(
+                        tool_call_id=event.tool_id,
+                        content=event.content,
+                        is_error=event.is_error,
+                    )
+
+                elif isinstance(event, ResultLlmEvent):  # pyright: ignore[reportUnnecessaryIsInstance]
                     _result_received = True
+                    # Synthesize ToolCallEnd for any open tool_call_ids that
+                    # never received a content_block_stop (truncated stream,
+                    # partial tool call). Loud WARN log per orphan.
+                    for orphan_event in self._synth_orphan_tool_ends():
+                        yield orphan_event
                     if self._has_any_tool_events():
                         yield self._emit_snapshot(is_complete=True)
                     # On error with no streamed text, surface the structured WorkerError
@@ -148,6 +191,16 @@ class StreamProcessor:
                         text=final_text,
                         is_final=True,
                         is_error=event.is_error,  # #392: propagate error state
+                    )
+
+                else:
+                    # Defensive: pyright's exhaustiveness on the LlmEvent union
+                    # makes this branch unreachable at type-check time. Kept as
+                    # a runtime guard against silent drop if the union widens
+                    # without dispatch update.
+                    raise TypeError(  # pyright: ignore[reportUnreachable]
+                        f"StreamProcessor.process: unhandled LlmEvent "
+                        f"{type(event).__name__}"
                     )
 
             # Stream ended without ResultLlmEvent (truncation or upstream error)
@@ -195,16 +248,25 @@ class StreamProcessor:
     ) -> AsyncGenerator[RenderEvent, None]:
         """Handle a single ``ToolUseLlmEvent``, yielding any resulting ``RenderEvent``s.
 
-        Flushes pending text as an intermediate event when ``show_intermediate``
-        is enabled, then accumulates the tool call and emits a throttled
-        ``ToolSummaryRenderEvent`` if the window has elapsed.
+        Slice 3 (#1100) emits ``ToolCallStartRenderEvent`` with cross-event
+        ``tool_call_id`` correlator. The parser emits ``ToolUseLlmEvent`` from
+        BOTH the streaming ``content_block_start`` path AND the post-hoc
+        ``assistant``-message path; we dedupe by ``tool_id`` so adapters see
+        exactly one ``ToolCallStart`` per call.
 
-        When intermediate text is flushed, the ``ToolSummaryRenderEvent`` is
-        intentionally skipped for this iteration so adapters have time to display
-        the text before the tool card overwrites it.  The summary will still be
-        emitted by the next tool event (once the throttle window elapses) or
-        unconditionally by the final ``ResultLlmEvent``.
+        Flushes pending text as an intermediate event when ``show_intermediate``
+        is enabled, then accumulates the tool call (v1 ``ToolSummaryRenderEvent``
+        dual-emit, kept until Slice 5).
         """
+        # Slice 3 dedupe: drop second emission for the same tool_id.
+        is_dupe = event.tool_id in self._seen_tool_ids
+        if not is_dupe:
+            self._seen_tool_ids.add(event.tool_id)
+            self._open_tool_call_ids.add(event.tool_id)
+            yield ToolCallStartRenderEvent(
+                tool_call_id=event.tool_id, tool_name=event.tool_name
+            )
+
         # Flush any text accumulated before this tool call so adapters
         # can show inter-tool text progressively (show_intermediate gate).
         flushed_intermediate = False
@@ -222,6 +284,29 @@ class StreamProcessor:
             and self._has_any_tool_events()
         ):
             yield self._emit_snapshot()
+
+    def _synth_orphan_tool_ends(
+        self,
+    ) -> "list[ToolCallEndRenderEvent]":
+        """Synthesize ``ToolCallEndRenderEvent`` for any open tool_call_ids.
+
+        Called at ``ResultLlmEvent`` time (or at stream-end without result).
+        Tool calls that started but never received a ``content_block_stop``
+        leave adapters with a dangling open-call card; the synthesized end
+        closes it. WARN-logged once per orphan.
+        """
+        import logging
+
+        log = logging.getLogger(__name__)
+        events: list[ToolCallEndRenderEvent] = []
+        for tid in sorted(self._open_tool_call_ids):
+            log.warning(
+                "StreamProcessor: synthesizing orphan ToolCallEnd for tool_call_id=%s",
+                tid,
+            )
+            events.append(ToolCallEndRenderEvent(tool_call_id=tid))
+        self._open_tool_call_ids.clear()
+        return events
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -58,14 +58,20 @@ log = logging.getLogger(__name__)
 
 # Slice 3 (#1100 review) — security boundary for ToolCallResultRenderEvent.
 # ``ToolResultLlmEvent.content`` carries raw tool output (file contents, shell
-# stdout, etc.). The output is published on the NATS bus where any subscriber
-# can read it. Mirror the ``RunErrorRenderEvent`` discipline:
-#  * for tools known to read sensitive payloads (Read/Bash/Edit/Write), replace
-#    content with a fixed redaction placeholder before encoding.
-#  * for everything else, truncate to MAX_CONTENT_BYTES with a ``[…truncated]``
-#    sentinel so a runaway tool output cannot exceed NATS message limits.
-_SENSITIVE_TOOL_NAMES_FOR_REDACTION: frozenset[str] = frozenset(
-    {"read", "bash", "edit", "write"}
+# stdout, web fetch responses, etc.). The output is published on the NATS bus
+# where any subscriber can read it. Mirror the ``RunErrorRenderEvent``
+# discipline: secure-by-default — redact unless explicitly safe.
+#
+# Rationale (per #1131 iter-2 review): an inclusion list of "sensitive" names
+# leaves any future tool (MCP servers, ``WebFetch`` to a metadata endpoint,
+# third-party plugins) leaking credentials unredacted. The allowlist below
+# names tools that return path-only / structural data — never file content,
+# shell output, or arbitrary network responses. Everything else is redacted
+# by default. Slice 5 (#1102) is the natural place to refine with a per-tool
+# ``is_sensitive: bool`` flag in ``ToolDisplayConfig`` if richer rendering is
+# needed.
+_NON_SENSITIVE_TOOL_NAMES: frozenset[str] = frozenset(
+    {"glob", "grep", "ls", "todoread", "todowrite"}
 )
 _MAX_CONTENT_BYTES = 65_536
 _REDACTED_PLACEHOLDER = "[redacted — tool output suppressed for security]"
@@ -75,18 +81,16 @@ _TRUNCATED_SENTINEL = "…[truncated]"
 def _sanitize_tool_result_content(content: str, tool_name: str | None) -> str:
     """Apply secret-leak guard + size cap to ``ToolCallResultRenderEvent.content``.
 
-    Returns either:
-      * the redaction placeholder when the tool name matches a sensitive set
-        (file/shell I/O — file paths in errors, secrets in env, etc.), or
-      * the truncated content with a sentinel when length exceeds the NATS
-        message size budget, or
-      * the content unchanged.
+    Secure-by-default: returns the redaction placeholder UNLESS the tool name
+    is in the explicit ``_NON_SENSITIVE_TOOL_NAMES`` allowlist (path-only or
+    structural-data tools). For allowlisted tools, content passes through with
+    only the size cap applied.
 
-    ``tool_name`` is `None` when the parser receives a ``tool_result`` block
+    ``tool_name`` is ``None`` when the parser receives a ``tool_result`` block
     whose ``tool_use_id`` did not correlate with a prior ``ToolUseLlmEvent``
-    (orphan result). Treat orphans as sensitive — fail closed.
+    (orphan result). Treated as sensitive — fail-closed.
     """
-    if tool_name is None or tool_name.lower() in _SENSITIVE_TOOL_NAMES_FOR_REDACTION:
+    if tool_name is None or tool_name.lower() not in _NON_SENSITIVE_TOOL_NAMES:
         return _REDACTED_PLACEHOLDER
     encoded = content.encode("utf-8", errors="replace")
     if len(encoded) <= _MAX_CONTENT_BYTES:

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -15,6 +15,10 @@ from lyra.core.messaging.render_events import (
     SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT,
     SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT,
     SCHEMA_VERSION_TEXT_RENDER_EVENT,
+    SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT,
+    SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT,
+    SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT,
+    SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT,
     SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT,
     FileEditSummary,
     RenderEvent,
@@ -23,6 +27,10 @@ from lyra.core.messaging.render_events import (
     RunStartedRenderEvent,
     SilentCounts,
     TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
     ToolSummaryRenderEvent,
 )
 from lyra.nats.type_registry import TYPE_REGISTRY_RESOLVER
@@ -74,8 +82,16 @@ class NatsRenderEventCodec:
             return "run_started", payload, False
         if isinstance(event, RunFinishedRenderEvent):
             return "run_finished", payload, True
-        if isinstance(event, RunErrorRenderEvent):  # pyright: ignore[reportUnnecessaryIsInstance]
+        if isinstance(event, RunErrorRenderEvent):
             return "run_error", payload, True
+        if isinstance(event, ToolCallStartRenderEvent):
+            return "tool_call_start", payload, False
+        if isinstance(event, ToolCallArgsRenderEvent):
+            return "tool_call_args", payload, False
+        if isinstance(event, ToolCallEndRenderEvent):
+            return "tool_call_end", payload, False
+        if isinstance(event, ToolCallResultRenderEvent):  # pyright: ignore[reportUnnecessaryIsInstance]
+            return "tool_call_result", payload, False
         raise TypeError(  # pyright: ignore[reportUnreachable]
             f"Unsupported RenderEvent subtype: {type(event)!r}"
         )
@@ -172,6 +188,58 @@ class NatsRenderEventCodec:
             return deserialize(
                 json.dumps(payload, ensure_ascii=False).encode("utf-8"),
                 RunErrorRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "tool_call_start":
+            if not check_schema_version(
+                payload,
+                envelope_name="ToolCallStartRenderEvent",
+                expected=SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                ToolCallStartRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "tool_call_args":
+            if not check_schema_version(
+                payload,
+                envelope_name="ToolCallArgsRenderEvent",
+                expected=SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                ToolCallArgsRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "tool_call_end":
+            if not check_schema_version(
+                payload,
+                envelope_name="ToolCallEndRenderEvent",
+                expected=SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                ToolCallEndRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "tool_call_result":
+            if not check_schema_version(
+                payload,
+                envelope_name="ToolCallResultRenderEvent",
+                expected=SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                ToolCallResultRenderEvent,
                 resolver=self._resolver,
             )
         if event_type == "stream_end":

--- a/tests/adapters/test_streaming_emitter_toolcall_v2.py
+++ b/tests/adapters/test_streaming_emitter_toolcall_v2.py
@@ -103,3 +103,44 @@ class TestSharedEmitterIgnoresToolCallV2:
             )
         )
         cb.edit_placeholder_tool.assert_called()  # type: ignore[attr-defined]
+
+    async def test_subclass_override_receives_toolcall_v2(self) -> None:
+        """PL1 (#1100 review): _on_toolcall_v2 override seam is invoked.
+
+        Ensures the dispatch actually awaits the method on the session, so
+        platform subclasses can render richer when they migrate off v1.
+        """
+        captured: list[RenderEvent] = []
+
+        class _RecordingSession(StreamingSession):
+            async def _on_toolcall_v2(
+                self,
+                event: ToolCallStartRenderEvent
+                | ToolCallArgsRenderEvent
+                | ToolCallEndRenderEvent
+                | ToolCallResultRenderEvent,
+            ) -> None:
+                captured.append(event)
+
+        cb = _make_callbacks()
+        outbound = OutboundMessage.from_text("hi")
+        session = _RecordingSession(cb, outbound=outbound)
+        await session.run(
+            _events(
+                RunStartedRenderEvent(run_id="r1"),
+                ToolCallStartRenderEvent(tool_call_id="t1", tool_name="Read"),
+                ToolCallArgsRenderEvent(tool_call_id="t1", delta='{"k":'),
+                ToolCallEndRenderEvent(tool_call_id="t1"),
+                ToolCallResultRenderEvent(tool_call_id="t1", content="ok"),
+                TextRenderEvent("bye", is_final=True),
+                RunFinishedRenderEvent(run_id="r1"),
+            )
+        )
+        # All 4 ToolCall* event types must reach the override.
+        types = [type(e).__name__ for e in captured]
+        assert types == [
+            "ToolCallStartRenderEvent",
+            "ToolCallArgsRenderEvent",
+            "ToolCallEndRenderEvent",
+            "ToolCallResultRenderEvent",
+        ]

--- a/tests/adapters/test_streaming_emitter_toolcall_v2.py
+++ b/tests/adapters/test_streaming_emitter_toolcall_v2.py
@@ -1,0 +1,105 @@
+"""Slice 3 of #1096: shared streaming emitter must ignore ToolCall* v2 events.
+
+Adapter parity story: Slice 3 emits ToolCall{Start,Args,End,Result} v2 events
+alongside the v1 ``ToolSummaryRenderEvent`` (dual-emit, per umbrella resolved
+decision 6). The existing v1-driven UX (Telegram edit-in-place, Discord embed)
+must continue to drive what the user sees — adapters skip the v2 events for
+parity until Slice 5 sunsets v1.
+
+Discord opt-in inline args streaming is deferred to a follow-up issue
+(``LYRA_DISCORD_TOOLCALL_STREAM_ARGS`` flag — not implemented this slice).
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+from lyra.adapters.shared._shared_streaming import PlatformCallbacks, StreamingSession
+from lyra.core.messaging.message import OutboundMessage
+from lyra.core.messaging.render_events import (
+    RenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
+    TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
+    ToolSummaryRenderEvent,
+)
+
+
+def _make_callbacks() -> PlatformCallbacks:
+    return PlatformCallbacks(
+        send_placeholder=AsyncMock(return_value=(object(), 42)),
+        edit_placeholder_text=AsyncMock(),
+        edit_placeholder_tool=AsyncMock(),
+        send_message=AsyncMock(return_value=99),
+        send_fallback=AsyncMock(return_value=77),
+        chunk_text=MagicMock(side_effect=lambda t: [t] if t else []),
+        start_typing=MagicMock(),
+        cancel_typing=MagicMock(),
+        get_msg=MagicMock(side_effect=lambda key, fallback: fallback),
+        placeholder_text="…",
+    )
+
+
+async def _events(*evts: RenderEvent) -> AsyncIterator[RenderEvent]:
+    for e in evts:
+        yield e
+
+
+class TestSharedEmitterIgnoresToolCallV2:
+    """ToolCall* v2 events must not raise, must not crash dispatch, must not edit."""
+
+    async def test_toolcall_v2_events_do_not_raise(self) -> None:
+        cb = _make_callbacks()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(cb, outbound=outbound)
+        # Must not raise — assert_never branch in dispatch must cover ToolCall*
+        await session.run(
+            _events(
+                RunStartedRenderEvent(run_id="r1"),
+                ToolCallStartRenderEvent(tool_call_id="t1", tool_name="Read"),
+                ToolCallArgsRenderEvent(tool_call_id="t1", delta='{"k":'),
+                ToolCallEndRenderEvent(tool_call_id="t1"),
+                ToolCallResultRenderEvent(tool_call_id="t1", content="ok"),
+                TextRenderEvent("bye", is_final=True),
+                RunFinishedRenderEvent(run_id="r1"),
+            )
+        )
+
+    async def test_toolcall_v2_does_not_call_edit_placeholder_tool(self) -> None:
+        # Parity contract: v1 ``ToolSummaryRenderEvent`` drives the tool card edit;
+        # v2 ToolCall* events are silently absorbed (no extra
+        # ``edit_placeholder_tool`` invocation against the v2 events directly).
+        cb = _make_callbacks()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(cb, outbound=outbound)
+        await session.run(
+            _events(
+                RunStartedRenderEvent(run_id="r1"),
+                ToolCallStartRenderEvent(tool_call_id="t1", tool_name="Read"),
+                ToolCallEndRenderEvent(tool_call_id="t1"),
+                TextRenderEvent("bye", is_final=True),
+                RunFinishedRenderEvent(run_id="r1"),
+            )
+        )
+        cb.edit_placeholder_tool.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_v1_tool_summary_still_drives_tool_card(self) -> None:
+        cb = _make_callbacks()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(cb, outbound=outbound)
+        await session.run(
+            _events(
+                RunStartedRenderEvent(run_id="r1"),
+                ToolCallStartRenderEvent(tool_call_id="t1", tool_name="Edit"),
+                ToolSummaryRenderEvent(is_complete=True),
+                ToolCallEndRenderEvent(tool_call_id="t1"),
+                TextRenderEvent("done", is_final=True),
+                RunFinishedRenderEvent(run_id="r1"),
+            )
+        )
+        cb.edit_placeholder_tool.assert_called()  # type: ignore[attr-defined]

--- a/tests/core/test_cli_streaming_parse.py
+++ b/tests/core/test_cli_streaming_parse.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import pytest
 
 from lyra.core.cli.cli_protocol import StreamingIterator
-from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
+from lyra.core.messaging.events import (
+    ResultLlmEvent,
+    TextLlmEvent,
+    ToolResultLlmEvent,
+    ToolUseDeltaLlmEvent,
+    ToolUseEndLlmEvent,
+    ToolUseLlmEvent,
+)
 
 from .conftest import (
     ASSISTANT_INTERMEDIATE_LINE,
@@ -19,6 +26,71 @@ from .conftest import (
     make_entry,
     make_fake_proc,
 )
+
+
+def _tool_use_start_line(
+    index: int = 1, tool_id: str = "toolu_AB", name: str = "Read"
+) -> bytes:
+    return _ndjson(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": index,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": name,
+                    "input": {},
+                },
+            },
+        }
+    )
+
+
+def _input_json_delta_line(index: int = 1, partial_json: str = '{"key":') -> bytes:
+    return _ndjson(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {"type": "input_json_delta", "partial_json": partial_json},
+            },
+        }
+    )
+
+
+def _content_block_stop_line(index: int = 1) -> bytes:
+    return _ndjson(
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_stop", "index": index},
+        }
+    )
+
+
+def _tool_result_user_line(
+    tool_use_id: str = "toolu_AB",
+    content: object = "ok",
+    is_error: bool = False,
+) -> bytes:
+    return _ndjson(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use_id,
+                        "content": content,
+                        "is_error": is_error,
+                    }
+                ],
+            },
+        }
+    )
 
 # ---------------------------------------------------------------------------
 # TestStreamingIteratorYields
@@ -415,3 +487,180 @@ class TestStreamingIteratorAssistant:
             TextLlmEvent(text=" world"),
             ResultLlmEvent(is_error=False, duration_ms=100, session_id="abc-123"),
         ]
+
+
+# ---------------------------------------------------------------------------
+# TestStreamingIteratorToolDeltas — Slice 3 of #1096
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingIteratorToolDeltas:
+    """Parser surfaces input_json_delta + content_block_stop + tool_result."""
+
+    async def test_input_json_delta_after_tool_use_start_yields_delta_event(
+        self,
+    ) -> None:
+        # Arrange — content_block_start tool_use opens index=1; subsequent
+        # input_json_delta on the same index yields ToolUseDeltaLlmEvent.
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(index=1, tool_id="toolu_AB", name="Read"),
+                _input_json_delta_line(index=1, partial_json='{"file_path":'),
+                _input_json_delta_line(index=1, partial_json='"/tmp/x"}'),
+                _content_block_stop_line(index=1),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert — Start, Delta, Delta, End, Result, all sharing tool_id
+        assert events == [
+            ToolUseLlmEvent(tool_name="Read", tool_id="toolu_AB", input={}),
+            ToolUseDeltaLlmEvent(tool_id="toolu_AB", partial_json='{"file_path":'),
+            ToolUseDeltaLlmEvent(tool_id="toolu_AB", partial_json='"/tmp/x"}'),
+            ToolUseEndLlmEvent(tool_id="toolu_AB"),
+            ResultLlmEvent(is_error=False, duration_ms=100, session_id="abc-123"),
+        ]
+
+    async def test_input_json_delta_without_open_tool_block_silently_skipped(
+        self,
+    ) -> None:
+        # Arrange — input_json_delta arrives without a prior content_block_start;
+        # parser must silently drop (existing pre-Slice-3 behaviour preserved).
+        proc = make_fake_proc(
+            [INIT_LINE, INPUT_JSON_DELTA_LINE, TEXT_DELTA_LINE, RESULT_LINE]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert
+        assert events == [
+            TextLlmEvent(text="Hello"),
+            ResultLlmEvent(is_error=False, duration_ms=100, session_id="abc-123"),
+        ]
+
+    async def test_empty_partial_json_delta_skipped(self) -> None:
+        # Arrange — empty partial_json should not yield a delta event.
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(),
+                _input_json_delta_line(partial_json=""),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert — no ToolUseDeltaLlmEvent
+        assert events == [
+            ToolUseLlmEvent(tool_name="Read", tool_id="toolu_AB", input={}),
+            ResultLlmEvent(is_error=False, duration_ms=100, session_id="abc-123"),
+        ]
+
+    async def test_content_block_stop_unknown_index_silent(self) -> None:
+        # Arrange — content_block_stop for a text block (no open tool block at
+        # index=0) must not emit ToolUseEndLlmEvent.
+        proc = make_fake_proc(
+            [INIT_LINE, _content_block_stop_line(index=0), TEXT_DELTA_LINE, RESULT_LINE]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert
+        assert events == [
+            TextLlmEvent(text="Hello"),
+            ResultLlmEvent(is_error=False, duration_ms=100, session_id="abc-123"),
+        ]
+
+    async def test_user_message_tool_result_yields_event(self) -> None:
+        # Arrange — user message with tool_result block.
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(),
+                _content_block_stop_line(),
+                _tool_result_user_line(content="file contents…", is_error=False),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert
+        assert events == [
+            ToolUseLlmEvent(tool_name="Read", tool_id="toolu_AB", input={}),
+            ToolUseEndLlmEvent(tool_id="toolu_AB"),
+            ToolResultLlmEvent(
+                tool_id="toolu_AB", content="file contents…", is_error=False
+            ),
+            ResultLlmEvent(is_error=False, duration_ms=100, session_id="abc-123"),
+        ]
+
+    async def test_user_message_tool_result_error_propagates(self) -> None:
+        # Arrange — is_error=True flows through verbatim.
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(),
+                _tool_result_user_line(content="boom", is_error=True),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert
+        assert any(
+            isinstance(e, ToolResultLlmEvent) and e.is_error and e.content == "boom"
+            for e in events
+        )
+
+    async def test_user_message_tool_result_list_content_concatenates(self) -> None:
+        # Arrange — content can be a list of typed blocks; parser concatenates
+        # text-only with placeholders for non-text.
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(),
+                _tool_result_user_line(
+                    content=[
+                        {"type": "text", "text": "first"},
+                        {"type": "image", "data": "..."},
+                        {"type": "text", "text": "third"},
+                    ],
+                    is_error=False,
+                ),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        # Act
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        # Assert — non-text block placeholdered as [image]
+        results = [e for e in events if isinstance(e, ToolResultLlmEvent)]
+        assert len(results) == 1
+        assert results[0].content == "first[image]third"

--- a/tests/core/test_cli_streaming_parse.py
+++ b/tests/core/test_cli_streaming_parse.py
@@ -664,3 +664,80 @@ class TestStreamingIteratorToolDeltas:
         results = [e for e in events if isinstance(e, ToolResultLlmEvent)]
         assert len(results) == 1
         assert results[0].content == "first[image]third"
+
+    async def test_concurrent_tool_calls_interleaved_deltas(self) -> None:
+        """T3 (#1100 review): two simultaneous tool blocks at distinct indices,
+        interleaved deltas — each delta routes to its own tool_id.
+        """
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(index=1, tool_id="t1", name="Read"),
+                _tool_use_start_line(index=2, tool_id="t2", name="Bash"),
+                _input_json_delta_line(index=2, partial_json='{"cmd":'),
+                _input_json_delta_line(index=1, partial_json='{"path":'),
+                _input_json_delta_line(index=2, partial_json='"ls"}'),
+                _input_json_delta_line(index=1, partial_json='"/tmp"}'),
+                _content_block_stop_line(index=1),
+                _content_block_stop_line(index=2),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        deltas = [e for e in events if isinstance(e, ToolUseDeltaLlmEvent)]
+        # Each delta must route to the correct tool_id by index, not by order.
+        assert [(e.tool_id, e.partial_json) for e in deltas] == [
+            ("t2", '{"cmd":'),
+            ("t1", '{"path":'),
+            ("t2", '"ls"}'),
+            ("t1", '"/tmp"}'),
+        ]
+
+        ends = [e for e in events if isinstance(e, ToolUseEndLlmEvent)]
+        assert [e.tool_id for e in ends] == ["t1", "t2"]
+
+    async def test_dedupe_tool_use_across_streaming_and_post_hoc(self) -> None:
+        """B1+A1 (#1100 review): parser dedupes the dual emission of tool_use.
+
+        CLI emits tool_use once at content_block_start and again post-hoc in
+        the assistant message. Parser must announce each tool_id exactly once.
+        """
+        post_hoc_line = _ndjson(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_AB",
+                            "name": "Read",
+                            "input": {"file_path": "/tmp/x"},
+                        }
+                    ],
+                },
+            }
+        )
+        proc = make_fake_proc(
+            [
+                INIT_LINE,
+                _tool_use_start_line(index=1, tool_id="toolu_AB", name="Read"),
+                post_hoc_line,
+                _content_block_stop_line(index=1),
+                RESULT_LINE,
+            ]
+        )
+        entry = make_entry(proc)
+
+        it = StreamingIterator(entry, DEFAULT_POOL_ID)
+        events = [ev async for ev in it]
+
+        starts = [e for e in events if isinstance(e, ToolUseLlmEvent)]
+        # Exactly one ToolUseLlmEvent for toolu_AB despite both wire paths.
+        assert len(starts) == 1
+        assert starts[0].tool_id == "toolu_AB"
+        assert starts[0].tool_name == "Read"

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -150,5 +150,8 @@ class TestLlmEventUnion:
             "LlmEvent",
             "ResultLlmEvent",
             "TextLlmEvent",
+            "ToolResultLlmEvent",
+            "ToolUseDeltaLlmEvent",
+            "ToolUseEndLlmEvent",
             "ToolUseLlmEvent",
         }

--- a/tests/core/test_render_events.py
+++ b/tests/core/test_render_events.py
@@ -5,6 +5,7 @@ Source: src/lyra/core/messaging/render_events.py
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from typing import Any
 
 import pytest
@@ -234,11 +235,94 @@ class TestRenderEventUnion:
             "SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT",
             "SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT",
             "SCHEMA_VERSION_TEXT_RENDER_EVENT",
+            "SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT",
+            "SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT",
+            "SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT",
+            "SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT",
             "SCHEMA_VERSION_TOOL_SUMMARY_RENDER_EVENT",
             "SilentCounts",
             "TextRenderEvent",
+            "ToolCallArgsRenderEvent",
+            "ToolCallEndRenderEvent",
+            "ToolCallResultRenderEvent",
+            "ToolCallStartRenderEvent",
             "ToolSummaryRenderEvent",
         }
+
+
+# ---------------------------------------------------------------------------
+# ToolCall* lifecycle events (Slice 3 of #1096)
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallEvents:
+    def test_tool_call_start_frozen_and_default_schema(self) -> None:
+        from lyra.core.messaging.render_events import (
+            SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT,
+            ToolCallStartRenderEvent,
+        )
+
+        e = ToolCallStartRenderEvent(tool_call_id="toolu_AB", tool_name="Read")
+        assert e.tool_call_id == "toolu_AB"
+        assert e.tool_name == "Read"
+        assert e.schema_version == SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT == 1
+        with pytest.raises(FrozenInstanceError):
+            e.tool_call_id = "x"  # type: ignore[misc]
+
+    def test_tool_call_args_frozen_and_default_schema(self) -> None:
+        from lyra.core.messaging.render_events import (
+            SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT,
+            ToolCallArgsRenderEvent,
+        )
+
+        e = ToolCallArgsRenderEvent(tool_call_id="toolu_AB", delta='{"foo":')
+        assert e.delta == '{"foo":'
+        assert e.schema_version == SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT == 1
+        with pytest.raises(FrozenInstanceError):
+            e.delta = "y"  # type: ignore[misc]
+
+    def test_tool_call_end_frozen_and_default_schema(self) -> None:
+        from lyra.core.messaging.render_events import (
+            SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT,
+            ToolCallEndRenderEvent,
+        )
+
+        e = ToolCallEndRenderEvent(tool_call_id="toolu_AB")
+        assert e.schema_version == SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT == 1
+        with pytest.raises(FrozenInstanceError):
+            e.tool_call_id = "x"  # type: ignore[misc]
+
+    def test_tool_call_result_frozen_and_default_schema(self) -> None:
+        from lyra.core.messaging.render_events import (
+            SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT,
+            ToolCallResultRenderEvent,
+        )
+
+        e = ToolCallResultRenderEvent(tool_call_id="toolu_AB", content="ok")
+        assert e.is_error is False
+        assert e.schema_version == SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT == 1
+        e_err = ToolCallResultRenderEvent(
+            tool_call_id="toolu_AB", content="boom", is_error=True
+        )
+        assert e_err.is_error is True
+        with pytest.raises(FrozenInstanceError):
+            e.content = "y"  # type: ignore[misc]
+
+    def test_tool_call_events_in_union(self) -> None:
+        from lyra.core.messaging.render_events import (
+            ToolCallArgsRenderEvent,
+            ToolCallEndRenderEvent,
+            ToolCallResultRenderEvent,
+            ToolCallStartRenderEvent,
+        )
+
+        events: list[RenderEvent] = [
+            ToolCallStartRenderEvent(tool_call_id="x", tool_name="Read"),
+            ToolCallArgsRenderEvent(tool_call_id="x", delta="{}"),
+            ToolCallEndRenderEvent(tool_call_id="x"),
+            ToolCallResultRenderEvent(tool_call_id="x", content="ok"),
+        ]
+        assert len(events) == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -1014,15 +1014,20 @@ class TestToolCallLifecycle:
         ]
         assert all(e.tool_call_id == "t1" for e in v2)
 
-    async def test_dedupe_post_hoc_tool_use_event(self) -> None:
-        """Parser emits ToolUseLlmEvent twice (start + post-hoc); SP dedupes."""
+    async def test_each_tool_use_yields_one_start_event(self) -> None:
+        """Each ToolUseLlmEvent the SP receives produces one ToolCallStart.
+
+        Dedupe of CLI's dual emission (content_block_start + post-hoc
+        assistant message) lives in the parser since #1100 review (A1+B1):
+        wire-level artifacts stay below the application boundary. This SP
+        test asserts the post-dedupe contract — each `ToolUseLlmEvent` that
+        reaches `process()` corresponds to a unique tool_call. Parser-level
+        dedupe is verified separately in test_cli_streaming_parse.py.
+        """
         cfg_ = ToolDisplayConfig(throttle_window=0.0)
         processor = StreamProcessor(cfg_)
         events = async_events(
-            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
-            ToolUseLlmEvent(
-                tool_name="Read", tool_id="t1", input={"path": "/x"}
-            ),
+            ToolUseLlmEvent(tool_name="Glob", tool_id="t1", input={}),
             ToolUseEndLlmEvent(tool_id="t1"),
             ResultLlmEvent(is_error=False, duration_ms=10),
         )
@@ -1030,6 +1035,11 @@ class TestToolCallLifecycle:
         result = await collect(processor.process(events))
         starts = [e for e in result if isinstance(e, ToolCallStartRenderEvent)]
         assert len(starts) == 1
+        # T1 strengthening (#1100 review): also verify tool_call_id and
+        # tool_name correlation, so a regression that dropped the wrong fields
+        # would not silently pass.
+        assert starts[0].tool_call_id == "t1"
+        assert starts[0].tool_name == "Glob"
 
     async def test_orphan_end_synthesis_at_result(self) -> None:
         """Start without End triggers synthesized End at ResultLlmEvent time."""
@@ -1046,8 +1056,12 @@ class TestToolCallLifecycle:
         assert len(ends) == 1
         assert ends[0].tool_call_id == "t1"
 
-    async def test_dual_emit_tool_summary_preserved(self) -> None:
-        """v1 ToolSummaryRenderEvent still emitted at result with is_complete=True."""
+    async def test_dual_emit_v1_and_v2_both_present(self) -> None:
+        """T4 (#1100 review): assert BOTH v1 ToolSummary AND v2 ToolCall* are emitted.
+
+        The dual-emit contract is umbrella-spec invariant 5 (coexistence).
+        Asserting only v1 count would let a silent drop of ToolCallStart pass.
+        """
         cfg_ = ToolDisplayConfig(throttle_window=0.0)
         processor = StreamProcessor(cfg_)
         events = async_events(
@@ -1058,10 +1072,13 @@ class TestToolCallLifecycle:
         )
 
         result = await collect(processor.process(events))
-        summaries = [
+        v1_summaries = [
             e for e in result if isinstance(e, ToolSummaryRenderEvent) and e.is_complete
         ]
-        assert len(summaries) == 1
+        v2_starts = [e for e in result if isinstance(e, ToolCallStartRenderEvent)]
+        # Both halves of the dual-emit must fire for the same source event.
+        assert len(v1_summaries) == 1
+        assert len(v2_starts) == 1
 
     async def test_tool_call_args_passes_partial_json_verbatim(self) -> None:
         cfg_ = ToolDisplayConfig(throttle_window=0.0)
@@ -1080,8 +1097,10 @@ class TestToolCallLifecycle:
     async def test_tool_call_result_carries_is_error(self) -> None:
         cfg_ = ToolDisplayConfig(throttle_window=0.0)
         processor = StreamProcessor(cfg_)
+        # Use a non-sensitive tool name so the S1 boundary scrubber does not
+        # redact the content (Read/Bash/Edit/Write are sanitized by default).
         events = async_events(
-            ToolUseLlmEvent(tool_name="Bash", tool_id="t1", input={}),
+            ToolUseLlmEvent(tool_name="Glob", tool_id="t1", input={}),
             ToolUseEndLlmEvent(tool_id="t1"),
             ToolResultLlmEvent(tool_id="t1", content="boom", is_error=True),
             ResultLlmEvent(is_error=False, duration_ms=10),
@@ -1092,6 +1111,75 @@ class TestToolCallLifecycle:
         assert len(results) == 1
         assert results[0].is_error is True
         assert results[0].content == "boom"
+
+    async def test_sensitive_tool_result_content_is_redacted(self) -> None:
+        """S1 (#1100 review): tool result for sensitive tools is redacted on the bus."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
+            ToolUseEndLlmEvent(tool_id="t1"),
+            ToolResultLlmEvent(
+                tool_id="t1",
+                content="aws_access_key_id=AKIA1234SECRETLEAK",
+                is_error=False,
+            ),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        results = [e for e in result if isinstance(e, ToolCallResultRenderEvent)]
+        assert len(results) == 1
+        assert "AKIA" not in results[0].content
+        assert results[0].content.startswith("[redacted")
+
+    async def test_orphan_tool_result_redacted_fail_closed(self) -> None:
+        """ToolResult without prior ToolUseLlmEvent (unknown tool_name) is redacted."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        # No ToolUseLlmEvent → tool_name unknown → fail-closed redaction.
+        events = async_events(
+            ToolResultLlmEvent(tool_id="t1", content="leaked", is_error=False),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        results = [e for e in result if isinstance(e, ToolCallResultRenderEvent)]
+        assert len(results) == 1
+        assert results[0].content.startswith("[redacted")
+
+    async def test_large_tool_result_content_truncated(self) -> None:
+        """S3 (#1100 review): content larger than MAX_CONTENT_BYTES is truncated."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        large = "x" * 100_000
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Glob", tool_id="t1", input={}),
+            ToolUseEndLlmEvent(tool_id="t1"),
+            ToolResultLlmEvent(tool_id="t1", content=large, is_error=False),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        results = [e for e in result if isinstance(e, ToolCallResultRenderEvent)]
+        assert len(results) == 1
+        assert len(results[0].content.encode("utf-8")) <= 65_536
+        assert results[0].content.endswith("…[truncated]")
+
+    async def test_multi_orphan_end_synthesis_preserves_ids(self) -> None:
+        """T2 (#1100 review): two open tools both get their own synthesized End."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Glob", tool_id="t1", input={}),
+            ToolUseLlmEvent(tool_name="Glob", tool_id="t2", input={}),
+            # Neither tool sees ToolUseEndLlmEvent.
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        ends = [e for e in result if isinstance(e, ToolCallEndRenderEvent)]
+        assert [e.tool_call_id for e in ends] == ["t1", "t2"]
 
     async def test_no_explicit_dispatch_silent_drop(self) -> None:
         """ToolUseDeltaLlmEvent reaches process() and is mapped, not absorbed."""

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -6,13 +6,24 @@ import ast
 from pathlib import Path
 from typing import AsyncIterator
 
-from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
+from lyra.core.messaging.events import (
+    ResultLlmEvent,
+    TextLlmEvent,
+    ToolResultLlmEvent,
+    ToolUseDeltaLlmEvent,
+    ToolUseEndLlmEvent,
+    ToolUseLlmEvent,
+)
 from lyra.core.messaging.render_events import (
     RenderEvent,
     RunErrorRenderEvent,
     RunFinishedRenderEvent,
     RunStartedRenderEvent,
     TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
     ToolSummaryRenderEvent,
 )
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
@@ -25,16 +36,31 @@ _RUN_LIFECYCLE_TYPES = (
     RunErrorRenderEvent,
 )
 
+# Slice 3 (#1100) v2 events. Stripped from v1-focused test results so the
+# existing assertions remain stable; ToolCall*-specific tests live in
+# TestToolCallLifecycle and inspect the unstripped stream.
+_TOOLCALL_V2_TYPES = (
+    ToolCallStartRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+)
+
 
 def strip_run_lifecycle(events: list[RenderEvent]) -> list[RenderEvent]:
-    """Drop ``Run{Started,Finished,Error}RenderEvent`` from a result list.
+    """Drop ``Run{Started,Finished,Error}`` + ``ToolCall*`` events.
 
-    Slice 1 of #1096 added unconditional Run lifecycle bookends to every
-    ``StreamProcessor.process()`` invocation. Tests that focus on text/tool
-    payload count and ordering use this helper to keep their original
-    assertions intact; lifecycle-specific tests live in ``TestRunLifecycle``.
+    Slice 1 added Run lifecycle bookends; Slice 3 added per-call ToolCall*
+    streaming. v1-focused tests strip both so their original (v1
+    ``TextRenderEvent`` + ``ToolSummaryRenderEvent``) assertions remain
+    stable. v2 lifecycle is asserted in dedicated test classes
+    (``TestRunLifecycle``, ``TestToolCallLifecycle``).
     """
-    return [e for e in events if not isinstance(e, _RUN_LIFECYCLE_TYPES)]
+    return [
+        e
+        for e in events
+        if not isinstance(e, (*_RUN_LIFECYCLE_TYPES, *_TOOLCALL_V2_TYPES))
+    ]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -940,3 +966,144 @@ class TestRunLifecycle:
         assert RunErrorRenderEvent(run_id="x", message="m").schema_version == (
             SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT
         )
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 of #1096 — ToolCall* lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallLifecycle:
+    """ToolCall{Start,Args,End,Result} streamed events with dual-emit + dedupe."""
+
+    async def test_emission_order_single_call(self) -> None:
+        """Start → Args (×N) → End → Result, all sharing tool_call_id."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
+            ToolUseDeltaLlmEvent(tool_id="t1", partial_json='{"file_path":'),
+            ToolUseDeltaLlmEvent(tool_id="t1", partial_json='"/tmp/x"}'),
+            ToolUseEndLlmEvent(tool_id="t1"),
+            ToolResultLlmEvent(tool_id="t1", content="ok"),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+
+        v2 = [
+            e
+            for e in result
+            if isinstance(
+                e,
+                (
+                    ToolCallStartRenderEvent,
+                    ToolCallArgsRenderEvent,
+                    ToolCallEndRenderEvent,
+                    ToolCallResultRenderEvent,
+                ),
+            )
+        ]
+        types = [type(e).__name__ for e in v2]
+        assert types == [
+            "ToolCallStartRenderEvent",
+            "ToolCallArgsRenderEvent",
+            "ToolCallArgsRenderEvent",
+            "ToolCallEndRenderEvent",
+            "ToolCallResultRenderEvent",
+        ]
+        assert all(e.tool_call_id == "t1" for e in v2)
+
+    async def test_dedupe_post_hoc_tool_use_event(self) -> None:
+        """Parser emits ToolUseLlmEvent twice (start + post-hoc); SP dedupes."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
+            ToolUseLlmEvent(
+                tool_name="Read", tool_id="t1", input={"path": "/x"}
+            ),
+            ToolUseEndLlmEvent(tool_id="t1"),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        starts = [e for e in result if isinstance(e, ToolCallStartRenderEvent)]
+        assert len(starts) == 1
+
+    async def test_orphan_end_synthesis_at_result(self) -> None:
+        """Start without End triggers synthesized End at ResultLlmEvent time."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
+            # NO ToolUseEndLlmEvent
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        ends = [e for e in result if isinstance(e, ToolCallEndRenderEvent)]
+        assert len(ends) == 1
+        assert ends[0].tool_call_id == "t1"
+
+    async def test_dual_emit_tool_summary_preserved(self) -> None:
+        """v1 ToolSummaryRenderEvent still emitted at result with is_complete=True."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(
+                tool_name="Edit", tool_id="t1", input={"path": "src/x.py"}
+            ),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        summaries = [
+            e for e in result if isinstance(e, ToolSummaryRenderEvent) and e.is_complete
+        ]
+        assert len(summaries) == 1
+
+    async def test_tool_call_args_passes_partial_json_verbatim(self) -> None:
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
+            ToolUseDeltaLlmEvent(tool_id="t1", partial_json="{\"a\":"),
+            ToolUseDeltaLlmEvent(tool_id="t1", partial_json="1}"),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        args = [e for e in result if isinstance(e, ToolCallArgsRenderEvent)]
+        assert [e.delta for e in args] == ["{\"a\":", "1}"]
+
+    async def test_tool_call_result_carries_is_error(self) -> None:
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Bash", tool_id="t1", input={}),
+            ToolUseEndLlmEvent(tool_id="t1"),
+            ToolResultLlmEvent(tool_id="t1", content="boom", is_error=True),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        results = [e for e in result if isinstance(e, ToolCallResultRenderEvent)]
+        assert len(results) == 1
+        assert results[0].is_error is True
+        assert results[0].content == "boom"
+
+    async def test_no_explicit_dispatch_silent_drop(self) -> None:
+        """ToolUseDeltaLlmEvent reaches process() and is mapped, not absorbed."""
+        cfg_ = ToolDisplayConfig(throttle_window=0.0)
+        processor = StreamProcessor(cfg_)
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="t1", input={}),
+            ToolUseDeltaLlmEvent(tool_id="t1", partial_json="{}"),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        # If the bare-else regressed, the delta would crash on event.is_error
+        # access. Successful dispatch surfaces a ToolCallArgsRenderEvent.
+        assert any(isinstance(e, ToolCallArgsRenderEvent) for e in result)

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -15,7 +15,14 @@ import logging
 
 import pytest
 
-from lyra.core.messaging.render_events import TextRenderEvent, ToolSummaryRenderEvent
+from lyra.core.messaging.render_events import (
+    TextRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
+    ToolSummaryRenderEvent,
+)
 from lyra.nats.render_event_codec import NatsRenderEventCodec
 
 
@@ -189,3 +196,109 @@ class TestRenderEventCodecVersionCheck:
         # Assert — counts are independent
         assert c1 == {"TextRenderEvent:schema": 2}
         assert c2 == {"TextRenderEvent:schema": 1}
+
+
+# ---------------------------------------------------------------------------
+# ToolCall* round-trip + schema floor (Slice 3 of #1096)
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallCodecRoundTrip:
+    """Encode then decode each ToolCall* event and assert byte-for-byte fidelity."""
+
+    def test_tool_call_start_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = ToolCallStartRenderEvent(tool_call_id="toolu_AB", tool_name="Read")
+
+        event_type, payload, is_done = codec.encode(original)
+
+        assert event_type == "tool_call_start"
+        assert is_done is False
+        assert payload["tool_call_id"] == "toolu_AB"
+        assert payload["tool_name"] == "Read"
+        assert payload["schema_version"] == 1
+
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_tool_call_args_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = ToolCallArgsRenderEvent(tool_call_id="toolu_AB", delta='{"foo":')
+
+        event_type, payload, is_done = codec.encode(original)
+
+        assert event_type == "tool_call_args"
+        assert is_done is False
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_tool_call_end_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = ToolCallEndRenderEvent(tool_call_id="toolu_AB")
+
+        event_type, payload, is_done = codec.encode(original)
+
+        assert event_type == "tool_call_end"
+        assert is_done is False
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_tool_call_result_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = ToolCallResultRenderEvent(
+            tool_call_id="toolu_AB", content="ok", is_error=False
+        )
+
+        event_type, payload, is_done = codec.encode(original)
+
+        assert event_type == "tool_call_result"
+        assert is_done is False
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_tool_call_result_is_error_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = ToolCallResultRenderEvent(
+            tool_call_id="toolu_AB", content="boom", is_error=True
+        )
+
+        event_type, payload, _is_done = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_tool_call_is_terminal_false(self) -> None:
+        # ToolCall* are mid-stream — never terminal sentinels.
+        for et in (
+            "tool_call_start",
+            "tool_call_args",
+            "tool_call_end",
+            "tool_call_result",
+        ):
+            assert NatsRenderEventCodec.is_terminal(et) is False
+
+    def test_tool_call_start_schema_floor_drops(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        codec = NatsRenderEventCodec()
+        counter: dict[str, int] = {}
+
+        with caplog.at_level(logging.ERROR, logger="lyra.nats._version_check"):
+            result = codec.decode(
+                "tool_call_start",
+                {"schema_version": 99, "tool_call_id": "x", "tool_name": "Read"},
+                counter=counter,
+            )
+
+        assert result is None
+        assert counter == {"ToolCallStartRenderEvent:schema": 1}
+
+    def test_tool_call_args_schema_floor_drops(self) -> None:
+        codec = NatsRenderEventCodec()
+        counter: dict[str, int] = {}
+        result = codec.decode(
+            "tool_call_args",
+            {"schema_version": 99, "tool_call_id": "x", "delta": "y"},
+            counter=counter,
+        )
+        assert result is None
+        assert counter == {"ToolCallArgsRenderEvent:schema": 1}

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -11,3 +11,4 @@ src/lyra/core/processors/stream_processor.py  # 322 lines — #1016 WorkerError 
 src/lyra/adapters/shared/_shared_streaming_emitter.py  # 315 lines — #1098 Run lifecycle skip branch (Slice 2 of #1096 lands the full v1+v2 isinstance ladder)
 src/lyra/llm/drivers/nats_driver.py  # 364 lines — #1016 WorkerError population on transport.* failures (P3 will refactor with NatsDriverBase)
 src/lyra/adapters/clipool/clipool_worker.py  # 334 lines — #1016 WorkerError population + exception classifier
+src/lyra/core/cli/cli_streaming_parser.py  # 310 lines — #1100 ToolCall streamed events (input_json_delta + content_block_stop + user-message tool_result; cleanup in Slice 5 / #1102)


### PR DESCRIPTION
## Summary

Slice 3 of #1096 (RenderEvent v2 — adopt AG-UI modeling).

- 4 new frozen `RenderEvent` types: `ToolCallStartRenderEvent`, `ToolCallArgsRenderEvent`, `ToolCallEndRenderEvent`, `ToolCallResultRenderEvent` with per-event `SCHEMA_VERSION_TOOL_CALL_*` constants. `RenderEvent` union widened.
- 3 new frozen `LlmEvent` types: `ToolUseDeltaLlmEvent`, `ToolUseEndLlmEvent`, `ToolResultLlmEvent`. `LlmEvent` union widened.
- `cli_streaming_parser` instrumented for Anthropic CLI `input_json_delta`, `content_block_stop`, and user-message `tool_result` wire shapes (per ADR-028 `--include-partial-messages`). Tracks `_open_tool_blocks` index → `tool_id`.
- `StreamProcessor.process()` now dispatches every `LlmEvent` variant explicitly — no bare-`else` fallthrough (architect-flagged in spec review). Dedupes `ToolUseLlmEvent` by `tool_id` (parser emits both `content_block_start` and post-hoc `assistant`-message paths). Orphan `ToolCallEnd` synthesis at `ResultLlmEvent` time with WARN log.
- `ToolSummaryRenderEvent` v1 dual-emit kept — sunset planned in Slice 5 (#1102).
- NATS codec encodes + decodes 4 `ToolCall*` events with per-event schema floor enforcement; round-trip + drop-on-pre-floor tests.
- Shared adapter dispatch absorbs `ToolCall*` (parity-by-default — v1 `ToolSummary` continues to drive placeholder edits). Discord opt-in inline args streaming (`LYRA_DISCORD_TOOLCALL_STREAM_ARGS`) deferred to a follow-up issue per F-lite scope.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1100: feat(render-events): ToolCall{Start,Args,End,Result} streamed events | OPEN |
| Frame | [1100-toolcall-streamed-events-frame.mdx](artifacts/frames/1100-toolcall-streamed-events-frame.mdx) | Approved |
| Spec | [1100-toolcall-streamed-events-spec.mdx](artifacts/specs/1100-toolcall-streamed-events-spec.mdx) | Approved (5/5 pre-check; CLI subprocess instrumentation analysis inlined) |
| Plan | [1100-toolcall-streamed-events-plan.mdx](artifacts/plans/1100-toolcall-streamed-events-plan.mdx) | Approved (23 micro-tasks, 5 waves) |
| Implementation | 1 commit on \`feat/1100-toolcall-streamed-events\` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3139 lyra tests passed; 25 new) | Passed |

## Test Plan

- [ ] CI green on the PR (lint + typecheck + tests + coverage + import-linter)
- [ ] CLI smoke: trigger a tool-using turn (Read / Bash / Edit) and confirm v1 \`ToolSummaryRenderEvent\` rendering is unchanged on Telegram + Discord
- [ ] Verify NATS chunks for the 4 new \`tool_call_*\` event types appear on the bus during a real tool call
- [ ] Confirm orphan \`ToolCallEnd\` synthesis fires (WARN log) when CLI stream is truncated mid-tool-call

Closes #1100

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`