### PR TITLE
chore(nats): #1247 apply deferred follow-ups from #1242 review

### DIFF
--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -96,8 +96,10 @@ class NatsImageClient(NatsWorkerClientBase):
         super().__init__(nc, timeout=timeout)
 
     async def stop(self) -> None:
-        await super().stop()
-        log.debug("NatsImageClient stopped")
+        try:
+            await super().stop()
+        finally:
+            log.debug("NatsImageClient stopped")
 
     def _parse_reply(self, raw: bytes) -> ImageResponse:
         """Validate a NATS reply against ImageResponse; translate a ValidationError

--- a/src/lyra/nats/nats_image_client.py
+++ b/src/lyra/nats/nats_image_client.py
@@ -95,6 +95,10 @@ class NatsImageClient(NatsWorkerClientBase):
     def __init__(self, nc: NATS, *, timeout: float = 120.0) -> None:
         super().__init__(nc, timeout=timeout)
 
+    async def stop(self) -> None:
+        await super().stop()
+        log.debug("NatsImageClient stopped")
+
     def _parse_reply(self, raw: bytes) -> ImageResponse:
         """Validate a NATS reply against ImageResponse; translate a ValidationError
         into ImageUnavailableError + record a circuit-breaker failure."""

--- a/tests/nats/test_worker_client_base.py
+++ b/tests/nats/test_worker_client_base.py
@@ -185,8 +185,10 @@ class TestNatsWorkerClientBase:
     ) -> None:
         """_any_worker_alive() and any_alive() both report False for expired workers.
 
-        WorkerRegistry uses DEFAULT_HB_TTL=15s; NatsDriverBase uses HB_TTL=30s.
-        We manipulate both timestamps directly so the test is deterministic and fast.
+        WorkerRegistry uses DEFAULT_HB_TTL=15s; NatsWorkerClientBase overrides
+        HB_TTL=15.0 to align with the registry (the parent NatsDriverBase
+        default is 30s). We manipulate both timestamps directly so the test
+        is deterministic and fast.
         """
         msg = _make_msg(_VALID_HB)
         await client._on_heartbeat(msg)

--- a/tests/nats/test_worker_client_base.py
+++ b/tests/nats/test_worker_client_base.py
@@ -134,11 +134,23 @@ class TestNatsWorkerClientBase:
         assert client._worker_freshness == {}
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(b"not-json{", id="ascii-garbage-JSONDecodeError"),
+            pytest.param(b"\xff\xfe\x00\x01", id="invalid-utf8-ValueError"),
+        ],
+    )
     async def test_malformed_json_silently_dropped(
-        self, client: FakeWorkerClient
+        self, client: FakeWorkerClient, payload: bytes
     ) -> None:
-        """Malformed JSON bytes produce no exception, registry/freshness stay empty."""
-        msg = _make_msg(b"not-json{")
+        """Malformed payloads produce no exception, registry/freshness stay empty.
+
+        Covers both branches of ``(json.JSONDecodeError, ValueError)``: ASCII
+        garbage (JSONDecodeError) and invalid UTF-8 sequences (ValueError from
+        the codec layer before json.loads sees it).
+        """
+        msg = _make_msg(payload)
 
         # Act — must not raise
         await client._on_heartbeat(msg)
@@ -179,11 +191,11 @@ class TestNatsWorkerClientBase:
         msg = _make_msg(_VALID_HB)
         await client._on_heartbeat(msg)
 
-        # Simulate expiry: push timestamps far into the past
+        # Simulate expiry: push parent freshness timestamp far into the past
+        # and use the registry's public mark_stale API (sets last_heartbeat=0.0).
         stale_ts = time.monotonic() - 1000.0
         client._worker_freshness["worker-1"] = stale_ts
-        if "worker-1" in client._registry._workers:
-            client._registry._workers["worker-1"].last_heartbeat = stale_ts
+        client._registry.mark_stale("worker-1")
 
         assert client._any_worker_alive() is False
         assert client.any_alive() is False
@@ -193,12 +205,21 @@ class TestNatsWorkerClientBase:
     async def test_any_alive_delegates_to_registry(
         self, client: FakeWorkerClient
     ) -> None:
-        """any_alive() is a pure delegation to WorkerRegistry.any_alive()."""
+        """any_alive() is a pure delegation to WorkerRegistry.any_alive().
+
+        A constant ``return True`` would still pass the True branch, so after
+        seeding we mark the worker stale via the registry's public API and
+        assert any_alive() flips back to False — proving the delegation is
+        live, not a tautology.
+        """
         # Initially both False
         assert client.any_alive() is False
         # Seed registry directly (bypass _on_heartbeat)
         client._registry.record_heartbeat(_VALID_HB)
         assert client.any_alive() is True
+        # Anti-tautology: flip registry state and verify delegation tracks it
+        client._registry.mark_stale("worker-1")
+        assert client.any_alive() is False
 
     @pytest.mark.asyncio
     async def test_defense_in_depth_registry_rejects_wildcard_id(self) -> None:

--- a/tools/folder_exemptions.txt
+++ b/tools/folder_exemptions.txt
@@ -10,4 +10,4 @@ src/lyra/core           # 15 files — DEBT:folder-exemptions — #858 config da
 src/lyra/infrastructure/stores  # 15 files — DEBT:folder-exemptions — #935 ADR-048 store migration (4 files moved from core/stores)
 src/lyra/core/cli           # 14 files — DEBT:folder-exemptions — #957 cli_pool_entry.py extracted to break _ProcessEntry circular import
 src/lyra/core/messaging     # 13 files — DEBT:folder-exemptions — #1016 WorkerError: error_extractor.py + metrics.py added; #1031 tool_recap_format.py + tool_display_config.py added
-src/lyra/nats  # 15 files — #1235 — dedup of heartbeat lifecycle adds _worker_client_base.py; NATS subsystem owns transport + per-protocol client + per-protocol helper modules + shared worker-client base; see ADR-049
+src/lyra/nats  # 15 files — DEBT:folder-exemptions — #1235 — dedup of heartbeat lifecycle adds _worker_client_base.py; NATS subsystem owns transport + per-protocol client + per-protocol helper modules + shared worker-client base; see ADR-049


### PR DESCRIPTION
## Summary
- Apply items 2–6 from #1247: harden 2 tests, add the missing UTF-8 branch parametrize, swap a double-private reach-around for the registry's public `mark_stale` API, restore the dropped `NatsImageClient stopped` debug log, and add the `DEBT:folder-exemptions` slug to the `src/lyra/nats` entry so `audit_quality_debt.py` picks it up.
- Item 1 (rename `NatsDriverBase._stream_gen` → `_dict_stream_gen`) is deferred — the issue acceptance criteria explicitly allow landing it in a separate `roxabi-nats` semver bump PR; it touches the package's `pyproject.toml` version + tests across both packages and doesn't sit cleanly in this chore PR.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1247: chore(nats): follow-up cleanup deferred from #1242 review | OPEN |
| Implementation | 1 commit on `chore/1247-nats-followup-1242` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (13/13 worker_client_base, 335/335 nats/) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats/test_worker_client_base.py -v` — 13 tests pass (parametrize splits malformed-JSON into 2 IDs)
- [ ] `uv run pytest tests/ -k image -v` — 15 tests pass; `NatsImageClient.stop()` emits debug log
- [ ] `bash tools/check_folder_size.sh` — clean exit
- [ ] `uv run python tools/audit_quality_debt.py --out /tmp/qd.json` — `src/lyra/nats` row tagged with `folder-exemptions` slug

Closes #1247

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`