### PR TITLE
fix(cli-streaming-parser): sanitize str(exc) in WorkerError.message

### DIFF
--- a/src/lyra/core/cli/cli_streaming_parser.py
+++ b/src/lyra/core/cli/cli_streaming_parser.py
@@ -124,10 +124,16 @@ class CliStreamingParser:
             # line; debug lines use prefixes like `[DEBUG]`, `INFO:`, blank, etc.
             stripped = line.lstrip()
             if stripped.startswith("{"):
+                # Sanitize bus-bound message (#1219, sibling of #1212/#1215).
+                # JSONDecodeError.__str__ on current CPython is well-behaved,
+                # but defense-in-depth keeps `.doc` content (the raw malformed
+                # line) off the bus across Python versions and custom decoder
+                # subclasses. Full diagnostic preserved in log.warning below.
+                log.warning("CLI JSON parse error: %r", exc)
                 meta = KNOWN_CODES["cli.parse"]
                 worker_error = WorkerError(
                     code="cli.parse",
-                    message=f"CLI emitted malformed JSON: {exc}",
+                    message=f"CLI emitted malformed JSON: {type(exc).__name__}",
                     retryable=meta.default_retryable,
                 )
                 emit_populated_total(domain="cli")
@@ -137,9 +143,6 @@ class CliStreamingParser:
                         is_error=True,
                         duration_ms=0,
                         cost_usd=None,
-                        # Reuse the WorkerError.message — already credential-
-                        # scrubbed and bounded. Avoids a parallel `str(exc)`
-                        # path that would bypass sanitisation.
                         error_text=worker_error.message,
                         session_id=self.session_id,
                         worker_error=worker_error,

--- a/tests/core/test_cli_streaming_parse.py
+++ b/tests/core/test_cli_streaming_parse.py
@@ -360,6 +360,14 @@ class TestStreamingIteratorNonJson:
         """#1219 (sibling of #1212/#1215): bus-bound message keeps only the
         exception type name; the raw malformed line (`JSONDecodeError.doc`)
         must NOT surface in `WorkerError.message` or `error_text`.
+
+        Falsification: this test must fail if line 134 reverts to
+        ``f"...: {exc}"``. On CPython 3.12, ``str(JSONDecodeError)`` returns
+        a position string like ``"Unterminated string starting at: line 1
+        column 34 (char 33)"`` — it does NOT embed ``.doc``. A weak negative
+        assertion like ``sentinel not in msg`` passes both before and after
+        the fix (tautology). We therefore assert the exact sanitized form,
+        which differs from the reverted form character-for-character.
         """
         # Arrange — sensitive sentinel embedded in the malformed JSON payload.
         # Picked to fail json.loads (unterminated string) while still looking
@@ -378,17 +386,25 @@ class TestStreamingIteratorNonJson:
         assert result.worker_error is not None
         assert result.worker_error.code == "cli.parse"
 
-        # Assert — sentinel does NOT appear on the bus-bound surfaces
+        # Assert — exact sanitized form. Strong falsifier: reverting line 134
+        # to ``f"...: {exc}"`` produces ``"CLI emitted malformed JSON:
+        # Unterminated string starting at: ..."`` which fails this equality.
         msg = result.worker_error.message
-        assert sentinel not in msg, (
-            f"sentinel leaked into worker_error.message: {msg!r}"
+        assert msg == "CLI emitted malformed JSON: JSONDecodeError", (
+            f"unexpected worker_error.message: {msg!r}"
         )
-        assert result.error_text is not None
-        assert sentinel not in result.error_text, (
+
+        # Assert — error_text mirrors worker_error.message verbatim. Guards
+        # against a future regression where error_text is sourced from a
+        # parallel path (e.g. raw ``str(exc)``) instead of the sanitized
+        # message. The raw malformed line (``exc.doc``) must never appear.
+        assert result.error_text == msg
+        assert malformed not in (result.error_text or ""), (
+            f"raw malformed line leaked into error_text: {result.error_text!r}"
+        )
+        assert sentinel not in (result.error_text or ""), (
             f"sentinel leaked into error_text: {result.error_text!r}"
         )
-        # Positive: type name still surfaces for diagnostic value
-        assert "JSONDecodeError" in result.worker_error.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_cli_streaming_parse.py
+++ b/tests/core/test_cli_streaming_parse.py
@@ -356,6 +356,40 @@ class TestStreamingIteratorNonJson:
         # error_text reuses the (scrubbed) WorkerError.message — never raw str(exc)
         assert result.error_text == result.worker_error.message
 
+    def test_malformed_json_does_not_leak_payload_into_worker_error(self) -> None:
+        """#1219 (sibling of #1212/#1215): bus-bound message keeps only the
+        exception type name; the raw malformed line (`JSONDecodeError.doc`)
+        must NOT surface in `WorkerError.message` or `error_text`.
+        """
+        # Arrange — sensitive sentinel embedded in the malformed JSON payload.
+        # Picked to fail json.loads (unterminated string) while still looking
+        # like protocol content (`{`-shaped → triggers the cli.parse branch).
+        sentinel = "SENTINEL-LEAK-42"
+        malformed = f'{{"type": "result", "session_id": "{sentinel}'
+        parser = CliStreamingParser(pool_id=DEFAULT_POOL_ID)
+
+        # Act
+        events = _collect_all(parser, malformed)
+
+        # Assert — exactly one terminal ResultLlmEvent with cli.parse envelope
+        assert len(events) == 1
+        result = events[0]
+        assert isinstance(result, ResultLlmEvent)
+        assert result.worker_error is not None
+        assert result.worker_error.code == "cli.parse"
+
+        # Assert — sentinel does NOT appear on the bus-bound surfaces
+        msg = result.worker_error.message
+        assert sentinel not in msg, (
+            f"sentinel leaked into worker_error.message: {msg!r}"
+        )
+        assert result.error_text is not None
+        assert sentinel not in result.error_text, (
+            f"sentinel leaked into error_text: {result.error_text!r}"
+        )
+        # Positive: type name still surfaces for diagnostic value
+        assert "JSONDecodeError" in result.worker_error.message
+
 
 # ---------------------------------------------------------------------------
 # TestStreamingIteratorAssistant

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -10,7 +10,7 @@ src/lyra/bootstrap/standalone/adapter_standalone.py  # 301 lines — DEBT:file-e
 src/lyra/core/processors/stream_processor.py  # 630 lines — DEBT:file-exemptions — #1016 WorkerError extractor + #1098 Run lifecycle + #1101 Reasoning emission (cleanup in Slice 5 / #1102)
 src/lyra/adapters/shared/_shared_streaming_emitter.py  # 465 lines — DEBT:file-exemptions — #1098 Run lifecycle + #1101 PlatformCallbacks.edit_reasoning + dispatch + #1214 T5b _ensure_trace_obj helper (cleanup deferred)
 src/lyra/adapters/clipool/clipool_worker.py  # 387 lines — DEBT:file-exemptions — #1016 WorkerError population + exception classifier; #1215 +9 lines (sanitization log.warning + comments at 4 sites); #1150 +5 lines (agent identity kwargs forwarded to pool.send)
-src/lyra/core/cli/cli_streaming_parser.py  # 336 lines — DEBT:file-exemptions — #1100 ToolCall streamed events + #1101 thinking-block recognition (cleanup in Slice 5 / #1102)
+src/lyra/core/cli/cli_streaming_parser.py  # 339 lines — DEBT:file-exemptions — #1100 ToolCall streamed events + #1101 thinking-block recognition + #1219 bus-message sanitization (log.warning + comment) (cleanup in Slice 5 / #1102)
 src/lyra/core/messaging/render_events.py  # 359 lines — DEBT:file-exemptions — #1099 Text v2 triplet + #1101 Reasoning v2 triplet (refactor deferred to Slice 5 / #1102)
 src/lyra/adapters/telegram/telegram_outbound.py  # 376 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate (cleanup in Slice 5 / #1102: extract shared reasoning helper)
 src/lyra/adapters/discord/discord_outbound.py  # 368 lines — DEBT:file-exemptions — #1101 _render_reasoning closure + show_intermediate gate; #1214 T9 _edit_tool_recap embed callback (cleanup deferred)


### PR DESCRIPTION
## Summary

- Third structurally identical bus-bound `str(exc)` leak (sibling of #1212 / #1215), this one in `src/lyra/core/cli/cli_streaming_parser.py` at the JSON decode path that emits the terminal `cli.parse` envelope.
- Switch `WorkerError.message` to `type(exc).__name__` form; preserve the full `JSONDecodeError` (incl. `.doc`) via `log.warning("CLI JSON parse error: %r", exc)` only — never on the bus.
- Drop the inline `# already credential-scrubbed` comment that claimed an invariant without evidence; sanitisation is now uniform across the three sites.

Defense-in-depth: current CPython `JSONDecodeError.__str__` is well-behaved (line/col only, not `.doc`), but a future Python version or a custom `JSONDecoder` subclass could change that, and `.doc` remains reachable via `exc.args` in edge cases.

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | #1219: sanitize `str(exc)` in WorkerError.message (sibling of #1212/#1215) | Open |
| Implementation | 1 commit on `feat/1219-sanitize-cli-streaming-parser-workererror` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new regression test, 52/52 parser tests pass) | Passed |

## Test Plan

- [x] `tests/core/test_cli_streaming_parse.py::TestStreamingIteratorNonJson::test_malformed_json_does_not_leak_payload_into_worker_error` — injects sentinel inside an unterminated JSON string, asserts the sentinel surfaces in neither `worker_error.message` nor `error_text`, and that `JSONDecodeError` type name still appears.
- [x] Existing `test_brace_shaped_malformed_json_emits_cli_parse_envelope` still passes — terminal `cli.parse` envelope shape preserved.
- [x] File-length exemption bumped 336 → 339 (log.warning + comment additions); rationale updated in `tools/file_exemptions.txt`.

Closes #1219

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`