### PR TITLE
chore(contracts): add sanitize_for_wire + migrate hub literals

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/errors.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/errors.py
@@ -10,7 +10,13 @@ from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field, field_validator
 
-__all__ = ["WorkerError", "CodeMeta", "KNOWN_CODES"]
+__all__ = [
+    "WorkerError",
+    "CodeMeta",
+    "KNOWN_CODES",
+    "scrub_credentials",
+    "truncate_with_marker",
+]
 
 # Maximum stored length for free-text fields. Long stack traces / framing errors
 # are truncated to fit; we never raise a ValidationError on overflow because
@@ -70,12 +76,18 @@ def _scrub_url(url: str) -> str:
     )
 
 
-def _scrub(value: str) -> str:
-    """Scrub credentials from any embedded URLs in `value`."""
+def scrub_credentials(value: str) -> str:
+    """Scrub credentials from any embedded URLs in `value`.
+
+    Replaces the userinfo (``user:pass@``) of every URL whose scheme is in
+    ``_CREDENTIAL_SCHEMES`` with ``***:***``. Returns the value unchanged
+    if no scrubbing applies. Safe to call on arbitrary free-text such as
+    ``str(exc)``.
+    """
     return _URL_RE.sub(lambda m: _scrub_url(m.group(0)), value)
 
 
-def _truncate(value: str, limit: int) -> str:
+def truncate_with_marker(value: str, limit: int) -> str:
     """Truncate `value` to `limit` chars, replacing the tail with `…` on overflow.
 
     Truncates rather than raises so error-path code never crashes on long
@@ -107,16 +119,14 @@ class WorkerError(BaseModel):
     @field_validator("message")
     @classmethod
     def _sanitize_message(cls, v: str) -> str:
-        scrubbed = _scrub(v)
-        return _truncate(scrubbed, _MESSAGE_MAX)
+        return truncate_with_marker(scrub_credentials(v), _MESSAGE_MAX)
 
     @field_validator("detail")
     @classmethod
     def _sanitize_detail(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        scrubbed = _scrub(v)
-        return _truncate(scrubbed, _DETAIL_MAX)
+        return truncate_with_marker(scrub_credentials(v), _DETAIL_MAX)
 
 
 class CodeMeta(BaseModel):

--- a/packages/roxabi-contracts/src/roxabi_contracts/errors.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/errors.py
@@ -80,9 +80,11 @@ def scrub_credentials(value: str) -> str:
     """Scrub credentials from any embedded URLs in `value`.
 
     Replaces the userinfo (``user:pass@``) of every URL whose scheme is in
-    ``_CREDENTIAL_SCHEMES`` with ``***:***``. Returns the value unchanged
-    if no scrubbing applies. Safe to call on arbitrary free-text such as
-    ``str(exc)``.
+    the credential-bearing allowlist (``nats``, ``nats+tls``, ``amqp``,
+    ``amqps``, ``redis``, ``rediss``, ``http``, ``https``, ``postgres``,
+    ``postgresql``, ``mysql``) with ``***:***``. Returns the value
+    unchanged if no scrubbing applies. Safe to call on arbitrary free-text
+    such as ``str(exc)``.
     """
     return _URL_RE.sub(lambda m: _scrub_url(m.group(0)), value)
 

--- a/packages/roxabi-nats/CLAUDE.md
+++ b/packages/roxabi-nats/CLAUDE.md
@@ -29,8 +29,8 @@ for external consumers (branch pinning only in plugin-dev branches).
 
 | Package | Owns |
 |---|---|
-| `roxabi-nats` | Transport primitives: connection, adapter lifecycle, serialization, circuit breaker, readiness, worker base |
-| `roxabi-contracts` | Wire schemas, `CONTRACT_VERSION`, envelope definitions |
+| `roxabi-nats` | Transport primitives: connection, adapter lifecycle, serialization, circuit breaker, readiness, worker base; wire-side error sanitization helpers (`sanitize_for_wire`) for socket-bound daemon paths |
+| `roxabi-contracts` | Wire schemas, `CONTRACT_VERSION`, envelope definitions; sanitization primitives (`scrub_credentials`, `truncate_with_marker`) reused by `WorkerError` and `sanitize_for_wire` |
 
 `CONTRACT_VERSION` canonical home is `roxabi_contracts.envelope`. The compat
 re-export in `roxabi_nats.adapter_base` was removed at v0.3.0 (BREAKING CHANGE).

--- a/packages/roxabi-nats/src/roxabi_nats/__init__.py
+++ b/packages/roxabi-nats/src/roxabi_nats/__init__.py
@@ -15,6 +15,7 @@ from ._serialize import _TypeHintResolver as TypeHintResolver
 from .adapter_base import NatsAdapterBase
 from .connect import nats_connect
 from .driver_base import NatsDriverBase, WorkerUnavailableError
+from .errors import sanitize_for_wire
 
 __all__ = [
     "CONTRACT_VERSION",
@@ -23,4 +24,5 @@ __all__ = [
     "TypeHintResolver",
     "WorkerUnavailableError",
     "nats_connect",
+    "sanitize_for_wire",
 ]

--- a/packages/roxabi-nats/src/roxabi_nats/__init__.py
+++ b/packages/roxabi-nats/src/roxabi_nats/__init__.py
@@ -4,9 +4,11 @@ See docs/architecture/adr/045-roxabi-nats-sdk-uv-workspace-extraction.mdx
 and docs/architecture/adr/044-lyra-voicecli-nats-contract.mdx.
 
 Public API: only the names in ``__all__`` are part of the stable external
-contract. ``_``-prefixed submodules (``_serialize``, ``_sanitize``,
-``_validate``, ``_version_check``, ``_tts_constants``) are hub-internal and
-may change without notice — external consumers MUST NOT import them.
+contract. Public utility submodules: ``errors`` (``sanitize_for_wire``,
+``DEFAULT_MAX_LEN``). ``_``-prefixed submodules (``_serialize``,
+``_sanitize``, ``_validate``, ``_version_check``, ``_tts_constants``) are
+hub-internal and may change without notice — external consumers MUST NOT
+import them.
 """
 
 from roxabi_contracts.envelope import CONTRACT_VERSION
@@ -15,10 +17,11 @@ from ._serialize import _TypeHintResolver as TypeHintResolver
 from .adapter_base import NatsAdapterBase
 from .connect import nats_connect
 from .driver_base import NatsDriverBase, WorkerUnavailableError
-from .errors import sanitize_for_wire
+from .errors import DEFAULT_MAX_LEN, sanitize_for_wire
 
 __all__ = [
     "CONTRACT_VERSION",
+    "DEFAULT_MAX_LEN",
     "NatsAdapterBase",
     "NatsDriverBase",
     "TypeHintResolver",

--- a/packages/roxabi-nats/src/roxabi_nats/errors.py
+++ b/packages/roxabi-nats/src/roxabi_nats/errors.py
@@ -32,8 +32,13 @@ def sanitize_for_wire(exc: BaseException, *, max_len: int = DEFAULT_MAX_LEN) -> 
     ``postgres``, ``redis``, ``http``, etc.) → ``truncate_with_marker``
     (caps at ``max_len`` chars, replacing the tail with ``…`` on overflow).
 
+    ``max_len`` must be ≥ 1 (the truncation marker length). Smaller values
+    cannot produce a bounded string and raise ``ValueError``.
+
     Prefer ``WorkerError(code=..., message=str(exc))`` on NATS reply
     subjects — it applies the same sanitization via field validators
     inside a typed envelope the consumer can dispatch on.
     """
+    if max_len < 1:
+        raise ValueError(f"max_len must be >= 1, got {max_len}")
     return truncate_with_marker(scrub_credentials(str(exc)), max_len)

--- a/packages/roxabi-nats/src/roxabi_nats/errors.py
+++ b/packages/roxabi-nats/src/roxabi_nats/errors.py
@@ -1,0 +1,39 @@
+"""Wire-boundary error sanitization for socket-bound daemon paths.
+
+The canonical structured error path on NATS reply subjects is
+``WorkerError`` from ``roxabi_contracts.errors`` (ADR-066). Its field
+validators scrub credentials from embedded URLs and truncate free-text
+fields to bounded length.
+
+``sanitize_for_wire`` is the **free-function** counterpart for callers
+that cannot return a typed envelope — e.g. legacy daemon error frames
+written to a raw socket, or fallback paths inside an ``except`` handler
+where constructing a Pydantic model would itself fail.
+
+It reuses the same primitives (``scrub_credentials`` +
+``truncate_with_marker``) so producer and consumer share a single
+sanitization contract.
+"""
+
+from __future__ import annotations
+
+from roxabi_contracts.errors import scrub_credentials, truncate_with_marker
+
+__all__ = ["sanitize_for_wire", "DEFAULT_MAX_LEN"]
+
+DEFAULT_MAX_LEN = 200
+
+
+def sanitize_for_wire(exc: BaseException, *, max_len: int = DEFAULT_MAX_LEN) -> str:
+    """Return a wire-safe string representation of ``exc``.
+
+    Pipeline: ``str(exc)`` → ``scrub_credentials`` (strips userinfo from
+    embedded URLs of known credential-bearing schemes: ``nats``,
+    ``postgres``, ``redis``, ``http``, etc.) → ``truncate_with_marker``
+    (caps at ``max_len`` chars, replacing the tail with ``…`` on overflow).
+
+    Prefer ``WorkerError(code=..., message=str(exc))`` on NATS reply
+    subjects — it applies the same sanitization via field validators
+    inside a typed envelope the consumer can dispatch on.
+    """
+    return truncate_with_marker(scrub_credentials(str(exc)), max_len)

--- a/packages/roxabi-nats/tests/test_errors.py
+++ b/packages/roxabi-nats/tests/test_errors.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from roxabi_nats import sanitize_for_wire
-from roxabi_nats.errors import DEFAULT_MAX_LEN
+from roxabi_nats import DEFAULT_MAX_LEN, sanitize_for_wire
 
 
 class TestStrCast:
@@ -44,23 +43,27 @@ class TestStrCast:
 
 
 class TestCredentialScrub:
-    def test_nats_url_userinfo_scrubbed(self) -> None:
-        exc = RuntimeError("connect failed: nats://admin:s3cret@broker:4222")
-        assert "admin:s3cret" not in sanitize_for_wire(exc)
-        assert "***:***@broker:4222" in sanitize_for_wire(exc)
-
-    def test_postgres_url_userinfo_scrubbed(self) -> None:
-        exc = RuntimeError("pg error: postgres://u:p@db.host/mydb")
-        assert "u:p" not in sanitize_for_wire(exc)
-        assert "***:***@db.host" in sanitize_for_wire(exc)
-
     @pytest.mark.parametrize(
         "scheme",
-        ["nats", "nats+tls", "redis", "rediss", "amqp", "amqps", "http", "https"],
+        [
+            "nats",
+            "nats+tls",
+            "redis",
+            "rediss",
+            "amqp",
+            "amqps",
+            "http",
+            "https",
+            "postgres",
+            "postgresql",
+            "mysql",
+        ],
     )
-    def test_allowlisted_scheme_scrubbed(self, scheme: str) -> None:
+    def test_allowlisted_scheme_userinfo_scrubbed(self, scheme: str) -> None:
         exc = RuntimeError(f"err: {scheme}://user:pass@host/path")
-        assert "user:pass" not in sanitize_for_wire(exc)
+        result = sanitize_for_wire(exc)
+        assert "user:pass" not in result
+        assert "***:***@host" in result
 
     def test_unknown_scheme_unchanged(self) -> None:
         # custom:// is not in the credential scheme allowlist
@@ -81,6 +84,29 @@ class TestCredentialScrub:
         assert "***:***@x" in result
         assert "***:***@y" in result
 
+    def test_ipv6_host_userinfo_scrubbed(self) -> None:
+        # Bracketed IPv6 host is a common regex blind spot. Delegating to
+        # urlsplit (RFC 3986) handles it correctly; pin the behavior so a
+        # future regex change cannot regress silently.
+        exc = RuntimeError("connect: nats://user:pass@[::1]:4222")
+        result = sanitize_for_wire(exc)
+        assert "user:pass" not in result
+        assert "***:***@[::1]:4222" in result
+
+    def test_password_with_percent_encoded_at(self) -> None:
+        exc = RuntimeError("connect: nats://user:p%40ss@host:4222")
+        result = sanitize_for_wire(exc)
+        assert "p%40ss" not in result
+        assert "***:***@host:4222" in result
+
+    def test_password_with_raw_at(self) -> None:
+        # RFC 3986 anchors userinfo on the LAST `@` before the host,
+        # so a raw `@` inside the password must still be scrubbed.
+        exc = RuntimeError("connect: nats://user:p@ss@host:4222")
+        result = sanitize_for_wire(exc)
+        assert "user:p@ss" not in result
+        assert "***:***@host:4222" in result
+
 
 class TestTruncation:
     def test_below_limit_unchanged(self) -> None:
@@ -97,26 +123,48 @@ class TestTruncation:
         assert len(result) == 100
         assert result.endswith("…")
 
+    def test_overflow_at_marker_length_returns_marker_only(self) -> None:
+        # max_len=1 is the smallest legal limit (marker length).
+        # An overflowing input must reduce to just the marker.
+        result = sanitize_for_wire(RuntimeError("hello"), max_len=1)
+        assert result == "…"
+
     def test_default_max_len_applied(self) -> None:
         msg = "z" * (DEFAULT_MAX_LEN + 100)
         result = sanitize_for_wire(RuntimeError(msg))
         assert len(result) == DEFAULT_MAX_LEN
         assert result.endswith("…")
 
-    def test_default_max_len_is_200(self) -> None:
-        # Pinned for ADR/contract clarity — if the default ever moves,
-        # update consumers + this test in the same change.
+    def test_default_max_len_contract_value_200(self) -> None:
+        # Pinned by contract — worker repos consume `sanitize_for_wire` from
+        # `roxabi-nats` and may size their own buffers to this value. Moving
+        # the default is a contract change: bump it deliberately and update
+        # consumers in lockstep.
         assert DEFAULT_MAX_LEN == 200
+
+    @pytest.mark.parametrize("max_len", [0, -1, -100])
+    def test_max_len_below_marker_raises(self, max_len: int) -> None:
+        # Below the marker length (1) the truncate primitive cannot produce
+        # a bounded string. Refuse loudly rather than return an oversized
+        # result that violates the caller's max_len contract.
+        with pytest.raises(ValueError):
+            sanitize_for_wire(RuntimeError("hello"), max_len=max_len)
 
 
 class TestScrubBeforeTruncate:
-    def test_scrub_then_truncate_order(self) -> None:
-        # Scrub first: a long URL with credentials must have its userinfo
-        # replaced before truncation, so secrets cannot survive by virtue
-        # of being past the cutoff.
-        url = "nats://verylonguser:verylongpassword@broker.example.com:4222/path"
-        msg = f"failure connecting: {url}"
-        result = sanitize_for_wire(RuntimeError(msg), max_len=80)
-        assert "verylonguser" not in result
-        assert "verylongpassword" not in result
-        assert len(result) <= 80
+    def test_scrub_runs_before_truncate(self) -> None:
+        # Pipeline order matters: scrub MUST run before truncate. Otherwise
+        # truncation could cut the URL between the credential and the `@host`
+        # anchor, and scrub (which keys off `@`) would leave the partial
+        # credential exposed.
+        #
+        # With max_len=35:
+        #   scrub-first:    "connect_error: nats://***:***@brok…"  (credentials gone)
+        #   truncate-first: "connect_error: nats://canary_user:…"  (no @, scrub no-ops)
+        #
+        # If the pipeline order ever flips, the canary_user assertion fails.
+        msg = "connect_error: nats://canary_user:canary_pass@broker:4222"
+        result = sanitize_for_wire(RuntimeError(msg), max_len=35)
+        assert "canary_user" not in result
+        assert "canary_pass" not in result
+        assert result.endswith("…")

--- a/packages/roxabi-nats/tests/test_errors.py
+++ b/packages/roxabi-nats/tests/test_errors.py
@@ -1,0 +1,122 @@
+"""Tests for sanitize_for_wire — socket-bound exception sanitization.
+
+Covers the contract enforced by ``roxabi_nats.errors.sanitize_for_wire``:
+str-cast + URL credential scrub (delegated to
+``roxabi_contracts.errors.scrub_credentials``) + bounded-length truncation
+(delegated to ``truncate_with_marker``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from roxabi_nats import sanitize_for_wire
+from roxabi_nats.errors import DEFAULT_MAX_LEN
+
+
+class TestStrCast:
+    def test_plain_message_passes_through(self) -> None:
+        exc = RuntimeError("worker crashed")
+        assert sanitize_for_wire(exc) == "worker crashed"
+
+    def test_empty_message(self) -> None:
+        exc = RuntimeError("")
+        assert sanitize_for_wire(exc) == ""
+
+    def test_works_on_base_exception_subtypes(self) -> None:
+        # BaseException covers SystemExit / KeyboardInterrupt / GeneratorExit;
+        # caller decides whether to call us on those. We must not refuse them.
+        for exc in (
+            ValueError("bad input"),
+            KeyError("missing"),
+            SystemExit("shutting down"),
+            KeyboardInterrupt(),
+        ):
+            result = sanitize_for_wire(exc)
+            assert isinstance(result, str)
+
+    def test_custom_exception_str(self) -> None:
+        class MyError(Exception):
+            def __str__(self) -> str:
+                return "custom repr"
+
+        assert sanitize_for_wire(MyError()) == "custom repr"
+
+
+class TestCredentialScrub:
+    def test_nats_url_userinfo_scrubbed(self) -> None:
+        exc = RuntimeError("connect failed: nats://admin:s3cret@broker:4222")
+        assert "admin:s3cret" not in sanitize_for_wire(exc)
+        assert "***:***@broker:4222" in sanitize_for_wire(exc)
+
+    def test_postgres_url_userinfo_scrubbed(self) -> None:
+        exc = RuntimeError("pg error: postgres://u:p@db.host/mydb")
+        assert "u:p" not in sanitize_for_wire(exc)
+        assert "***:***@db.host" in sanitize_for_wire(exc)
+
+    @pytest.mark.parametrize(
+        "scheme",
+        ["nats", "nats+tls", "redis", "rediss", "amqp", "amqps", "http", "https"],
+    )
+    def test_allowlisted_scheme_scrubbed(self, scheme: str) -> None:
+        exc = RuntimeError(f"err: {scheme}://user:pass@host/path")
+        assert "user:pass" not in sanitize_for_wire(exc)
+
+    def test_unknown_scheme_unchanged(self) -> None:
+        # custom:// is not in the credential scheme allowlist
+        exc = RuntimeError("err: custom://user:pass@host")
+        assert "user:pass" in sanitize_for_wire(exc)
+
+    def test_url_without_userinfo_unchanged(self) -> None:
+        exc = RuntimeError("err: nats://broker:4222")
+        assert sanitize_for_wire(exc) == "err: nats://broker:4222"
+
+    def test_multiple_urls_all_scrubbed(self) -> None:
+        exc = RuntimeError(
+            "primary nats://a:1@x and fallback postgres://b:2@y both down"
+        )
+        result = sanitize_for_wire(exc)
+        assert "a:1" not in result
+        assert "b:2" not in result
+        assert "***:***@x" in result
+        assert "***:***@y" in result
+
+
+class TestTruncation:
+    def test_below_limit_unchanged(self) -> None:
+        msg = "short"
+        assert sanitize_for_wire(RuntimeError(msg), max_len=100) == msg
+
+    def test_exact_limit_unchanged(self) -> None:
+        msg = "x" * 50
+        assert sanitize_for_wire(RuntimeError(msg), max_len=50) == msg
+
+    def test_overflow_truncated_with_marker(self) -> None:
+        msg = "y" * 500
+        result = sanitize_for_wire(RuntimeError(msg), max_len=100)
+        assert len(result) == 100
+        assert result.endswith("…")
+
+    def test_default_max_len_applied(self) -> None:
+        msg = "z" * (DEFAULT_MAX_LEN + 100)
+        result = sanitize_for_wire(RuntimeError(msg))
+        assert len(result) == DEFAULT_MAX_LEN
+        assert result.endswith("…")
+
+    def test_default_max_len_is_200(self) -> None:
+        # Pinned for ADR/contract clarity — if the default ever moves,
+        # update consumers + this test in the same change.
+        assert DEFAULT_MAX_LEN == 200
+
+
+class TestScrubBeforeTruncate:
+    def test_scrub_then_truncate_order(self) -> None:
+        # Scrub first: a long URL with credentials must have its userinfo
+        # replaced before truncation, so secrets cannot survive by virtue
+        # of being past the cutoff.
+        url = "nats://verylonguser:verylongpassword@broker.example.com:4222/path"
+        msg = f"failure connecting: {url}"
+        result = sanitize_for_wire(RuntimeError(msg), max_len=80)
+        assert "verylonguser" not in result
+        assert "verylongpassword" not in result
+        assert len(result) <= 80

--- a/src/lyra/bootstrap/factory/voice_overlay.py
+++ b/src/lyra/bootstrap/factory/voice_overlay.py
@@ -100,9 +100,11 @@ async def probe_voice_services(
     """Ping STT/TTS adapters at startup; log a warning if unreachable."""
     from nats.errors import NoRespondersError
 
+    from roxabi_contracts.voice import SUBJECTS
+
     checks = [
-        ("STT", "lyra.voice.stt.request", stt),
-        ("TTS", "lyra.voice.tts.request", tts),
+        ("STT", SUBJECTS.stt_request, stt),
+        ("TTS", SUBJECTS.tts_request, tts),
     ]
     for name, subject, client in checks:
         if client is None:

--- a/src/lyra/cli_voice_smoke.py
+++ b/src/lyra/cli_voice_smoke.py
@@ -15,15 +15,12 @@ import nats.errors
 import typer
 from nats.aio.client import Client as NATS
 
+from roxabi_contracts.voice import SUBJECTS
 from roxabi_nats.connect import nats_connect  # noqa: F401 — DEBT:re-export-init
 
 _SMOKE_TEXT = "Voice cutover smoke test one two three"
 _SMOKE_KEYWORDS = {"voice", "cutover", "smoke", "one", "two", "three"}
 
-_TTS_SUBJECT = "lyra.voice.tts.request"
-_STT_SUBJECT = "lyra.voice.stt.request"
-_TTS_HEARTBEAT = "lyra.voice.tts.heartbeat"
-_STT_HEARTBEAT = "lyra.voice.stt.heartbeat"
 _VOICECLI_WORKER_PREFIX = "voicecli-"
 _CONTRACT_VERSION = "1"
 
@@ -138,8 +135,8 @@ async def _require_voicecli_heartbeats(nc: NATS, wait_seconds: float) -> None:
         if worker_id and worker_id.startswith(_VOICECLI_WORKER_PREFIX):
             seen["stt"] = worker_id
 
-    sub_tts = await nc.subscribe(_TTS_HEARTBEAT, cb=on_tts)
-    sub_stt = await nc.subscribe(_STT_HEARTBEAT, cb=on_stt)
+    sub_tts = await nc.subscribe(SUBJECTS.tts_heartbeat, cb=on_tts)
+    sub_stt = await nc.subscribe(SUBJECTS.stt_heartbeat, cb=on_stt)
     try:
         deadline = asyncio.get_event_loop().time() + wait_seconds
         while asyncio.get_event_loop().time() < deadline:
@@ -191,7 +188,7 @@ async def _step_tts(nc: NATS, timeout: float) -> tuple[bytes, str]:
     ).encode("utf-8")
 
     try:
-        reply = await nc.request(_TTS_SUBJECT, payload, timeout=timeout)
+        reply = await nc.request(SUBJECTS.tts_request, payload, timeout=timeout)
     except (nats.errors.TimeoutError, TimeoutError):
         typer.echo("")
         typer.echo(
@@ -238,7 +235,7 @@ async def _step_stt(
     ).encode("utf-8")
 
     try:
-        reply = await nc.request(_STT_SUBJECT, payload, timeout=timeout)
+        reply = await nc.request(SUBJECTS.stt_request, payload, timeout=timeout)
     except (nats.errors.TimeoutError, TimeoutError):
         typer.echo("")
         typer.echo(


### PR DESCRIPTION
## Summary
- Adds `roxabi_nats.sanitize_for_wire(exc, *, max_len=200)` — a free-function wire-safe serializer for socket-bound daemon paths that cannot return a typed `WorkerError` envelope. Reuses `roxabi_contracts.errors` scrub + truncate primitives so producer and consumer share one sanitization contract.
- Promotes the previously-private `_scrub` / `_truncate` in `roxabi_contracts.errors` to public `scrub_credentials` / `truncate_with_marker` (no behavior change; `WorkerError` validators preserved verbatim).
- Migrates the last 6 hardcoded `lyra.voice.*` literals on the lyra side (`cli_voice_smoke.py`, `voice_overlay.probe_voice_services`) to `roxabi_contracts.voice.SUBJECTS`.

## Drift note — scope adjusted at recheck
Pre-implementation drift check (see issue comment) found that **Finding A from the audit was already shipped** in PR #777 (voice) + #806 (image) — production hub clients (`nats_tts_client`, `nats_stt_client`, `nats_image_client`) already consume `roxabi_contracts.{voice,image}.SUBJECTS`. **Finding B** was partially covered too: `WorkerError`'s pydantic field validators already do scrub+truncate. This PR delivers the free-function `sanitize_for_wire` so worker daemons that cannot construct a typed envelope can apply the same sanitization in one import.

Worker repos (llmCLI #53, voiceCLI #162, imageCLI #89) consume `sanitize_for_wire` from `roxabi-nats` after this lands.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1291: contracts: voice/image SUBJECTS + sanitize_for_wire | OPEN |
| Implementation | 1 commit on `worktree-1291-sanitize-for-wire-helper` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (23 new in `test_errors.py`; 4081 total pass) | Passed |

## Test Plan
- [ ] `uv run pytest packages/roxabi-nats/tests/test_errors.py -v` → 23 pass (URL scrub × 8 schemes, truncate edge cases, scrub-before-truncate ordering, BaseException subtypes).
- [ ] `uv run pytest packages/roxabi-contracts/tests/test_worker_error.py packages/roxabi-contracts/tests/test_envelopes_worker_error.py` → 79 pass (existing `WorkerError` behavior unchanged after rename).
- [ ] `from roxabi_nats import sanitize_for_wire` from a fresh consumer works.
- [ ] Spot-check `cli_voice_smoke` invocation against a live NATS broker still publishes to `lyra.voice.tts.request` (now via `SUBJECTS.tts_request`).

Closes #1291

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`