### PR TITLE
test(typing): #1397 close T2 coverage gaps from #1389 review

### DIFF
--- a/tests/typing/test_resolvers.py
+++ b/tests/typing/test_resolvers.py
@@ -19,9 +19,17 @@ def test_telegram_resolver_is_module_level() -> None:
     from lyra.adapters.telegram.telegram import _telegram_scope_resolver
 
     assert callable(_telegram_scope_resolver)
+    # Group/supergroup chat: negative chat_id (-100xxx).
     assert (
         _telegram_scope_resolver(
             WorkScope(platform="telegram", bot_id="x", scope_id=-100123, trace_id="t")
         )
         == -100123
+    )
+    # Private chat: positive chat_id.
+    assert (
+        _telegram_scope_resolver(
+            WorkScope(platform="telegram", bot_id="x", scope_id=12345, trace_id="t")
+        )
+        == 12345
     )

--- a/tests/typing/test_typing_listener.py
+++ b/tests/typing/test_typing_listener.py
@@ -106,6 +106,9 @@ async def test_factory_builder_exception_triggers_defensive_cancel() -> None:
     )
     scope = WorkScope(platform="discord", bot_id="x", scope_id=99, trace_id="t")
     await listener._on_msg(_make_msg(TypingEvent(kind="started", scope=scope, ts=1.0)))
+    # Cancel must come from the defensive finally, not from an "ended" dispatch:
+    # start was never reached because the builder raised pre-dispatch.
+    mgr.start.assert_not_called()
     mgr.cancel.assert_called_once_with(99)
 
 


### PR DESCRIPTION
## Summary
- Add positive `chat_id` case to the Telegram resolver test — covers private chats (positive ids), complementing the existing group-chat (`-100xxx`) case.
- Add `mgr.start.assert_not_called()` to `test_factory_builder_exception_triggers_defensive_cancel` — locks in that the cancel comes from the defensive `finally`, not from a future `kind="ended"` dispatch path.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1397: T2 coverage gaps — Telegram positive chat_id + factory_builder cancel assert | OPEN |
| Implementation | 1 commit on `worktree-1397-t2-coverage-gaps-typing` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (existing + augmented assertions) | Passed |

## Test Plan
- [x] `uv run pytest tests/typing/test_resolvers.py tests/typing/test_typing_listener.py` (8 passed)
- [x] `uv run ruff check` + `uv run pyright` on changed files (clean)
- [x] Pre-commit hooks (lint, typecheck, file-length, import-layers, etc.) — all green

Closes #1397

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`