### PR TITLE
chore(lint): add rationale to bare BLE001 noqa annotations

### DIFF
--- a/src/lyra/adapters/clipool/clipool_worker.py
+++ b/src/lyra/adapters/clipool/clipool_worker.py
@@ -200,7 +200,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
                 model_cfg,
                 cmd.system_prompt,
             )
-        except Exception as exc:  # noqa: BLE001 - external boundary: catch all to ensure error reply
+        except Exception as exc:  # noqa: BLE001 — external boundary: catch all to ensure error reply
             log.exception(
                 "clipool_worker: send_streaming failed for pool_id=%r", cmd.pool_id
             )
@@ -262,7 +262,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
                 model_cfg,
                 cmd.system_prompt,
             )
-        except Exception as exc:  # noqa: BLE001 - external boundary: catch all to ensure error reply
+        except Exception as exc:  # noqa: BLE001 — external boundary: catch all to ensure error reply
             log.exception("clipool_worker: send failed for pool_id=%r", cmd.pool_id)
             worker_error = _classify_exception(exc)
             emit_populated_total(domain="cli")
@@ -301,7 +301,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
 
         try:
             ack_bytes = await self._dispatch_control(cmd)
-        except Exception:  # noqa: BLE001 - external boundary: catch all to ensure error ack
+        except Exception:  # noqa: BLE001 — external boundary: catch all to ensure error ack
             log.exception(
                 "clipool_worker: control op %r failed for pool_id=%r",
                 cmd.op,

--- a/src/lyra/bootstrap/standalone/hub_standalone_helpers.py
+++ b/src/lyra/bootstrap/standalone/hub_standalone_helpers.py
@@ -52,7 +52,7 @@ async def start_mint_failure_subscriber(nc: Any) -> "MintFailureSubscriber | Non
             ops_telegram_chat_id=int(chat_id_raw),
         )
         await sub.start()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001 — resilient: ops alerting subscriber is optional, startup failure is logged and skipped
         log.warning("MintFailureSubscriber failed to start: %s", exc)
         return None
     return sub

--- a/src/lyra/tools/gh_token/dispenser.py
+++ b/src/lyra/tools/gh_token/dispenser.py
@@ -159,5 +159,5 @@ class Dispenser:
             writer.close()
             try:
                 await writer.wait_closed()
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001 — resilient: writer is already closed, wait_closed failure is harmless
                 pass

--- a/src/lyra/tools/gh_token/helper.py
+++ b/src/lyra/tools/gh_token/helper.py
@@ -118,6 +118,7 @@ class JWTSigner:
 
 # ── Section D: TokenCache ─────────────────────────────────────────────────────
 
+
 def _parse_expires_at(raw: str) -> datetime:
     """Parse ISO-8601 datetime with mandatory timezone component."""
     # Python 3.11+ fromisoformat handles Z; 3.12 enforces it too.
@@ -154,7 +155,7 @@ class TokenCache:
                 log.debug("TokenCache: cached token expired at %s", expires_at)
                 return None
             return InstallationToken(token=token, expires_at=expires_at)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001 — resilient: corrupted or missing cache file is treated as a cold-cache miss
             log.debug("TokenCache read error (cold cache): %s", exc)
             return None
 
@@ -203,9 +204,7 @@ async def mint(
         MintError:   Any non-201 HTTP response or network failure.
     """
     if not _INSTALL_ID_RE.match(install_id):
-        raise ValueError(
-            f"install_id must be purely numeric, got: {install_id!r}"
-        )
+        raise ValueError(f"install_id must be purely numeric, got: {install_id!r}")
 
     now = datetime.now(tz=timezone.utc)
     jwt = signer.sign(app_id, now=now)
@@ -246,7 +245,7 @@ async def mint(
         expires_at = _parse_expires_at(body["expires_at"])
         if expires_at.tzinfo is None:
             expires_at = expires_at.replace(tzinfo=timezone.utc)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001 — resilient: wraps any json/key/parse error into a typed MintError for callers
         raise MintError(
             reason=f"failed to parse GitHub API response: {exc}",
             http_status=resp.status_code,

--- a/src/lyra/tools/gh_token/refresh.py
+++ b/src/lyra/tools/gh_token/refresh.py
@@ -90,9 +90,7 @@ async def refresh_loop(  # noqa: PLR0913
         now = datetime.now(tz=timezone.utc)
         cached = cache.read()
         if cached is None or cached.is_near_expiry(now, near_expiry_leeway_s):
-            log.debug(
-                "refresh_loop: token near expiry or absent — minting proactively"
-            )
+            log.debug("refresh_loop: token near expiry or absent — minting proactively")
             try:
                 await mint_capped(
                     app_id,
@@ -104,5 +102,5 @@ async def refresh_loop(  # noqa: PLR0913
                     rate_limiter=rate_limiter,
                     leeway_s=near_expiry_leeway_s,
                 )
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001 — resilient: mint failure is logged and the loop continues to the next refresh cycle
                 log.warning("refresh_loop: mint failed: %s", exc)


### PR DESCRIPTION
## Summary
- Add inline rationale to 8 `# noqa: BLE001` sites that were bare or used `-` instead of `—`.
- Pure comment change — no logic touched, no exemption files modified.
- Brings these sites in line with the existing repo pattern (`# noqa: BLE001 — resilient: <reason>`).

## Files touched
- `src/lyra/tools/gh_token/{refresh,dispenser,helper}.py` — 5 sites with context-specific rationale
- `src/lyra/bootstrap/standalone/hub_standalone_helpers.py` — 1 site
- `src/lyra/adapters/clipool/clipool_worker.py` — 3 sites harmonized (`-` → `—`)

## Verification
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `bash tools/check_file_length.sh` ✅
- All pre-commit hooks ✅

## Test Plan
- [ ] CI green on lint/typecheck
- [ ] No behavioral change expected (comment-only)

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`