### PR TITLE
fix(test): isolate LYRA_VAULT_DIR per test to prevent discord.db worker race

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -180,6 +181,9 @@ def _patch_nats_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
     monkeypatch.setenv("LYRA_HEALTH_PORT", "0")
+    # Isolate vault dir per test to prevent parallel-worker races on
+    # ~/.lyra/discord.db (_ensure_discord_db TOCTOU with -n auto).
+    monkeypatch.setenv("LYRA_VAULT_DIR", tempfile.mkdtemp())
 
 
 def make_fake_stores(


### PR DESCRIPTION
## Summary

Fixes a parallel-worker race on `~/.lyra/discord.db` that surfaces in CI as:

```
FileNotFoundError: /home/runner/.lyra/discord.db
test_discord_token_passed_to_adapter_start
```

This failure has been blocking auto-merge on every deploy/security PR (it's a required CI check) — surfaced during the #1118/#1120/#1125/#1126 cleanup pass.

## Root cause

`pytest -n auto` runs tests in parallel workers. All tests using the shared `_patch_nats_stubs` helper (called from `patch_bootstrap_common` / `patch_all` / `patch_auth_config_test`) write to the same default vault dir `~/.lyra`. `_ensure_discord_db` has a TOCTOU window:

1. Worker A creates `discord.db`
2. Worker B sees `exists() == True`, `_has_sentinel() == False`
3. Worker A deletes the file
4. Worker B calls `unlink()` → `FileNotFoundError`

## Fix

`tests/conftest.py` (+4 lines): set `LYRA_VAULT_DIR=tempfile.mkdtemp()` inside `_patch_nats_stubs`. Each worker now writes to its own isolated tmp dir.

## Test plan

- [x] `uv run pytest tests/ -n auto` — full suite passes
- [x] `uv run pytest tests/adapters/test_discord_*.py -n auto` — passes
- [x] All pre-push hooks (lint, typecheck, trufflehog, import-layers) pass
- [ ] CI green on this PR (this is the test that's currently failing — verifies the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)