### PR TITLE
feat(typing): WorkScope.trace_id non-empty __post_init__ guard

### DIFF
--- a/src/lyra/transport/work_scope.py
+++ b/src/lyra/transport/work_scope.py
@@ -9,5 +9,5 @@ class WorkScope:
     trace_id: str
 
     def __post_init__(self) -> None:
-        if not self.trace_id:
+        if not self.trace_id.strip():
             raise ValueError("WorkScope.trace_id must be non-empty")

--- a/src/lyra/transport/work_scope.py
+++ b/src/lyra/transport/work_scope.py
@@ -7,3 +7,7 @@ class WorkScope:
     bot_id: str
     scope_id: int
     trace_id: str
+
+    def __post_init__(self) -> None:
+        if not self.trace_id:
+            raise ValueError("WorkScope.trace_id must be non-empty")

--- a/tests/transport/test_work_scope.py
+++ b/tests/transport/test_work_scope.py
@@ -8,13 +8,12 @@ from lyra.transport.work_scope import WorkScope
 
 
 def test_workscope_constructs_with_non_empty_trace_id() -> None:
-    scope = WorkScope(
+    WorkScope(
         platform="telegram",
         bot_id="bot-1",
         scope_id=42,
         trace_id="abc123",
     )
-    assert scope.trace_id == "abc123"
 
 
 def test_workscope_rejects_empty_trace_id() -> None:
@@ -24,4 +23,14 @@ def test_workscope_rejects_empty_trace_id() -> None:
             bot_id="bot-1",
             scope_id=42,
             trace_id="",
+        )
+
+
+def test_workscope_rejects_whitespace_only_trace_id() -> None:
+    with pytest.raises(ValueError, match="trace_id must be non-empty"):
+        WorkScope(
+            platform="telegram",
+            bot_id="bot-1",
+            scope_id=42,
+            trace_id="   ",
         )

--- a/tests/transport/test_work_scope.py
+++ b/tests/transport/test_work_scope.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from lyra.transport.work_scope import WorkScope
@@ -34,3 +36,14 @@ def test_workscope_rejects_whitespace_only_trace_id() -> None:
             scope_id=42,
             trace_id="   ",
         )
+
+
+def test_workscope_replace_rejects_empty_trace_id() -> None:
+    scope = WorkScope(
+        platform="telegram",
+        bot_id="bot-1",
+        scope_id=42,
+        trace_id="abc123",
+    )
+    with pytest.raises(ValueError, match="trace_id must be non-empty"):
+        dataclasses.replace(scope, trace_id="")

--- a/tests/transport/test_work_scope.py
+++ b/tests/transport/test_work_scope.py
@@ -1,0 +1,27 @@
+"""Unit tests for lyra.transport.work_scope.WorkScope (#1392)."""
+
+from __future__ import annotations
+
+import pytest
+
+from lyra.transport.work_scope import WorkScope
+
+
+def test_workscope_constructs_with_non_empty_trace_id() -> None:
+    scope = WorkScope(
+        platform="telegram",
+        bot_id="bot-1",
+        scope_id=42,
+        trace_id="abc123",
+    )
+    assert scope.trace_id == "abc123"
+
+
+def test_workscope_rejects_empty_trace_id() -> None:
+    with pytest.raises(ValueError, match="trace_id must be non-empty"):
+        WorkScope(
+            platform="telegram",
+            bot_id="bot-1",
+            scope_id=42,
+            trace_id="",
+        )


### PR DESCRIPTION
## Summary
- Add `__post_init__` to `WorkScope` raising `ValueError` when `trace_id` is empty (#1392 T2).
- Lands before T2 call-site wiring (`Pool.process_one()`) so the invariant is operationally load-bearing the moment it gets threaded.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#1392](https://github.com/Roxabi/lyra/issues/1392): WorkScope.trace_id non-empty __post_init__ guard (T2) | Open |
| Implementation | 1 commit on `worktree-1392-workscope-trace-id-guard` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (2 new) | Passed |

S-tier — no analysis/spec artifacts (origin: PR #1389 review consensus, S2 deferred).

## Test Plan
- [x] `WorkScope(trace_id="abc")` constructs successfully (happy path).
- [x] `WorkScope(trace_id="")` raises `ValueError: WorkScope.trace_id must be non-empty`.
- [x] All existing `WorkScope(...)` call-sites already pass non-empty `trace_id` (verified via grep — no regressions).
- [ ] CI green on `worktree-1392-workscope-trace-id-guard`.

## Notes
- One pre-existing flake observed: `tests/typing/test_integration_nats.py::test_publisher_to_listener_e2e_discord` fails under loadgroup xdist but passes in isolation. Not introduced by this change (commit history shows the test landed in #1376 T1 d673c993). Out of scope for this guard.

Closes #1392

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`