### PR TITLE
ci(auto-merge): switch from --squash to --merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,10 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (squash) once the "reviewed" label is present.
+# Adds the PR to GitHub's merge queue (merge commit) once the "reviewed" label is present.
 # GitHub natively waits for all required status checks before merging.
+#
+# Project convention: merge commits only (¬squash) — see ~/projects/CLAUDE.md
+# "Release Convention". Squash merges flatten the per-commit history that
+# Conventional Commits + release-please rely on.
 #
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
 # auto-merges don't trigger GitHub's native "Closes #X" issue closure.
@@ -31,8 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable auto-merge (squash)
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+      - name: Enable auto-merge (merge commit)
+        run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

The `Enable auto-merge` workflow has been silently squashing every reviewed PR via `gh pr merge --auto --squash` (line 35). This contradicts the documented project convention **merge commits only (¬squash)** from `~/projects/CLAUDE.md` → Release Convention.

## Why it matters

- Squash merges flatten per-commit history that Conventional Commits + release-please rely on for changelog generation
- Manual `gh pr merge --merge` calls consistently lose the race against this auto-merge workflow once the `reviewed` label is added
- Surfaced during the #1118/#1120/#1125/#1126 cleanup pass (2026-05-07): 3 of 5 PRs landed via SQUASH (#1127, #1128, #1130) before the root cause was caught

## Change

```diff
- - name: Enable auto-merge (squash)
-   run: gh pr merge "$PR_NUMBER" --auto --squash
+ - name: Enable auto-merge (merge commit)
+   run: gh pr merge "$PR_NUMBER" --auto --merge
```

Plus:
- Header comment updated to mention "merge commit" instead of "squash"
- Cross-reference to project convention added

## Test plan

- [ ] Workflow lints (actionlint via CI)
- [ ] Manual smoke: future PR landing via `reviewed` label produces a 2-parent merge commit on staging (vs current 1-parent squash)
- [ ] No regression to the `update-behind-prs` or `close-linked-issues` jobs (they don't reference the merge method)

Refs #1118 #1120 #1125 #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)