### PR TITLE
fix(roxabi-blobs): #1367 HttpBlobStore.exists sentinel content_hash=""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@ Entries are generated automatically by `/promote` and committed to staging befor
 - `HttpBlobStore.exists()` sentinel `BlobRef.content_hash` is now `""` instead of
   carrying the `store_key` argument (which is a wire path, not a sha256). HEAD does
   not return a content_hash, so failing fast on any downstream integrity check is
-  preferable to silently passing a wrong-typed value. Updates `roxabi-blobs` to
+  preferable to silently passing a wrong-typed value. Adds `BlobRef.is_sentinel:
+  bool = False` field + `model_validator` that rejects `content_hash=""` unless
+  `is_sentinel=True` — mirrors the `roxabi-contracts.BlobRef` /
+  `PENDING_STORE_KEY` guard on the storage side. Updates `roxabi-blobs` to
   `0.1.1`. (#1367)
 - Tool activity recap card (`🔧 Working… / Done ✅`) restored on Telegram and Discord
   multi-tool turns. Card had been blank since the v1 cutover (#1192 slice 3) which removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ Entries are generated automatically by `/promote` and committed to staging befor
 
 ### Fixed
 
+- `HttpBlobStore.exists()` sentinel `BlobRef.content_hash` is now `""` instead of
+  carrying the `store_key` argument (which is a wire path, not a sha256). HEAD does
+  not return a content_hash, so failing fast on any downstream integrity check is
+  preferable to silently passing a wrong-typed value. Updates `roxabi-blobs` to
+  `0.1.1`. (#1367)
 - Tool activity recap card (`🔧 Working… / Done ✅`) restored on Telegram and Discord
   multi-tool turns. Card had been blank since the v1 cutover (#1192 slice 3) which removed
   the v1 emitter while leaving `_on_toolcall_v2` as a stub. Rebuild sources card state

--- a/packages/roxabi-blobs/pyproject.toml
+++ b/packages/roxabi-blobs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-blobs"
-version = "0.1.0"
+version = "0.1.1"
 description = "Content-addressed BlobStore (Flat-FS + SQLite manifest) for the Roxabi plugin ecosystem"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
@@ -130,6 +130,10 @@ class HttpBlobStore:
 
         Over HTTP the argument is treated as a store_key (wire path), NOT a
         content_hash as in FsBlobStore.exists — see CLAUDE.md §HttpBlobStore.
+
+        Returned ``BlobRef.content_hash`` is empty — full content_hash is not
+        available via HEAD; callers needing it should PUT and capture the
+        response.
         """
         # HEAD endpoint only returns 200/404; reconstruct a minimal BlobRef on hit.
         # Full BlobRef data is not available via HEAD — callers needing the full
@@ -141,10 +145,12 @@ class HttpBlobStore:
         resp.raise_for_status()
         # HEAD returns no body — synthesise a sentinel BlobRef so Protocol
         # callers that only test truthiness get a non-None result.
-        # The content_hash field is set to the argument value (store_key in HTTP).
+        # content_hash="" — the argument is a store_key in HTTP, and the full
+        # sha256 is not available via HEAD; empty fails fast in any downstream
+        # integrity check rather than silently passing a wrong-typed value.
         return BlobRef(
             store_key=content_hash,
-            content_hash=content_hash,
+            content_hash="",
             mime="application/octet-stream",
             size=0,
             source="http",

--- a/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
@@ -126,14 +126,22 @@ class HttpBlobStore:
         return resp.content
 
     async def exists(self, content_hash: str) -> BlobRef | None:
-        """HEAD /blobs/{content_hash}; returns BlobRef-like object or None.
+        """HEAD /blobs/{content_hash}; returns sentinel BlobRef or None.
 
         Over HTTP the argument is treated as a store_key (wire path), NOT a
         content_hash as in FsBlobStore.exists — see CLAUDE.md §HttpBlobStore.
 
-        Returned ``BlobRef.content_hash`` is empty — full content_hash is not
-        available via HEAD; callers needing it should PUT and capture the
-        response.
+        Returns a **sentinel BlobRef** (``is_sentinel=True``,
+        ``content_hash=""``) on hit. The sentinel carries no metadata beyond
+        existence — ``content_hash``/``size``/``mime``/``created_at`` are
+        placeholders. Callers needing the full envelope should PUT and capture
+        the response.
+
+        WARNING: do NOT forward this sentinel into a ``roxabi_contracts.BlobRef``
+        constructor — the wire model's validator requires either a non-empty
+        ``content_hash`` or ``store_key == PENDING_STORE_KEY``, and this
+        sentinel satisfies neither. Convert deliberately (substitute
+        ``PENDING_STORE_KEY``) or call PUT to obtain a full envelope.
         """
         # HEAD endpoint only returns 200/404; reconstruct a minimal BlobRef on hit.
         # Full BlobRef data is not available via HEAD — callers needing the full
@@ -144,10 +152,9 @@ class HttpBlobStore:
             return None
         resp.raise_for_status()
         # HEAD returns no body — synthesise a sentinel BlobRef so Protocol
-        # callers that only test truthiness get a non-None result.
-        # content_hash="" — the argument is a store_key in HTTP, and the full
-        # sha256 is not available via HEAD; empty fails fast in any downstream
-        # integrity check rather than silently passing a wrong-typed value.
+        # callers that only test truthiness get a non-None result. is_sentinel=True
+        # makes the sparseness machine-checkable (BlobRef validator rejects
+        # content_hash="" without it, mirroring roxabi-contracts PENDING_STORE_KEY).
         return BlobRef(
             store_key=content_hash,
             content_hash="",
@@ -155,6 +162,7 @@ class HttpBlobStore:
             size=0,
             source="http",
             created_at=datetime.now(tz=UTC),
+            is_sentinel=True,
         )
 
     async def delete(self, blob_ref_id: int) -> None:

--- a/packages/roxabi-blobs/src/roxabi_blobs/models.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class BlobRef(BaseModel):
@@ -19,6 +19,11 @@ class BlobRef(BaseModel):
     consumed by `BlobStore.get`. For the FS impl it is the absolute path;
     for a future S3/MinIO impl it would be the `s3://bucket/key` URI.
     Callers MUST treat it as opaque.
+
+    Sentinel BlobRefs (`is_sentinel=True`) are sparse — only `store_key` is
+    meaningful; `content_hash`, `size`, `mime`, etc. carry placeholder values.
+    Produced by `HttpBlobStore.exists()` where HEAD has no body. See
+    `CLAUDE.md §HttpBlobStore.exists`.
     """
 
     model_config = ConfigDict(extra="ignore", frozen=True)
@@ -49,6 +54,14 @@ class BlobRef(BaseModel):
         description="SQLite blob_refs row id; None for non-FS impls or pre-put state.",
     )
     created_at: datetime = Field(description="Provenance: when this ref was ingested.")
+    is_sentinel: bool = Field(
+        default=False,
+        description=(
+            "True for sparse BlobRefs from HEAD-only paths (HttpBlobStore.exists). "
+            "When True, content_hash/size/mime/created_at are placeholders — "
+            "callers must not use them. Mirrors roxabi-contracts PENDING_STORE_KEY."
+        ),
+    )
 
     @field_validator("created_at")
     @classmethod
@@ -59,3 +72,14 @@ class BlobRef(BaseModel):
                 "BlobRef.created_at must be timezone-aware (got naive datetime)"
             )
         return v
+
+    @model_validator(mode="after")
+    def _require_content_hash_unless_sentinel(self) -> BlobRef:
+        # Mirrors roxabi_contracts.BlobRef guard: content_hash=="" is only valid
+        # for sentinel BlobRefs; otherwise it would silently pass a wrong-typed
+        # value to any downstream sha256/dedup check (#1367).
+        if self.content_hash == "" and not self.is_sentinel:
+            raise ValueError(
+                "BlobRef.content_hash must be non-empty unless is_sentinel=True"
+            )
+        return self

--- a/packages/roxabi-blobs/tests/test_fs_store.py
+++ b/packages/roxabi-blobs/tests/test_fs_store.py
@@ -84,6 +84,11 @@ class TestExists:
         # Latest = the discord ingestion
         assert found.source == "discord"
         assert found.platform_ref == "dc:2"
+        # FsBlobStore-specific: returned BlobRef carries the full sha256.
+        # (HttpBlobStore returns a sentinel with content_hash="", is_sentinel=True;
+        # asserting equality here pins the FS-side contract — #1367.)
+        assert found.content_hash == first.content_hash
+        assert found.is_sentinel is False
 
     async def test_exists_missing(self, store: FsBlobStore) -> None:
         result = await store.exists("deadbeef" * 8)

--- a/packages/roxabi-blobs/tests/test_protocol.py
+++ b/packages/roxabi-blobs/tests/test_protocol.py
@@ -79,6 +79,7 @@ class TestBlobRefEnvelope:
         "platform_ref",
         "platform_message_id",
         "created_at",
+        "is_sentinel",
     }
 
     def test_field_set(self) -> None:
@@ -131,6 +132,32 @@ class TestBlobRefEnvelope:
                 source="x",
                 created_at=datetime(2026, 5, 21),  # naive
             )
+
+    def test_empty_content_hash_rejected_without_sentinel_flag(self) -> None:
+        """content_hash="" requires is_sentinel=True — #1367."""
+        with pytest.raises(ValueError, match="content_hash must be non-empty"):
+            BlobRef(
+                store_key="x",
+                content_hash="",
+                mime="x",
+                size=0,
+                source="x",
+                created_at=_utc(),
+            )
+
+    def test_empty_content_hash_accepted_for_sentinel(self) -> None:
+        """Sentinel BlobRef bypasses the content_hash guard (#1367)."""
+        ref = BlobRef(
+            store_key="wire/path",
+            content_hash="",
+            mime="application/octet-stream",
+            size=0,
+            source="http",
+            created_at=_utc(),
+            is_sentinel=True,
+        )
+        assert ref.is_sentinel is True
+        assert ref.content_hash == ""
 
 
 class TestTypedErrors:

--- a/packages/roxabi-blobs/tests/test_protocol_parametrized.py
+++ b/packages/roxabi-blobs/tests/test_protocol_parametrized.py
@@ -92,7 +92,13 @@ class TestBlobStoreProtocol:
     async def test_exists_returns_true_after_put_false_before(
         self, store: BlobStore
     ) -> None:
-        """exists() returns BlobRef after put, None for unknown content_hash."""
+        """exists() returns BlobRef after put, None for unknown content_hash.
+
+        Protocol contract is non-None on hit / None on miss only. The returned
+        BlobRef's content_hash is backend-specific: FsBlobStore returns the full
+        sha256; HttpBlobStore returns a sentinel with ``content_hash=""`` because
+        HEAD has no body (see CLAUDE.md §HttpBlobStore, #1367).
+        """
         # Arrange
         payload = b"exists check"
         # Act
@@ -101,7 +107,6 @@ class TestBlobStoreProtocol:
         missing = await store.exists("aaaa" * 16)  # 64-char hex that was never put
         # Assert
         assert found is not None
-        assert found.content_hash == ref.content_hash
         assert missing is None
 
     async def test_delete_removes_blob_from_store(self, store: BlobStore) -> None:

--- a/packages/roxabi-blobs/tests/test_protocol_parametrized.py
+++ b/packages/roxabi-blobs/tests/test_protocol_parametrized.py
@@ -110,7 +110,15 @@ class TestBlobStoreProtocol:
         assert missing is None
 
     async def test_delete_removes_blob_from_store(self, store: BlobStore) -> None:
-        """delete(blob_ref_id) causes exists() to return None for that hash."""
+        """delete(blob_ref_id) causes exists() to return None for that hash.
+
+        Cross-backend note: ``store.exists(ref.content_hash)`` is the natural
+        argument for FsBlobStore (which looks up by content_hash). For
+        HttpBlobStore the argument is structurally a store_key — the server-side
+        HEAD handler does dual lookup (store_path then content_hash fallback,
+        see src/lyra/blobstore/CLAUDE.md §HEAD handler dual lookup), so the call
+        succeeds pre-delete and fails post-delete on both backends.
+        """
         # Arrange
         payload = b"blob to delete"
         # Act

--- a/tests/blobstore/test_http_store.py
+++ b/tests/blobstore/test_http_store.py
@@ -76,7 +76,14 @@ class TestHttpBlobStoreExists:
     async def test_http_blob_store_exists_sentinel_content_hash_is_empty(
         self, asgi_store: HttpBlobStore
     ) -> None:
-        """exists() sentinel BlobRef has empty content_hash — HEAD has no body."""
+        """exists() returns a sentinel BlobRef (content_hash="", is_sentinel=True).
+
+        Spec-pin regression guard for #1367: if a future implementation populates
+        content_hash from a response header (e.g., X-Blob-Content-Hash), this
+        test must be updated deliberately. The empty-string sentinel is the
+        explicit contract — wrong-typed values must not silently pass downstream
+        sha256/dedup checks.
+        """
         # Arrange
         payload = b"sentinel content_hash check"
         # Act
@@ -88,6 +95,7 @@ class TestHttpBlobStoreExists:
         # Assert
         assert found is not None
         assert found.content_hash == ""
+        assert found.is_sentinel is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/blobstore/test_http_store.py
+++ b/tests/blobstore/test_http_store.py
@@ -73,6 +73,22 @@ class TestHttpBlobStoreExists:
         assert found is not None
         assert missing is None
 
+    async def test_http_blob_store_exists_sentinel_content_hash_is_empty(
+        self, asgi_store: HttpBlobStore
+    ) -> None:
+        """exists() sentinel BlobRef has empty content_hash — HEAD has no body."""
+        # Arrange
+        payload = b"sentinel content_hash check"
+        # Act
+        async with asgi_store:
+            ref = await asgi_store.put(
+                payload, mime="application/octet-stream", source="test"
+            )
+            found = await asgi_store.exists(ref.content_hash)
+        # Assert
+        assert found is not None
+        assert found.content_hash == ""
+
 
 # ---------------------------------------------------------------------------
 # N4 — delete removes blob

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "roxabi-blobs"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/roxabi-blobs" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- `HttpBlobStore.exists()` sentinel `BlobRef` now sets `content_hash=""` instead of carrying the `store_key` argument as content_hash — a wrong-typed value (wire path, not sha256) that would silently pass downstream integrity checks. Empty fails fast.
- Bumps `roxabi-blobs` patch version `0.1.0` → `0.1.1`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1367: fix(roxabi-blobs): HttpBlobStore.exists sentinel content_hash carries store_key | OPEN |
| Implementation | 1 commit on `feat/1367-http-store-sentinel-content-hash` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new test method) | Passed |

## Test Plan
- [ ] `uv run pytest tests/blobstore/test_http_store.py` — 5 pass, including new `test_http_blob_store_exists_sentinel_content_hash_is_empty`
- [ ] `uv run pytest packages/roxabi-blobs/tests/test_protocol_parametrized.py` — parametrized exists test no longer asserts content_hash equality (backend-specific per Protocol contract)
- [ ] Confirm `BlobRef.content_hash == ""` in the sentinel returned by `HEAD 200`

## Context

- Origin: PR #1364 review [comment-4537497690](https://github.com/Roxabi/lyra/pull/1364#issuecomment-4537497690), deferred per consensus 2026-05-26.
- Architect's risk note: `"unknown"` (Solution 2) would pass downstream sha256 validation silently — empty string fails fast.
- Parametrized exists test (`test_protocol_parametrized.py`) was implicitly asserting the bug (`found.content_hash == ref.content_hash`); removed that assertion, kept the Protocol-level contract (non-None on hit / None on miss).

Closes #1367

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`