### PR TITLE
docs: clarify ports taxonomy + add CLAUDE.md for agent_cmd and obs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,10 @@ File/rename → update P immediately
 | `src/lyra/commands/CLAUDE.md` | plugin commands |
 | `src/lyra/infrastructure/CLAUDE.md` | store implementations (ADR-048) |
 | `src/lyra/integrations/CLAUDE.md` | external boundary layer (supervisor, systemctl, vault-cli, web-intel) |
+| `src/lyra/agent_cmd/CLAUDE.md` | agent CLI commands (init, edit, list, show, …) — applicative layer above core |
 | `src/lyra/llm/CLAUDE.md` | LLM drivers |
 | `src/lyra/monitoring/CLAUDE.md` | standalone health-check subsystem (`python -m lyra.monitoring`) |
+| `src/lyra/obs/CLAUDE.md` | observability scaffolding (OTel/Langfuse) — ¬wired, see #1235 |
 | `src/lyra/nats/CLAUDE.md` | in-tree NATS integration (subjects, codec, NatsLlmClient) |
 | `src/lyra/tools/CLAUDE.md` | GitHub token dispenser (gh_token submodule) |
 | `packages/roxabi-nats/CLAUDE.md` | NATS transport SDK (ADR-045) |

--- a/src/lyra/agent_cmd/CLAUDE.md
+++ b/src/lyra/agent_cmd/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — lyra.agent_cmd
+
+## Role
+
+CLI command implementations for `lyra agent ...` (init, list, show, edit, patch,
+validate, create, delete, assign, unassign, refine). Wired via `src/lyra/agents/`
+subdir and dispatched by the Typer CLI entrypoint.
+
+## Position in the architecture
+
+Applicative layer — sits above `core/` and may import from it directly. This is
+intentional and **not** an import-linter violation. `agent_cmd` is a user-facing
+CLI boundary, not a domain module; the same logic that permits `bootstrap/` to
+wire everything applies here.
+
+```
+lyra CLI entrypoint
+      ↓
+  lyra.agent_cmd     ← you are here
+      ↓
+  lyra.core (stores, auth.db)
+```
+
+## Why distinct from `agents/`
+
+| `agents/` | `agent_cmd/` |
+|---|---|
+| Agent implementations (SimpleAgent, …) | CLI commands that manage agents |
+| Runtime behaviour | CRUD via SQLite store (`~/.lyra/auth.db`) |
+
+## Invariants
+
+- `lyra agent init` **must** be called before the hub can use an agent.
+  `~/.lyra/auth.db` is the SSoT; TOML files are seed inputs only (¬override at runtime).
+- Commands in `agent_cmd/agents/` must not bypass the store — always go through
+  `AgentStore` (read/write), never directly to the TOML file.
+- `agent_cmd` must not import from `adapters/`, `commands/`, or any plugin layer.

--- a/src/lyra/core/hub/hub_protocol.py
+++ b/src/lyra/core/hub/hub_protocol.py
@@ -1,4 +1,14 @@
-"""Protocol types for the hub: ChannelAdapter, RoutingKey, Binding."""
+"""Protocol types for the hub: ChannelAdapter, RoutingKey, Binding.
+
+ChannelAdapter is an **orchestration port** intentionally co-located here.
+It defines the contract a channel (Telegram/Discord/CLI/NATS) must fulfil to
+plug into the hub. RoutingKey and Binding form the same hub sub-domain
+vocabulary — splitting them across packages would obscure that cohesion.
+
+This file does NOT belong in core/ports/ (capability ports). See the taxonomy
+rule in core/ports/__init__.py: capability ports consume external services;
+orchestration ports define roles local to a sub-domain.
+"""
 
 from __future__ import annotations
 

--- a/src/lyra/core/hub/middleware/middleware.py
+++ b/src/lyra/core/hub/middleware/middleware.py
@@ -77,6 +77,10 @@ Next = Callable[[InboundMessage, PipelineContext], Awaitable[PipelineResult]]
 class PipelineMiddleware(Protocol):
     """One stage of the inbound message pipeline.
 
+    This is an **orchestration port** intentionally co-located with the pipeline
+    it describes. It defines a role internal to the hub sub-domain and must NOT
+    migrate to core/ports/ (see taxonomy rule in core/ports/__init__.py).
+
     Return a ``PipelineResult`` to short-circuit (DROP / COMMAND_HANDLED),
     or call ``await next(msg, ctx)`` to pass to the next middleware.
     """

--- a/src/lyra/core/ports/__init__.py
+++ b/src/lyra/core/ports/__init__.py
@@ -1,4 +1,21 @@
-"""Domain ports — pure Protocol definitions with no infrastructure imports."""
+"""Capability ports — Protocols the domain uses to consume an external capability.
+
+Taxonomy rule
+-------------
+core/ports/ = **capability ports**: interfaces for external capabilities that the
+domain consumes (LLM inference, TTS, STT, audit, …). Every port here is pure
+Protocol with no infrastructure import (TYPE_CHECKING-only is permitted for types).
+
+**Orchestration ports** — Protocols that define a role local to a sub-domain
+(e.g. ChannelAdapter in core/hub/, PipelineMiddleware in core/hub/middleware/) —
+are intentionally co-located with their sub-domain and must NOT migrate here.
+
+Constraints
+-----------
+- Pure Protocol definitions only — no concrete classes, no infrastructure imports.
+- New capability interfaces belong here; new orchestration interfaces belong
+  alongside the sub-domain they serve.
+"""
 
 from lyra.core.ports.llm import LlmProvider, LlmResult
 from lyra.core.ports.stt import STTProtocol

--- a/src/lyra/obs/CLAUDE.md
+++ b/src/lyra/obs/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md — lyra.obs
+
+## Role
+
+`ObservabilityProvider` abstraction over OTel / Langfuse / NoOp backends.
+Defines the Protocol + dataclasses (`ObsTrace`, `ObsSpan`, `ObsCapabilities`)
+and ships a `NoOpObsProvider` default.
+
+## Status: scaffolding — ¬dead code
+
+0 runtime consumers exist in `src/lyra/` today. This is **intentional** — the
+module is advance infrastructure for the Langfuse integration planned in #1235.
+
+**A Claude seeing "0 imports entrants" must not propose deletion.** This is
+roadmap investment, not legacy. Any removal or structural change requires
+explicit user approval (roadmap decision).
+
+## PII contract
+
+`obs/base.py` imposes: callers **must** scrub PII, credentials, and raw user
+content before passing values via `metadata`, `input_data`, `output_data`, or
+`error`. Backend implementations must not log these fields at INFO+ without
+explicit opt-in. ∀ future consumer must respect this contract.
+
+## Layer
+
+`obs` is a shared floating module (`.importlinter`: `shared-modules-independence`
+active). It must not import from its peers: `errors`, `config`, `integrations`,
+`monitoring`, `agent_cmd`.
+
+## Known asymmetry
+
+`ObsCapabilities.async_flush: bool` is declared but no `flush()` method exists
+on the Protocol. Intentionally deferred — address when wiring Langfuse.


### PR DESCRIPTION
## Summary
- 2 CLAUDE.md créés (`agent_cmd/`, `obs/`) — modules existaient mais étaient invisibles à l'index racine
- Tableau racine `CLAUDE.md` complété (2 lignes)
- Docstrings enrichis sur `core/ports/__init__.py`, `core/hub/hub_protocol.py`, `core/hub/middleware/middleware.py` pour documenter la règle **capability ports vs orchestration ports**
- Audit reference: `artifacts/analyses/2026-05-18-codebase-audit.md` cluster 1.5 + cluster 2 (recalibré)

## Pourquoi
L'audit a interprété la dispersion de Protocols comme "ports égarés" alors que certains sont intentionnellement co-localisés avec leur sous-domaine (orchestration ports). Cette PR documente la distinction pour éviter la confusion future.

## Test plan
- [x] Pas de changement de code
- [x] ruff / pyright / lint-imports green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update — post-review design correction (2026-05-18)

The taxonomy distinction "capability port vs orchestration port" was reviewed against canonical hexagonal/Fowler sources and found to be a home-grown term that mixed two distinct concepts. Replaced with:

- **Driven port** (Cockburn, secondary) → `core/ports/` only
- **Role interface** (Fowler) → co-located with its sub-domain

Also flagged: `ChannelAdapter` is currently a header interface that fuses an inbound (driver) port with an outbound (driven) port. Tracked as future "orthodoxie pure" work in `src/lyra/core/CLAUDE.md` — non-blocking.

Sources consulted: [Cockburn](https://alistair.cockburn.us/hexagonal-architecture), [Fowler — Role Interface](https://martinfowler.com/bliki/RoleInterface.html), [Garrido Paz reference impl](https://jmgarridopaz.github.io/content/hexagonalarchitecture-ig/chapter2.html).
