### PR TITLE
feat(bootstrap): guard LYRA_RUN_SECRETS_DIR override against prod environments

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -358,6 +358,19 @@ After migration: regenerate the Quadlet fragments (`make quadlet-bot-secrets-ren
 
 webhook_secret packing: separate secret (not packed into JSON). This matches the project's raw-bytes single-purpose convention (every other Podman secret in `Makefile:181-200`), keeps the failure-loud bootstrap path free of a JSON parser, and supports independent rotation of token vs. webhook.
 
+### Production guard
+
+`LYRA_RUN_SECRETS_DIR` lets tests and local development point at a temporary directory instead of `/run/secrets`. In production this override is **ignored** as a defense-in-depth measure: an attacker with env-write access on a prod host cannot redirect token reads to a path they control.
+
+The guard activates when **either** condition is true:
+
+| Condition | Detection |
+|---|---|
+| Inside a container | `/run/.containerenv` exists (Podman runtime marker) |
+| Explicit prod mode | `LYRA_ENV=prod` |
+
+When active, `load_bot_token` logs a warning and falls back to `/run/secrets` regardless of the env variable. Operators should **never** set `LYRA_RUN_SECRETS_DIR=` in Quadlet `.container` files — the override is intended for local dev and CI only.
+
 ### Backup
 
 Podman secrets are the authoritative copy of bot tokens. There is no automatic backup; operators must snapshot them explicitly.

--- a/src/lyra/bootstrap/credentials.py
+++ b/src/lyra/bootstrap/credentials.py
@@ -11,16 +11,40 @@ from lyra.errors import MissingCredentialsError
 log = logging.getLogger(__name__)
 
 
+_PROD_SECRETS_DIR = Path("/run/secrets")
+
+
+def _is_prod_env() -> bool:
+    """Detect production runtime: container or explicit prod flag."""
+    in_container = Path("/run/.containerenv").exists()
+    explicit_prod = os.environ.get("LYRA_ENV") == "prod"
+    return bool(explicit_prod or in_container)
+
+
 def load_bot_token(platform: str, bot_id: str) -> tuple[str, str | None]:
     """Read a bot's token and optional webhook secret from /run/secrets/.
 
     The base directory is overridable via LYRA_RUN_SECRETS_DIR (used by tests
     and local development). Defaults to /run/secrets in production containers.
 
+    In production (container or LYRA_ENV=prod) the override is ignored as a
+    defense-in-depth measure — an attacker with env-write access cannot redirect
+    token reads to an arbitrary path.
+
     Raises MissingCredentialsError when the token file is absent — the message
     points the operator at `lyra bot secret install`.
     """
-    base = Path(os.environ.get("LYRA_RUN_SECRETS_DIR", "/run/secrets"))
+    override = os.environ.get("LYRA_RUN_SECRETS_DIR")
+    if override and _is_prod_env():
+        log.warning(
+            "LYRA_RUN_SECRETS_DIR is set to %s but ignored in production "
+            "(container or LYRA_ENV=prod). Using %s.",
+            override,
+            _PROD_SECRETS_DIR,
+        )
+        base = _PROD_SECRETS_DIR
+    else:
+        base = Path(override) if override else _PROD_SECRETS_DIR
     tok_path = base / f"bot_token-{bot_id}"
     try:
         raw_token = tok_path.read_text()

--- a/tests/bootstrap/test_adapter_run_secrets_e2e.py
+++ b/tests/bootstrap/test_adapter_run_secrets_e2e.py
@@ -52,6 +52,25 @@ def test_adapter_and_wiring_use_credentials_module() -> None:
         )
 
 
+def test_credentials_has_prod_guard_on_env_override() -> None:
+    """`bootstrap/credentials.py` must contain a production guard that ignores
+    LYRA_RUN_SECRETS_DIR when running inside a container or when LYRA_ENV=prod
+    (issue #1304)."""
+    src = CREDENTIALS.read_text()
+    assert "_is_prod_env" in src, (
+        "credentials.py must define _is_prod_env (production detection helper)"
+    )
+    assert "LYRA_ENV=prod" in src or 'os.environ.get("LYRA_ENV") == "prod"' in src, (
+        "credentials.py must check LYRA_ENV=prod in the production guard"
+    )
+    assert "/run/.containerenv" in src, (
+        "credentials.py must check /run/.containerenv in the production guard"
+    )
+    assert "ignored in production" in src, (
+        "credentials.py docstring must warn that the override is ignored in production"
+    )
+
+
 def test_no_credential_store_in_adapter_call_chain() -> None:
     """The deleted CredentialStore class must not be imported anywhere in the
     adapter credential path."""

--- a/tests/bootstrap/test_credentials_prod_guard.py
+++ b/tests/bootstrap/test_credentials_prod_guard.py
@@ -1,0 +1,164 @@
+"""Tests for production guard on LYRA_RUN_SECRETS_DIR (issue #1304).
+
+Verifies that load_bot_token ignores the env override when running inside a
+container (/run/.containerenv exists) or when LYRA_ENV=prod, falling back to
+/run/secrets as a defense-in-depth measure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lyra.bootstrap.credentials import _is_prod_env, load_bot_token
+
+
+class TestIsProdEnv:
+    """Unit tests for _is_prod_env helper."""
+
+    def test_true_when_lyra_env_is_prod(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("LYRA_ENV", "prod")
+        assert _is_prod_env() is True
+
+    def test_true_when_containerenv_exists(self, tmp_path: Path) -> None:
+        fake_containerenv = tmp_path / ".containerenv"
+        fake_containerenv.write_text("")
+        with patch(
+            "lyra.bootstrap.credentials.Path",
+            side_effect=lambda p: (
+                fake_containerenv if p == "/run/.containerenv" else Path(p)
+            ),
+        ):
+            assert _is_prod_env() is True
+
+    def test_false_when_neither(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv("LYRA_ENV", raising=False)
+        missing = tmp_path / "missing"
+        with patch(
+            "lyra.bootstrap.credentials.Path",
+            side_effect=lambda p: missing if p == "/run/.containerenv" else Path(p),
+        ):
+            assert _is_prod_env() is False
+
+
+class TestLoadBotTokenProdGuard:
+    """Unit tests for the production guard in load_bot_token."""
+
+    def test_ignores_override_in_container(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When /run/.containerenv exists, LYRA_RUN_SECRETS_DIR is ignored."""
+        fake_containerenv = tmp_path / ".containerenv"
+        fake_containerenv.write_text("")
+
+        fake_secrets = tmp_path / "fake-secrets"
+        fake_secrets.mkdir()
+        (fake_secrets / "bot_token-mybot").write_text("OVERRIDE_TOKEN")
+
+        prod_secrets = tmp_path / "prod-secrets"
+        prod_secrets.mkdir()
+        (prod_secrets / "bot_token-mybot").write_text("PROD_TOKEN")
+
+        monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(fake_secrets))
+
+        with patch("lyra.bootstrap.credentials._PROD_SECRETS_DIR", prod_secrets):
+            with patch(
+                "lyra.bootstrap.credentials.Path",
+                side_effect=lambda p: (
+                    fake_containerenv if p == "/run/.containerenv" else Path(p)
+                ),
+            ):
+                token, webhook = load_bot_token("telegram", "mybot")
+
+        assert token == "PROD_TOKEN"
+        assert webhook is None
+
+    def test_ignores_override_when_lyra_env_prod(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When LYRA_ENV=prod, LYRA_RUN_SECRETS_DIR is ignored."""
+        fake_secrets = tmp_path / "fake-secrets"
+        fake_secrets.mkdir()
+        (fake_secrets / "bot_token-mybot").write_text("OVERRIDE_TOKEN")
+
+        prod_secrets = tmp_path / "prod-secrets"
+        prod_secrets.mkdir()
+        (prod_secrets / "bot_token-mybot").write_text("PROD_TOKEN")
+
+        monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(fake_secrets))
+        monkeypatch.setenv("LYRA_ENV", "prod")
+
+        with patch("lyra.bootstrap.credentials._PROD_SECRETS_DIR", prod_secrets):
+            token, webhook = load_bot_token("telegram", "mybot")
+
+        assert token == "PROD_TOKEN"
+        assert webhook is None
+
+    def test_allows_override_in_dev(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """In development (no container, no LYRA_ENV=prod), override is honored."""
+        dev_secrets = tmp_path / "dev-secrets"
+        dev_secrets.mkdir()
+        (dev_secrets / "bot_token-mybot").write_text("DEV_TOKEN")
+
+        monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(dev_secrets))
+        monkeypatch.delenv("LYRA_ENV", raising=False)
+
+        missing = tmp_path / "missing"
+        with patch(
+            "lyra.bootstrap.credentials.Path",
+            side_effect=lambda p: missing if p == "/run/.containerenv" else Path(p),
+        ):
+            token, webhook = load_bot_token("telegram", "mybot")
+
+        assert token == "DEV_TOKEN"
+        assert webhook is None
+
+    def test_reads_webhook_from_prod_when_override_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Webhook is also read from /run/secrets when override is ignored."""
+        fake_secrets = tmp_path / "fake-secrets"
+        fake_secrets.mkdir()
+
+        prod_secrets = tmp_path / "prod-secrets"
+        prod_secrets.mkdir()
+        (prod_secrets / "bot_token-mybot").write_text("PROD_TOKEN")
+        (prod_secrets / "bot_webhook-mybot").write_text("PROD_WEBHOOK")
+
+        monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(fake_secrets))
+        monkeypatch.setenv("LYRA_ENV", "prod")
+
+        with patch("lyra.bootstrap.credentials._PROD_SECRETS_DIR", prod_secrets):
+            token, webhook = load_bot_token("telegram", "mybot")
+
+        assert token == "PROD_TOKEN"
+        assert webhook == "PROD_WEBHOOK"
+
+    def test_missing_token_raises_with_prod_path_when_override_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Error message references /run/secrets when override is ignored in prod."""
+        fake_secrets = tmp_path / "fake-secrets"
+        fake_secrets.mkdir()
+        (fake_secrets / "bot_token-mybot").write_text("OVERRIDE_TOKEN")
+
+        prod_secrets = tmp_path / "prod-secrets"
+        prod_secrets.mkdir()
+        # No token file in prod_secrets
+
+        monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(fake_secrets))
+        monkeypatch.setenv("LYRA_ENV", "prod")
+
+        with patch("lyra.bootstrap.credentials._PROD_SECRETS_DIR", prod_secrets):
+            with pytest.raises(Exception) as exc_info:
+                load_bot_token("telegram", "mybot")
+
+        assert "bot_token-mybot" in str(exc_info.value)

--- a/tests/bootstrap/test_credentials_prod_guard.py
+++ b/tests/bootstrap/test_credentials_prod_guard.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from lyra.bootstrap.credentials import _is_prod_env, load_bot_token
+from lyra.errors import MissingCredentialsError
 
 
 class TestIsProdEnv:
@@ -24,7 +25,10 @@ class TestIsProdEnv:
         monkeypatch.setenv("LYRA_ENV", "prod")
         assert _is_prod_env() is True
 
-    def test_true_when_containerenv_exists(self, tmp_path: Path) -> None:
+    def test_true_when_containerenv_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv("LYRA_ENV", raising=False)
         fake_containerenv = tmp_path / ".containerenv"
         fake_containerenv.write_text("")
         with patch(
@@ -66,6 +70,7 @@ class TestLoadBotTokenProdGuard:
         (prod_secrets / "bot_token-mybot").write_text("PROD_TOKEN")
 
         monkeypatch.setenv("LYRA_RUN_SECRETS_DIR", str(fake_secrets))
+        monkeypatch.delenv("LYRA_ENV", raising=False)
 
         with patch("lyra.bootstrap.credentials._PROD_SECRETS_DIR", prod_secrets):
             with patch(
@@ -158,7 +163,7 @@ class TestLoadBotTokenProdGuard:
         monkeypatch.setenv("LYRA_ENV", "prod")
 
         with patch("lyra.bootstrap.credentials._PROD_SECRETS_DIR", prod_secrets):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(MissingCredentialsError) as exc_info:
                 load_bot_token("telegram", "mybot")
 
-        assert "bot_token-mybot" in str(exc_info.value)
+        assert str(prod_secrets / "bot_token-mybot") in str(exc_info.value)

--- a/tests/test_bootstrap_credential_resolution.py
+++ b/tests/test_bootstrap_credential_resolution.py
@@ -68,6 +68,7 @@ async def test_adapter_reads_token_from_run_secrets(
             "lyra.bootstrap.standalone.adapter_standalone.wait_for_hub",
             AsyncMock(return_value=True),
         ),
+        patch("lyra.bootstrap.credentials._is_prod_env", return_value=False),
     ):
         # Act
         await _bootstrap_adapter_standalone(raw_config, "telegram", _stop=stop)
@@ -131,6 +132,7 @@ async def test_adapter_reads_webhook_when_present(
             "lyra.bootstrap.standalone.adapter_standalone.wait_for_hub",
             AsyncMock(return_value=True),
         ),
+        patch("lyra.bootstrap.credentials._is_prod_env", return_value=False),
     ):
         # Act
         await _bootstrap_adapter_standalone(raw_config, "telegram", _stop=stop)
@@ -194,6 +196,7 @@ async def test_adapter_omits_webhook_when_absent(
             "lyra.bootstrap.standalone.adapter_standalone.wait_for_hub",
             AsyncMock(return_value=True),
         ),
+        patch("lyra.bootstrap.credentials._is_prod_env", return_value=False),
     ):
         # Act
         await _bootstrap_adapter_standalone(raw_config, "telegram", _stop=stop)
@@ -266,6 +269,7 @@ async def test_adapter_handles_multi_bot(
             "lyra.bootstrap.standalone.adapter_standalone.wait_for_hub",
             AsyncMock(return_value=True),
         ),
+        patch("lyra.bootstrap.credentials._is_prod_env", return_value=False),
     ):
         # Act
         await _bootstrap_adapter_standalone(raw_config, "telegram", _stop=stop)
@@ -368,6 +372,7 @@ async def test_discord_adapter_handles_multi_bot(
             "lyra.bootstrap.standalone.adapter_standalone.wait_for_hub",
             AsyncMock(return_value=True),
         ),
+        patch("lyra.bootstrap.credentials._is_prod_env", return_value=False),
     ):
         # Act
         await _bootstrap_adapter_standalone(raw_config, "discord", _stop=stop)

--- a/tests/test_bootstrap_missing_credentials.py
+++ b/tests/test_bootstrap_missing_credentials.py
@@ -53,6 +53,7 @@ async def test_adapter_raises_bootstrap_error_on_missing_token(
             "lyra.bootstrap.standalone.adapter_standalone.wait_for_hub",
             AsyncMock(return_value=True),
         ),
+        patch("lyra.bootstrap.credentials._is_prod_env", return_value=False),
     ):
         # Act + Assert — error raised with path hint and install command
         with pytest.raises(


### PR DESCRIPTION
## Summary
- Add runtime guard that ignores `LYRA_RUN_SECRETS_DIR` env override in production environments
- Detects prod via `/run/.containerenv` (Podman container marker) or `LYRA_ENV=prod`
- Documents the guard in `docs/CONFIGURATION.md` § Bot credentials

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1304: feat(bootstrap): guard LYRA_RUN_SECRETS_DIR override against prod environments | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1304-guard-lyra-run-secrets-dir-override` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (8 new) | Passed |

## Test Plan
- [ ] `LYRA_RUN_SECRETS_DIR` honored in local dev (no container, no LYRA_ENV=prod)
- [ ] Override ignored when `LYRA_ENV=prod`
- [ ] Override ignored inside a container (`/run/.containerenv` exists)

Closes #1304

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`