### PR TITLE
feat(ci): renderer→consumer roundtrip workflow + standards doc (#1091)

### DIFF
--- a/.github/actions/install-nats-server/action.yml
+++ b/.github/actions/install-nats-server/action.yml
@@ -1,0 +1,29 @@
+name: Install nats-server
+description: Download, verify (SHA256), and install nats-server to /usr/local/bin
+
+inputs:
+  nats-version:
+    description: nats-server version to install (without leading v)
+    required: false
+    default: "2.10.22"
+
+runs:
+  using: composite
+  steps:
+    - name: Install nats-server
+      shell: bash
+      env:
+        NATS_VERSION: ${{ inputs.nats-version }}
+      run: |
+        set -euo pipefail
+        ARCH=$(dpkg --print-architecture)
+        TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
+        TMPDIR=$(mktemp -d)
+        curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
+          -o "${TMPDIR}/${TARBALL}"
+        curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
+          -o "${TMPDIR}/SHA256SUMS"
+        cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
+        tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+        sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
+        nats-server --version

--- a/.github/workflows/renderer-roundtrip.yml
+++ b/.github/workflows/renderer-roundtrip.yml
@@ -44,6 +44,23 @@ jobs:
           sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
           nats-server --version
 
+      - name: Install nk
+        env:
+          NK_VERSION: "0.4.15"
+        run: |
+          set -euo pipefail
+          ARCH=$(dpkg --print-architecture)
+          ZIPFILE="nkeys-v${NK_VERSION}-linux-${ARCH}.zip"
+          TMPDIR=$(mktemp -d)
+          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/${ZIPFILE}" \
+            -o "${TMPDIR}/${ZIPFILE}"
+          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/nkeys-v${NK_VERSION}-checksums.txt" \
+            -o "${TMPDIR}/checksums.txt"
+          cd "${TMPDIR}" && grep -F "${ZIPFILE}" checksums.txt | sha256sum --check
+          unzip -q "${TMPDIR}/${ZIPFILE}" -d "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nkeys-v${NK_VERSION}-linux-${ARCH}/nk" /usr/local/bin/nk
+          nk -v
+
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7
 

--- a/.github/workflows/renderer-roundtrip.yml
+++ b/.github/workflows/renderer-roundtrip.yml
@@ -133,3 +133,34 @@ jobs:
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/certs"
           bash tools/check_renderer_roundtrip.sh gen-certs "$RUNNER_TEMP/certs"
+
+  helper-self-test:
+    # Self-test calls invariant helper functions directly — no nats-server needed.
+    # Only nk is required (for case-c: generating a mismatched seed pair).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install nk
+        env:
+          NK_VERSION: "0.4.15"
+        run: |
+          set -euo pipefail
+          ARCH=$(dpkg --print-architecture)
+          ZIPFILE="nkeys-v${NK_VERSION}-linux-${ARCH}.zip"
+          TMPDIR=$(mktemp -d)
+          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/${ZIPFILE}" \
+            -o "${TMPDIR}/${ZIPFILE}"
+          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/nkeys-v${NK_VERSION}-checksums.txt" \
+            -o "${TMPDIR}/checksums.txt"
+          cd "${TMPDIR}" && grep -F "${ZIPFILE}" checksums.txt | sha256sum --check
+          unzip -q "${TMPDIR}/${ZIPFILE}" -d "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nkeys-v${NK_VERSION}-linux-${ARCH}/nk" /usr/local/bin/nk
+          nk -v
+
+      - name: Run helper self-test
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/self-test"
+          bash tools/check_renderer_roundtrip.sh self-test "$RUNNER_TEMP/self-test"

--- a/.github/workflows/renderer-roundtrip.yml
+++ b/.github/workflows/renderer-roundtrip.yml
@@ -1,0 +1,117 @@
+name: Renderer Roundtrip
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main, staging]
+    paths:
+      - "lyra-acl/**"
+      - "deploy/nats/**"
+      - "tools/check_renderer_roundtrip.sh"
+      - ".github/workflows/renderer-roundtrip.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: renderer-roundtrip-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lyra-acl-parse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # No actions/cache for nats-server: this workflow is the only consumer,
+      # actions/cache is not used elsewhere in this repo, and pinning a wrong
+      # SHA is worse than a 5-second re-download of a ~15 MB tarball.
+      - name: Install nats-server
+        env:
+          NATS_VERSION: "2.10.22"
+        run: |
+          set -euo pipefail
+          ARCH=$(dpkg --print-architecture)
+          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
+          TMPDIR=$(mktemp -d)
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
+            -o "${TMPDIR}/${TARBALL}"
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
+            -o "${TMPDIR}/SHA256SUMS"
+          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
+          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
+          nats-server --version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v7
+
+      - name: Install project dependencies
+        run: |
+          set -euo pipefail
+          uv sync --frozen
+
+      - name: Run lyra-acl roundtrip
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/lyra-acl"
+          bash tools/check_renderer_roundtrip.sh lyra-acl "$RUNNER_TEMP/lyra-acl"
+
+  nats-conf-parse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install nats-server
+        env:
+          NATS_VERSION: "2.10.22"
+        run: |
+          set -euo pipefail
+          ARCH=$(dpkg --print-architecture)
+          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
+          TMPDIR=$(mktemp -d)
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
+            -o "${TMPDIR}/${TARBALL}"
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
+            -o "${TMPDIR}/SHA256SUMS"
+          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
+          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
+          nats-server --version
+
+      - name: Run nats-conf roundtrip
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/nats-conf"
+          bash tools/check_renderer_roundtrip.sh nats-conf "$RUNNER_TEMP/nats-conf"
+
+  gen-certs-roundtrip:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install nats-server
+        env:
+          NATS_VERSION: "2.10.22"
+        run: |
+          set -euo pipefail
+          ARCH=$(dpkg --print-architecture)
+          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
+          TMPDIR=$(mktemp -d)
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
+            -o "${TMPDIR}/${TARBALL}"
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
+            -o "${TMPDIR}/SHA256SUMS"
+          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
+          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
+          nats-server --version
+
+      - name: Run gen-certs roundtrip
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/certs"
+          bash tools/check_renderer_roundtrip.sh gen-certs "$RUNNER_TEMP/certs"

--- a/.github/workflows/renderer-roundtrip.yml
+++ b/.github/workflows/renderer-roundtrip.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches: [main, staging]
     paths:
-      - "lyra-acl/**"
+      - "scripts/**"
+      - "tests/scripts/**"
       - "deploy/nats/**"
       - "tools/check_renderer_roundtrip.sh"
       - ".github/workflows/renderer-roundtrip.yml"

--- a/.github/workflows/renderer-roundtrip.yml
+++ b/.github/workflows/renderer-roundtrip.yml
@@ -29,21 +29,9 @@ jobs:
       # actions/cache is not used elsewhere in this repo, and pinning a wrong
       # SHA is worse than a 5-second re-download of a ~15 MB tarball.
       - name: Install nats-server
-        env:
-          NATS_VERSION: "2.10.22"
-        run: |
-          set -euo pipefail
-          ARCH=$(dpkg --print-architecture)
-          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
-          TMPDIR=$(mktemp -d)
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
-            -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
-            -o "${TMPDIR}/SHA256SUMS"
-          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
-          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
-          nats-server --version
+        uses: ./.github/actions/install-nats-server
+        with:
+          nats-version: "2.10.22"
 
       - name: Install nk
         env:
@@ -83,21 +71,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install nats-server
-        env:
-          NATS_VERSION: "2.10.22"
-        run: |
-          set -euo pipefail
-          ARCH=$(dpkg --print-architecture)
-          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
-          TMPDIR=$(mktemp -d)
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
-            -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
-            -o "${TMPDIR}/SHA256SUMS"
-          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
-          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
-          nats-server --version
+        uses: ./.github/actions/install-nats-server
+        with:
+          nats-version: "2.10.22"
 
       - name: Run nats-conf roundtrip
         run: |
@@ -112,21 +88,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install nats-server
-        env:
-          NATS_VERSION: "2.10.22"
-        run: |
-          set -euo pipefail
-          ARCH=$(dpkg --print-architecture)
-          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
-          TMPDIR=$(mktemp -d)
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
-            -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
-            -o "${TMPDIR}/SHA256SUMS"
-          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
-          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
-          nats-server --version
+        uses: ./.github/actions/install-nats-server
+        with:
+          nats-version: "2.10.22"
 
       - name: Run gen-certs roundtrip
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,12 @@ lyra agent assign my_agent --platform telegram --bot my_bot
 
 For a custom agent class (beyond `SimpleAgent`), subclass `AgentBase` from `src/lyra/core/agent.py` and implement `process()`.
 
+## Adding a config renderer
+
+A *renderer* is any tool or static file that produces output consumed by an external binary (`nats-server`, `podman`/Quadlet, `systemd`, `openssl`). Any new renderer in `deploy/` or any new CLI that writes a config file must come with a roundtrip test in `tools/check_renderer_roundtrip.sh` + a CI job in `.github/workflows/renderer-roundtrip.yml`.
+
+See **[docs/standards/renderer-roundtrip.md](docs/standards/renderer-roundtrip.md)** for the pattern, the required shape (render → consumer parse → invariant assertions), the worked example (`lyra-acl`), and the reviewer checklist. Skipping this leads to bugs accepted at write-time and rejected at reboot — see #1083 and #1089.
+
 ## Code review expectations
 
 Reviews focus on correctness, clarity, and architectural consistency — not style (ruff handles that).

--- a/artifacts/frames/1091-renderer-roundtrip-tests-frame.mdx
+++ b/artifacts/frames/1091-renderer-roundtrip-tests-frame.mdx
@@ -1,0 +1,59 @@
+---
+title: Renderer→consumer roundtrip tests + standards
+issue: 1091
+status: approved
+tier: F-lite
+date: 2026-05-18
+---
+
+## Problem
+
+Two prod incidents in 2026-Q2 share one pattern: a renderer (tool that writes a config file) produces output accepted at write-time but rejected by the downstream consumer when the service next restarts — sometimes hours or days later.
+
+| # | Renderer | Bug | Consumer | Bite latency |
+|---|---|---|---|---|
+| #1083 | Quadlet generator | inline `#` in `Volume=` value | `podman` | ~47 h |
+| #1089 | `lyra-acl genkeys --regen-authconf` | nkeys rendered at 62 chars (valid = 56) | `nats-server` | minutes (M₁ down 2026-05-06) |
+
+Audit shows the renderer→consumer roundtrip pattern already exists in 3 isolated silos (`test_parity_e2e.py`, `test_genkeys_modes.py::TestRenderedNkeyLength`, `.github/workflows/quadlet-lint.yml`) but is not generalized, not documented, and not applied to all known renderers in the repo. Three renderers currently have no roundtrip gate at all: `deploy/nats/nats.conf`, `deploy/nats/gen-certs.sh`, `deploy/lyra-monitor.{service,timer}`.
+
+The bite latency makes this a high-leverage gap: every incident costs hours of prod downtime that a CI parse-gate would have prevented in seconds.
+
+## Who
+
+- **Primary:** Lyra ops/on-call (Mickael) — bears the cost of reboot-time failures on M₁ (prod hub).
+- **Secondary:** Future contributors adding new config renderers — need a documented pattern so they don't reinvent it (or skip it).
+
+## Constraints
+
+- CI runner must have `nats-server`, `systemd-analyze`, `openssl`, `podman` available (apt-installable, pin versions, cacheable).
+- Pattern must be lightweight enough that contributors actually apply it — heavy fixtures defeat the purpose.
+- Standards doc must live under `docs/standards/` and cross-link from `docs/standards/testing.md` (existing testing conventions home).
+- No mocking the consumer — the whole point is to use the real downstream binary.
+- Pattern applies to both **generated** files (lyra-acl) and **static** files consumed by an external binary (nats.conf, lyra-monitor.service).
+
+## Out of Scope
+
+- Refactoring `test_parity_e2e.py` to use the new helper (it works as-is).
+- Roundtrip tests for renderers outside the NATS / podman / systemd surface (no other consumers identified yet; covered by the standards doc going forward).
+- Runtime layer probes (e.g. lyra-monitor service health checks — that's #1085).
+- Migrating the audit findings into individual follow-up issues — bundled here for F-lite scope.
+
+## Premise Validity
+
+**Success in 6 months:** Zero prod incidents caused by a renderer whose output is rejected by its downstream consumer. Every new config-generating tool merged after #1091 ships with its roundtrip test, enforced by the standards doc and reflected in PR reviews.
+
+**Failure in 6 months:** ≥1 new incident matching the #1083/#1089 pattern (renderer ships output accepted at write-time, rejected at reboot/restart by the consumer) after #1091 merges. OR: ≥2 new renderers added to the repo without a roundtrip test, with no reviewer flagging the omission.
+
+**Simplest alternative:** Continue writing ad-hoc regression tests reactively each time a renderer bug fires — same approach used for #1089's `TestRenderedNkeyLength`.
+**Why not simplest:** (a) keeps the cost of one prod incident per renderer baked in; (b) the pattern stays implicit, so the next contributor adding a renderer won't think of the test; (c) no shape consistency — each test reinvents the structure. A documented standard + generic CI workflow internalizes the lesson once.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (CI + tests + docs), no architectural unknowns, 4 renderers + 1 standards doc + 1 workflow file = ~6–10 files.
+
+Signals:
+- Single domain (CI/quality gates)
+- No new architecture — extends existing patterns (`quadlet-lint.yml` model)
+- Known consumers, known invariants
+- Existing `size:F-lite` label on issue

--- a/artifacts/plans/1091-renderer-roundtrip-tests-plan.mdx
+++ b/artifacts/plans/1091-renderer-roundtrip-tests-plan.mdx
@@ -9,7 +9,7 @@ generated: 2026-05-18
 
 ## Summary
 
-Ship a generic `renderer-roundtrip` CI workflow that validates 4 renderers (lyra-acl genkeys, deploy/nats/nats.conf, gen-certs.sh, deploy/nats/nats.service) via their actual downstream consumers (`nats-server -t -c`, `openssl verify`, `systemd-analyze verify`), plus a standards doc + cross-link from testing.md.
+Ship a generic `renderer-roundtrip` CI workflow that validates 3 renderers (lyra-acl genkeys, deploy/nats/nats.conf, gen-certs.sh) via their actual downstream consumers (`nats-server -t -c`, `openssl verify`), plus a standards doc + cross-link from testing.md. `systemd-analyze verify` is documented as a canonical consumer for future static units but has no current target (all `deploy/*.service` are retired in favor of Quadlet-generated units).
 
 ## Architecture
 
@@ -19,7 +19,6 @@ flowchart TD
         W1[on PR paths → setup nats-server F1] --> J1
         W1 --> J2
         W1 --> J3
-        W1 --> J4
     end
 
     subgraph helper ["tools/check_renderer_roundtrip.sh"]
@@ -27,18 +26,15 @@ flowchart TD
         T1 -->|lyra-acl| L[lyra-acl subcmd]
         T1 -->|nats-conf| C[nats-conf subcmd]
         T1 -->|gen-certs| G[gen-certs subcmd]
-        T1 -->|systemd| S[systemd subcmd]
     end
 
     J1 --> L
     J2 --> C
     J3 --> G
-    J4 --> S
 
     L --> NS1[nats-server -t -c auth.conf]
     C --> NS2[nats-server -t -c nats.conf]
     G --> O[openssl verify] --> NS3[nats-server -t -c TLS-cfg]
-    S --> SA[systemd-analyze verify]
 
     subgraph docs ["docs/standards/"]
         D1[renderer-roundtrip.md] -.referenced.-> T1
@@ -55,17 +51,15 @@ flowchart TD
 ```mermaid
 flowchart LR
     subgraph workflow [".github/workflows/renderer-roundtrip.yml"]
-        WF[jobs: J1, J2, J3, J4]
+        WF[jobs: J1, J2, J3]
     end
     subgraph helper ["tools/check_renderer_roundtrip.sh"]
         H_lyra[lyra-acl: render + parse]
         H_natsconf[nats-conf: stub + parse]
         H_certs[gen-certs: render + verify + parse]
-        H_sys[systemd: verify unit]
     end
     subgraph deploy ["deploy/nats/"]
         GC[gen-certs.sh: CERT_DIR overridable]
-        NSV[nats.service]
         NC[nats.conf · nats-container.conf]
     end
     subgraph docs ["docs/standards/"]
@@ -73,9 +67,8 @@ flowchart LR
         TM[testing.md]
     end
 
-    WF --> H_lyra & H_natsconf & H_certs & H_sys
+    WF --> H_lyra & H_natsconf & H_certs
     H_certs --> GC
-    H_sys --> NSV
     H_natsconf --> NC
     DR --> H_lyra
     TM --> DR
@@ -87,7 +80,7 @@ flowchart LR
 |---|---|---|
 | devops | 3 | `.github/workflows/renderer-roundtrip.yml`, `tools/check_renderer_roundtrip.sh`, `deploy/nats/gen-certs.sh` |
 | doc-writer | 2 | `docs/standards/renderer-roundtrip.md`, `docs/standards/testing.md` |
-| tester | 5 | RED-GATE verifications (1 per slice) |
+| tester | 4 | RED-GATE verifications (1 per slice) |
 
 ## Wave Structure
 
@@ -97,7 +90,7 @@ flowchart LR
 |------|---------|--------|-------|
 | 1 | start | 2 ∥ | devops-A: T1→T3 · doc-writer-A: T2→T5 |
 | 2 | Wave 1 done | 1 | devops-A: T4 |
-| 3 | Wave 2 done | 1 | tester-A: T6, T7, T8, T9, T10 (serial; each <10 min) |
+| 3 | Wave 2 done | 1 | tester-A: T6, T7, T8, T10 (serial; each <10 min) |
 
 ### Budget
 
@@ -105,12 +98,12 @@ flowchart LR
 |------|-------|-------|----------|--------|
 | T1 (F2 1-line edit) | 1 file | trivial | 2 | — |
 | T2 (D1 doc, 6 sections) | 1 file | judgmental | 8 | — |
-| T3 (T1 helper, 4 subcmds) | 1 file | judgmental | 10 | — |
-| T4 (W1 workflow, 4 jobs) | 1 file | judgmental | 6 | — |
+| T3 (T1 helper, 3 subcmds) | 1 file | judgmental | 8 | — |
+| T4 (W1 workflow, 3 jobs) | 1 file | judgmental | 5 | — |
 | T5 (L1 cross-link) | 1 file | bounded | 3 | — |
-| T6–T10 (RED-GATEs) | 5 verifs | bounded | 15 | — |
+| T6–T10 (RED-GATEs, T9 dropped) | 4 verifs | bounded | 12 | — |
 
-**Total estimated ops: ~44**
+**Total estimated ops: ~38**
 
 ## Consistency Report
 
@@ -120,13 +113,12 @@ flowchart LR
 | Slice 1 — lyra-acl 62-char fail | SC2 | T6 (RED-GATE V1) |
 | Slice 2 — nats.conf stray `}` fail | SC3 | T7 (RED-GATE V2) |
 | Slice 3 — gen-certs invalid cert fail | SC4 | T8 (RED-GATE V3) |
-| Slice 4 — service ExecStart= fail | SC5 | T9 (RED-GATE V4) |
-| Clean staging all green | SC6 | T4 + RED-GATEs invert |
-| D1 sections + worked example | SC7 | T2 + T10 |
-| testing.md cross-link | SC8 | T5 + T10 |
-| D1 reviewer checklist | SC9 | T2 + T10 |
+| Clean staging all green | SC5 | T4 + RED-GATEs invert |
+| D1 sections + worked example | SC6 | T2 + T10 |
+| testing.md cross-link | SC7 | T5 + T10 |
+| D1 reviewer checklist | SC8 | T2 + T10 |
 
-Coverage: 9/9 SCs traced.
+Coverage: 8/8 SCs traced (J4/systemd scope dropped — see spec Context).
 
 ## Micro-Tasks
 
@@ -154,7 +146,7 @@ Coverage: 9/9 SCs traced.
 
 ### Cross-slice helper
 
-**T3 — T1 helper script with 4 subcommands** *(devops, GREEN, difficulty 3, blockedBy T1)*
+**T3 — T1 helper script with 3 subcommands** *(devops, GREEN, difficulty 3, blockedBy T1)*
 
 - File: `tools/check_renderer_roundtrip.sh` (new)
 - Shebang `#!/usr/bin/env bash`, `set -euo pipefail`, dispatch on `$1`
@@ -162,11 +154,11 @@ Coverage: 9/9 SCs traced.
   - `lyra-acl <tmpdir>`: invoke `lyra-acl genkeys --regen-authconf` → parse output → assert ∀ nkey: len==56 ∧ no embedded `\n` in quoted strings → `nats-server -t -c $tmpdir/auth.conf`
   - `nats-conf <tmpdir>`: create stub `$tmpdir/nkeys/auth.conf` (empty authorization block) → `nats-server -t -c deploy/nats/nats.conf` then `deploy/nats/nats-container.conf`
   - `gen-certs <tmpdir>`: `CERT_DIR=$tmpdir bash deploy/nats/gen-certs.sh` → `openssl verify -CAfile $tmpdir/ca.crt $tmpdir/server.crt` → emit minimal TLS-only nats config to `$tmpdir/tls.conf` referencing those paths → `nats-server -t -c $tmpdir/tls.conf`
-  - `systemd <unit-path>`: `systemd-analyze verify <unit-path>` (allow warnings, fail on errors)
+- Extensible: adding a new subcommand (case branch) is the canonical way to register a new renderer
 - Error format: `expected X, got Y` style diffs on invariant violations
-- Verify: `bash -n tools/check_renderer_roundtrip.sh && tools/check_renderer_roundtrip.sh 2>&1 | grep -E 'lyra-acl|nats-conf|gen-certs|systemd'`
-- Expected: usage line listing all 4 subcommands
-- Spec trace: T1 affordance (W1 wiring), SC2–SC5
+- Verify: `bash -n tools/check_renderer_roundtrip.sh && tools/check_renderer_roundtrip.sh 2>&1 | grep -E 'lyra-acl|nats-conf|gen-certs'`
+- Expected: usage line listing all 3 subcommands
+- Spec trace: T1 affordance (W1 wiring), SC2–SC4
 
 **T4 — W1 workflow file** *(devops, GREEN, difficulty 2, blockedBy T3)*
 
@@ -174,16 +166,15 @@ Coverage: 9/9 SCs traced.
 - Top-level: `permissions: contents: read`, `concurrency: group: renderer-roundtrip-${{ github.ref }}, cancel-in-progress: true`
 - Triggers: `pull_request` (paths: `lyra-acl/**`, `deploy/nats/**`, `tools/check_renderer_roundtrip.sh`, `.github/workflows/renderer-roundtrip.yml`), `workflow_dispatch`
 - Each job: `runs-on: ubuntu-latest`, `timeout-minutes: 10`, `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`, `set -euo pipefail` in run blocks
-- Composite install step `Install nats-server` (jobs J1–J3): NATS_VERSION=2.10.22 tarball+SHA256, mirror `.github/workflows/ci.yml` lines 28–42
+- Composite install step `Install nats-server` (all 3 jobs): NATS_VERSION=2.10.22 tarball+SHA256, mirror `.github/workflows/ci.yml` lines 28–42
 - Cache nats-server tarball: `actions/cache@<pinned>` keyed on `nats-server-${{ env.NATS_VERSION }}-${{ runner.arch }}`
-- Jobs:
+- Jobs (3 parallel):
   - J1 `lyra-acl-parse`: install nats-server → `lyra-acl genkeys --regen-authconf` → `tools/check_renderer_roundtrip.sh lyra-acl $RUNNER_TEMP/lyra-acl`
   - J2 `nats-conf-parse`: install nats-server → `tools/check_renderer_roundtrip.sh nats-conf $RUNNER_TEMP/nats-conf`
   - J3 `gen-certs-roundtrip`: install nats-server → `tools/check_renderer_roundtrip.sh gen-certs $RUNNER_TEMP/certs`
-  - J4 `nats-service-verify`: (no nats-server needed) → `tools/check_renderer_roundtrip.sh systemd deploy/nats/nats.service`
 - Verify: `yamllint .github/workflows/renderer-roundtrip.yml && grep -c '^  [a-z-]*:$' .github/workflows/renderer-roundtrip.yml`
-- Expected: 4 (job count)
-- Spec trace: SC1, SC6
+- Expected: 3 (job count)
+- Spec trace: SC1, SC5
 
 **T5 [P] — L1: cross-link from testing.md** *(doc-writer, GREEN, difficulty 1, blockedBy T2)*
 
@@ -211,16 +202,11 @@ Coverage: 9/9 SCs traced.
 - Locally: remove `-subj` flag from one openssl invocation in `gen-certs.sh` (or otherwise break cert) → run J3 → confirm exit non-zero (openssl or nats-server step) → revert
 - Spec trace: SC4
 
-**T9 — RED-GATE V4: J4 fails on bad service** *(tester, RED-GATE, difficulty 1, blockedBy T4)*
-
-- Locally: inject `ExecStart=` (empty value) into `deploy/nats/nats.service` → run J4 → confirm `systemd-analyze verify` exits non-zero → revert
-- Spec trace: SC5
-
-**T10 — RED-GATE V5: docs complete** *(tester, RED-GATE, difficulty 1, blockedBy T5)*
+**T10 — RED-GATE V4: docs complete** *(tester, RED-GATE, difficulty 1, blockedBy T5)*
 
 - Confirm `docs/standards/renderer-roundtrip.md` has all 6 non-empty sections, reviewer-checklist item present, worked example contains the verbatim `tools/check_renderer_roundtrip.sh lyra-acl` invocation
 - Confirm `docs/standards/testing.md` links to `renderer-roundtrip.md`
-- Spec trace: SC7, SC8, SC9
+- Spec trace: SC6, SC7, SC8
 
 ## Task Seeding Blueprint
 
@@ -241,14 +227,14 @@ Coverage: 9/9 SCs traced.
 
 | Task | Agent instance | blockedBy | Subject |
 |------|---------------|-----------|---------|
-| T3 | devops-A | T1 | T1 helper: tools/check_renderer_roundtrip.sh with lyra-acl/nats-conf/gen-certs/systemd subcommands |
+| T3 | devops-A | T1 | T1 helper: tools/check_renderer_roundtrip.sh with lyra-acl/nats-conf/gen-certs subcommands |
 | T5 | doc-writer-A | T2 | L1: cross-link from docs/standards/testing.md to renderer-roundtrip.md |
 
 ### Wave 3 — after T3, 1 agent
 
 | Task | Agent instance | blockedBy | Subject |
 |------|---------------|-----------|---------|
-| T4 | devops-A | T3 | W1: .github/workflows/renderer-roundtrip.yml with 4 parallel jobs + nats-server install + conventions |
+| T4 | devops-A | T3 | W1: .github/workflows/renderer-roundtrip.yml with 3 parallel jobs + nats-server install + conventions |
 
 ### Wave 4 — after T4 + T5, 1 tester (serial)
 
@@ -257,19 +243,17 @@ Coverage: 9/9 SCs traced.
 | T6 | tester-A | T4 | RED-GATE V1: confirm J1 fails on 62-char nkey injection |
 | T7 | tester-A | T4, T6 | RED-GATE V2: confirm J2 fails on stray `}` in nats.conf |
 | T8 | tester-A | T4, T7 | RED-GATE V3: confirm J3 fails on invalid cert |
-| T9 | tester-A | T4, T8 | RED-GATE V4: confirm J4 fails on bad service unit |
-| T10 | tester-A | T5, T9 | RED-GATE V5: confirm D1 sections + reviewer checklist + testing.md cross-link |
+| T10 | tester-A | T5, T8 | RED-GATE V4: confirm D1 sections + reviewer checklist + testing.md cross-link |
 
 ## Task IDs
 
 <!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
 - T1: 11 — F2: CERT_DIR overridable in deploy/nats/gen-certs.sh
 - T2: 12 — D1: write docs/standards/renderer-roundtrip.md
-- T3: 13 — T1 helper: tools/check_renderer_roundtrip.sh with 4 subcommands
-- T4: 14 — W1: .github/workflows/renderer-roundtrip.yml with 4 parallel jobs
+- T3: 13 — T1 helper: tools/check_renderer_roundtrip.sh with 3 subcommands
+- T4: 14 — W1: .github/workflows/renderer-roundtrip.yml with 3 parallel jobs
 - T5: 15 — L1: cross-link docs/standards/testing.md → renderer-roundtrip.md
 - T6: 16 — RED-GATE V1: J1 fails on 62-char nkey injection
 - T7: 17 — RED-GATE V2: J2 fails on stray `}` in nats.conf
 - T8: 18 — RED-GATE V3: J3 fails on invalid cert
-- T9: 19 — RED-GATE V4: J4 fails on bad service unit
-- T10: 20 — RED-GATE V5: docs complete
+- T10: 20 — RED-GATE V4: docs complete

--- a/artifacts/plans/1091-renderer-roundtrip-tests-plan.mdx
+++ b/artifacts/plans/1091-renderer-roundtrip-tests-plan.mdx
@@ -1,0 +1,275 @@
+---
+title: "Plan: Renderer→consumer roundtrip tests + standards"
+issue: 1091
+spec: artifacts/specs/1091-renderer-roundtrip-tests-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-05-18
+---
+
+## Summary
+
+Ship a generic `renderer-roundtrip` CI workflow that validates 4 renderers (lyra-acl genkeys, deploy/nats/nats.conf, gen-certs.sh, deploy/nats/nats.service) via their actual downstream consumers (`nats-server -t -c`, `openssl verify`, `systemd-analyze verify`), plus a standards doc + cross-link from testing.md.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph workflow [".github/workflows/renderer-roundtrip.yml"]
+        W1[on PR paths → setup nats-server F1] --> J1
+        W1 --> J2
+        W1 --> J3
+        W1 --> J4
+    end
+
+    subgraph helper ["tools/check_renderer_roundtrip.sh"]
+        T1{T1 dispatch}
+        T1 -->|lyra-acl| L[lyra-acl subcmd]
+        T1 -->|nats-conf| C[nats-conf subcmd]
+        T1 -->|gen-certs| G[gen-certs subcmd]
+        T1 -->|systemd| S[systemd subcmd]
+    end
+
+    J1 --> L
+    J2 --> C
+    J3 --> G
+    J4 --> S
+
+    L --> NS1[nats-server -t -c auth.conf]
+    C --> NS2[nats-server -t -c nats.conf]
+    G --> O[openssl verify] --> NS3[nats-server -t -c TLS-cfg]
+    S --> SA[systemd-analyze verify]
+
+    subgraph docs ["docs/standards/"]
+        D1[renderer-roundtrip.md] -.referenced.-> T1
+        TM[testing.md] -->|cross-link| D1
+    end
+
+    subgraph deploy ["deploy/nats/"]
+        F2[gen-certs.sh CERT_DIR override]
+    end
+
+    G --> F2
+```
+
+```mermaid
+flowchart LR
+    subgraph workflow [".github/workflows/renderer-roundtrip.yml"]
+        WF[jobs: J1, J2, J3, J4]
+    end
+    subgraph helper ["tools/check_renderer_roundtrip.sh"]
+        H_lyra[lyra-acl: render + parse]
+        H_natsconf[nats-conf: stub + parse]
+        H_certs[gen-certs: render + verify + parse]
+        H_sys[systemd: verify unit]
+    end
+    subgraph deploy ["deploy/nats/"]
+        GC[gen-certs.sh: CERT_DIR overridable]
+        NSV[nats.service]
+        NC[nats.conf · nats-container.conf]
+    end
+    subgraph docs ["docs/standards/"]
+        DR[renderer-roundtrip.md]
+        TM[testing.md]
+    end
+
+    WF --> H_lyra & H_natsconf & H_certs & H_sys
+    H_certs --> GC
+    H_sys --> NSV
+    H_natsconf --> NC
+    DR --> H_lyra
+    TM --> DR
+```
+
+## Agents
+
+| Agent | Task count | Files |
+|---|---|---|
+| devops | 3 | `.github/workflows/renderer-roundtrip.yml`, `tools/check_renderer_roundtrip.sh`, `deploy/nats/gen-certs.sh` |
+| doc-writer | 2 | `docs/standards/renderer-roundtrip.md`, `docs/standards/testing.md` |
+| tester | 5 | RED-GATE verifications (1 per slice) |
+
+## Wave Structure
+
+3 waves, max 2 parallel agents. Elapsed ~1 hour vs ~2 hours sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | devops-A: T1→T3 · doc-writer-A: T2→T5 |
+| 2 | Wave 1 done | 1 | devops-A: T4 |
+| 3 | Wave 2 done | 1 | tester-A: T6, T7, T8, T9, T10 (serial; each <10 min) |
+
+### Budget
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 (F2 1-line edit) | 1 file | trivial | 2 | — |
+| T2 (D1 doc, 6 sections) | 1 file | judgmental | 8 | — |
+| T3 (T1 helper, 4 subcmds) | 1 file | judgmental | 10 | — |
+| T4 (W1 workflow, 4 jobs) | 1 file | judgmental | 6 | — |
+| T5 (L1 cross-link) | 1 file | bounded | 3 | — |
+| T6–T10 (RED-GATEs) | 5 verifs | bounded | 15 | — |
+
+**Total estimated ops: ~44**
+
+## Consistency Report
+
+| Spec criterion | Trace | Task |
+|---|---|---|
+| Workflow + conventions | SC1 | T4 |
+| Slice 1 — lyra-acl 62-char fail | SC2 | T6 (RED-GATE V1) |
+| Slice 2 — nats.conf stray `}` fail | SC3 | T7 (RED-GATE V2) |
+| Slice 3 — gen-certs invalid cert fail | SC4 | T8 (RED-GATE V3) |
+| Slice 4 — service ExecStart= fail | SC5 | T9 (RED-GATE V4) |
+| Clean staging all green | SC6 | T4 + RED-GATEs invert |
+| D1 sections + worked example | SC7 | T2 + T10 |
+| testing.md cross-link | SC8 | T5 + T10 |
+| D1 reviewer checklist | SC9 | T2 + T10 |
+
+Coverage: 9/9 SCs traced.
+
+## Micro-Tasks
+
+### V1 — lyra-acl parse-gate
+
+**T1 [P] — F2: `CERT_DIR` overridable in gen-certs.sh** *(devops, GREEN, difficulty 1)*
+
+- File: `deploy/nats/gen-certs.sh`
+- Change: `CERT_DIR="/etc/nats/certs"` → `CERT_DIR="${CERT_DIR:-/etc/nats/certs}"`
+- Verify: `CERT_DIR=/tmp/foo bash -c 'CERT_DIR="${CERT_DIR:-/etc/nats/certs}"; echo "$CERT_DIR"'`
+- Expected: `/tmp/foo`
+- Spec trace: enables SC4
+
+### V5 — standards doc (parallel with V1–V4 prep)
+
+**T2 [P] — D1: write standards doc** *(doc-writer, GREEN, difficulty 2)*
+
+- File: `docs/standards/renderer-roundtrip.md` (new)
+- Sections (each non-empty): Pattern · When to apply · Required shape · Worked example · Failure modes · Reviewer checklist
+- Worked example: full verbatim invocation `bash tools/check_renderer_roundtrip.sh lyra-acl $TMPDIR`
+- Reviewer checklist line: "Does this PR add or modify a config renderer? If yes, verify a roundtrip test in `renderer-roundtrip.yml` covers it."
+- Verify: `test -f docs/standards/renderer-roundtrip.md && grep -c '^## ' docs/standards/renderer-roundtrip.md`
+- Expected: `6` (six top-level sections)
+- Spec trace: SC7, SC9
+
+### Cross-slice helper
+
+**T3 — T1 helper script with 4 subcommands** *(devops, GREEN, difficulty 3, blockedBy T1)*
+
+- File: `tools/check_renderer_roundtrip.sh` (new)
+- Shebang `#!/usr/bin/env bash`, `set -euo pipefail`, dispatch on `$1`
+- Subcommands:
+  - `lyra-acl <tmpdir>`: invoke `lyra-acl genkeys --regen-authconf` → parse output → assert ∀ nkey: len==56 ∧ no embedded `\n` in quoted strings → `nats-server -t -c $tmpdir/auth.conf`
+  - `nats-conf <tmpdir>`: create stub `$tmpdir/nkeys/auth.conf` (empty authorization block) → `nats-server -t -c deploy/nats/nats.conf` then `deploy/nats/nats-container.conf`
+  - `gen-certs <tmpdir>`: `CERT_DIR=$tmpdir bash deploy/nats/gen-certs.sh` → `openssl verify -CAfile $tmpdir/ca.crt $tmpdir/server.crt` → emit minimal TLS-only nats config to `$tmpdir/tls.conf` referencing those paths → `nats-server -t -c $tmpdir/tls.conf`
+  - `systemd <unit-path>`: `systemd-analyze verify <unit-path>` (allow warnings, fail on errors)
+- Error format: `expected X, got Y` style diffs on invariant violations
+- Verify: `bash -n tools/check_renderer_roundtrip.sh && tools/check_renderer_roundtrip.sh 2>&1 | grep -E 'lyra-acl|nats-conf|gen-certs|systemd'`
+- Expected: usage line listing all 4 subcommands
+- Spec trace: T1 affordance (W1 wiring), SC2–SC5
+
+**T4 — W1 workflow file** *(devops, GREEN, difficulty 2, blockedBy T3)*
+
+- File: `.github/workflows/renderer-roundtrip.yml` (new)
+- Top-level: `permissions: contents: read`, `concurrency: group: renderer-roundtrip-${{ github.ref }}, cancel-in-progress: true`
+- Triggers: `pull_request` (paths: `lyra-acl/**`, `deploy/nats/**`, `tools/check_renderer_roundtrip.sh`, `.github/workflows/renderer-roundtrip.yml`), `workflow_dispatch`
+- Each job: `runs-on: ubuntu-latest`, `timeout-minutes: 10`, `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`, `set -euo pipefail` in run blocks
+- Composite install step `Install nats-server` (jobs J1–J3): NATS_VERSION=2.10.22 tarball+SHA256, mirror `.github/workflows/ci.yml` lines 28–42
+- Cache nats-server tarball: `actions/cache@<pinned>` keyed on `nats-server-${{ env.NATS_VERSION }}-${{ runner.arch }}`
+- Jobs:
+  - J1 `lyra-acl-parse`: install nats-server → `lyra-acl genkeys --regen-authconf` → `tools/check_renderer_roundtrip.sh lyra-acl $RUNNER_TEMP/lyra-acl`
+  - J2 `nats-conf-parse`: install nats-server → `tools/check_renderer_roundtrip.sh nats-conf $RUNNER_TEMP/nats-conf`
+  - J3 `gen-certs-roundtrip`: install nats-server → `tools/check_renderer_roundtrip.sh gen-certs $RUNNER_TEMP/certs`
+  - J4 `nats-service-verify`: (no nats-server needed) → `tools/check_renderer_roundtrip.sh systemd deploy/nats/nats.service`
+- Verify: `yamllint .github/workflows/renderer-roundtrip.yml && grep -c '^  [a-z-]*:$' .github/workflows/renderer-roundtrip.yml`
+- Expected: 4 (job count)
+- Spec trace: SC1, SC6
+
+**T5 [P] — L1: cross-link from testing.md** *(doc-writer, GREEN, difficulty 1, blockedBy T2)*
+
+- File: `docs/standards/testing.md` (edit)
+- Insert under existing "Integration tests" heading (or add "Config validation" subsection if absent): one paragraph + link to `renderer-roundtrip.md`
+- Verify: `grep -c "renderer-roundtrip" docs/standards/testing.md`
+- Expected: `≥1`
+- Spec trace: SC8
+
+### RED-GATEs (Wave 3 — Verify slices)
+
+**T6 — RED-GATE V1: J1 fails on 62-char nkey** *(tester, RED-GATE, difficulty 2, blockedBy T4)*
+
+- Locally: patch `lyra-acl genkeys` to emit 62-char nkeys → run `act -j lyra-acl-parse` (or push to a throwaway branch) → confirm J1 fails with output containing `expected 56` and `got 62` → revert patch
+- Verify: J1 fails with the expected diff strings
+- Spec trace: SC2
+
+**T7 — RED-GATE V2: J2 fails on stray `}`** *(tester, RED-GATE, difficulty 1, blockedBy T4)*
+
+- Locally: append a stray `}` to `deploy/nats/nats.conf` → run J2 → confirm exit non-zero → revert
+- Spec trace: SC3
+
+**T8 — RED-GATE V3: J3 fails on invalid cert** *(tester, RED-GATE, difficulty 2, blockedBy T4)*
+
+- Locally: remove `-subj` flag from one openssl invocation in `gen-certs.sh` (or otherwise break cert) → run J3 → confirm exit non-zero (openssl or nats-server step) → revert
+- Spec trace: SC4
+
+**T9 — RED-GATE V4: J4 fails on bad service** *(tester, RED-GATE, difficulty 1, blockedBy T4)*
+
+- Locally: inject `ExecStart=` (empty value) into `deploy/nats/nats.service` → run J4 → confirm `systemd-analyze verify` exits non-zero → revert
+- Spec trace: SC5
+
+**T10 — RED-GATE V5: docs complete** *(tester, RED-GATE, difficulty 1, blockedBy T5)*
+
+- Confirm `docs/standards/renderer-roundtrip.md` has all 6 non-empty sections, reviewer-checklist item present, worked example contains the verbatim `tools/check_renderer_roundtrip.sh lyra-acl` invocation
+- Confirm `docs/standards/testing.md` links to `renderer-roundtrip.md`
+- Spec trace: SC7, SC8, SC9
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs).
+     Agent instances are named so parallel tasks map to distinct spawned agents.
+     Seed in wave order; within a wave all rows are parallel (∥). -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | F2: `CERT_DIR` overridable in deploy/nats/gen-certs.sh |
+| T2 | doc-writer-A | — | D1: write docs/standards/renderer-roundtrip.md (6 sections, reviewer checklist, worked example) |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | devops-A | T1 | T1 helper: tools/check_renderer_roundtrip.sh with lyra-acl/nats-conf/gen-certs/systemd subcommands |
+| T5 | doc-writer-A | T2 | L1: cross-link from docs/standards/testing.md to renderer-roundtrip.md |
+
+### Wave 3 — after T3, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | devops-A | T3 | W1: .github/workflows/renderer-roundtrip.yml with 4 parallel jobs + nats-server install + conventions |
+
+### Wave 4 — after T4 + T5, 1 tester (serial)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | tester-A | T4 | RED-GATE V1: confirm J1 fails on 62-char nkey injection |
+| T7 | tester-A | T4, T6 | RED-GATE V2: confirm J2 fails on stray `}` in nats.conf |
+| T8 | tester-A | T4, T7 | RED-GATE V3: confirm J3 fails on invalid cert |
+| T9 | tester-A | T4, T8 | RED-GATE V4: confirm J4 fails on bad service unit |
+| T10 | tester-A | T5, T9 | RED-GATE V5: confirm D1 sections + reviewer checklist + testing.md cross-link |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 11 — F2: CERT_DIR overridable in deploy/nats/gen-certs.sh
+- T2: 12 — D1: write docs/standards/renderer-roundtrip.md
+- T3: 13 — T1 helper: tools/check_renderer_roundtrip.sh with 4 subcommands
+- T4: 14 — W1: .github/workflows/renderer-roundtrip.yml with 4 parallel jobs
+- T5: 15 — L1: cross-link docs/standards/testing.md → renderer-roundtrip.md
+- T6: 16 — RED-GATE V1: J1 fails on 62-char nkey injection
+- T7: 17 — RED-GATE V2: J2 fails on stray `}` in nats.conf
+- T8: 18 — RED-GATE V3: J3 fails on invalid cert
+- T9: 19 — RED-GATE V4: J4 fails on bad service unit
+- T10: 20 — RED-GATE V5: docs complete

--- a/artifacts/specs/1091-renderer-roundtrip-tests-spec.mdx
+++ b/artifacts/specs/1091-renderer-roundtrip-tests-spec.mdx
@@ -1,0 +1,106 @@
+---
+title: Renderer→consumer roundtrip tests + standards
+issue: 1091
+status: approved
+tier: F-lite
+date: 2026-05-18
+source: artifacts/frames/1091-renderer-roundtrip-tests-frame.mdx
+---
+
+## Context
+
+Promoted from [frame](../frames/1091-renderer-roundtrip-tests-frame.mdx). Two prod incidents (#1083, #1089) shared one pattern: a renderer produces output accepted at write-time, rejected by the downstream consumer at next restart. The roundtrip pattern already exists in 3 isolated silos but is not generalized, not documented, and not applied to all known renderers.
+
+Audit (see frame) identified 3 uncovered renderers: `deploy/nats/nats.conf` (+ container variant), `deploy/nats/gen-certs.sh`, `deploy/nats/nats.service`. Plus a missing fast `nats-server -t -c` parse-gate for `lyra-acl genkeys` output (current coverage is the slow live-server e2e in `test_parity_e2e.py`).
+
+`deploy/lyra-monitor.{service,timer}` are explicitly NOT covered here — they are deprecated and will be removed by #1035. `deploy/nats/nats.service` is the active systemd-unit roundtrip target.
+
+## Goal
+
+Every config-generating tool (and every static config consumed by an external binary) is validated by that binary in CI before merge, following a documented pattern future contributors can reuse.
+
+## Users
+
+- **Primary:** Lyra ops/on-call — bears the cost of reboot-time failures on M₁ (prod hub).
+- **Secondary:** Future contributors adding new config renderers — get a documented pattern + working CI scaffold to copy.
+
+## Expected Behavior
+
+1. Contributor opens PR touching `lyra-acl/**`, `deploy/nats/**`, or the workflow/helper script itself.
+2. CI workflow `renderer-roundtrip` triggers, runs one job per affected renderer category, in parallel (no `needs:` chain).
+3. Each job: renders (or reads) the config → invokes the consumer in check/dry-run mode → asserts semantic invariants.
+4. Any failure surfaces a clear diff (e.g. `nkey expected 56 chars, got 62`) and blocks merge.
+5. Clean staging: all jobs green.
+6. Contributor adding a new renderer reads `docs/standards/renderer-roundtrip.md`, copies the worked example (J1), adapts.
+
+## Data Model & Consumers
+
+```mermaid
+flowchart LR
+    R1[lyra-acl genkeys] --> N[nats-server -t -c]
+    R2[deploy/nats/nats.conf] --> N
+    R3[deploy/nats/nats-container.conf] --> N
+    R4[gen-certs.sh] --> O[openssl verify]
+    R4 --> N
+    R5[deploy/nats/nats.service] --> S[systemd-analyze verify]
+    R6[deploy/quadlet/*] -.existing.-> Q[podman quadlet --dryrun]
+```
+
+| Consumer | Binary | Check invocation | Renderers it gates | Status |
+|---|---|---|---|---|
+| nats-server | `nats-server` | `-t -c <file>` | lyra-acl, nats.conf, nats-container.conf, gen-certs (TLS stanza) | this issue |
+| openssl | `openssl` | `verify -CAfile ca.crt server.crt` | gen-certs.sh | this issue |
+| systemd-analyze | `systemd-analyze` | `verify <unit>` (static; no running PID 1 needed) | nats.service | this issue |
+| podman | `podman` | `quadlet --dryrun --user` | deploy/quadlet/* | existing (#1086) |
+
+## Breadboard
+
+### Affordances
+
+| ID | Name | Type | Where | Notes |
+|---|---|---|---|---|
+| W1 | `renderer-roundtrip` workflow | GHA workflow | `.github/workflows/renderer-roundtrip.yml` | Path-filtered, parallel jobs; SHA-pinned actions; `concurrency` block; `permissions: contents: read`; `timeout-minutes: 10` |
+| J1 | `lyra-acl-parse` job | GHA job | W1 | Generates auth.conf then parses with `nats-server -t -c` |
+| J2 | `nats-conf-parse` job | GHA job | W1 | Static parse of `nats.conf` + `nats-container.conf` against a stub `nkeys/auth.conf` |
+| J3 | `gen-certs-roundtrip` job | GHA job | W1 | openssl verify + nats-server -t with TLS stanza |
+| J4 | `nats-service-verify` job | GHA job | W1 | `systemd-analyze verify deploy/nats/nats.service` |
+| T1 | `tools/check_renderer_roundtrip.sh` | helper script | `tools/` | Per-renderer subcommands; `set -euo pipefail`; exit non-zero on consumer failure or invariant violation |
+| F1 | nats-server install step | composite step (reused) | W1 | Pinned tarball + SHA256 verify, mirrors `.github/workflows/ci.yml` (`NATS_VERSION=2.10.22`); cache keyed on `NATS_VERSION` |
+| F2 | gen-certs `CERT_DIR` override | script change | `deploy/nats/gen-certs.sh` | One-line: `CERT_DIR="${CERT_DIR:-/etc/nats/certs}"` to allow CI override without sudo |
+| D1 | standards doc | doc | `docs/standards/renderer-roundtrip.md` | Sections: Pattern · When to apply · Required shape · Worked example (J1) · Failure modes · Reviewer checklist |
+| L1 | testing.md cross-link | doc edit | `docs/standards/testing.md` | Insert under existing "Integration tests" heading (or add a "Config validation" subsection if absent) |
+
+### Wiring
+
+| Affordance | Calls/Reads | Asserts |
+|---|---|---|
+| J1 | `lyra-acl genkeys --regen-authconf` → `nats-server -t -c $TMPDIR/auth.conf` (via T1) | exit 0 ∧ ∀ nkey: `len==56` ∧ `pubkey(seed)==nkey` ∧ no embedded `\n` in `"…"` |
+| J2 | `printf '%s\n' 'authorization {\nusers = []\n}' > $TMPDIR/nkeys/auth.conf` (stub) → `nats-server -t -c deploy/nats/nats.conf` (and `nats-container.conf`) | exit 0 |
+| J3 | `CERT_DIR=$TMPDIR gen-certs.sh` → `openssl verify -CAfile $TMPDIR/ca.crt $TMPDIR/server.crt` → `nats-server -t -c <tls-cfg referencing $TMPDIR>` | exit 0 (both) |
+| J4 | `systemd-analyze verify deploy/nats/nats.service` | exit 0; warnings about undeclared dependency targets are tolerated, fatal-error exit is not |
+| T1 | dispatches `lyra-acl | nats-conf | gen-certs | systemd` subcommands; sources nats-server install via F1 | invariant errors print `expected X, got Y` style diff |
+| D1 | references T1 worked-example invocation verbatim | — |
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|---|---|---|
+| 1 | lyra-acl parse-gate | W1 skeleton + F1 + T1 (lyra-acl subcommand) + J1 | Inject 62-char nkey into renderer output → J1 fails with `expected 56, got 62` |
+| 2 | static nats.conf validation | T1 (nats-conf subcommand) + J2 | Inject stray `}` in `nats.conf` → J2 fails |
+| 3 | gen-certs roundtrip | F2 + T1 (gen-certs subcommand) + J3 | Produce an invalid leaf cert → J3 fails (openssl or nats-server step) |
+| 4 | systemd unit verify | T1 (systemd subcommand) + J4 | Inject `ExecStart=` (empty value) → J4 fails |
+| 5 | standards doc + cross-link | D1 + L1 | Doc renders; testing.md links to it; reviewer-checklist section present |
+
+All 5 slices ship in one PR — they share `W1` + `T1`. Slicing orders implementation; rolling each as a separate PR would create merge conflicts on the same workflow file.
+
+## Success Criteria
+
+- [ ] `.github/workflows/renderer-roundtrip.yml` exists, uses SHA-pinned `actions/checkout`, declares `concurrency` with `cancel-in-progress: true`, `permissions: contents: read`, `timeout-minutes: 10`, and triggers on paths: `lyra-acl/**`, `deploy/nats/**`, `tools/check_renderer_roundtrip.sh`, `.github/workflows/renderer-roundtrip.yml`
+- [ ] Injecting a 62-char nkey into `lyra-acl genkeys` output (matching the pre-#1089 bug state) → J1 fails with output containing `expected 56` and `got 62`
+- [ ] Injecting a stray `}` into `deploy/nats/nats.conf` → J2 exits non-zero
+- [ ] Removing `-subj` from `gen-certs.sh` (or producing an invalid cert chain) → J3 exits non-zero from either `openssl verify` or `nats-server -t`
+- [ ] Injecting `ExecStart=` (empty value) into `deploy/nats/nats.service` → J4 exits non-zero from `systemd-analyze verify`
+- [ ] Clean staging branch: all 4 jobs (J1–J4) pass on CI
+- [ ] `docs/standards/renderer-roundtrip.md` exists with non-empty sections — Pattern, When to apply, Required shape, Worked example, Failure modes, Reviewer checklist — and Worked example contains the verbatim T1 lyra-acl invocation
+- [ ] `docs/standards/testing.md` contains a link to renderer-roundtrip.md (under "Integration tests" heading, or new "Config validation" subsection)
+- [ ] D1 reviewer checklist includes: "Does this PR add or modify a config renderer? If yes, verify a roundtrip test in `renderer-roundtrip.yml` covers it."

--- a/artifacts/specs/1091-renderer-roundtrip-tests-spec.mdx
+++ b/artifacts/specs/1091-renderer-roundtrip-tests-spec.mdx
@@ -11,9 +11,9 @@ source: artifacts/frames/1091-renderer-roundtrip-tests-frame.mdx
 
 Promoted from [frame](../frames/1091-renderer-roundtrip-tests-frame.mdx). Two prod incidents (#1083, #1089) shared one pattern: a renderer produces output accepted at write-time, rejected by the downstream consumer at next restart. The roundtrip pattern already exists in 3 isolated silos but is not generalized, not documented, and not applied to all known renderers.
 
-Audit (see frame) identified 3 uncovered renderers: `deploy/nats/nats.conf` (+ container variant), `deploy/nats/gen-certs.sh`, `deploy/nats/nats.service`. Plus a missing fast `nats-server -t -c` parse-gate for `lyra-acl genkeys` output (current coverage is the slow live-server e2e in `test_parity_e2e.py`).
+Audit (see frame) identified 2 uncovered renderers: `deploy/nats/nats.conf` (+ container variant), `deploy/nats/gen-certs.sh`. Plus a missing fast `nats-server -t -c` parse-gate for `lyra-acl genkeys` output (current coverage is the slow live-server e2e in `test_parity_e2e.py`).
 
-`deploy/lyra-monitor.{service,timer}` are explicitly NOT covered here — they are deprecated and will be removed by #1035. `deploy/nats/nats.service` is the active systemd-unit roundtrip target.
+Static systemd units in `deploy/` (`lyra-monitor.{service,timer}`, `nats/nats.service`) are NOT covered here — they are all retired (lyra-monitor by #1035; host `nats.service` replaced by `lyra-nats.container` per `deploy/CLAUDE.md`). Active systemd is generated at runtime by Podman Quadlet and already validated by `.github/workflows/quadlet-lint.yml` (#1086). `systemd-analyze verify` is documented in the standards doc as a canonical consumer for any future static unit, but no current target exists to wire into CI.
 
 ## Goal
 
@@ -27,7 +27,7 @@ Every config-generating tool (and every static config consumed by an external bi
 ## Expected Behavior
 
 1. Contributor opens PR touching `lyra-acl/**`, `deploy/nats/**`, or the workflow/helper script itself.
-2. CI workflow `renderer-roundtrip` triggers, runs one job per affected renderer category, in parallel (no `needs:` chain).
+2. CI workflow `renderer-roundtrip` triggers, runs one job per affected renderer (3 jobs), in parallel (no `needs:` chain).
 3. Each job: renders (or reads) the config → invokes the consumer in check/dry-run mode → asserts semantic invariants.
 4. Any failure surfaces a clear diff (e.g. `nkey expected 56 chars, got 62`) and blocks merge.
 5. Clean staging: all jobs green.
@@ -42,16 +42,16 @@ flowchart LR
     R3[deploy/nats/nats-container.conf] --> N
     R4[gen-certs.sh] --> O[openssl verify]
     R4 --> N
-    R5[deploy/nats/nats.service] --> S[systemd-analyze verify]
-    R6[deploy/quadlet/*] -.existing.-> Q[podman quadlet --dryrun]
+    R5[deploy/quadlet/*] -.existing.-> Q[podman quadlet --dryrun]
+    R6[future static .service] -.future.-> S[systemd-analyze verify]
 ```
 
 | Consumer | Binary | Check invocation | Renderers it gates | Status |
 |---|---|---|---|---|
 | nats-server | `nats-server` | `-t -c <file>` | lyra-acl, nats.conf, nats-container.conf, gen-certs (TLS stanza) | this issue |
 | openssl | `openssl` | `verify -CAfile ca.crt server.crt` | gen-certs.sh | this issue |
-| systemd-analyze | `systemd-analyze` | `verify <unit>` (static; no running PID 1 needed) | nats.service | this issue |
 | podman | `podman` | `quadlet --dryrun --user` | deploy/quadlet/* | existing (#1086) |
+| systemd-analyze | `systemd-analyze` | `verify <unit>` | future static .service units | documented (standards doc), no current target |
 
 ## Breadboard
 
@@ -63,8 +63,7 @@ flowchart LR
 | J1 | `lyra-acl-parse` job | GHA job | W1 | Generates auth.conf then parses with `nats-server -t -c` |
 | J2 | `nats-conf-parse` job | GHA job | W1 | Static parse of `nats.conf` + `nats-container.conf` against a stub `nkeys/auth.conf` |
 | J3 | `gen-certs-roundtrip` job | GHA job | W1 | openssl verify + nats-server -t with TLS stanza |
-| J4 | `nats-service-verify` job | GHA job | W1 | `systemd-analyze verify deploy/nats/nats.service` |
-| T1 | `tools/check_renderer_roundtrip.sh` | helper script | `tools/` | Per-renderer subcommands; `set -euo pipefail`; exit non-zero on consumer failure or invariant violation |
+| T1 | `tools/check_renderer_roundtrip.sh` | helper script | `tools/` | Per-renderer subcommands (lyra-acl, nats-conf, gen-certs); `set -euo pipefail`; exit non-zero on consumer failure or invariant violation; extensible — adding a new subcommand is the canonical way to register a new renderer |
 | F1 | nats-server install step | composite step (reused) | W1 | Pinned tarball + SHA256 verify, mirrors `.github/workflows/ci.yml` (`NATS_VERSION=2.10.22`); cache keyed on `NATS_VERSION` |
 | F2 | gen-certs `CERT_DIR` override | script change | `deploy/nats/gen-certs.sh` | One-line: `CERT_DIR="${CERT_DIR:-/etc/nats/certs}"` to allow CI override without sudo |
 | D1 | standards doc | doc | `docs/standards/renderer-roundtrip.md` | Sections: Pattern · When to apply · Required shape · Worked example (J1) · Failure modes · Reviewer checklist |
@@ -77,8 +76,7 @@ flowchart LR
 | J1 | `lyra-acl genkeys --regen-authconf` → `nats-server -t -c $TMPDIR/auth.conf` (via T1) | exit 0 ∧ ∀ nkey: `len==56` ∧ `pubkey(seed)==nkey` ∧ no embedded `\n` in `"…"` |
 | J2 | `printf '%s\n' 'authorization {\nusers = []\n}' > $TMPDIR/nkeys/auth.conf` (stub) → `nats-server -t -c deploy/nats/nats.conf` (and `nats-container.conf`) | exit 0 |
 | J3 | `CERT_DIR=$TMPDIR gen-certs.sh` → `openssl verify -CAfile $TMPDIR/ca.crt $TMPDIR/server.crt` → `nats-server -t -c <tls-cfg referencing $TMPDIR>` | exit 0 (both) |
-| J4 | `systemd-analyze verify deploy/nats/nats.service` | exit 0; warnings about undeclared dependency targets are tolerated, fatal-error exit is not |
-| T1 | dispatches `lyra-acl | nats-conf | gen-certs | systemd` subcommands; sources nats-server install via F1 | invariant errors print `expected X, got Y` style diff |
+| T1 | dispatches `lyra-acl | nats-conf | gen-certs` subcommands; sources nats-server install via F1 | invariant errors print `expected X, got Y` style diff |
 | D1 | references T1 worked-example invocation verbatim | — |
 
 ## Slices
@@ -88,10 +86,9 @@ flowchart LR
 | 1 | lyra-acl parse-gate | W1 skeleton + F1 + T1 (lyra-acl subcommand) + J1 | Inject 62-char nkey into renderer output → J1 fails with `expected 56, got 62` |
 | 2 | static nats.conf validation | T1 (nats-conf subcommand) + J2 | Inject stray `}` in `nats.conf` → J2 fails |
 | 3 | gen-certs roundtrip | F2 + T1 (gen-certs subcommand) + J3 | Produce an invalid leaf cert → J3 fails (openssl or nats-server step) |
-| 4 | systemd unit verify | T1 (systemd subcommand) + J4 | Inject `ExecStart=` (empty value) → J4 fails |
-| 5 | standards doc + cross-link | D1 + L1 | Doc renders; testing.md links to it; reviewer-checklist section present |
+| 4 | standards doc + cross-link | D1 + L1 | Doc renders; testing.md links to it; reviewer-checklist section present |
 
-All 5 slices ship in one PR — they share `W1` + `T1`. Slicing orders implementation; rolling each as a separate PR would create merge conflicts on the same workflow file.
+All 4 slices ship in one PR — they share `W1` + `T1`. Slicing orders implementation; rolling each as a separate PR would create merge conflicts on the same workflow file.
 
 ## Success Criteria
 
@@ -99,8 +96,7 @@ All 5 slices ship in one PR — they share `W1` + `T1`. Slicing orders implement
 - [ ] Injecting a 62-char nkey into `lyra-acl genkeys` output (matching the pre-#1089 bug state) → J1 fails with output containing `expected 56` and `got 62`
 - [ ] Injecting a stray `}` into `deploy/nats/nats.conf` → J2 exits non-zero
 - [ ] Removing `-subj` from `gen-certs.sh` (or producing an invalid cert chain) → J3 exits non-zero from either `openssl verify` or `nats-server -t`
-- [ ] Injecting `ExecStart=` (empty value) into `deploy/nats/nats.service` → J4 exits non-zero from `systemd-analyze verify`
-- [ ] Clean staging branch: all 4 jobs (J1–J4) pass on CI
+- [ ] Clean staging branch: all 3 jobs (J1–J3) pass on CI
 - [ ] `docs/standards/renderer-roundtrip.md` exists with non-empty sections — Pattern, When to apply, Required shape, Worked example, Failure modes, Reviewer checklist — and Worked example contains the verbatim T1 lyra-acl invocation
 - [ ] `docs/standards/testing.md` contains a link to renderer-roundtrip.md (under "Integration tests" heading, or new "Config validation" subsection)
 - [ ] D1 reviewer checklist includes: "Does this PR add or modify a config renderer? If yes, verify a roundtrip test in `renderer-roundtrip.yml` covers it."

--- a/deploy/nats/gen-certs.sh
+++ b/deploy/nats/gen-certs.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Generate self-signed CA + NATS server TLS certificate (TLS 1.3 compatible)
 #
-# Usage: sudo ./deploy/nats/gen-certs.sh [--san "DNS:host.local,IP:192.168.1.16"]
+# Usage: sudo ./deploy/nats/gen-certs.sh [--san "DNS:host.local,IP:192.168.1.16"] [--unprivileged]
 #
 # Default SAN: DNS:localhost,IP:127.0.0.1,IP:192.168.1.16
 # Outputs: /etc/nats/certs/{ca.key,ca.crt,server.key,server.crt}
 #
 # Idempotent — skips if certs already exist. Delete /etc/nats/certs/ to regenerate.
+#
+# --unprivileged: skip root check and all chown calls (for CI / dev use).
+#   Default (no flag): require root regardless of CERT_DIR.
 
 set -euo pipefail
 
@@ -14,6 +17,7 @@ CERT_DIR="${CERT_DIR:-/etc/nats/certs}"
 DEFAULT_SAN="DNS:localhost,IP:127.0.0.1,IP:192.168.1.16"
 SAN="${DEFAULT_SAN}"
 VALID_DAYS=3650  # 10 years — private LAN CA, no ACME; rotate manually on reprovision
+UNPRIVILEGED=0
 
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 info()  { echo -e "${GREEN}[+]${NC} $1"; }
@@ -23,17 +27,19 @@ error() { echo -e "${RED}[x]${NC} $1"; exit 1; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --san) SAN="$2"; shift 2 ;;
+    --unprivileged) UNPRIVILEGED=1; shift ;;
     *) error "Unknown option: $1" ;;
   esac
 done
 
-# Prod deployment: CERT_DIR=/etc/nats/certs requires root for chown root:nats.
-# Non-default CERT_DIR (CI roundtrip, dev) runs unprivileged and skips chown.
-if [ "${CERT_DIR}" = "/etc/nats/certs" ]; then
-  [ "$(id -u)" -eq 0 ] || error "Must be run as root (sudo ./deploy/nats/gen-certs.sh)"
-  PROD=1
-else
+# Prod deployment requires root for chown calls.
+# Pass --unprivileged (or set NATS_UNPRIVILEGED=1) for CI / dev runs.
+UNPRIVILEGED="${NATS_UNPRIVILEGED:-${UNPRIVILEGED}}"
+if [ "${UNPRIVILEGED}" = "1" ]; then
   PROD=0
+else
+  [ "$(id -u)" -eq 0 ] || error "Must be run as root (sudo ./deploy/nats/gen-certs.sh). Use --unprivileged for CI/dev."
+  PROD=1
 fi
 
 if [ -f "${CERT_DIR}/server.crt" ] && [ -f "${CERT_DIR}/server.key" ]; then

--- a/deploy/nats/gen-certs.sh
+++ b/deploy/nats/gen-certs.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-CERT_DIR="/etc/nats/certs"
+CERT_DIR="${CERT_DIR:-/etc/nats/certs}"
 DEFAULT_SAN="DNS:localhost,IP:127.0.0.1,IP:192.168.1.16"
 SAN="${DEFAULT_SAN}"
 VALID_DAYS=3650  # 10 years — private LAN CA, no ACME; rotate manually on reprovision

--- a/deploy/nats/gen-certs.sh
+++ b/deploy/nats/gen-certs.sh
@@ -27,24 +27,33 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[ "$(id -u)" -eq 0 ] || error "Must be run as root (sudo ./deploy/nats/gen-certs.sh)"
+# Prod deployment: CERT_DIR=/etc/nats/certs requires root for chown root:nats.
+# Non-default CERT_DIR (CI roundtrip, dev) runs unprivileged and skips chown.
+if [ "${CERT_DIR}" = "/etc/nats/certs" ]; then
+  [ "$(id -u)" -eq 0 ] || error "Must be run as root (sudo ./deploy/nats/gen-certs.sh)"
+  PROD=1
+else
+  PROD=0
+fi
 
 if [ -f "${CERT_DIR}/server.crt" ] && [ -f "${CERT_DIR}/server.key" ]; then
   warn "Certs already exist at ${CERT_DIR}/ — skipping. Delete to regenerate."
   exit 0
 fi
 
-# Ensure nats group exists for cert file ownership
-getent group nats >/dev/null 2>&1 || groupadd --system nats
+# Ensure nats group exists for cert file ownership (prod only).
+if [ "${PROD}" = "1" ]; then
+  getent group nats >/dev/null 2>&1 || groupadd --system nats
+fi
 
 mkdir -p "${CERT_DIR}"
 chmod 755 "${CERT_DIR}"
-chown root:root "${CERT_DIR}"
+[ "${PROD}" = "1" ] && chown root:root "${CERT_DIR}"
 
 info "Generating CA private key (ECDSA P-384)..."
 openssl ecparam -name secp384r1 -genkey -noout -out "${CERT_DIR}/ca.key"
 chmod 600 "${CERT_DIR}/ca.key"
-chown root:root "${CERT_DIR}/ca.key"
+[ "${PROD}" = "1" ] && chown root:root "${CERT_DIR}/ca.key"
 
 info "Creating self-signed CA certificate..."
 openssl req -new -x509 \
@@ -57,7 +66,7 @@ chmod 644 "${CERT_DIR}/ca.crt"
 info "Generating server private key (ECDSA P-384)..."
 openssl ecparam -name secp384r1 -genkey -noout -out "${CERT_DIR}/server.key"
 chmod 640 "${CERT_DIR}/server.key"
-chown root:nats "${CERT_DIR}/server.key"  # nats user reads this via group
+[ "${PROD}" = "1" ] && chown root:nats "${CERT_DIR}/server.key"  # nats user reads this via group
 
 info "Creating server certificate (SAN: ${SAN})..."
 EXT_FILE=$(mktemp)

--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -48,7 +48,6 @@ jetstream {
 # ── Monitoring ─────────────────────────────────────────────────────────────
 # HTTP monitoring — localhost only, never exposed externally.
 # Polled by lyra-monitor via check_nats_varz() for auth_errors + slow_consumers.
-http: 127.0.0.1
-http_port: 8222
+http: "127.0.0.1:8222"
 
 logtime: true

--- a/docs/standards/renderer-roundtrip.md
+++ b/docs/standards/renderer-roundtrip.md
@@ -117,7 +117,9 @@ Conversely, if `nats-server` emits a stderr warning about a deprecated directive
 
 ## Reviewer checklist
 
-> **Does this PR add or modify a config renderer? If yes, verify a roundtrip test in `renderer-roundtrip.yml` covers it.**
+> **Does this PR add or modify a config renderer? If yes:**
+> - (a) check that `.github/workflows/renderer-roundtrip.yml` has a job invoking `tools/check_renderer_roundtrip.sh <subcommand>` for the renderer
+> - (b) verify `tools/check_renderer_roundtrip.sh` has a `case` branch implementing the subcommand
 
 - Is the consumer the actual downstream binary (nats-server, systemd, openssl, podman), not a mock or re-implementation?
 - Does the test include a negative case — a known-bad input that causes the test to fail? A test that cannot fail on bad input is not a roundtrip test.

--- a/docs/standards/renderer-roundtrip.md
+++ b/docs/standards/renderer-roundtrip.md
@@ -80,10 +80,10 @@ Consumer exit code 0 is necessary but not sufficient. Add explicit assertions fo
 The roundtrip test covers this renderer:
 
 ```bash
-bash tools/check_renderer_roundtrip.sh lyra-acl "$TMPDIR"
+bash tools/check_renderer_roundtrip.sh lyra-acl "$(mktemp -d)"
 ```
 
-The helper generates a fresh keyset into `$TMPDIR`, renders an auth.conf, runs `nats-server -t -c` on it, then asserts three invariants:
+The helper generates a fresh keyset into the supplied tmpdir, renders an auth.conf, runs `nats-server -t -c` on it, then asserts three invariants:
 
 1. **Length** — every nkey in the rendered file is exactly 56 characters.
 2. **Round-trip** — `pubkey(seed)` recomputed from the seed file equals the nkey stored in auth.conf.

--- a/docs/standards/renderer-roundtrip.md
+++ b/docs/standards/renderer-roundtrip.md
@@ -1,0 +1,124 @@
+---
+title: Renderer→Consumer Roundtrip CI Pattern
+description: When and how to add CI validation that a config renderer's output is accepted by the downstream binary before merge.
+---
+
+# Renderer→Consumer Roundtrip CI Pattern
+
+> Status: LIVING
+> Scope: `deploy/`, `tools/` — any tool that generates a config file consumed by an external binary
+> Enforced by: `.github/workflows/renderer-roundtrip.yml` + `tools/check_renderer_roundtrip.sh`
+
+---
+
+## Pattern
+
+A *renderer* is any tool or static file that produces output consumed by an external binary (nats-server, systemd, openssl, podman). The downstream binary is the authoritative parser — it decides at runtime whether the output is valid. The problem: validation at write-time is often weaker than validation at read-time. A rendered config may be accepted on first deploy yet rejected silently at the next restart, sometimes days later.
+
+Two prod incidents drove this pattern:
+
+- **#1083** — a `#` character in a Quadlet `Volume=` line was consumed without error at deploy but caused podman to misparse the unit file at next container start.
+- **#1089** — `lyra-acl genkeys` emitted 62-char nkeys instead of the required 56; nats-server accepted the auth.conf at initial load but rejected the keys on restart.
+
+The fix: every renderer must be exercised in CI by invoking the actual downstream binary in parse/check mode on its output, with exit-code and structural-invariant assertions, before the PR is merged.
+
+Shape: **render → consumer parse → invariant assertions**.
+
+---
+
+## When to apply
+
+Apply when:
+
+- A tool (Python script, shell script, CLI subcommand) writes a file that an external binary will parse.
+- A static file in `deploy/` is shipped to be consumed by `nats-server`, `podman`/systemd Quadlet, `systemd`, or `openssl`.
+- An existing renderer is modified in a way that changes the output format or adds new fields.
+
+Skip when:
+
+- The file is an internal Python data structure (e.g. a pickled object, a JSON blob read only by Lyra itself).
+- The consumer is Lyra code, not an external binary — those cases belong in `tests/` as integration tests.
+- The file is documentation or a template that is never loaded by a binary directly.
+
+---
+
+## Required shape
+
+Every roundtrip test must implement all three steps. Partial coverage (render only, or consumer parse only) does not satisfy this standard.
+
+**Render step**
+
+The renderer must write its output to a CI-controllable directory. Use `$RUNNER_TEMP` in CI or an env-overridable path in the helper script — never hardcode `/tmp/`. Example: `deploy/nats/gen-certs.sh` accepts `CERT_DIR=$tmpdir`, making it safe to invoke in parallel CI jobs without path collisions. New renderers must accept an equivalent override.
+
+**Consumer parse step**
+
+Invoke the downstream binary in its check/dry-run mode on the rendered output. No live network binding is required or permitted. Canonical invocations:
+
+```bash
+nats-server -t -c "$conf_file"          # syntax + config parse only
+systemd-analyze verify "$unit_file"     # unit file semantic check
+openssl verify -CAfile ca.crt leaf.crt  # certificate chain validation
+podman quadlet --dryrun "$unit_file"    # Quadlet parse without starting
+```
+
+The binary must be the actual downstream binary, not a reimplementation or mock.
+
+**Invariant assertions**
+
+Consumer exit code 0 is necessary but not sufficient. Add explicit assertions for any structural semantic invariant the binary does not enforce at parse time. Format failures as `expected X, got Y` — not a generic error string. Examples:
+
+- nkeys must be exactly 56 chars (nats-server parses them but does not validate length at config load).
+- Every certificate in `certs/` must chain to the CA in `ca.crt`.
+- No embedded newline inside a quoted value in the rendered conf.
+
+---
+
+## Worked example
+
+`lyra-acl genkeys` renders an `auth.conf` block containing nkeys and seeds. Bug #1089: the keygen utility emitted 62-char public keys. nats-server accepted the auth.conf without error on the initial load but failed to authenticate connections at restart because the keys did not match the internal nkeys format.
+
+The roundtrip test covers this renderer:
+
+```bash
+bash tools/check_renderer_roundtrip.sh lyra-acl "$TMPDIR"
+```
+
+The helper generates a fresh keyset into `$TMPDIR`, renders an auth.conf, runs `nats-server -t -c` on it, then asserts three invariants:
+
+1. **Length** — every nkey in the rendered file is exactly 56 characters.
+2. **Round-trip** — `pubkey(seed)` recomputed from the seed file equals the nkey stored in auth.conf.
+3. **No embedded newline** — no quoted string value in the conf contains a literal newline character.
+
+`tools/check_renderer_roundtrip.sh` is the canonical dispatcher for all renderers. When adding a new renderer, add a subcommand (case branch) to that script rather than creating a new standalone script. This keeps all roundtrip invocations discoverable in one place and ensures the CI workflow (`renderer-roundtrip.yml`) picks them up automatically.
+
+---
+
+## Failure modes
+
+**Surface a useful diff, not a generic exit 1.**
+
+Error messages must name the violation, the location, and the observed value. Examples of compliant error output:
+
+```
+nkey expected length 56, got 62 at user 'hub'
+cert chain: leaf.crt does not verify against ca.crt (openssl exit 2)
+volume line contains '#': 'Volume=/data/lyra#backup:/backup' in lyra-hub.container
+```
+
+Bad: `Error: validation failed` — this is not actionable. The developer must be able to fix the issue without re-running locally.
+
+**Don't swallow consumer warnings as errors — but don't ignore real warnings either.**
+
+`systemd-analyze verify` emits warnings for undeclared dependency targets (e.g. `network.target` not present in the test environment). These are expected and should not cause the test to fail — only a non-zero exit code from the binary is a hard failure.
+
+Conversely, if `nats-server` emits a stderr warning about a deprecated directive, treat it as a failure signal: the warning indicates the binary did not fully parse the config as intended. The threshold rule: any warning that indicates the consumer does not understand a directive → fail; any warning about the test environment lacking runtime dependencies → tolerate.
+
+---
+
+## Reviewer checklist
+
+> **Does this PR add or modify a config renderer? If yes, verify a roundtrip test in `renderer-roundtrip.yml` covers it.**
+
+- Is the consumer the actual downstream binary (nats-server, systemd, openssl, podman), not a mock or re-implementation?
+- Does the test include a negative case — a known-bad input that causes the test to fail? A test that cannot fail on bad input is not a roundtrip test.
+- Does the helper script invocation follow the canonical shape in `tools/check_renderer_roundtrip.sh` (subcommand + output dir), not a bespoke script?

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -66,6 +66,8 @@ This rule is enforced at code review by `dev-core:tester` and is a **merge block
 
 Prefer integration tests over unit tests with heavy mocks. Import and call real source functions — never mock the module under test.
 
+When a tool or static file in `deploy/` is consumed by an external binary (nats-server, podman, systemd, openssl), add a renderer→consumer roundtrip test instead of a plain integration test. This pattern exercises the actual downstream binary in parse/check mode on the rendered output and adds structural-invariant assertions beyond exit-code 0. See [renderer-roundtrip.md](./renderer-roundtrip.md) for the full pattern, required shape, and reviewer checklist.
+
 ---
 
 ## Coverage Rules

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -28,9 +28,11 @@ Subcommands:
   lyra-acl   Render auth.conf via lyra-acl genkeys and parse with nats-server
   nats-conf  Parse deploy/nats/nats.conf + nats-container.conf with nats-server
   gen-certs  Run gen-certs.sh, verify cert chain with openssl, parse TLS stanza
+  self-test  Falsifiable self-test: constructs known-bad inputs and asserts each
+             invariant fires. nk must be on PATH. No nats-server required.
 
 Each subcommand writes scratch files to <tmpdir>; caller manages cleanup.
-nats-server must be on PATH.
+nats-server must be on PATH (not required for self-test).
 EOF
   exit 1
 }
@@ -52,6 +54,103 @@ require_nk() {
     echo "  Locally: install nkeys v0.4.15 from https://github.com/nats-io/nkeys/releases" >&2
     exit 1
   fi
+}
+
+# ── INVARIANT HELPERS ────────────────────────────────────────────────────────
+# Extracted from cmd_lyra_acl so cmd_self_test can call them directly with
+# crafted inputs. Each function reads auth.conf content from a variable and
+# seeds from a directory; exits non-zero if the invariant is violated.
+
+# check_nkey_lengths <content> — Invariant (a): all nkey values exactly 56 chars
+check_nkey_lengths() {
+  local content="$1"
+  local fail=0
+  local nkey_count=0
+  while IFS= read -r line; do
+    if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
+      nkey_count=$((nkey_count + 1))
+      local nkey="${BASH_REMATCH[1]}"
+      local nkey_len="${#nkey}"
+      if [[ "${nkey_len}" -ne 56 ]]; then
+        echo "error: nkey expected length 56, got ${nkey_len} at: ${line}" >&2
+        fail=1
+      fi
+    fi
+  done <<< "${content}"
+  if [[ "${nkey_count}" -eq 0 ]]; then
+    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
+    return 1
+  fi
+  [[ "${fail}" -eq 0 ]] || return 1
+  echo "    nkey lengths OK" >&2
+}
+
+# check_roundtrip <content> <seeds_dir> — Invariant (b): seed→pubkey round-trip
+# auth.conf structure (per-user block):
+#   nkey: "U..."        ← nkey comes FIRST
+#   # identity-name    ← identity comment comes AFTER the nkey line
+# Strategy: save the pending nkey when we see the nkey line; resolve it
+# against the seed when we see the identity comment on the next line.
+check_roundtrip() {
+  local content="$1"
+  local seeds_dir="$2"
+  local rt_fail=0
+  local rt_checked=0
+  local pending_nkey=""
+  while IFS= read -r line; do
+    if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
+      rt_checked=$((rt_checked + 1))
+      pending_nkey="${BASH_REMATCH[1]}"
+    elif [[ -n "${pending_nkey}" && "${line}" =~ ^[[:space:]]*#[[:space:]]+([a-z0-9_-]+)[[:space:]]*$ ]]; then
+      local identity="${BASH_REMATCH[1]}"
+      local seed_file="${seeds_dir}/${identity}.seed"
+      if [[ -f "${seed_file}" ]]; then
+        local computed_nkey
+        computed_nkey="$(nk -inkey "${seed_file}" -pubout | tr -d '[:space:]')"
+        if [[ "${computed_nkey}" != "${pending_nkey}" ]]; then
+          echo "error: seed→pubkey mismatch for '${identity}'" >&2
+          echo "  stored nkey:   ${pending_nkey}" >&2
+          echo "  computed nkey: ${computed_nkey}" >&2
+          rt_fail=1
+        fi
+      fi
+      pending_nkey=""
+    else
+      pending_nkey=""
+    fi
+  done <<< "${content}"
+  if [[ "${rt_checked}" -eq 0 ]]; then
+    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
+    return 1
+  fi
+  [[ "${rt_fail}" -eq 0 ]] || return 1
+  echo "    seed→pubkey round-trip OK" >&2
+}
+
+# check_no_embedded_newlines <content> — Invariant (c): no embedded newlines
+# Defends against the secondary failure mode from #1089: if a quoted value
+# spans multiple lines (e.g. nkey: "ABC\nDEF"), nats-server rejects the
+# config because the value contains a literal newline.
+check_no_embedded_newlines() {
+  local content="$1"
+  local nl_fail=0
+  local nl_checked=0
+  while IFS= read -r line; do
+    local stripped="${line#"${line%%[![:space:]]*}"}"  # ltrim
+    if [[ "${stripped}" == nkey:* ]]; then
+      nl_checked=$((nl_checked + 1))
+      if ! [[ "${stripped}" =~ ^nkey:[[:space:]]*\"[^\"]+\"[[:space:]]*$ ]]; then
+        echo "error: nkey line does not open and close quote on same line: ${line}" >&2
+        nl_fail=1
+      fi
+    fi
+  done <<< "${content}"
+  if [[ "${nl_checked}" -eq 0 ]]; then
+    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
+    return 1
+  fi
+  [[ "${nl_fail}" -eq 0 ]] || return 1
+  echo "    no embedded newlines in quoted strings OK" >&2
 }
 
 # ── SUBCOMMAND: lyra-acl ──────────────────────────────────────────────────────
@@ -105,100 +204,14 @@ cmd_lyra_acl() {
   local content
   content="$(cat "${auth_conf}")"
 
-  # ── Invariant (a): every nkey value must be exactly 56 characters ──────────
-  # nats-server rejects nkeys that are not valid Ed25519 public keys encoded
-  # in base32 (56 chars for a user key starting with 'U').
   echo "==> lyra-acl: checking nkey lengths (expected 56)" >&2
-  local fail=0
-  local nkey_count=0
-  while IFS= read -r line; do
-    # Extract value from: nkey: "UXXXXXXXXX..."
-    if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
-      nkey_count=$((nkey_count + 1))
-      local nkey="${BASH_REMATCH[1]}"
-      local nkey_len="${#nkey}"
-      if [[ "${nkey_len}" -ne 56 ]]; then
-        echo "error: nkey expected length 56, got ${nkey_len} at: ${line}" >&2
-        fail=1
-      fi
-    fi
-  done <<< "${content}"
-  if [[ "${nkey_count}" -eq 0 ]]; then
-    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
-    exit 1
-  fi
-  [[ "${fail}" -eq 0 ]] || exit 1
-  echo "    nkey lengths OK" >&2
+  check_nkey_lengths "${content}" || exit 1
 
-  # ── Invariant (b): seed→pubkey round-trip ──────────────────────────────────
-  # auth.conf structure (per-user block):
-  #   nkey: "U..."        ← nkey comes FIRST
-  #   # identity-name    ← identity comment comes AFTER the nkey line
-  # Strategy: save the pending nkey when we see the nkey line; resolve it
-  # against the seed when we see the identity comment on the next line.
-  # nk is guaranteed on PATH (require_nk was called at the top of cmd_lyra_acl).
   echo "==> lyra-acl: verifying seed→pubkey round-trip with nk" >&2
-  local rt_fail=0
-  local rt_checked=0
-  local pending_nkey=""
-  while IFS= read -r line; do
-    if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
-      # Save this nkey; the identity comment on the next line will resolve it.
-      rt_checked=$((rt_checked + 1))
-      pending_nkey="${BASH_REMATCH[1]}"
-    elif [[ -n "${pending_nkey}" && "${line}" =~ ^[[:space:]]*#[[:space:]]+([a-z0-9_-]+)[[:space:]]*$ ]]; then
-      # Identity comment immediately following a nkey line.
-      local identity="${BASH_REMATCH[1]}"
-      local seed_file="${seeds_dir}/${identity}.seed"
-      if [[ -f "${seed_file}" ]]; then
-        local computed_nkey
-        computed_nkey="$(nk -inkey "${seed_file}" -pubout | tr -d '[:space:]')"
-        if [[ "${computed_nkey}" != "${pending_nkey}" ]]; then
-          echo "error: seed→pubkey mismatch for '${identity}'" >&2
-          echo "  stored nkey:   ${pending_nkey}" >&2
-          echo "  computed nkey: ${computed_nkey}" >&2
-          rt_fail=1
-        fi
-      fi
-      pending_nkey=""
-    else
-      # Any other line resets the pending nkey (guards against stray matches).
-      pending_nkey=""
-    fi
-  done <<< "${content}"
-  if [[ "${rt_checked}" -eq 0 ]]; then
-    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
-    exit 1
-  fi
-  [[ "${rt_fail}" -eq 0 ]] || exit 1
-  echo "    seed→pubkey round-trip OK" >&2
+  check_roundtrip "${content}" "${seeds_dir}" || exit 1
 
-  # ── Invariant (c): no embedded newlines inside quoted strings ──────────────
-  # Defends against the secondary failure mode from #1089: if a quoted value
-  # spans multiple lines (e.g. nkey: "ABC\nDEF"), nats-server rejects the
-  # config because the value contains a literal newline. We check that every
-  # line starting with `nkey:` opens and closes its double-quote on the same
-  # line (i.e. the full value is inline, not multi-line).
   echo "==> lyra-acl: checking for embedded newlines in quoted strings" >&2
-  local nl_fail=0
-  local nl_checked=0
-  while IFS= read -r line; do
-    local stripped="${line#"${line%%[![:space:]]*}"}"  # ltrim
-    if [[ "${stripped}" == nkey:* ]]; then
-      nl_checked=$((nl_checked + 1))
-      # A well-formed nkey line starts with nkey: " and ends with "
-      if ! [[ "${stripped}" =~ ^nkey:[[:space:]]*\"[^\"]+\"[[:space:]]*$ ]]; then
-        echo "error: nkey line does not open and close quote on same line: ${line}" >&2
-        nl_fail=1
-      fi
-    fi
-  done <<< "${content}"
-  if [[ "${nl_checked}" -eq 0 ]]; then
-    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
-    exit 1
-  fi
-  [[ "${nl_fail}" -eq 0 ]] || exit 1
-  echo "    no embedded newlines in quoted strings OK" >&2
+  check_no_embedded_newlines "${content}" || exit 1
 
   echo "==> lyra-acl: all checks passed" >&2
 }
@@ -334,6 +347,102 @@ EOF
   echo "==> gen-certs: all checks passed" >&2
 }
 
+# ── SUBCOMMAND: self-test ─────────────────────────────────────────────────────
+# Falsifiable self-test: synthetically constructs known-bad inputs and calls
+# the invariant helper functions directly to assert each one fires as expected.
+#
+# Cases:
+#   (a) 62-char nkey → check_nkey_lengths fires
+#   (b) nkey with unclosed quote (embedded newline) → check_no_embedded_newlines fires
+#   (c) swapped nkey (different valid seed) → check_roundtrip fires
+#   (d) no nkey: lines at all → zero-match guard fires in all 3 checks
+#
+# Requires: nk on PATH (for case c to generate a second seed).
+# Does NOT require nats-server.
+cmd_self_test() {
+  local tmpdir="$1"
+  require_nk
+
+  local overall_fail=0
+
+  # _assert_check_fails: assert that calling a check_* function with given args
+  # exits non-zero AND writes expected_pattern to stderr.
+  _assert_check_fails() {
+    local case_name="$1"
+    local expected_pattern="$2"
+    shift 2
+    local stderr_file
+    stderr_file="$(mktemp)"
+    local rc=0
+    "$@" 2>"${stderr_file}" || rc=$?
+    if [[ "${rc}" -eq 0 ]]; then
+      echo "FAIL ${case_name}: expected non-zero exit, got 0" >&2
+      overall_fail=1
+    elif grep -qF "${expected_pattern}" "${stderr_file}"; then
+      echo "PASS ${case_name}" >&2
+    else
+      echo "FAIL ${case_name}: exit=${rc} but stderr did not contain '${expected_pattern}'" >&2
+      echo "  actual stderr:" >&2
+      sed 's/^/    /' "${stderr_file}" >&2
+      overall_fail=1
+    fi
+    rm -f "${stderr_file}"
+  }
+
+  # ── Prepare two seeds for case (c) ───────────────────────────────────────
+  # seed1 is the "correct" identity seed; seed2 is the "wrong" seed whose
+  # pubkey will be stored in auth.conf to trigger the round-trip mismatch.
+  local seed1_dir="${tmpdir}/seed1"
+  local seed2_dir="${tmpdir}/seed2"
+  mkdir -p "${seed1_dir}" "${seed2_dir}"
+  nk -gen user > "${seed1_dir}/testidentity.seed"
+  nk -gen user > "${seed2_dir}/testidentity.seed"
+  local pubkey2
+  pubkey2="$(nk -inkey "${seed2_dir}/testidentity.seed" -pubout | tr -d '[:space:]')"
+
+  # ── Case (a): 62-char nkey → check_nkey_lengths fires ───────────────────
+  local bad_62char="UAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNN12"
+  local content_a
+  content_a="$(printf '      nkey: "%s"\n      # testidentity\n' "${bad_62char}")"
+  _assert_check_fails "case-a (62-char nkey)" "expected length 56" \
+    check_nkey_lengths "${content_a}"
+
+  # ── Case (b): unclosed quote → check_no_embedded_newlines fires ──────────
+  # printf writes a literal newline inside the nkey: value so the line does
+  # not close its double-quote — the invariant must detect this.
+  local content_b
+  content_b="$(printf '      nkey: "UAAA\n"\n      # testidentity\n')"
+  _assert_check_fails "case-b (embedded newline)" "does not open and close quote on same line" \
+    check_no_embedded_newlines "${content_b}"
+
+  # ── Case (c): swapped pubkey → check_roundtrip fires ─────────────────────
+  # auth.conf stores pubkey2, but seeds_dir has seed1's seed for testidentity.
+  local content_c
+  content_c="$(printf '      nkey: "%s"\n      # testidentity\n' "${pubkey2}")"
+  _assert_check_fails "case-c (swapped pubkey)" "seed→pubkey mismatch" \
+    check_roundtrip "${content_c}" "${seed1_dir}"
+
+  # ── Case (d): no nkey: lines → zero-match guard fires in all 3 checks ────
+  local content_d
+  content_d="$(printf 'authorization {\n  users [\n    { username: "testidentity" }\n  ]\n}\n')"
+  local dummy_seeds="${tmpdir}/dummy-seeds"
+  mkdir -p "${dummy_seeds}"
+  _assert_check_fails "case-d-length (no nkey lines)" "no nkey lines found" \
+    check_nkey_lengths "${content_d}"
+  _assert_check_fails "case-d-roundtrip (no nkey lines)" "no nkey lines found" \
+    check_roundtrip "${content_d}" "${dummy_seeds}"
+  _assert_check_fails "case-d-newlines (no nkey lines)" "no nkey lines found" \
+    check_no_embedded_newlines "${content_d}"
+
+  # ── Summary ──────────────────────────────────────────────────────────────
+  if [[ "${overall_fail}" -eq 0 ]]; then
+    echo "==> self-test: all cases passed" >&2
+  else
+    echo "==> self-test: FAILED — one or more cases did not behave as expected" >&2
+    exit 1
+  fi
+}
+
 # ── DISPATCH ──────────────────────────────────────────────────────────────────
 if [[ $# -lt 1 ]]; then
   usage
@@ -354,6 +463,10 @@ case "${SUBCOMMAND}" in
   gen-certs)
     [[ $# -ge 1 ]] || { echo "error: gen-certs requires <tmpdir>" >&2; usage; }
     cmd_gen_certs "$1"
+    ;;
+  self-test)
+    [[ $# -ge 1 ]] || { echo "error: self-test requires <tmpdir>" >&2; usage; }
+    cmd_self_test "$1"
     ;;
   --help|-h)
     usage

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -203,19 +203,26 @@ cmd_nats_conf() {
   # ── nats.conf ─────────────────────────────────────────────────────────────
   # Copy to tmpdir so the include path "nkeys/auth.conf" resolves relative to
   # $tmpdir (i.e. $tmpdir/nkeys/auth.conf — which we just created above).
-  # Strip the TLS stanza cert_file/key_file/ca_file references since we don't
-  # have real certs here; nats-server -t only syntax-checks, doesn't connect.
-  # Actually nats-server -t -c DOES validate that referenced files exist for
-  # TLS — so we need to either provide dummy certs or strip the tls block.
-  # Strategy: copy the conf, replace cert paths with /dev/null (always exists).
+  # Strip the entire `tls { … }` block: `nats-server -t -c` validates that
+  # referenced cert/key/ca files exist and are valid PEM. We don't have real
+  # certs here (the gen-certs subcommand covers TLS roundtrip separately).
+  # awk depth-counter handles nested braces correctly.
   local nats_conf_src="${REPO_ROOT}/deploy/nats/nats.conf"
   local nats_conf_dst="${tmpdir}/nats.conf"
 
-  sed \
-    -e 's|cert_file:.*|cert_file: "/dev/null"|' \
-    -e 's|key_file:.*|key_file:  "/dev/null"|' \
-    -e 's|ca_file:.*|ca_file:   "/dev/null"|' \
-    "${nats_conf_src}" > "${nats_conf_dst}"
+  awk '
+    /^[[:space:]]*tls[[:space:]]*\{/ { depth=1; next }
+    depth > 0 {
+      for (i=1; i<=length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == "{") depth++
+        else if (c == "}") depth--
+      }
+      if (depth == 0) next
+      next
+    }
+    { print }
+  ' "${nats_conf_src}" > "${nats_conf_dst}"
 
   # Fix the include path: the original uses `include "nkeys/auth.conf"` which
   # resolves relative to the config file dir. Since our copy is in $tmpdir and
@@ -250,20 +257,9 @@ cmd_gen_certs() {
   local gen_certs_sh="${REPO_ROOT}/deploy/nats/gen-certs.sh"
 
   echo "==> gen-certs: generating certs into ${tmpdir}" >&2
-  # gen-certs.sh checks (id -u) == 0 when CERT_DIR=/etc/nats/certs (default).
-  # With CERT_DIR overridden to a user-writable tmpdir, the chown commands
-  # (root:nats) will still fail for non-root. Use sudo if available in CI;
-  # otherwise rely on the runner having root (containers, etc.).
-  if [[ "$(id -u)" -eq 0 ]]; then
-    CERT_DIR="${tmpdir}" bash "${gen_certs_sh}"
-  elif command -v sudo &>/dev/null; then
-    sudo env CERT_DIR="${tmpdir}" bash "${gen_certs_sh}"
-    # Fix ownership so subsequent steps (openssl, nats-server) can read files.
-    sudo chown -R "$(id -u):$(id -g)" "${tmpdir}"
-  else
-    echo "error: gen-certs.sh requires root or sudo" >&2
-    exit 1
-  fi
+  # gen-certs.sh skips the root check + chown calls when CERT_DIR is not the
+  # default /etc/nats/certs (i.e. it's a CI/dev tmpdir). No sudo needed.
+  CERT_DIR="${tmpdir}" bash "${gen_certs_sh}"
 
   local ca_crt="${tmpdir}/ca.crt"
   local server_crt="${tmpdir}/server.crt"

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -44,43 +44,53 @@ require_nats_server() {
   fi
 }
 
+# ── GUARD: require nk on PATH ─────────────────────────────────────────────────
+require_nk() {
+  if ! command -v nk &>/dev/null; then
+    echo "error: nk not found on PATH" >&2
+    echo "  In CI: installed by the 'Install nk' step in renderer-roundtrip.yml (lyra-acl-parse job)." >&2
+    echo "  Locally: install nkeys v0.4.15 from https://github.com/nats-io/nkeys/releases" >&2
+    exit 1
+  fi
+}
+
 # ── SUBCOMMAND: lyra-acl ──────────────────────────────────────────────────────
 # Exercises the bug from #1089: lyra-acl genkeys renders auth.conf, then
 # nats-server -t -c parse-gates it. Three semantic invariants are enforced:
 #   (a) every nkey value is exactly 56 characters
-#   (b) nk seed→pubkey round-trip matches stored nkey (if nk is available)
+#   (b) nk seed→pubkey round-trip matches stored nkey
 #   (c) no literal newline inside any quoted string (embedded-newline guard)
 cmd_lyra_acl() {
   local tmpdir="$1"
   require_nats_server
+  require_nk
 
   local seeds_dir="${tmpdir}/nkeys"
   mkdir -p "${seeds_dir}"
+
+  local acl_matrix="${REPO_ROOT}/deploy/nats/acl-matrix.json"
+  if [[ ! -f "${acl_matrix}" ]]; then
+    echo "error: acl-matrix.json not found at ${acl_matrix}" >&2
+    exit 1
+  fi
+
+  echo "==> lyra-acl: generating seeds from acl-matrix.json into ${seeds_dir}" >&2
+
+  # Read identity names from the acl-matrix.json map and generate a real seed
+  # for each one using nk. The seed (private key) is written to <identity>.seed.
+  local identities
+  identities=$(jq -r '.identities | keys[]' "${acl_matrix}")
+  while IFS= read -r identity; do
+    nk -gen user > "${seeds_dir}/${identity}.seed"
+  done <<< "${identities}"
 
   echo "==> lyra-acl: rendering auth.conf into ${seeds_dir}" >&2
 
   # Run lyra-acl genkeys --regen-authconf.
   # SEEDS_DIR redirects the read path (seeds) and the write path (auth.conf).
-  # AUTH_DIR bypass is not needed here — we only use --regen-authconf which
-  # reads seeds from SEEDS_DIR and writes auth.conf there (no root required).
-  #
-  # NOTE: seeds must already exist in seeds_dir for --regen-authconf to work.
-  # In CI, the workflow pre-populates seeds via a prior step. For local runs,
-  # point SEEDS_DIR at ~/.lyra/nkeys/ (which has real seeds) or seed the dir
-  # manually. This helper does not generate seeds — only validates the render.
-  if [[ -z "$(ls -A "${seeds_dir}" 2>/dev/null | grep '\.seed$' || true)" ]]; then
-    echo "warning: no *.seed files in ${seeds_dir}" >&2
-    echo "  For CI: the workflow pre-populates seeds before calling this subcommand." >&2
-    echo "  For local: copy ~/.lyra/nkeys/*.seed into ${seeds_dir}/" >&2
-    echo "  Falling back to --template-only (fake nkeys) for parse-gate only." >&2
-    # --template-only emits fake 56-char nkeys (UDET+uppercase-name pattern);
-    # the length and syntax checks will still fire but seed→pubkey round-trip is skipped.
-    SEEDS_DIR="${seeds_dir}" uv run --directory "${REPO_ROOT}" \
-      lyra-acl genkeys --template-only > "${seeds_dir}/auth.conf"
-  else
-    SEEDS_DIR="${seeds_dir}" uv run --directory "${REPO_ROOT}" \
-      lyra-acl genkeys --regen-authconf
-  fi
+  # Seeds now always exist — no fallback to --template-only.
+  SEEDS_DIR="${seeds_dir}" uv run --directory "${REPO_ROOT}" \
+    lyra-acl genkeys --regen-authconf
 
   local auth_conf="${seeds_dir}/auth.conf"
   if [[ ! -f "${auth_conf}" ]]; then
@@ -114,43 +124,42 @@ cmd_lyra_acl() {
   [[ "${fail}" -eq 0 ]] || exit 1
   echo "    nkey lengths OK" >&2
 
-  # ── Invariant (b): seed→pubkey round-trip (requires nk binary) ─────────────
-  # For each user that has both an nkey line and a matching .seed file in
-  # seeds_dir, recompute the public key from the seed and compare.
-  if command -v nk &>/dev/null; then
-    echo "==> lyra-acl: verifying seed→pubkey round-trip with nk" >&2
-    local rt_fail=0
-    while IFS= read -r line; do
-      # Match comment lines that identify the user: # <name>
-      if [[ "${line}" =~ ^[[:space:]]*#[[:space:]]+([a-z0-9_-]+)[[:space:]]*$ ]]; then
-        local identity="${BASH_REMATCH[1]}"
-        local seed_file="${seeds_dir}/${identity}.seed"
-        # Peek at the next nkey line — we parse the full file sequentially,
-        # so track the last seen identity comment per nkey line.
-        last_identity="${identity}"
-      fi
-      if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
-        local stored_nkey="${BASH_REMATCH[1]}"
-        local seed_file="${seeds_dir}/${last_identity:-}.seed"
-        if [[ -n "${last_identity:-}" && -f "${seed_file}" ]]; then
-          local computed_nkey
-          computed_nkey="$(nk -inkey "${seed_file}" -pubout 2>/dev/null | tr -d '[:space:]')"
-          if [[ "${computed_nkey}" != "${stored_nkey}" ]]; then
-            echo "error: seed→pubkey mismatch for '${last_identity}'" >&2
-            echo "  stored nkey:   ${stored_nkey}" >&2
-            echo "  computed nkey: ${computed_nkey}" >&2
-            rt_fail=1
-          fi
+  # ── Invariant (b): seed→pubkey round-trip ──────────────────────────────────
+  # auth.conf structure (per-user block):
+  #   nkey: "U..."        ← nkey comes FIRST
+  #   # identity-name    ← identity comment comes AFTER the nkey line
+  # Strategy: save the pending nkey when we see the nkey line; resolve it
+  # against the seed when we see the identity comment on the next line.
+  # nk is guaranteed on PATH (require_nk was called at the top of cmd_lyra_acl).
+  echo "==> lyra-acl: verifying seed→pubkey round-trip with nk" >&2
+  local rt_fail=0
+  local pending_nkey=""
+  while IFS= read -r line; do
+    if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
+      # Save this nkey; the identity comment on the next line will resolve it.
+      pending_nkey="${BASH_REMATCH[1]}"
+    elif [[ -n "${pending_nkey}" && "${line}" =~ ^[[:space:]]*#[[:space:]]+([a-z0-9_-]+)[[:space:]]*$ ]]; then
+      # Identity comment immediately following a nkey line.
+      local identity="${BASH_REMATCH[1]}"
+      local seed_file="${seeds_dir}/${identity}.seed"
+      if [[ -f "${seed_file}" ]]; then
+        local computed_nkey
+        computed_nkey="$(nk -inkey "${seed_file}" -pubout 2>/dev/null | tr -d '[:space:]')"
+        if [[ "${computed_nkey}" != "${pending_nkey}" ]]; then
+          echo "error: seed→pubkey mismatch for '${identity}'" >&2
+          echo "  stored nkey:   ${pending_nkey}" >&2
+          echo "  computed nkey: ${computed_nkey}" >&2
+          rt_fail=1
         fi
-        last_identity=""
       fi
-    done <<< "${content}"
-    [[ "${rt_fail}" -eq 0 ]] || exit 1
-    echo "    seed→pubkey round-trip OK" >&2
-  else
-    echo "warning: nk not on PATH — skipping seed→pubkey round-trip check" >&2
-    echo "  In CI, nk is installed by the workflow's NK install step." >&2
-  fi
+      pending_nkey=""
+    else
+      # Any other line resets the pending nkey (guards against stray matches).
+      pending_nkey=""
+    fi
+  done <<< "${content}"
+  [[ "${rt_fail}" -eq 0 ]] || exit 1
+  echo "    seed→pubkey round-trip OK" >&2
 
   # ── Invariant (c): no embedded newlines inside quoted strings ──────────────
   # Defends against the secondary failure mode from #1089: if a quoted value

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -293,6 +293,27 @@ cmd_gen_certs() {
   openssl verify -CAfile "${ca_crt}" "${server_crt}"
   echo "    openssl verify OK" >&2
 
+  # ── Full nats.conf TLS stanza parse-gate ──────────────────────────────────
+  # Parse the real nats.conf UNSTRIPPED (with TLS block intact) so that TLS
+  # directive typos (e.g. misspelled cipher_suites) are caught in CI.
+  # We substitute the prod cert paths with the tmpdir certs and create a minimal
+  # stub nkeys/auth.conf so the include resolves.
+  local nats_conf_src="${REPO_ROOT}/deploy/nats/nats.conf"
+  local nats_full_dst="${tmpdir}/nats-full.conf"
+  local nkeys_dir="${tmpdir}/nkeys"
+  mkdir -p "${nkeys_dir}"
+  printf 'authorization {\n  users = []\n}\n' > "${nkeys_dir}/auth.conf"
+
+  sed \
+    -e "s|/etc/nats/certs/server.crt|${server_crt}|g" \
+    -e "s|/etc/nats/certs/server.key|${server_key}|g" \
+    -e "s|/etc/nats/certs/ca.crt|${ca_crt}|g" \
+    "${nats_conf_src}" > "${nats_full_dst}"
+
+  echo "==> gen-certs: parse-gating full nats.conf (TLS stanza unstripped) with nats-server -t -c" >&2
+  nats-server -t -c "${nats_full_dst}"
+  echo "    nats.conf full TLS parse-gate OK" >&2
+
   # Emit a minimal TLS-only nats config that references the generated certs.
   # nats-server -t -c verifies that the referenced files exist and are parseable.
   local tls_conf="${tmpdir}/tls.conf"

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -275,9 +275,8 @@ cmd_gen_certs() {
   local gen_certs_sh="${REPO_ROOT}/deploy/nats/gen-certs.sh"
 
   echo "==> gen-certs: generating certs into ${tmpdir}" >&2
-  # gen-certs.sh skips the root check + chown calls when CERT_DIR is not the
-  # default /etc/nats/certs (i.e. it's a CI/dev tmpdir). No sudo needed.
-  CERT_DIR="${tmpdir}" bash "${gen_certs_sh}"
+  # Pass --unprivileged so gen-certs.sh skips root check + chown calls.
+  CERT_DIR="${tmpdir}" bash "${gen_certs_sh}" --unprivileged
 
   local ca_crt="${tmpdir}/ca.crt"
   local server_crt="${tmpdir}/server.crt"

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -180,6 +180,14 @@ cmd_lyra_acl() {
   local identities
   identities=$(jq -r '.identities | keys[]' "${acl_matrix}")
   while IFS= read -r identity; do
+    # Validate identity name against the canonical charset before using it as a
+    # filename component — defends against a malicious acl-matrix.json with
+    # `../` traversal or shell-meta keys. Same charset as the auth.conf
+    # comment parser (check_roundtrip line 104).
+    if ! [[ "${identity}" =~ ^[a-z0-9_-]+$ ]]; then
+      echo "error: invalid identity name '${identity}' in acl-matrix.json — must match ^[a-z0-9_-]+\$" >&2
+      exit 1
+    fi
     nk -gen user > "${seeds_dir}/${identity}.seed"
   done <<< "${identities}"
 

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# check_renderer_roundtrip.sh — renderer→consumer roundtrip helper
+#
+# Exercises each config renderer through its real downstream consumer in
+# check/dry-run mode. Intended for CI (renderer-roundtrip.yml) and local runs.
+#
+# Usage:
+#   tools/check_renderer_roundtrip.sh lyra-acl  <tmpdir>
+#   tools/check_renderer_roundtrip.sh nats-conf <tmpdir>
+#   tools/check_renderer_roundtrip.sh gen-certs <tmpdir>
+#
+# <tmpdir>: writable scratch directory; caller is responsible for cleanup.
+# nats-server must be on PATH (installed by the workflow's F1 install step).
+
+set -euo pipefail
+
+# ── REPO ROOT ─────────────────────────────────────────────────────────────────
+# Resolve repo root relative to this script so all paths are absolute.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ── USAGE ─────────────────────────────────────────────────────────────────────
+usage() {
+  cat >&2 <<'EOF'
+Usage: tools/check_renderer_roundtrip.sh <subcommand> <tmpdir>
+
+Subcommands:
+  lyra-acl   Render auth.conf via lyra-acl genkeys and parse with nats-server
+  nats-conf  Parse deploy/nats/nats.conf + nats-container.conf with nats-server
+  gen-certs  Run gen-certs.sh, verify cert chain with openssl, parse TLS stanza
+
+Each subcommand writes scratch files to <tmpdir>; caller manages cleanup.
+nats-server must be on PATH.
+EOF
+  exit 1
+}
+
+# ── GUARD: require nats-server on PATH ────────────────────────────────────────
+require_nats_server() {
+  if ! command -v nats-server &>/dev/null; then
+    echo "error: nats-server not found on PATH" >&2
+    echo "  Install via the F1 step in renderer-roundtrip.yml or ci.yml" >&2
+    exit 1
+  fi
+}
+
+# ── SUBCOMMAND: lyra-acl ──────────────────────────────────────────────────────
+# Exercises the bug from #1089: lyra-acl genkeys renders auth.conf, then
+# nats-server -t -c parse-gates it. Three semantic invariants are enforced:
+#   (a) every nkey value is exactly 56 characters
+#   (b) nk seed→pubkey round-trip matches stored nkey (if nk is available)
+#   (c) no literal newline inside any quoted string (embedded-newline guard)
+cmd_lyra_acl() {
+  local tmpdir="$1"
+  require_nats_server
+
+  local seeds_dir="${tmpdir}/nkeys"
+  mkdir -p "${seeds_dir}"
+
+  echo "==> lyra-acl: rendering auth.conf into ${seeds_dir}" >&2
+
+  # Run lyra-acl genkeys --regen-authconf.
+  # SEEDS_DIR redirects the read path (seeds) and the write path (auth.conf).
+  # AUTH_DIR bypass is not needed here — we only use --regen-authconf which
+  # reads seeds from SEEDS_DIR and writes auth.conf there (no root required).
+  #
+  # NOTE: seeds must already exist in seeds_dir for --regen-authconf to work.
+  # In CI, the workflow pre-populates seeds via a prior step. For local runs,
+  # point SEEDS_DIR at ~/.lyra/nkeys/ (which has real seeds) or seed the dir
+  # manually. This helper does not generate seeds — only validates the render.
+  if [[ -z "$(ls -A "${seeds_dir}" 2>/dev/null | grep '\.seed$' || true)" ]]; then
+    echo "warning: no *.seed files in ${seeds_dir}" >&2
+    echo "  For CI: the workflow pre-populates seeds before calling this subcommand." >&2
+    echo "  For local: copy ~/.lyra/nkeys/*.seed into ${seeds_dir}/" >&2
+    echo "  Falling back to --template-only (fake nkeys) for parse-gate only." >&2
+    # --template-only emits fake 56-char nkeys (UDET+uppercase-name pattern);
+    # the length and syntax checks will still fire but seed→pubkey round-trip is skipped.
+    SEEDS_DIR="${seeds_dir}" uv run --directory "${REPO_ROOT}" \
+      lyra-acl genkeys --template-only > "${seeds_dir}/auth.conf"
+  else
+    SEEDS_DIR="${seeds_dir}" uv run --directory "${REPO_ROOT}" \
+      lyra-acl genkeys --regen-authconf
+  fi
+
+  local auth_conf="${seeds_dir}/auth.conf"
+  if [[ ! -f "${auth_conf}" ]]; then
+    echo "error: lyra-acl genkeys did not produce ${auth_conf}" >&2
+    exit 1
+  fi
+
+  echo "==> lyra-acl: parse-gating with nats-server -t -c" >&2
+  nats-server -t -c "${auth_conf}"
+
+  # Read the file once for all invariant checks.
+  local content
+  content="$(cat "${auth_conf}")"
+
+  # ── Invariant (a): every nkey value must be exactly 56 characters ──────────
+  # nats-server rejects nkeys that are not valid Ed25519 public keys encoded
+  # in base32 (56 chars for a user key starting with 'U').
+  echo "==> lyra-acl: checking nkey lengths (expected 56)" >&2
+  local fail=0
+  while IFS= read -r line; do
+    # Extract value from: nkey: "UXXXXXXXXX..."
+    if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
+      local nkey="${BASH_REMATCH[1]}"
+      local nkey_len="${#nkey}"
+      if [[ "${nkey_len}" -ne 56 ]]; then
+        echo "error: nkey expected length 56, got ${nkey_len} at: ${line}" >&2
+        fail=1
+      fi
+    fi
+  done <<< "${content}"
+  [[ "${fail}" -eq 0 ]] || exit 1
+  echo "    nkey lengths OK" >&2
+
+  # ── Invariant (b): seed→pubkey round-trip (requires nk binary) ─────────────
+  # For each user that has both an nkey line and a matching .seed file in
+  # seeds_dir, recompute the public key from the seed and compare.
+  if command -v nk &>/dev/null; then
+    echo "==> lyra-acl: verifying seed→pubkey round-trip with nk" >&2
+    local rt_fail=0
+    while IFS= read -r line; do
+      # Match comment lines that identify the user: # <name>
+      if [[ "${line}" =~ ^[[:space:]]*#[[:space:]]+([a-z0-9_-]+)[[:space:]]*$ ]]; then
+        local identity="${BASH_REMATCH[1]}"
+        local seed_file="${seeds_dir}/${identity}.seed"
+        # Peek at the next nkey line — we parse the full file sequentially,
+        # so track the last seen identity comment per nkey line.
+        last_identity="${identity}"
+      fi
+      if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
+        local stored_nkey="${BASH_REMATCH[1]}"
+        local seed_file="${seeds_dir}/${last_identity:-}.seed"
+        if [[ -n "${last_identity:-}" && -f "${seed_file}" ]]; then
+          local computed_nkey
+          computed_nkey="$(nk -inkey "${seed_file}" -pubout 2>/dev/null | tr -d '[:space:]')"
+          if [[ "${computed_nkey}" != "${stored_nkey}" ]]; then
+            echo "error: seed→pubkey mismatch for '${last_identity}'" >&2
+            echo "  stored nkey:   ${stored_nkey}" >&2
+            echo "  computed nkey: ${computed_nkey}" >&2
+            rt_fail=1
+          fi
+        fi
+        last_identity=""
+      fi
+    done <<< "${content}"
+    [[ "${rt_fail}" -eq 0 ]] || exit 1
+    echo "    seed→pubkey round-trip OK" >&2
+  else
+    echo "warning: nk not on PATH — skipping seed→pubkey round-trip check" >&2
+    echo "  In CI, nk is installed by the workflow's NK install step." >&2
+  fi
+
+  # ── Invariant (c): no embedded newlines inside quoted strings ──────────────
+  # Defends against the secondary failure mode from #1089: if a quoted value
+  # spans multiple lines (e.g. nkey: "ABC\nDEF"), nats-server rejects the
+  # config because the value contains a literal newline. We check that every
+  # line starting with `nkey:` opens and closes its double-quote on the same
+  # line (i.e. the full value is inline, not multi-line).
+  echo "==> lyra-acl: checking for embedded newlines in quoted strings" >&2
+  local nl_fail=0
+  while IFS= read -r line; do
+    local stripped="${line#"${line%%[![:space:]]*}"}"  # ltrim
+    if [[ "${stripped}" == nkey:* ]]; then
+      # A well-formed nkey line starts with nkey: " and ends with "
+      if ! [[ "${stripped}" =~ ^nkey:[[:space:]]*\"[^\"]+\"[[:space:]]*$ ]]; then
+        echo "error: nkey line does not open and close quote on same line: ${line}" >&2
+        nl_fail=1
+      fi
+    fi
+  done <<< "${content}"
+  [[ "${nl_fail}" -eq 0 ]] || exit 1
+  echo "    no embedded newlines in quoted strings OK" >&2
+
+  echo "==> lyra-acl: all checks passed" >&2
+}
+
+# ── SUBCOMMAND: nats-conf ─────────────────────────────────────────────────────
+# Static parse-gate for deploy/nats/nats.conf and deploy/nats/nats-container.conf.
+# Both configs include "nkeys/auth.conf" relative to the config file location;
+# we create a minimal stub so nats-server -t -c can resolve the include without
+# touching real system files.
+cmd_nats_conf() {
+  local tmpdir="$1"
+  require_nats_server
+
+  # Create stub nkeys/auth.conf — must be parse-valid so the include resolves.
+  # Content is the minimum authorization block that nats-server accepts.
+  local nkeys_dir="${tmpdir}/nkeys"
+  mkdir -p "${nkeys_dir}"
+  printf 'authorization {\n  users = []\n}\n' > "${nkeys_dir}/auth.conf"
+
+  # ── nats.conf ─────────────────────────────────────────────────────────────
+  # Copy to tmpdir so the include path "nkeys/auth.conf" resolves relative to
+  # $tmpdir (i.e. $tmpdir/nkeys/auth.conf — which we just created above).
+  # Strip the TLS stanza cert_file/key_file/ca_file references since we don't
+  # have real certs here; nats-server -t only syntax-checks, doesn't connect.
+  # Actually nats-server -t -c DOES validate that referenced files exist for
+  # TLS — so we need to either provide dummy certs or strip the tls block.
+  # Strategy: copy the conf, replace cert paths with /dev/null (always exists).
+  local nats_conf_src="${REPO_ROOT}/deploy/nats/nats.conf"
+  local nats_conf_dst="${tmpdir}/nats.conf"
+
+  sed \
+    -e 's|cert_file:.*|cert_file: "/dev/null"|' \
+    -e 's|key_file:.*|key_file:  "/dev/null"|' \
+    -e 's|ca_file:.*|ca_file:   "/dev/null"|' \
+    "${nats_conf_src}" > "${nats_conf_dst}"
+
+  # Fix the include path: the original uses `include "nkeys/auth.conf"` which
+  # resolves relative to the config file dir. Since our copy is in $tmpdir and
+  # our stub is at $tmpdir/nkeys/auth.conf, the relative path is already correct.
+
+  echo "==> nats-conf: parse-gating nats.conf with nats-server -t -c" >&2
+  nats-server -t -c "${nats_conf_dst}"
+  echo "    nats.conf OK" >&2
+
+  # ── nats-container.conf ───────────────────────────────────────────────────
+  # Container config has no TLS block — simpler case.
+  local container_conf_src="${REPO_ROOT}/deploy/nats/nats-container.conf"
+  local container_conf_dst="${tmpdir}/nats-container.conf"
+  cp "${container_conf_src}" "${container_conf_dst}"
+
+  echo "==> nats-conf: parse-gating nats-container.conf with nats-server -t -c" >&2
+  nats-server -t -c "${container_conf_dst}"
+  echo "    nats-container.conf OK" >&2
+
+  echo "==> nats-conf: all checks passed" >&2
+}
+
+# ── SUBCOMMAND: gen-certs ─────────────────────────────────────────────────────
+# Cert renderer + dual consumer:
+#   1. CERT_DIR=$tmpdir bash deploy/nats/gen-certs.sh  (renders CA + server certs)
+#   2. openssl verify -CAfile $tmpdir/ca.crt $tmpdir/server.crt  (chain validation)
+#   3. nats-server -t -c <tls.conf>  (parse-gate a minimal TLS stanza)
+cmd_gen_certs() {
+  local tmpdir="$1"
+  require_nats_server
+
+  local gen_certs_sh="${REPO_ROOT}/deploy/nats/gen-certs.sh"
+
+  echo "==> gen-certs: generating certs into ${tmpdir}" >&2
+  # gen-certs.sh checks (id -u) == 0 when CERT_DIR=/etc/nats/certs (default).
+  # With CERT_DIR overridden to a user-writable tmpdir, the chown commands
+  # (root:nats) will still fail for non-root. Use sudo if available in CI;
+  # otherwise rely on the runner having root (containers, etc.).
+  if [[ "$(id -u)" -eq 0 ]]; then
+    CERT_DIR="${tmpdir}" bash "${gen_certs_sh}"
+  elif command -v sudo &>/dev/null; then
+    sudo env CERT_DIR="${tmpdir}" bash "${gen_certs_sh}"
+    # Fix ownership so subsequent steps (openssl, nats-server) can read files.
+    sudo chown -R "$(id -u):$(id -g)" "${tmpdir}"
+  else
+    echo "error: gen-certs.sh requires root or sudo" >&2
+    exit 1
+  fi
+
+  local ca_crt="${tmpdir}/ca.crt"
+  local server_crt="${tmpdir}/server.crt"
+  local server_key="${tmpdir}/server.key"
+
+  for f in "${ca_crt}" "${server_crt}" "${server_key}"; do
+    if [[ ! -f "${f}" ]]; then
+      echo "error: gen-certs.sh did not produce expected file: ${f}" >&2
+      exit 1
+    fi
+  done
+
+  echo "==> gen-certs: verifying cert chain with openssl" >&2
+  openssl verify -CAfile "${ca_crt}" "${server_crt}"
+  echo "    openssl verify OK" >&2
+
+  # Emit a minimal TLS-only nats config that references the generated certs.
+  # nats-server -t -c verifies that the referenced files exist and are parseable.
+  local tls_conf="${tmpdir}/tls.conf"
+  cat > "${tls_conf}" <<EOF
+# Minimal TLS stanza for nats-server parse-gate (gen-certs roundtrip check).
+tls {
+  cert_file: "${server_crt}"
+  key_file:  "${server_key}"
+  ca_file:   "${ca_crt}"
+  timeout:   5
+}
+EOF
+
+  echo "==> gen-certs: parse-gating TLS stanza with nats-server -t -c" >&2
+  nats-server -t -c "${tls_conf}"
+  echo "    nats-server TLS parse-gate OK" >&2
+
+  echo "==> gen-certs: all checks passed" >&2
+}
+
+# ── DISPATCH ──────────────────────────────────────────────────────────────────
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+SUBCOMMAND="$1"
+shift
+
+case "${SUBCOMMAND}" in
+  lyra-acl)
+    [[ $# -ge 1 ]] || { echo "error: lyra-acl requires <tmpdir>" >&2; usage; }
+    cmd_lyra_acl "$1"
+    ;;
+  nats-conf)
+    [[ $# -ge 1 ]] || { echo "error: nats-conf requires <tmpdir>" >&2; usage; }
+    cmd_nats_conf "$1"
+    ;;
+  gen-certs)
+    [[ $# -ge 1 ]] || { echo "error: gen-certs requires <tmpdir>" >&2; usage; }
+    cmd_gen_certs "$1"
+    ;;
+  --help|-h)
+    usage
+    ;;
+  *)
+    echo "error: unknown subcommand '${SUBCOMMAND}'" >&2
+    usage
+    ;;
+esac

--- a/tools/check_renderer_roundtrip.sh
+++ b/tools/check_renderer_roundtrip.sh
@@ -110,9 +110,11 @@ cmd_lyra_acl() {
   # in base32 (56 chars for a user key starting with 'U').
   echo "==> lyra-acl: checking nkey lengths (expected 56)" >&2
   local fail=0
+  local nkey_count=0
   while IFS= read -r line; do
     # Extract value from: nkey: "UXXXXXXXXX..."
     if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
+      nkey_count=$((nkey_count + 1))
       local nkey="${BASH_REMATCH[1]}"
       local nkey_len="${#nkey}"
       if [[ "${nkey_len}" -ne 56 ]]; then
@@ -121,6 +123,10 @@ cmd_lyra_acl() {
       fi
     fi
   done <<< "${content}"
+  if [[ "${nkey_count}" -eq 0 ]]; then
+    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
+    exit 1
+  fi
   [[ "${fail}" -eq 0 ]] || exit 1
   echo "    nkey lengths OK" >&2
 
@@ -133,10 +139,12 @@ cmd_lyra_acl() {
   # nk is guaranteed on PATH (require_nk was called at the top of cmd_lyra_acl).
   echo "==> lyra-acl: verifying seed→pubkey round-trip with nk" >&2
   local rt_fail=0
+  local rt_checked=0
   local pending_nkey=""
   while IFS= read -r line; do
     if [[ "${line}" =~ nkey:[[:space:]]*\"([^\"]+)\" ]]; then
       # Save this nkey; the identity comment on the next line will resolve it.
+      rt_checked=$((rt_checked + 1))
       pending_nkey="${BASH_REMATCH[1]}"
     elif [[ -n "${pending_nkey}" && "${line}" =~ ^[[:space:]]*#[[:space:]]+([a-z0-9_-]+)[[:space:]]*$ ]]; then
       # Identity comment immediately following a nkey line.
@@ -144,7 +152,7 @@ cmd_lyra_acl() {
       local seed_file="${seeds_dir}/${identity}.seed"
       if [[ -f "${seed_file}" ]]; then
         local computed_nkey
-        computed_nkey="$(nk -inkey "${seed_file}" -pubout 2>/dev/null | tr -d '[:space:]')"
+        computed_nkey="$(nk -inkey "${seed_file}" -pubout | tr -d '[:space:]')"
         if [[ "${computed_nkey}" != "${pending_nkey}" ]]; then
           echo "error: seed→pubkey mismatch for '${identity}'" >&2
           echo "  stored nkey:   ${pending_nkey}" >&2
@@ -158,6 +166,10 @@ cmd_lyra_acl() {
       pending_nkey=""
     fi
   done <<< "${content}"
+  if [[ "${rt_checked}" -eq 0 ]]; then
+    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
+    exit 1
+  fi
   [[ "${rt_fail}" -eq 0 ]] || exit 1
   echo "    seed→pubkey round-trip OK" >&2
 
@@ -169,9 +181,11 @@ cmd_lyra_acl() {
   # line (i.e. the full value is inline, not multi-line).
   echo "==> lyra-acl: checking for embedded newlines in quoted strings" >&2
   local nl_fail=0
+  local nl_checked=0
   while IFS= read -r line; do
     local stripped="${line#"${line%%[![:space:]]*}"}"  # ltrim
     if [[ "${stripped}" == nkey:* ]]; then
+      nl_checked=$((nl_checked + 1))
       # A well-formed nkey line starts with nkey: " and ends with "
       if ! [[ "${stripped}" =~ ^nkey:[[:space:]]*\"[^\"]+\"[[:space:]]*$ ]]; then
         echo "error: nkey line does not open and close quote on same line: ${line}" >&2
@@ -179,6 +193,10 @@ cmd_lyra_acl() {
       fi
     fi
   done <<< "${content}"
+  if [[ "${nl_checked}" -eq 0 ]]; then
+    echo "error: no nkey lines found in auth.conf — format may have drifted (expected at least 1)" >&2
+    exit 1
+  fi
   [[ "${nl_fail}" -eq 0 ]] || exit 1
   echo "    no embedded newlines in quoted strings OK" >&2
 


### PR DESCRIPTION
## Summary

- New CI workflow `renderer-roundtrip.yml` runs 3 parallel jobs that exercise each renderer through its real downstream consumer in check/dry-run mode: `lyra-acl genkeys` → `nats-server -t -c`, `nats.conf`/`nats-container.conf` → `nats-server -t -c`, `gen-certs.sh` → `openssl verify` + `nats-server -t -c`.
- New `tools/check_renderer_roundtrip.sh` dispatcher consolidates per-renderer logic with `set -euo pipefail` and `expected X, got Y` diff format; adding a new renderer = new case branch.
- New `docs/standards/renderer-roundtrip.md` documents the pattern (6 sections incl. reviewer checklist) + cross-linked from `docs/standards/testing.md`.
- `deploy/nats/gen-certs.sh`: `CERT_DIR` is now env-overridable; root check + `chown` calls run only when targeting the prod path. Helper can invoke unprivileged.
- `deploy/nats/nats.conf`: surfaced + fixed live bug — `http: 127.0.0.1` was invalid syntax (`nats-server -t -c` rejects bare address); merged into `http: "127.0.0.1:8222"` and dropped the redundant `http_port` line.

## Why

Two recent prod incidents — #1083 (Quadlet `#` in `Volume=`, 47h to detection) and #1089 (`lyra-acl genkeys` emitting 62-char nkeys vs. valid 56, M₁ down 2026-05-06) — share one pattern: a renderer produces output accepted at write-time but rejected by the consumer downstream at next restart. The roundtrip pattern already lived in 3 isolated silos (`test_parity_e2e.py`, `test_genkeys_modes.py`, `quadlet-lint.yml`) but was not generalized, documented, or applied to all known renderers.

## Scope notes

- Initial audit identified `deploy/lyra-monitor.{service,timer}` and `deploy/nats/nats.service` as candidate systemd-analyze targets, but all are retired (lyra-monitor by #1035; host `nats.service` replaced by `lyra-nats.container` per `deploy/CLAUDE.md`). `systemd-analyze verify` is documented as a canonical consumer in the standards doc, but no current static unit warrants wiring it into CI. Active systemd is generated by Quadlet at runtime — already covered by `quadlet-lint.yml` (#1086).
- Local RED-GATE verifications confirm the 3 jobs detect injected breakage: 62-char nkey → length invariant fires; mid-file stray `}` in nats.conf → `nats-server` parse error; unsigned leaf cert → `openssl verify` rejection.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1091 — ci: roundtrip-test rendered configs | OPEN |
| Frame | [1091-renderer-roundtrip-tests-frame.mdx](artifacts/frames/1091-renderer-roundtrip-tests-frame.mdx) | approved |
| Spec | [1091-renderer-roundtrip-tests-spec.mdx](artifacts/specs/1091-renderer-roundtrip-tests-spec.mdx) | approved |
| Plan | [1091-renderer-roundtrip-tests-plan.mdx](artifacts/plans/1091-renderer-roundtrip-tests-plan.mdx) | approved |
| Implementation | 10 commits on `feat/1091-renderer-roundtrip-tests` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (120/120) RED-GATEs ✅ 4/4 | Passed |

## Test Plan
- [ ] CI: the new `renderer-roundtrip` workflow runs and all 3 jobs pass on this PR
- [ ] CI: `quadlet-lint` continues to pass (unchanged behavior — Quadlet stays under its own workflow)
- [ ] Local: `bash tools/check_renderer_roundtrip.sh lyra-acl $(mktemp -d)` exits 0 with all 3 invariants confirmed (length, seed→pubkey, no embedded newlines)
- [ ] Local: `bash tools/check_renderer_roundtrip.sh nats-conf $(mktemp -d)` exits 0 (both `nats.conf` + `nats-container.conf` parse cleanly)
- [ ] Local: `bash tools/check_renderer_roundtrip.sh gen-certs $(mktemp -d)` exits 0 (certs render, openssl verifies, TLS stanza parses)
- [ ] Negative: temporarily inject a 62-char nkey into the rendered auth.conf → length check fires with `expected 56, got 62`
- [ ] Negative: temporarily inject a stray `}` mid-file in `deploy/nats/nats.conf` → `nats-server -t -c` rejects with parse error
- [ ] Docs: `docs/standards/testing.md` links to `renderer-roundtrip.md`; reviewer checklist visible in the standards doc

Closes #1091

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`