### PR TITLE
chore: phase 1A foundation — provision purge + role-aware setup

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -466,29 +466,6 @@ else
   info "uv installed ($(uv --version))."
 fi
 
-section "supervisord (process manager)"
-if command -v supervisord &>/dev/null; then
-  info "supervisord already installed."
-else
-  uv tool install supervisor
-  info "supervisord installed."
-fi
-
-section "systemd user unit (lyra auto-start)"
-UNIT_DIR="$HOME/.config/systemd/user"
-UNIT_FILE="$UNIT_DIR/lyra.service"
-mkdir -p "$UNIT_DIR"
-if [ -f "$UNIT_FILE" ]; then
-  info "lyra.service already exists."
-else
-  SRC_UNIT="$(dirname "$0")/lyra.service"
-  if [ ! -f "$SRC_UNIT" ]; then
-    error "Source unit not found: $SRC_UNIT"
-  fi
-  cp "$SRC_UNIT" "$UNIT_FILE"
-  info "lyra.service created (copied from $SRC_UNIT)."
-fi
-
 # Linger is already enabled (and verified) in the Podman section above —
 # do not call it again here. A duplicate `loginctl enable-linger ... || true`
 # would silently log success even if the real call had failed, creating false
@@ -568,21 +545,23 @@ if [ "${NEEDS_REBOOT:-false}" = true ]; then
 else
   echo ""
   info "Next steps:"
-  echo "  1. Clone lyra and run setup:"
+  echo "  1. Clone lyra:"
   echo ""
   echo "     git clone git@github.com:Roxabi/lyra.git ~/projects/lyra"
+  echo ""
+  echo "  2. Run the lyra setup (clones optional modules, installs Quadlets if this host has the lyra-hub role):"
+  echo ""
   echo "     cd ~/projects/lyra && python3 deploy/setup.py"
   echo ""
-  echo "  2. Enable auto-start on boot:"
+  echo "  3. For multi-repo deploys across hosts (lyra + voiceCLI + llmCLI + imageCLI), use the cross-repo deployer:"
   echo ""
-  echo "     systemctl --user daemon-reload"
-  echo "     systemctl --user enable lyra.service"
+  echo "     ~/projects/deploy.sh        # idempotent, role-aware via ~/projects/hosts.toml"
   echo ""
-  echo "  3. Authenticate Claude CLI:"
+  echo "  4. Authenticate Claude CLI:"
   echo ""
   echo "     claude"
   echo ""
-  echo "  Recommended — NATS setup for multi-machine production (embedded nats-server covers dev/single-machine use):"
+  echo "  5. Recommended — NATS setup for multi-machine production (embedded nats-server covers dev/single-machine use):"
   echo ""
   echo "     cd ~/projects/lyra && make nats-setup"
   echo ""

--- a/deploy/setup.py
+++ b/deploy/setup.py
@@ -12,11 +12,32 @@ Prereqs (checked on entry): git, uv, podman, claude, GitHub SSH access.
 
 import os
 import shutil
+import socket
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 LYRA_DIR = Path(os.environ.get("LYRA_DIR", Path.home() / "projects" / "lyra"))
+HOSTS_TOML = Path(os.environ.get("HOSTS_TOML", Path.home() / "projects" / "hosts.toml"))
+
+
+def get_host_roles(hostname: str | None = None) -> set[str]:
+    """Read ~/projects/hosts.toml, return roles for current host.
+
+    Returns empty set if hosts.toml is missing or hostname is not listed
+    (non-destructive fallback — caller should warn and treat as no-roles).
+    """
+    name = hostname or socket.gethostname()
+    if not HOSTS_TOML.exists():
+        return set()
+    with open(HOSTS_TOML, "rb") as f:
+        data = tomllib.load(f)
+    entry = data.get("host", {}).get(name)
+    if not entry:
+        return set()
+    return set(entry.get("roles", []))
+
 
 # Hardcoded optional module registry — replaces the legacy deploy/stack.toml.
 # Lyra (this repo) is always installed by the caller before setup.py runs.
@@ -27,6 +48,7 @@ OPTIONAL_MODULES: list[dict[str, object]] = [
         "path": Path.home() / "projects" / "voiceCLI",
         "install": "uv sync",
         "description": "TTS/STT (requires NVIDIA GPU, ~3 GB)",
+        "requires_role": "voice-worker",
     },
     {
         "name": "imageCLI",
@@ -34,6 +56,7 @@ OPTIONAL_MODULES: list[dict[str, object]] = [
         "path": Path.home() / "projects" / "imageCLI",
         "install": "uv sync",
         "description": "Image generation CLI",
+        "requires_role": "image-worker",
     },
     {
         "name": "roxabi-vault",
@@ -41,6 +64,7 @@ OPTIONAL_MODULES: list[dict[str, object]] = [
         "path": Path.home() / "projects" / "roxabi-vault",
         "install": "uv sync",
         "description": "Knowledge vault",
+        "requires_role": None,
     },
 ]
 
@@ -111,10 +135,19 @@ def install_lyra(lyra_dir: Path) -> None:
     print("  ✓  lyra installed")
 
 
-def install_optional_module(module: dict, include_all: bool) -> Path | None:
+def install_optional_module(
+    module: dict, include_all: bool, host_roles: set[str]
+) -> Path | None:
     name = module["name"]
     path = Path(module["path"]).expanduser()
     desc = module["description"]
+    requires_role = module.get("requires_role")
+
+    # Role filter: skip silently when host has known roles but lacks the required one.
+    # When host_roles is empty (fallback), skip the filter to preserve old behaviour.
+    if host_roles and requires_role and requires_role not in host_roles:
+        print(f"  skip  {name}  (host lacks role '{requires_role}')")
+        return None
 
     if path.exists():
         print(f"  ✓  {name}  (already at {path})")
@@ -373,7 +406,11 @@ def setup_plugins(
 # ── Quadlet install + auto-start ────────────────────────────────────────────
 
 
-def install_quadlet_units(lyra_dir: Path) -> None:
+def install_quadlet_units(lyra_dir: Path, host_roles: set[str]) -> None:
+    # If we know the roles AND lyra-hub is not in them, skip cleanly.
+    if host_roles and "lyra-hub" not in host_roles:
+        print("  skip  Quadlet install (host lacks 'lyra-hub' role)")
+        return
     print("Installing Quadlet units (lyra)...")
     result = subprocess.run(["make", "quadlet-install"], cwd=lyra_dir)
     if result.returncode == 0:
@@ -384,7 +421,11 @@ def install_quadlet_units(lyra_dir: Path) -> None:
         sys.exit(1)
 
 
-def enable_linger() -> None:
+def enable_linger(host_roles: set[str]) -> None:
+    container_roles = {"lyra-hub", "voice-worker", "llm-worker", "image-worker"}
+    if host_roles and not (host_roles & container_roles):
+        print("  skip  linger (host runs no containers)")
+        return
     print("Enabling systemd linger...")
     user = os.environ.get("USER") or os.environ.get("LOGNAME")
     if not user:
@@ -401,11 +442,29 @@ def enable_linger() -> None:
 # ── Main ────────────────────────────────────────────────────────────────────
 
 
+def _print_host_roles(hostname: str, host_roles: set[str]) -> None:
+    """Print host/role banner; warn when hostname unknown or hosts.toml missing."""
+    if host_roles:
+        print(f"Host: {hostname} → roles: {sorted(host_roles)}")
+    elif not HOSTS_TOML.exists():
+        print(f"  !  {HOSTS_TOML} not found — proceeding without role filter")
+    else:
+        print(
+            f"  !  Host '{hostname}' not in {HOSTS_TOML}"
+            " — proceeding without role filter"
+        )
+
+
 def main() -> None:
     include_optional = "--all" in sys.argv
 
     print("\nLyra setup")
     print("─" * 40)
+    print()
+
+    hostname = socket.gethostname()
+    host_roles = get_host_roles(hostname)
+    _print_host_roles(hostname, host_roles)
     print()
 
     if not check_prereqs():
@@ -423,7 +482,7 @@ def main() -> None:
     print("Optional modules")
     print("─" * 40)
     for module in OPTIONAL_MODULES:
-        installed_path = install_optional_module(module, include_optional)
+        installed_path = install_optional_module(module, include_optional, host_roles)
         if module["name"] == "voiceCLI" and installed_path:
             voicecli_dir = installed_path
     print()
@@ -454,8 +513,8 @@ def main() -> None:
     setup_plugins(lyra_dir, voicecli_dir, include_optional)
 
     # Phase 5: Quadlet install + linger
-    install_quadlet_units(lyra_dir)
-    enable_linger()
+    install_quadlet_units(lyra_dir, host_roles)
+    enable_linger(host_roles)
 
     print()
     print("─" * 40)


### PR DESCRIPTION
## Summary

Phase 1A of the container-deployment cleanup (SSoT: `~/projects/docs/container-deployment-standard.md`, plan: `~/projects/docs/cleanup-plan.md`).

Foundation for Phase 1B (3 parallel repo fixers). Scope is strict: 2 files, no docs/tests/Makefile.

- **1A.3** `deploy/provision.sh` — remove supervisord install (S1 — Quadlet only) + delete broken `cp $(dirname \"\$0\")/lyra.service` block that errored at every run (file never existed) + rewrite Next-steps (drop bogus `systemctl --user enable lyra.service`, point to role-aware setup + cross-repo `deploy.sh`).
- **1A.4** `deploy/setup.py` — role-aware via `~/projects/hosts.toml`: `get_host_roles()` helper, `requires_role` per optional module (voiceCLI→`voice-worker`, imageCLI→`image-worker`, vault→any), gates on `install_optional_module()` / `install_quadlet_units()` / `enable_linger()`. Empty `host_roles` = fallback = non-destructive (no filter).

## Validation

Smoke (worktree run, pre-push):

\`\`\`
M1: ['llm-worker', 'lyra-hub', 'ops-cockpit', 'voice-worker']
M2: ['image-worker', 'llm-worker']
unknown: []
\`\`\`

All hooks green (ruff, pyright, importlinter, trufflehog). 5 pre-existing ruff violations in `setup.py` (C901/PLR0915/E501) confirmed pre-existing — zero new violations.

## Test plan

- [ ] Manual review of `provision.sh` diff (Next-steps wording)
- [ ] Manual review of `setup.py` role-gating logic
- [ ] Dry-run `python3 deploy/setup.py` on M₂ (host lacks `lyra-hub` → expect Quadlet skip)
- [ ] Merge unlocks Phase 1B (3 parallel fixers: lyra Stream 1, voiceCLI Stream 2, llmCLI+imageCLI Stream 3)