### PR TITLE
fix(nats/auth): allow llm-worker to subscribe to its own inbox

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -21,6 +21,7 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 | `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — |
 | `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | PUB | — | PUB | — |
 | `_inbox.image-worker.>` | — | — | — | — | — | — | SUB | — | — | — |
+| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — |
 | `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — |
 | `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — |
 | `_inbox.voice-client.>` | — | — | — | — | PUB | — | — | — | — | SUB |

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -115,13 +115,14 @@
       "status": "active",
       "created_at": "2026-04-21",
       "owner": "reserved",
-      "description": "Reserved LLM worker identity — publishes heartbeat, subscribes to lyra.llm.generate.request queue. Inbox grant derived from request_reply_flows (Fix 3 / #992).",
+      "description": "llmCLI nats-serve worker. Worker uses inbox_prefix=_inbox.llmcli-llm (does not match the llm-worker role name), so the renderer's request_reply_flows derivation cannot auto-grant it — the inbox is listed explicitly in subscribe. See #1142.",
       "allow_responses": true,
       "publish": [
         "lyra.llm.heartbeat"
       ],
       "subscribe": [
-        "lyra.llm.generate.request"
+        "lyra.llm.generate.request",
+        "_inbox.llmcli-llm.>"
       ]
     },
     "image-worker": {

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -59,7 +59,7 @@ authorization {
       # llm-worker
       permissions: {
         publish:   { allow: ["lyra.llm.heartbeat","_inbox.hub.>"] }
-        subscribe: { allow: ["lyra.llm.generate.request"] }
+        subscribe: { allow: ["lyra.llm.generate.request","_inbox.llmcli-llm.>"] }
         allow_responses: true
       }
     }


### PR DESCRIPTION
## Summary

One-line ACL template fix: add `_inbox.llmcli-llm.>` to the llm-worker subscribe list so the worker can subscribe to its own private reply inbox (mirrors image-worker's `_inbox.image-worker.>` pattern).

## Problem

`gen_nkeys.py` renders `deploy/nats/auth.conf` into `~/.lyra/nkeys/auth.conf`. The current llm-worker subscribe ACL only allows `lyra.llm.generate.request`. The llmCLI worker's request-reply implementation subscribes to `_inbox.llmcli-llm.<worker-id>` — denied by the hub → NATS Subscription Violation → worker non-functional.

## Discovered during

M₂ remote-worker deploy (Roxabi/llmCLI#25). Smoke 1 only passed after manually patching the rendered file in place — that patch is wiped on next regen, so the template must be the SSoT.

## Test plan

- [x] Diff: 1 line changed, parallel to image-worker line 71
- [ ] On M₁ after merge: \`uv run python deploy/nats/gen_nkeys.py\` → grep \`_inbox.llmcli-llm\` in rendered file
- [ ] \`podman secret rm lyra-nats-auth && podman secret create lyra-nats-auth ~/.lyra/nkeys/auth.conf\`
- [ ] \`systemctl --user restart lyra-nats.service\`
- [ ] Smoke 1 from M₂: \`nats request --inbox-prefix=_inbox.hub lyra.llm.generate.request '{...}'\` → \`ok:true\`

Closes #1142