### PR TITLE
fix(deploy): #1383 quadlet-install missing blobstore + turn-writer copies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,8 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 	@cp deploy/quadlet/lyra-gh.pod                     "$(QUADLET_DIR)/lyra-gh.pod"
 	@cp deploy/quadlet/lyra-gh-helper.container        "$(QUADLET_DIR)/lyra-gh-helper.container"
 	@cp deploy/quadlet/lyra-clipool.container          "$(QUADLET_DIR)/lyra-clipool.container"
+	@cp deploy/quadlet/lyra-blobstore.container        "$(QUADLET_DIR)/lyra-blobstore.container"
+	@cp deploy/quadlet/lyra-turn-writer.container      "$(QUADLET_DIR)/lyra-turn-writer.container"
 	@echo "Quadlet units copied."
 	@if [ "$(NO_RESTART)" = "1" ]; then \
 		echo "NO_RESTART=1 — skipping daemon-reload, restart, and verification."; \

--- a/deploy/quadlet-install-verify.sh
+++ b/deploy/quadlet-install-verify.sh
@@ -20,6 +20,8 @@ UNITS=(
     lyra-telegram
     lyra-discord
     lyra-clipool
+    lyra-blobstore
+    lyra-turn-writer
 )
 
 # ── 1. Reload daemon so Quadlet generates fresh .service files ────────────────

--- a/deploy/quadlet-install-verify.sh
+++ b/deploy/quadlet-install-verify.sh
@@ -20,6 +20,7 @@ UNITS=(
     lyra-telegram
     lyra-discord
     lyra-clipool
+    lyra-gh-helper
     lyra-blobstore
     lyra-turn-writer
 )


### PR DESCRIPTION
Closes #1383

## Summary

The `quadlet-install` Makefile target hardcoded a list of `.container` cp lines that was never updated when `lyra-blobstore` (#1330) and `lyra-turn-writer` (#1331) were merged. This caused silent absence on fresh installs; on M₁ both units were recovered manually on 2026-05-26. The `rm -f` glob already covered both filenames — only the cp lines were missing.

Also updates `deploy/quadlet-install-verify.sh` UNITS array (same omission) so the post-install health check actually verifies both services reach `active` state.

M₁ is already in the recovered state; this PR aligns the code to match.

## Test plan

- [x] `make quadlet-preflight` — passes (quadlet lint + template purity check)
- [x] `grep -E 'lyra-(blobstore|turn-writer)\.container' Makefile` — both match cp pattern (not only rm)
- [x] `uv run pytest -x` — 4369 passed, 18 skipped, 1 xfailed; one flaky e2e test (`test_retired_identity_connect_rejected@nats_server`) confirmed pre-existing timing flake (passes in isolation and on baseline staging)
- [x] `uv run ruff check .` — 0 errors; format drift (11 files) is pre-existing on staging, unrelated to this PR
- [x] All pre-commit hooks passed (trim, lint, typecheck, file-length, import-layers, trufflehog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)