### PR TITLE
chore(blobstore): V8.1 hardening + cleanup pass

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -109,6 +109,9 @@ forbidden_modules =
     lyra.bootstrap.wiring
 allow_indirect_imports = true
 
+# NOTE: lyra.blobstore is intentionally absent from source_modules below — it is a
+# peer-layer service (own systemd unit + NATS attach, ADR-073), not a shared floating
+# module. See src/lyra/blobstore/CLAUDE.md "peer-of-adapters" placement.
 [importlinter:contract:shared-modules-upper-boundary]
 name = Shared floating modules must not import bootstrap, adapters, or infrastructure
 type = forbidden

--- a/artifacts/analyses/1330-v8-http-fronted-blobstore-analysis.mdx
+++ b/artifacts/analyses/1330-v8-http-fronted-blobstore-analysis.mdx
@@ -195,23 +195,7 @@ Step 1 must happen **before** step 2 (else a blob_refs row may point to a hash w
 
 Cloned from `deploy/quadlet/lyra-hub.container` with the following deltas:
 
-| Setting | Value | Rationale |
-|---------|-------|-----------|
-| `Description=` | `Lyra BlobStore HTTP service` | `[Unit]` stanza — `systemctl status` clarity |
-| `ContainerName=` | `lyra-blobstore` | Quadlet DNS handle for same-host clients (`http://lyra-blobstore:8449`) |
-| `Network=` | `roxabi.network` | shared Podman network with hub/adapters/NATS |
-| `Image=` | `ghcr.io/roxabi/lyra:staging-svc` | svc-runtime variant — requires `config.toml` bind-mount; same as hub/telegram/discord |
-| `Exec=` | `lyra blobstore serve` | typer subcommand |
-| `Environment=NATS_URL=` | `nats://lyra-nats:4222` | audit sink + readiness KV target — matches hub convention |
-| `PublishPort=` | bind to Tailscale IPv4 (resolved at provision time via `tailscale ip -4`) — `<ts-ipv4>:8449:8449` | LAN exposure is unintentional surface — bearer token is the only auth; restrict to Tailnet. `0.0.0.0:8449` is the fallback if `tailscale0` is absent, accepted as documented residual risk. |
-| `HealthCmd=` | `pgrep -f "lyra blobstore serve"` | mirrors hub pattern |
-| `CPUQuota=` | `100%` | cold-path I/O; doesn't need hub's `200%` |
-| `After=` / `Wants=` | `lyra-nats.service` (soft) | audit sink degrades to logger if NATS unreachable; service can start without NATS |
-| `Volume=` | `%h/.lyra/blobs:/data/lyra/blobs:z` + `%h/.lyra/config.toml:/app/config.toml:ro,z` | content dir bind + config bind |
-| `Secret=` | `lyra_blobstore_token,type=mount,target=lyra_blobstore_token,uid=1500,gid=1500,mode=0400` | ADR-054 |
-| `Label=` | `io.containers.autoupdate=registry` | same autoupdate cadence as svc-runtime peers |
-| `EnvironmentFile=` | `%h/.lyra/env/blobstore.env` | per Quadlet env convention |
-| Hardening | `NoNewPrivileges=true`, `ReadOnly=true`, `DropCapability=all`, `UserNS=keep-id:uid=1500,gid=1500` | clones hub |
+| _(superseded — see [docs/QUADLET-DEPLOYMENT.md](../../docs/QUADLET-DEPLOYMENT.md))_ |
 
 ### Cross-host integration test
 

--- a/artifacts/analyses/1362-v8-1-hardening-cleanup-consensus.mdx
+++ b/artifacts/analyses/1362-v8-1-hardening-cleanup-consensus.mdx
@@ -1,0 +1,83 @@
+---
+title: "PR #1364 residual findings — Expert Consensus"
+issue: 1362
+status: consensus-reached
+date: 2026-05-26
+panel: architect, devops, product-lead
+confidence: high
+---
+
+## Problem
+
+PR #1364 (V8.1 BlobStore hardening cleanup) received a first auto-applied commit
+draining B1 (Tailscale guard env scope), B2 (BlobAuditSink dead exception),
+and N1 (dead `_conn_ro`). 6 residual review findings remain (N2-N7). N5 was
+auto-resolved by the B2 fix. The panel evaluated whether each remaining finding
+warrants in-PR action, deferral to a follow-up issue, or skip.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | encapsulation, layer boundaries, Protocol v2 readiness |
+| devops | Quadlet correctness, audit forensic completeness, package release hygiene |
+| product-lead | scope discipline, parking-lot drain principle, F-lite tier shape |
+
+## Consensus ρ
+
+| Finding | Verdict | Vote | Solution |
+|---------|---------|------|----------|
+| N2 (double `nc.jetstream()`) | **SKIP** | 3-0 unanimous | — (idempotent in nats-py; both fix options trade encapsulation for zero behavioral gain) |
+| N3 (tautological snapshot test) | **APPLY** | 2-1 majority | Tighten regex to require `${VAR}` sigil + `-n` test |
+| N4 (HttpBlobStore sentinel `content_hash`) | **DEFER** | 2-1 majority | Follow-up issue tied to roxabi-blobs package release boundary + Protocol v2 ambiguity |
+| N5 (provision async w/ zero await) | **RESOLVED** | — | B2 fix already added `await self._js.account_info()` |
+| N6 (HEAD audit drops `content_hash`) | **APPLY** | 3-0 unanimous | Add `content_hash=str(row[0])` to `_emit_audit` call (already in scope) |
+| N7 (whitespace `TAILSCALE_IPV4` bypass) | **DEFER** | 3-0 unanimous | Follow-up — Podman's parse error provides accidental defense in depth; correct fix is a behavioral guard change |
+
+### Rationale
+
+The two unanimous applies (N3, N6) are both single-line changes with data
+already in scope. N3 locks the guard's `${VAR}` sigil shape so a future
+refactor of the H1 ExecStartPre cannot regress vacuously. N6 reinstates the
+content_hash field that the L1 lookup-collapse silently dropped from HEAD
+audit events — a forensic regression vs the pre-V8.1 path.
+
+The two deferrals (N4, N7) both cross genuine scope lines: N4 touches the
+`packages/roxabi-blobs/` release boundary and may be obviated by Protocol v2;
+N7 changes a security-adjacent guard behavior and warrants its own tracked
+PR rather than a rushed shell-pipeline change inside a 30-min budget.
+
+N2 was unanimously skipped: `nc.jetstream()` is documented idempotent in
+nats-py (the client caches the JetStream context), and the proposed fixes
+either widen the encapsulation surface of `BlobAuditSink` or introduce
+SLF001 noqa for a private attribute — both worse than the status quo.
+
+### Trade-offs
+
+- **In-PR scope**: 2 trivial applies (N3, N6) keep PR within F-lite shape; deferrals add ticket noise but preserve cleanup-tier discipline
+- **Parking-lot drain**: 4 of 6 findings get terminal action (apply or defer with traceable follow-up issue); N5 self-resolved; N2 skipped with rationale — no residual debt
+- **Architect dissent on N4**: silent type confusion in `BlobRef.content_hash` could compromise future dedup callers — recorded as known risk in the deferred issue body
+
+## Alternatives
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| Apply N4 (content_hash="") in-PR | architect | crosses roxabi-blobs package release boundary; Protocol v2 may restructure exists() entirely |
+| Apply N7 (tr -d whitespace) in-PR | (none) | shell pipeline in ExecStartPre is brittle; Podman's downstream parse error provides defense in depth |
+| Defer N3 to follow-up | product-lead | test-tautology class is hard to revisit later because nobody hits it as a runtime bug; 1-line regex fix is well-defined |
+
+## Dissent
+
+- **N3**: product-lead preferred deferral (test-quality, not correctness) but conceded the regex tighten is 1-line and locks in the sigil shape that N7's eventual fix will rely on. 2-1 APPLY stands.
+- **N4**: architect argued that silent type confusion in `BlobRef.content_hash` (storing a store_key in a sha256-typed field) could corrupt future dedup logic; recommended in-PR fix `content_hash=""`. devops + product-lead both deferred citing package release hygiene + Protocol v2 ambiguity. 2-1 DEFER stands, but architect's risk note is preserved in the N4 follow-up issue.
+
+## Implementation Notes
+
+- **N3 fix**: edit `tests/blobstore/test_quadlet_unit.py` — replace the loose `any("TAILSCALE_IPV4" in line ...)` check with `re.search(r'\[\s*-n.*\$\{?TAILSCALE_IPV4\}?', line)` per ExecStartPre line.
+- **N6 fix**: edit `src/lyra/blobstore/_handlers.py:208` — add `content_hash=str(row[0])` to the `_emit_audit(...)` kwargs. `row` is in scope.
+- **N4 follow-up**: file issue "fix(roxabi-blobs): HttpBlobStore.exists sentinel content_hash field type" with body referencing PR #1364 #issuecomment-4537497690 and architect's risk note. Blocked-by #1362.
+- **N7 follow-up**: file issue "fix(deploy): blobstore Tailscale guard whitespace-safe" referencing comment + devops original finding. Blocked-by #1362.
+
+## Next
+
+Return to `/fix` Phase 6 — apply N3 + N6, defer N4 + N7 via `triage.ts create --blocked-by #1362`.

--- a/deploy/quadlet/lyra-blobstore.container
+++ b/deploy/quadlet/lyra-blobstore.container
@@ -43,7 +43,9 @@ Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 # Bind port to the Tailscale IPv4 of M₁ so the service is reachable from the Tailnet
 # but NOT from the LAN. Resolved at provision time via `tailscale ip -4 | head -1`.
 # RESIDUAL RISK: if TAILSCALE_IPV4 is unset or tailscale0 is absent, PublishPort falls
-# back to 0.0.0.0:8449 (LAN-exposed). Bearer token is then the sole auth boundary.
+# back to 0.0.0.0:8449 (LAN-exposed). The ExecStartPre guard below prevents the container
+# from entering running state in that case, so no traffic is ever served (fail-closed).
+# Bearer token remains the sole auth boundary on a misconfigured host (guard circumvented).
 # Accepted for V8; document in deploy/CLAUDE.md §Residual risks.
 PublishPort=${TAILSCALE_IPV4}:8449:8449
 Exec=lyra blobstore serve --token-path /run/secrets/lyra_blobstore_token --host 0.0.0.0 --port 8449
@@ -51,6 +53,13 @@ HealthCmd=pgrep -f "lyra blobstore serve"
 HealthInterval=30s
 
 [Service]
+# Fail-closed guard: refuse to start when TAILSCALE_IPV4 is empty/unset.
+# Note: the `PublishPort=${TAILSCALE_IPV4}:8449:8449` line above is resolved
+# by Podman BEFORE this ExecStartPre fires — so the publish-port spec is
+# already constructed (and could read as 0.0.0.0). This guard prevents the
+# CONTAINER from entering running state, so no traffic is ever served.
+# Operationally equivalent to closing the port (nothing accepts traffic).
+ExecStartPre=/bin/sh -c '[ -n "${TAILSCALE_IPV4}" ] || exit 1'
 Restart=on-failure
 RestartSec=10
 # Cold-path I/O service — 1 full core is sufficient; prevents it from starving

--- a/deploy/quadlet/lyra-blobstore.container
+++ b/deploy/quadlet/lyra-blobstore.container
@@ -53,6 +53,12 @@ HealthCmd=pgrep -f "lyra blobstore serve"
 HealthInterval=30s
 
 [Service]
+# `[Container] EnvironmentFile=` becomes Podman's `--env-file` (container scope only) —
+# the generated `[Service]` carries no env vars, so `${TAILSCALE_IPV4}` is UNSET in
+# ExecStartPre's systemd scope without this second declaration. Quadlet passes `[Service]`
+# through verbatim, so this loads the file twice — once for systemd (here), once for
+# Podman (above) — both intentional.
+EnvironmentFile=%h/.lyra/env/blobstore.env
 # Fail-closed guard: refuse to start when TAILSCALE_IPV4 is empty/unset.
 # Note: the `PublishPort=${TAILSCALE_IPV4}:8449:8449` line above is resolved
 # by Podman BEFORE this ExecStartPre fires — so the publish-port spec is

--- a/packages/roxabi-blobs/CLAUDE.md
+++ b/packages/roxabi-blobs/CLAUDE.md
@@ -68,27 +68,7 @@ async with FsBlobStore(root) as store:
 
 ### Retry policy
 
-**V8 ships with default httpx behaviour — no in-band retry logic is implemented.**
-
-`connect_retry_max_s` (constructor param, default `10.0`) is accepted and stored but is
-not wired to any retry loop in V8. Future work will implement exponential-backoff connect
-retries against this budget (first retry after 0.5 s, cap 5 s per attempt, terminal
-exception `httpx.ConnectError` when budget exhausted — per spec §Breadboard C1).
-
-**Per-request timeout:** `httpx.Timeout(5.0, connect=5.0)` — 5 s connect / 5 s read,
-applied to every request.
-
-**Per-method behaviour (V8 — no retry):**
-
-| Method | Idempotent | Retry safe | V8 behaviour |
-|--------|-----------|------------|--------------|
-| GET | yes | yes | single attempt; raises `BlobNotFoundError` on 404, `httpx.HTTPStatusError` on other 4xx/5xx |
-| HEAD | yes | yes | single attempt; returns `None` on 404, raises on other errors |
-| DELETE | yes | yes | single attempt; raises `BlobNotFoundError` on 404 |
-| PUT | no | no | single attempt; `BlobWriteError` NOT raised client-side — caller gets `httpx.HTTPStatusError` on 5xx |
-
-Until retry is implemented, callers operating over Tailnet should wrap `HttpBlobStore`
-operations in their own retry / circuit-breaker logic if the connection window matters.
+Retry-on-connect-error is not implemented; callers operating over Tailnet should wrap `HttpBlobStore` with their own retry policy.
 
 ## Invariants
 

--- a/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
@@ -116,6 +116,16 @@ class FsBlobStore:
             raise BlobStateError("FsBlobStore used outside an `async with` context.")
         return self._conn, self._lock
 
+    def _conn_ro(self) -> aiosqlite.Connection:
+        """Return the open connection for read-only callers (no write-lock needed).
+
+        WAL read-isolation makes lock-skip safe: SQLite WAL mode lets readers see a
+        consistent snapshot without blocking writers; the write-lock is the writer's
+        concern, not the reader's.
+        """
+        conn, _ = self._require_open()
+        return conn
+
     async def put(  # noqa: PLR0913 — signature locked by ADR-067 §Interface
         self,
         data: bytes,

--- a/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
@@ -111,20 +111,16 @@ class FsBlobStore:
         self._lock = None
 
     def _require_open(self) -> tuple[aiosqlite.Connection, asyncio.Lock]:
-        """Lifecycle guard — raises `BlobStateError` (neutral re. read/write)."""
+        """Lifecycle guard — raises `BlobStateError` (neutral re. read/write).
+
+        Returns `(conn, lock)`. Read-only callers may use `conn` without acquiring
+        `lock`: SQLite WAL mode gives readers a consistent snapshot without
+        blocking writers, so the write-lock is the writer's concern, not the
+        reader's.
+        """
         if self._conn is None or self._lock is None:
             raise BlobStateError("FsBlobStore used outside an `async with` context.")
         return self._conn, self._lock
-
-    def _conn_ro(self) -> aiosqlite.Connection:
-        """Return the open connection for read-only callers (no write-lock needed).
-
-        WAL read-isolation makes lock-skip safe: SQLite WAL mode lets readers see a
-        consistent snapshot without blocking writers; the write-lock is the writer's
-        concern, not the reader's.
-        """
-        conn, _ = self._require_open()
-        return conn
 
     async def put(  # noqa: PLR0913 — signature locked by ADR-067 §Interface
         self,

--- a/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -14,7 +15,6 @@ from .models import BlobRef
 class HttpBlobStore:
     """HTTP client for a remote `lyra blobstore serve` service.
 
-    Retry policy (T24): not yet implemented.
     Per-request timeout = 5 s connect / 5 s read.
     """
 
@@ -23,12 +23,10 @@ class HttpBlobStore:
         base_url: str,
         token: str,
         *,
-        connect_retry_max_s: float = 10.0,
         _transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._token = token
-        self._connect_retry_max_s = connect_retry_max_s
         self._transport = _transport
         self._client: httpx.AsyncClient | None = None
         # ASGI lifespan support (test seam only — production uses real HTTP)
@@ -144,8 +142,6 @@ class HttpBlobStore:
         # HEAD returns no body — synthesise a sentinel BlobRef so Protocol
         # callers that only test truthiness get a non-None result.
         # The content_hash field is set to the argument value (store_key in HTTP).
-        from datetime import UTC, datetime
-
         return BlobRef(
             store_key=content_hash,
             content_hash=content_hash,

--- a/src/lyra/blobstore/CLAUDE.md
+++ b/src/lyra/blobstore/CLAUDE.md
@@ -107,6 +107,15 @@ URL path argument is tested against `^\d+$`:
 
 Protocol signature uses `blob_ref_id`; HTTP wire identifier is `store_key`.
 
+## HEAD handler dual lookup
+
+`handle_head` in `src/lyra/blobstore/_handlers.py` performs two sequential database lookups:
+
+1. **`store_key` lookup** — primary path for callers that pass an opaque `store_key` (the wire path on disk); the handler resolves it directly via `store_path` in the manifest.
+2. **`content_hash` fallback** — secondary path for callers like `HttpBlobStore.exists` that pass a `content_hash` directly (see `packages/roxabi-blobs/CLAUDE.md §HttpBlobStore.exists` for the call shape); the symmetry between the two lookup paths is asserted via the existing inline comment at `_handlers.py:181-182`.
+
+Both `content_hash` and `store_key` must be handled because the `BlobStore` Protocol allows either opaque identifier to act as an existence key. The dual-lookup design keeps the server handler generic without requiring callers to pre-resolve which form they hold.
+
 ## Reference pointers
 
 - `docs/QUADLET-DEPLOYMENT.md` — install runbook, secret rotation, backup procedures

--- a/src/lyra/blobstore/_handlers.py
+++ b/src/lyra/blobstore/_handlers.py
@@ -201,11 +201,17 @@ async def handle_head(store_key: str, request: Request) -> Response:
 
     # Row confirms existence — no need to call store.exists() (which would be a
     # redundant 3rd DB hit). HEAD only signals existence; body is always empty.
-    # content_hash is available as str(row[0]) if callers need it in a future
-    # Content-Digest header. Fallback path (content_hash lookup) is preserved
-    # above: ≤2 SELECTs total, 0 calls to store.exists().
+    # Fallback path (content_hash lookup) is preserved above: ≤2 SELECTs total,
+    # 0 calls to store.exists(). content_hash flows into the audit event so the
+    # forensic record matches the pre-collapse 3-lookup behavior.
 
-    await _emit_audit(request.app, op="exists", result="ok", store_key=store_key)
+    await _emit_audit(
+        request.app,
+        op="exists",
+        result="ok",
+        store_key=store_key,
+        content_hash=str(row[0]),
+    )
     return Response(status_code=200)
 
 

--- a/src/lyra/blobstore/_handlers.py
+++ b/src/lyra/blobstore/_handlers.py
@@ -199,21 +199,11 @@ async def handle_head(store_key: str, request: Request) -> Response:
         )
         return Response(status_code=404)
 
-    content_hash = str(row[0])
-    try:
-        blob_ref = await store.exists(content_hash)
-    except Exception:  # noqa: BLE001
-        _log.exception("HEAD /blobs/%s exists check failed", store_key)
-        await _emit_audit(
-            request.app, op="exists", result="internal_error", store_key=store_key
-        )
-        return JSONResponse({"detail": "internal error"}, status_code=500)
-
-    if blob_ref is None:
-        await _emit_audit(
-            request.app, op="exists", result="not_found", store_key=store_key
-        )
-        return Response(status_code=404)
+    # Row confirms existence — no need to call store.exists() (which would be a
+    # redundant 3rd DB hit). HEAD only signals existence; body is always empty.
+    # content_hash is available as str(row[0]) if callers need it in a future
+    # Content-Digest header. Fallback path (content_hash lookup) is preserved
+    # above: ≤2 SELECTs total, 0 calls to store.exists().
 
     await _emit_audit(request.app, op="exists", result="ok", store_key=store_key)
     return Response(status_code=200)
@@ -276,6 +266,8 @@ async def handle_delete(key: str, request: Request) -> Response:
         )
         return JSONResponse({"detail": "internal error"}, status_code=500)
 
+    # DELETE is idempotent (RFC 9110 §9.3.5) — the 204↔404 TOCTOU window between
+    # the existence check and the unlink is safe; concurrent deletes converge.
     if exists_row is None:
         await _emit_audit(request.app, op="delete", result="not_found", store_key=key)
         return JSONResponse({"detail": "blob not found"}, status_code=404)

--- a/src/lyra/blobstore/audit_sink.py
+++ b/src/lyra/blobstore/audit_sink.py
@@ -37,10 +37,12 @@ class BlobAuditSink:
 
         Stream LYRA_AUDIT is shared and managed by JetStreamAuditSink — this sink
         only takes a jetstream handle and falls back to the lyra.security logger
-        on error.
+        on error. The `account_info()` probe forces a live JetStream RPC at boot
+        so degradation is detected synchronously, not deferred to first emit().
         """
+        self._js = nc.jetstream()
         try:
-            self._js = nc.jetstream()
+            await self._js.account_info()
         except nats.errors.Error as exc:
             log.warning(
                 "BLOB-AUDIT: JetStream unavailable — falling back to lyra.security: %s",

--- a/src/lyra/blobstore/audit_sink.py
+++ b/src/lyra/blobstore/audit_sink.py
@@ -10,18 +10,43 @@ import nats.errors
 from roxabi_contracts.audit.blobs import BlobAuditEvent
 
 if TYPE_CHECKING:
+    from nats.aio.client import Client as NatsClient
     from nats.js.client import JetStreamContext
 
 log = logging.getLogger(__name__)
 
 
 class BlobAuditSink:
-    """Emit BlobAuditEvent to NATS JetStream; falls back to logger when degraded."""
+    """Emit BlobAuditEvent to NATS JetStream; falls back to logger when degraded.
+
+    Lifecycle::
+
+        sink = BlobAuditSink()
+        await sink.provision(nc)   # at bootstrap, after NATS connect
+        # ... runtime ...
+        await sink.emit(event)
+    """
 
     def __init__(self) -> None:
         self._js: JetStreamContext | None = None
         self._degraded: bool = False
         self._security_log = logging.getLogger("lyra.security")
+
+    async def provision(self, nc: NatsClient) -> None:
+        """Attach to JetStream; mark degraded on failure.
+
+        Stream LYRA_AUDIT is shared and managed by JetStreamAuditSink — this sink
+        only takes a jetstream handle and falls back to the lyra.security logger
+        on error.
+        """
+        try:
+            self._js = nc.jetstream()
+        except nats.errors.Error as exc:
+            log.warning(
+                "BLOB-AUDIT: JetStream unavailable — falling back to lyra.security: %s",
+                exc,
+            )
+            self._degraded = True
 
     async def emit(self, event: BlobAuditEvent) -> None:
         """Publish event; never raises — falls back to lyra.security logger on error."""

--- a/src/lyra/blobstore/serve.py
+++ b/src/lyra/blobstore/serve.py
@@ -53,16 +53,13 @@ async def _provision_nats(app: FastAPI, nc: NATS) -> None:
     """Wire JetStream audit sink and KV readiness announce."""
     from nats.js.errors import BucketNotFoundError
 
-    try:
-        js = nc.jetstream()
-        sink = BlobAuditSink()
-        sink._js = js  # noqa: SLF001
-        app.state.audit_sink = sink
-    except Exception:  # noqa: BLE001
-        _log.warning("BLOBSTORE: JetStream unavailable — audit sink degraded")
-        app.state.audit_sink = BlobAuditSink()
+    sink = BlobAuditSink()
+    await sink.provision(nc)
+    app.state.audit_sink = sink
+    if sink._degraded:  # noqa: SLF001 — read-only check
         return
 
+    js = nc.jetstream()  # provision() succeeded — JetStream is available
     try:
         try:
             kv = await js.key_value("lyra-state")
@@ -116,11 +113,14 @@ def _make_lifespan(blob_root: pathlib.Path, injected_nats: NATS | None):  # type
 
         async with FsBlobStore(root=blob_root) as store:
             app.state.store = store
-            app.state.audit_sink = BlobAuditSink()
             app.state.nats_provisioned = False
             app.state.nats_client = nc
             if nc is not None:
+                # _provision_nats sets app.state.audit_sink (success OR degraded)
                 await _provision_nats(app, nc)
+            else:
+                # No NATS at all — audit sink is a logger-only stub.
+                app.state.audit_sink = BlobAuditSink()
             yield
 
         if nc is not None and _own_nc:

--- a/tests/blobstore/test_quadlet_unit.py
+++ b/tests/blobstore/test_quadlet_unit.py
@@ -1,0 +1,25 @@
+"""Snapshot test for deploy/quadlet/lyra-blobstore.container — H1 (#1362)."""
+from __future__ import annotations
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+QUADLET_UNIT = REPO_ROOT / "deploy" / "quadlet" / "lyra-blobstore.container"
+
+
+def test_exec_start_pre_guards_tailscale_ipv4() -> None:
+    """The unit must refuse to start when TAILSCALE_IPV4 is empty/unset.
+
+    Without this guard, an empty/unset TAILSCALE_IPV4 lets Podman resolve
+    PublishPort=${TAILSCALE_IPV4}:8449:8449 to 0.0.0.0:8449 (LAN-exposed).
+    The ExecStartPre= guard prevents the container from entering running
+    state in that condition.
+    """
+    content = QUADLET_UNIT.read_text(encoding="utf-8")
+    exec_start_pre_lines = [
+        line for line in content.splitlines() if line.startswith("ExecStartPre=")
+    ]
+    assert exec_start_pre_lines, "ExecStartPre= directive missing from Quadlet unit"
+    assert any("TAILSCALE_IPV4" in line for line in exec_start_pre_lines), (
+        "ExecStartPre= must reference TAILSCALE_IPV4 to fail-closed"
+    )

--- a/tests/blobstore/test_quadlet_unit.py
+++ b/tests/blobstore/test_quadlet_unit.py
@@ -2,9 +2,16 @@
 from __future__ import annotations
 
 import pathlib
+import re
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 QUADLET_UNIT = REPO_ROOT / "deploy" / "quadlet" / "lyra-blobstore.container"
+
+# Match the shell expression shape `[ -n "${TAILSCALE_IPV4}" ]` (with optional
+# braces / whitespace around the bracket). An inert stub like
+# `ExecStartPre=/bin/sh -c 'exit 0' # TAILSCALE_IPV4` (string-only mention)
+# fails this pattern — the test is no longer tautological.
+_GUARD_PATTERN = re.compile(r'\[\s*-n\s+"\$\{?TAILSCALE_IPV4\}?"\s*\]')
 
 
 def test_exec_start_pre_guards_tailscale_ipv4() -> None:
@@ -20,6 +27,36 @@ def test_exec_start_pre_guards_tailscale_ipv4() -> None:
         line for line in content.splitlines() if line.startswith("ExecStartPre=")
     ]
     assert exec_start_pre_lines, "ExecStartPre= directive missing from Quadlet unit"
-    assert any("TAILSCALE_IPV4" in line for line in exec_start_pre_lines), (
-        "ExecStartPre= must reference TAILSCALE_IPV4 to fail-closed"
+    guarded = [line for line in exec_start_pre_lines if _GUARD_PATTERN.search(line)]
+    assert guarded, (
+        "No ExecStartPre= line carries the `[ -n \"${TAILSCALE_IPV4}\" ]` "
+        "shell test — guard is missing or refactored to a tautology"
+    )
+
+
+def test_service_env_file_in_scope_for_exec_start_pre() -> None:
+    """`${TAILSCALE_IPV4}` must be in systemd scope when ExecStartPre fires.
+
+    `[Container] EnvironmentFile=` becomes Podman's `--env-file` (container
+    scope only); the systemd-level `ExecStartPre=` runs BEFORE the container
+    starts, so it needs a `[Service] EnvironmentFile=` declaration to read
+    `${TAILSCALE_IPV4}` from the env file. Without this, the guard always
+    fires (empty var → exit 1) and the service is permanently broken.
+    """
+    content = QUADLET_UNIT.read_text(encoding="utf-8")
+    # Split into sections by header lines like [Service], [Container], etc.
+    in_service = False
+    service_lines: list[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_service = stripped == "[Service]"
+            continue
+        if in_service:
+            service_lines.append(line)
+    assert any(
+        line.strip().startswith("EnvironmentFile=") for line in service_lines
+    ), (
+        "[Service] section must declare EnvironmentFile= so ${TAILSCALE_IPV4} "
+        "resolves in the ExecStartPre= systemd scope"
     )

--- a/tests/blobstore/test_serve_api.py
+++ b/tests/blobstore/test_serve_api.py
@@ -169,6 +169,43 @@ class TestHeadBlob:
         assert response.status_code == 404
 
 
+    def test_head_does_not_call_store_exists(
+        self, blob_root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HEAD /blobs/{store_key} must not call FsBlobStore.exists — L1 (#1362).
+
+        The handler was refactored (T3) to query the DB directly (≤2 SELECTs).
+        Calling store.exists() would be a redundant 3rd DB hit.  We assert the
+        absence of that call by replacing exists with a sentinel that raises if
+        reached; a successful HEAD proves the handler never touched it.
+        """
+
+        # Arrange — PUT a blob so HEAD can succeed on the happy path
+        app = build_app(token="test-token", blob_root=blob_root)
+        with TestClient(app) as client:
+            put_resp = client.put(
+                "/blobs",
+                content=_PNG_BYTES,
+                headers=_put_headers(),
+            )
+            assert put_resp.status_code == 201
+            store_key = put_resp.json()["store_key"]
+
+            # Replace exists on the live store instance so the monkeypatch is
+            # scoped to the already-opened store (lifespan has run by this point).
+            def _exists_must_not_be_called(*_a: object, **_kw: object) -> None:
+                raise AssertionError("HEAD must not call store.exists()")
+
+            monkeypatch.setattr(app.state.store, "exists", _exists_must_not_be_called)
+
+            # Act — HEAD on the known key
+            response = client.head(f"/blobs/{store_key}", headers=_auth_headers())
+
+        # Assert — 200 proves the handler reached the success path without
+        # calling exists() (which would have raised AssertionError → 500).
+        assert response.status_code == 200
+
+
 # ---------------------------------------------------------------------------
 # N4 — DELETE /blobs/{store_key}
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Drain the PR #1358 parking-lot — 12 non-structural items from the V8 BlobStore multi-domain review (1 hardening, 2 medium API drift, 9 low cleanup/docs).
- Production-relevant: Tailscale fail-closed `ExecStartPre=` guard on the Quadlet unit; `BlobAuditSink.provision()` mirrors `JetStreamAuditSink` lifecycle (sink owns its NATS attach, removes the SLF001 `sink._js = js` poke); `HttpBlobStore.__init__` signature is honest (dead `connect_retry_max_s` param removed); HEAD handler 3→≤2 DB lookups; `.importlinter` peer-layer comment + 2 CLAUDE.md updates + stale analysis table superseded.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1362: V8.1 hardening + cleanup pass (parking-lot from PR #1358) | OPEN |
| Frame | [1362-v8-1-hardening-cleanup-frame.mdx](artifacts/frames/1362-v8-1-hardening-cleanup-frame.mdx) | Approved |
| Spec | [1362-v8-1-hardening-cleanup-spec.mdx](artifacts/specs/1362-v8-1-hardening-cleanup-spec.mdx) | Approved (8 grouped criteria) |
| Plan | [1362-v8-1-hardening-cleanup-plan.mdx](artifacts/plans/1362-v8-1-hardening-cleanup-plan.mdx) | Approved (16 micro-tasks, 6 agents, 3 waves) |
| Implementation | 1 commit on `feat/1362-v8-1-hardening-cleanup` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new) Import contracts ✅ | Passed |

## Test Plan
- [ ] Inspect `deploy/quadlet/lyra-blobstore.container` and confirm the `ExecStartPre=` line is present and references `TAILSCALE_IPV4`.
- [ ] `uv run pytest tests/blobstore/test_quadlet_unit.py -v` — H1 snapshot test passes.
- [ ] `uv run pytest tests/blobstore/test_serve_api.py::TestHeadBlob::test_head_does_not_call_store_exists -v` — L1 SQL-trace assertion passes (the live `app.state.store.exists` is never reached during HEAD).
- [ ] `grep -rn 'connect_retry_max_s' packages/roxabi-blobs/` — 0 hits (M2 dead-knob removal).
- [ ] `grep -nE 'async def provision' src/lyra/blobstore/audit_sink.py` — 1 line (M1).
- [ ] `grep -c 'sink._js' src/lyra/blobstore/serve.py` — 0 (SLF001 poke gone).
- [ ] `uv run lint-imports` — 8 contracts kept, 0 broken (L6 peer-layer comment doesn't add `lyra.blobstore` to `shared-modules-upper-boundary`).
- [ ] Full blobstore suite: `uv run pytest tests/blobstore/ packages/roxabi-blobs/tests/` — 125 passed, no new failures.

## Reviewer notes
- M1 expanded beyond the original review item: also removes the `SLF001`-noqa private-field mutation in `_provision_nats` (caught by /spec architect review).
- H1 semantic: the `ExecStartPre=` guard fires *after* Podman has already constructed the publish-port spec — so the operational outcome is "container never serves traffic" rather than "bind decision averted" (clarified in `# RESIDUAL RISK` comment and in the spec).
- L4 `_conn_ro()` is a new method, no callers yet — added as the WAL-doc anchor since `_conn` is an attribute on `FsBlobStore`, not a method. Worth a sanity check on whether to keep as a clean read-only API or replace with an inline comment near `self._conn`.
- L2 fix landed inline during /implement: the lifespan-body default `app.state.audit_sink = BlobAuditSink()` was being overwritten on the success path; moved into the `else` branch so it's set only when `nc is None`.

Closes #1362

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`