### PR TITLE
refactor(roxabi-nats)!: rename _stream_gen → _dict_stream_gen (#1254)

### DIFF
--- a/docs/ops/nats-acl-postmortem-remaining.md
+++ b/docs/ops/nats-acl-postmortem-remaining.md
@@ -24,7 +24,7 @@ Source: [nats-acl-inbox-case-postmortem.md](nats-acl-inbox-case-postmortem.md)
 | Drop `allow_responses: true` from all identities | `5b3b6c4a` — hub/adapters explicit `false`; others omit field (NATS default = false) |
 | Kill hardcoded identity list in gen-nkeys.sh — IDENTITIES[] driven from JSON SSoT | `load_matrix()` populates from acl-matrix.json |
 | Alert on `permissions violation` in NATS logs | `src/lyra/monitoring/checks_log.py` — `check_nats_log_errors` |
-| Alert on sustained `_stream_gen timeout` in hub logs | `src/lyra/monitoring/checks_log.py:57` — `check_hub_stream_gen_timeout` |
+| Alert on sustained `_dict_stream_gen timeout` in hub logs | `src/lyra/monitoring/checks_log.py:57` — `check_hub_dict_stream_gen_timeout` |
 | NATS HTTP monitoring on 127.0.0.1 | `bcab1197` |
 | Retire `tts-adapter`/`sst-adapter` from acl-matrix.json | `5b3b6c4a` |
 | Fix gen-nkeys.sh missing `clipool-worker` in key-gen block | `5b3b6c4a` |

--- a/packages/roxabi-nats/pyproject.toml
+++ b/packages/roxabi-nats/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-nats"
-version = "0.3.0"
+version = "0.4.0"
 description = "NATS transport SDK for Lyra and Roxabi plugin ecosystem"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/roxabi-nats/src/roxabi_nats/driver_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/driver_base.py
@@ -2,7 +2,7 @@
 
 Provides:
 - Heartbeat subscription and worker-freshness tracking
-- Ephemeral-inbox streaming (_stream_gen)
+- Ephemeral-inbox streaming (_dict_stream_gen)
 - Simple request-reply (_request)
 
 Subclass this to build hub-side drivers (e.g. CliNatsDriver).
@@ -36,7 +36,7 @@ class NatsDriverBase:
     # Subclasses set this to the heartbeat subject they subscribe to.
     # NatsDriverBase uses it in start()/stop() only if set.
     HB_SUBJECT: str = ""
-    # Absolute upper bound on a single _stream_gen call. Backstop against a
+    # Absolute upper bound on a single _dict_stream_gen call. Backstop against a
     # hung worker that keeps emitting keepalive chunks forever; the per-chunk
     # `timeout` is a liveness check, not a duration cap.
     DEFAULT_MAX_TOTAL_DURATION: float = 1800.0
@@ -133,14 +133,16 @@ class NatsDriverBase:
                     )
                 if elapsed_idle >= effective_timeout:
                     # Last-resort: 120s backstop (no liveness signal)
-                    log.warning("nats_driver_base: _stream_gen timeout on %s", subject)
+                    log.warning(
+                        "nats_driver_base: _dict_stream_gen timeout on %s", subject
+                    )
                     return None
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return None
                 poll = min(self.LIVENESS_POLL_INTERVAL, remaining)
 
-    async def _stream_gen(
+    async def _dict_stream_gen(
         self,
         subject: str,
         payload_dict: dict,
@@ -171,7 +173,7 @@ class NatsDriverBase:
                 queue.put_nowait(msg)
             except asyncio.QueueFull:
                 log.warning(
-                    "nats_driver_base: _stream_gen inbox queue full,"
+                    "nats_driver_base: _dict_stream_gen inbox queue full,"
                     " dropping chunk on %s",
                     subject,
                 )
@@ -185,7 +187,7 @@ class NatsDriverBase:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     log.warning(
-                        "nats_driver_base: _stream_gen absolute deadline (%.0fs) "
+                        "nats_driver_base: _dict_stream_gen absolute deadline (%.0fs) "
                         "exceeded on %s",
                         max_total,
                         subject,

--- a/packages/roxabi-nats/tests/test_driver_base.py
+++ b/packages/roxabi-nats/tests/test_driver_base.py
@@ -4,7 +4,7 @@ NatsDriverBase does not exist yet — all tests are expected to fail with
 ImportError until the implementation is in place (T2).
 
 Covers:
-- _stream_gen: yields chunks, stops on done=True, terminates on timeout
+- _dict_stream_gen: yields chunks, stops on done=True, terminates on timeout
 - is_alive: threshold behaviour (within/outside HB_TTL)
 - _on_heartbeat: updates _worker_freshness from JSON msg
 - _any_worker_alive: prunes stale entries older than HB_TTL*2
@@ -60,15 +60,15 @@ def _make_msg(data: dict) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# T_stream — _stream_gen
+# T_stream — _dict_stream_gen
 # ---------------------------------------------------------------------------
 
 
 class TestStreamGen:
-    """_stream_gen yields raw dict chunks until done=True."""
+    """_dict_stream_gen yields raw dict chunks until done=True."""
 
     @pytest.mark.asyncio
-    async def test_stream_gen_yields_chunks(self) -> None:
+    async def test_dict_stream_gen_yields_chunks(self) -> None:
         """Chunks without done=True are yielded in order."""
         # Arrange
         nc = _make_mock_nc()
@@ -106,7 +106,7 @@ class TestStreamGen:
 
         async def _run() -> None:
             nonlocal collected
-            gen = driver._stream_gen("lyra.clipool.exec", {"cmd": "echo hi"})
+            gen = driver._dict_stream_gen("lyra.clipool.exec", {"cmd": "echo hi"})
 
             # Consume the generator in a task; inject chunks from this coroutine.
             async def _consume() -> None:
@@ -133,7 +133,7 @@ class TestStreamGen:
         assert " world" in texts
 
     @pytest.mark.asyncio
-    async def test_stream_gen_stops_on_done(self) -> None:
+    async def test_dict_stream_gen_stops_on_done(self) -> None:
         """Generator terminates when a chunk with done=True arrives."""
         # Arrange
         nc = _make_mock_nc()
@@ -153,7 +153,7 @@ class TestStreamGen:
         collected: list[dict] = []
 
         async def _run() -> None:
-            gen = driver._stream_gen("lyra.clipool.exec", {"cmd": "ls"})
+            gen = driver._dict_stream_gen("lyra.clipool.exec", {"cmd": "ls"})
 
             async def _consume() -> None:
                 async for chunk in gen:
@@ -169,15 +169,15 @@ class TestStreamGen:
 
         await _run()
 
-        # Assert — _stream_gen yields the done=True chunk (yield before done check).
-        # The generator must have exited after yielding it.
+        # Assert — _dict_stream_gen yields the done=True chunk
+        # (yield before done check). The generator must have exited after yielding it.
         assert len(collected) == 1
         assert collected[0].get("done") is True
         # Find the sub_mock from the captured callback's closure to verify unsubscribe.
-        # (unsubscribe is called in the finally block of _stream_gen)
+        # (unsubscribe is called in the finally block of _dict_stream_gen)
 
     @pytest.mark.asyncio
-    async def test_stream_gen_timeout(self) -> None:
+    async def test_dict_stream_gen_timeout(self) -> None:
         """Generator terminates (yields nothing extra) when queue.get times out."""
         # Arrange
         nc = _make_mock_nc()
@@ -194,7 +194,9 @@ class TestStreamGen:
 
         # Act — no messages pushed; queue.get will time out after timeout seconds.
         async def _run() -> None:
-            async for chunk in driver._stream_gen("lyra.clipool.exec", {"cmd": "ls"}):
+            async for chunk in driver._dict_stream_gen(
+                "lyra.clipool.exec", {"cmd": "ls"}
+            ):
                 collected.append(chunk)
 
         await _run()
@@ -206,7 +208,7 @@ class TestStreamGen:
         sub_mock.unsubscribe.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_stream_gen_absolute_deadline(self) -> None:
+    async def test_dict_stream_gen_absolute_deadline(self) -> None:
         """Stream stops at max_total_duration even if keepalive chunks keep arriving.
 
         Backstop against a stuck worker that emits tool_use keepalives forever
@@ -235,7 +237,7 @@ class TestStreamGen:
         keepalive_pump_done = asyncio.Event()
 
         async def _run() -> None:
-            gen = driver._stream_gen("lyra.clipool.exec", {"cmd": "ls"})
+            gen = driver._dict_stream_gen("lyra.clipool.exec", {"cmd": "ls"})
 
             async def _consume() -> None:
                 async for chunk in gen:
@@ -722,12 +724,12 @@ class TestConstruction:
 
 
 # ---------------------------------------------------------------------------
-# T_stream_gen_liveness — health-check-driven stream abort
+# T_dict_stream_gen_liveness — health-check-driven stream abort
 # ---------------------------------------------------------------------------
 
 
 class TestStreamGenLiveness:
-    """_stream_gen raises WorkerUnavailableError when worker heartbeats stop."""
+    """_dict_stream_gen raises WorkerUnavailableError when worker heartbeats stop."""
 
     @pytest.mark.asyncio
     async def test_worker_unavailable_raises(self) -> None:
@@ -744,7 +746,7 @@ class TestStreamGenLiveness:
         from roxabi_nats.driver_base import WorkerUnavailableError
 
         with pytest.raises(WorkerUnavailableError):
-            async for _ in driver._stream_gen("lyra.clipool.exec", {"cmd": "ls"}):
+            async for _ in driver._dict_stream_gen("lyra.clipool.exec", {"cmd": "ls"}):
                 pass
 
     @pytest.mark.asyncio
@@ -762,7 +764,7 @@ class TestStreamGenLiveness:
         nc.subscribe = AsyncMock(return_value=sub_mock)
 
         collected: list[dict] = []
-        async for chunk in driver._stream_gen("lyra.test.exec", {"cmd": "ls"}):
+        async for chunk in driver._dict_stream_gen("lyra.test.exec", {"cmd": "ls"}):
             collected.append(chunk)
 
         # Falls back to timeout exit — no error raised

--- a/src/lyra/llm/drivers/cli_nats.py
+++ b/src/lyra/llm/drivers/cli_nats.py
@@ -99,7 +99,7 @@ class CliNatsDriver(NatsDriverBase):
         payload = self._build_cmd_payload(
             pool_id, text, model_cfg, system_prompt, stream=True
         )
-        async for chunk in self._stream_gen(self.SUBJECT_CMD, payload):
+        async for chunk in self._dict_stream_gen(self.SUBJECT_CMD, payload):
             event_type = chunk.get("event_type", "text")
             if event_type == "text":
                 t = chunk.get("text") or ""

--- a/src/lyra/monitoring/checks.py
+++ b/src/lyra/monitoring/checks.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 import httpx
 
-from .checks_log import check_hub_stream_gen_timeout, check_nats_log_errors
+from .checks_log import check_hub_dict_stream_gen_timeout, check_nats_log_errors
 from .checks_varz import check_disk, check_nats_varz
 from .config import MonitoringConfig
 from .models import CheckResult, HealthReport
@@ -252,10 +252,10 @@ async def run_checks(config: MonitoringConfig) -> HealthReport:
         )
     )
 
-    # Check 8: Hub stream_gen timeouts (blocking → offload to thread)
+    # Check 8: Hub _dict_stream_gen timeouts (blocking → offload to thread)
     checks.append(
         await asyncio.to_thread(
-            check_hub_stream_gen_timeout,
+            check_hub_dict_stream_gen_timeout,
             config.hub_container_name,
             config.stream_gen_timeout_minutes,
             config.stream_gen_timeout_threshold,

--- a/src/lyra/monitoring/checks_log.py
+++ b/src/lyra/monitoring/checks_log.py
@@ -54,13 +54,13 @@ def check_nats_log_errors(container_name: str, max_age_minutes: int) -> CheckRes
         )
 
 
-def check_hub_stream_gen_timeout(
+def check_hub_dict_stream_gen_timeout(
     container_name: str, max_age_minutes: int, threshold: int
 ) -> CheckResult:
-    """Check hub container logs for _stream_gen timeout occurrences.
+    """Check hub container logs for _dict_stream_gen timeout occurrences.
 
     Runs `podman logs --since {max_age_minutes}m {container_name}` and counts
-    lines containing "_stream_gen timeout" (case-insensitive). Fails when
+    lines containing "_dict_stream_gen timeout" (case-insensitive). Fails when
     count >= threshold.
     """
     now = datetime.now(timezone.utc)
@@ -73,20 +73,22 @@ def check_hub_stream_gen_timeout(
         )
         combined = result.stdout + result.stderr
         count = sum(
-            1 for line in combined.splitlines() if "_stream_gen timeout" in line.lower()
+            1
+            for line in combined.splitlines()
+            if "_dict_stream_gen timeout" in line.lower()
         )
         if count >= threshold:
             return CheckResult(
-                name="hub:stream_gen_timeout",
+                name="hub:dict_stream_gen_timeout",
                 passed=False,
                 detail=(
-                    f"_stream_gen timeout: {count} in last {max_age_minutes}m"
+                    f"_dict_stream_gen timeout: {count} in last {max_age_minutes}m"
                     f" (threshold={threshold})"
                 ),
                 timestamp=now,
             )
         return CheckResult(
-            name="hub:stream_gen_timeout",
+            name="hub:dict_stream_gen_timeout",
             passed=True,
             detail=(
                 f"{count} timeouts in last {max_age_minutes}m (threshold={threshold})"
@@ -95,7 +97,7 @@ def check_hub_stream_gen_timeout(
         )
     except _LOG_EXCEPTIONS as exc:
         return CheckResult(
-            name="hub:stream_gen_timeout",
+            name="hub:dict_stream_gen_timeout",
             passed=False,
             detail=str(exc),
             timestamp=now,

--- a/src/lyra/nats/_worker_client_base.py
+++ b/src/lyra/nats/_worker_client_base.py
@@ -59,7 +59,7 @@ class NatsWorkerClientBase(NatsDriverBase):
     # Keeps the inherited _any_worker_alive() backstop in sync with any_alive() —
     # otherwise a stopped worker would be evicted from any_alive() at 15s but remain
     # "alive" in _worker_freshness for another 15s, delaying detection by future
-    # subclasses that use the parent's _stream_gen primitive.
+    # subclasses that use the parent's _dict_stream_gen primitive.
     HB_TTL: float = 15.0
     # Callable that raises ValueError for unsafe worker_id values. Subclasses
     # assign their domain-specific re-export of validate_worker_id. The

--- a/tests/adapters/test_clipool_worker.py
+++ b/tests/adapters/test_clipool_worker.py
@@ -247,7 +247,7 @@ async def test_handle_cmd_streaming_forwards_tool_use_as_keepalive() -> None:
     """ToolUseLlmEvent is forwarded as event_type='tool_use' chunk (done=False).
 
     Tool execution can take minutes without producing TextLlmEvents; without
-    this forward, the hub-side `_stream_gen` per-chunk timer would kill the
+    this forward, the hub-side `_dict_stream_gen` per-chunk timer would kill the
     healthy session. The chunk acts as a keepalive — the hub ignores its
     payload but the arrival resets the timer.
     """

--- a/tests/llm/drivers/test_cli_nats_driver.py
+++ b/tests/llm/drivers/test_cli_nats_driver.py
@@ -70,16 +70,16 @@ def _make_reply(data: dict) -> MagicMock:
 
 
 async def _collect_stream(driver: CliNatsDriver, mock_chunks: list[dict]) -> list:
-    """Drive driver.stream() by patching the lower-level _stream_gen."""
+    """Drive driver.stream() by patching the lower-level _dict_stream_gen."""
 
-    async def _mock_stream_gen(
+    async def _mock_dict_stream_gen(
         subject: str, payload_dict: dict, *, timeout: float | None = None
     ) -> AsyncIterator[dict]:
         for chunk in mock_chunks:
             yield chunk
 
     events = []
-    with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+    with patch.object(driver, "_dict_stream_gen", new=_mock_dict_stream_gen):
         async for event in await driver.stream(
             "pool-1", "hello", _make_model_cfg(), "You are helpful."
         ):
@@ -112,7 +112,7 @@ class TestConstants:
 
 
 class TestStream:
-    """stream() parses dict chunks from _stream_gen into LlmEvents."""
+    """stream() parses dict chunks from _dict_stream_gen into LlmEvents."""
 
     @pytest.mark.asyncio
     async def test_stream_yields_text_events(self) -> None:
@@ -196,14 +196,14 @@ class TestStream:
         chunks = [{"event_type": "text", "text": "hello", "done": True}]
         events = []
 
-        async def _mock_stream_gen(
+        async def _mock_dict_stream_gen(
             subject: str, payload_dict: dict, *, timeout: float | None = None
         ) -> AsyncIterator[dict]:
             for c in chunks:
                 yield c
 
         # Act
-        with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+        with patch.object(driver, "_dict_stream_gen", new=_mock_dict_stream_gen):
             async for ev in await driver.stream(
                 "pool-1", "hi", _make_model_cfg(), "sys"
             ):
@@ -216,20 +216,20 @@ class TestStream:
         assert events[1].is_error is False
 
     @pytest.mark.asyncio
-    async def test_stream_calls_stream_gen_with_subject_cmd(self) -> None:
-        """stream() delegates to _stream_gen using SUBJECT_CMD."""
+    async def test_stream_calls_dict_stream_gen_with_subject_cmd(self) -> None:
+        """stream() delegates to _dict_stream_gen using SUBJECT_CMD."""
         # Arrange
         driver = _make_driver()
         called_subjects: list[str] = []
 
-        async def _spy_stream_gen(
+        async def _spy_dict_stream_gen(
             subject: str, payload_dict: dict, *, timeout: float | None = None
         ) -> AsyncIterator[dict]:
             called_subjects.append(subject)
             yield {"event_type": "result", "is_error": False, "done": True}
 
         # Act
-        with patch.object(driver, "_stream_gen", new=_spy_stream_gen):
+        with patch.object(driver, "_dict_stream_gen", new=_spy_dict_stream_gen):
             async for _ in await driver.stream("p1", "hi", _make_model_cfg(), "sys"):
                 pass
 
@@ -776,14 +776,14 @@ class TestStreamGenSessionPersistence:
 
         events = []
 
-        async def _mock_stream_gen(
+        async def _mock_dict_stream_gen(
             subject: str, payload_dict: dict, *, timeout: float | None = None
         ) -> AsyncIterator[dict]:
             for c in chunks:
                 yield c
 
         # Act
-        with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+        with patch.object(driver, "_dict_stream_gen", new=_mock_dict_stream_gen):
             async for ev in await driver.stream(
                 "pool-1", "hello", _make_model_cfg(), "sys"
             ):
@@ -816,14 +816,14 @@ class TestStreamGenSessionPersistence:
             }
         ]
 
-        async def _mock_stream_gen(
+        async def _mock_dict_stream_gen(
             subject: str, payload_dict: dict, *, timeout: float | None = None
         ) -> AsyncIterator[dict]:
             for c in chunks:
                 yield c
 
         # Act / Assert — no AttributeError
-        with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+        with patch.object(driver, "_dict_stream_gen", new=_mock_dict_stream_gen):
             async for _ in await driver.stream(
                 "pool-1", "hi", _make_model_cfg(), "sys"
             ):
@@ -853,7 +853,7 @@ class TestStreamGenSessionPersistence:
             },
         ]
 
-        async def _mock_stream_gen(
+        async def _mock_dict_stream_gen(
             subject: str, payload_dict: dict, *, timeout: float | None = None
         ) -> AsyncIterator[dict]:
             for c in chunks:
@@ -861,7 +861,7 @@ class TestStreamGenSessionPersistence:
 
         # Act
         events = []
-        with patch.object(driver, "_stream_gen", new=_mock_stream_gen):
+        with patch.object(driver, "_dict_stream_gen", new=_mock_dict_stream_gen):
             async for ev in await driver.stream("pool-1", "hi", _make_model_cfg(), ""):
                 events.append(ev)
         await asyncio.sleep(0)  # let the fire-and-forget task run

--- a/tests/test_monitoring_checks_orchestrator.py
+++ b/tests/test_monitoring_checks_orchestrator.py
@@ -89,7 +89,7 @@ class TestRunChecks:
         assert report.all_passed is True
         assert report.failed_count == 0
         # process:lyra-hub + http_health + queue_depth + circuits + reaper
-        # + nats:permissions_violation + hub:stream_gen_timeout + disk + nats:varz
+        # + nats:permissions_violation + hub:dict_stream_gen_timeout + disk + nats:varz
         assert len(report.checks) == 9
 
     async def test_failure_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Renames `NatsDriverBase._stream_gen` → `_dict_stream_gen` to signal exactly what it yields (raw dicts) and prevent collision with domain-specific stream generators (e.g. `NatsLlmClient._llm_stream_gen` had to be renamed during #1235).
- Bumps `roxabi-nats` 0.3.0 → 0.4.0 (BREAKING CHANGE for external consumers calling the renamed method).
- Mechanical rename: parent method + log strings + sole external caller (`CliNatsDriver._stream_gen_llm`) + monitoring log-search check + tests (patch targets, mock/spy fn names, test method names).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1254: Rename NatsDriverBase._stream_gen → _dict_stream_gen | OPEN |
| Implementation | 1 commit on `feat/1254-rename-stream-gen` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4096 + 103 roxabi-nats pass) | Passed |

## Test Plan
- [ ] CI green on `feat/1254-rename-stream-gen`
- [ ] Verify `grep -r "_stream_gen\b"` in `src/` and `tests/` returns only `_llm_stream_gen` (different method) — no straggling references
- [ ] After merge: cut `roxabi-nats/v0.4.0` git tag per `~/projects/docs/release-convention.md`

## Notes

- Monitoring log-search (`check_hub_stream_gen_timeout`) renamed to `check_hub_dict_stream_gen_timeout` + `CheckResult.name` updated so the prod log scanner matches the new log line.
- Historical references in `docs/architecture/adr/051-*` and `artifacts/analyses/*` are intentionally untouched — they refer to the deleted legacy `NatsLlmDriver._stream_gen()` or are immutable analysis records.

Closes #1254

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`