### PR TITLE
fix(cli-nats-driver): sanitize str(exc) in LlmResult.error (#1253)

### DIFF
--- a/src/lyra/llm/drivers/cli_nats.py
+++ b/src/lyra/llm/drivers/cli_nats.py
@@ -153,12 +153,14 @@ class CliNatsDriver(NatsDriverBase):
             reply = await self._request(self.SUBJECT_CMD, payload)
         except nats.errors.Error as exc:
             log.warning(
-                "cli_nats: complete() transport error [pool:%s]: %s: %s",
+                "cli_nats: complete() transport error [pool:%s]: %r",
                 pool_id,
-                type(exc).__name__,
                 exc,
             )
-            return LlmResult(error=f"NATS transport error: {exc}", retryable=True)
+            return LlmResult(
+                error=f"NATS transport error: {type(exc).__name__}",
+                retryable=True,
+            )
 
         error = reply.get("error", "")
         if error:

--- a/tests/llm/drivers/test_cli_nats_driver.py
+++ b/tests/llm/drivers/test_cli_nats_driver.py
@@ -359,8 +359,9 @@ class TestComplete:
         assert _SENSITIVE_TOKEN not in result.error, (
             f"sensitive token leaked into LlmResult.error: {result.error!r}"
         )
-        # Assert — exact bus-bound form: only the exception class name
-        assert result.error == f"NATS transport error: {nats.errors.Error.__name__}"
+        # Assert — exact bus-bound form: only the exception class name, never str(exc).
+        # Mock raises base nats.errors.Error directly, so type(exc).__name__ == "Error".
+        assert result.error == "NATS transport error: Error"
         # Baseline guards
         assert result.ok is False
         assert result.retryable is True

--- a/tests/llm/drivers/test_cli_nats_driver.py
+++ b/tests/llm/drivers/test_cli_nats_driver.py
@@ -326,6 +326,45 @@ class TestComplete:
         assert result.ok is False
         assert result.error != ""
 
+    @pytest.mark.asyncio
+    async def test_complete_transport_error_does_not_leak_exc_str_to_bus(
+        self,
+    ) -> None:
+        """nats.errors.Error.__str__ must NOT appear in LlmResult.error (#1253).
+
+        nats.errors.Error.__str__ can embed server addresses / connection
+        metadata. LlmResult.error is bus-bound and may reach user-visible
+        renders. Only type(exc).__name__ is permitted on the bus.
+
+        Falsification: if the fix is reverted to f"NATS transport error: {exc}"
+        the sentinel host token present in str(exc) leaks into result.error and
+        this test fails.
+        """
+        # Arrange — sentinel embeds a host token that must NOT surface on bus
+        _SENSITIVE_TOKEN = "goose-logarithm.ts.net:4222"
+        driver = _make_driver()
+
+        async def _mock_request(
+            subject: str, payload_dict: dict, *, timeout: float | None = None
+        ) -> dict:
+            raise nats.errors.Error(
+                f"connection refused: {_SENSITIVE_TOKEN}"
+            )
+
+        # Act
+        with patch.object(driver, "_request", new=_mock_request):
+            result = await driver.complete("pool-1", "hello", _make_model_cfg(), "sys")
+
+        # Assert — sentinel did not leak onto the bus
+        assert _SENSITIVE_TOKEN not in result.error, (
+            f"sensitive token leaked into LlmResult.error: {result.error!r}"
+        )
+        # Assert — exact bus-bound form: only the exception class name
+        assert result.error == f"NATS transport error: {nats.errors.Error.__name__}"
+        # Baseline guards
+        assert result.ok is False
+        assert result.retryable is True
+
 
 # ---------------------------------------------------------------------------
 # reset()


### PR DESCRIPTION
## Summary
- Sanitize `str(exc)` leak in `CliNatsDriver.complete()` error path (4th instance of the same pattern). `nats.errors.Error.__str__` can embed server addresses / connection metadata; `LlmResult.error` is bus-bound and may reach user-visible renders.
- Replace `f"NATS transport error: {exc}"` with `f"NATS transport error: {type(exc).__name__}"`. Switch log format from `%s: %s` to `%r` for parity with siblings (log-only, never on bus).
- Sibling fixes: #1212 (`lyra.nats.nats_llm_client`), #1215 (`clipool_worker`), #1219 (`cli_streaming_parser`).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1253: fix(cli-nats-driver): sanitize str(exc) in LlmResult.error | Open |
| Implementation | 1 commit on `worktree-1253-cli-nats-driver-sanitize-error` | Complete |
| Verification | Tests ✅ (1 new regression test, falsification-checked) | Passed |

## Test Plan
- [x] `tests/llm/drivers/test_cli_nats_driver.py::TestComplete::test_complete_transport_error_does_not_leak_exc_str_to_bus` — passes
- [x] Falsification: test fails when production code reverted to `f"NATS transport error: {exc}"` (verified locally — sentinel `goose-logarithm.ts.net:4222` leaks)
- [x] Existing suite: 43/43 passing

Closes #1253

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`