### PR TITLE
fix(simple_agent): drop await on provider.stream (now async-gen, not coroutine)

### DIFF
--- a/src/lyra/agents/simple_agent.py
+++ b/src/lyra/agents/simple_agent.py
@@ -257,7 +257,7 @@ class SimpleAgent(AgentBase):
         # Streaming path: wrap with StreamProcessor to emit RenderEvent (#387)
         _stream_fn = getattr(self._provider, "stream", None)
         if model_cfg.streaming and _stream_fn is not None:
-            stream_iter = await _stream_fn(
+            stream_iter = _stream_fn(
                 pool.pool_id,
                 text,
                 model_cfg,

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -199,7 +199,7 @@ class TestSimpleAgentStreaming:
         # Arrange — provider has a stream() method
         provider = MagicMock()
         fake_iterator = _fake_async_gen("Hello", " world")
-        provider.stream = AsyncMock(return_value=fake_iterator)
+        provider.stream = MagicMock(return_value=fake_iterator)
         provider.is_alive = MagicMock(return_value=True)
         agent = make_streaming_agent(provider, streaming=True)
         msg = make_inbound_message("hello")
@@ -236,7 +236,7 @@ class TestSimpleAgentStreaming:
         # Arrange
         provider = MagicMock()
         fake_iterator = _fake_async_gen("token")
-        provider.stream = AsyncMock(return_value=fake_iterator)
+        provider.stream = MagicMock(return_value=fake_iterator)
         provider.is_alive = MagicMock(return_value=True)
         agent = make_streaming_agent(provider, streaming=True)
         msg = make_inbound_message("my question")
@@ -247,7 +247,7 @@ class TestSimpleAgentStreaming:
 
         # Assert — stream() called with the right pool_id, text, model_cfg,
         # system_prompt
-        provider.stream.assert_awaited_once()
+        provider.stream.assert_called_once()
         args = provider.stream.call_args[0]
         assert args[0] == "tg:main:user1"
         assert args[1] == "<user_message>my question</user_message>"
@@ -277,7 +277,7 @@ class TestSimpleAgentStreaming:
         # Arrange — pool has a custom system prompt override
         provider = MagicMock()
         fake_iterator = _fake_async_gen()
-        provider.stream = AsyncMock(return_value=fake_iterator)
+        provider.stream = MagicMock(return_value=fake_iterator)
         provider.is_alive = MagicMock(return_value=True)
         agent = make_streaming_agent(provider, streaming=True)
         msg = make_inbound_message("hello")
@@ -297,7 +297,7 @@ class TestSimpleAgentStreaming:
         # Arrange — no pool system prompt → agent config system_prompt used
         provider = MagicMock()
         fake_iterator = _fake_async_gen()
-        provider.stream = AsyncMock(return_value=fake_iterator)
+        provider.stream = MagicMock(return_value=fake_iterator)
         provider.is_alive = MagicMock(return_value=True)
         agent = make_streaming_agent(provider, streaming=True)
         msg = make_inbound_message("hello")


### PR DESCRIPTION
## Summary

Production bug surfacing on every Telegram + Discord message to M₁ post-#1311 staging deploy:

\`\`\`
TypeError: object async_generator can't be used in 'await' expression
  File \"src/lyra/core/pool/pool_processor_exec.py\", line 168, in process_one
    result = await result
  File \"src/lyra/agents/simple_agent.py\", line 260, in process
    stream_iter = await _stream_fn(...)
\`\`\`

User-visible: \"Something went wrong. Please try again.\" reply to every message.

## Root cause

Commit f28395bc (#1278 B4 review fix) collapsed \`LlmClient.stream\` into a real async-generator:
- Body has \`yield\` directly (no \`_stream_gen\` coroutine wrapper)
- LlmProvider Protocol updated to declare \`stream()\` as regular function returning \`AsyncIterator\`
- Drivers (ClaudeCliDriver, CliNatsDriver, RetryDecorator, CircuitBreakerDecorator) all delegate via \`async for / yield\`

The commit message explicitly states: \"Callers can \`async for ev in provider.stream(...)\` without \`await\`.\"

\`SimpleAgent.process:260\` was the one caller MISSED — still has \`await\`:

\`\`\`python
stream_iter = await _stream_fn(...)  # ← BUG: _stream_fn is now async-gen function
\`\`\`

Async-generator objects are not awaitable. Hence the runtime TypeError on every streaming inbound message.

## Fix

Drop the \`await\`:

\`\`\`diff
-stream_iter = await _stream_fn(
+stream_iter = _stream_fn(
     pool.pool_id,
     text,
     model_cfg,
     pool._system_prompt or self.config.system_prompt,
 )
\`\`\`

Plus: update unit tests to match the new contract — \`MagicMock(return_value=fake_iter)\` instead of \`AsyncMock\`, \`assert_called_once()\` instead of \`assert_awaited_once()\`.

## Test plan
- [x] \`uv run pytest tests/agents/ -n 4\` → 57/57 pass
- [x] \`uv run pytest tests/agents/test_simple_agent.py::TestSimpleAgentStreaming -v\` → 6/6 pass
- [ ] Deploy to M₁ + verify Telegram/Discord roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)