### PR TITLE
chore(arch): enforce lyra.streaming layer in .importlinter

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -4,7 +4,7 @@ source_root = src
 include_external_packages = True
 
 [importlinter:contract:clean-architecture-layers]
-name = Clean architecture layers (core ← llm/nats ← infrastructure ← adapters ← bootstrap)
+name = Clean architecture layers (transport ← streaming ← core ← llm/nats ← infrastructure ← adapters ← bootstrap)
 type = layers
 layers =
     lyra.bootstrap
@@ -13,6 +13,7 @@ layers =
     lyra.infrastructure
     lyra.llm | lyra.nats
     lyra.core
+    lyra.streaming
     lyra.transport
 ignore_imports =
     # Downward TYPE_CHECKING imports (ADR-048 transition) — DEBT:importlinter-adr048-transition


### PR DESCRIPTION
## Summary

Follows up #1319 / PR #1339. That PR added `lyra.transport` as the bottom layer in `.importlinter`'s `clean-architecture-layers` contract but deferred `lyra.streaming` because the fixer agent flagged `event_emitter → SanitizedError` (from `lyra.transport`) as a potential blocker.

**Investigation shows no blocker**: `lyra.streaming` sits ABOVE `lyra.transport` in the layer stack (`core > streaming > transport`), so `streaming → transport` is a downward import — allowed. The constraint enforced is `transport ↛ streaming`.

## Changes

- `.importlinter`: adds `lyra.streaming` between `lyra.core` and `lyra.transport` in `clean-architecture-layers`; updates contract name to reflect full stack
- No new `ignore_imports` directives

## Layer position rationale

- `lyra.core.processors.stream_processor` imports from `lyra.streaming` → core must be above streaming
- `lyra.streaming.event_emitter` imports `SanitizedError` from `lyra.transport` → streaming must be above transport (downward = allowed)
- Final order: `... > lyra.core > lyra.streaming > lyra.transport`

## Quality gates

- `lint-imports`: 8 contracts kept, 0 broken
- `ruff format/check`: passed
- `pyright`: 0 errors
- `pytest`: 4224 passed, 15 skipped

## Note

Stacked on PR #1339 (`refactor/1319-transport-nats-layering`). This branch branched off that PR's HEAD. Once #1339 merges to `staging`, this PR rebases cleanly (the only change here is the 2-line addition to `.importlinter`).

Closes #1340

Related: #1319 (parent), #1339 (stacked dependency), #1277 (epic)