### PR TITLE
fix(deploy): #1370 Quadlet HealthCmd quoting — replace pgrep with grep /proc/1/cmdline

### DIFF
--- a/.github/workflows/quadlet-lint.yml
+++ b/.github/workflows/quadlet-lint.yml
@@ -76,6 +76,25 @@ jobs:
           /usr/libexec/podman/quadlet --dryrun --user 2>&1
           echo "quadlet --dryrun passed"
 
+      - name: Quadlet HealthCmd double-quote check
+        # The Quadlet generator silently drops the closing double-quote from
+        # HealthCmd= values, producing ["CMD-SHELL","pgrep -f \"lyra X"] which
+        # /bin/sh rejects with "Syntax error: Unterminated quoted string".
+        # All containers report unhealthy indefinitely.  Fix: use /proc/1/cmdline
+        # (no quotes needed).  Reject any HealthCmd= containing a double-quote.
+        # See issue #1370.
+        run: |
+          set -euo pipefail
+          if grep -nP 'HealthCmd=.*"' deploy/quadlet/*.container; then
+            echo "::error::Double-quotes found in HealthCmd= in the above Quadlet unit(s)."
+            echo "The Quadlet generator drops the closing quote, producing a broken CMD-SHELL"
+            echo "array (/bin/sh: Syntax error: Unterminated quoted string). Use"
+            echo "  HealthCmd=grep -q <keyword> /proc/1/cmdline"
+            echo "instead (no quotes, no procps dependency). See issue #1370."
+            exit 1
+          fi
+          echo "No double-quotes in HealthCmd= lines — OK"
+
       - name: Quadlet inline-comment check
         # Quadlet does NOT strip trailing # comments from option values.
         # A line such as:  Volume=foo:bar:z  # comment

--- a/deploy/quadlet/lyra-blobstore.container
+++ b/deploy/quadlet/lyra-blobstore.container
@@ -49,7 +49,7 @@ Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 # Accepted for V8; document in deploy/CLAUDE.md §Residual risks.
 PublishPort=${TAILSCALE_IPV4}:8449:8449
 Exec=lyra blobstore serve --token-path /run/secrets/lyra_blobstore_token --host 0.0.0.0 --port 8449
-HealthCmd=pgrep -f "lyra blobstore serve"
+HealthCmd=grep -q blobstore /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/lyra-clipool.container
+++ b/deploy/quadlet/lyra-clipool.container
@@ -73,7 +73,7 @@ Environment=GIT_CONFIG_GLOBAL=/etc/lyra/git.config.tmpl
 # (token cache 0600/uid 1501; env scoped via `lyra-gh` exec). Revisit if a
 # future threat model surfaces /proc/<helper-pid>/environ as a leak vector.
 Exec=lyra adapter clipool
-HealthCmd=pgrep -f "lyra adapter clipool"
+HealthCmd=grep -q clipool /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/lyra-discord.container.tmpl
+++ b/deploy/quadlet/lyra-discord.container.tmpl
@@ -36,7 +36,7 @@ Volume=lyra-data.volume:/home/lyra/.lyra:z
 # Inline single-file bind mount — see rationale in lyra-hub.container.
 Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 Exec=lyra adapter discord
-HealthCmd=pgrep -f "lyra adapter discord"
+HealthCmd=grep -q discord /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/lyra-gh-helper.container
+++ b/deploy/quadlet/lyra-gh-helper.container
@@ -46,7 +46,7 @@ Environment=LYRA_GH_PEM_PATH=/run/secrets/gh-app.pem
 Volume=lyra-gh-token.volume:/run/lyra-gh-token:rw
 
 Exec=python -m lyra.tools.gh_token.daemon
-HealthCmd=pgrep -f "lyra.tools.gh_token.daemon"
+HealthCmd=grep -q gh_token /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -54,7 +54,7 @@ Environment=LYRA_HEALTH_HOST=0.0.0.0
 Environment=LYRA_TTS_TIMEOUT=90
 PublishPort=127.0.0.1:8443:8443
 Exec=lyra hub
-HealthCmd=pgrep -f "lyra hub"
+HealthCmd=grep -q hub /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/lyra-telegram.container.tmpl
+++ b/deploy/quadlet/lyra-telegram.container.tmpl
@@ -36,7 +36,7 @@ Volume=lyra-data.volume:/home/lyra/.lyra:z
 # Inline single-file bind mount — see rationale in lyra-hub.container.
 Volume=%h/.lyra/config.toml:/app/config.toml:ro,z
 Exec=lyra adapter telegram
-HealthCmd=pgrep -f "lyra adapter telegram"
+HealthCmd=grep -q telegram /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/lyra-turn-writer.container
+++ b/deploy/quadlet/lyra-turn-writer.container
@@ -34,7 +34,7 @@ Environment=LYRA_TURNS_DB=/data/turns.db
 Environment=LYRA_VAULT_DIR=/data
 Environment=PYTHONUNBUFFERED=1
 Exec=lyra turn-writer
-HealthCmd=pgrep -f "lyra turn-writer"
+HealthCmd=grep -q turn-writer /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -307,6 +307,26 @@ systemctl --user status podman-auto-update.timer
 | Container restart loop | `RestartSec=10` applies — check logs | `journalctl --user -u <svc> -n 50` |
 | Auto-update not pulling | Timer inactive | `systemctl --user start podman-auto-update.timer` |
 
+## Pitfall: double-quotes in HealthCmd= are dropped by the Quadlet generator
+
+The Quadlet generator silently drops the closing double-quote from `HealthCmd=` values,
+turning `HealthCmd=pgrep -f "lyra adapter X"` into the JSON array
+`["CMD-SHELL","pgrep -f \"lyra adapter X"]` — note the missing closing `"`.
+`/bin/sh` then fails with `Syntax error: Unterminated quoted string`, and the container
+reports `unhealthy` indefinitely (all 6 `lyra-*` units were affected until issue #1370).
+
+Workaround: use `/proc/1/cmdline` — no quotes required, and `grep`/`cat` are present in
+both the slim (`:staging-svc`) and fat (`:staging`) images (unlike `pgrep` which requires
+`procps`):
+
+```ini
+# correct — no quotes, no procps dependency
+HealthCmd=grep -q telegram /proc/1/cmdline
+```
+
+The `quadlet-lint.yml` CI workflow enforces this via a `grep -nP 'HealthCmd=.*"'` check that
+fails on any double-quote in a `HealthCmd=` line. See issue #1370.
+
 ## References
 
 - `deploy/quadlet/` — unit files (authoritative)


### PR DESCRIPTION
## Summary

- **Bug**: The Quadlet generator silently drops the closing `"` from `HealthCmd=pgrep -f "lyra X"`, producing `["CMD-SHELL","pgrep -f \"lyra X"]`; `/bin/sh` rejects this with `Syntax error: Unterminated quoted string` — all 7 `lyra-*` containers reported `unhealthy` indefinitely.
- **Fix**: Replace every `pgrep -f "..."` with `grep -q <keyword> /proc/1/cmdline` — no quotes, no `procps` dependency (absent from the slim `:staging-svc` image).
- **Scope**: 7 units fixed (`lyra-telegram`, `lyra-discord`, `lyra-hub`, `lyra-turn-writer`, `lyra-clipool`, `lyra-gh-helper`, `lyra-blobstore`); `lyra-blobstore` was not in the original issue table but has the same bug and is caught by the new guard.
- **CI guard**: New step in `quadlet-lint.yml` — `grep -nP 'HealthCmd=.*"' deploy/quadlet/*.container` fails on any double-quote in a `HealthCmd=` line.
- **Doc**: Pitfall section added to `docs/QUADLET-DEPLOYMENT.md` with workaround and CI guard reference.

## Test plan

- [ ] Apply on M₁: `make quadlet-install` → `systemctl --user daemon-reload` → restart each unit → verify `podman inspect <unit> --format "{{.State.Health.Status}}"` reports `healthy` within 30 s
- [ ] `grep -nP 'HealthCmd=.*"' deploy/quadlet/*.container` returns empty (exit 1)
- [ ] CI guard fires when re-introducing a quoted `HealthCmd=` (manual test: add a `"` to one unit, confirm the new workflow step fails, revert)

Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)