### PR TITLE
refactor(transport): move WorkerRegistry lookup out of WorkerPoolClient (#1319)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -38,11 +38,6 @@ ignore_imports =
     lyra.core.cli.cli_pool_session -> lyra.infrastructure.stores.turn_store
     lyra.core.pool.pool -> lyra.infrastructure.stores.turn_store
     lyra.core.pool.pool_observer -> lyra.infrastructure.stores.turn_store
-    # LlmClient (lyra.llm) TYPE_CHECKING import of WorkerPoolClient (lyra.transport),
-    # which transitively imports lyra.nats.worker_registry. LlmClient is semantically
-    # at the same layer as voice clients in lyra.nats; llm/ placement is domain grouping
-    # only. Track for lyra.transport layer extraction — DEBT:importlinter-llm-transport-nats
-    lyra.llm.llm_client -> lyra.transport.worker_pool_client
     # OutboundEmitter (lyra.outbound) imports shared state types that REMAIN in
     # lyra.adapters.shared per resolved Open Q 2 (spec §Resolved Open Questions).
     # classify_stream_error has moved to OutboundErrorHandler (#1279), but StreamState

--- a/.importlinter
+++ b/.importlinter
@@ -13,6 +13,7 @@ layers =
     lyra.infrastructure
     lyra.llm | lyra.nats
     lyra.core
+    lyra.transport
 ignore_imports =
     # Downward TYPE_CHECKING imports (ADR-048 transition) — DEBT:importlinter-adr048-transition
     lyra.core.agent.agent_refiner -> lyra.infrastructure.stores.agent_store

--- a/src/lyra/bootstrap/factory/hub_builder.py
+++ b/src/lyra/bootstrap/factory/hub_builder.py
@@ -52,6 +52,7 @@ async def build_llm_client(
     """Build and start an LlmClient connected to the clipool worker via NATS."""
     from lyra.llm.cli_pool_codec import CliPoolCodec
     from lyra.llm.llm_client import LlmClient
+    from lyra.nats.worker_registry import WorkerRegistry
     from lyra.transport.nats_request_response import NatsTransport
     from lyra.transport.worker_pool_client import WorkerPoolClient
     from roxabi_contracts._nats_utils import validate_worker_id
@@ -59,6 +60,7 @@ async def build_llm_client(
     transport = NatsTransport(nc)
     pool = WorkerPoolClient(
         transport,
+        registry=WorkerRegistry(),
         hb_subject="lyra.clipool.heartbeat",
         validate_worker_id=validate_worker_id,
         name="clipool",

--- a/src/lyra/bootstrap/factory/llm_overlay.py
+++ b/src/lyra/bootstrap/factory/llm_overlay.py
@@ -23,6 +23,7 @@ async def init_nats_llm(nc: "NATS | None") -> "LlmClient | None":
 
     from lyra.llm.cli_nats_codec import CliNatsCodec
     from lyra.llm.llm_client import LlmClient
+    from lyra.nats.worker_registry import WorkerRegistry
     from lyra.transport.nats_request_response import NatsTransport
     from lyra.transport.worker_pool_client import WorkerPoolClient
     from roxabi_contracts.llm import SUBJECTS, validate_worker_id
@@ -30,6 +31,7 @@ async def init_nats_llm(nc: "NATS | None") -> "LlmClient | None":
     transport = NatsTransport(nc)
     pool = WorkerPoolClient(
         transport,
+        registry=WorkerRegistry(),
         hb_subject=SUBJECTS.heartbeat,
         validate_worker_id=validate_worker_id,
         name="llm",

--- a/src/lyra/bootstrap/factory/voice_overlay.py
+++ b/src/lyra/bootstrap/factory/voice_overlay.py
@@ -32,6 +32,7 @@ def init_nats_tts(nc: "NATS") -> "NatsTtsClient":
     """Create NatsTtsClient (3-layer). Call ``await client.start()`` to activate hb."""
     from lyra.nats.nats_tts_client import NatsTtsClient
     from lyra.nats.nats_tts_codec import TtsCodec
+    from lyra.nats.worker_registry import WorkerRegistry
     from lyra.transport.nats_request_response import NatsTransport
     from lyra.transport.worker_pool_client import WorkerPoolClient
     from roxabi_contracts.voice import SUBJECTS, validate_worker_id
@@ -39,6 +40,7 @@ def init_nats_tts(nc: "NATS") -> "NatsTtsClient":
     transport = NatsTransport(nc)
     pool = WorkerPoolClient(
         transport,
+        registry=WorkerRegistry(),
         hb_subject=SUBJECTS.tts_heartbeat,
         validate_worker_id=validate_worker_id,
         name="tts",
@@ -51,6 +53,7 @@ def init_nats_stt(nc: "NATS") -> "NatsSttClient":
     """Create NatsSttClient (3-layer). Call ``await client.start()`` to activate hb."""
     from lyra.nats.nats_stt_client import NatsSttClient
     from lyra.nats.nats_stt_codec import SttCodec
+    from lyra.nats.worker_registry import WorkerRegistry
     from lyra.transport.nats_request_response import NatsTransport
     from lyra.transport.worker_pool_client import WorkerPoolClient
     from roxabi_contracts.voice import SUBJECTS, validate_worker_id
@@ -63,6 +66,7 @@ def init_nats_stt(nc: "NATS") -> "NatsSttClient":
     transport = NatsTransport(nc)
     pool = WorkerPoolClient(
         transport,
+        registry=WorkerRegistry(),
         hb_subject=SUBJECTS.stt_heartbeat,
         validate_worker_id=validate_worker_id,
         name="stt",
@@ -77,6 +81,7 @@ def init_nats_image(nc: "NATS") -> "NatsImageClient":
     """Create NatsImageClient (3-layer). Call ``client.start()`` to start hb."""
     from lyra.nats.nats_image_client import NatsImageClient
     from lyra.nats.nats_image_codec import ImageCodec
+    from lyra.nats.worker_registry import WorkerRegistry
     from lyra.transport.nats_request_response import NatsTransport
     from lyra.transport.worker_pool_client import WorkerPoolClient
     from roxabi_contracts.image import SUBJECTS, validate_worker_id
@@ -84,6 +89,7 @@ def init_nats_image(nc: "NATS") -> "NatsImageClient":
     transport = NatsTransport(nc)
     pool = WorkerPoolClient(
         transport,
+        registry=WorkerRegistry(),
         hb_subject=SUBJECTS.image_heartbeat,
         validate_worker_id=validate_worker_id,
         name="image",

--- a/src/lyra/nats/CLAUDE.md
+++ b/src/lyra/nats/CLAUDE.md
@@ -99,8 +99,9 @@ consumer (`nats_tts_client.py`). `stt_helpers.py` provides Whisper noise tokens
 - `NatsBus`: caller owns the NATS connection; bus only manages subscriptions.
   Registrations survive `stop()` — safe to restart without re-registering. Never
   `register()` after `start()`.
-- `WorkerPoolClient` (from `lyra.transport`) owns CB + `WorkerRegistry` + heartbeat
-  subscription. Domain clients here DO NOT touch `nc.new_inbox()` / `nc.subscribe()`
+- `WorkerPoolClient` (from `lyra.transport`) owns CB + heartbeat subscription; accepts
+  `WorkerRegistry` via DI (bootstrap/factory owns the instance). Domain clients here DO
+  NOT touch `nc.new_inbox()` / `nc.subscribe()`
   directly — they call `pool.request_with_routing(subject_fn, payload)` or
   `pool.stream_request(payload)`.
 - All error paths in domain clients return either a populated domain value object

--- a/src/lyra/transport/CLAUDE.md
+++ b/src/lyra/transport/CLAUDE.md
@@ -9,7 +9,7 @@ Domain-agnostic NATS transport primitives consumed by all domain worker clients
 
 ```
 NatsTransport          — call() + open_inbox() CM; owns NATS inbox lifecycle
-WorkerPoolClient       — routing + CB + WorkerRegistry + heartbeat subscription
+WorkerPoolClient       — routing + CB + heartbeat subscription; registry via DI
 DomainClient           — thin wrapper in lyra.nats / lyra.llm (compose pool + codec)
 ```
 
@@ -17,8 +17,9 @@ DomainClient           — thin wrapper in lyra.nats / lyra.llm (compose pool + 
 
 - `NatsTransport.open_inbox()` is an async context manager; the `InboxStream` it yields
   is only valid inside the `async with` block — never escape the CM.
-- `WorkerPoolClient` owns the `WorkerRegistry` and heartbeat subscription. Domain clients
-  MUST NOT subscribe to heartbeat subjects or open inboxes directly.
+- `WorkerPoolClient` accepts a `WorkerRegistry` via dependency injection (bootstrap/factory
+  owns the instance) and manages the heartbeat subscription. Domain clients MUST NOT
+  subscribe to heartbeat subjects or open inboxes directly.
 - `Result[T]` / `Ok[T]` / `Err` are the return types for all transport-level calls.
   `SanitizedError` strips internal detail before propagation to users (#1212).
 - CB lives in `WorkerPoolClient` — domain clients must NOT add a second CB layer.

--- a/src/lyra/transport/worker_pool_client.py
+++ b/src/lyra/transport/worker_pool_client.py
@@ -14,7 +14,6 @@ import logging
 from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Protocol
 
-from lyra.nats.worker_registry import WorkerRegistry
 from lyra.transport._result import Err, InboxStream, Ok, Result, SanitizedError
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
 
@@ -23,6 +22,22 @@ if TYPE_CHECKING:
     from nats.aio.subscription import Subscription
 
 log = logging.getLogger(__name__)
+
+
+class _RegistryLike(Protocol):
+    """Structural type for the worker registry dependency.
+
+    WorkerRegistry (lyra.nats.worker_registry) satisfies this protocol.
+    Defined here so lyra.transport has no import dependency on lyra.nats.
+    """
+
+    def record_heartbeat(self, payload: dict) -> None: ...
+
+    def any_alive(self) -> bool: ...
+
+    def ordered_by_score(self) -> list[Any]: ...
+
+    def mark_stale(self, worker_id: str) -> None: ...
 
 
 class _TransportLike(Protocol):
@@ -45,17 +60,18 @@ class _TransportLike(Protocol):
 
 
 class WorkerPoolClient:
-    def __init__(
+    def __init__(  # noqa: PLR0913 — DEBT:wiring-bootstrap-deps
         self,
         transport: _TransportLike,
         *,
+        registry: _RegistryLike,
         hb_subject: str,
         validate_worker_id: Callable[[str], None],
         hb_ttl: float = 15.0,
         name: str = "pool",
     ) -> None:
         self._transport = transport
-        self._registry: WorkerRegistry = WorkerRegistry()
+        self._registry = registry
         self._cb: NatsCircuitBreaker = NatsCircuitBreaker()
         self._hb_subject = hb_subject
         self._validate_worker_id = validate_worker_id

--- a/src/lyra/transport/worker_pool_client.py
+++ b/src/lyra/transport/worker_pool_client.py
@@ -1,9 +1,10 @@
 """WorkerPoolClient — hub-side worker pool with CB + registry + heartbeat.
 
-Composes a transport (NATS today, HTTP tomorrow). Owns CircuitBreaker
-+ WorkerRegistry + heartbeat subscription. Domain clients (LLM, TTS, STT,
-Image) call request_with_routing() / stream_request(); pool stays
-domain-agnostic. Spec § Slice S3. Consensus § B2.
+Composes a transport (NATS today, HTTP tomorrow). Owns CircuitBreaker +
+heartbeat subscription; accepts WorkerRegistry via DI (bootstrap owns the
+instance). Domain clients (LLM, TTS, STT, Image) call
+request_with_routing() / stream_request(); pool stays domain-agnostic.
+Spec § Slice S3. Consensus § B2.
 """
 
 from __future__ import annotations

--- a/tests/transport/test_worker_pool_client.py
+++ b/tests/transport/test_worker_pool_client.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from lyra.nats.worker_registry import WorkerRegistry
 from lyra.transport._result import Err, InboxStream, Ok, SanitizedError
 from lyra.transport.nats_request_response import NatsTransport
 from lyra.transport.worker_pool_client import WorkerPoolClient
@@ -24,6 +25,7 @@ def _make_pool_with_workers(*worker_ids: str):
     mock_transport = MagicMock(spec=NatsTransport)
     pool = WorkerPoolClient(
         mock_transport,
+        registry=WorkerRegistry(),
         hb_subject="hb",
         validate_worker_id=lambda _: None,
         name="test-pool",
@@ -98,7 +100,7 @@ class TestRequestWithRoutingMarksStaleOnTimeout:
         await pool.request_with_routing(lambda wid: f"subj.{wid}", b"payload")
 
         # w-1 must be stale: last_heartbeat set to 0.0
-        assert pool._registry._workers["w-1"].last_heartbeat == 0.0
+        assert pool._registry._workers["w-1"].last_heartbeat == 0.0  # type: ignore[union-attr]
 
 
 class TestRequestWithRoutingNoLiveWorkers:


### PR DESCRIPTION
## Summary

- Removes `lyra.transport → lyra.nats.worker_registry` import by introducing a `_RegistryLike` Protocol in `lyra.transport`
- `WorkerPoolClient.__init__` now accepts `registry: _RegistryLike` as a keyword argument; callers in `lyra.bootstrap` resolve `WorkerRegistry` and inject it
- Adds `lyra.transport` as a layer at the bottom of `.importlinter`, enforcing `transport ↛ nats`
- `lyra.streaming` not added as a layer: `lyra.streaming.event_emitter` currently imports from `lyra.transport` (`SanitizedError`), so `streaming ↛ transport` cannot be enforced yet without a separate fix

## Acceptance

- [x] `uv run lint-imports` clean — all 8 contracts KEPT
- [x] `transport ↛ nats` enforced (lyra.transport added as bottom layer)
- [x] No new `ignore_imports` directives
- [x] `streaming ↛ transport` deferred — `lyra.streaming.event_emitter` imports `SanitizedError` from `lyra.transport`; scoped out per issue instructions (option a)

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 4224 passed, 15 skipped
- [x] `uv run lint-imports` — 8 kept, 0 broken
- [x] Pre-commit hooks — all passed

Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)