### PR TITLE
fix(nats): correct llm-operator creds ref llmCLI#61 → llmCLI#38

### DIFF
--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -139,8 +139,8 @@
       "status": "active",
       "created_at": "2026-05-22",
       "owner": "reserved",
-      "description": "llmCLI operator CLI — publishes lifecycle commands (swap/stop/status/list/reload-catalog) to llm-worker from M₂. Implements llmCLI spec #34 Slice 0 (A1). Creds installed at ~/.roxabi/llmcli/nkeys/operator.creds (S6 standard, llmCLI#61).",
-      "notes": "CLI tool, not a daemon — ¬wait_for_hub, ¬JetStream readiness probe. Inbox uses llm-operator role name (no #1142 mismatch). Coordinate cred path migration (legacy ~/.config/llmcli → ~/.roxabi/llmcli) with llmCLI#61.",
+      "description": "llmCLI operator CLI — publishes lifecycle commands (swap/stop/status/list/reload-catalog) to llm-worker from M₂. Implements llmCLI spec #34 Slice 0 (A1). Creds installed at ~/.roxabi/llmcli/nkeys/operator.creds (S6 standard, llmCLI#38).",
+      "notes": "CLI tool, not a daemon — ¬wait_for_hub, ¬JetStream readiness probe. Inbox uses llm-operator role name (no #1142 mismatch). Coordinate cred path migration (legacy ~/.config/llmcli → ~/.roxabi/llmcli) with llmCLI#38.",
       "allow_responses": true,
       "publish": [
         "lyra.llm.lifecycle.>"


### PR DESCRIPTION
## Summary
- Correct wrong issue reference in `deploy/nats/acl-matrix.json` for the `llm-operator` identity
- Creds path migration (`~/.config/llmcli` → `~/.roxabi/llmcli`) was tracked in llmCLI#38 (closed), not llmCLI#61 (--fleet ops + _nats_client.py)
- Fixed in both `description` and `notes` fields

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1327: fix(nats): acl-matrix.json llm-operator creds note references wrong issue (#61 → #38) | Open |
| Implementation | 1 commit on `feat/1327-fix-acl-matrix-issue-ref` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ | Passed |

## Test Plan
- [ ] Verify `deploy/nats/acl-matrix.json` `llm-operator` description references `llmCLI#38`
- [ ] Verify `deploy/nats/acl-matrix.json` `llm-operator` notes references `llmCLI#38`

Closes #1327

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`