### PR TITLE
perf(image): split lyra runtime into svc + agent stages, slim hub/telegram/discord (#1095)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,3 +12,24 @@ jobs:
     with:
       image_name: ghcr.io/roxabi/lyra
       release_please_component: lyra
+  publish-svc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: svc-runtime
+          push: true
+          tags: ghcr.io/roxabi/lyra:staging-svc
+          cache-from: type=gha,scope=lyra-svc
+          cache-to: type=gha,mode=max,scope=lyra-svc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,7 @@ jobs:
           tags: ghcr.io/roxabi/lyra:staging-svc
           cache-from: type=gha,scope=lyra-svc
           cache-to: type=gha,mode=max,scope=lyra-svc
+      - name: Verify forbidden binaries absent (SC-3)
+        run: |
+          docker run --rm ghcr.io/roxabi/lyra:staging-svc \
+            sh -c 'which bun claude corepack node lyra-gh 2>/dev/null && exit 1 || exit 0'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,19 +13,20 @@ jobs:
       image_name: ghcr.io/roxabi/lyra
       release_please_component: lyra
   publish-svc:
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           target: svc-runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY src/ src/
 RUN uv sync --frozen --no-dev
 
 # ── Slim service runtime (hub, telegram, discord) ───────────────────────────
+# TODO: pin base-svc by digest — track alongside base:latest pinning issue
 FROM ghcr.io/roxabi/base-svc:latest AS svc-runtime
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,27 @@ COPY packages/ packages/
 COPY src/ src/
 RUN uv sync --frozen --no-dev
 
-# ── Runtime stage ────────────────────────────────────────────────────────────
-FROM ghcr.io/roxabi/base:latest AS runtime
+# ── Slim service runtime (hub, telegram, discord) ───────────────────────────
+FROM ghcr.io/roxabi/base-svc:latest AS svc-runtime
+
+USER root
+
+# UID 1500 pinned per ADR-053 (Quadlet container UID stability)
+RUN useradd -u 1500 -m lyra
+
+COPY --from=builder --chown=lyra:lyra /app /app
+
+WORKDIR /app
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+USER lyra
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD lyra config validate || exit 1
+
+# ── Agent runtime (clipool — full gh_token tooling) ───────────────────────────
+FROM ghcr.io/roxabi/base:latest AS agent-runtime
 
 USER root
 

--- a/deploy/quadlet/lyra-discord.container
+++ b/deploy/quadlet/lyra-discord.container
@@ -10,7 +10,7 @@ StartLimitBurst=5
 [Container]
 # Image digest pinning for localhost/lyra:latest tracks on a follow-up issue
 # (CI tag-by-SHA strategy).
-Image=ghcr.io/roxabi/lyra:staging
+Image=ghcr.io/roxabi/lyra:staging-svc
 Label=io.containers.autoupdate=registry
 ContainerName=lyra-discord
 Network=roxabi.network

--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -9,7 +9,7 @@ StartLimitBurst=5
 # Image digest pinning for localhost/lyra:latest tracks on a follow-up issue
 # (CI tag-by-SHA strategy). Upstream registry images (e.g. nats.container)
 # are pinned by digest directly.
-Image=ghcr.io/roxabi/lyra:staging
+Image=ghcr.io/roxabi/lyra:staging-svc
 Label=io.containers.autoupdate=registry
 ContainerName=lyra-hub
 Network=roxabi.network

--- a/deploy/quadlet/lyra-telegram.container
+++ b/deploy/quadlet/lyra-telegram.container
@@ -10,7 +10,7 @@ StartLimitBurst=5
 [Container]
 # Image digest pinning for localhost/lyra:latest tracks on a follow-up issue
 # (CI tag-by-SHA strategy).
-Image=ghcr.io/roxabi/lyra:staging
+Image=ghcr.io/roxabi/lyra:staging-svc
 Label=io.containers.autoupdate=registry
 ContainerName=lyra-telegram
 Network=roxabi.network

--- a/docs/ops/container-publishing.md
+++ b/docs/ops/container-publishing.md
@@ -30,6 +30,12 @@ caller workflow that feeds project-specific inputs.
   > silently drop this instruction. The reusable workflow sets `oci-mediatypes=false` on the
   > `docker/build-push-action` step to force Docker v2 schema 2, so `HEALTHCHECK` is preserved
   > in the published image. No action needed in the Dockerfile or caller workflow.
+
+  > **svc-runtime (`staging-svc`) requires `config.toml` bind-mount:** `lyra config validate`
+  > opens `config.toml` from `WORKDIR /app` and exits 1 on `FileNotFoundError`. In production
+  > Quadlets the file is bind-mounted, so this is fine. Running `docker run` without the mount
+  > (local dev, CI smoke tests) will immediately mark the container unhealthy — this is expected
+  > behaviour, not a bug.
 - **OCI labels** — do not set `org.opencontainers.image.*` labels in the Dockerfile. They are
   injected at build time by `docker/metadata-action@v5` in the reusable workflow, ensuring labels
   always match the actual pushed tag and commit SHA.

--- a/docs/ops/container-publishing.md
+++ b/docs/ops/container-publishing.md
@@ -129,10 +129,11 @@ containers. No manual intervention is needed after a staging merge.
 
 | Container | Image | AutoUpdate |
 |---|---|---|
-| lyra-hub | `ghcr.io/roxabi/lyra:staging` | registry |
-| lyra-telegram | `ghcr.io/roxabi/lyra:staging` | registry |
-| lyra-discord | `ghcr.io/roxabi/lyra:staging` | registry |
+| lyra-hub | `ghcr.io/roxabi/lyra:staging-svc` | registry |
+| lyra-telegram | `ghcr.io/roxabi/lyra:staging-svc` | registry |
+| lyra-discord | `ghcr.io/roxabi/lyra:staging-svc` | registry |
 | lyra-clipool | `ghcr.io/roxabi/lyra:staging` | registry |
+| lyra-gh-helper | `ghcr.io/roxabi/lyra:staging` | registry |
 | voicecli-tts | `ghcr.io/roxabi/voicecli-tts:staging` | registry |
 | voicecli-stt | `ghcr.io/roxabi/voicecli-stt:staging` | registry |
 | lyra-nats | pinned by digest | none (pinned) |
@@ -158,6 +159,11 @@ podman auto-update
   `podman login --get-login ghcr.io`.
 - Podman does not auto-rollback on startup failure. A bad image enters a restart loop
   (`Restart=on-failure`). Check with `podman ps` or `journalctl --user -u <unit>`.
+- **Parallel publish inconsistency window (known):** `publish` (`:staging`) and `publish-svc`
+  (`:staging-svc`) jobs run in parallel — if one fails, the other may still push. During that
+  window, autoupdate can pull one variant while the other is stale. Accepted risk at staging;
+  long-term fix is a single `docker buildx bake` job that pushes both targets atomically —
+  tracked in #1325.
 
 ---
 


### PR DESCRIPTION
## Summary
- Split `Dockerfile` single `runtime` stage into `svc-runtime` (FROM `base-svc:latest`, no claude/bun/lyra-gh tooling) and `agent-runtime` (FROM `base:latest`, full toolchain, last stage = default)
- Add `publish-svc` inline CI job to publish `ghcr.io/roxabi/lyra:staging-svc` in parallel with the existing reusable workflow; uses GHA cache scope `lyra-svc` to avoid key collision
- Flip `lyra-hub`, `lyra-telegram`, `lyra-discord` Quadlets to `Image=ghcr.io/roxabi/lyra:staging-svc`; `lyra-clipool` and `lyra-gh-helper` unchanged

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1095: perf(image): slim non-clipool services | Open |
| Frame | [1095-slim-non-clipool-services-frame.mdx](artifacts/frames/1095-slim-non-clipool-services-frame.mdx) | Approved |
| Spec | [1095-slim-non-clipool-services-spec.mdx](artifacts/specs/1095-slim-non-clipool-services-spec.mdx) | Approved |
| Plan | [1095-slim-non-clipool-services-plan.mdx](artifacts/plans/1095-slim-non-clipool-services-plan.mdx) | Approved |
| Implementation | 3 commits on `feat/1095-slim-non-clipool-services` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4219 passed) | Passed |

## Test Plan
- [ ] Push to staging → CI publishes both `ghcr.io/roxabi/lyra:staging` and `ghcr.io/roxabi/lyra:staging-svc` (requires `base-svc:latest` available in GHCR first)
- [ ] `docker build --target svc-runtime` locally once `base-svc:latest` is published
- [ ] `docker run --rm <svc-image> which bun claude node lyra-gh` → all exit non-zero (tools absent)
- [ ] `docker inspect --format='{{.Size}}' <svc-image>` → ≤ 838860800 bytes
- [ ] `lyra config validate` passes on hub/telegram/discord with svc image (HEALTHCHECK)
- [ ] clipool + lyra-gh-helper smoke test unchanged

> ⚠️ **Upstream gate:** `ghcr.io/roxabi/base-svc:latest` must be published from `roxabi-container` before merging — the `publish-svc` CI job will fail without it. Merge as a unit once the companion issue lands.

Closes #1095

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`