### PR TITLE
fix(gh_token): disable httpx keepalive pool to stop CLOSE-WAIT leak

### DIFF
--- a/artifacts/frames/1057-bot-token-podman-secrets-frame.mdx
+++ b/artifacts/frames/1057-bot-token-podman-secrets-frame.mdx
@@ -1,0 +1,60 @@
+---
+title: bot_secrets table → per-bot Podman secrets
+issue: 1057
+status: approved
+tier: F-lite
+date: 2026-05-21
+---
+
+## Problem
+
+Bot tokens are stored Fernet-encrypted in the `bot_secrets` table of `~/.lyra/config.db`. Adapters read this table once at boot (`adapter_standalone.py:75-93,178-197`) via `CredentialStore.get_full(...)`, then close. This shape keeps three dependencies alive that nothing else in the adapter path needs anymore:
+
+1. A shared-volume `config.db` mount on adapter containers — read **only** for credentials.
+2. The `CredentialStore` class + Fernet encryption layer (~220 LOC) — a custom encrypt-at-rest scheme.
+3. The `~/.lyra/keyring.key` file managed by `LyraKeyring` — required to decrypt `bot_secrets` rows.
+
+The project already uses Podman secrets for every other secret it ships (`lyra-nats-auth`, `lyra-nkey-*`, `lyra-gh-pem`, `lyra-claude-oauth` — see `Makefile:181-200`). Bot tokens are the lone outlier. Migrating them to the same pattern eliminates all three dependencies, hands encryption-at-rest to the OS, and lets the adapter container drop its `config.db` mount (unblocks #1060).
+
+`#1056` (keyring elimination as its own task) was absorbed here once it became clear the keyring is *only* used for `bot_secrets`; removing one entails removing the other.
+
+## Who
+
+- **Primary:** Lyra operators provisioning/rotating bot credentials on deploy hosts. Today: `lyra bot add` writes an encrypted DB row. Tomorrow: `podman secret create` + one `Secret=` line in the Quadlet unit.
+- **Secondary:** Telegram and Discord adapter processes — read `/run/secrets/bot_token` at bootstrap instead of opening `config.db` and decrypting via Fernet.
+
+## Constraints
+
+- **Aggregated container mode** (resolved 2026-05-18): one `.container` file per platform with N `Secret=` lines (one per bot). Per-bot containers explicitly rejected — over-engineering at current scale.
+- **Process-level isolation unchanged**: if the Telegram process is compromised, all Telegram bot tokens (in RAM) are exposed. Same blast radius as today.
+- **Adding a bot becomes a Quadlet edit + restart** (vs. pure DB insert today). Accepted given low bot count (<10).
+- **Backwards-compat shim explicitly forbidden** — no `config.db` fallback path in the adapter bootstrap.
+- **One-shot migration** — existing `bot_secrets` rows must be re-issued as Podman secrets before the table is dropped.
+
+## Out of Scope
+
+- Per-bot container isolation (rejected as over-engineering).
+- Multi-tenant or multi-machine secret distribution — single-host Podman remains the deployment target.
+- Rotating tokens automatically — operator-driven via `podman secret create --replace`.
+- Touching `auth.db` Fernet usage: `LyraKeyring` only deleted if no other consumer remains; verify before removal.
+
+## Premise Validity
+
+**Success in 6 months:** All adapter processes read tokens from `/run/secrets/bot_token`. `bot_secrets` table dropped from `config.db`. `CredentialStore` class + Fernet imports removed from the adapter path. Multi-bot Telegram/Discord configs (>1 bot per platform) verified working end-to-end. `lyra bot secret install` documented in `docs/CONFIGURATION.md`.
+
+**Failure in 6 months (falsifiable):** `grep -rF "CredentialStore" src/lyra/bootstrap/ src/lyra/adapters/` returns matches, OR `sqlite3 ~/.lyra/config.db ".tables"` lists `bot_secrets`. Either signals the migration is incomplete or a backwards-compat fallback was retained.
+
+**Simplest alternative:** Keep the current `CredentialStore` + Fernet keyring + `config.db` credential path unchanged.
+**Why not enough:** The issue is motivated by eliminating exactly the three dependencies that simpler path retains (shared-volume DB read, custom encrypt-at-rest layer, keyring file). Keeping it defeats Phase 3 of #1049 in its entirety.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (credential delivery), no new architecture (Podman secret pattern already used 5× elsewhere in `Makefile:181-200`).
+
+Signals:
+- ~7 files touched (Makefile, 2 Quadlet `.container` files, `adapter_standalone.py`, `cli_bot.py`, schema/migration, docs)
+- New library/pattern? **No** — Podman secrets pattern proven for nkeys, NATS auth, gh-pem, claude-oauth
+- Architectural impact: deletes a layer (`CredentialStore`) rather than adding one
+- Unknowns: 1 (webhook_secret packing — single secret with JSON vs. separate secret)
+- Domain breadth: deploy + bootstrap + CLI + infrastructure + docs, but unified under one concern (credential delivery)
+- Security-sensitive ⇒ frame → spec → plan gates de-risk the migration and force the one-shot vs. dual-write decision before code is written

--- a/artifacts/frames/1063-roxabi-blobs-package-frame.mdx
+++ b/artifacts/frames/1063-roxabi-blobs-package-frame.mdx
@@ -1,0 +1,57 @@
+---
+title: "Frame: #1063 — roxabi-blobs package (V1 BlobStore)"
+issue: 1063
+status: approved
+tier: F-lite
+date: 2026-05-21
+---
+
+## Problem
+
+V1 slice of epic [#1061](https://github.com/Roxabi/lyra/issues/1061) (BlobStore for large binary payloads). Today, audio bytes ride inline through NATS as `audio_b64` / `audio_bytes` on `SttRequest`, `TtsResponse`, `AudioPayload` — fragile (50 MB JetStream ceiling, base64 overhead, hub memory spikes, no dedup). [ADR-067](../../docs/architecture/adr/067-blobstore-abstraction-flat-fs-content-addressed.mdx) (accepted) locks in a content-addressed flat-FS + SQLite store behind a `BlobStore` Protocol.
+
+This issue ships **only the package** — the foundation that V2 (contracts), V3/V4 (adapters), V5 (workers), V6 (ops) build on. No consumer changes here.
+
+## Who
+
+- **Primary:** lyra hub/adapters/workers — future consumers of `BlobStore.put/get/exists`
+- **Secondary:** ML/debug operator (Mickael) — queries SQLite directly (`sqlite3 index.sqlite`) for training-data extraction
+- **Tertiary:** voiceCLI STT/TTS workers — cross-repo consumer in V5
+
+## Constraints
+
+- **ADR-067 binding** — flat-FS, SQLite split schema, sha256 dedup, fsync ordering, no inline-threshold, GC interface present but retain-all policy
+- **uv workspace member** — joins `packages/roxabi-nats`, `packages/roxabi-contracts`
+- **Async API** — `put` / `get` / `exists` are coroutines (consumers are asyncio)
+- **Single writer per instance** — SQLite WAL; readers bypass SQLite (raw FS read by `store_key`)
+- **No consumer changes in this slice** — package only; contracts/adapters/workers are V2+
+- **`BlobRef` envelope defined in `roxabi-contracts`** — but its delivery is V2 (#1064); V1 may inline the Pydantic model or import from a stub
+
+## Out of Scope
+
+- `BlobRef` field on contract models (V2 / #1064)
+- Telegram / Discord adapter ingest (V3/V4 / #1065/#1066)
+- voiceCLI STT/TTS worker rewire (V5 / #1067 + voiceCLI repo)
+- Quadlet bind-mount, alerts, reconciler, backup runbook (V6 / #1068)
+- Cross-host transport (FS → MinIO/S3 swap deferred)
+- Active GC / TTL enforcement (interface designed; v1 retain-all)
+- Encryption at rest, access control, signed URLs
+
+## Premise Validity
+
+**Success in 6 months:** `packages/roxabi-blobs` shipped as uv workspace member with `BlobStore` Protocol (`put` / `get` / `exists` + `delete` designed) + Flat-FS + SQLite impl + ≥90% public-API unit-test coverage. Importable cleanly from lyra + voiceCLI. Unblocks V2–V6.
+
+**Failure in 6 months:** After 3 release cycles from V1 merge, EITHER package still not imported by any consumer (V2 contracts blocked), OR public-API unit-test coverage <90%, OR SHA-256 dedup ratio <1.5× on synthetic round-trip test (put same blob 5×, observe 1 file + 5 `blob_refs` rows + 1 `blobs` row).
+
+**Simplest alternative:** Keep `audio_b64` inline; bump NATS `max_payload` to 200 MB; no package, no dedup.
+**Why not simplest:** Per ADR-067 Option A rejection — JetStream archive grows unbounded on shared `store_dir`, hub memory spikes per audio exchange, no cross-blob dedup, ML/debug can't query archive without a NATS client. Doesn't address the scope-expanded epic (TG/Discord attachment archive).
+
+## Complexity
+
+**Tier: F-lite** — single domain (package internals), clear scope (3-method Protocol + FS+SQLite impl), no architecture unknowns (ADR-067 binding).
+
+Signals observed:
+- Single domain — `packages/roxabi-blobs/` only; no cross-package call-sites in V1
+- New package but established pattern — mirrors `roxabi-nats` / `roxabi-contracts` workspace shape
+- No unknowns — all 4 brainstorm Open Questions resolved at spec/ADR level
+- Issue label `size:F-lite` confirms classification

--- a/artifacts/plans/1057-bot-token-podman-secrets-plan.mdx
+++ b/artifacts/plans/1057-bot-token-podman-secrets-plan.mdx
@@ -1,0 +1,684 @@
+---
+title: "Plan: bot_secrets table → per-bot Podman secrets"
+issue: 1057
+spec: artifacts/specs/1057-bot-token-podman-secrets-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-05-21
+---
+
+## Summary
+
+Migrate bot tokens from the Fernet-encrypted `bot_secrets` table in `~/.lyra/config.db` to per-bot Podman secrets mounted at `/run/secrets/bot_token-<bot_id>` (and `/run/secrets/bot_webhook-<bot_id>` when set). After the cutover, `CredentialStore`, `LyraKeyring`, and the `config.db` mount on adapter containers are all deleted — the file `src/lyra/infrastructure/stores/credential_store.py` is removed entirely (all 5 `LyraKeyring.load_or_create` call sites are bot-token-related).
+
+3 slices, sequential by construction: slice 1 (CLI + Quadlet plumbing) is additive; slice 2 (migrate one-shot) is additive; slice 3 (cutover) is destructive and must come last.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph operator [Operator host]
+        toml[config.toml<br/>telegram.bots, discord.bots]
+        ktok[Token stdin/env]
+    end
+
+    subgraph cli [src/lyra/cli_bot.py]
+        bs_install[secret install]
+        bs_rm[secret rm]
+        bs_list[secret list]
+        bs_migrate[secret migrate]
+    end
+
+    subgraph podman [Podman secret store]
+        ps_tok[(lyra-bot-{p}-{id})]
+        ps_wh[(lyra-bot-{p}-{id}-webhook)]
+    end
+
+    subgraph quadlet [deploy/quadlet/]
+        qd_tg[lyra-telegram.container<br/>N Secret= lines]
+        qd_dc[lyra-discord.container<br/>N Secret= lines]
+        mk[Makefile<br/>quadlet-bot-secrets-render]
+    end
+
+    subgraph adapter [bootstrap/standalone/adapter_standalone.py]
+        ad_boot[Read /run/secrets/bot_token-id]
+        ad_run[TelegramAdapter / DiscordAdapter]
+    end
+
+    ktok --> bs_install --> ps_tok
+    ktok --> bs_install --> ps_wh
+    legacy_db[(legacy bot_secrets table)] -.->|migrate one-shot| bs_migrate --> ps_tok
+    bs_list --> ps_tok
+    mk -->|reads| ps_tok -->|emits Secret= lines| qd_tg
+    mk --> ps_tok --> qd_dc
+    qd_tg -->|mount| ad_boot
+    qd_dc -->|mount| ad_boot
+    ad_boot --> ad_run
+
+    style legacy_db stroke-dasharray: 5 5
+    style ps_tok fill:#c8e6c9
+    style ps_wh fill:#c8e6c9
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph cli_bot["src/lyra/cli_bot.py"]
+        f_secret[secret_app: Typer]
+        f_install[install()]
+        f_rm[rm()]
+        f_list[list_()]
+        f_migrate[migrate()]
+    end
+
+    subgraph adapter_std["src/lyra/bootstrap/standalone/adapter_standalone.py"]
+        f_load[_load_bot_token(platform, bot_id)<br/>NEW helper]
+        f_bs[_bootstrap_adapter_standalone()]
+    end
+
+    subgraph bs_stores["src/lyra/bootstrap/bootstrap_stores.py"]
+        f_unified[_open_unified_stores()<br/>cred_store block REMOVED]
+    end
+
+    subgraph cli_setup_f["src/lyra/cli_setup.py"]
+        f_setup[setup_telegram()<br/>cred_store param REMOVED]
+    end
+
+    subgraph deleted_f["DELETED in slice 3"]
+        f_credstore[CredentialStore<br/>LyraKeyring<br/>BotSecretRow]
+    end
+
+    subgraph tests_f["tests/"]
+        t_new[tests/cli/test_bot_secret.py<br/>NEW]
+        t_boot_cr[tests/test_bootstrap_credential_resolution.py<br/>REWRITTEN]
+        t_boot_mc[tests/test_bootstrap_missing_credentials.py<br/>REWRITTEN]
+        t_credstore[tests/core/test_credential_store.py<br/>DELETED]
+        t_bot_cmd[tests/cli/test_bot_commands.py<br/>UPDATED]
+    end
+
+    f_install --> ps_call["podman secret create --replace"]
+    f_migrate --> ps_call
+    f_load --> fs_read["/run/secrets/ read"]
+    f_bs --> f_load
+    t_new -.tests.-> f_install
+    t_boot_cr -.tests.-> f_load
+```
+
+## Agents
+
+| Agent | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T2, T3, T5, T6, T8, T9, T10, T11 | `src/lyra/cli_bot.py`, `src/lyra/cli_setup.py`, `src/lyra/bootstrap/standalone/adapter_standalone.py`, `src/lyra/bootstrap/bootstrap_stores.py`, `src/lyra/infrastructure/stores/credential_store.py` (delete), `src/lyra/infrastructure/stores/__init__.py`, `src/lyra/config.py` |
+| devops-A | T4, T12, T13 | `Makefile`, `deploy/quadlet/lyra-telegram.container`, `deploy/quadlet/lyra-discord.container` |
+| doc-writer-A | T14, T15 | `docs/CONFIGURATION.md`, `src/lyra/infrastructure/CLAUDE.md` |
+| tester-A | T1, T7, T16, T17, T18 | `tests/cli/test_bot_secret.py` (new), `tests/test_bootstrap_credential_resolution.py`, `tests/test_bootstrap_missing_credentials.py`, `tests/core/test_credential_store.py` (delete), `tests/cli/test_bot_commands.py` |
+
+## Wave Structure
+
+3 waves, max 3 parallel agents. Elapsed ~1.5d vs ~3d sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 (slice 1) | start | 3 ∥ | tester-A: T1 RED → T7 GATE · backend-dev-A: T2→T3 · devops-A: T4 |
+| 2 (slice 2) | wave 1 done | 2 ∥ | tester-A: T5 RED · backend-dev-A: T6 GREEN; then tester-A: T7-already-done (gate is wave-end) — actually slice 2 has its own gate, see below |
+| 3 (slice 3 cutover) | wave 2 done | 4 ∥ | tester-A: T8 RED → T16 RED-GATE · backend-dev-A: T9→T10→T11 · devops-A: T12→T13 · doc-writer-A: T14→T15 |
+
+Corrected wave table (slice-aligned):
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | tester-A, backend-dev-A, devops-A ∥ | tester-A: **T1** (RED) · backend-dev-A: **T2** (GREEN) · devops-A: **T4** (GREEN). Then chain on tester-A: **T3** (verify list); then tester-A: **T7** (RED-GATE V1) |
+| 2 | Wave 1 done | tester-A, backend-dev-A ∥ | tester-A: **T5** (RED) → **T17** (RED-GATE V2) · backend-dev-A: **T6** (GREEN migrate) |
+| 3 | Wave 2 done | tester-A, backend-dev-A, devops-A, doc-writer-A ∥ | tester-A: **T8** (RED) → **T16** (RED-GATE V3) · backend-dev-A: **T9**→**T10**→**T11** · devops-A: **T12**→**T13** · doc-writer-A: **T14**→**T15** |
+
+### Budget
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 — RED bot-secret CLI tests | 1 file, 4 commands | judgmental | 8 | — |
+| T2 — GREEN install/rm/list impl | 1 file | bounded | 5 | — |
+| T3 — RED chain to list semantics | 1 file | trivial | 2 | — |
+| T4 — Makefile quadlet-bot-secrets-render | 1 target | bounded | 4 | — |
+| T5 — RED migrate test | 1 file | judgmental | 6 | — |
+| T6 — GREEN migrate impl | 1 file | bounded | 5 | — |
+| T7 — RED-GATE V1 integration | 1 test | bounded | 3 | — |
+| T8 — RED adapter /run/secrets/ test | 2 files | judgmental | 8 | — |
+| T9 — GREEN adapter_standalone.py rewrite | 1 file (2 blocks) | judgmental | 10 | — |
+| T10 — Delete CredentialStore + bootstrap_stores.py + __init__.py | 3 files | bounded | 6 | — |
+| T11 — Clean cli_bot.py/_make_store + cli_setup.py/cred_store param + config.py docstrings | 3 files | judgmental | 8 | — |
+| T12 — Quadlet telegram.container update | 1 file | bounded | 4 | — |
+| T13 — Quadlet discord.container update | 1 file | bounded | 4 | — |
+| T14 — docs/CONFIGURATION.md Bot credentials section | 1 file | judgmental | 6 | — |
+| T15 — src/lyra/infrastructure/CLAUDE.md cleanup (keyring removed) | 1 file | bounded | 3 | — |
+| T16 — RED-GATE V3 multi-bot e2e | 1 test | judgmental | 8 | — |
+| T17 — RED-GATE V2 migrate idempotency | 1 test | bounded | 3 | — |
+| T18 — Delete tests/core/test_credential_store.py + rewrite test_bootstrap_*credentials*.py | 3 files | judgmental | 8 | — |
+
+**Total estimated ops: ~101.** No task > 50 — no split required.
+
+## Consistency Report
+
+| Spec Item | Covered by tasks | Status |
+|---|---|---|
+| CR-1 (no CredentialStore refs) | T10, T11, T16 | ✓ |
+| CR-2 (bot_secrets table dropped) | T10 (drops DDL when deleting class), T16 | ✓ |
+| CR-3 (install creates correct secret) | T1, T2, T7 | ✓ |
+| CR-4 (migrate idempotent) | T5, T6, T17 | ✓ |
+| CR-5 (adapter reads /run/secrets/) | T8, T9, T16 | ✓ |
+| CR-6 (multi-bot config) | T16 | ✓ |
+| CR-7 (LyraKeyring removed) | T10, T11, T15 | ✓ |
+| CR-8 (CONFIGURATION.md content) | T14 | ✓ |
+| U1 install | T1, T2 | ✓ |
+| U2 rm | T1, T2 | ✓ |
+| U3 list | T1, T2, T3 | ✓ |
+| U4 migrate | T5, T6, T17 | ✓ |
+| N1 /run/secrets/ read | T8, T9 | ✓ |
+| N2 Quadlet Secret= lines | T4, T12, T13 | ✓ |
+| S1 drop DDL | T10 | ✓ |
+| S2 delete CredentialStore class | T10 | ✓ |
+| S3 delete LyraKeyring (all consumers bot-token only) | T10 | ✓ |
+| S4 strip config.db mount | T12, T13 | ✓ |
+| Edge: bot_id slug-safe | T1, T2 (validation in install) | ✓ |
+| Edge: missing token at bootstrap | T8 (RED), T9 (raises BootstrapError) | ✓ |
+
+**Covered: 19/19. Untraced: 0. Uncovered: 0.**
+
+## Micro-Tasks
+
+### Slice 1 — CLI + Quadlet plumbing (additive)
+
+#### T1 — RED: failing tests for `lyra bot secret install/rm/list`
+
+- **File:** `tests/cli/test_bot_secret.py` (new)
+- **Snippet:**
+  ```python
+  def test_install_creates_podman_secret(mocker, tmp_path): ...
+  def test_install_rejects_unsafe_bot_id(): ...  # slashes, spaces
+  def test_install_with_webhook_creates_two_secrets(mocker): ...
+  def test_rm_removes_both_token_and_webhook(mocker): ...
+  def test_list_filters_by_lyra_bot_prefix(mocker): ...
+  ```
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py -x`
+- **Expected:** 5 failing tests (commands not yet implemented)
+- **Time:** 8 min
+- **`[P]`:** Y (independent of T2/T4)
+- **Agent:** tester-A
+- **Spec trace:** CR-3, U1, U2, U3, edge: bot_id slug-safe
+- **Slice:** V1
+- **Phase:** RED
+- **Difficulty:** 3
+
+#### T2 — GREEN: implement `secret install/rm/list` in `cli_bot.py`
+
+- **File:** `src/lyra/cli_bot.py`
+- **Snippet:**
+  ```python
+  secret_app = typer.Typer(help="Manage bot credentials as Podman secrets.")
+  bot_app.add_typer(secret_app, name="secret")
+
+  _BOT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+  @secret_app.command("install")
+  def install(
+      platform: str, bot_id: str,
+      from_env: str = typer.Option(None, "--from-env"),
+      webhook_from_env: str = typer.Option(None, "--webhook-from-env"),
+  ) -> None:
+      if not _BOT_ID_RE.match(bot_id):
+          typer.echo(f"bot_id must match {_BOT_ID_RE.pattern}", err=True)
+          raise typer.Exit(2)
+      token = os.environ[from_env] if from_env else getpass.getpass("Token: ")
+      _podman_secret_create(f"lyra-bot-{platform}-{bot_id}", token.encode())
+      if webhook_from_env:
+          _podman_secret_create(f"lyra-bot-{platform}-{bot_id}-webhook", os.environ[webhook_from_env].encode())
+
+  # rm: subprocess.run(["podman", "secret", "rm", ...], check=False)  # webhook absence OK
+  # list_: subprocess.run(["podman", "secret", "ls", "--filter", "name=lyra-bot-", "--format", "json"])
+  ```
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py -x` (after T2)
+- **Expected:** all T1 tests pass
+- **Time:** 15 min
+- **`[P]`:** N (depends on T1 to know shape)
+- **Agent:** backend-dev-A
+- **Spec trace:** U1, U2, U3, CR-3
+- **Slice:** V1
+- **Phase:** GREEN
+- **Difficulty:** 3
+
+#### T3 — Verify list behavior matches install
+
+- **File:** `tests/cli/test_bot_secret.py`
+- **Snippet:** `test_list_returns_what_was_installed(...)` — install 2 secrets via the CLI, then `list` returns both with the `lyra-bot-` prefix
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py::test_list_returns_what_was_installed -x`
+- **Expected:** pass
+- **Time:** 5 min
+- **`[P]`:** N (after T2)
+- **Agent:** tester-A
+- **Spec trace:** U3, CR-3
+- **Slice:** V1
+- **Phase:** REFACTOR
+- **Difficulty:** 2
+
+#### T4 — Makefile target `quadlet-bot-secrets-render`
+
+- **File:** `Makefile`
+- **Snippet:**
+  ```makefile
+  .PHONY: quadlet-bot-secrets-render
+  quadlet-bot-secrets-render:
+  	@bots=$$(podman secret ls --filter name=lyra-bot- --format '{{.Name}}'); \
+  	for s in $$bots; do \
+  	  case "$$s" in \
+  	    lyra-bot-telegram-*-webhook) bot=$${s#lyra-bot-telegram-}; bot=$${bot%-webhook}; target=bot_webhook-$$bot; container=lyra-telegram.container ;; \
+  	    lyra-bot-telegram-*)         bot=$${s#lyra-bot-telegram-}; target=bot_token-$$bot;   container=lyra-telegram.container ;; \
+  	    lyra-bot-discord-*-webhook)  bot=$${s#lyra-bot-discord-};  bot=$${bot%-webhook}; target=bot_webhook-$$bot; container=lyra-discord.container ;; \
+  	    lyra-bot-discord-*)          bot=$${s#lyra-bot-discord-};  target=bot_token-$$bot;   container=lyra-discord.container ;; \
+  	  esac; \
+  	  echo "Secret=$$s,type=mount,target=$$target,mode=0400,uid=1500,gid=1500"; \
+  	done > deploy/quadlet/.bot-secrets.fragment
+  	@echo "Wrote deploy/quadlet/.bot-secrets.fragment — paste into the appropriate .container files."
+  ```
+  (Render-only target — operator pastes manually for slice 1. Slice 3 wires the paste step.)
+- **Verify:** `make quadlet-bot-secrets-render` after installing one secret per platform
+- **Expected:** `.bot-secrets.fragment` lists both lines
+- **Time:** 10 min
+- **`[P]`:** Y (independent of T1-T3)
+- **Agent:** devops-A
+- **Spec trace:** N2
+- **Slice:** V1
+- **Phase:** GREEN
+- **Difficulty:** 3
+
+#### T7 — RED-GATE V1: end-to-end CLI install + render
+
+- **File:** `tests/cli/test_bot_secret.py::test_e2e_install_then_list_then_render`
+- **Snippet:** integration test that mocks Podman → install creates secret → list shows it → render emits the right Secret= fragment
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py::test_e2e_install_then_list_then_render -x`
+- **Expected:** pass
+- **Time:** 8 min
+- **`[P]`:** N (after T2, T4)
+- **Agent:** tester-A
+- **Spec trace:** Slice V1 acceptance
+- **Slice:** V1
+- **Phase:** RED-GATE
+- **Difficulty:** 3
+
+### Slice 2 — Migration command
+
+#### T5 — RED: failing test for `lyra bot secret migrate`
+
+- **File:** `tests/cli/test_bot_secret.py`
+- **Snippet:**
+  ```python
+  def test_migrate_copies_all_bot_secrets_rows(mocker, tmp_path):
+      # set up a tmp config.db with 2 rows + Fernet keyring
+      # invoke migrate → assert podman secret create called per row
+  def test_migrate_handles_null_webhook(mocker, tmp_path): ...
+  def test_migrate_exits_zero_on_idempotent_rerun(mocker, tmp_path): ...
+  ```
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py -k migrate -x`
+- **Expected:** 3 failing tests
+- **Time:** 10 min
+- **`[P]`:** Y (independent of T6)
+- **Agent:** tester-A
+- **Spec trace:** U4, CR-4
+- **Slice:** V2
+- **Phase:** RED
+- **Difficulty:** 3
+
+#### T6 — GREEN: implement `secret migrate` in `cli_bot.py`
+
+- **File:** `src/lyra/cli_bot.py`
+- **Snippet:**
+  ```python
+  @secret_app.command("migrate")
+  def migrate(vault: Path = typer.Option(Path.home() / ".lyra")) -> None:
+      keyring = LyraKeyring.load_or_create(vault / "keyring.key")  # still imported during slice 2; removed in slice 3
+      store = CredentialStore(db_path=vault / "config.db", keyring=keyring)
+      asyncio.run(_migrate(store))
+
+  async def _migrate(store: CredentialStore) -> None:
+      await store.connect()
+      try:
+          tokens = 0; webhooks = 0
+          for row in await store.list_all():
+              tok = await store.get(row.platform, row.bot_id)
+              _podman_secret_create(f"lyra-bot-{row.platform}-{row.bot_id}", tok.encode())
+              tokens += 1
+              if row.encrypted_webhook_secret:
+                  full = await store.get_full(row.platform, row.bot_id)
+                  _podman_secret_create(f"lyra-bot-{row.platform}-{row.bot_id}-webhook", full[1].encode())
+                  webhooks += 1
+              typer.echo(f"{row.platform} {row.bot_id} OK OK" if row.encrypted_webhook_secret else f"{row.platform} {row.bot_id} OK -")
+          typer.echo(f"Migrated {tokens} tokens, {webhooks} webhook secrets; safe to drop bot_secrets table.")
+      finally:
+          await store.close()
+  ```
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py -k migrate -x`
+- **Expected:** all migrate tests pass
+- **Time:** 12 min
+- **`[P]`:** N (after T5)
+- **Agent:** backend-dev-A
+- **Spec trace:** U4, CR-4
+- **Slice:** V2
+- **Phase:** GREEN
+- **Difficulty:** 3
+
+#### T17 — RED-GATE V2: migrate is idempotent
+
+- **File:** `tests/cli/test_bot_secret.py::test_migrate_idempotency_summary_matches`
+- **Snippet:** run migrate twice; both runs print the same `Migrated N tokens, M webhook secrets` summary; both exit 0
+- **Verify:** `uv run pytest tests/cli/test_bot_secret.py::test_migrate_idempotency_summary_matches -x`
+- **Expected:** pass
+- **Time:** 5 min
+- **`[P]`:** N (after T6)
+- **Agent:** tester-A
+- **Spec trace:** CR-4
+- **Slice:** V2
+- **Phase:** RED-GATE
+- **Difficulty:** 2
+
+### Slice 3 — Adapter cutover + cleanup
+
+#### T8 — RED: tests for adapter reading from `/run/secrets/`
+
+- **File:** `tests/test_bootstrap_credential_resolution.py`, `tests/test_bootstrap_missing_credentials.py`
+- **Snippet:**
+  ```python
+  # test_bootstrap_credential_resolution.py — REWRITE:
+  def test_adapter_reads_token_from_run_secrets(tmp_path, monkeypatch):
+      run_secrets = tmp_path / "run-secrets"; run_secrets.mkdir()
+      (run_secrets / "bot_token-mybot").write_text("ABC123")
+      monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(run_secrets))  # test-only override
+      # bootstrap → assert token "ABC123" passed to TelegramAdapter
+  def test_adapter_reads_webhook_when_present(...): ...
+
+  # test_bootstrap_missing_credentials.py — REWRITE:
+  def test_adapter_raises_when_token_file_missing(tmp_path, monkeypatch):
+      # bootstrap with no /run/secrets/bot_token-* → BootstrapError naming the expected path
+  ```
+- **Verify:** `uv run pytest tests/test_bootstrap_credential_resolution.py tests/test_bootstrap_missing_credentials.py -x`
+- **Expected:** failing (adapter still reads from CredentialStore)
+- **Time:** 15 min
+- **`[P]`:** Y (independent of T9)
+- **Agent:** tester-A
+- **Spec trace:** N1, CR-5, edge: missing token
+- **Slice:** V3
+- **Phase:** RED
+- **Difficulty:** 4
+
+#### T9 — GREEN: rewrite `adapter_standalone.py` to read from `/run/secrets/`
+
+- **File:** `src/lyra/bootstrap/standalone/adapter_standalone.py`
+- **Snippet:**
+  ```python
+  # New helper near top of file:
+  def _load_bot_token(platform: str, bot_id: str) -> tuple[str, str | None]:
+      base = Path(os.environ.get("LYRA_RUN_SECRETS_DIR", "/run/secrets"))
+      tok_path = base / f"bot_token-{bot_id}"
+      if not tok_path.exists():
+          raise BootstrapError(
+              f"missing bot token: {tok_path} (provision via `lyra bot secret install {platform} {bot_id}`)"
+          )
+      token = tok_path.read_text().strip()
+      wh_path = base / f"bot_webhook-{bot_id}"
+      webhook = wh_path.read_text().strip() if wh_path.exists() else None
+      return (token, webhook)
+
+  # Replace lines 72-93 (telegram block) AND 175-197 (discord block):
+  # OLD:
+  #   keyring = LyraKeyring.load_or_create(vault_dir / "keyring.key")
+  #   cred_store = CredentialStore(db_path=vault_dir / "config.db", keyring=keyring)
+  #   await cred_store.connect()
+  #   try: ... cred_store.get_full(...) ...; finally: await cred_store.close()
+  # NEW (per bot):
+  #   for bot_cfg in <platform>_multi_cfg.bots:
+  #       tg_creds[bot_cfg.bot_id] = _load_bot_token("<platform>", bot_cfg.bot_id)
+  #       log.info("read token from /run/secrets/bot_token-%s", bot_cfg.bot_id)
+  # Remove the `from lyra.infrastructure.stores.credential_store import` line.
+  ```
+- **Verify:** `uv run pytest tests/test_bootstrap_credential_resolution.py tests/test_bootstrap_missing_credentials.py -x`
+- **Expected:** T8 tests pass; no CredentialStore import remains in this file
+- **Time:** 15 min
+- **`[P]`:** N (after T8)
+- **Agent:** backend-dev-A
+- **Spec trace:** N1, CR-5
+- **Slice:** V3
+- **Phase:** GREEN
+- **Difficulty:** 4
+
+#### T10 — Delete `CredentialStore` class file + remove from exports + `bootstrap_stores.py` cred_store block
+
+- **Files:**
+  - `src/lyra/infrastructure/stores/credential_store.py` — DELETE
+  - `src/lyra/infrastructure/stores/__init__.py` — remove `CredentialStore`, `LyraKeyring`, `BotSecretRow` from imports + `__all__`
+  - `src/lyra/bootstrap/bootstrap_stores.py:23,260-269` — remove import + cred_store loading block + close in teardown
+- **Snippet:**
+  ```python
+  # bootstrap_stores.py: delete the 5-line block at L260-269 and remove cred_store from the returned tuple.
+  # __init__.py: drop 3 names from imports and __all__.
+  ```
+- **Verify:**
+  - `test ! -f src/lyra/infrastructure/stores/credential_store.py`
+  - `! grep -F "CredentialStore" src/lyra/infrastructure/stores/__init__.py src/lyra/bootstrap/bootstrap_stores.py`
+- **Expected:** file gone; 0 grep matches
+- **Time:** 10 min
+- **`[P]`:** N (after T9)
+- **Agent:** backend-dev-A
+- **Spec trace:** CR-1, CR-2, S1, S2, S3
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 3
+
+#### T11 — Clean remaining CredentialStore consumers + docstrings
+
+- **Files:**
+  - `src/lyra/cli_bot.py` — remove `_make_store`, the top-level imports, and update `migrate` (T6) to read from the now-deleted CredentialStore. Migrate command becomes a no-op stub that prints "migrate already completed; this command is a no-op post-slice 3" (or is deleted entirely — see DP point in spec edge cases). Recommended: DELETE the `migrate` subcommand since slice 3 follows slice 2 by definition.
+  - `src/lyra/cli_setup.py` — remove `cred_store` parameter + CredentialStore/LyraKeyring imports; replace L101 `creds = await cred_store.get_full(...)` with `creds = _load_bot_token("telegram", bot_id)` (use helper from T9 or inline it).
+  - `src/lyra/config.py` — update 5 docstring lines that mention `CredentialStore` to reference `/run/secrets/bot_token-<bot_id>` instead.
+- **Verify:** `grep -rF "CredentialStore" src/lyra/ | grep -v "git\|__pycache__" | wc -l` → 0
+- **Expected:** 0 matches
+- **Time:** 15 min
+- **`[P]`:** N (after T10)
+- **Agent:** backend-dev-A
+- **Spec trace:** CR-1, CR-7
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 3
+
+#### T12 — Update `deploy/quadlet/lyra-telegram.container`
+
+- **File:** `deploy/quadlet/lyra-telegram.container`
+- **Snippet:**
+  - Add per-bot Secret= lines (one or two per bot, generated by T4):
+    ```
+    Secret=lyra-bot-telegram-mybot,type=mount,target=bot_token-mybot,mode=0400,uid=1500,gid=1500
+    # Optional webhook:
+    # Secret=lyra-bot-telegram-mybot-webhook,type=mount,target=bot_webhook-mybot,mode=0400,uid=1500,gid=1500
+    ```
+  - Remove the `~/.lyra/config.db` Volume= line if exclusive to credentials (verify no other store reads it from adapter — agent_store + prefs_store are owned by hub, not adapter).
+- **Verify:** `quadlet-lint` (existing CI target from #1083); container starts on M₂ smoke
+- **Expected:** lint passes; container boots
+- **Time:** 8 min
+- **`[P]`:** Y with T13
+- **Agent:** devops-A
+- **Spec trace:** N2, S4
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 2
+
+#### T13 — Update `deploy/quadlet/lyra-discord.container`
+
+- **File:** `deploy/quadlet/lyra-discord.container`
+- **Snippet:** mirror of T12 for Discord.
+- **Verify:** `quadlet-lint`
+- **Expected:** lint passes
+- **Time:** 5 min
+- **`[P]`:** Y with T12
+- **Agent:** devops-A
+- **Spec trace:** N2, S4
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 2
+
+#### T14 — `docs/CONFIGURATION.md` Bot credentials section
+
+- **File:** `docs/CONFIGURATION.md`
+- **Snippet:**
+  ```markdown
+  ## Bot credentials
+
+  Bot tokens and webhook secrets are stored as **Podman secrets**, not in `config.db`.
+
+  | Command | Purpose |
+  |---|---|
+  | `lyra bot secret install <platform> <bot_id> [--from-env VAR] [--webhook-from-env VAR]` | Create or replace a bot's token (and webhook secret) |
+  | `lyra bot secret rm <platform> <bot_id>` | Remove the token + webhook secret |
+  | `lyra bot secret list` | List provisioned bot secrets |
+
+  ### Quadlet wiring (one Secret= line per bot, plus an optional webhook line):
+
+  ```
+  Secret=lyra-bot-telegram-mybot,type=mount,target=bot_token-mybot,mode=0400,uid=1500,gid=1500
+  Secret=lyra-bot-telegram-mybot-webhook,type=mount,target=bot_webhook-mybot,mode=0400,uid=1500,gid=1500
+  ```
+
+  Generate the fragment via `make quadlet-bot-secrets-render`.
+
+  ### Rationale: webhook_secret packing: separate secret
+
+  Token and webhook secret are two distinct Podman secrets (not packed into a single JSON secret). Matches the project's raw-bytes single-purpose convention and avoids a JSON parser in the bootstrap path.
+  ```
+- **Verify:**
+  - `grep -F "## Bot credentials" docs/CONFIGURATION.md`
+  - `grep -F "Secret=lyra-bot-" docs/CONFIGURATION.md`
+  - `grep -F "webhook_secret packing: separate secret" docs/CONFIGURATION.md`
+- **Expected:** all 3 grep matches
+- **Time:** 12 min
+- **`[P]`:** Y with T15
+- **Agent:** doc-writer-A
+- **Spec trace:** CR-8
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 2
+
+#### T15 — `src/lyra/infrastructure/CLAUDE.md` cleanup
+
+- **File:** `src/lyra/infrastructure/CLAUDE.md`
+- **Snippet:** Since `LyraKeyring` is deleted entirely, no scope note is needed. Update the file to remove any stale reference to `credential_store.py` or `bot_secrets` if present.
+- **Verify:** `! grep -F "credential_store" src/lyra/infrastructure/CLAUDE.md && ! grep -F "bot_secrets" src/lyra/infrastructure/CLAUDE.md`
+- **Expected:** 0 matches
+- **Time:** 5 min
+- **`[P]`:** Y with T14
+- **Agent:** doc-writer-A
+- **Spec trace:** CR-7
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 1
+
+#### T18 — Delete `tests/core/test_credential_store.py` + cleanup orphan tests
+
+- **Files:**
+  - `tests/core/test_credential_store.py` — DELETE
+  - `tests/cli/test_bot_commands.py` — remove any tests that exercise `CredentialStore` directly; replace with calls through the new CLI surface (`lyra bot secret install/list`)
+- **Verify:**
+  - `test ! -f tests/core/test_credential_store.py`
+  - `! grep -F "CredentialStore" tests/cli/test_bot_commands.py`
+- **Expected:** file gone; 0 grep matches
+- **Time:** 10 min
+- **`[P]`:** N (after T10, T11)
+- **Agent:** tester-A
+- **Spec trace:** CR-1
+- **Slice:** V3
+- **Phase:** REFACTOR
+- **Difficulty:** 2
+
+#### T16 — RED-GATE V3: multi-bot end-to-end
+
+- **File:** new integration test `tests/integration/test_adapter_run_secrets_e2e.py` (or extend existing)
+- **Snippet:**
+  ```python
+  def test_multi_bot_telegram_reads_distinct_secrets(tmp_path, monkeypatch):
+      run_secrets = tmp_path / "run"; run_secrets.mkdir()
+      (run_secrets / "bot_token-bot1").write_text("TOK1")
+      (run_secrets / "bot_token-bot2").write_text("TOK2")
+      monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(run_secrets))
+      # config.toml with 2 telegram bots → bootstrap → assert each adapter wires its own token
+  def test_no_config_db_open_for_credentials(...):  # smoke: strace replacement via grep of bootstrap code
+      assert "config.db" not in (Path("src/lyra/bootstrap/standalone/adapter_standalone.py")).read_text() \
+          or "bot" not in <...>  # boundary check
+  ```
+- **Verify:** `uv run pytest tests/integration/test_adapter_run_secrets_e2e.py -x`
+- **Expected:** pass; both `read token from /run/secrets/bot_token-bot1` and `bot2` log lines emitted
+- **Time:** 15 min
+- **`[P]`:** N (after T9, T11)
+- **Agent:** tester-A
+- **Spec trace:** CR-5, CR-6
+- **Slice:** V3
+- **Phase:** RED-GATE
+- **Difficulty:** 4
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs). -->
+
+### Wave 1 — no deps, 3 agents ∥ (slice 1)
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | tester-A | — | RED bot-secret CLI tests (install/rm/list) |
+| T2 | backend-dev-A | T1 | GREEN bot-secret install/rm/list impl in cli_bot.py |
+| T3 | tester-A | T2 | Verify list returns installed secrets |
+| T4 | devops-A | — | Makefile quadlet-bot-secrets-render target |
+| T7 | tester-A | T2, T4 | RED-GATE V1: e2e install + list + render |
+
+### Wave 2 — after Wave 1, 2 agents ∥ (slice 2)
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T5 | tester-A | T7 | RED migrate test (rows → secrets, null webhook, idempotent) |
+| T6 | backend-dev-A | T5 | GREEN migrate impl in cli_bot.py |
+| T17 | tester-A | T6 | RED-GATE V2: migrate idempotency summary |
+
+### Wave 3 — after Wave 2, 4 agents ∥ (slice 3 cutover)
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T8 | tester-A | T17 | RED adapter /run/secrets/ tests (token, webhook, missing-file) |
+| T9 | backend-dev-A | T8 | GREEN adapter_standalone.py rewrite (both telegram+discord blocks) |
+| T10 | backend-dev-A | T9 | DELETE credential_store.py + remove from __init__.py + bootstrap_stores.py cred_store block |
+| T11 | backend-dev-A | T10 | Clean cli_bot.py/_make_store + cli_setup.py/cred_store param + config.py docstrings |
+| T12 | devops-A | T9 | Update lyra-telegram.container (add Secret= lines, strip config.db) |
+| T13 | devops-A | T12 | Update lyra-discord.container (mirror) |
+| T14 | doc-writer-A | T11 | docs/CONFIGURATION.md ## Bot credentials section |
+| T15 | doc-writer-A | T14 | src/lyra/infrastructure/CLAUDE.md cleanup |
+| T18 | tester-A | T10, T11 | DELETE tests/core/test_credential_store.py + cleanup test_bot_commands.py |
+| T16 | tester-A | T11, T12, T13, T18 | RED-GATE V3: multi-bot e2e + no config.db read for credentials |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+
+- T1: 13 — RED bot-secret CLI tests
+- T2: 14 — GREEN install/rm/list impl
+- T3: 15 — list semantics test
+- T4: 16 — Makefile quadlet-bot-secrets-render
+- T5: 17 — RED migrate tests
+- T6: 18 — GREEN migrate impl
+- T7: 19 — RED-GATE V1
+- T8: 20 — RED adapter /run/secrets/ tests
+- T9: 21 — GREEN adapter_standalone.py rewrite
+- T10: 22 — DELETE credential_store.py + bootstrap_stores.py cred_store block
+- T11: 23 — Clean cli_bot/cli_setup/config docstrings
+- T12: 24 — Update lyra-telegram.container
+- T13: 25 — Update lyra-discord.container
+- T14: 26 — docs/CONFIGURATION.md Bot credentials section
+- T15: 27 — src/lyra/infrastructure/CLAUDE.md cleanup
+- T16: 28 — RED-GATE V3 multi-bot e2e
+- T17: 29 — RED-GATE V2 migrate idempotency
+- T18: 30 — Delete tests/core/test_credential_store.py

--- a/artifacts/plans/1063-roxabi-blobs-package-plan.mdx
+++ b/artifacts/plans/1063-roxabi-blobs-package-plan.mdx
@@ -1,0 +1,376 @@
+---
+title: "Plan: #1063 — roxabi-blobs package (V1 BlobStore)"
+issue: 1063
+spec: artifacts/specs/1063-roxabi-blobs-package-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-05-21
+---
+
+## Summary
+
+Ship `packages/roxabi-blobs/` as a uv workspace member exposing a `BlobStore` Protocol + `FsBlobStore` impl (Flat-FS + SQLite, content-addressed, async). 15 micro-tasks + 3 RED-GATE sentinels across 4 waves; backend-dev + tester + devops single-instance.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    Caller["Consumer (test / V2+ caller)"]
+    Caller -->|"put(data, ...)"| Lock["asyncio.Lock"]
+    Lock --> Hash["sha256(data)"]
+    Hash --> CheckS1[("SELECT blobs WHERE content_hash=?")]
+    CheckS1 -->|hit| RefOnly["INSERT blob_refs"]
+    CheckS1 -->|miss| WriteFS["write <root>/<sha[:2]>/<sha>"]
+    WriteFS --> FsyncFile["fsync(file)"]
+    FsyncFile --> FsyncDir["fsync(shard dir)"]
+    FsyncDir --> InsertBlobs[("INSERT blobs")]
+    InsertBlobs --> RefOnly
+    RefOnly --> ReturnRef["return BlobRef"]
+
+    Caller -->|"get(store_key)"| ReadFS["open + read FS path"]
+    ReadFS --> ReturnBytes["return bytes"]
+
+    Caller -->|"exists(content_hash)"| ExistsQ[("SELECT blob_refs ORDER BY ingested_at DESC LIMIT 1")]
+    ExistsQ -->|hit| BuildRef["build BlobRef"]
+    ExistsQ -->|miss| None["return None"]
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph pkg ["packages/roxabi-blobs/src/roxabi_blobs/"]
+        Init["__init__.py — public exports"]
+        Protocol["protocol.py — BlobStore Protocol"]
+        Models["models.py — BlobRef Pydantic"]
+        Errors["errors.py — BlobNotFoundError / BlobWriteError"]
+        Schema["schema.py — SQLite DDL + index"]
+        FsStore["fs_store.py — FsBlobStore impl"]
+    end
+    subgraph tests ["packages/roxabi-blobs/tests/"]
+        TProto["test_protocol.py"]
+        TFs["test_fs_store.py"]
+        TDedup["test_dedup.py"]
+        TCrash["test_crash_injection.py"]
+        TConc["test_concurrent.py"]
+        TDelete["test_delete.py"]
+    end
+    Init --> Protocol & Models & Errors & FsStore
+    FsStore --> Schema & Models & Errors & Protocol
+    TProto --> Protocol & Models & Errors
+    TFs & TDedup & TCrash & TConc & TDelete --> FsStore
+```
+
+## Agents
+
+| Agent | Tasks | Files |
+|---|---|---|
+| backend-dev | 10 | `src/roxabi_blobs/*.py`, `pyproject.toml`, `README.md`, `CLAUDE.md` |
+| tester | 6 | `tests/*.py` |
+| devops | 1 | root `pyproject.toml` workspace registration |
+
+## Wave Structure
+
+4 waves, max 2 parallel agents. Elapsed ~3 days vs ~5 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 2 ∥ | devops: T1 · backend-dev: T2 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev: T3 · tester: T4 → RED-GATE-V1a (T5) |
+| 3 | Wave 2 + RED-GATE-V1a green | 1 sequential | backend-dev: T6 → T7 → T8 → T9 → T10 → T11 → RED-GATE-V1b (T12) |
+| 4 | Wave 3 + RED-GATE-V1b green | 1 agent ∥ tasks | tester: T13 [P] T14 [P] T15 [P] T16 [P] T17 → RED-GATE-V1c (T18) |
+
+### Budget
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 workspace register | 1 file edit | bounded | 3 | — |
+| T2 package scaffold | 4 files | bounded | 4 | — |
+| T3 types layer | 3 files | judgmental | 5 | — |
+| T4 test_protocol | 1 file | bounded | 3 | — |
+| T6 schema | 1 file | bounded | 3 | — |
+| T7 fs_store skeleton | 1 file | bounded | 3 | — |
+| T8 put impl | 1 file edit | judgmental | 6 | — |
+| T9 get impl | 1 file edit | trivial | 2 | — |
+| T10 exists impl | 1 file edit | bounded | 3 | — |
+| T11 delete impl | 1 file edit | judgmental | 5 | — |
+| T13 test_fs_store | 1 file | judgmental | 5 | — |
+| T14 test_dedup | 1 file | bounded | 3 | — |
+| T15 test_crash_injection | 1 file | judgmental | 6 | — |
+| T16 test_concurrent | 1 file | judgmental | 5 | — |
+| T17 test_delete | 1 file | bounded | 3 | — |
+
+**Total estimated ops: ~63** — no force-split required.
+
+## Consistency Report
+
+- **Spec criteria covered:** 8/8 (every `- [ ]` from spec §Success Criteria mapped to ≥1 task)
+- **Spec affordances covered:** N1, N2, N3, N4, N5, S1, S2, S3 — all touched
+- **Untraced tasks:** 0
+- **Exemptions:** none
+
+| Spec SC# | Task(s) |
+|---|---|
+| SC#1 workspace + imports | T1, T2, RED-GATE-V1a (T5) |
+| SC#2 Protocol + impl 4 methods | T3, T7–T11 |
+| SC#3 WAL + schema | T6, T7 |
+| SC#4 sha256 dedup 5× | T8, T14 |
+| SC#5 write order fsync(file)+fsync(dir) | T8, T15 |
+| SC#6 asyncio.Lock concurrent | T7, T16 |
+| SC#7 get + BlobNotFoundError | T9, T13 |
+| SC#8 exists ORDER BY latest | T10, T13 |
+| SC#9 delete signature + tested + not called | T11, T17 |
+| SC#10 ≥90% coverage incl. delete | RED-GATE-V1c (T18) |
+| SC#11 no file >300 LOC | enforced by quality_gates at /validate |
+
+## Micro-Tasks
+
+### V1a — Package skeleton
+
+#### T1 — Register workspace member · devops · [P]
+- **File:** `pyproject.toml` (root)
+- **Snippet:**
+  ```toml
+  [tool.uv.workspace]
+  members = ["packages/roxabi-nats", "packages/roxabi-contracts", "packages/roxabi-blobs"]
+
+  [tool.uv.sources]
+  roxabi-blobs = { workspace = true }
+  ```
+  Plus add `"packages/roxabi-blobs/tests"` to `[tool.pytest.ini_options].testpaths`.
+- **Verify:** `uv sync 2>&1 | grep -i "roxabi-blobs"`
+- **Expected:** package recognized as workspace member (no error)
+- **Est:** 2 min · **Diff:** 1 · **Slice:** V1a · **Phase:** GREEN · **Trace:** SC#1
+
+#### T2 — Package scaffold · backend-dev · [P]
+- **Files:**
+  - `packages/roxabi-blobs/pyproject.toml` (hatchling, deps: `pydantic>=2`, `aiosqlite>=0.20`)
+  - `packages/roxabi-blobs/src/roxabi_blobs/__init__.py` (re-exports)
+  - `packages/roxabi-blobs/src/roxabi_blobs/py.typed` (empty marker)
+  - `packages/roxabi-blobs/README.md` (1-paragraph stub)
+  - `packages/roxabi-blobs/CLAUDE.md` (invariants per pattern)
+- **Snippet (pyproject):** mirror `packages/roxabi-nats/pyproject.toml` shape — `[build-system] hatchling`, `[tool.hatch.build.targets.wheel] packages = ["src/roxabi_blobs"]`
+- **Verify:** `test -f packages/roxabi-blobs/pyproject.toml && test -d packages/roxabi-blobs/src/roxabi_blobs`
+- **Expected:** scaffold files exist
+- **Est:** 5 min · **Diff:** 2 · **Slice:** V1a · **Phase:** GREEN · **Trace:** SC#1
+
+#### T3 — Types layer (protocol + models + errors) · backend-dev
+- **Files:**
+  - `packages/roxabi-blobs/src/roxabi_blobs/errors.py` — `BlobNotFoundError(Exception)`, `BlobWriteError(Exception)`, `BlobConsistencyError(Exception)`
+  - `packages/roxabi-blobs/src/roxabi_blobs/models.py` — `BlobRef(BaseModel)` per ADR-067 §BlobRef envelope
+  - `packages/roxabi-blobs/src/roxabi_blobs/protocol.py` — `class BlobStore(Protocol)` with 4 `async def` methods (put/get/exists/delete) per ADR-067 §Interface
+- **Snippet (protocol):**
+  ```python
+  from typing import Protocol, runtime_checkable
+  from .models import BlobRef
+
+  @runtime_checkable
+  class BlobStore(Protocol):
+      async def put(self, data: bytes, *, mime: str, source: str,
+                    filename: str | None = None,
+                    platform_ref: str | None = None,
+                    platform_message_id: str | None = None) -> BlobRef: ...
+      async def get(self, store_key: str) -> bytes: ...
+      async def exists(self, content_hash: str) -> BlobRef | None: ...
+      async def delete(self, blob_ref_id: int) -> None: ...
+  ```
+- **Verify:** `uv run python -c "from roxabi_blobs import BlobStore, BlobRef, BlobNotFoundError, BlobWriteError; print('ok')"`
+- **Expected:** `ok`
+- **Est:** 8 min · **Diff:** 2 · **Slice:** V1a · **Phase:** GREEN · **Trace:** SC#2
+
+#### T4 — Protocol conformance tests · tester · [P with T3]
+- **File:** `packages/roxabi-blobs/tests/test_protocol.py`
+- **Snippet:** assert `isinstance(FsBlobStore, BlobStore)` won't work pre-T7 — instead use `typing.get_type_hints` + manual signature comparison; assert `BlobRef` schema matches ADR-067 fields exactly.
+- **Verify:** `uv run pytest packages/roxabi-blobs/tests/test_protocol.py -v`
+- **Expected:** all pass
+- **Est:** 6 min · **Diff:** 2 · **Slice:** V1a · **Phase:** RED→GREEN · **Trace:** SC#2
+
+#### T5 — RED-GATE V1a — uv sync + imports
+- **Verify:**
+  ```bash
+  uv sync && \
+  uv run python -c "from roxabi_blobs import BlobStore, BlobRef, BlobNotFoundError, BlobWriteError, BlobConsistencyError; print('ok')" && \
+  uv run pytest packages/roxabi-blobs/tests/test_protocol.py
+  ```
+- **Expected:** `ok` + pytest green
+- **Est:** 1 min · **Diff:** 1 · **Slice:** V1a · **Phase:** RED-GATE · **Trace:** SC#1, SC#2
+
+### V1b — FsBlobStore impl
+
+#### T6 — Schema · backend-dev
+- **File:** `packages/roxabi-blobs/src/roxabi_blobs/schema.py`
+- **Snippet:** `SCHEMA_SQL` string with `CREATE TABLE blobs (content_hash TEXT PRIMARY KEY, mime TEXT, size INTEGER, store_path TEXT, first_seen_at TEXT)`, `CREATE TABLE blob_refs (id INTEGER PRIMARY KEY, content_hash TEXT NOT NULL REFERENCES blobs(content_hash), source TEXT NOT NULL, platform_ref TEXT, platform_message_id TEXT, filename TEXT, ingested_at TEXT NOT NULL)`, `CREATE INDEX idx_blob_refs_hash_ingested ON blob_refs(content_hash, ingested_at DESC)`. PRAGMA journal_mode=WAL, busy_timeout=5000.
+- **Verify:** `uv run python -c "import sqlite3, tempfile; from roxabi_blobs.schema import SCHEMA_SQL; db=sqlite3.connect(':memory:'); db.executescript(SCHEMA_SQL); print(db.execute(\"SELECT name FROM sqlite_master WHERE type='table'\").fetchall())"`
+- **Expected:** `[('blobs',), ('blob_refs',)]`
+- **Est:** 6 min · **Diff:** 2 · **Slice:** V1b · **Phase:** GREEN · **Trace:** SC#3
+
+#### T7 — FsBlobStore skeleton · backend-dev
+- **File:** `packages/roxabi-blobs/src/roxabi_blobs/fs_store.py`
+- **Snippet:** `class FsBlobStore` — `__init__(root, db_path=None)` resolves paths; `_lock = asyncio.Lock()`; `__aenter__` opens `aiosqlite` conn, applies `SCHEMA_SQL`, sets WAL + busy_timeout; `__aexit__` closes; stub methods for `put`/`get`/`exists`/`delete` raising `NotImplementedError`.
+- **Verify:** `uv run python -c "import asyncio, tempfile; from pathlib import Path; from roxabi_blobs.fs_store import FsBlobStore; asyncio.run((lambda: FsBlobStore(Path(tempfile.mkdtemp())).__aenter__())()) ; print('ok')"`
+- **Expected:** opens cleanly
+- **Est:** 8 min · **Diff:** 3 · **Slice:** V1b · **Phase:** GREEN · **Trace:** SC#2, SC#3
+
+#### T8 — put implementation · backend-dev
+- **File edit:** `packages/roxabi-blobs/src/roxabi_blobs/fs_store.py`
+- **Snippet:** inside `async with self._lock`: compute `content_hash = hashlib.sha256(data).hexdigest()`; SELECT FROM blobs; on miss: `fpath = root/sha[:2]/sha`; `mkdir parents=True exist_ok=True`; write bytes via `os.open(O_CREAT|O_WRONLY) + os.write + os.fsync(fd) + os.close`; `os.fsync(dir_fd)` on shard dir; INSERT blobs; INSERT blob_refs (always); build & return BlobRef.
+- **Verify:** unit test in T13; smoke: `pytest packages/roxabi-blobs/tests/test_fs_store.py -k test_put_then_get -v`
+- **Expected:** test passes after T13 lands
+- **Est:** 12 min · **Diff:** 4 · **Slice:** V1b · **Phase:** GREEN · **Trace:** SC#4, SC#5, SC#6
+
+#### T9 — get implementation · backend-dev
+- **File edit:** `fs_store.py`
+- **Snippet:** `try: with open(store_key, 'rb') as f: return f.read() except FileNotFoundError: raise BlobNotFoundError(store_key)`
+- **Verify:** smoke in T13
+- **Est:** 3 min · **Diff:** 1 · **Slice:** V1b · **Phase:** GREEN · **Trace:** SC#7
+
+#### T10 — exists implementation · backend-dev
+- **File edit:** `fs_store.py`
+- **Snippet:** SELECT FROM blob_refs WHERE content_hash=? ORDER BY ingested_at DESC LIMIT 1, joined with blobs row to assemble `BlobRef`; return None if absent.
+- **Verify:** smoke in T13
+- **Est:** 5 min · **Diff:** 2 · **Slice:** V1b · **Phase:** GREEN · **Trace:** SC#8
+
+#### T11 — delete implementation · backend-dev
+- **File edit:** `fs_store.py`
+- **Snippet:** under `async with self._lock`: SELECT content_hash + store_path via JOIN; DELETE blob_refs WHERE id=?; if `COUNT(*) FROM blob_refs WHERE content_hash=? == 0` → DELETE blobs WHERE content_hash=? + `os.unlink(store_path)`.
+- **Verify:** smoke in T17
+- **Est:** 8 min · **Diff:** 3 · **Slice:** V1b · **Phase:** GREEN · **Trace:** SC#9
+
+#### T12 — RED-GATE V1b — round-trip smoke
+- **Verify:**
+  ```bash
+  uv run pytest packages/roxabi-blobs/tests/test_fs_store.py::test_put_then_get -v && \
+  uv run pytest packages/roxabi-blobs/tests/test_fs_store.py::test_exists -v
+  ```
+- **Expected:** both green (depends on T13 stub of these test names)
+- **Est:** 2 min · **Diff:** 1 · **Slice:** V1b · **Phase:** RED-GATE · **Trace:** SC#2
+
+### V1c — Test suite + coverage
+
+#### T13 — test_fs_store happy path · tester · [P]
+- **File:** `packages/roxabi-blobs/tests/test_fs_store.py`
+- **Snippet:** `async def test_put_then_get(tmp_path)`, `async def test_exists`, `async def test_exists_missing`, `async def test_get_missing_raises`, `async def test_blob_ref_envelope_fields`.
+- **Verify:** `uv run pytest packages/roxabi-blobs/tests/test_fs_store.py -v`
+- **Expected:** 5 tests green
+- **Est:** 10 min · **Diff:** 3 · **Slice:** V1c · **Phase:** GREEN · **Trace:** SC#2, SC#7, SC#8
+
+#### T14 — test_dedup 5× same blob · tester · [P]
+- **File:** `packages/roxabi-blobs/tests/test_dedup.py`
+- **Snippet:** put same bytes 5 times with 5 different sources → assert 1 row in `blobs`, 5 rows in `blob_refs`, 1 file on FS, all 5 returned refs share `content_hash`.
+- **Verify:** `uv run pytest packages/roxabi-blobs/tests/test_dedup.py -v`
+- **Expected:** green
+- **Est:** 6 min · **Diff:** 2 · **Slice:** V1c · **Phase:** GREEN · **Trace:** SC#4
+
+#### T15 — test_crash_injection — write ordering · tester · [P]
+- **File:** `packages/roxabi-blobs/tests/test_crash_injection.py`
+- **Snippet:** subprocess fork that calls put + `os.kill(os.getpid(), SIGKILL)` between fsync and INSERT (mock the lock via monkeypatch); assert in parent process that FS file exists at correct shard path AND `blobs` table either has the row (clean) OR doesn't (orphan recoverable by future reconciler). Negative test: skip dir-fsync → simulate dir-block-loss → reconciler can't find the file (regression sentinel).
+- **Verify:** `uv run pytest packages/roxabi-blobs/tests/test_crash_injection.py -v`
+- **Expected:** green; negative test marked `xfail` to catch regression
+- **Est:** 12 min · **Diff:** 4 · **Slice:** V1c · **Phase:** GREEN · **Trace:** SC#5
+
+#### T16 — test_concurrent — asyncio.Lock · tester · [P]
+- **File:** `packages/roxabi-blobs/tests/test_concurrent.py`
+- **Snippet:** spawn 50 coroutines all calling `store.put(same_bytes, ...)`; await all; assert 1 file + 1 `blobs` row + 50 `blob_refs` rows; no `aiosqlite.OperationalError`.
+- **Verify:** `uv run pytest packages/roxabi-blobs/tests/test_concurrent.py -v`
+- **Expected:** green
+- **Est:** 8 min · **Diff:** 3 · **Slice:** V1c · **Phase:** GREEN · **Trace:** SC#6
+
+#### T17 — test_delete · tester · [P]
+- **File:** `packages/roxabi-blobs/tests/test_delete.py`
+- **Snippet:** put same blob 2× → 2 refs; delete 1 → file remains, `blobs` row remains, 1 `blob_refs` row remains; delete the other → file gone, `blobs` row gone, 0 `blob_refs` rows.
+- **Verify:** `uv run pytest packages/roxabi-blobs/tests/test_delete.py -v`
+- **Expected:** green
+- **Est:** 6 min · **Diff:** 2 · **Slice:** V1c · **Phase:** GREEN · **Trace:** SC#9
+
+#### T18 — RED-GATE V1c — coverage ≥90%
+- **Verify:**
+  ```bash
+  uv run pytest packages/roxabi-blobs --cov=roxabi_blobs --cov-report=term-missing --cov-fail-under=90 -v
+  ```
+- **Expected:** all green; coverage ≥90% (includes `delete` paths)
+- **Est:** 2 min · **Diff:** 1 · **Slice:** V1c · **Phase:** RED-GATE · **Trace:** SC#10
+
+## Reference Patterns
+
+Patterns to mirror (read during T2/T6/T7):
+
+| Pattern | Reference file |
+|---|---|
+| Package scaffold + hatchling | `packages/roxabi-nats/pyproject.toml` |
+| `src/<pkg>/` + `py.typed` layout | `packages/roxabi-nats/src/roxabi_nats/` |
+| `errors.py` style | `packages/roxabi-nats/src/roxabi_nats/errors.py` |
+| `Protocol` + `runtime_checkable` shape | `packages/roxabi-nats/src/roxabi_nats/adapter_base.py` |
+| pytest conftest + asyncio_mode | `packages/roxabi-nats/tests/conftest.py` |
+| CLAUDE.md per-package invariants pattern | `packages/roxabi-nats/CLAUDE.md` |
+
+## Task Seeding Blueprint
+
+<!-- /implement seeds these as TaskCreate calls. Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | devops-A | — | Register `packages/roxabi-blobs` as uv workspace member |
+| T2 | backend-dev-A | — | Scaffold `packages/roxabi-blobs/{pyproject,README,CLAUDE,src/__init__,py.typed}` |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T3 | backend-dev-A | T1,T2 | Types layer — `errors.py`, `models.py` (BlobRef), `protocol.py` (BlobStore Protocol) |
+| T4 | tester-A | T2 | `test_protocol.py` — Protocol shape + BlobRef schema conformance |
+| T5 | backend-dev-A | T3,T4 | RED-GATE V1a — `uv sync` + imports + protocol tests green |
+
+### Wave 3 — after Wave 2 (RED-GATE-V1a green), 1 agent sequential
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T6 | backend-dev-A | T5 | `schema.py` — SQLite DDL (blobs + blob_refs + index, WAL, BUSY_TIMEOUT=5000) |
+| T7 | backend-dev-A | T6 | `fs_store.py` skeleton — class, `__aenter__/__aexit__`, asyncio.Lock, stubs |
+| T8 | backend-dev-A | T7 | `put` impl — sha256, file→fsync(file)→fsync(dir)→INSERT, dedup, under lock |
+| T9 | backend-dev-A | T7 | `get` impl — open + read + raise `BlobNotFoundError` |
+| T10 | backend-dev-A | T7 | `exists` impl — `ORDER BY ingested_at DESC LIMIT 1` + BlobRef build |
+| T11 | backend-dev-A | T7 | `delete` impl — ref count + unlink at zero |
+| T12 | backend-dev-A | T8,T9,T10,T11 | RED-GATE V1b — round-trip put/get/exists smoke green |
+
+### Wave 4 — after Wave 3 (RED-GATE-V1b green), 1 tester ∥ tasks
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T13 | tester-A | T12 | `test_fs_store.py` — put/get/exists happy path + edge cases |
+| T14 | tester-A | T12 | `test_dedup.py` — 5× same blob → 1 file + 1 blobs + 5 blob_refs |
+| T15 | tester-A | T12 | `test_crash_injection.py` — kill simulation, fsync-dir regression sentinel |
+| T16 | tester-A | T12 | `test_concurrent.py` — 50 coroutines + asyncio.Lock |
+| T17 | tester-A | T12 | `test_delete.py` — 2 refs, delete 1 then 2 cycle |
+| T18 | tester-A | T13,T14,T15,T16,T17 | RED-GATE V1c — `pytest --cov-fail-under=90` green |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: #11 — Register roxabi-blobs as uv workspace member
+- T2: #12 — Scaffold packages/roxabi-blobs/ skeleton
+- T3: #13 — Types layer (errors + models + protocol)
+- T4: #14 — test_protocol.py Protocol conformance
+- T5: #15 — RED-GATE V1a (uv sync + imports + protocol tests)
+- T6: #16 — schema.py SQLite DDL
+- T7: #17 — fs_store.py skeleton (class + async ctx + Lock)
+- T8: #18 — put impl (sha256, fsync ordering, dedup, lock)
+- T9: #19 — get impl
+- T10: #20 — exists impl (ORDER BY latest)
+- T11: #21 — delete impl (ref count + unlink at zero)
+- T12: #22 — RED-GATE V1b (round-trip smoke)
+- T13: #23 — test_fs_store.py happy path + edges
+- T14: #24 — test_dedup.py (5× same blob)
+- T15: #25 — test_crash_injection.py (write ordering)
+- T16: #26 — test_concurrent.py (50 coroutines + Lock)
+- T17: #27 — test_delete.py (ref count cycle)
+- T18: #28 — RED-GATE V1c (≥90% coverage)
+
+## Open Issues / Risks
+
+- **aiosqlite vs sqlite3 in thread executor:** plan assumes `aiosqlite>=0.20`. If introducing aiosqlite is too heavy a new dep, fallback = stdlib `sqlite3` wrapped in `asyncio.to_thread`. Decision deferred to T6/T7 implementation; either is consistent with the spec.
+- **Crash-injection test (T15) cross-platform:** `os.kill(SIGKILL)` is POSIX-only. Acceptable for Linux-only target (M₁/M₂ both Pop!_OS/Ubuntu).
+- **Coverage gate strictness:** `--cov-fail-under=90` is binary. If coverage lands at 88% on first pass, decide between (a) add tests or (b) lower gate to 85% with note. Default = add tests.

--- a/artifacts/specs/1057-bot-token-podman-secrets-spec.mdx
+++ b/artifacts/specs/1057-bot-token-podman-secrets-spec.mdx
@@ -1,0 +1,183 @@
+---
+title: bot_secrets table → per-bot Podman secrets
+issue: 1057
+status: approved
+tier: F-lite
+date: 2026-05-21
+source: artifacts/frames/1057-bot-token-podman-secrets-frame.mdx
+---
+
+## Context
+
+Promoted from [frame #1057](../frames/1057-bot-token-podman-secrets-frame.mdx). Phase 3 of Epic #1049 (shared-state migration); absorbs #1056. Aggregated-container mode resolved 2026-05-18: one `.container` per platform, N `Secret=` lines per container.
+
+## Goal
+
+Bot tokens reach the Telegram/Discord adapter processes via `/run/secrets/bot_token` (Podman secrets) instead of the `bot_secrets` table in `~/.lyra/config.db`. `CredentialStore` + `LyraKeyring` + the `config.db` mount on adapter containers are deleted.
+
+## Users
+
+- **Primary:** Lyra operators on deploy hosts (M₁). Lifecycle: `lyra bot secret install <platform> <bot_id>` → edit Quadlet `.container` (or run installer) → `make <svc> restart`.
+- **Secondary:** Adapter processes (Telegram, Discord). Read `/run/secrets/bot_token` once at bootstrap; never touch `config.db` for credentials.
+
+## Expected Behavior
+
+1. **Operator provisions a bot token.**
+   `lyra bot secret install telegram bot42` → prompts for token (or reads `--from-env LYRA_BOT_TOKEN`) → calls `podman secret create --replace lyra-bot-telegram-bot42 <stdin>`. Idempotent: re-running overwrites.
+
+2. **Operator migrates existing rows.**
+   `lyra bot secret migrate` reads every `(platform, bot_id, token, webhook_secret)` row from `~/.lyra/config.db:bot_secrets`, decrypts via the existing `LyraKeyring`, then issues `podman secret create --replace` per row. Idempotent by construction (`--replace` overwrites). On success, prints a per-row table `PLATFORM BOT_ID TOKEN_OK WEBHOOK_OK` and a summary line `Migrated N tokens, M webhook secrets; safe to drop bot_secrets table.` Re-runs reproduce the same output (operator must read the summary, not the exit code, to know whether work happened).
+
+3. **Quadlet wiring is updated.**
+   `deploy/quadlet/lyra-telegram.container` and `lyra-discord.container` carry two `Secret=` lines per bot — one for the token, one for the optional webhook secret (per χ-1 resolution → option **(b)**, two single-purpose secrets):
+
+   ```
+   Secret=lyra-bot-telegram-<bot_id>,type=mount,target=bot_token-<bot_id>,mode=0400,uid=1500,gid=1500
+   Secret=lyra-bot-telegram-<bot_id>-webhook,type=mount,target=bot_webhook-<bot_id>,mode=0400,uid=1500,gid=1500
+   ```
+
+   `uid=1500,gid=1500` mirrors the existing `lyra-nkey-*` mount pattern at `deploy/quadlet/lyra-telegram.container:28` (the adapter container runs under user-NS keep-id with uid 1500; without these the file is owned by uid 0 inside the namespace and unreadable). The webhook line is omitted when no webhook secret is configured for that bot.
+
+4. **Adapter bootstrap reads from `/run/secrets/`.**
+   `adapter_standalone.py:75-93,178-197` is rewritten: instead of `cred_store.get_full(platform, bot_id)`, it reads the mounted file. No fallback to `config.db` — boot fails loud if the expected file is missing.
+
+5. **`CredentialStore` + `bot_secrets` are deleted.**
+   After migration is run on prod (M₁), the DDL is dropped from `CredentialStore.connect`, the class file removed, and the `~/.lyra/config.db` mount stripped from adapter `.container` files. `LyraKeyring` is retained iff other consumers remain in `config.db`'s sibling stores (agent/prefs); if only the adapter path consumed it, the class is deleted entirely and `~/.lyra/keyring.key` documented as safe to remove.
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class BotSecret_Legacy {
+        <<table: config.db>>
+        string platform
+        string bot_id
+        string token "Fernet-encrypted"
+        string webhook_secret "Fernet-encrypted, nullable"
+        datetime updated_at
+    }
+    class PodmanTokenSecret {
+        <<podman secret>>
+        string name "lyra-bot-{platform}-{bot_id}"
+        bytes content "raw token bytes"
+    }
+    class PodmanWebhookSecret {
+        <<podman secret, optional>>
+        string name "lyra-bot-{platform}-{bot_id}-webhook"
+        bytes content "raw webhook secret bytes"
+    }
+    class QuadletMount {
+        <<.container directive>>
+        string Secret "lyra-bot-{p}-{id} or -webhook"
+        string target "bot_token-{id} or bot_webhook-{id}"
+        int mode "0400"
+        int uid "1500"
+        int gid "1500"
+    }
+    BotSecret_Legacy --> PodmanTokenSecret : migrate
+    BotSecret_Legacy --> PodmanWebhookSecret : migrate (if non-null)
+    PodmanTokenSecret <-- QuadletMount : ref by name
+    PodmanWebhookSecret <-- QuadletMount : ref by name
+    QuadletMount --> AdapterProcess : /run/secrets/{target}
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    op[Operator] -->|lyra bot secret install| cli[CLI]
+    cli -->|podman secret create --replace| ps[(Podman secret store)]
+    ps -->|mount| qd[Quadlet container]
+    qd -->|/run/secrets/bot_token-id| ad[Adapter bootstrap]
+    ad -->|token string| tg[Telegram/Discord client]
+
+    legacy[Legacy CredentialStore.get_full] -. removed .-> bs[(bot_secrets table)]
+    bs -. removed .-> kr[LyraKeyring decrypt]
+```
+
+### Consumer summary
+
+| Consumer | Reads | When | Status |
+|---|---|---|---|
+| CLI `lyra bot secret install` | platform, bot_id, token (operator input) | Operator action | **this issue** |
+| CLI `lyra bot secret migrate` | `bot_secrets` rows + `LyraKeyring` | One-shot at deploy | **this issue** |
+| Telegram/Discord adapter bootstrap | `/run/secrets/bot_token-<bot_id>` | Process start | **this issue** |
+| `CredentialStore.get_full` | `bot_secrets` table | ~previously: process start~ | **removed** |
+| `LyraKeyring.load_or_create` (adapter path) | `~/.lyra/keyring.key` | ~previously: process start~ | **removed (adapter path)** |
+| `LyraKeyring` (other consumers, e.g. `auth.db`) | `~/.lyra/keyring.key` | Process start | **verify before deletion** |
+
+## Breadboard
+
+### Affordances
+
+| ID | Affordance | Surface |
+|---|---|---|
+| U1 | `lyra bot secret install <platform> <bot_id> [--from-env VAR] [--webhook-from-env VAR]` | CLI |
+| U2 | `lyra bot secret rm <platform> <bot_id>` | CLI |
+| U3 | `lyra bot secret list` | CLI |
+| U4 | `lyra bot secret migrate` | CLI (one-shot) |
+| N1 | Adapter bootstrap reads `/run/secrets/bot_token-<bot_id>` (+ optional `bot_webhook-<bot_id>`) | bootstrap path |
+| N2 | Quadlet `Secret=` line(s) per bot in `.container` | deploy/quadlet |
+| S1 | Drop `bot_secrets` DDL from `CredentialStore.connect` | schema |
+| S2 | Delete `CredentialStore` class file | code |
+| S3 | Delete `LyraKeyring` iff no `config.db` sibling-store consumer remains; otherwise retain + document scope | code |
+| S4 | Strip `~/.lyra/config.db` mount from adapter `.container` | deploy/quadlet |
+
+**Precondition (U1, U2, N1, N2):** `<bot_id>` must match `^[A-Za-z0-9_-]+$` (Podman secret names and tmpfs mount targets disallow slashes and most punctuation). Validated at install time; install rejects unsafe IDs.
+
+### Wiring
+
+- **U1** → `echo -n "$TOKEN" | podman secret create --replace lyra-bot-<platform>-<bot_id> -` ; if `--webhook-from-env` provided, also `echo -n "$WEBHOOK" | podman secret create --replace lyra-bot-<platform>-<bot_id>-webhook -`. `--replace` makes it inherently idempotent.
+- **U2** → `podman secret rm lyra-bot-<platform>-<bot_id> lyra-bot-<platform>-<bot_id>-webhook` (second is best-effort; absence is OK).
+- **U3** → `podman secret ls --filter name=lyra-bot- --format json` — single source of truth for "which bots are provisioned" after `bot_secrets` is dropped.
+- **U4** → for each `bot_secrets` row → decrypt via existing `LyraKeyring` → invoke U1 path → exit non-zero on any failure.
+- **N1** → `Path("/run/secrets/bot_token-" + bot_id).read_text().strip()` at bootstrap; webhook is `Path("/run/secrets/bot_webhook-" + bot_id)` if present (`.exists()` check, then read). Token-file absence raises `BootstrapError`; webhook absence is silent (matches today's nullable behavior).
+- **N2** → new Makefile target `quadlet-bot-secrets-render` (separate from `quadlet-secrets-install`, which handles nkeys/auth/gh-pem). It calls `podman secret ls --filter name=lyra-bot- --format '{{.Name}}'`, emits the corresponding `Secret=` lines into `deploy/quadlet/lyra-<platform>.container`, then prompts the operator to `make <svc> restart`. The active bot list source is **Podman's own secret store** — never `config.db`, which is the entire point of the migration.
+
+## Slices
+
+| # | Title | Demo |
+|---|---|---|
+| 1 | CLI + Quadlet plumbing (additive) | `lyra bot secret install telegram demo` works; `podman secret ls` shows the new secret; `lyra bot secret list` matches. No adapter or DDL change. |
+| 2 | Migration command | `lyra bot secret migrate` copies all `bot_secrets` rows to Podman secrets; re-run is no-op; decrypted Podman-secret content matches DB content. `bot_secrets` table still present (not yet dropped). |
+| 3 | Adapter cutover + cleanup | Telegram + Discord `.container` files updated; adapter reads `/run/secrets/bot_token-<bot_id>`; `CredentialStore` class deleted; `bot_secrets` DDL removed; `config.db` mount stripped; multi-bot config verified. |
+
+Slice ordering keeps each step independently demonstrable and rolls back cleanly: slice 1 is purely additive, slice 2 only writes new secrets, slice 3 is the destructive cutover.
+
+**Slice coverage of affordances:**
+- Slice 1: U1, U2, U3, N2 (install/rm/list + Quadlet templating)
+- Slice 2: U4
+- Slice 3: N1, S1, S2, S3, S4
+
+## Success Criteria
+
+**Joint premise (frame falsifiable failure):** CR-1 + CR-2 together encode the frame's failure signal. Either one failing = migration incomplete.
+
+- [ ] **CR-1** `grep -rF "CredentialStore" src/lyra/bootstrap/ src/lyra/adapters/ src/lyra/cli_setup.py src/lyra/cli_bot.py` returns no matches (joint with CR-2 — see premise note above).
+- [ ] **CR-2** `sqlite3 ~/.lyra/config.db ".tables"` does not list `bot_secrets` after slice 3 (joint with CR-1).
+- [ ] **CR-3** `lyra bot secret install telegram demo` followed by `podman secret inspect lyra-bot-telegram-demo` returns a secret whose decoded content equals the supplied token bytes.
+- [ ] **CR-4** `lyra bot secret migrate` exit code is 0 after both first run and second run. First-run summary line matches regex `^Migrated [0-9]+ tokens, [0-9]+ webhook secrets`. Second-run summary line shows the same counts (because `--replace` is idempotent by construction — no skip-on-match logic required).
+- [ ] **CR-5** Adapter bootstrap code does not reference `config.db` for credential reads: `grep -rF "config.db" src/lyra/bootstrap/ src/lyra/adapters/ | grep -v test` returns no matches related to bot tokens. Adapter container boot log contains a line matching `read token from /run/secrets/bot_token-<bot_id>` and the bot completes a round-trip test message end-to-end on M₁.
+- [ ] **CR-6** Multi-bot config (≥2 bots per platform) works end-to-end: each bot reads its own `/run/secrets/bot_token-<bot_id>`; adapter log emits one `read token from /run/secrets/bot_token-<bot_id>` line per bot at startup.
+- [ ] **CR-7** `grep -rF "LyraKeyring" src/lyra/bootstrap/ src/lyra/adapters/ src/lyra/cli_setup.py src/lyra/cli_bot.py` returns no matches. If `LyraKeyring` is retained for `config.db` sibling stores, its scope is documented in `src/lyra/infrastructure/CLAUDE.md` (verified by `grep -F "LyraKeyring scope:" src/lyra/infrastructure/CLAUDE.md` returning a match).
+- [ ] **CR-8** `docs/CONFIGURATION.md` contains: (a) a `## Bot credentials` section with the `lyra bot secret install/rm/list/migrate` CLI table, AND (b) a fenced `Secret=lyra-bot-` example block matching the wiring in this spec, AND (c) the literal string `webhook_secret packing: separate secret` documenting the χ-1 resolution. Verified by 3 grep commands in CI.
+
+## Edge Cases
+
+| Edge case | Handling |
+|---|---|
+| Adapter starts but `/run/secrets/bot_token-<bot_id>` missing | Fail loud at bootstrap with `BootstrapError` naming the expected path; ¬fallback to `config.db`. |
+| Token rotation | Operator runs `lyra bot secret install <platform> <bot_id>` (replaces) then `make <svc> restart` — covered by [feedback_nats_runbook_restart_not_hup] equivalent (mount-secret refresh requires restart). |
+| Migration: row decrypts but `podman secret create` fails | Log row, exit non-zero, don't drop table. Operator retries after fixing root cause. |
+| Multi-bot container: one bot's secret missing | Quadlet fails to start the container (Podman validates `Secret=` references at start). Operator sees a clear error per missing secret. |
+| `LyraKeyring` still consumed by other `config.db` sibling stores (agent/prefs) | Retain `LyraKeyring` class, document the surviving scope in `src/lyra/infrastructure/CLAUDE.md` (`LyraKeyring scope: <consumers>`). Adapter-path imports removed regardless. |
+| webhook_secret missing for a bot | Quadlet mounts only the present secrets; bot operates without webhook (today's behavior). |
+| Existing `~/.lyra/keyring.key` after migration | Migration command prints `keyring.key safe to delete (only consumer was bot_secrets)` iff `LyraKeyring` fully removed; otherwise prints retention reason. |
+
+## Open Questions
+
+**χ-1 resolved (during spec review):** webhook_secret packing → **option (b), two separate Podman secrets per bot**. Rationale: matches the project's raw-bytes single-purpose convention (every existing secret in `Makefile:181-200` is raw bytes); avoids introducing a JSON parser in the failure-loud bootstrap path; allows independent rotation of token vs. webhook; cleanly expresses nullable webhook by omitting the secret (option (a) would require sentinel values). Documented in CR-8 (c).
+
+_No open χ remaining._

--- a/artifacts/specs/1063-roxabi-blobs-package-spec.mdx
+++ b/artifacts/specs/1063-roxabi-blobs-package-spec.mdx
@@ -1,0 +1,160 @@
+---
+title: "Spec: #1063 — roxabi-blobs package (V1 BlobStore)"
+description: V1 of epic #1061 — ship `packages/roxabi-blobs/` as a uv workspace member exposing a BlobStore Protocol over a content-addressed Flat-FS + SQLite store. Foundation slice; no consumer changes.
+issue: 1063
+status: approved
+tier: F-lite
+date: 2026-05-21
+---
+
+## Context
+
+**Promoted from:** [Frame: #1063 — roxabi-blobs package](../frames/1063-roxabi-blobs-package-frame.mdx)
+**Parent spec:** [Spec: #1061 — BlobStore for large binary payloads](./1061-blobstore-spec.mdx) (epic; V1 = this issue)
+**Decision of record:** [ADR-067 — BlobStore abstraction (content-addressed flat-FS v1)](../../docs/architecture/adr/067-blobstore-abstraction-flat-fs-content-addressed.mdx)
+**Issue:** [#1063](https://github.com/Roxabi/lyra/issues/1063)
+
+V1 of epic [#1061](https://github.com/Roxabi/lyra/issues/1061) ships **only the package** — the foundation that V2 (#1064 contracts), V3/V4 (#1065/#1066 adapters), V5 (#1067 workers, cross-repo with voiceCLI), V6 (#1068 ops) build on. No consumer changes in this slice.
+
+## Goal
+
+`packages/roxabi-blobs/` exists as a uv workspace member exposing a `BlobStore` Protocol (`put` / `get` / `exists` + designed-but-not-called `delete`) implemented over a content-addressed Flat-FS + SQLite store, with ≥90% public-API unit-test coverage and clean imports from any other workspace member.
+
+## Users
+
+- **Primary:** lyra hub/adapters/workers (V2+) — call `BlobStore` for ingress/egress
+- **Secondary:** voiceCLI STT/TTS workers (V5) — cross-repo consumer of the same package
+- **Tertiary:** ML/debug operator (Mickael) — direct SQLite queries on `index.sqlite` for training-data extraction
+
+> **V1 delivers no user-visible behaviour.** All primary/secondary users become active at V2+ (#1064 contracts, #1065/#1066 adapters, #1067 workers). V1 is a prerequisite, not a standalone deliverable.
+
+## Expected Behavior
+
+### Happy path — round-trip put/get/exists
+
+1. Consumer calls `await store.put(data, mime="audio/ogg", source="telegram", platform_ref="tg:42", platform_message_id="100")`.
+2. `put` computes `sha256(data)`.
+3. `put` SELECTs `blobs` WHERE `content_hash = ?`. Hit → skip file write. Miss → write file `<root>/<sha[:2]>/<sha>` → `fsync` on the blob file → `fsync` on the shard directory `<root>/<sha[:2]>/` (otherwise the directory entry may be lost on crash even with file data flushed) → INSERT `blobs(content_hash, mime, size, store_path, first_seen_at)`.
+4. `put` always INSERTs a new `blob_refs(content_hash, source, platform_ref, platform_message_id, filename, ingested_at)` row.
+5. `put` returns a `BlobRef` envelope `{store_key, content_hash, mime, size, filename, source, platform_ref, platform_message_id, created_at}`.
+6. Later: `await store.get(ref.store_key)` opens the FS path and returns bytes; raises `BlobNotFoundError` if missing.
+7. `await store.exists(content_hash)` returns the latest `BlobRef` for that hash, or `None`.
+
+### Edge cases
+
+| Case | Handling |
+|---|---|
+| Same content put 5× from 5 sources | 1 file on FS · 1 `blobs` row · 5 `blob_refs` rows |
+| Crash between file `fsync` and `blobs` INSERT | Orphan file on FS; recoverable by V6 reconciler (out of scope here — benign for V1) |
+| Crash between `blobs` INSERT and `blob_refs` INSERT | `blobs` row without refs; benign — next `put` reuses it |
+| `get` on missing `store_key` | Raise `BlobNotFoundError` (typed) |
+| `exists` on unknown `content_hash` | Return `None` |
+| SQLite locked (inter-process) | `BUSY_TIMEOUT=5000` — covers OS-level contention only |
+| Concurrent `put` from multiple coroutines (same process) | `FsBlobStore` holds an `asyncio.Lock` over the write path (sha-compute + file write + fsync + INSERT) — single-writer-per-instance enforced at the asyncio layer, not just documented |
+| Disk full on `put` | Surface OS error as typed `BlobWriteError` |
+| sha-256 collision | Operationally impossible; ¬handled |
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class BlobRef {
+        +str store_key
+        +str content_hash
+        +str mime
+        +int size
+        +str|None filename
+        +str source
+        +str|None platform_ref
+        +str|None platform_message_id
+        +datetime created_at
+    }
+    class BlobsRow {
+        +str content_hash PK
+        +str mime
+        +int size
+        +str store_path
+        +datetime first_seen_at
+    }
+    class BlobRefsRow {
+        +int id PK
+        +str content_hash FK
+        +str source
+        +str|None platform_ref
+        +str|None platform_message_id
+        +str|None filename
+        +datetime ingested_at
+    }
+    BlobsRow "1" --> "N" BlobRefsRow : dedup
+    BlobRefsRow ..> BlobRef : projected
+```
+
+### Consumer map (V1 scope = solid; future = dashed)
+
+```mermaid
+flowchart LR
+    Tests[unit tests] --> Store[BlobStore impl]
+    Store --> FS[(Flat-FS)]
+    Store --> SQLite[(SQLite WAL)]
+    Contracts[roxabi-contracts BlobRef] -.->|V2 / #1064| Store
+    TG[TG adapter] -.->|V3 / #1065| Store
+    DC[Discord adapter] -.->|V4 / #1066| Store
+    STT[STT worker] -.->|V5 / #1067| Store
+    TTS[TTS worker] -.->|V5 / #1067| Store
+```
+
+### Consumer summary
+
+| Consumer | Surface used | When | Status |
+|---|---|---|---|
+| unit tests | full public API + both SQLite rows | V1 (this issue) | this issue |
+| `roxabi-contracts` `BlobRef` | mirror envelope | V2 / #1064 | future |
+| TG adapter | `put` ingress, `get` egress | V3 / #1065 | future |
+| Discord adapter | `put` ingress, `get` egress | V4 / #1066 | future |
+| voiceCLI STT/TTS | `get` (STT), `put` (TTS) | V5 / #1067 | future |
+
+## Breadboard
+
+### API affordances (V1 = package only — no UI)
+
+| ID | Affordance | Wiring | Logic |
+|----|---|---|---|
+| N1 | `async put(data, *, mime, source, filename=None, platform_ref=None, platform_message_id=None) → BlobRef` | tests → N1 → S1, S2, S3 | sha256; SELECT S1; miss → write S3 → fsync → INSERT S1; INSERT S2; return BlobRef |
+| N2 | `async get(store_key) → bytes` | tests → N2 → S3 | open(store_key, "rb").read(); raise `BlobNotFoundError` if missing |
+| N3 | `async exists(content_hash) → BlobRef \| None` | tests → N3 → S1, S2 | SELECT S1; build BlobRef from `S2 WHERE content_hash=? ORDER BY ingested_at DESC LIMIT 1` (deterministic "latest"); None if absent |
+| N4 | `async delete(blob_ref_id) → None` | designed; ¬called in V1 paths | DELETE S2 row; if no remaining refs → DELETE S1 row + unlink S3 file |
+| N5 | `FsBlobStore(root: Path, *, db_path: Path \| None = None)` + `__aenter__/__aexit__` | factory | open SQLite WAL, ensure schema (incl. index `blob_refs(content_hash, ingested_at DESC)`), ensure root dir, set `BUSY_TIMEOUT=5000`, instantiate `asyncio.Lock` for write-path serialisation |
+
+### Data stores
+
+| ID | Store | Type | Accessed by |
+|---|---|---|---|
+| S1 | `blobs(content_hash PK, mime, size, store_path, first_seen_at)` | SQLite WAL | N1, N3, N4 |
+| S2 | `blob_refs(id PK, content_hash FK, source, platform_ref, platform_message_id, filename, ingested_at)` + index on `(content_hash, ingested_at DESC)` | SQLite WAL | N1, N3, N4 |
+| S3 | Flat-FS: `<root>/<sha[:2]>/<sha>` | tmpdir in tests; bind-mount in prod (V6) | N1 (write), N2 (read), N4 (unlink) |
+
+## Slices
+
+| Slice | Description | Affordances | Demo |
+|---|---|---|---|
+| V1a | Package skeleton — `pyproject.toml`, `src/roxabi_blobs/__init__.py`, workspace member, `BlobStore` Protocol type, `BlobRef` Pydantic model (internal envelope — see note below), typed errors (`BlobNotFoundError`, `BlobWriteError`) | type stubs | `uv sync` succeeds; `from roxabi_blobs import BlobStore, BlobRef, BlobNotFoundError, BlobWriteError` works (import-level demo only; full round-trip lands in V1b) |
+| V1b | `FsBlobStore` impl — N5 factory + N1/N2/N3/N4 methods + WAL schema bootstrap + sha256 dedup + write ordering (file → fsync → INSERT) | N1, N2, N3, N4, N5, S1, S2, S3 | tmpdir round-trip; put same blob 5× → 1 file + 1 `blobs` row + 5 `blob_refs` rows |
+| V1c | Test suite — ≥90% line+branch coverage on public API (`delete` covered by direct unit tests even though no production caller in V1); crash-injection test for write ordering; concurrent-put smoke test (asserts `asyncio.Lock` serialises) | (test module) | `pytest packages/roxabi-blobs --cov` shows ≥90% on public API |
+
+> **`BlobRef` ownership note:** V1 defines `BlobRef` internally in `roxabi-blobs` (package-local envelope). V2 (#1064) mirrors `BlobRef` in `roxabi-contracts` as the on-wire type. The two coexist intentionally — `roxabi-blobs` does **not** import from `roxabi-contracts` (avoids cyclic dependency between storage and transport layers). Field shapes are kept identical by spec, not by import.
+
+## Success Criteria
+
+- [ ] `packages/roxabi-blobs/` exists as uv workspace member; `uv sync` resolves clean; `from roxabi_blobs import BlobStore, BlobRef, BlobNotFoundError, BlobWriteError` imports work
+- [ ] `BlobStore` is a `typing.Protocol` with 4 async methods (`put` / `get` / `exists` / `delete`) matching ADR-067 §Interface; `FsBlobStore` implements all 4 + async context manager
+- [ ] SQLite WAL mode enabled; `BUSY_TIMEOUT=5000` set; schema (split `blobs` + `blob_refs`) created at bootstrap
+- [ ] `put` sha256 dedup verified — same blob put 5× → 1 file on FS + 1 `blobs` row + 5 `blob_refs` rows
+- [ ] `put` write order is `file → fsync(file) → fsync(shard dir) → INSERT` — crash-injection test passes (process-kill between fsync and INSERT leaves recoverable state; missing dir-fsync is a regression)
+- [ ] Concurrent `put` from N coroutines in one process is serialised via `asyncio.Lock` (smoke test: 50 coroutines, same blob → 1 file, 1 `blobs` row, 50 `blob_refs` rows, no `OperationalError`)
+- [ ] `get` returns exact bytes for a known `store_key`; raises `BlobNotFoundError` on missing key
+- [ ] `exists(content_hash)` returns the latest `BlobRef` (deterministic via `ORDER BY ingested_at DESC LIMIT 1`) or `None`
+- [ ] `delete(blob_ref_id)` signature is defined on the Protocol and implemented on `FsBlobStore` per ADR-067 §Interface; behaviour unit-tested in V1b (2 refs → delete 1 → file remains; delete 2 → file + `blobs` row gone); not called from any production path in V1
+- [ ] ≥90% line + branch coverage on public API (`pytest-cov`) — `delete` included in the coverage target
+- [ ] No file in `packages/roxabi-blobs/src/` exceeds 300 LOC (`quality_gates.file_length` from `stack.yml`)

--- a/src/lyra/tools/gh_token/daemon.py
+++ b/src/lyra/tools/gh_token/daemon.py
@@ -110,7 +110,10 @@ async def run_daemon(config: DaemonConfig) -> None:
     rate_limiter = RateLimiter(min_interval_s=config.rate_limit_s)
     lock = asyncio.Lock()
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as http:
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(10.0),
+        limits=httpx.Limits(max_keepalive_connections=0),
+    ) as http:
         dispenser = Dispenser(
             cache=cache,
             signer=signer,


### PR DESCRIPTION
## Summary

Daemon was leaking ~28 CLOSE-WAIT sockets/day to GitHub on M₁ (419 accumulated over 14 days, all held by host-side pasta socket for the rootless-Podman netns).

**Root cause:** long-lived `httpx.AsyncClient` uses default keepalive pool (`max_keepalive_connections=5`, `keepalive_expiry=5.0s`). GitHub edge LB FINs idle keepalives after ~60s, but httpx's pool doesn't drain proactively. The daemon is lazy (~30 calls/day, token TTL refresh at <15min) so pool slots sit FIN'd in CLOSE-WAIT indefinitely on the host-side pasta socket.

**Fix:** `max_keepalive_connections=0` — disables the keepalive pool entirely. With ~30 calls/day, TLS-handshake overhead is negligible; the pool provides zero benefit for this workload. Permanent fix, not a workaround.

File: `src/lyra/tools/gh_token/daemon.py` line 113, one config key added.

## Verification on prod

After deploy, `ssh roxabituwer 'ss -Htan state close-wait | wc -l'` should drop to near-zero and stop growing.