### PR TITLE
fix(transport): remove SanitizedError.detail field

### DIFF
--- a/src/lyra/core/cli/cli_streaming_parser.py
+++ b/src/lyra/core/cli/cli_streaming_parser.py
@@ -225,7 +225,6 @@ class CliStreamingParser:
                 code="cli.parse",
                 message=f"CLI emitted malformed JSON: {type(exc).__name__}",
                 retryable=meta.default_retryable,
-                detail=None,
             )
         ):
             self._pending.append(result_event)

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -276,7 +276,6 @@ class StreamProcessor:
                     code="stream.error",
                     message=type(exc).__name__,
                     retryable=False,
-                    detail=None,
                 )
             ):
                 yield _ev
@@ -306,7 +305,6 @@ class StreamProcessor:
                     code=_we.code,
                     message=_we.message,
                     retryable=_we.retryable,
-                    detail=None,
                 )
             else:
                 _sanitized = SanitizedError.from_message(self._result_error_text or "")

--- a/src/lyra/llm/cli_nats_codec.py
+++ b/src/lyra/llm/cli_nats_codec.py
@@ -121,7 +121,7 @@ class CliNatsCodec:
                 error=err.message,
                 retryable=err.retryable,
                 worker_error=_make_worker_error(
-                    err.code, err.message, err.retryable, err.detail
+                    err.code, err.message, err.retryable
                 ),
             )
         try:
@@ -164,7 +164,7 @@ class CliNatsCodec:
                 cost_usd=None,
                 error_text=err.message,
                 worker_error=_make_worker_error(
-                    err.code, err.message, err.retryable, err.detail
+                    err.code, err.message, err.retryable
                 ),
             )
         try:

--- a/src/lyra/llm/cli_nats_codec.py
+++ b/src/lyra/llm/cli_nats_codec.py
@@ -52,11 +52,9 @@ class _CliSessionStore(Protocol):
     async def get_cli_session(self, session_id: str) -> str | None: ...
 
 
-def _make_worker_error(
-    code: str, message: str, retryable: bool, detail: str | None = None
-) -> WorkerError:
+def _make_worker_error(code: str, message: str, retryable: bool) -> WorkerError:
     assert code in KNOWN_CODES, f"unknown WorkerError code: {code}"
-    return WorkerError(code=code, message=message, retryable=retryable, detail=detail)
+    return WorkerError(code=code, message=message, retryable=retryable, detail=None)
 
 
 class CliNatsCodec:
@@ -120,9 +118,7 @@ class CliNatsCodec:
             return LlmResult(
                 error=err.message,
                 retryable=err.retryable,
-                worker_error=_make_worker_error(
-                    err.code, err.message, err.retryable
-                ),
+                worker_error=_make_worker_error(err.code, err.message, err.retryable),
             )
         try:
             resp = LlmResponse.model_validate_json(result.value)
@@ -163,9 +159,7 @@ class CliNatsCodec:
                 duration_ms=0,
                 cost_usd=None,
                 error_text=err.message,
-                worker_error=_make_worker_error(
-                    err.code, err.message, err.retryable
-                ),
+                worker_error=_make_worker_error(err.code, err.message, err.retryable),
             )
         try:
             chunk = LlmChunkEvent.model_validate_json(result.value)

--- a/src/lyra/outbound/error_handler.py
+++ b/src/lyra/outbound/error_handler.py
@@ -51,7 +51,6 @@ class OutboundErrorHandler:
             code=context,
             message=type(exc).__name__,
             retryable=False,
-            detail=None,
         )
 
     async def guard(

--- a/src/lyra/transport/_result.py
+++ b/src/lyra/transport/_result.py
@@ -36,7 +36,6 @@ class SanitizedError:
     code: str
     message: str
     retryable: bool
-    detail: str | None = None
 
     @classmethod
     def from_message(
@@ -50,13 +49,11 @@ class SanitizedError:
         bus raw). Falls back to ``"model_error"`` when ``message`` is empty.
         """
         if not message:
-            return cls(code=code, message="model_error", retryable=False, detail=None)
+            return cls(code=code, message="model_error", retryable=False)
         scrubbed = "".join(c if c.isprintable() else " " for c in message)
         if len(scrubbed) > _BUS_MESSAGE_MAX_LEN:
             scrubbed = scrubbed[: _BUS_MESSAGE_MAX_LEN - 1] + "…"
-        return cls(
-            code=code, message=scrubbed or "model_error", retryable=False, detail=None
-        )
+        return cls(code=code, message=scrubbed or "model_error", retryable=False)
 
 
 @dataclass(frozen=True)

--- a/tests/transport/test_result_types.py
+++ b/tests/transport/test_result_types.py
@@ -54,16 +54,9 @@ def test_sanitized_error_frozen() -> None:
         se.retryable = False  # type: ignore[misc]
 
 
-def test_sanitized_error_detail_defaults_none() -> None:
-    se = SanitizedError(code="transport.err", message="ValueError", retryable=False)
-    assert se.detail is None
-
-
-def test_sanitized_error_detail_explicit() -> None:
-    se = SanitizedError(
-        code="transport.err", message="ValueError", retryable=False, detail="extra"
-    )
-    assert se.detail == "extra"
+def test_sanitized_error_has_exactly_expected_fields() -> None:
+    fields = {f.name for f in dataclasses.fields(SanitizedError)}
+    assert fields == {"code", "message", "retryable"}
 
 
 async def _stub_messages() -> AsyncIterator[Result[bytes, SanitizedError]]:
@@ -107,7 +100,6 @@ class TestSanitizedErrorFromMessage:
         assert result.message == "model_error"
         assert result.code == "stream.error"
         assert result.retryable is False
-        assert result.detail is None
 
     def test_control_chars_are_stripped(self) -> None:
         """Non-printable control chars (NUL, BEL, newline, CR) become spaces."""


### PR DESCRIPTION
## Summary

- Removes the `detail: str | None = None` field from `SanitizedError` dataclass in `src/lyra/transport/_result.py`
- Updates all callers (4 files) that passed `detail=None` or accessed `err.detail`
- Replaces the two old `detail`-testing tests with a field-set assertion guard

## Why

The `detail` field was unused by any caller but created a regression surface for the #1212 invariant: sanitized errors must carry `type(exc).__name__` only, never `str(exc)`. Removing the field eliminates the path entirely — no validator to maintain.

Scope is localized to `src/lyra/transport/_result.py`; `packages/roxabi-contracts/` is untouched to preserve parallel-safety with #1330/#1333.

Closes #1290
Parent epic: #1277

## Test plan

- [ ] All quality gates pass: ruff, pyright, pytest, lint-imports
- [ ] `test_sanitized_error_has_exactly_expected_fields` asserts `{"code", "message", "retryable"}` — prevents silent reintroduction of the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)