### PR TITLE
chore(agent-config): #1198 backend-enum cleanup tail — field_validator + test polish

### DIFF
--- a/artifacts/analyses/1198-backend-enum-cleanup-tail-consensus.mdx
+++ b/artifacts/analyses/1198-backend-enum-cleanup-tail-consensus.mdx
@@ -1,0 +1,120 @@
+---
+title: "PR #1267 review findings — Expert Consensus"
+issue: 1198
+pr: 1267
+status: consensus-reached
+date: 2026-05-19
+panel: architect, backend-dev, tester
+confidence: high
+---
+
+## Problem
+
+PR #1267 (`chore(agent-config): #1198 backend-enum cleanup tail`) added a Pydantic `@field_validator("backend")` to `ModelConfig` plus test polish. CI green. The `/code-review` pass produced 7 findings (2 `issue:`, 2 `suggestion:`, 3 `nitpick:`). Need to decide which apply before merge — with particular attention to finding #3 (replace `frozenset` + `field_validator` with `Literal["claude-cli", "nats"]` field type).
+
+## Panel
+
+| α | Focus |
+|---|-------|
+| architect | Validation layering, type-vs-runtime constraint, scalability for growing backend set |
+| backend-dev | Pydantic idioms, NATS serialization compat, error message quality |
+| tester | Coverage gap reality, falsification rule, test-tautology risk |
+
+## Consensus ρ
+
+Per-finding application:
+
+| # | Label | C | Decision | Vote |
+|---|-------|---|---------|------|
+| 1 | issue | 85% | **APPLY-NOW** | 3-0 (tester: blocking) |
+| 2 | issue | 88% | **APPLY-NOW** | 2-1 (tester defers as out-of-test-scope; does not object to fix) |
+| 3 | suggestion | 82% | **REJECT** | 3-0 |
+| 4 | suggestion | 72% | **APPLY-NOW** | 3-0 |
+| 5 | nitpick | 78% | **NOT-NOW** (defer/reject) | 0-0-3 (none APPLY) |
+| 6 | nitpick | 75% | **APPLY-NOW** | 3-0 |
+| 7 | nitpick | 70% | **DEFER** | 3-0 |
+
+### Rationale
+
+**APPLY-NOW (1, 2, 4, 6):** Cheap, low-risk improvements that directly strengthen the validation pattern the PR introduces. Together ~10 LOC across 2 source-adjacent files + 1 test file.
+
+- **#1** — parametrize `test_backend_invalid_at_construction` over `["litellm", "ollama", "unknown-xyz"]`. Tester escalated this to *blocking* per the negative-test rule: a guard introduced in this PR must have a falsification test covering the *class* of unknowns, not a single coincident value.
+- **#2** — 1-line comment at `agent_db_loader.py:51` documenting that L1 (field_validator) also fires on the `ModelConfig()` call below; L2 (`_validate_backend_model`) is kept here for richer `agent_name` error context. Without the comment, future cleanup would silently strip the defense-in-depth the PR was built to preserve.
+- **#4** — `test_frozen` value `"claude-cli"` is the field default; switch to `"nats"` so the freeze check is isolated from validator semantics. 1 LOC.
+- **#6** — Add a `# test-only: bypasses field_validator` comment near the `model_construct(backend="unknown")` call site in `tests/test_main_auth.py`. The PR comment cites NATS deserialization paths as the *motivation* for the new validator; documenting the bypass pattern at the call site closes the gap between PR prose and code.
+
+**REJECT (#3):** `backend: Literal["claude-cli", "nats"]` would trade growth-readiness for static typing. Three converging reasons:
+
+1. **Backends will grow** — `agent_config.py:49–56` explicitly reserves `base_url`/`api_key` for a "future Ollama driver"; the field validator + frozenset pattern is the correct shape for an open-but-controlled set. `Literal` requires touching every pyright consumer when a backend is added.
+2. **NATS serialization brittleness** — `cli_nats.py:294` publishes `model_dump(...)` payloads. The receiver does `model_validate`. A Literal field hard-fails on the receiver side for any legacy row or pre-deploy backend value, breaking forward/backward compat without a coordinated migration plan.
+3. **Test-tautology risk** — Pydantic raises `literal_error` (not `value_error`) for Literal mismatches. The existing `pytest.raises(ValidationError, match="Invalid backend")` regex would silently start passing for the wrong reason if the field type were switched. The suggestion *introduces* the very failure mode finding #1 exists to prevent.
+
+If a future ticket weighs the full migration cost (payload schema versioning, receiver-side tolerance, type-system surface), it can re-open the question. Out of scope for #1198.
+
+**DEFER (#5, #7):**
+
+- **#5** — `test_unknown_backend_raises` rename is editorial. Test names should describe behavior, not internal architecture layers. The 0-0-3 vote (no one wants to apply now) signals it's not worth the diff churn in this PR.
+- **#7** — `_VALID_BACKENDS_STR` extraction is a real parallel-path drift risk, but only materializes if a third validation site is added. Pick up atomically when (and if) that happens. Premature module-interface widening now.
+
+### Trade-offs
+
+1. **Growth-readiness over static narrowing.** Rejecting #3 keeps `backend: str` wider than the actual domain. pyright cannot catch `backend="ollama"` at compile time; relies on runtime validator. Acceptable price for forward-compat with NATS payloads and future backends.
+2. **Defense-in-depth requires documentation.** The 3-layer validation pattern (#1198 acceptance: "Keep both; document this as the canonical pattern") only works if every reader knows the layers exist. Applying #2 + #6 turns latent design intent into explicit code commentary.
+3. **Test signal isolation.** Applying #1 + #4 + rejecting #3 keeps the existing assertion regexes meaningful and broadens negative-test coverage to the whole class of unknowns.
+
+## Alternatives
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| Apply #3 (Literal field type) | architect finding (review) | Couples type to growing set; breaks NATS payload compat; introduces test-tautology risk |
+| Apply all 7 | (implicit "all-or-nothing") | #3 actively wrong, #5/#7 churn without payoff |
+| Merge as-is, open follow-up issue for all 7 | (DP option 3) | #1 raised to blocking by tester (negative-test rule); doc/test fixes (#2, #4, #6) are too small to justify a follow-up issue |
+| Apply #1+#2+#3+#4 | (DP option 2) | #3 rejected on architectural + serialization + test-tautology grounds |
+
+## Dissent
+
+- **Tester defers #2** while architect+backend-dev say APPLY-NOW. No objection to the change itself — only its scope (source vs. test PR). Recorded but overruled: the comment is a 1-line non-functional change that protects the explicit design intent of the PR; bundling avoids a separate trivial PR.
+- **Tester escalated #1 to *blocking*** per the negative-test rule. Architect + backend-dev had it as APPLY-NOW (not blocking). Recorded: panel honors the strongest signal — treat as required pre-merge.
+
+## Implementation Notes
+
+Single follow-up commit on the same PR branch (`worktree-1198-backend-enum-cleanup-tail`):
+
+1. `tests/core/test_agent_config.py` — parametrize `test_backend_invalid_at_construction`:
+   ```python
+   @pytest.mark.parametrize("bad", ["litellm", "ollama", "unknown-xyz"])
+   def test_backend_invalid_at_construction(self, bad: str) -> None:
+       with pytest.raises(ValidationError, match="Invalid backend"):
+           ModelConfig(backend=bad)
+   ```
+
+2. `src/lyra/core/agent/agent_db_loader.py:51` — add comment:
+   ```python
+   # ModelConfig() below also fires _validate_backend (Pydantic field validator).
+   # We keep _validate_backend_model here for the richer agent_name context in
+   # the error message. The double-check is intentional defense-in-depth.
+   ```
+
+3. `tests/core/test_agent_config.py::test_frozen` — change assigned value to `"nats"`:
+   ```python
+   def test_frozen(self) -> None:
+       # frozen=True rejects any mutation. Using "nats" (≠ default "claude-cli")
+       # so the test is isolated from _validate_backend semantics.
+       cfg = ModelConfig()
+       with pytest.raises(ValidationError):
+           setattr(cfg, "backend", "nats")
+   ```
+
+4. `tests/test_main_auth.py` — augment the existing comment near `model_construct`:
+   ```python
+   # model_construct bypasses Pydantic validators — TEST-ONLY pattern.
+   # Must NOT appear in production deserialization paths (NATS, DB rows, etc.),
+   # which is exactly what _validate_backend (L1) was added to defend against.
+   llm_cfg = ModelConfig.model_construct(backend="unknown")
+   ```
+
+Run quality gates (`uv run ruff format . && uv run ruff check . && uv run pytest tests/core/test_agent_config.py tests/test_main_auth.py`). Push, no new PR — same branch.
+
+## Next
+
+→ `/fix` to apply consensus items #1, #2, #4, #6 to PR #1267.

--- a/src/lyra/core/agent/agent_config.py
+++ b/src/lyra/core/agent/agent_config.py
@@ -74,6 +74,19 @@ class ModelConfig(BaseModel):
     # #1101 — per-agent extended-thinking config (effort token budget)
     effort: Literal["low", "medium", "high", "xhigh", "max"] | None = None
 
+    @field_validator("backend")
+    @classmethod
+    def _validate_backend(cls, v: str) -> str:
+        # Pydantic-level guard so direct construction (tests, NATS payload
+        # deserialization, ad-hoc code) cannot bypass _VALID_BACKENDS.
+        # _validate_backend_model (agent_builder) keeps the agent-name context
+        # in its error message and remains the canonical load-time check.
+        if v not in _VALID_BACKENDS:
+            raise ValueError(
+                f"Invalid backend {v!r}: must be one of {sorted(_VALID_BACKENDS)}"
+            )
+        return v
+
     @field_validator("base_url")
     @classmethod
     def _validate_base_url_scheme(cls, v: str | None) -> str | None:

--- a/src/lyra/core/agent/agent_db_loader.py
+++ b/src/lyra/core/agent/agent_db_loader.py
@@ -48,6 +48,9 @@ def agent_row_to_config(  # noqa: C901, PLR0915 — DEBT:complexity-residual —
     # Resolve cwd: DB row wins, then instance_overrides, then None
     cwd = _resolve_cwd(row.cwd or overrides.get("cwd"), row.name)
 
+    # ModelConfig() below also fires _validate_backend (Pydantic field validator).
+    # _validate_backend_model is kept here for the richer agent_name context in
+    # the error message. The double-check is intentional defense-in-depth.
     _validate_backend_model(row.backend, row.model, row.name)
 
     model_cfg = ModelConfig(

--- a/tests/bootstrap/test_hub_builder.py
+++ b/tests/bootstrap/test_hub_builder.py
@@ -30,7 +30,7 @@ class TestBuildCliPool:
                 name="agent_b",
                 system_prompt="prompt",
                 memory_namespace="test",
-                llm_config=ModelConfig(backend="ollama"),
+                llm_config=ModelConfig(backend="nats"),
             ),
         }
         raw_config: dict = {}

--- a/tests/core/test_agent_config.py
+++ b/tests/core/test_agent_config.py
@@ -49,11 +49,14 @@ class TestModelConfig:
         # must not raise
         _validate_backend_model("claude-cli", "claude-opus-4-6", "test-agent")
 
-    def test_backend_invalid_at_construction(self) -> None:
-        # Pydantic field_validator must reject invalid backends at construction
-        # time — direct ModelConfig() calls cannot bypass _VALID_BACKENDS.
+    @pytest.mark.parametrize("bad", ["litellm", "ollama", "unknown-xyz"])
+    def test_backend_invalid_at_construction(self, bad: str) -> None:
+        # Pydantic field_validator must reject the whole class of unknowns at
+        # construction time — direct ModelConfig() calls cannot bypass
+        # _VALID_BACKENDS. Parametrized to prove the guard fires for any
+        # non-member, not just a single coincident value.
         with pytest.raises(ValidationError, match="Invalid backend"):
-            ModelConfig(backend="litellm")
+            ModelConfig(backend=bad)
 
     def test_base_url_invalid_scheme_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -71,10 +74,13 @@ class TestModelConfig:
         assert cfg.tools == ("Read", "Grep")
 
     def test_frozen(self) -> None:
-        # frozen=True rejects any mutation — the assigned value is irrelevant.
+        # frozen=True rejects any mutation. Using "nats" (≠ default "claude-cli")
+        # so the test is isolated from _validate_backend semantics — if a future
+        # Pydantic version no-op'd same-value set on frozen models, this would
+        # still catch the regression.
         cfg = ModelConfig()
         with pytest.raises(ValidationError):
-            setattr(cfg, "backend", "claude-cli")
+            setattr(cfg, "backend", "nats")
 
     def test_cwd_defaults_to_none(self) -> None:
         cfg = ModelConfig()

--- a/tests/core/test_agent_config.py
+++ b/tests/core/test_agent_config.py
@@ -43,6 +43,18 @@ class TestModelConfig:
         # must not raise
         _validate_backend_model("nats", "claude-sonnet-4-6", "test-agent")
 
+    def test_backend_claude_cli_accepted(self) -> None:
+        from lyra.core.agent.agent_builder import _validate_backend_model
+
+        # must not raise
+        _validate_backend_model("claude-cli", "claude-opus-4-6", "test-agent")
+
+    def test_backend_invalid_at_construction(self) -> None:
+        # Pydantic field_validator must reject invalid backends at construction
+        # time — direct ModelConfig() calls cannot bypass _VALID_BACKENDS.
+        with pytest.raises(ValidationError, match="Invalid backend"):
+            ModelConfig(backend="litellm")
+
     def test_base_url_invalid_scheme_rejected(self) -> None:
         with pytest.raises(ValidationError):
             ModelConfig(base_url="file:///etc/passwd")
@@ -59,9 +71,10 @@ class TestModelConfig:
         assert cfg.tools == ("Read", "Grep")
 
     def test_frozen(self) -> None:
+        # frozen=True rejects any mutation — the assigned value is irrelevant.
         cfg = ModelConfig()
         with pytest.raises(ValidationError):
-            setattr(cfg, "backend", "ollama")
+            setattr(cfg, "backend", "claude-cli")
 
     def test_cwd_defaults_to_none(self) -> None:
         cfg = ModelConfig()

--- a/tests/llm/drivers/test_cli_nats_driver.py
+++ b/tests/llm/drivers/test_cli_nats_driver.py
@@ -60,7 +60,7 @@ def _make_driver(nc: MagicMock | None = None, timeout: float = 5.0) -> CliNatsDr
 
 
 def _make_model_cfg() -> ModelConfig:
-    return ModelConfig(backend="cli-nats", model="claude-cli")
+    return ModelConfig(backend="claude-cli", model="claude-cli")
 
 
 def _make_reply(data: dict) -> MagicMock:

--- a/tests/llm/test_nats_llm_client_provider.py
+++ b/tests/llm/test_nats_llm_client_provider.py
@@ -52,7 +52,7 @@ def _seed_registry(client: NatsLlmClient, worker_id: str = "w-1") -> None:
 
 def _make_model_cfg() -> ModelConfig:
     """Return a minimal ModelConfig for test use."""
-    return ModelConfig(model="gpt-4o", backend="litellm")
+    return ModelConfig(model="gpt-4o", backend="nats")
 
 
 def _ok_response_bytes(request_id: str = "req0001", text: str = "hi") -> bytes:

--- a/tests/test_main_auth.py
+++ b/tests/test_main_auth.py
@@ -34,8 +34,10 @@ class TestAgentFactory:
         assert isinstance(agent, SimpleAgent)
 
     def test_unknown_backend_raises(self) -> None:
-        # Bypass the ModelConfig field validator (which rejects "unknown" at
-        # construction) to exercise the factory's defense-in-depth check.
+        # model_construct bypasses Pydantic validators — TEST-ONLY pattern.
+        # Must NOT appear in production deserialization paths (NATS, DB rows),
+        # which is exactly what ModelConfig._validate_backend was added to guard.
+        # Here we use it to reach the factory's defense-in-depth check.
         llm_cfg = ModelConfig.model_construct(backend="unknown")
         config = Agent(
             name="test",

--- a/tests/test_main_auth.py
+++ b/tests/test_main_auth.py
@@ -34,11 +34,14 @@ class TestAgentFactory:
         assert isinstance(agent, SimpleAgent)
 
     def test_unknown_backend_raises(self) -> None:
+        # Bypass the ModelConfig field validator (which rejects "unknown" at
+        # construction) to exercise the factory's defense-in-depth check.
+        llm_cfg = ModelConfig.model_construct(backend="unknown")
         config = Agent(
             name="test",
             system_prompt="",
             memory_namespace="test",
-            llm_config=ModelConfig(backend="unknown"),
+            llm_config=llm_cfg,
         )
         with pytest.raises(ValueError, match="Unknown backend"):
             agent_factory_mod._create_agent(config, None)


### PR DESCRIPTION
## Summary

Bundles items 1, 4, 5 from #1198 (items 2 and 3 split off to #1264 and #1265).

- **Item 1** — Add `@field_validator(\"backend\")` on `ModelConfig` so direct construction (tests, NATS payload deserialization, ad-hoc code) cannot bypass `_VALID_BACKENDS`. `_validate_backend_model` (agent_builder) remains the canonical load-time check that keeps agent-name context in its error message.
- **Item 4** — `test_frozen`: the assigned value is irrelevant to the test (we exercise `frozen=True`, not backend validation). Changed to a valid backend + clarifying comment.
- **Item 5** — Added `test_backend_claude_cli_accepted` symmetric to `test_backend_nats_accepted`; added `test_backend_invalid_at_construction` covering the new validator.

Four test fixtures/callers previously passed now-rejected backend values (`\"ollama\"`, `\"litellm\"`, `\"cli-nats\"`, `\"unknown\"`). Updated:
- `tests/bootstrap/test_hub_builder.py` — `\"ollama\"` → `\"nats\"`
- `tests/llm/test_nats_llm_client_provider.py` fixture — `\"litellm\"` → `\"nats\"`
- `tests/llm/drivers/test_cli_nats_driver.py` fixture — `\"cli-nats\"` → `\"claude-cli\"` (matches the registry key it serves)
- `tests/test_main_auth.py::test_unknown_backend_raises` — switched to `ModelConfig.model_construct(backend=\"unknown\")` to bypass the field validator and still exercise the factory's defense-in-depth guard.

## Test plan

- [x] `uv run pytest tests/core/test_agent_config.py` — 40 passed (incl. 2 new)
- [x] `uv run pytest` (full suite) — 4104 passed, 31 skipped, 2 xfailed
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run pyright src/lyra/core/agent/agent_config.py` — 0 errors

Closes #1198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)