### PR TITLE
docs(adr): #1378 add ADR-076 three NATS planes + xref ADR-073/075

### DIFF
--- a/artifacts/analyses/1378-three-nats-planes-consensus.mdx
+++ b/artifacts/analyses/1378-three-nats-planes-consensus.mdx
@@ -1,0 +1,171 @@
+---
+title: "ADR-076 Three NATS planes — Expert Consensus on PR #1388 review findings"
+issue: 1378
+pr: 1388
+status: consensus-reached
+date: 2026-05-26
+panel: architect, devops, product-lead
+confidence: high
+---
+
+## Problem
+
+PR #1388 adds ADR-076 (three NATS planes — messages, persistence, typing/lifecycle) as
+T5 of Epic #1375. The `/code-review` pass returned 4 actionable suggestions + 2 forward-looking
+thoughts (no blockers, verdict = Approve with comments). User invoked `/consensus` to decide
+per-finding whether to apply, modify, or reject before merging.
+
+## Panel
+
+| α | Focus |
+|---|-------|
+| architect | ADR rigor, durability of the decision against future planes |
+| devops | NATS ops, ACL surface, Quadlet implications, M₁ deploy safety |
+| product-lead | Contributor-developer experience, ADR readability, T1/T2 runway |
+
+## Consensus ρ (per-finding)
+
+### F1 — WorkScope keying enforcement note (axial 85%)
+
+**Decision:** Apply Sol 1, modified. Add an "Enforcement" line to the Typing plane row in
+the Decision table that:
+1. Points at T1 (#1376) spec as the locus where `scope_id` validation lands.
+2. Phrases the requirement as "envelope MUST carry `scope_id`; subscribers reject on
+   absence and log a structured error" (ADR prescribes *what*, T1 spec owns *how*).
+3. Notes the operator-side observability path: scope_id validation failures surface in
+   the adapter's `journalctl --user -u lyra-{discord,telegram}`, NOT in
+   `lyra-nats.service` — devops monitoring lens.
+
+**Rationale (unanimous):** ACL enforces only `platform+bot_id`; `scope_id` lives in the
+envelope body and is unvalidated today — same gap class as #1374. One sentence in the
+table row closes the paper-claim risk and points future implementers + operators at the
+right enforcement and observability sites.
+
+**Rejected:** Sol 2 (cross-ref Alternative D only) — adds rationale, not enforcement
+locus. Insufficient on its own.
+
+### F2 — ASCII diagram orientation annotation (architect + axial 78%)
+
+**Decision:** Apply Sol 1. Annotate the diagram with a `(transport stage only)` label (or
+equivalent column-bracket) so the plane rows are visually confined to the transport
+stage. Keep the ASCII diagram.
+
+**Rationale (unanimous):** Horizontal plane rows spanning inbound→outbound impersonate
+the primary axis at a glance; a single-label fix preserves the spatial relationship
+without rewriting the diagram. Fumadocs renderer parity for ASCII art should be
+spot-checked but does not block the fix.
+
+**Rejected:** Sol 2 (replace ASCII with prose) — destroys the only visual that makes the
+primary-axis / sub-axis orthogonality spatially legible. All three panellists rejected.
+
+### F3 — 3-prong gate partial-case rule (axial 75%)
+
+**Decision:** Apply Sol 1 only. Add the sentence: "Partial difference (1 or 2 of 3
+prongs) is **not** sufficient — the existing plane must be stretched or the subject
+reclassified, never a new plane opened."
+
+**Rationale (2-1 majority):** Sol 1 alone closes the gate logically with one sentence.
+Sol 2 (worked rejection example for `lyra.progress.*`) partially duplicates the
+"Distinguish from sibling subjects" table that already shows `lyra.progress.*` is not
+a Typing plane member.
+
+**Recorded dissent (architect):** Architect preferred applying both Sol 1 + Sol 2
+together for compound clarity. Majority (devops + product-lead) viewed the worked example
+as duplicative of existing content. Dissent does not block; future drift can be addressed
+in a follow-up if the abstract rule proves insufficient.
+
+### F4 — Procedure duplication cleanup (architect 65%)
+
+**Decision:** Apply Sol 1. Collapse "Where new subjects go" step 1 to a forward-reference:
+"1. Decide durability (see 'Choosing Core vs JetStream' above) — that determines the
+plane."
+
+**Rationale (2-1 majority — architect + devops):** Single source for the rule; removes
+the drift surface where the two versions could diverge if rationale is updated. ADR is
+~235 lines — section bouncing is acceptable.
+
+**Recorded dissent (product-lead):** Restatement is intentional reader affordance for
+skimmers reading the procedure section standalone. Collapse forces section-bouncing for
+a 3-step checklist. Confidence 65% on the original finding; not load-bearing if dissent
+prevails. Recorded but overridden by majority.
+
+### F5 — Worker ACL wildcard note (security 65%, escalated to suggestion-class by devops)
+
+**Decision:** Apply Sol 1. Add to Consequences → Negative: "When workers are admitted as
+producers (#1044), their pub grant MUST be scoped to `lyra.typing.<platform>.<bot_id>`
+matching the job's assigned scope, not the plane-level wildcard. Updating the
+`type=mount` secret requires a container restart (¬HUP) per
+`~/projects/docs/container-deployment-standard.md` S7."
+
+**Rationale (unanimous on Sol 1; devops escalated severity):** The ACL spec
+`artifacts/specs/706-per-role-nkeys-acls-spec.mdx` currently carries **zero**
+`lyra.typing.*` rows — T1 has not added them yet. The ADR is the design contract read
+first by T1 implementers; absent guidance, a plane-level wildcard grant could land in
+`auth.conf` before per-bot scoping is documented. The note in Consequences → Negative
+forecloses that.
+
+**Out-of-scope follow-up (devops recommendation):** File a sibling task under Epic #1375
+to add `lyra.typing.*` rows to the ACL spec. This is OWNED by T1 (#1376) per the epic
+body and is NOT filed here — T1 already enumerates the ACL spec updates as in-scope.
+
+### F6 — `lyra.progress.*` lossy + job_id edge case (axial 70%)
+
+**Decision:** Apply Sol 1. Extend the escape-hatch rule: "If lossy-OK AND keyed on
+`job_id` (not `WorkScope`) → Workers plane, not Typing." Phrase tightly to avoid
+duplicating Alternative D's rejection rationale.
+
+**Rationale (unanimous):** Current escape-hatch is binary (JetStream vs Typing) and does
+not handle the user-facing TTS-progress case where lossy-OK + `job_id`-keyed would
+mislead a reader into the Typing plane. One additive sentence closes the alternative
+that Alt D currently rejects only implicitly.
+
+## Trade-offs (overall)
+
+- **Net additions:** ~7–9 sentences across F1/F2/F3/F4/F5/F6. ADR grows from ~235 to
+  ~245 lines — comfortably within the project's ≤350-line guidance for self-contained
+  docs.
+- **Defense-in-depth on the keying contract:** F1 + F5 + F6 together harden the same
+  invariant from publisher, ACL, and plane-membership angles. Correct for the
+  security-adjacent claim that triggered #1374.
+- **Fumadocs render parity (F2):** ASCII art in MDX can break on some renderers; the
+  `(transport stage only)` annotation must be visually verified before merge.
+- **Dissent on F3 (architect, compound rule) and F4 (product-lead, reader affordance):**
+  both are non-blocking and override-able by future PRs if they prove load-bearing.
+
+## Alternatives
+
+| ω | Proposed by | Rejected because |
+|---|-------------|------------------|
+| Sol 2 for F2 (replace ASCII with prose) | review (architect option) | Loses bidirectional/unidirectional legibility at a glance |
+| Sol 2 for F3 (worked rejection example) | review (axial-adr-review option) | Duplicates existing "Distinguish from sibling subjects" table |
+| Reject F4 entirely | product-lead (dissent) | Architect + devops view single-source rule as more durable; recorded as δ |
+| Defer F5/F6 to follow-up issues | n/a (panel rejected) | 1-sentence fixes cheaper than issue churn |
+| Escalate F5 to `suggestion(blocking)` | devops | Severity acknowledged; solution unchanged, no merge block needed |
+
+## Dissent
+
+- **architect** on F3: preferred Sol 1 + Sol 2 combined for compound clarity. Overridden
+  by majority. Future drift may resurface this; addressable in follow-up.
+- **product-lead** on F4: preferred Reject. Argued the restatement is intentional reader
+  affordance. Overridden by majority. ADR length not yet load-bearing.
+
+## Implementation Notes
+
+All edits land in a single file: `docs/architecture/adr/076-three-nats-planes.mdx`.
+
+Sequence:
+1. F1 — add Enforcement line to Typing plane row (Decision table) + journalctl pointer.
+2. F2 — add `(transport stage only)` annotation to ASCII diagram.
+3. F3 — add "Partial difference is not sufficient" sentence in "Where new subjects go".
+4. F4 — collapse "Where new subjects go" step 1 to forward-reference.
+5. F5 — append worker-ACL-scoping sentence to Consequences → Negative.
+6. F6 — extend escape-hatch rule with `job_id` clause in "Distinguish from sibling
+   subjects".
+
+Quality gates: ruff + pyright + pytest already pass (CI green). Pre-commit hooks will
+re-run on commit; expected to pass (no Python touched).
+
+## Next
+
+`/fix` Phase 6 (apply all 6 edits) → Phase 7 (push + `reviewed` label) → Phase 8 (post
+"Review Fixes Applied" comment) → return to `/dev` → cleanup.

--- a/docs/architecture/adr/073-axial-stage-of-pipeline-decomposition.mdx
+++ b/docs/architecture/adr/073-axial-stage-of-pipeline-decomposition.mdx
@@ -2,6 +2,7 @@
 title: "ADR-073: Axis of Decomposition — Stage of Pipeline"
 description: Primary axis chosen for system variation — prevents N×M drift across platform/adapter dimension
 axial: true
+related: [076]
 ---
 
 ## Status

--- a/docs/architecture/adr/075-turn-writer-subscriber.mdx
+++ b/docs/architecture/adr/075-turn-writer-subscriber.mdx
@@ -6,7 +6,7 @@ date: 2026-05-25
 deciders: [Mickael, architect, devops, axial-adr-review]
 supersedes: []
 superseded_by: []
-related: [068, 073]
+related: [068, 073, 076]
 ---
 
 ## Status

--- a/docs/architecture/adr/076-three-nats-planes.mdx
+++ b/docs/architecture/adr/076-three-nats-planes.mdx
@@ -57,6 +57,20 @@ envelope shape may appear on Messages and Persistence (a `TurnEvelope` is shippe
 Persistence plane today, but a future hot-path replay over the Messages plane would not change
 its shape).
 
+### Enforcement
+
+The plane assignment governs the wire (subject + NATS type), not the envelope payload. The
+Typing plane in particular has a keying contract that lives outside the plane table and
+must be enforced explicitly:
+
+- **Typing plane keying** — keyed on `WorkScope` (`platform + bot_id + scope_id`). ACL
+  enforces only `platform + bot_id` (the subject tokens); `scope_id` lives in the envelope
+  body. The publisher contract (T1, see #1376 spec) requires every envelope to carry
+  `scope_id`; subscribers MUST reject envelopes missing `scope_id` and log a structured
+  error. Validation failures surface in the **adapter** units
+  (`journalctl --user -u lyra-{discord,telegram}`), NOT in `lyra-nats.service` — this is
+  the monitoring grep target if the #1374 bug class re-emerges.
+
 ### Choosing Core vs JetStream
 
 The choice is forced by the durability column, not by convenience:
@@ -76,11 +90,16 @@ only correct choice.
 
 When adding a NATS subject:
 
-1. Decide durability first (Core vs JetStream) — that decides the plane.
+1. Decide durability first (see "Choosing Core vs JetStream" above) — that determines the plane.
 2. If the durability + direction shape already matches one of the three planes → use that
    plane's prefix.
 3. Only file a new ADR + open a new plane if **durability + direction + lifecycle ownership**
    all differ from the three existing planes.
+
+Partial difference (1 or 2 of 3 prongs) is **not** sufficient — the existing plane must be
+stretched or the subject reclassified, never a new plane opened. The three-prong test is
+conjunctive on purpose: partial matches mean an existing plane is the right home with a
+narrower (or wider) keying contract, not a new wire shape.
 
 ## Distinguish from sibling subjects
 
@@ -96,6 +115,12 @@ each other:
 If a future emitter sits between "job-internal" and "display feedback" (e.g. TTS rendering
 progress visible to the user), the rule is: **does the consumer need it to drive UX it will
 re-render after restart?** Yes → JetStream; no → Typing plane.
+
+**Caveat — `job_id` keying disqualifies the Typing plane.** If the answer above is "no"
+(lossy-OK) **AND** the natural key is `job_id` (not `WorkScope`), this is **NOT** the Typing
+plane — open or extend a Workers plane that keys on `job_id`. The Typing plane's `WorkScope`
+keying contract (per Alternative D) is precisely what prevents the #1374 bug class;
+re-keying on `job_id` re-opens it.
 
 ## Relationship to ADR-073 (axial: stage-of-pipeline)
 
@@ -117,13 +142,19 @@ Diagrammatically:
                        primary axis (ADR-073) — stages
                        ───────────────────────────────►
                        inbound │ router │ session │ dispatcher │ outbound
-                               │        │         │            │
-   transport sub-axis          │        │         │            │
-   (this ADR — ADR-076)        │        │         │            │
-   ─────────────────           │        │         │            │
-   messages   ◄════════════════│════════│═════════│════════════│═══════════►
-   persistence ════════════════│════════│═════════►                          (hub-only)
-   typing     ═════════════════│════════│═════════►════════════►════════════►
+
+   ┌─── transport sub-axis (this ADR — confined to the transport hop, NOT a new stage) ───┐
+   │                                                                                       │
+   │   messages    ◄═══════════════════════════════════════════════════════════════════►   │
+   │               (Core, ephemeral, bidirectional adapter ↔ hub)                          │
+   │                                                                                       │
+   │   persistence ═══════════════════════════════════►        (hub-only)                  │
+   │               (JetStream durable, hub → turn-writer)                                  │
+   │                                                                                       │
+   │   typing     ═══════════════════════════════════════════════════════════════►         │
+   │               (Core, ephemeral, hub → adapters)                                       │
+   │                                                                                       │
+   └───────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 The transport sub-axis slices the transport stage horizontally; it does not slice the
@@ -160,6 +191,14 @@ the design question — surface it, do not silently file a new plane.
   `deploy/nats/auth.conf` for every identity that publishes or subscribes. Tracked in
   `artifacts/specs/706-per-role-nkeys-acls-spec.mdx` (T1 of Epic #1375 adds
   `lyra.typing.>` grants).
+- **Worker pub grants MUST be per-platform/bot, not plane-wildcard** (when #1044 lands).
+  A future worker identity publishing on the Typing plane must hold a grant on
+  `lyra.typing.<platform>.<bot_id>` matching the job's assigned scope — never the
+  plane-level wildcard `lyra.typing.>`. The wildcard would let any worker publish typing
+  on behalf of any bot, regardless of the job's relationship to that bot. Refreshing the
+  grant means rewriting `auth.conf` and restarting `lyra-nats` (`systemctl --user restart
+  lyra-nats`); the `type=mount` secret pattern (per
+  `~/projects/docs/container-deployment-standard.md` S7) does NOT support HUP refresh.
 - **Sub-axis is invisible from filenames.** Unlike the stage axis (where the directory name
   IS the stage), plane membership is encoded in the subject string only. Mitigation: this ADR's
   table is the lookup; the documentation pattern (domain page → ADR archive) places it in

--- a/docs/architecture/adr/076-three-nats-planes.mdx
+++ b/docs/architecture/adr/076-three-nats-planes.mdx
@@ -1,0 +1,235 @@
+---
+title: "ADR-076: Three NATS planes — messages, persistence, typing/lifecycle"
+description: Catalogue the three orthogonal NATS planes that emerged in Lyra and the rule for choosing Core vs JetStream when adding a subject.
+status: accepted
+date: 2026-05-26
+deciders: [Mickael, architect, product-lead, devops, axial-adr-review]
+supersedes: []
+superseded_by: []
+related: [035, 045, 065, 073, 075]
+---
+
+## Status
+
+Accepted — 2026-05-26.
+
+The decision is ratified now; the third plane (`lyra.typing.*`) lands operationally with
+Epic #1375 / T1 (#1376). The ADR documents the pattern that already underlies the messages
+and persistence planes and prescribes where the new plane fits.
+
+## Context
+
+Lyra runs three structurally distinct NATS usage patterns. The first two have been in place
+since ADR-035 (subject naming) and ADR-075 (TurnWriter); they were never described as a single
+family. The third pattern — ephemeral display-feedback events keyed on a work scope — emerged
+implicitly while wiring typing indicators across `discord`/`telegram` adapters.
+
+Before this ADR, the third pattern had no SSoT: typing was started imperatively on one key
+(`channel.id`) and cancelled on another (`thread.id`) once an inbound pre-session hook mutated
+the message, → orphan `TypingTaskManager` tasks pinging Discord every 9s until the process
+restarted (#1374; same bug class in `discord_audio.py:250`). Without a documented plane there
+was no place for "Where does this NATS subject belong?" to land — every new emitter risked
+re-inventing the keying contract.
+
+The three patterns differ on three axes the codebase already cares about:
+
+| Axis | Implication |
+|---|---|
+| **Durability** | Core (in-memory, lossy-OK) vs JetStream durable (at-least-once, replay) |
+| **Direction** | bidirectional adapter↔hub vs unidirectional hub→subscriber |
+| **Lifecycle ownership** | producer drives state (Core) vs consumer replays state from stream (JetStream) |
+
+A single ADR cataloguing the three planes makes "what plane is this subject?" answerable by
+reading a table rather than reverse-engineering from existing subject naming.
+
+## Decision
+
+Three planes are recognised. Every NATS subject in Lyra MUST belong to exactly one.
+
+| Plane | Subject prefix | NATS type | Durability | Producers | Consumers | When to use |
+|---|---|---|---|---|---|---|
+| **Messages** | `lyra.{inbound,outbound}.<platform>.<bot_id>` | Core | ephemeral | adapters ↔ hub | hub, adapters | bidirectional hub↔adapter routing of user content |
+| **Persistence** | `lyra.turns.>` | JetStream durable (stream `LYRA_TURNS`, `MaxAge=24h`, WorkQueue) | durable | hub | turn-writer | append-only state changes (turn log, session lifecycle, resume counts) requiring at-least-once delivery |
+| **Typing / Lifecycle** *(NEW)* | `lyra.typing.<platform>.<bot_id>` | Core | ephemeral | hub (future: workers) | adapters | ephemeral display-feedback events (typing indicators; future progress UX) — lossy-OK because consumer state auto-expires |
+
+Plane membership is a frontmatter property of the subject, not of the message: the same
+envelope shape may appear on Messages and Persistence (a `TurnEvelope` is shipped over the
+Persistence plane today, but a future hot-path replay over the Messages plane would not change
+its shape).
+
+### Choosing Core vs JetStream
+
+The choice is forced by the durability column, not by convenience:
+
+- **Hard guarantee needed** (write must survive a crash, must be re-readable from offset) → JetStream.
+- **Lossy-OK** (consumer state auto-expires or is recomputable) → Core.
+
+A typing event has no recovery value 30s after it was emitted (Discord/Telegram both expire
+the indicator client-side in ≤10s; the worst case after an adapter restart is ~20s without a
+visible typing bubble). Putting it on JetStream would pay storage + ACK overhead for a signal
+whose useful life is shorter than the round-trip.
+
+A turn-log event, by contrast, MUST land or the L1 audit invariant breaks — JetStream is the
+only correct choice.
+
+### Where new subjects go
+
+When adding a NATS subject:
+
+1. Decide durability first (Core vs JetStream) — that decides the plane.
+2. If the durability + direction shape already matches one of the three planes → use that
+   plane's prefix.
+3. Only file a new ADR + open a new plane if **durability + direction + lifecycle ownership**
+   all differ from the three existing planes.
+
+## Distinguish from sibling subjects
+
+Three subjects routinely cause confusion with the Typing plane; they belong to neither it nor
+each other:
+
+| Subject | Plane | Why it is NOT typing |
+|---|---|---|
+| `lyra.progress.<job_id>` (#1044) | Workers (TBD) | Progress is **job-internal** — reports "step 3/7" inside a long-running compute job. Typing is **display feedback** — reports "the bot is thinking about your scope right now." Same wire shape, different semantic owner; conflating them would force progress to be keyed on `WorkScope` rather than `job_id`. |
+| `lyra.clipool.heartbeat` | Health (control-plane) | Internal liveness of a subprocess runner. Not user-facing, not scoped to a conversation. Lives alongside `lyra.{voice,llm,image}.heartbeat` and `lyra.system.ready` — a control-plane that may eventually become its own catalogued plane but is not the same shape as Typing. |
+| `$KV.lyra-state.hub.ready` | KV (control-plane) | Persistent flag in JetStream KV, watched by adapters. Lifecycle owned by the **store**, not by a producer-publish event. |
+
+If a future emitter sits between "job-internal" and "display feedback" (e.g. TTS rendering
+progress visible to the user), the rule is: **does the consumer need it to drive UX it will
+re-render after restart?** Yes → JetStream; no → Typing plane.
+
+## Relationship to ADR-073 (axial: stage-of-pipeline)
+
+This section is the load-bearing one. ADR-073 ratifies **stage-of-pipeline** as the primary
+axis of decomposition. Reading this ADR's three-plane table as a competing primary axis would
+re-introduce exactly the N×M drift ADR-073 closes.
+
+The three-plane decomposition is a **sub-axis of the `transport/` stage**, not a primary axis.
+
+- **Primary axis (unchanged):** stage-of-pipeline — parse → route → session → dispatch →
+  outbound. One stage = one module = one process boundary (ADR-073, ADR-075).
+- **Transport sub-axis (this ADR):** within the transport stage, NATS subjects partition
+  horizontally into messages / persistence / typing planes. This is a property of *what flows
+  over the wire*, not of *which stage produced or consumes it*.
+
+Diagrammatically:
+
+```
+                       primary axis (ADR-073) — stages
+                       ───────────────────────────────►
+                       inbound │ router │ session │ dispatcher │ outbound
+                               │        │         │            │
+   transport sub-axis          │        │         │            │
+   (this ADR — ADR-076)        │        │         │            │
+   ─────────────────           │        │         │            │
+   messages   ◄════════════════│════════│═════════│════════════│═══════════►
+   persistence ════════════════│════════│═════════►                          (hub-only)
+   typing     ═════════════════│════════│═════════►════════════►════════════►
+```
+
+The transport sub-axis slices the transport stage horizontally; it does not slice the
+adapters/stages vertically. Adding a new adapter does NOT add a new plane (that would be the
+prohibited platform-axis growth from ADR-073 Option A). Adding a new plane MUST be justified
+by a durability + direction + lifecycle shape that none of the three existing planes accommodates.
+
+When extending Lyra, a contributor adding a NATS subject MUST consult both ADRs:
+
+1. **ADR-073** → which stage produces / consumes the subject. Determines the module home.
+2. **ADR-076** → which plane the subject belongs to. Determines `Core` vs `JetStream`,
+   durability config, and subject prefix.
+
+If the two ADRs disagree (e.g. a stage that wants its own bespoke plane), the disagreement is
+the design question — surface it, do not silently file a new plane.
+
+## Consequences
+
+### Positive
+
+- The Core-vs-JetStream choice is now mechanical: durability column → plane → wire type. No
+  per-subject re-deliberation.
+- Typing indicator bugs of the #1374 class (orphan tasks from key drift) become structurally
+  impossible: the publisher owns the keying contract, subscribers are the only side-effect site.
+- Future worker subjects (#1044) have a documented home: progress events on `lyra.progress.*`,
+  user-facing typing on `lyra.typing.*` — same publisher, different planes, different durability.
+- Adapter authors get a single grep target (`lyra.typing.<platform>.*`) for "what is the bot
+  currently telling this scope," instead of inspecting `_start_typing/_cancel_typing` call sites
+  scattered across inbound, outbound, and audio modules.
+
+### Negative / Expected debt
+
+- **Per-plane ACL surface grows.** Each plane requires its own ACL entries in
+  `deploy/nats/auth.conf` for every identity that publishes or subscribes. Tracked in
+  `artifacts/specs/706-per-role-nkeys-acls-spec.mdx` (T1 of Epic #1375 adds
+  `lyra.typing.>` grants).
+- **Sub-axis is invisible from filenames.** Unlike the stage axis (where the directory name
+  IS the stage), plane membership is encoded in the subject string only. Mitigation: this ADR's
+  table is the lookup; the documentation pattern (domain page → ADR archive) places it in
+  `messaging.md` as the SSoT contributors hit first.
+- **Plane proliferation pressure.** The next emitter that does not cleanly fit will face the
+  question "new plane or stretched plane." The "durability + direction + lifecycle" three-prong
+  test in this ADR is the gate, but it requires judgement; expect at least one panel review
+  before adding a 4th plane.
+
+### Revisit triggers
+
+- A 4th plane is proposed → re-open this ADR's gate test, do not pattern-match.
+- Typing events start being lost in a user-visible way (≥10s of missing indicator after
+  adapter restart consistently) → re-evaluate `Core` choice for the Typing plane.
+- Workers (#1044) require a typing-like ephemeral plane keyed on `job_id` rather than
+  `WorkScope` → may indicate the Typing plane should split, not extend.
+
+## Alternatives considered
+
+### A. Embed typing as a field on `OutboundMessage`
+
+Treat typing-start/typing-end as flags on the existing outbound envelope so no new subject
+is required.
+
+- **Rejected.** Typing must start **before** any `OutboundMessage` exists — at inbound receipt,
+  while the agent is still computing whether there will even be a response. There is no
+  envelope to hang a flag on at the moment the signal is needed.
+
+### B. Use JetStream for typing with a short `max_age`
+
+Reuse the `LYRA_TURNS`-style durable consumer pattern for typing, with `max_age=10s` to keep
+storage bounded.
+
+- **Rejected.** Typing has no recovery value past its on-screen lifetime. Paying JetStream's
+  ACK + persistence cost for a signal whose consumer auto-expires the state client-side is
+  pure overhead. The wire shape would suggest replay semantics that the consumer cannot
+  meaningfully act on.
+
+### C. In-process callback on a shared event bus
+
+Keep typing entirely in-process via a callback registry in the hub.
+
+- **Rejected.** Hub and adapters are split processes (ADR-073 stage = process). An in-process
+  bus does not cross the process boundary, so adapters could not subscribe. The NATS bus is
+  already the cross-process channel; reusing it is cheaper than building a parallel transport.
+
+### D. A single plane for "everything ephemeral"
+
+Collapse Typing and any future ephemeral subjects into one open-ended plane.
+
+- **Rejected.** Erases the keying contract that prevents the #1374 bug class. Typing is keyed
+  on `WorkScope` (`platform + bot_id + scope_id`); progress is keyed on `job_id`. A shared
+  plane forces a lowest-common-denominator key and re-opens the orphan-task vulnerability.
+
+## References
+
+- **ADR-073** — Axis of Decomposition: Stage of Pipeline (primary axial; transport sub-axis
+  positioning).
+- **ADR-075** — TurnWriter subscriber-writer sublayer (established `lyra.turns.>` Persistence
+  plane; same shape this ADR extends).
+- **ADR-035** — NATS subject naming convention (`lyra.{domain}.{qualifier...}` rule the
+  Typing plane inherits).
+- **ADR-045** — `roxabi-nats` SDK (transport abstraction the three planes share).
+- **ADR-065** — KV readiness probe (control-plane example called out in "Distinguish from
+  sibling subjects").
+- Epic **#1277** — stage-axis refactor (primary-axis epic ADR-073 ratifies).
+- Epic **#1044** — workers (future consumer of Typing plane; introduces
+  `lyra.progress.<job_id>` as a sibling, not a member).
+- Epic **#1375** — typing-indicator lifecycle via `lyra.typing.*` (operational landing of
+  this ADR; T1 ships the publisher/listener, T2 closes #1374).
+- Spec: `artifacts/specs/706-per-role-nkeys-acls-spec.mdx` — ACL grants for the new plane.
+- Domain page: `docs/architecture/messaging.md` — SSoT for messaging/NATS current truth;
+  carries the plane table in living form.

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -10,6 +10,7 @@
     "035-nats-subject-naming-convention",
     "036-renderevent-streaming-chunk-protocol",
     "065-nats-kv-readiness-probe",
+    "076-three-nats-planes",
     "---LLM, Streaming & Agents---",
     "028-token-level-streaming-path-shape",
     "032-llmevent-streamprocessor-renderevent-hexagonal-streaming",

--- a/docs/architecture/messaging.md
+++ b/docs/architecture/messaging.md
@@ -6,15 +6,16 @@ description: Living current-truth document for all messaging and NATS transport 
 # Messaging & NATS — Lyra
 
 > Status: LIVING — current truth for messaging/NATS decisions.
-> Last updated: 2026-05-09.
-> Source ADRs: 001, 002, 035, 036, 065. Absorbed via 045: 037, 040, 047, 062.
+> Last updated: 2026-05-26.
+> Source ADRs: 001, 002, 035, 036, 065, 076. Absorbed via 045: 037, 040, 047, 062.
 
 ## Scope
 
-This document covers routing key semantics, hub dispatch invariants, NATS subject naming,
-the Hub→Adapter streaming chunk protocol, and the hub readiness probe. It does not cover
-security/ACL policy (see `security-routing.md`), cross-project contract schemas (see
-`contracts.md`), or LLM streaming internals (see `llm-streaming.md`).
+This document covers the three NATS planes (messages, persistence, typing/lifecycle),
+routing key semantics, hub dispatch invariants, NATS subject naming, the Hub→Adapter
+streaming chunk protocol, and the hub readiness probe. It does not cover security/ACL
+policy (see `security-routing.md`), cross-project contract schemas (see `contracts.md`),
+or LLM streaming internals (see `llm-streaming.md`).
 
 ## Current state
 
@@ -98,6 +99,36 @@ removed entirely during the Phase 1b→2 refactor; the canonical routing fields 
 
 → ADR-002
 
+### NATS planes (catalogue)
+
+Every NATS subject in Lyra belongs to exactly one of three planes. The plane decides the
+NATS type (Core vs JetStream), the durability contract, and the keying shape:
+
+| Plane | Subject prefix | NATS type | Durability | Producers | Consumers | When to use |
+|---|---|---|---|---|---|---|
+| Messages | `lyra.{inbound,outbound}.<platform>.<bot_id>` | Core | ephemeral | adapters ↔ hub | hub, adapters | bidirectional hub↔adapter routing of user content |
+| Persistence | `lyra.turns.>` | JetStream durable (stream `LYRA_TURNS`, `MaxAge=24h`, WorkQueue) | durable | hub | turn-writer | append-only state changes requiring at-least-once delivery |
+| Typing / Lifecycle | `lyra.typing.<platform>.<bot_id>` | Core | ephemeral | hub (future: workers) | adapters | ephemeral display-feedback events (typing indicators; future progress UX) — lossy-OK because consumer state auto-expires |
+
+**Choosing a plane when adding a subject:**
+
+1. Decide durability first — hard guarantee needed → JetStream → Persistence plane; lossy-OK
+   → Core → Messages or Typing depending on direction.
+2. If durability + direction shape matches an existing plane, use that plane's prefix; do not
+   open a new one.
+3. A new plane requires a separate ADR — and a justification that durability + direction +
+   lifecycle ownership all differ from the three existing planes.
+
+**Distinguish from sibling subjects** — these are NOT typing-plane members despite the
+surface resemblance:
+
+- `lyra.progress.<job_id>` (#1044, future) — job-internal progress, keyed on `job_id`, not on
+  `WorkScope`.
+- `lyra.clipool.heartbeat` and the `*.heartbeat` family — internal liveness, control-plane.
+- `$KV.lyra-state.hub.ready` — persistent flag in JetStream KV, watched by adapters.
+
+→ ADR-076
+
 ### NATS subject naming
 
 All subjects follow `lyra.{domain}.{qualifier...}` (domain-first, NATS convention
@@ -107,6 +138,7 @@ All subjects follow `lyra.{domain}.{qualifier...}` (domain-first, NATS conventio
 |---|---|---|
 | `lyra.inbound.{platform}.{bot_id}` | adapter → hub | User message delivery |
 | `lyra.outbound.{platform}.{bot_id}` | hub → adapter | Response chunk delivery |
+| `lyra.typing.{platform}.{bot_id}` | hub → adapter | Ephemeral typing indicator lifecycle (Typing plane — Epic #1375, lands with T1 #1376) |
 | `lyra.llm.request` | hub → worker | LLM compute offload |
 | `lyra.llm.health.{worker_id}` | worker → hub | Satellite LLM worker heartbeats |
 | `lyra.clipool.cmd` | hub → CliPool | Submit turn + resume UUID |
@@ -249,4 +281,5 @@ part of the adapter startup path.
 | 036 | RenderEvent chunk protocol | Accepted |
 | 065 | KV readiness probe | Accepted |
 | 072 | Codec registry pattern (v2 RenderEvent) | Accepted — supersedes ADR-032 v1 wire shape |
+| 076 | Three NATS planes (messages / persistence / typing) | Accepted — 2026-05-26; operational landing with Epic #1375 |
 | 037, 040, 047, 062 | (various transport ADRs) | Absorbed by ADR-045 (roxabi-nats SDK) |


### PR DESCRIPTION
## Summary

- Add **ADR-076 — Three NATS planes (messages, persistence, typing/lifecycle)** as the SSoT for choosing Core vs JetStream and where new NATS subjects belong.
- Document the **transport sub-axis relationship to ADR-073** (mandatory section): the three-plane decomposition slices `transport/` horizontally; it is **not** a competing primary axis to stage-of-pipeline.
- Cross-reference from ADR-073 / ADR-075 frontmatter (`related:`) and the `messaging.md` domain page (NATS planes catalogue + Live subjects row + ADR archive table).

T5 of Epic **#1375** — parallelisable with T1 (#1376) and T2; pure docs, no code.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1378: docs(adr): T5 — Three NATS planes ADR + Relationship to ADR-073 | OPEN |
| Implementation | 1 commit on `docs/1378-three-nats-planes-adr` | Complete |
| Verification | Lint ✅ Typecheck ✅ File-length ✅ Folder-size ✅ Import-layers ✅ (no tests — pure docs) | Passed |

## Test Plan

- [ ] `python3 -c "import json; json.load(open('docs/architecture/adr/meta.json'))"` → meta.json still parses (61 pages, +1 added under "Messaging & NATS").
- [ ] `grep -n "^related:" docs/architecture/adr/{073,075,076}-*.mdx` → confirms cross-refs `[076]`, `[068, 073, 076]`, `[035, 045, 065, 073, 075]`.
- [ ] Render `docs/architecture/adr/076-three-nats-planes.mdx` in Fumadocs preview → all 8 sections present, ASCII diagram in "Relationship to ADR-073" renders intact.
- [ ] Render `docs/architecture/messaging.md` → "NATS planes" section appears above "NATS subject naming"; `lyra.typing.{platform}.{bot_id}` row visible in Live subjects table; ADR-076 row in ADR archive.

## Acceptance criteria (from #1378)

- [x] AC1 — `docs/architecture/adr/076-three-nats-planes.mdx` exists with all 8 required sections.
- [x] AC2 — Frontmatter complete: title, description, status (accepted), date (2026-05-26), deciders, supersedes, superseded_by, related.
- [x] AC3 — Linked from `docs/architecture/messaging.md` (new "NATS planes" section + Source ADRs line + Live subjects row + ADR archive table).
- [x] AC4 — `meta.json` updated under `---Messaging & NATS---` separator.
- [x] AC5 — Cross-references in ADR-073 and ADR-075 frontmatter (`related: [076]`).

Closes #1378
Parent: #1375

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`