### PR TITLE
fix(deploy): #1390 nats-regen-authconf must restart hub+adapters on ACL change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ remote:
 nats-setup:
 	@bash deploy/nats/setup.sh
 
-nats-regen-authconf:          ## re-render auth.conf, refresh lyra-nats-auth secret only, restart NATS
+nats-regen-authconf:          ## re-render auth.conf, refresh lyra-nats-auth secret only, restart NATS + hub + adapters
 	@lyra-acl genkeys --regen-authconf
 	@test -s "$(LYRA_NKEYS_DIR)/auth.conf" \
 		|| { echo "ERROR: $(LYRA_NKEYS_DIR)/auth.conf missing or empty after genkeys"; exit 1; }
@@ -305,6 +305,14 @@ nats-regen-authconf:          ## re-render auth.conf, refresh lyra-nats-auth sec
 	@podman secret create --replace lyra-nats-auth "$(LYRA_NKEYS_DIR)/auth.conf"
 	@# Restart, not HUP — see docs/ops/nats-authconf-update.md.
 	@systemctl --user restart lyra-nats
+	@# Hub + adapters must also restart: they hold stale subject auth after an ACL change (#1390).
+	@failed=""; \
+	for svc in lyra-hub lyra-telegram lyra-discord lyra-clipool; do \
+	  if systemctl --user is-active --quiet $$svc; then \
+	    systemctl --user restart $$svc || { echo "ERROR: restart $$svc failed"; failed="$$failed $$svc"; }; \
+	  fi; \
+	done; \
+	[ -z "$$failed" ] || { echo "ERROR: restart failed for:$$failed"; exit 1; }
 
 nats-add-identity:  ## add a single NATS identity rootless; idempotent after full-consistency (seed+secret present)
 	@test -n "$(NAME)" || { echo "usage: make nats-add-identity NAME=<x>"; exit 2; }

--- a/Makefile
+++ b/Makefile
@@ -294,10 +294,15 @@ remote:
 
 # ── Dev tools ────────────────────────────────────────────────────────────────
 
+# Shared list of services that hold NATS subject auth and must restart
+# whenever `auth.conf` is regenerated or a new identity is added. The bare
+# `lyra-nats` is restarted separately by the target itself before this list.
+LYRA_NATS_CLIENTS := lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper
+
 nats-setup:
 	@bash deploy/nats/setup.sh
 
-nats-regen-authconf:          ## re-render auth.conf, refresh lyra-nats-auth secret only, restart NATS + hub + adapters
+nats-regen-authconf:          ## re-render auth.conf, refresh lyra-nats-auth secret only, restart all NATS clients
 	@lyra-acl genkeys --regen-authconf
 	@test -s "$(LYRA_NKEYS_DIR)/auth.conf" \
 		|| { echo "ERROR: $(LYRA_NKEYS_DIR)/auth.conf missing or empty after genkeys"; exit 1; }
@@ -305,9 +310,11 @@ nats-regen-authconf:          ## re-render auth.conf, refresh lyra-nats-auth sec
 	@podman secret create --replace lyra-nats-auth "$(LYRA_NKEYS_DIR)/auth.conf"
 	@# Restart, not HUP — see docs/ops/nats-authconf-update.md.
 	@systemctl --user restart lyra-nats
-	@# Hub + adapters must also restart: they hold stale subject auth after an ACL change (#1390).
+	@systemctl --user is-active --wait lyra-nats \
+		|| { echo "ERROR: lyra-nats failed to reach active state"; exit 1; }
+	@# All NATS clients hold stale subject auth after an ACL change (#1390).
 	@failed=""; \
-	for svc in lyra-hub lyra-telegram lyra-discord lyra-clipool; do \
+	for svc in $(LYRA_NATS_CLIENTS); do \
 	  if systemctl --user is-active --quiet $$svc; then \
 	    systemctl --user restart $$svc || { echo "ERROR: restart $$svc failed"; failed="$$failed $$svc"; }; \
 	  fi; \
@@ -330,7 +337,7 @@ nats-add-identity:  ## add a single NATS identity rootless; idempotent after ful
 	podman secret create --replace "lyra-nats-$(NAME)" "$(LYRA_NKEYS_DIR)/$(NAME).seed"; \
 	podman secret create --replace lyra-nats-auth "$(LYRA_NKEYS_DIR)/auth.conf"; \
 	failed=""; \
-	for svc in lyra-nats lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper; do \
+	for svc in lyra-nats $(LYRA_NATS_CLIENTS); do \
 	  if systemctl --user is-active --quiet $$svc; then \
 	    systemctl --user restart $$svc || { echo "ERROR: restart $$svc failed"; failed="$$failed $$svc"; }; \
 	  fi; \


### PR DESCRIPTION
## Summary

- Closes #1390
- `make nats-regen-authconf` previously only restarted `lyra-nats`, leaving hub and adapters holding stale subject auth after an ACL change (silent split-brain)
- Extended the target to also restart `lyra-hub`, `lyra-telegram`, `lyra-discord`, and `lyra-clipool` using the same `is-active`-gated loop pattern as `nats-add-identity` (~line 329)

## Test plan

- [ ] Run `make nats-regen-authconf` on M₁; verify all four services restart in sequence after `lyra-nats`
- [ ] Inactive services (e.g. `lyra-clipool` stopped) are silently skipped — no error
- [ ] If any restart fails, the target exits non-zero with an error listing the failing service(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)