### PR TITLE
fix(agents): #1225 remove STTNoiseError shadow

### DIFF
--- a/src/lyra/agents/simple_agent.py
+++ b/src/lyra/agents/simple_agent.py
@@ -23,12 +23,13 @@ from lyra.core.messaging.message import (
 from lyra.core.messaging.messages import MessageManager
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
 from lyra.core.pool import Pool
+from lyra.core.ports.stt import STTNoiseError
 from lyra.core.processors.stream_processor import StreamProcessor
 from lyra.core.runtime_config import RuntimeConfig, RuntimeConfigHolder
 from lyra.integrations.base import SessionTools
 from lyra.llm.base import LlmProvider
 
-from .simple_agent_prompts import STTError, STTNoiseError, build_llm_text
+from .simple_agent_prompts import STTError, build_llm_text
 
 _AGENTS_DIR = Path(__file__).resolve().parent
 

--- a/src/lyra/agents/simple_agent_prompts.py
+++ b/src/lyra/agents/simple_agent_prompts.py
@@ -13,6 +13,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from lyra.core.ports.stt import STTNoiseError
+
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage
     from lyra.core.ports.stt import STTProtocol, TranscriptionResult
@@ -95,14 +97,6 @@ async def _build_audio_text(
 
     escaped = html.escape(stt_result.text)
     return f"<voice_transcript>{escaped}</voice_transcript>", stt_result.text
-
-
-class STTNoiseError(Exception):
-    """Raised when STT detects only noise/silence."""
-
-    def __init__(self, text: str) -> None:
-        self.text = text
-        super().__init__(f"STT detected noise: {text[:50]}...")
 
 
 class STTError(Exception):

--- a/src/lyra/core/ports/stt.py
+++ b/src/lyra/core/ports/stt.py
@@ -32,6 +32,9 @@ class STTNoiseError(Exception):
 
     The STT adapter is the owner of noise detection — middleware and agents catch
     this to dispatch the stt_noise template without re-implementing the logic.
+
+    Any positional arg is treated as an opaque human-readable message for logs
+    only; callers must not parse it or rely on a `.text` attribute.
     """
 
 

--- a/tests/agents/test_simple_agent_prompts_imports.py
+++ b/tests/agents/test_simple_agent_prompts_imports.py
@@ -1,0 +1,20 @@
+"""Regression guard for #1225 — STTNoiseError shadow class.
+
+The local `STTNoiseError` class previously defined in
+`lyra.agents.simple_agent_prompts` shadowed the canonical class in
+`lyra.core.ports.stt`. If a future change reintroduces a local definition,
+callers that `except STTNoiseError` from the port would silently stop
+catching the exception raised by `_build_audio_text`. This test fails
+immediately on re-shadow.
+"""
+
+from __future__ import annotations
+
+
+def test_stt_noise_error_is_canonical() -> None:
+    from lyra.agents.simple_agent import STTNoiseError as AgentSTT
+    from lyra.agents.simple_agent_prompts import STTNoiseError as PromptSTT
+    from lyra.core.ports.stt import STTNoiseError as PortSTT
+
+    assert PromptSTT is PortSTT
+    assert AgentSTT is PortSTT

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -5,7 +5,7 @@ src/lyra/bootstrap/factory/wiring_helpers.py  # 410 lines — DEBT:file-exemptio
 src/lyra/bootstrap/bootstrap_stores.py  # 307 lines — DEBT:file-exemptions — #957 idx_sql DDL validation adds allowlist guard before sqlite_master replay
 src/lyra/core/cli/cli_pool.py  # 341 lines — DEBT:file-exemptions — #1150 agent identity kwargs added to send() signature
 src/lyra/core/cli/cli_pool_worker.py  # 330 lines — DEBT:file-exemptions — #1150 _identity_env helper (layered gate + newline sanitisation per /code-review #1243) extracted from _spawn()
-src/lyra/agents/simple_agent.py  # 316 lines — DEBT:file-exemptions — #1008 cli_nats_driver wiring for NATS-mode resume + link_lyra_session
+src/lyra/agents/simple_agent.py  # 317 lines — DEBT:file-exemptions — #1008 cli_nats_driver wiring for NATS-mode resume + link_lyra_session; #1225 +1 line (STTNoiseError imported directly from canonical port)
 src/lyra/bootstrap/standalone/adapter_standalone.py  # 301 lines — DEBT:file-exemptions — #1016 WorkerError startup version log
 src/lyra/core/processors/stream_processor.py  # 630 lines — DEBT:file-exemptions — #1016 WorkerError extractor + #1098 Run lifecycle + #1101 Reasoning emission (cleanup in Slice 5 / #1102)
 src/lyra/adapters/shared/_shared_streaming_emitter.py  # 465 lines — DEBT:file-exemptions — #1098 Run lifecycle + #1101 PlatformCallbacks.edit_reasoning + dispatch + #1214 T5b _ensure_trace_obj helper (cleanup deferred)


### PR DESCRIPTION
## Summary
- Remove the local `STTNoiseError` class in `src/lyra/agents/simple_agent_prompts.py` and import the canonical one from `lyra.core.ports.stt`.
- Callers that `except STTNoiseError` from the port now catch the exception raised by `_build_audio_text` — previously the two were distinct class objects with the same name.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1225: fix(agents): simple_agent_prompts.py shadows STTNoiseError | OPEN |
| Implementation | 1 commit on `feat/1225-stt-noise-error-shadow` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4093 passed) | Passed |

## Test Plan
- [x] `from lyra.core.ports.stt import STTNoiseError as A; from lyra.agents.simple_agent_prompts import STTNoiseError as B; assert A is B`
- [x] Only one `class STTNoiseError` definition remains (in `lyra/core/ports/stt.py`)
- [x] `pytest tests/agents tests/core/hub/test_message_pipeline_stt.py` — 69 passed
- [x] Full suite — 4093 passed

Closes #1225

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`