### PR TITLE
fix(nats): codec assert_never + Text v2 triplet branches; PR-template DoD

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,16 @@
 - [ ] Lint passes
 - [ ] Docs updated if needed
 - [ ] Commits follow Conventional Commits format
+
+## RenderEvent changes (if applicable)
+
+Tick this section when adding/modifying a `RenderEvent` subtype, the
+`StreamProcessor` emission path, or any wire boundary in the hub↔adapter
+streaming pipeline. Otherwise leave blank.
+
+- [ ] `RenderEvent` union in `src/lyra/core/messaging/render_events.py` updated
+- [ ] `NatsRenderEventCodec.encode` branch added (forced by `assert_never`)
+- [ ] `NatsRenderEventCodec.decode` branch added with matching `event_type` string + schema-version check
+- [ ] Codec round-trip test in `tests/nats/test_render_event_codec.py` for every new subtype
+- [ ] `_shared_streaming_emitter.py` dispatch updated (consumer side)
+- [ ] Wire-format docstring in `NatsRenderEventCodec` lists the new `event_type`

--- a/artifacts/analyses/1190-codec-review-findings-consensus.mdx
+++ b/artifacts/analyses/1190-codec-review-findings-consensus.mdx
@@ -1,0 +1,101 @@
+---
+title: "PR #1190 codec review — long-term solutions for 4 remaining findings"
+issue: null
+pr: 1190
+status: consensus-reached
+date: 2026-05-14
+panel: architect, backend-dev, security-auditor
+confidence: high
+---
+
+## Problem
+
+PR #1190 (`fix(nats): codec assert_never + Text v2 triplet branches`) shipped a hotfix for a Slice 2 codec gap that crashed prod streaming, plus an `assert_never` exhaustiveness guard and a PR-template DoD section. Code review surfaced 8 findings; 4 high-confidence blockers/suggestions were auto-applied and pushed. 4 remain — all in `nitpick`/`suggestion(non-blocking)` territory, but each carries a long-term-direction question (apply now vs defer to the planned #1102 registry refactor vs skip permanently).
+
+## Panel
+
+| Agent | Focus |
+|---|---|
+| architect | architectural soundness, alignment with the #1102 codec-registry refactor, scope discipline |
+| backend-dev | Python implementation complexity, idiomatic patterns, maintenance burden |
+| security-auditor | wire-boundary resilience, defense-in-depth, partial-deploy attack surface |
+
+## Consensus ρ
+
+| # | Finding | Verdict | Vote |
+|---|---|---|---|
+| #4 | `decode()` error propagation — `TypeError` from `deserialize()` aborts whole stream | **defer-to-#1102** | 3-0 |
+| #6 | `encode()` `is_done` docstring doesn't mention Text v2 events | **apply-now** | 2-1* |
+| #7 | No runtime test for `assert_never` on non-`RenderEvent` | **apply-now** | 3-0 |
+| #8 | AAA-comment structure consistency in test file | **skip-permanently** | 3-0 |
+
+*Security-auditor abstained on #6 ("no security surface") rather than opposing — recorded as accepted dissent on relevance, not on direction.
+
+### Rationale per finding
+
+**#4 — defer-to-#1102 (unanimous).** The 16 decode branches each call `deserialize()`; wrapping each in `try/except (TypeError, ValueError, KeyError)` now would add ~50 lines of near-identical boilerplate that #1102's registry pattern will collapse into one centralised guard. The realistic threat is partial-deploy within-version type drift (not adversarial — internal authenticated NATS); the schema-version gate already handles cross-version drift. Stream-abort on a bad chunk is recoverable, logged at exception level, not silent data corruption. Backend-dev explicitly flagged that applying now would create code-review noise, git-blame churn, and incident-postmortem clutter for a refactor about to delete those exact lines.
+
+**#6 — apply-now (2-1, with abstention).** One-sentence doc addition. Zero risk, zero cost, permanently improves clarity. The docstring currently lists `is_done=True` cases (final `TextRenderEvent`, complete `ToolSummaryRenderEvent`, terminal Run lifecycle) but is silent on the 4 Text v2 events. A new reader has no signal that `TextStart/Delta/End/Chunk` always return `False`. Architect and backend-dev unanimous; security-auditor noted no security surface but did not dissent on the action.
+
+**#7 — apply-now (unanimous).** A single `pytest.raises` test on a non-`RenderEvent` input. The original Slice 2 incident was exactly this class of bug — encoder exhaustiveness gap reaching runtime. `assert_never` is a static typing guarantee; pyright config drift, stub regeneration, or accidental union widening can all silently suppress the check while leaving a live crash path. Static analysis is *not* part of the test harness and can lapse without notice. ~3 lines of permanent insurance. Orthogonal to #1102's planned registry-completeness test (registry completeness ≠ type exhaustiveness at the call site — both invariants warrant their own guard).
+
+**#8 — skip-permanently (unanimous).** Test file has 4 classes: 1 uses explicit `# Arrange / # Act / # Assert` comments (28 tests of code, 6 of comments per AAA class), 3 use terse style (the actual majority by test count). Refactoring 13 new tests to add AAA comments would produce a noisy diff with zero semantic change. The correct long-term direction is to *strip* the AAA ceremony from the outlier class during #1102's test pass, not propagate it forward. Terse is the established majority pattern.
+
+### Cross-finding architectural observations
+
+1. **#1102 scope discipline (architect).** Issue #1102 (Slice 5 cleanup) currently bundles: (a) v1 backward-compat removal, (b) `SCHEMA_VERSION_RENDER` floor bump, (c) `ToolSummaryRenderEvent` deletion, (d) codec registry pattern, (e) registry-completeness test, (f) hub→NATS→adapter integration test, (g) [now] decode error propagation guard from #4, (h) [now] strip AAA comments from `TestRenderEventCodecVersionCheck`. That is a god-slice. Recommend split:
+   - **#1102a** — codec registry structural refactor: registry pattern + completeness test + per-class try/except for #4 + nats_stream_decoder.py default-routing fix (see #3 below). Pure infra change, independently shippable.
+   - **#1102b** — hub→NATS→adapter outbound render-event integration test. Independently shippable, no blocking dependency on #1102a.
+   - **#1102** retains: v1 removal, schema floor bump, `ToolSummaryRenderEvent` deletion, coordinated deploy note. The original Slice 5 acceptance.
+
+2. **Don't proxy-fix #4 (backend-dev).** Wrapping `decode()` in a broad `pytest.raises` or `except Exception` shim as a stopgap for #4 would be *bidouillage* — masks stream-abort behaviour without fixing error propagation. Hold the line: surgical fix inside #1102a's registry refactor.
+
+3. **Pre-existing bug, low severity (security-auditor).** `src/lyra/adapters/nats/nats_stream_decoder.py:122` uses `chunk.get("event_type", "text")` — a missing `event_type` field silently routes to the text decoder. Not introduced by this PR. Inside an authenticated NATS boundary so low severity, but #1102a should make this an explicit `None → log.warning + break` path.
+
+## Trade-offs
+
+- **Defer #4:** accepts continued stream-abort risk on within-version type drift until #1102a ships. Mitigant: schema_version gate covers the common partial-deploy case; internal NATS authenticated boundary; failures are loud (logged at exception level), not silent.
+- **Apply #6, #7 now:** 4 lines of code total. Cost = trivial commit + re-review iteration on PR #1190.
+- **Skip #8:** accepts ongoing two-style coexistence in `test_render_event_codec.py` until #1102a's test refactor normalises toward terse.
+
+## Alternatives considered
+
+| ω | Proposed by | Rejected because |
+|---|---|---|
+| Apply #4 per-branch try/except now | hypothetical | 50 lines of repetition gets deleted in #1102a; creates 2-touch git-blame on every branch |
+| Skip #4 permanently | hypothetical | Stream-abort on bad chunk is a real operational hazard if it ever fires; the schema gate doesn't cover within-version type drift |
+| Apply #8 — add AAA comments to all 13 new tests | hypothetical | Annotation noise > body in tests <10 lines; majority of file is already terse; propagates ceremony in the wrong direction |
+| Apply #6 as part of #1102 docs pass | architect (rejected) | Docstring drift compounds; no benefit to waiting; the registry refactor won't auto-fix prose docs |
+| Defer #7 to #1102's registry-completeness test | hypothetical | Two orthogonal invariants — registry completeness ≠ type exhaustiveness at the call site; needs both |
+
+## Dissent
+
+Security-auditor noted "no security surface" on #6 and #8 — recorded as **abstention** on direct relevance, not opposition to the chosen action. Action items align with architect + backend-dev.
+
+## Implementation Notes
+
+For PR #1190 follow-up commit (still in `/fix` 1b1 walkthrough):
+1. **#6** — append one sentence to `encode()` docstring at `src/lyra/nats/render_event_codec.py:88-94`:
+   > "Text v2 lifecycle events (`TextStartRenderEvent`, `TextDeltaRenderEvent`, `TextEndRenderEvent`, `TextChunkRenderEvent`) always yield `is_done=False`."
+2. **#7** — add one test to `TestRenderEventCodecTextTriplet` (or a new tiny class) at `tests/nats/test_render_event_codec.py`:
+   ```python
+   def test_encode_rejects_non_render_event(self) -> None:
+       codec = NatsRenderEventCodec()
+       with pytest.raises(Exception):
+           codec.encode(object())  # pyright: ignore[reportArgumentType]
+   ```
+3. **#4 + #8** — no code change on this PR; trust the #1102 split.
+
+For #1102 follow-up (post-merge):
+- Split #1102 into #1102a (registry refactor + #4 guard + nats_stream_decoder default fix + AAA strip) and #1102b (integration test) per architect's blocking ξ.
+- Surface the `chunk.get("event_type", "text")` default-routing observation as an explicit acceptance item on #1102a.
+
+## Next
+
+Return to `/fix` Phase 5 walkthrough with these decisions:
+- #4: Defer (record issue created note in PR comment — already noted in #1102 body)
+- #6: Solution 1 (apply)
+- #7: Solution 1 (apply)
+- #8: Skip
+
+Then `/fix` Phase 6 → 7 → 8 (post Review Fixes Applied comment + apply `reviewed` label).

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -92,6 +92,12 @@ class NatsRenderEventCodec:
         a complete ``ToolSummaryRenderEvent`` (``is_complete``), or any of the
         terminal Run lifecycle events (``RunFinishedRenderEvent``,
         ``RunErrorRenderEvent``). ``RunStartedRenderEvent`` is not terminal.
+
+        Text v2 lifecycle events (``TextStartRenderEvent``,
+        ``TextDeltaRenderEvent``, ``TextEndRenderEvent``,
+        ``TextChunkRenderEvent``) always yield ``is_done=False`` — the
+        stream terminator remains the Run lifecycle event, not the
+        text-block boundary.
         """
         payload: dict = json.loads(serialize(event).decode("utf-8"))
         if isinstance(event, TextRenderEvent):

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -70,13 +70,14 @@ class NatsRenderEventCodec:
                           | "tool_call_start" | "tool_call_args"
                           | "tool_call_end" | "tool_call_result"
                           | "reasoning_start" | "reasoning_delta"
-                          | "reasoning_end" | "stream_end",
+                          | "reasoning_end" | "stream_end" | "stream_error",
             "payload":    dict,   # serialized event fields
             "done":       bool,
         }
 
-    ``"stream_end"`` is a synthetic terminal sentinel emitted by
-    ``NatsChannelProxy``; ``decode()`` returns ``None`` for it. The
+    ``"stream_end"`` and ``"stream_error"`` are synthetic terminal sentinels
+    (the latter emitted by the transport on mid-stream hub crash, #538);
+    ``decode()`` returns ``None`` for both. The
     ``run_*`` types were added by Slice 1 of #1096 (#1098).
     """
 
@@ -365,6 +366,8 @@ class NatsRenderEventCodec:
                 resolver=self._resolver,
             )
         if event_type == "stream_end":
+            return None
+        if event_type == "stream_error":
             return None
         # Unknown event_type — surface via log + counter so partial-deploy
         # mismatches are visible. Synthetic transport sentinels (stream_end /

--- a/src/lyra/nats/render_event_codec.py
+++ b/src/lyra/nats/render_event_codec.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import assert_never
 
 from lyra.core.messaging.render_events import (
     SCHEMA_VERSION_REASONING_DELTA_RENDER_EVENT,
@@ -17,7 +18,11 @@ from lyra.core.messaging.render_events import (
     SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT,
     SCHEMA_VERSION_RUN_FINISHED_RENDER_EVENT,
     SCHEMA_VERSION_RUN_STARTED_RENDER_EVENT,
+    SCHEMA_VERSION_TEXT_CHUNK_RENDER_EVENT,
+    SCHEMA_VERSION_TEXT_DELTA_RENDER_EVENT,
+    SCHEMA_VERSION_TEXT_END_RENDER_EVENT,
     SCHEMA_VERSION_TEXT_RENDER_EVENT,
+    SCHEMA_VERSION_TEXT_START_RENDER_EVENT,
     SCHEMA_VERSION_TOOL_CALL_ARGS_RENDER_EVENT,
     SCHEMA_VERSION_TOOL_CALL_END_RENDER_EVENT,
     SCHEMA_VERSION_TOOL_CALL_RESULT_RENDER_EVENT,
@@ -32,7 +37,11 @@ from lyra.core.messaging.render_events import (
     RunFinishedRenderEvent,
     RunStartedRenderEvent,
     SilentCounts,
+    TextChunkRenderEvent,
+    TextDeltaRenderEvent,
+    TextEndRenderEvent,
     TextRenderEvent,
+    TextStartRenderEvent,
     ToolCallArgsRenderEvent,
     ToolCallEndRenderEvent,
     ToolCallResultRenderEvent,
@@ -55,9 +64,13 @@ class NatsRenderEventCodec:
         {
             "stream_id": str,
             "seq":        int,
-            "event_type": "text" | "tool_summary"
+            "event_type": "text" | "text_start" | "text_delta"
+                          | "text_end" | "text_chunk" | "tool_summary"
                           | "run_started" | "run_finished" | "run_error"
-                          | "stream_end",
+                          | "tool_call_start" | "tool_call_args"
+                          | "tool_call_end" | "tool_call_result"
+                          | "reasoning_start" | "reasoning_delta"
+                          | "reasoning_end" | "stream_end",
             "payload":    dict,   # serialized event fields
             "done":       bool,
         }
@@ -82,6 +95,14 @@ class NatsRenderEventCodec:
         payload: dict = json.loads(serialize(event).decode("utf-8"))
         if isinstance(event, TextRenderEvent):
             return "text", payload, event.is_final
+        if isinstance(event, TextStartRenderEvent):
+            return "text_start", payload, False
+        if isinstance(event, TextDeltaRenderEvent):
+            return "text_delta", payload, False
+        if isinstance(event, TextEndRenderEvent):
+            return "text_end", payload, False
+        if isinstance(event, TextChunkRenderEvent):
+            return "text_chunk", payload, False
         if isinstance(event, ToolSummaryRenderEvent):
             return "tool_summary", payload, event.is_complete
         if isinstance(event, RunStartedRenderEvent):
@@ -102,11 +123,9 @@ class NatsRenderEventCodec:
             return "reasoning_start", payload, False
         if isinstance(event, ReasoningDeltaRenderEvent):
             return "reasoning_delta", payload, False
-        if isinstance(event, ReasoningEndRenderEvent):  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
+        if isinstance(event, ReasoningEndRenderEvent):  # pyright: ignore[reportUnnecessaryIsInstance] — last branch is provably exhaustive; isinstance kept for runtime symmetry with the others before assert_never
             return "reasoning_end", payload, False
-        raise TypeError(  # pyright: ignore[reportUnreachable] — DEBT:defensive-narrow-payloads
-            f"Unsupported RenderEvent subtype: {type(event)!r}"
-        )
+        assert_never(event)
 
     def decode(  # noqa: C901 — DEBT:complexity-residual — per-event-type version-check + decode; refactored when Slice 5 sunsets v1
         self,
@@ -139,6 +158,58 @@ class NatsRenderEventCodec:
             return deserialize(
                 json.dumps(payload, ensure_ascii=False).encode("utf-8"),
                 TextRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "text_start":
+            if not check_schema_version(
+                payload,
+                envelope_name="TextStartRenderEvent",
+                expected=SCHEMA_VERSION_TEXT_START_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                TextStartRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "text_delta":
+            if not check_schema_version(
+                payload,
+                envelope_name="TextDeltaRenderEvent",
+                expected=SCHEMA_VERSION_TEXT_DELTA_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                TextDeltaRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "text_end":
+            if not check_schema_version(
+                payload,
+                envelope_name="TextEndRenderEvent",
+                expected=SCHEMA_VERSION_TEXT_END_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                TextEndRenderEvent,
+                resolver=self._resolver,
+            )
+        if event_type == "text_chunk":
+            if not check_schema_version(
+                payload,
+                envelope_name="TextChunkRenderEvent",
+                expected=SCHEMA_VERSION_TEXT_CHUNK_RENDER_EVENT,
+                counter=counter,
+            ):
+                return None
+            return deserialize(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                TextChunkRenderEvent,
                 resolver=self._resolver,
             )
         if event_type == "tool_summary":

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -19,7 +19,11 @@ from lyra.core.messaging.render_events import (
     ReasoningDeltaRenderEvent,
     ReasoningEndRenderEvent,
     ReasoningStartRenderEvent,
+    TextChunkRenderEvent,
+    TextDeltaRenderEvent,
+    TextEndRenderEvent,
     TextRenderEvent,
+    TextStartRenderEvent,
     ToolCallArgsRenderEvent,
     ToolCallEndRenderEvent,
     ToolCallResultRenderEvent,
@@ -370,3 +374,87 @@ class TestReasoningCodecRoundTrip:
 
         assert result is None
         assert counter == {"ReasoningStartRenderEvent:schema": 1}
+
+
+class TestRenderEventCodecTextTriplet:
+    """Slice 2 (#1099) v2 Text triplet — encode + round-trip coverage.
+
+    Guards against the Slice 2 codec gap where TextStart/Delta/End/Chunk
+    were emitted by StreamProcessor but unhandled by NatsRenderEventCodec,
+    crashing the hub→adapter stream with TypeError.
+    """
+
+    def test_text_start_encodes(self) -> None:
+        codec = NatsRenderEventCodec()
+        event_type, payload, is_done = codec.encode(
+            TextStartRenderEvent(message_id="msg_001")
+        )
+        assert event_type == "text_start"
+        assert is_done is False
+        assert payload["message_id"] == "msg_001"
+        assert payload["schema_version"] == 1
+
+    def test_text_delta_encodes(self) -> None:
+        codec = NatsRenderEventCodec()
+        event_type, payload, is_done = codec.encode(
+            TextDeltaRenderEvent(message_id="msg_001", delta="hello")
+        )
+        assert event_type == "text_delta"
+        assert is_done is False
+        assert payload["delta"] == "hello"
+
+    def test_text_end_encodes(self) -> None:
+        codec = NatsRenderEventCodec()
+        event_type, _payload, is_done = codec.encode(
+            TextEndRenderEvent(message_id="msg_001")
+        )
+        assert event_type == "text_end"
+        assert is_done is False
+
+    def test_text_chunk_encodes(self) -> None:
+        codec = NatsRenderEventCodec()
+        event_type, payload, is_done = codec.encode(
+            TextChunkRenderEvent(message_id="msg_001", delta="hi")
+        )
+        assert event_type == "text_chunk"
+        assert is_done is False
+        assert payload["delta"] == "hi"
+
+    def test_text_start_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = TextStartRenderEvent(message_id="msg_001")
+        event_type, payload, _ = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_text_delta_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = TextDeltaRenderEvent(message_id="msg_001", delta="hello world")
+        event_type, payload, _ = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_text_end_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = TextEndRenderEvent(message_id="msg_001")
+        event_type, payload, _ = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_text_chunk_round_trip(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = TextChunkRenderEvent(message_id="msg_001", delta="hi")
+        event_type, payload, _ = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+
+    def test_text_start_floor_rejects_future_schema(self) -> None:
+        codec = NatsRenderEventCodec()
+        counter: dict[str, int] = {}
+        result = codec.decode(
+            "text_start",
+            {"schema_version": 99, "message_id": "msg_001"},
+            counter=counter,
+        )
+        assert result is None
+        assert counter == {"TextStartRenderEvent:schema": 1}

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -401,15 +401,19 @@ class TestRenderEventCodecTextTriplet:
         )
         assert event_type == "text_delta"
         assert is_done is False
+        assert payload["message_id"] == "msg_001"
         assert payload["delta"] == "hello"
+        assert payload["schema_version"] == 1
 
     def test_text_end_encodes(self) -> None:
         codec = NatsRenderEventCodec()
-        event_type, _payload, is_done = codec.encode(
+        event_type, payload, is_done = codec.encode(
             TextEndRenderEvent(message_id="msg_001")
         )
         assert event_type == "text_end"
         assert is_done is False
+        assert payload["message_id"] == "msg_001"
+        assert payload["schema_version"] == 1
 
     def test_text_chunk_encodes(self) -> None:
         codec = NatsRenderEventCodec()
@@ -418,7 +422,9 @@ class TestRenderEventCodecTextTriplet:
         )
         assert event_type == "text_chunk"
         assert is_done is False
+        assert payload["message_id"] == "msg_001"
         assert payload["delta"] == "hi"
+        assert payload["schema_version"] == 1
 
     def test_text_start_round_trip(self) -> None:
         codec = NatsRenderEventCodec()
@@ -458,3 +464,36 @@ class TestRenderEventCodecTextTriplet:
         )
         assert result is None
         assert counter == {"TextStartRenderEvent:schema": 1}
+
+    def test_text_delta_floor_rejects_future_schema(self) -> None:
+        codec = NatsRenderEventCodec()
+        counter: dict[str, int] = {}
+        result = codec.decode(
+            "text_delta",
+            {"schema_version": 99, "message_id": "msg_001", "delta": "x"},
+            counter=counter,
+        )
+        assert result is None
+        assert counter == {"TextDeltaRenderEvent:schema": 1}
+
+    def test_text_end_floor_rejects_future_schema(self) -> None:
+        codec = NatsRenderEventCodec()
+        counter: dict[str, int] = {}
+        result = codec.decode(
+            "text_end",
+            {"schema_version": 99, "message_id": "msg_001"},
+            counter=counter,
+        )
+        assert result is None
+        assert counter == {"TextEndRenderEvent:schema": 1}
+
+    def test_text_chunk_floor_rejects_future_schema(self) -> None:
+        codec = NatsRenderEventCodec()
+        counter: dict[str, int] = {}
+        result = codec.decode(
+            "text_chunk",
+            {"schema_version": 99, "message_id": "msg_001", "delta": "x"},
+            counter=counter,
+        )
+        assert result is None
+        assert counter == {"TextChunkRenderEvent:schema": 1}

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -497,3 +497,32 @@ class TestRenderEventCodecTextTriplet:
         )
         assert result is None
         assert counter == {"TextChunkRenderEvent:schema": 1}
+
+
+class TestRenderEventCodecExhaustivenessGuard:
+    """Runtime tripwire for the assert_never guard in encode().
+
+    Pyright catches union-exhaustiveness at static-check time, but pyright
+    config drift, stub regeneration, or accidental union widening can all
+    silently disable the static check while leaving a live crash path.
+    The original Slice 2 (#1099) incident was exactly this class of bug:
+    a new RenderEvent subclass reached encode() at runtime with no branch
+    to handle it. This test fires if assert_never is ever removed or
+    bypassed — uses a serializable dataclass that survives the upstream
+    serialize() call and reaches the isinstance dispatch chain.
+    """
+
+    def test_encode_assert_never_fires_on_unknown_render_event(self) -> None:
+        # Fake RenderEvent-shaped dataclass NOT in the union. serialize()
+        # accepts it (it's a dataclass); the isinstance ladder falls through
+        # every branch; assert_never raises AssertionError.
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class _FakeRenderEvent:
+            payload: str = "x"
+            schema_version: int = 1
+
+        codec = NatsRenderEventCodec()
+        with pytest.raises(AssertionError):
+            codec.encode(_FakeRenderEvent())  # pyright: ignore[reportArgumentType]

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,4 +14,4 @@ src/lyra/core/cli/cli_streaming_parser.py  # 336 lines — DEBT:file-exemptions 
 src/lyra/core/messaging/render_events.py  # 359 lines — DEBT:file-exemptions — #1099 Text v2 triplet + #1101 Reasoning v2 triplet (refactor deferred to Slice 5 / #1102)
 src/lyra/adapters/telegram/telegram_outbound.py  # 392 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
 src/lyra/adapters/discord/discord_outbound.py  # 381 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
-src/lyra/nats/render_event_codec.py  # 403 lines — DEBT:file-exemptions — #1099 Text v2 triplet encode/decode branches × 4 + assert_never exhaustiveness (cleanup in Slice 5 / #1102: collapse to registry-driven dispatch)
+src/lyra/nats/render_event_codec.py  # 406 lines — DEBT:file-exemptions — #1099 Text v2 triplet encode/decode branches × 4 + assert_never exhaustiveness + stream_error decode branch (cleanup in Slice 5 / #1102: collapse to registry-driven dispatch)

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,4 +14,4 @@ src/lyra/core/cli/cli_streaming_parser.py  # 336 lines — DEBT:file-exemptions 
 src/lyra/core/messaging/render_events.py  # 359 lines — DEBT:file-exemptions — #1099 Text v2 triplet + #1101 Reasoning v2 triplet (refactor deferred to Slice 5 / #1102)
 src/lyra/adapters/telegram/telegram_outbound.py  # 392 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
 src/lyra/adapters/discord/discord_outbound.py  # 381 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
-src/lyra/nats/render_event_codec.py  # 406 lines — DEBT:file-exemptions — #1099 Text v2 triplet encode/decode branches × 4 + assert_never exhaustiveness + stream_error decode branch (cleanup in Slice 5 / #1102: collapse to registry-driven dispatch)
+src/lyra/nats/render_event_codec.py  # 412 lines — DEBT:file-exemptions — #1099 Text v2 triplet encode/decode branches × 4 + assert_never exhaustiveness + stream_error decode branch + is_done docstring (cleanup in Slice 5 / #1102: collapse to registry-driven dispatch)

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -14,4 +14,4 @@ src/lyra/core/cli/cli_streaming_parser.py  # 336 lines — DEBT:file-exemptions 
 src/lyra/core/messaging/render_events.py  # 359 lines — DEBT:file-exemptions — #1099 Text v2 triplet + #1101 Reasoning v2 triplet (refactor deferred to Slice 5 / #1102)
 src/lyra/adapters/telegram/telegram_outbound.py  # 392 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
 src/lyra/adapters/discord/discord_outbound.py  # 381 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
-src/lyra/nats/render_event_codec.py  # 332 lines — DEBT:file-exemptions — #1101 Reasoning encode/decode branches × 3 (cleanup in Slice 5 / #1102: collapse to registry-driven dispatch)
+src/lyra/nats/render_event_codec.py  # 403 lines — DEBT:file-exemptions — #1099 Text v2 triplet encode/decode branches × 4 + assert_never exhaustiveness (cleanup in Slice 5 / #1102: collapse to registry-driven dispatch)


### PR DESCRIPTION
## Summary

Closes the Slice 2 (#1099) codec gap that crashed prod streaming today: `NatsRenderEventCodec.encode` had no branch for `TextStart/Delta/End/Chunk` events, so when `StreamProcessor` emitted them the encoder raised `TypeError: Unsupported RenderEvent subtype: TextStartRenderEvent`, the iterator was drained, and adapters showed "no display text" to users.

Sister fix that makes this class of bug **catchable by pyright at review time**, not at runtime in prod.

## Why this slipped through CI

- Codec has 14 `isinstance` branches + a `raise TypeError` final fall-through with `# pyright: ignore[reportUnreachable]` — pyright was muted, so the encoder was not enforced exhaustive
- All Slice 2 tests were in-process (`test_render_events.py`, `test_stream_processor.py`, `test_shared.py`) — none cross the `NatsChannelProxy` wire boundary
- The codec test file referenced only `TextRenderEvent` (v1) — zero coverage of v2 Text events
- Sibling slices 1/3/4 all updated the codec ✅; Slice 2 (#1173) did not

## Changes

- `src/lyra/nats/render_event_codec.py`
  - `encode()`: 4 new branches (`text_start`, `text_delta`, `text_end`, `text_chunk`)
  - `encode()`: replace `raise TypeError` + `pyright: ignore[reportUnreachable]` with `assert_never(event)`
  - `decode()`: 4 new `event_type` branches with schema-version check
  - Wire-format docstring lists the full event_type set
- `tests/nats/test_render_event_codec.py`: 9 new tests (encode shape + round-trip + schema floor)
- `tools/file_exemptions.txt`: bump codec cap 332→403 with #1099 rationale
- `.github/PULL_REQUEST_TEMPLATE.md`: new "RenderEvent changes" DoD section so future render-event PRs cannot omit the codec + test + docstring checklist

## Mechanical guarantee going forward

```python
# new RenderEvent subclass added to the union without a codec branch:
$ pyright src/lyra/nats/render_event_codec.py
error: Argument of type "NewRenderEvent" cannot be assigned to parameter "arg" of type "Never"
```

The encoder is now sum-type exhaustive: adding to the `RenderEvent` union without handling it in the codec fails pyright. Same mechanism `_shared_streaming_emitter.py` already uses on the consumer side.

## Type of change

- [x] Bug fix
- [x] Refactoring (assert_never + DoD checklist)

## Checklist

- [x] Tests pass (`pytest tests/nats/test_render_event_codec.py` — 27 passed)
- [x] Lint passes (`ruff check`)
- [x] Typecheck passes (`pyright src/lyra/nats/render_event_codec.py`)
- [x] Commits follow Conventional Commits format

## RenderEvent changes

- [x] `RenderEvent` union — unchanged (already had Text v2 from #1173)
- [x] `NatsRenderEventCodec.encode` branches added
- [x] `NatsRenderEventCodec.decode` branches added
- [x] Codec round-trip tests added
- [x] `_shared_streaming_emitter.py` already handled the v2 events (from #1173)
- [x] Wire-format docstring updated

## Follow-ups (deferred to #1102 Slice 5)

- Codec registry pattern (`dict[Type[RenderEvent], (event_type_str, is_done_fn)]`) — single source of truth, registry-completeness test
- New sibling-of-#632 issue: hub→NATS→adapter render-event integration test (parameterized over the full union)

🤖 Generated with [Claude Code](https://claude.com/claude-code)