### PR TITLE
refactor(typing): promote CoroFactory/FactoryBuilder to types.py

### DIFF
--- a/src/lyra/typing/__init__.py
+++ b/src/lyra/typing/__init__.py
@@ -1,4 +1,15 @@
 from lyra.typing.listener import TypingListener
-from lyra.typing.types import ScopeResolver, TypingManagerProtocol
+from lyra.typing.types import (
+    CoroFactory,
+    FactoryBuilder,
+    ScopeResolver,
+    TypingManagerProtocol,
+)
 
-__all__ = ["ScopeResolver", "TypingListener", "TypingManagerProtocol"]
+__all__ = [
+    "CoroFactory",
+    "FactoryBuilder",
+    "ScopeResolver",
+    "TypingListener",
+    "TypingManagerProtocol",
+]

--- a/src/lyra/typing/listener.py
+++ b/src/lyra/typing/listener.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from lyra.transport.typing_event import TypingEvent
-from lyra.typing.types import ScopeResolver, TypingManagerProtocol
+from lyra.typing.types import (
+    FactoryBuilder,
+    ScopeResolver,
+    TypingManagerProtocol,
+)
 
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATS
@@ -14,9 +17,6 @@ if TYPE_CHECKING:
     from nats.aio.subscription import Subscription
 
 log = logging.getLogger(__name__)
-
-CoroFactory = Callable[[], Coroutine[Any, Any, None]]
-FactoryBuilder = Callable[[int], CoroFactory]
 
 
 class TypingListener:

--- a/src/lyra/typing/types.py
+++ b/src/lyra/typing/types.py
@@ -3,6 +3,9 @@ from typing import Any, Protocol, runtime_checkable
 
 from lyra.transport.work_scope import WorkScope
 
+CoroFactory = Callable[[], Coroutine[Any, Any, None]]
+FactoryBuilder = Callable[[int], CoroFactory]
+
 
 @runtime_checkable
 class ScopeResolver(Protocol):

--- a/src/lyra/typing/types.py
+++ b/src/lyra/typing/types.py
@@ -29,7 +29,7 @@ class TypingManagerProtocol(Protocol):
     def start(
         self,
         target: int,
-        coro_factory: Callable[[], Coroutine[Any, Any, None]],
+        coro_factory: CoroFactory,
     ) -> None: ...
 
     def cancel(self, target: int) -> None: ...


### PR DESCRIPTION
## Summary
- Move `CoroFactory` and `FactoryBuilder` type aliases from `src/lyra/typing/listener.py` to `src/lyra/typing/types.py` alongside the existing `ScopeResolver` + `TypingManagerProtocol`.
- Re-export both aliases from `lyra.typing` so T2 callers (Pool, adapter wrappers) can annotate against them without a deep import into the listener module.
- Pure relocation — no behavior change.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1394: refactor(typing): promote CoroFactory/FactoryBuilder to lyra.typing.types | Open |
| Implementation | 1 commit on `worktree-1394-promote-corofactory-factorybuilder-to-lyra-typing-types` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (existing — refactor adds no new behavior) | Passed |

## Test Plan
- [ ] `uv run python -c "from lyra.typing import CoroFactory, FactoryBuilder; print(CoroFactory, FactoryBuilder)"` resolves both names.
- [ ] `tests/typing/` continues to pass (`uv run pytest tests/typing/ -n0`).
- [ ] `lyra.typing.listener` import path still re-exports `FactoryBuilder` transitively (back-compat — though no callers rely on it yet).

Closes #1394

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`