### PR TITLE
fix(turn-writer): #1359 ACL _inbox prefix + vault_dir mkdir guard

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -33,6 +33,7 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 | `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — | — | — |
 | `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — | — |
 | `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.turn-writer.>` | — | — | — | — | — | — | — | — | — | — | — | PUB+SUB |
 | `_inbox.voice-client.>` | — | — | — | — | PUB | — | — | — | — | — | SUB | — |
 | `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — | — |
 | `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — | — |

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -218,10 +218,10 @@
       "created_at": "2026-05-25",
       "owner": "lyra",
       "description": "TurnWriter JetStream subscriber-writer — sole writer for turns.db (ADR-075, #1331). Consumes lyra.turns.> durable consumer turn-writer-v1, queue group turn-writer. nkey seed delivered via lyra-nats-turn-writer Podman secret (provisioned by install.sh T25).",
-      "notes": "JetStream API subjects scoped to LYRA_TURNS stream + turn-writer-v1 consumer only (principle of least privilege). _INBOX.> required for pull-subscribe ACK reply path. allow_responses=true for pull-subscribe protocol. $JS.API.* in publish (not subscribe) because nc.request() publishes at protocol level (B1). CONSUMER.CREATE uses wildcard suffix to cover filter-subject variants (B2). STREAM.UPDATE added for retention/limits changes on subsequent boots (B3).",
+      "notes": "JetStream API subjects scoped to LYRA_TURNS stream + turn-writer-v1 consumer only (principle of least privilege). _inbox.turn-writer.> required for pull-subscribe ACK reply path — nats-py emits lowercase identity-scoped inboxes when identity_name is set (#1359). allow_responses=true for pull-subscribe protocol. $JS.API.* in publish (not subscribe) because nc.request() publishes at protocol level (B1). CONSUMER.CREATE uses wildcard suffix to cover filter-subject variants (B2). STREAM.UPDATE added for retention/limits changes on subsequent boots (B3).",
       "allow_responses": true,
       "publish": [
-        "_INBOX.>",
+        "_inbox.turn-writer.>",
         "$JS.API.STREAM.CREATE.LYRA_TURNS",
         "$JS.API.STREAM.INFO.LYRA_TURNS",
         "$JS.API.STREAM.UPDATE.LYRA_TURNS",
@@ -231,7 +231,7 @@
       ],
       "subscribe": [
         "lyra.turns.>",
-        "_INBOX.>"
+        "_inbox.turn-writer.>"
       ]
     }
   }

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -112,8 +112,8 @@ authorization {
       nkey: "UDETTURNWRITER"
       # turn-writer
       permissions: {
-        publish:   { allow: ["_INBOX.>","$JS.API.STREAM.CREATE.LYRA_TURNS","$JS.API.STREAM.INFO.LYRA_TURNS","$JS.API.STREAM.UPDATE.LYRA_TURNS","$JS.API.CONSUMER.CREATE.LYRA_TURNS.turn-writer-v1.>","$JS.API.CONSUMER.INFO.LYRA_TURNS.turn-writer-v1","$JS.API.CONSUMER.MSG.NEXT.LYRA_TURNS.turn-writer-v1"] }
-        subscribe: { allow: ["lyra.turns.>","_INBOX.>"] }
+        publish:   { allow: ["_inbox.turn-writer.>","$JS.API.STREAM.CREATE.LYRA_TURNS","$JS.API.STREAM.INFO.LYRA_TURNS","$JS.API.STREAM.UPDATE.LYRA_TURNS","$JS.API.CONSUMER.CREATE.LYRA_TURNS.turn-writer-v1.>","$JS.API.CONSUMER.INFO.LYRA_TURNS.turn-writer-v1","$JS.API.CONSUMER.MSG.NEXT.LYRA_TURNS.turn-writer-v1"] }
+        subscribe: { allow: ["lyra.turns.>","_inbox.turn-writer.>"] }
         allow_responses: true
       }
     }

--- a/deploy/quadlet/lyra-turn-writer.container
+++ b/deploy/quadlet/lyra-turn-writer.container
@@ -28,6 +28,10 @@ Environment=NATS_URL=nats://lyra-nats:4222
 # and Podman receives the literal comment text as a mount-option string (issue #1083).
 Volume=%h/.lyra/turn-writer/:/data/:z
 Environment=LYRA_TURNS_DB=/data/turns.db
+# LYRA_VAULT_DIR=/data ensures bootstrap mkdir targets the writable bind-mount
+# under ReadOnly=true rootfs even when LYRA_TURNS_DB resolution falls back
+# (defense in depth for #1359).
+Environment=LYRA_VAULT_DIR=/data
 Environment=PYTHONUNBUFFERED=1
 Exec=lyra turn-writer
 HealthCmd=pgrep -f "lyra turn-writer"

--- a/src/lyra/bootstrap/standalone/turn_writer_standalone.py
+++ b/src/lyra/bootstrap/standalone/turn_writer_standalone.py
@@ -42,9 +42,16 @@ async def _bootstrap_turn_writer_standalone(raw_config: dict) -> None:
     if not nats_url:
         sys.exit("NATS_URL is required for standalone turn-writer mode.")
 
-    vault_dir = Path(os.environ.get("LYRA_VAULT_DIR", str(Path.home() / ".lyra")))
-    vault_dir.mkdir(parents=True, exist_ok=True)
-    db_path = Path(os.environ.get("LYRA_TURNS_DB") or (vault_dir / "turns.db"))
+    # mkdir the actual db parent — avoids EROFS when LYRA_TURNS_DB overrides
+    # to a writable bind-mount under a ReadOnly=true rootfs (#1359).
+    db_path = Path(
+        os.environ.get("LYRA_TURNS_DB")
+        or (
+            Path(os.environ.get("LYRA_VAULT_DIR", str(Path.home() / ".lyra")))
+            / "turns.db"
+        )
+    )
+    db_path.parent.mkdir(parents=True, exist_ok=True)
 
     log.info(
         "turn-writer: starting (db=%s, nats=%s)",

--- a/tests/bootstrap/test_turn_writer_standalone_paths.py
+++ b/tests/bootstrap/test_turn_writer_standalone_paths.py
@@ -1,0 +1,72 @@
+"""Regression test for #1359 — turn-writer bootstrap path resolution.
+
+Asserts that mkdir targets the parent of the resolved db_path, not a
+hypothetical vault_dir that is never used. This guards the ReadOnly=true
+rootfs case where Path.home()/.lyra doesn't exist and can't be created.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_lyra_turns_db_set_skips_vault_dir_mkdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LYRA_TURNS_DB set → mkdir targets its parent, never Path.home()/.lyra."""
+    from lyra.bootstrap.standalone.turn_writer_standalone import (
+        _bootstrap_turn_writer_standalone,
+    )
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    db_path = data_dir / "turns.db"
+
+    # Point HOME at a nonexistent path that can't be created (read-only parent).
+    unwritable_root = tmp_path / "ro"
+    unwritable_root.mkdir(mode=0o555)
+    monkeypatch.setenv("HOME", str(unwritable_root / "nobody"))
+    monkeypatch.setenv("LYRA_TURNS_DB", str(db_path))
+    monkeypatch.setenv("NATS_URL", "nats://invalid:4222")
+    monkeypatch.delenv("LYRA_VAULT_DIR", raising=False)
+
+    # Make the connect call fail early so we exit before NATS state is touched —
+    # the only behavior under test is path resolution + mkdir.
+    with patch(
+        "lyra.bootstrap.standalone.turn_writer_standalone.nats_connect",
+        side_effect=ConnectionError("stub: skip NATS"),
+    ):
+        with pytest.raises(SystemExit):
+            await _bootstrap_turn_writer_standalone({})
+
+    assert data_dir.exists(), "db_path.parent should exist after bootstrap"
+    # Path.home()/.lyra must NOT have been created — proof we skipped vault_dir mkdir.
+    assert not (unwritable_root / "nobody" / ".lyra").exists()
+
+
+@pytest.mark.asyncio
+async def test_no_lyra_turns_db_falls_back_to_vault_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LYRA_TURNS_DB unset → mkdir targets LYRA_VAULT_DIR (dev-mode path)."""
+    from lyra.bootstrap.standalone.turn_writer_standalone import (
+        _bootstrap_turn_writer_standalone,
+    )
+
+    vault = tmp_path / "vault"
+    monkeypatch.delenv("LYRA_TURNS_DB", raising=False)
+    monkeypatch.setenv("LYRA_VAULT_DIR", str(vault))
+    monkeypatch.setenv("NATS_URL", "nats://invalid:4222")
+
+    with patch(
+        "lyra.bootstrap.standalone.turn_writer_standalone.nats_connect",
+        side_effect=ConnectionError("stub: skip NATS"),
+    ):
+        with pytest.raises(SystemExit):
+            await _bootstrap_turn_writer_standalone({})
+
+    assert vault.exists(), "vault dir should be created when LYRA_TURNS_DB unset"


### PR DESCRIPTION
## Summary

Two prod-blocker bugs surfaced during M₁ smoke test of #1331 — both real, neither caught by CI because integration tests use mock NATS + writable tmpdirs.

- **ACL bug**: turn-writer's publish/subscribe in `acl-matrix.json` used uppercase `_INBOX.>` but `nats-py` with `identity_name="turn-writer"` emits lowercase identity-scoped inboxes `_inbox.turn-writer.<id>.*`. NATS subjects are case-sensitive → pull-subscribe ACK reply subscription rejected with permissions violation. Aligned with the convention every other identity already uses.
- **Bootstrap bug**: `vault_dir.mkdir()` ran unconditionally before `LYRA_TURNS_DB` override was consulted. Under `ReadOnly=true` rootfs the default `~/.lyra` doesn't exist and can't be created → `OSError [Errno 30] Read-only file system`. Reordered to mkdir the actual db parent. Quadlet also gets `Environment=LYRA_VAULT_DIR=/data` for defense in depth.

Closes #1359 · Follow-up to #1331.

## Test plan

- [x] `make lint` + `make typecheck` clean
- [x] 128 ACL/NATS tests pass (no schema drift)
- [x] 2 new regression tests covering override-set + fallback paths
- [x] Validated live on M₁ (2026-05-25 17:54–18:06) — `lyra-turn-writer` started cleanly, JetStream consumer `turn-writer-v1` active, health endpoint :8083 up, `turns.db` schema present with WAL sidecars
- [ ] CI green