### PR TITLE
fix(deploy): #1368 blobstore Tailscale guard whitespace-safe

### DIFF
--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -102,6 +102,12 @@ is absent at container start, Podman falls back to `0.0.0.0:8449` (LAN-exposed).
 token (`lyra_blobstore_token`) is then the **sole** auth boundary. Accepted for V8; Phase 2
 (network policy / per-identity tokens) will address this systematically.
 
+The `ExecStartPre=` guard strips all whitespace before the `-n` test (POSIX `tr -d`) so
+empty, unset, **and whitespace-only** values are all rejected at the systemd layer (#1368).
+Prior to #1368, `[ -n "   " ]` was TRUE in POSIX sh — a whitespace-only value passed the
+guard and Podman's downstream parse error provided fail-closed behaviour by accident, not
+by design. The guard is now the authoritative rejection point.
+
 ### Known residual risk — clipool `core.hooksPath` override (tracked #1245)
 
 The clipool unit sets `core.hooksPath = /opt/lyra-gh/hooks` via `GIT_CONFIG_GLOBAL`

--- a/deploy/quadlet/lyra-blobstore.container
+++ b/deploy/quadlet/lyra-blobstore.container
@@ -59,13 +59,18 @@ HealthInterval=30s
 # through verbatim, so this loads the file twice — once for systemd (here), once for
 # Podman (above) — both intentional.
 EnvironmentFile=%h/.lyra/env/blobstore.env
-# Fail-closed guard: refuse to start when TAILSCALE_IPV4 is empty/unset.
+# Fail-closed guard: refuse to start when TAILSCALE_IPV4 is empty, unset,
+# or whitespace-only. `[ -n "   " ]` is TRUE in POSIX sh, so a bare -n test
+# passes on whitespace-only values — Podman would then construct a malformed
+# PublishPort spec and reject it downstream (fail-closed by accident, not by
+# intent). The tr-based strip removes all whitespace before the -n test so
+# the guard is the authoritative rejection point, not Podman's parser.
 # Note: the `PublishPort=${TAILSCALE_IPV4}:8449:8449` line above is resolved
 # by Podman BEFORE this ExecStartPre fires — so the publish-port spec is
 # already constructed (and could read as 0.0.0.0). This guard prevents the
 # CONTAINER from entering running state, so no traffic is ever served.
 # Operationally equivalent to closing the port (nothing accepts traffic).
-ExecStartPre=/bin/sh -c '[ -n "${TAILSCALE_IPV4}" ] || exit 1'
+ExecStartPre=/bin/sh -c 'v=$(printf %s "${TAILSCALE_IPV4}" | tr -d "[:space:]"); [ -n "$v" ] || exit 1'
 Restart=on-failure
 RestartSec=10
 # Cold-path I/O service — 1 full core is sufficient; prevents it from starving

--- a/tests/blobstore/test_quadlet_unit.py
+++ b/tests/blobstore/test_quadlet_unit.py
@@ -1,17 +1,24 @@
 """Snapshot test for deploy/quadlet/lyra-blobstore.container — H1 (#1362)."""
+
 from __future__ import annotations
 
 import pathlib
 import re
+import subprocess
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 QUADLET_UNIT = REPO_ROOT / "deploy" / "quadlet" / "lyra-blobstore.container"
 
-# Match the shell expression shape `[ -n "${TAILSCALE_IPV4}" ]` (with optional
-# braces / whitespace around the bracket). An inert stub like
-# `ExecStartPre=/bin/sh -c 'exit 0' # TAILSCALE_IPV4` (string-only mention)
-# fails this pattern — the test is no longer tautological.
-_GUARD_PATTERN = re.compile(r'\[\s*-n\s+"\$\{?TAILSCALE_IPV4\}?"\s*\]')
+# Match the whitespace-safe guard shape: tr -d strips whitespace then -n tests
+# the residue. An inert stub or the old bare `[ -n "${TAILSCALE_IPV4}" ]` form
+# fails this pattern — the test is no longer tautological after #1368.
+# Two sub-patterns checked independently on the same line:
+#   - tr -d is present (whitespace strip)
+#   - [ -n "$v" ] is present (test on stripped residue, not raw var)
+_TR_STRIP_PATTERN = re.compile(r"tr\s+-d")
+_STRIPPED_TEST_PATTERN = re.compile(r'\[\s*-n\s+"\\?\$v"\s*\]')
+# Also verify the variable is still referenced in the guard line.
+_VAR_PATTERN = re.compile(r"\$\{?TAILSCALE_IPV4\}?")
 
 
 def test_exec_start_pre_guards_tailscale_ipv4() -> None:
@@ -27,10 +34,81 @@ def test_exec_start_pre_guards_tailscale_ipv4() -> None:
         line for line in content.splitlines() if line.startswith("ExecStartPre=")
     ]
     assert exec_start_pre_lines, "ExecStartPre= directive missing from Quadlet unit"
-    guarded = [line for line in exec_start_pre_lines if _GUARD_PATTERN.search(line)]
+    # Verify tr-based whitespace strip + stripped-residue test + variable reference
+    # are all present on the same ExecStartPre= line.
+    guarded = [
+        line
+        for line in exec_start_pre_lines
+        if (
+            _TR_STRIP_PATTERN.search(line)
+            and _STRIPPED_TEST_PATTERN.search(line)
+            and _VAR_PATTERN.search(line)
+        )
+    ]
     assert guarded, (
-        "No ExecStartPre= line carries the `[ -n \"${TAILSCALE_IPV4}\" ]` "
-        "shell test — guard is missing or refactored to a tautology"
+        "No ExecStartPre= line carries the whitespace-safe guard "
+        '(tr -d + [ -n "$v" ] + ${TAILSCALE_IPV4} reference) — '
+        "guard is missing, uses old bare -n form, or refactored to a tautology (#1368)"
+    )
+
+
+def _extract_exec_start_pre_shell(content: str) -> str | None:
+    """Return the shell command string from the first ExecStartPre= line, or None."""
+    for line in content.splitlines():
+        if line.startswith("ExecStartPre="):
+            # Strip the directive prefix and any surrounding /bin/sh -c '...' wrapper.
+            value = line[len("ExecStartPre=") :]
+            # Extract the inner shell script from `/bin/sh -c '<script>'`.
+            m = re.search(r"/bin/sh\s+-c\s+'(.+)'", value)
+            if m:
+                return m.group(1)
+    return None
+
+
+def test_whitespace_only_tailscale_ipv4_rejected() -> None:
+    """Whitespace-only TAILSCALE_IPV4 must exit 1 (not pass the guard).
+
+    `[ -n "   " ]` is TRUE in POSIX sh — the old bare -n guard let whitespace
+    values through. The tr-based strip must strip first so the test sees an
+    empty string and exits 1. Behavioral test: runs the extracted shell command
+    via /bin/sh with controlled env vars (#1368).
+    """
+    content = QUADLET_UNIT.read_text(encoding="utf-8")
+    script = _extract_exec_start_pre_shell(content)
+    assert script is not None, "Could not extract shell script from ExecStartPre= line"
+
+    # Whitespace-only — must be rejected (exit 1).
+    result_ws = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env={"TAILSCALE_IPV4": "   ", "PATH": "/bin:/usr/bin"},
+        capture_output=True,
+    )
+    assert result_ws.returncode == 1, (
+        "Whitespace-only TAILSCALE_IPV4 passed the guard "
+        f"(exit {result_ws.returncode}); "
+        "expected exit 1 — guard is not whitespace-safe (#1368)"
+    )
+
+    # Empty string — must be rejected (exit 1).
+    result_empty = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env={"TAILSCALE_IPV4": "", "PATH": "/bin:/usr/bin"},
+        capture_output=True,
+    )
+    assert result_empty.returncode == 1, (
+        f"Empty TAILSCALE_IPV4 passed the guard (exit {result_empty.returncode}); "
+        "expected exit 1"
+    )
+
+    # Valid IP — must be accepted (exit 0).
+    result_valid = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env={"TAILSCALE_IPV4": "100.64.1.2", "PATH": "/bin:/usr/bin"},
+        capture_output=True,
+    )
+    assert result_valid.returncode == 0, (
+        "Valid TAILSCALE_IPV4 was rejected by the guard "
+        f"(exit {result_valid.returncode}); expected exit 0"
     )
 
 
@@ -54,9 +132,7 @@ def test_service_env_file_in_scope_for_exec_start_pre() -> None:
             continue
         if in_service:
             service_lines.append(line)
-    assert any(
-        line.strip().startswith("EnvironmentFile=") for line in service_lines
-    ), (
+    assert any(line.strip().startswith("EnvironmentFile=") for line in service_lines), (
         "[Service] section must declare EnvironmentFile= so ${TAILSCALE_IPV4} "
         "resolves in the ExecStartPre= systemd scope"
     )

--- a/tests/blobstore/test_quadlet_unit.py
+++ b/tests/blobstore/test_quadlet_unit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import subprocess
@@ -16,6 +17,8 @@ QUADLET_UNIT = REPO_ROOT / "deploy" / "quadlet" / "lyra-blobstore.container"
 #   - tr -d is present (whitespace strip)
 #   - [ -n "$v" ] is present (test on stripped residue, not raw var)
 _TR_STRIP_PATTERN = re.compile(r"tr\s+-d")
+# `\\?` makes the backslash optional: matches both literal `"$v"` and
+# systemd-escaped `"\$v"` (the latter prevents %-expansion in some scopes).
 _STRIPPED_TEST_PATTERN = re.compile(r'\[\s*-n\s+"\\?\$v"\s*\]')
 # Also verify the variable is still referenced in the guard line.
 _VAR_PATTERN = re.compile(r"\$\{?TAILSCALE_IPV4\}?")
@@ -59,7 +62,7 @@ def _extract_exec_start_pre_shell(content: str) -> str | None:
             # Strip the directive prefix and any surrounding /bin/sh -c '...' wrapper.
             value = line[len("ExecStartPre=") :]
             # Extract the inner shell script from `/bin/sh -c '<script>'`.
-            m = re.search(r"/bin/sh\s+-c\s+'(.+)'", value)
+            m = re.search(r"/bin/sh\s+-c\s+'([^']+)'", value)
             if m:
                 return m.group(1)
     return None
@@ -80,7 +83,7 @@ def test_whitespace_only_tailscale_ipv4_rejected() -> None:
     # Whitespace-only — must be rejected (exit 1).
     result_ws = subprocess.run(
         ["/bin/sh", "-c", script],
-        env={"TAILSCALE_IPV4": "   ", "PATH": "/bin:/usr/bin"},
+        env=os.environ | {"TAILSCALE_IPV4": "   "},
         capture_output=True,
     )
     assert result_ws.returncode == 1, (
@@ -92,7 +95,7 @@ def test_whitespace_only_tailscale_ipv4_rejected() -> None:
     # Empty string — must be rejected (exit 1).
     result_empty = subprocess.run(
         ["/bin/sh", "-c", script],
-        env={"TAILSCALE_IPV4": "", "PATH": "/bin:/usr/bin"},
+        env=os.environ | {"TAILSCALE_IPV4": ""},
         capture_output=True,
     )
     assert result_empty.returncode == 1, (
@@ -103,12 +106,61 @@ def test_whitespace_only_tailscale_ipv4_rejected() -> None:
     # Valid IP — must be accepted (exit 0).
     result_valid = subprocess.run(
         ["/bin/sh", "-c", script],
-        env={"TAILSCALE_IPV4": "100.64.1.2", "PATH": "/bin:/usr/bin"},
+        env=os.environ | {"TAILSCALE_IPV4": "100.64.1.2"},
         capture_output=True,
     )
     assert result_valid.returncode == 0, (
         "Valid TAILSCALE_IPV4 was rejected by the guard "
         f"(exit {result_valid.returncode}); expected exit 0"
+    )
+
+    # Tab-only — must be rejected (exit 1).
+    result_tab = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env=os.environ | {"TAILSCALE_IPV4": "\t"},
+        capture_output=True,
+    )
+    assert result_tab.returncode == 1, (
+        "Tab-only TAILSCALE_IPV4 passed the guard "
+        f"(exit {result_tab.returncode}); "
+        "expected exit 1 — guard is not whitespace-safe (#1368)"
+    )
+
+    # Newline-only — must be rejected (exit 1).
+    result_newline = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env=os.environ | {"TAILSCALE_IPV4": "\n"},
+        capture_output=True,
+    )
+    assert result_newline.returncode == 1, (
+        "Newline-only TAILSCALE_IPV4 passed the guard "
+        f"(exit {result_newline.returncode}); "
+        "expected exit 1 — guard is not whitespace-safe (#1368)"
+    )
+
+    # Mixed-whitespace — must be rejected (exit 1).
+    result_mixed = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env=os.environ | {"TAILSCALE_IPV4": " \t  "},
+        capture_output=True,
+    )
+    assert result_mixed.returncode == 1, (
+        "Mixed-whitespace TAILSCALE_IPV4 passed the guard "
+        f"(exit {result_mixed.returncode}); "
+        "expected exit 1 — guard is not whitespace-safe (#1368)"
+    )
+
+    # Unset (key absent) — also rejected via POSIX empty-expansion.
+    parent_env = {k: v for k, v in os.environ.items() if k != "TAILSCALE_IPV4"}
+    result_unset = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env=parent_env,
+        capture_output=True,
+    )
+    assert result_unset.returncode == 1, (
+        f"Unset TAILSCALE_IPV4 passed the guard (exit {result_unset.returncode}); "
+        "expected exit 1 — POSIX expands unset to empty, "
+        "which the guard should reject (#1368)"
     )
 
 


### PR DESCRIPTION
Closes #1368

## Summary

- Replace `[ -n "${TAILSCALE_IPV4}" ]` with POSIX-sh `tr -d "[:space:]"` strip before the `-n` test, making the guard the authoritative rejection point for empty, unset, and whitespace-only values
- Prior behavior: `[ -n "   " ]` is TRUE in POSIX sh — whitespace-only values passed the guard and fail-closed relied on Podman's downstream parse error (accident, not intent)
- New behavior: systemd-layer rejection via `ExecStartPre=` before the container ever enters running state

## POSIX-sh compatibility

`${v// /}` (bash parameter substitution with global replace) is bash-specific and fails on dash (`/bin/sh` on some hosts). `printf %s … | tr -d "[:space:]"` is fully POSIX: `tr`, `printf`, `$(…)`, and `[ ]` are all specified by POSIX.1-2017.

## Test plan

- [x] `uv run pytest tests/blobstore/test_quadlet_unit.py -xvs` — 3 tests pass (snapshot guard shape + behavioral + env-file scope)
- [x] Test shape: **(b) behavioral** — `subprocess.run(["/bin/sh", "-c", <extracted script>])` with `TAILSCALE_IPV4="   "` asserts exit 1; with `TAILSCALE_IPV4=""` asserts exit 1; with `TAILSCALE_IPV4="100.64.1.2"` asserts exit 0
- [x] `uv run pytest -x --timeout=60 -q` — full suite green (pre-existing flaky NATS e2e excluded)
- [x] `uv run ruff check tests/blobstore/test_quadlet_unit.py` — no errors
- [x] `uv run pyright tests/blobstore/test_quadlet_unit.py` — 0 errors, 0 warnings
- [x] `grep "tr -d" deploy/quadlet/lyra-blobstore.container` — confirmed
- [x] `grep "whitespace" tests/blobstore/test_quadlet_unit.py` — confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)