### PR TITLE
feat(deploy): #1373 wire webhook Secret= rendering into render_quadlet.py

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -22,7 +22,7 @@
 # ----------------------------------------------------------------------------
 
 [defaults]
-cwd = "~/projects"                      # working directory for agent subprocesses
+cwd = "~/projects"  # working directory for agent subprocesses
 # workspaces.lyra     = "~/projects/lyra"   # adds /lyra slash command
 # workspaces.projects = "~/projects"        # adds /projects slash command
 
@@ -64,15 +64,16 @@ user_ids = [
 # ----------------------------------------------------------------------------
 
 [[telegram.bots]]
-bot_id = "lyra"                         # must match the bot_id used in `lyra bot add`
+bot_id = "lyra"  # must match the bot_id used in `lyra bot add`
 # bot_username = "MyLyraBot"            # optional — used in help text (default: "lyra_bot")
 # agent = "lyra_default"               # fallback if DB has no bot→agent mapping yet
 
 [[auth.telegram_bots]]
 bot_id = "lyra"
-default = "blocked"                     # "blocked" | "trusted" | "owner"
-owner_users = []                        # numeric Telegram IDs — seeded into DB on startup
+default = "blocked"  # "blocked" | "trusted" | "owner"
+owner_users = []  # numeric Telegram IDs — seeded into DB on startup
 # trusted_users = []                    # numeric Telegram IDs with trusted (non-admin) access
+# webhook_enabled = false               # set true for webhook-mode bots; emits bot_webhook-<bot_id> Secret=
 
 # Add more bots by repeating the pair above:
 # [[telegram.bots]]
@@ -88,14 +89,14 @@ owner_users = []                        # numeric Telegram IDs — seeded into D
 # ----------------------------------------------------------------------------
 
 [[discord.bots]]
-bot_id = "lyra"                         # must match the bot_id used in `lyra bot add`
+bot_id = "lyra"  # must match the bot_id used in `lyra bot add`
 # auto_thread = true                    # optional — thread per conversation (default: true)
 # agent = "lyra_default"               # fallback if DB has no bot→agent mapping yet
 
 [[auth.discord_bots]]
 bot_id = "lyra"
-default = "blocked"                     # "blocked" | "trusted" | "owner"
-owner_users = []                        # numeric Discord snowflake IDs — seeded into DB on startup
+default = "blocked"  # "blocked" | "trusted" | "owner"
+owner_users = []  # numeric Discord snowflake IDs — seeded into DB on startup
 # trusted_roles = []                    # numeric Discord role snowflake IDs with trusted access
 
 # Add more bots by repeating the pair above:

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -94,6 +94,13 @@ API keys) use underscores (`lyra_<service>_<purpose>`, e.g. `lyra_blobstore_toke
 Mixing styles is intentional and tracked; do not "normalize" without coordinating
 with the operator (Mickael).
 
+Bot per-platform secrets follow the hyphen convention:
+
+| Secret name | In-container target | Mode | Notes |
+|---|---|---|---|
+| `lyra-bot-<platform>-<bot_id>` | `bot_token-<bot_id>` | 0400 | Bot token; always emitted per bot |
+| `lyra-bot-<platform>-<bot_id>-webhook` | `bot_webhook-<bot_id>` | 0400 | Telegram webhook secret; only emitted when `[[auth.<platform>_bots]].webhook_enabled = true` |
+
 ### Known residual risk — blobstore PublishPort Tailscale fallback (#1330)
 
 `lyra-blobstore.container` binds `PublishPort` to `${TAILSCALE_IPV4}:8449:8449` (resolved at

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -161,6 +161,10 @@ bot_id = "lyra"
 default = "blocked"            # "blocked" | "trusted" | "owner"
 owner_users = [123456789]      # numeric Telegram IDs — seeded into DB
 trusted_users = [987654321]    # can interact, cannot admin
+# Optional: webhook_enabled — bool, default false. When true, the
+#   render_quadlet pipeline emits an additional Secret=…bot_webhook-<bot_id>
+#   mount for the Telegram webhook secret verification path.
+webhook_enabled = false
 
 [[auth.discord_bots]]
 bot_id = "lyra"

--- a/tests/scripts/test_render_quadlet.py
+++ b/tests/scripts/test_render_quadlet.py
@@ -20,6 +20,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "tools" / "render_quadlet.py"
 
@@ -357,19 +359,40 @@ def test_missing_config(tmp_path: Path) -> None:
 
 
 def make_config_with_webhook(
-    tmp_path: Path, bots: list[dict], filename: str = "config.toml"
+    tmp_path: Path,
+    bots: list[dict],
+    filename: str = "config.toml",
+    raw_webhook_value: str | None = None,
+    platform: str = "telegram",
 ) -> Path:
     """Write a config.toml supporting arbitrary per-bot fields (e.g. webhook_enabled).
 
     bots: list of dicts with at least 'bot_id'; may include 'webhook_enabled'.
+    raw_webhook_value: if provided, write this literal TOML text for webhook_enabled
+        on every bot that lacks an explicit 'webhook_enabled' key (e.g. '"yes"', '1',
+        'false', 'true'). Use this for non-bool TOML variants that cannot be
+        represented as Python bool without truthy-coercion.
+    platform: 'telegram' or 'discord' — determines the section name used.
+
+    Raises ValueError if a bot dict provides 'webhook_enabled' with a non-bool value
+    and raw_webhook_value is not set — callers MUST use raw_webhook_value for non-bool
+    TOML literals.
     """
     path = tmp_path / filename
+    section = f"auth.{platform}_bots"
     lines = ["[auth]\n"]
     for bot in bots:
-        lines.append(f'[[auth.telegram_bots]]\nbot_id = "{bot["bot_id"]}"\n')
-        if "webhook_enabled" in bot:
-            val = "true" if bot["webhook_enabled"] else "false"
-            lines.append(f"webhook_enabled = {val}\n")
+        lines.append(f'[[{section}]]\nbot_id = "{bot["bot_id"]}"\n')
+        if raw_webhook_value is not None:
+            lines.append(f"webhook_enabled = {raw_webhook_value}\n")
+        elif "webhook_enabled" in bot:
+            val = bot["webhook_enabled"]
+            if not isinstance(val, bool):
+                raise ValueError(
+                    f"webhook_enabled must be a bool; got {type(val).__name__!r}. "
+                    "Use raw_webhook_value= for non-bool TOML literals."
+                )
+            lines.append(f"webhook_enabled = {'true' if val else 'false'}\n")
         lines.append("\n")
     path.write_text("".join(lines))
     return path
@@ -437,8 +460,8 @@ def test_webhook_enabled_happy_path(tmp_path: Path) -> None:
     )
 
 
-def test_webhook_disabled_no_webhook_line(tmp_path: Path) -> None:
-    """Bot without webhook_enabled (default false) → only bot_token- line emitted.
+def test_webhook_key_absent_no_webhook_line(tmp_path: Path) -> None:
+    """Bot without webhook_enabled key (default false) → only bot_token- line emitted.
 
     Spec trace: #1373 regression — default false
     Negative sentinel: if webhook_enabled defaults to True, this test fails on the
@@ -519,23 +542,27 @@ def test_webhook_mixed_bots(tmp_path: Path) -> None:
     assert "bot_token-b" in content
 
 
-def test_webhook_string_value_does_not_emit(tmp_path: Path) -> None:
-    """webhook_enabled = "yes" (TOML string, not bool) must NOT emit webhook line.
+@pytest.mark.parametrize("string_value", ["yes", "true", "false"])
+def test_webhook_string_value_does_not_emit(tmp_path: Path, string_value: str) -> None:
+    """webhook_enabled = <string> (TOML string, not bool) must NOT emit webhook line.
 
     Defensive: tomllib produces a str for quoted values; strict `is True` check
     in render_secrets() must reject non-bool to avoid silent misconfig.
+    Covers "yes", "true", and "false" — all are truthy-ish strings that a
+    loose check would mishandle.
 
-    Spec trace: #1373 F5 follow-on
-    Negative sentinel: if the check were truthy (e.g. `if b.get(...):`), a string
-    "yes" would be truthy and incorrectly emit a bot_webhook- line.
+    Spec trace: #1373 F5 follow-on (G16: parametrized)
+    Negative sentinel: if the check were truthy (e.g. `if b.get(...):`), strings
+    "yes" and "true" would incorrectly emit a bot_webhook- line.
     """
-    # Write config.toml with webhook_enabled = "yes" (TOML string — NOT bool true)
-    config = tmp_path / "config.toml"
-    config.write_text(
-        '[auth]\n[[auth.telegram_bots]]\nbot_id = "lyra"\nwebhook_enabled = "yes"\n'
+    config = make_config_with_webhook(
+        tmp_path,
+        bots=[{"bot_id": "lyra"}],
+        raw_webhook_value=f'"{string_value}"',
+        filename=f"config-str-{string_value}.toml",
     )
     tmpl = make_tmpl(tmp_path, with_marker=True)
-    dest = tmp_path / "lyra-telegram.container"
+    dest = tmp_path / f"lyra-telegram-str-{string_value}.container"
 
     result = _run_render(
         [
@@ -555,10 +582,10 @@ def test_webhook_string_value_does_not_emit(tmp_path: Path) -> None:
     )
     content = dest.read_text()
 
-    # String "yes" must NOT trigger webhook line emission
+    # String value must NOT trigger webhook line emission
     assert "target=bot_webhook-" not in content, (
-        'webhook_enabled = "yes" (string) must NOT emit a bot_webhook- Secret= line; '
-        f"got:\n{content}"
+        f'webhook_enabled = "{string_value}" (string) must NOT emit a bot_webhook- '
+        f"Secret= line; got:\n{content}"
     )
     # Token line must still be emitted normally
     assert "target=bot_token-lyra" in content, (
@@ -612,4 +639,155 @@ def test_toml_syntax_error(tmp_path: Path) -> None:
     assert any(sig.lower() in combined.lower() for sig in toml_error_signals), (
         f"Error output must include TOML parser exception text.\n"
         f"Combined output: {combined!r}"
+    )
+
+
+def test_webhook_enabled_false_bool_no_emit(tmp_path: Path) -> None:
+    """webhook_enabled = false (explicit bool) → no webhook line, token line present.
+
+    Distinct from test_webhook_key_absent_no_webhook_line: here the key IS present
+    with value false (bool), exercising the explicit-false TOML path separately
+    from the absent-key path.
+
+    Spec trace: #1398 G10
+    Negative sentinel: if the check uses truthiness instead of `is True`, explicit
+    false (bool) still passes (since bool False is falsy), so the test would pass
+    vacuously — but the intent is to confirm the strict-is-True branch handles both
+    absent and explicit-false correctly.
+    """
+    config = make_config_with_webhook(
+        tmp_path, bots=[{"bot_id": "lyra", "webhook_enabled": False}]
+    )
+    tmpl = make_tmpl(tmp_path, with_marker=True)
+    dest = tmp_path / "lyra-telegram.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    assert "target=bot_webhook-" not in content, (
+        "webhook_enabled = false (explicit bool) must NOT emit a bot_webhook- line;\n"
+        f"got:\n{content}"
+    )
+    assert "target=bot_token-lyra" in content, (
+        "bot_token- line must still be present when webhook_enabled = false"
+    )
+
+
+def test_webhook_enabled_int_does_not_emit(tmp_path: Path) -> None:
+    """webhook_enabled = 1 (TOML integer, not bool) must NOT emit webhook line.
+
+    tomllib distinguishes int from bool: `1` is an int, not True. The strict
+    `is True` check must reject it.
+
+    Spec trace: #1398 G11
+    Negative sentinel: if the check were truthy (`if b.get("webhook_enabled"):`),
+    integer 1 is truthy and would incorrectly emit a bot_webhook- line.
+    """
+    config = make_config_with_webhook(
+        tmp_path,
+        bots=[{"bot_id": "lyra"}],
+        raw_webhook_value="1",
+    )
+    tmpl = make_tmpl(tmp_path, with_marker=True)
+    dest = tmp_path / "lyra-telegram.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    assert "target=bot_webhook-" not in content, (
+        "webhook_enabled = 1 (int) must NOT emit a bot_webhook- Secret= line "
+        "(strict `is True` must reject non-bool);\n"
+        f"got:\n{content}"
+    )
+    assert "target=bot_token-lyra" in content, (
+        "bot_token- line must still appear even when webhook_enabled is an int"
+    )
+
+
+def test_webhook_enabled_discord(tmp_path: Path) -> None:
+    """Discord bot with webhook_enabled = true → emits bot_webhook- for discord.
+
+    render_secrets() is platform-agnostic via {platform} substitution. This test
+    confirms the discord branch substitutes correctly:
+    lyra-bot-discord-<bot_id>-webhook, target=bot_webhook-<bot_id>.
+
+    Spec trace: #1398 G12 — Discord platform parity
+    Negative sentinel: if render_secrets() hard-codes 'telegram' instead of using
+    the platform variable, the discord secret name would contain 'telegram' and the
+    expected_webhook assertion would fail.
+    """
+    config = make_config_with_webhook(
+        tmp_path,
+        bots=[{"bot_id": "lyra", "webhook_enabled": True}],
+        platform="discord",
+    )
+    # Use a discord-named template file (name is cosmetic for the test)
+    tmpl_path = tmp_path / "lyra-discord.container.tmpl"
+    tmpl_path.write_text(
+        "[Unit]\nDescription=lyra-discord adapter\n\n[Container]\n{{bot_secrets}}\n"
+    )
+    dest = tmp_path / "lyra-discord.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "discord",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl_path),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    expected_webhook = (
+        "Secret=lyra-bot-discord-lyra-webhook,"
+        "type=mount,"
+        "target=bot_webhook-lyra,"
+        "mode=0400,"
+        "uid=1500,"
+        "gid=1500"
+    )
+    assert expected_webhook in content, (
+        f"Missing discord bot_webhook- Secret= line.\nExpected: {expected_webhook!r}\n"
+        f"Content:\n{content}"
+    )
+    assert "target=bot_token-lyra" in content, (
+        "bot_token- line must also be present for discord bot"
     )

--- a/tests/scripts/test_render_quadlet.py
+++ b/tests/scripts/test_render_quadlet.py
@@ -247,10 +247,14 @@ def test_missing_bots_key(tmp_path: Path) -> None:
 
     result = _run_render(
         [
-            "--platform", "telegram",
-            "--config", str(config),
-            "--tmpl", str(tmpl),
-            "--dest", str(dest),
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
         ]
     )
 
@@ -352,6 +356,169 @@ def test_missing_config(tmp_path: Path) -> None:
         "Error message must reference the missing config path.\n"
         f"Combined output: {combined!r}"
     )
+
+
+def make_config_with_webhook(
+    tmp_path: Path, bots: list[dict], filename: str = "config.toml"
+) -> Path:
+    """Write a config.toml supporting arbitrary per-bot fields (e.g. webhook_enabled).
+
+    bots: list of dicts with at least 'bot_id'; may include 'webhook_enabled'.
+    """
+    path = tmp_path / filename
+    lines = ["[auth]\n"]
+    for bot in bots:
+        lines.append(f'[[auth.telegram_bots]]\nbot_id = "{bot["bot_id"]}"\n')
+        if "webhook_enabled" in bot:
+            val = "true" if bot["webhook_enabled"] else "false"
+            lines.append(f"webhook_enabled = {val}\n")
+        lines.append("\n")
+    path.write_text("".join(lines))
+    return path
+
+
+def test_webhook_enabled_happy_path(tmp_path: Path) -> None:
+    """Bot with webhook_enabled = true → emits both bot_token- and bot_webhook- lines.
+
+    Spec trace: #1373 happy path webhook
+    Negative sentinel: if the webhook branch is absent, only the token line appears
+    and the bot_webhook- assertion fails.
+    """
+    config = make_config_with_webhook(
+        tmp_path, bots=[{"bot_id": "lyra", "webhook_enabled": True}]
+    )
+    tmpl = make_tmpl(tmp_path, with_marker=True)
+    dest = tmp_path / "lyra-telegram.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    expected_token = (
+        "Secret=lyra-bot-telegram-lyra,"
+        "type=mount,"
+        "target=bot_token-lyra,"
+        "mode=0400,"
+        "uid=1500,"
+        "gid=1500"
+    )
+    expected_webhook = (
+        "Secret=lyra-bot-telegram-lyra-webhook,"
+        "type=mount,"
+        "target=bot_webhook-lyra,"
+        "mode=0400,"
+        "uid=1500,"
+        "gid=1500"
+    )
+    assert expected_token in content, (
+        f"Missing bot_token- Secret= line.\nContent:\n{content}"
+    )
+    assert expected_webhook in content, (
+        f"Missing bot_webhook- Secret= line.\nContent:\n{content}"
+    )
+
+    # webhook line must appear immediately after the token line (grouped per bot)
+    token_idx = content.index(expected_token)
+    webhook_idx = content.index(expected_webhook)
+    assert token_idx < webhook_idx, (
+        "bot_token- line must precede bot_webhook- line in output"
+    )
+
+
+def test_webhook_disabled_no_webhook_line(tmp_path: Path) -> None:
+    """Bot without webhook_enabled (default false) → only bot_token- line emitted.
+
+    Spec trace: #1373 regression — default false
+    Negative sentinel: if webhook_enabled defaults to True, this test fails on the
+    no-webhook-line assertion.
+    """
+    # webhook_enabled absent → default false
+    config = make_config(tmp_path, bots=["lyra"])
+    tmpl = make_tmpl(tmp_path, with_marker=True)
+    dest = tmp_path / "lyra-telegram.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    assert "bot_token-lyra" in content, "bot_token- line must be present"
+    assert "bot_webhook-lyra" not in content, (
+        "bot_webhook- line must NOT appear when webhook_enabled is false/absent"
+    )
+
+
+def test_webhook_mixed_bots(tmp_path: Path) -> None:
+    """Bot A (webhook_enabled=true) + Bot B (default false) → webhook only for A.
+
+    Spec trace: #1373 mixed bots
+    Negative sentinel: if webhook_enabled is ignored and always emitted, bot_webhook-b
+    appears and the assertion fails.
+    """
+    config = make_config_with_webhook(
+        tmp_path,
+        bots=[
+            {"bot_id": "a", "webhook_enabled": True},
+            {"bot_id": "b"},
+        ],
+    )
+    tmpl = make_tmpl(tmp_path, with_marker=True)
+    dest = tmp_path / "lyra-telegram.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    assert "bot_webhook-a" in content, (
+        "bot_webhook-a must appear for webhook_enabled bot"
+    )
+    assert "bot_webhook-b" not in content, (
+        "bot_webhook-b must NOT appear for bot without webhook_enabled"
+    )
+    # Both token lines must be present
+    assert "bot_token-a" in content
+    assert "bot_token-b" in content
 
 
 def test_toml_syntax_error(tmp_path: Path) -> None:

--- a/tests/scripts/test_render_quadlet.py
+++ b/tests/scripts/test_render_quadlet.py
@@ -125,12 +125,10 @@ def test_happy_path(tmp_path: Path) -> None:
 
     content = dest.read_text()
 
-    # Two Secret= lines — one per bot
-    secret_lines = [
-        ln for ln in content.splitlines() if ln.startswith("Secret=lyra-bot-telegram-")
-    ]
-    assert len(secret_lines) == 2, (
-        f"Expected exactly 2 Secret=lyra-bot-telegram-* lines; got {secret_lines!r}"
+    # Two token Secret= lines — one per bot (excludes webhook lines)
+    token_lines = [ln for ln in content.splitlines() if "target=bot_token-" in ln]
+    assert len(token_lines) == 2, (
+        f"Expected exactly 2 bot_token- Secret= lines; got {token_lines!r}"
     )
 
     # Each bot's Secret= line has the full required attributes
@@ -519,6 +517,53 @@ def test_webhook_mixed_bots(tmp_path: Path) -> None:
     # Both token lines must be present
     assert "bot_token-a" in content
     assert "bot_token-b" in content
+
+
+def test_webhook_string_value_does_not_emit(tmp_path: Path) -> None:
+    """webhook_enabled = "yes" (TOML string, not bool) must NOT emit webhook line.
+
+    Defensive: tomllib produces a str for quoted values; strict `is True` check
+    in render_secrets() must reject non-bool to avoid silent misconfig.
+
+    Spec trace: #1373 F5 follow-on
+    Negative sentinel: if the check were truthy (e.g. `if b.get(...):`), a string
+    "yes" would be truthy and incorrectly emit a bot_webhook- line.
+    """
+    # Write config.toml with webhook_enabled = "yes" (TOML string — NOT bool true)
+    config = tmp_path / "config.toml"
+    config.write_text(
+        '[auth]\n[[auth.telegram_bots]]\nbot_id = "lyra"\nwebhook_enabled = "yes"\n'
+    )
+    tmpl = make_tmpl(tmp_path, with_marker=True)
+    dest = tmp_path / "lyra-telegram.container"
+
+    result = _run_render(
+        [
+            "--platform",
+            "telegram",
+            "--config",
+            str(config),
+            "--tmpl",
+            str(tmpl),
+            "--dest",
+            str(dest),
+        ]
+    )
+
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
+    )
+    content = dest.read_text()
+
+    # String "yes" must NOT trigger webhook line emission
+    assert "target=bot_webhook-" not in content, (
+        'webhook_enabled = "yes" (string) must NOT emit a bot_webhook- Secret= line; '
+        f"got:\n{content}"
+    )
+    # Token line must still be emitted normally
+    assert "target=bot_token-lyra" in content, (
+        "bot_token- line must still appear even when webhook_enabled is a string"
+    )
 
 
 def test_toml_syntax_error(tmp_path: Path) -> None:

--- a/tools/render_quadlet.py
+++ b/tools/render_quadlet.py
@@ -4,6 +4,7 @@
 Token in template: {{bot_secrets}}  →  one `Secret=` line per bot.
 Bots come from config.toml [[auth.<platform>_bots]]; sorted by bot_id.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -53,17 +54,26 @@ def sort_bots(bots: list[dict]) -> list[dict]:
 
 
 def render_secrets(platform: str, bots: list[dict]) -> str:
-    lines = [
-        (
-            f"Secret=lyra-bot-{platform}-{b['bot_id']},"
+    lines: list[str] = []
+    for b in bots:
+        bot_id = b["bot_id"]
+        lines.append(
+            f"Secret=lyra-bot-{platform}-{bot_id},"
             f"type=mount,"
-            f"target=bot_token-{b['bot_id']},"
+            f"target=bot_token-{bot_id},"
             f"mode=0400,"
             f"uid=1500,"
             f"gid=1500"
         )
-        for b in bots
-    ]
+        if b.get("webhook_enabled", False):
+            lines.append(
+                f"Secret=lyra-bot-{platform}-{bot_id}-webhook,"
+                f"type=mount,"
+                f"target=bot_webhook-{bot_id},"
+                f"mode=0400,"
+                f"uid=1500,"
+                f"gid=1500"
+            )
     return "\n".join(lines)
 
 

--- a/tools/render_quadlet.py
+++ b/tools/render_quadlet.py
@@ -65,7 +65,7 @@ def render_secrets(platform: str, bots: list[dict]) -> str:
             f"uid=1500,"
             f"gid=1500"
         )
-        if b.get("webhook_enabled", False):
+        if b.get("webhook_enabled") is True:
             lines.append(
                 f"Secret=lyra-bot-{platform}-{bot_id}-webhook,"
                 f"type=mount,"


### PR DESCRIPTION
## Summary
- Add `webhook_enabled: bool = False` to `[[auth.<platform>_bots]]` entries in config.toml (backward-compat, plain TOML field — no Pydantic model, `render_quadlet.py` reads raw dicts)
- `render_secrets()` emits a second `Secret=…bot_webhook-<bot_id>…` line when `webhook_enabled = true`, grouped per bot: token line then webhook line
- `config.toml.example` updated with commented hint on the new field

## Why
PR #1369 replaced dynamic `podman secret ls` discovery with config-driven enumeration, silently dropping the webhook `Secret=` line. Webhook-mode Telegram bots would degrade to "all webhook requests rejected" on next `make quadlet-install` with no crash signal. PR #1369 spec excluded the impl by design (forward-compat schema only); shipping the impl here per #1373.

## Alternative rejected
`--webhook-bot-ids` CLI arg populated from `podman secret ls` at install time — re-introduces the Podman dependency #1369 was unwinding.

## Test plan
- [x] happy path: `webhook_enabled = true` → both `Secret=…bot_token-…` AND `Secret=…bot_webhook-…` lines emitted, token before webhook
- [x] regression: default false (field absent) → only `bot_token-` line, no `bot_webhook-` anywhere
- [x] mixed: bot A (`webhook_enabled = true`) + bot B (default) → `bot_webhook-a` present, `bot_webhook-b` absent

Refs: #1373, #1369, #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)