### PR TITLE
fix(quality-debt): cluster A polish — Makefile/ratchet/playbook/registry-template (#1162)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,9 @@ quality-debt-report:  ## audit suppression annotations → artifacts/quality-deb
 	uv run python tools/audit_quality_debt.py --root . --out artifacts/quality-debt-report.json
 
 quality-debt-rebaseline:  ## re-audit and regenerate tools/quality_debt_baseline.json (sets cutover_date = today+7d)
+	# || true is intentional: audit exits non-zero when UNTAGGED rows or stale_references exist in src/,
+	# but always writes the report first. The rebaseline script reads the report, not the exit code.
+	# Same pattern as tools/check_quality_debt_ratchet.sh (inline audit path, lines 58-64).
 	uv run python tools/audit_quality_debt.py --root . --out artifacts/quality-debt-report.json || true
 	uv run python tools/rebaseline_quality_debt.py \
 		--report artifacts/quality-debt-report.json \

--- a/docs/playbooks/quality-debt-pipeline.md
+++ b/docs/playbooks/quality-debt-pipeline.md
@@ -37,6 +37,15 @@ Do NOT set `RATCHET_MODE=hard` manually before the backfill is merged. CI never 
 
 5. **Regenerate baseline.** `make quality-debt-rebaseline` overwrites `tools/quality_debt_baseline.json` with per-(rule, bucket, slug) counts and stamps `generated_by: "make quality-debt-rebaseline"`. Ratchet rejects baselines missing this field (forge-resistant).
 
+   **`--reset-cutover` flag** — `rebaseline_quality_debt.py` accepts `--reset-cutover` to force the cutover date forward.
+
+   | Scenario | Command | Effect |
+   |---|---|---|
+   | Routine rebaseline (default) | `make quality-debt-rebaseline` | Preserves existing `cutover_date` — no deadline drift |
+   | Intentional reset after a clean slice ships | `make quality-debt-rebaseline EXTRA_ARGS=--reset-cutover` | Sets `cutover_date = today + 7d` — defers hard mode by 7 days |
+
+   Use `--reset-cutover` only when the new backlog legitimately warrants a fresh soft window (e.g., a scope extension that adds many UNTAGGED sites). Avoid it on routine rebaselines — the default preserve behavior prevents indefinite soft-mode deferral.
+
 6. **Set cutover date.** First rebaseline writes `cutover_date = merge-date + 7d`. Subsequent rebaselines preserve it. After that date ratchet auto-promotes to hard mode — no follow-up PR, no manual flip, no forget risk.
 
 7. **File P2a drain epic + populate registry bodies.** One GH issue: `"Quality-debt drain pass — REFACTOR-NOW + first DEBT batch (P2a)"`, blocked-by #1162. Registry files (`artifacts/debt/<slug>.md`) already exist from step 4; populate `## Drain plan` bodies per slug.

--- a/tools/check_quality_debt_ratchet.sh
+++ b/tools/check_quality_debt_ratchet.sh
@@ -24,6 +24,18 @@ BASELINE="${QG_BASELINE:-${REPO_ROOT}/tools/quality_debt_baseline.json}"
 AUDIT_REPORT="${QG_AUDIT_REPORT:-${REPO_ROOT}/artifacts/quality-debt-report.json}"
 
 # ---------------------------------------------------------------------------
+# Cleanup - single EXIT trap covering all temp files created by this script.
+# Variables are pre-declared empty so the guard is safe before mktemp runs.
+# ---------------------------------------------------------------------------
+tmp_report=""
+jq_log=""
+_cleanup() {
+    [[ -f "$tmp_report" ]] && rm -f "$tmp_report"
+    [[ -f "$jq_log" ]] && rm -f "$jq_log"
+}
+trap '_cleanup' EXIT
+
+# ---------------------------------------------------------------------------
 # Dependency check
 # ---------------------------------------------------------------------------
 if ! command -v jq &>/dev/null; then
@@ -35,13 +47,13 @@ fi
 # Load baseline
 # ---------------------------------------------------------------------------
 if [[ ! -f "$BASELINE" ]]; then
-    echo "baseline missing: $BASELINE — run 'make quality-debt-rebaseline' to create it." >&2
+    echo "baseline missing: $BASELINE - run 'make quality-debt-rebaseline' to create it." >&2
     exit 1
 fi
 
 generated_by="$(jq -r '.generated_by // empty' "$BASELINE")"
 if [[ "$generated_by" != "make quality-debt-rebaseline" ]]; then
-    echo "baseline generated_by mismatch ('${generated_by}') — regenerate via 'make quality-debt-rebaseline'" >&2
+    echo "baseline generated_by mismatch ('${generated_by}') - regenerate via 'make quality-debt-rebaseline'" >&2
     exit 1
 fi
 
@@ -54,10 +66,9 @@ if [[ -f "$AUDIT_REPORT" ]]; then
     report="$AUDIT_REPORT"
 else
     tmp_report="$(mktemp /tmp/quality-debt-report.XXXXXX.json)"
-    trap 'rm -f "$tmp_report"' EXIT
     # Audit exits non-zero when UNTAGGED rows or stale_references exist in src/,
     # but it ALWAYS writes the report first. Ratchet is the gate that decides
-    # whether violations block the push (soft/hard) — so we tolerate the
+    # whether violations block the push (soft/hard) - so we tolerate the
     # non-zero exit here and rely on the report content + mode logic below.
     uv run python "${REPO_ROOT}/tools/audit_quality_debt.py" \
         --root "${REPO_ROOT}" \
@@ -81,7 +92,7 @@ fi
 case "$mode" in
     soft|hard) ;;
     "")
-        echo "ratchet: internal error — mode not determined" >&2
+        echo "ratchet: internal error - mode not determined" >&2
         exit 1
         ;;
     *)
@@ -98,7 +109,7 @@ violations=0
 # (a) UNTAGGED rows in src/
 untagged_count="$(jq '[.rows[] | select(.bucket == "UNTAGGED" and (.path | startswith("src/")))] | length' "$report")"
 if [[ "$untagged_count" -gt 0 ]]; then
-    echo "WARN: ${untagged_count} untagged suppression(s) found in src/ — add POLICY:<tag> or DEBT:<slug> suffix." >&2
+    echo "WARN: ${untagged_count} untagged suppression(s) found in src/ - add POLICY:<tag> or DEBT:<slug> suffix." >&2
     violations=1
 fi
 
@@ -108,12 +119,11 @@ fi
 
 # Pre-validate report structure before iterating.
 if ! jq -e '.counts_by_rule_bucket_slug | type == "object"' "$report" >/dev/null 2>&1; then
-    echo "ratchet: report missing or malformed counts_by_rule_bucket_slug — regenerate via 'make quality-debt-report'" >&2
+    echo "ratchet: report missing or malformed counts_by_rule_bucket_slug - regenerate via 'make quality-debt-report'" >&2
     exit 1
 fi
 
 jq_log="$(mktemp)"
-trap 'rm -f "$jq_log"' EXIT
 while IFS=$'\t' read -r rule slug report_count; do
     baseline_count="$(jq -r --arg rule "$rule" --arg slug "$slug" \
         '.counts[$rule].DEBT[$slug] // 0' "$BASELINE")"
@@ -138,7 +148,7 @@ done < <(jq -r '
 # (c) Stale registry references in src/
 stale_src_count="$(jq '[.stale_references[] | select(.path | startswith("src/"))] | length' "$report")"
 if [[ "$stale_src_count" -gt 0 ]]; then
-    echo "WARN: ${stale_src_count} stale registry reference(s) in src/ — update or remove debt registry entries." >&2
+    echo "WARN: ${stale_src_count} stale registry reference(s) in src/ - update or remove debt registry entries." >&2
     violations=1
 fi
 

--- a/tools/classify_quality_debt.py
+++ b/tools/classify_quality_debt.py
@@ -34,8 +34,8 @@ slug: {slug}
 title: {title}
 status: open
 created: {today}
-drain_slice: P2a
-parent_slice: '#1162'
+drain_slice: TBD  # TODO: set to actual slice (e.g., P2a) when promoting
+parent_slice: TBD  # TODO: set to actual parent issue (e.g., '#1162') when promoting
 rule: {rule}
 rules:
   - {rule}


### PR DESCRIPTION
## Summary

Polish pass on 4 non-blocking iter-2 review findings from PR #1164 (#1162 quality-debt invariant). All deliberately scoped — no behavior changes to merged production logic.

## Changes (4 commits, 4 files)

| Commit | File | Finding |
|---|---|---|
| `dabc42c1` | `Makefile` | Explain rebaseline `\|\| true` rationale inline (mirrors hotfix 6cae765f pattern) |
| `b9192521` | `tools/check_quality_debt_ratchet.sh` | Consolidate 2 shadowed `trap ... EXIT` calls into single `_cleanup` function — prevents temp file leak |
| `e25d19df` | `docs/playbooks/quality-debt-pipeline.md` | Document `--reset-cutover` flag on rebaseline tool |
| `cfea5bbc` | `tools/classify_quality_debt.py` | Replace hardcoded `parent_slice: P2a` / `drain_slice: P2a` in `_REGISTRY_TEMPLATE` with `TBD` + TODO comment |

## Test plan
- [x] `uv run pytest tests/tools/ -q` → 26 passed, 1 skipped
- [x] `bash tools/check_quality_debt_ratchet.sh` → exits 0, no temp leak
- [x] Pre-commit hooks pass on each commit (lint, typecheck, file-length, folder-size, dup tests, import-layers, license)
- [ ] CI green on PR

## Out of scope
- Test coverage gaps (8 items) → tracked in #1165
- Drain backlog → tracked in #1163

Closes part of #1162's iter-2 follow-up. Sibling: #1165 (test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)