### PR TITLE
fix(migration): make cli_session_id column add idempotent

### DIFF
--- a/src/lyra/infrastructure/stores/turn_store.py
+++ b/src/lyra/infrastructure/stores/turn_store.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -105,12 +106,19 @@ class TurnStore(SqliteStore, TurnStoreSessionMixin):
         await db.execute(_CREATE_POOL_SESSIONS)
         await db.execute(_CREATE_IDX_POOL_SESSIONS)
         await db.commit()
-        # v4 migration: add cli_session_id to pool_sessions (idempotent)
-        async with db.execute("PRAGMA table_info(pool_sessions)") as cur:
-            cols = {row[1] for row in await cur.fetchall()}
-        if "cli_session_id" not in cols:
+        # v4 migration: add cli_session_id to pool_sessions (idempotent).
+        # Use try/except instead of a PRAGMA table_info read-then-write to
+        # avoid a TOCTOU race under xdist parallel workers: two workers can
+        # both observe "column absent" before either runs ALTER TABLE, then
+        # both attempt the ALTER and the second raises
+        # OperationalError("duplicate column name: cli_session_id").
+        # aiosqlite.OperationalError is sqlite3.OperationalError.
+        try:
             await db.execute("ALTER TABLE pool_sessions ADD COLUMN cli_session_id TEXT")
             await db.commit()
+        except sqlite3.OperationalError as exc:
+            if "duplicate column" not in str(exc).lower():
+                raise
         # Gate backfill: skip if pool_sessions already has rows
         async with db.execute("SELECT 1 FROM pool_sessions LIMIT 1") as cur:
             if await cur.fetchone() is None:


### PR DESCRIPTION
## Summary

- **Root cause:** TOCTOU race in `TurnStore.connect()` — the v4 migration used a `PRAGMA table_info` read followed by `ALTER TABLE ADD COLUMN`, a non-atomic sequence. Under xdist parallel workers sharing `~/.lyra/turns.db` (fresh CI env, no `LYRA_VAULT_DIR` isolation in `test_nc_close_called_even_on_exception`), two workers both read "column absent" before either executes the ALTER, then both run it — the second raises `sqlite3.OperationalError: duplicate column name: cli_session_id`.
- **Fix:** Replace the two-step PRAGMA check with `try/except sqlite3.OperationalError` matching the existing pattern in `agent_store_migrations.py`. `aiosqlite.OperationalError is sqlite3.OperationalError` (same class, stdlib).
- **Manifestation:** Blocked CI on #1311 (Phase 1B Quadlet migration) and #1312 at 18% progress in the parallel pytest run (-n 4/xdist workers).

## Test plan

- [x] `uv run pytest tests/bootstrap/ -n 4` — 99 passed locally
- [x] `uv run ruff check .` — all checks passed
- [x] All pre-push hooks passed (lint, typecheck, import-layers, trufflehog)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)