### PR TITLE
feat(acl-matrix): add llm-operator identity + llm-worker lifecycle subscribes

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -14,41 +14,43 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 ## ACL Matrix
 
 <!-- acl-matrix:begin -->
-| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | image-worker | monitor | clipool-worker | voice-client |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| `$JS.API.>` | PUB | PUB | PUB | PUB | PUB | PUB | PUB | — | PUB | — |
-| `$KV.lyra-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | SUB | — | SUB | — |
-| `_inbox.clipool-worker.>` | — | — | — | — | — | — | — | — | SUB | — |
-| `_inbox.discord-adapter.*.*` | — | — | SUB | — | — | — | — | — | — | — |
-| `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — |
-| `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | PUB | — | PUB | — |
-| `_inbox.image-worker.>` | — | — | — | — | — | — | SUB | — | — | — |
-| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — |
-| `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — |
-| `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — |
-| `_inbox.voice-client.>` | — | — | — | — | PUB | — | — | — | — | SUB |
-| `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — |
-| `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — |
-| `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — |
-| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | SUB | — |
-| `lyra.clipool.control` | PUB | — | — | — | — | — | — | — | SUB | — |
-| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | PUB | — |
-| `lyra.image.generate.request` | PUB | — | — | — | — | — | SUB | — | — | — |
-| `lyra.image.heartbeat` | SUB | — | — | — | — | — | PUB | — | — | — |
-| `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — | — |
-| `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — | — |
-| `lyra.llm.generate.request` | PUB | — | — | — | — | SUB | — | — | — | — |
-| `lyra.llm.heartbeat` | SUB | — | — | — | — | PUB | — | — | — | — |
-| `lyra.monitor.>` | — | — | — | — | — | — | — | PUB+SUB | — | — |
-| `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — | — |
-| `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — | — |
-| `lyra.system.ready` | SUB | PUB | PUB | PUB | PUB | — | — | — | PUB | — |
-| `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — | — | — | — |
-| `lyra.voice.stt.request` | — | — | — | — | SUB | — | — | — | — | PUB |
-| `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — |
-| `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — |
-| `lyra.voice.tts.request` | — | — | — | SUB | — | — | — | — | — | — |
-| `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — |
+| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | llm-operator | image-worker | monitor | clipool-worker | voice-client |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| `$JS.API.>` | PUB | PUB | PUB | PUB | PUB | PUB | — | PUB | — | PUB | — |
+| `$KV.lyra-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | — | SUB | — | SUB | — |
+| `_inbox.clipool-worker.>` | — | — | — | — | — | — | — | — | — | SUB | — |
+| `_inbox.discord-adapter.*.*` | — | — | SUB | — | — | — | — | — | — | — | — |
+| `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — | — |
+| `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | — | PUB | — | PUB | — |
+| `_inbox.image-worker.>` | — | — | — | — | — | — | — | SUB | — | — | — |
+| `_inbox.llm-operator.>` | — | — | — | — | — | — | SUB | — | — | — | — |
+| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — | — |
+| `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — |
+| `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — |
+| `_inbox.voice-client.>` | — | — | — | — | PUB | — | — | — | — | — | SUB |
+| `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — |
+| `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — |
+| `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | — | SUB | — |
+| `lyra.clipool.control` | PUB | — | — | — | — | — | — | — | — | SUB | — |
+| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | — | PUB | — |
+| `lyra.image.generate.request` | PUB | — | — | — | — | — | — | SUB | — | — | — |
+| `lyra.image.heartbeat` | SUB | — | — | — | — | — | — | PUB | — | — | — |
+| `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — | — | — |
+| `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — | — | — |
+| `lyra.llm.generate.request` | PUB | — | — | — | — | SUB | — | — | — | — | — |
+| `lyra.llm.heartbeat` | SUB | — | — | — | — | PUB | — | — | — | — | — |
+| `lyra.llm.lifecycle.>` | — | — | — | — | — | SUB | PUB | — | — | — | — |
+| `lyra.monitor.>` | — | — | — | — | — | — | — | — | PUB+SUB | — | — |
+| `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — | — | — |
+| `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — | — | — |
+| `lyra.system.ready` | SUB | PUB | PUB | PUB | PUB | — | — | — | — | PUB | — |
+| `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — | — | — | — | — |
+| `lyra.voice.stt.request` | — | — | — | — | SUB | — | — | — | — | — | PUB |
+| `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — | — |
+| `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — | — |
+| `lyra.voice.tts.request` | — | — | — | SUB | — | — | — | — | — | — | — |
+| `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — | — |
 <!-- acl-matrix:end -->
 
 [^ready]: `lyra.system.ready` — adapters and workers publish once on startup; hub subscribes to track liveness.

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -130,8 +130,23 @@
       ],
       "subscribe": [
         "lyra.llm.generate.request",
+        "lyra.llm.lifecycle.>",
         "_inbox.llmcli-llm.>",
         "$KV.lyra-state.>"
+      ]
+    },
+    "llm-operator": {
+      "status": "active",
+      "created_at": "2026-05-22",
+      "owner": "reserved",
+      "description": "llmCLI operator CLI — publishes lifecycle commands (swap/stop/status/list/reload-catalog) to llm-worker from M₂. Implements llmCLI spec #34 Slice 0 (A1). Creds installed at ~/.roxabi/llmcli/nkeys/operator.creds (S6 standard, llmCLI#61).",
+      "notes": "CLI tool, not a daemon — ¬wait_for_hub, ¬JetStream readiness probe. Inbox uses llm-operator role name (no #1142 mismatch). Coordinate cred path migration (legacy ~/.config/llmcli → ~/.roxabi/llmcli) with llmCLI#61.",
+      "allow_responses": true,
+      "publish": [
+        "lyra.llm.lifecycle.>"
+      ],
+      "subscribe": [
+        "_inbox.llm-operator.>"
       ]
     },
     "image-worker": {

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -59,7 +59,16 @@ authorization {
       # llm-worker
       permissions: {
         publish:   { allow: ["lyra.llm.heartbeat","$JS.API.>","_inbox.hub.>"] }
-        subscribe: { allow: ["lyra.llm.generate.request","_inbox.llmcli-llm.>","$KV.lyra-state.>"] }
+        subscribe: { allow: ["lyra.llm.generate.request","lyra.llm.lifecycle.>","_inbox.llmcli-llm.>","$KV.lyra-state.>"] }
+        allow_responses: true
+      }
+    }
+    {
+      nkey: "UDETLLMOPERATOR"
+      # llm-operator
+      permissions: {
+        publish:   { allow: ["lyra.llm.lifecycle.>"] }
+        subscribe: { allow: ["_inbox.llm-operator.>"] }
         allow_responses: true
       }
     }


### PR DESCRIPTION
## Summary
- Add new `llm-operator` identity: `pub lyra.llm.lifecycle.>` + `sub _inbox.llm-operator.>` — enables `llmcli swap --host` operator commands from M₂
- Augment `llm-worker.subscribe` with `lyra.llm.lifecycle.>` — fixes 5 NATS permission violations logged on boot
- Regenerate `auth.conf` template via `lyra-acl genkeys --template-only` to reflect both changes

Implements llmCLI spec #34 Slice 0 (A1–A3), deferred when code slices 1-N shipped.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1315: acl-matrix: execute spec #34 Slice 0 | Open |
| Implementation | 1 commit on `feat/1315-acl-matrix-llm-operator` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (183 passed) | Passed |

## Test Plan
- [ ] On M₁: `sudo lyra-acl genkeys` (generates `llm-operator.seed`, rewrites real `auth.conf`)
- [ ] Rotate Podman secret `lyra-nats-auth` → `systemctl --user restart lyra-nats`
- [ ] `journalctl --user -u llmcli-nats-worker --since '1 min ago' | grep -i violation` → 0 hits
- [ ] Install operator creds on M₂: `~/.roxabi/llmcli/nkeys/operator.creds` (chmod 600, coordinate with llmCLI#61)
- [ ] Smoke test: `llmcli swap qwen3-4b --host roxabituwer` → succeeds

Closes #1315

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`