### PR TITLE
fix(migrate_bot_secrets): pass '-' arg so podman reads secret from stdin

### DIFF
--- a/tools/migrate_bot_secrets_to_podman.py
+++ b/tools/migrate_bot_secrets_to_podman.py
@@ -86,7 +86,7 @@ def _podman_secret_create(name: str, content: bytes, *, dry_run: bool) -> None:
         return
     try:
         subprocess.run(
-            ["podman", "secret", "create", "--replace", name],
+            ["podman", "secret", "create", "--replace", name, "-"],
             input=content,
             check=True,
         )


### PR DESCRIPTION
## Summary

Bug in `tools/migrate_bot_secrets_to_podman.py` (#1057 migration tool): missing `-` positional arg to `podman secret create`, causing the migration to fail on every secret with:

\`\`\`
Error: accepts 2 arg(s), received 1
podman secret create lyra-bot-discord-lyra failed (exit 125)
\`\`\`

\`podman secret create\` requires \`NAME FILE|-\` per its signature. Script invokes via \`subprocess.run\` with \`input=content\` (stdin bytes) but omits the \`-\` arg, so podman doesn't know to read from stdin.

## Fix

\`\`\`diff
-            ["podman", "secret", "create", "--replace", name],
+            ["podman", "secret", "create", "--replace", name, "-"],
\`\`\`

## Context

Caught during M₁ ops migration (Phase 1D-M₁ of `~/projects/docs/cleanup-plan.md`). Without this fix, the staging Quadlets refuse to start lyra-discord + lyra-telegram because they reference \`lyra-bot-{platform}-{bot_id}\` secrets that the migration tool couldn't create.

After fix on M₁: 4 bot tokens migrated successfully, both adapter services restored to active.

## Test plan
- [x] Verified on M₁ (Ubuntu 24.04, podman 5.7.0): migrate_bot_secrets_to_podman.py runs clean, 4 secrets created (lyra-bot-{discord,telegram}-{lyra,aryl})
- [x] Adapter containers start with the new secrets mounted at /run/secrets/bot_token-<bot_id>

🤖 Generated with [Claude Code](https://claude.com/claude-code)