### PR TITLE
docs(spec): #1395 add code-worker T3 TODO sentinel in ACL spec

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -13,6 +13,14 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 
 ## ACL Matrix
 
+**Deferred — `code-worker` ACL row (T3, blocked-by #1044/#1047 worker fleet integration):**
+
+```
+// TODO(T3): add code-worker row when nkey provisioned via make nats-add-identity NAME=code-worker (#1044, #1047)
+```
+
+The row will grant `subscribe: lyra.typing.>` to `code-worker` (it consumes typing events to throttle its own typing emission). Provisioning: `make nats-add-identity NAME=code-worker` when T3 worker fleet integration starts; the `_inbox.code-worker.>` grant is derived automatically from `request_reply_flows` per the renderer convention.
+
 <!-- acl-matrix:begin -->
 | Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | llm-operator | image-worker | clipool-worker | voice-client | turn-writer |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|


### PR DESCRIPTION
## Summary
- Add a greppable `// TODO(T3): ...` sentinel directly above the ACL matrix sentinel block in `artifacts/specs/706-per-role-nkeys-acls-spec.mdx` so a future T3 engineer cannot miss the deferred `code-worker` row (PR #1389 review consensus, S7).
- Documents the planned grant (`subscribe: lyra.typing.>`) and the provisioning command (`make nats-add-identity NAME=code-worker`). Blocked-by #1044/#1047 worker fleet integration.
- TODO lives **outside** `<!-- acl-matrix:begin/end -->` so `scripts/check-acl-matrix-spec.sh` exact-diff verifier continues to pass; JSON receives no change (no comments) — spec remains the single source of truth.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1395: ops(nats): add code-worker T3 TODO sentinel in acl-matrix.json + spec | OPEN |
| Implementation | 1 commit on `feat/1395-code-worker-t3-todo` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4388 passed) · `check-acl-matrix-spec.sh` ✅ | Passed |

## Test Plan
- [ ] `grep "TODO(T3)" artifacts/specs/706-per-role-nkeys-acls-spec.mdx` returns line 19
- [ ] `bash scripts/check-acl-matrix-spec.sh` exits 0 (matrix sentinel block unchanged)
- [ ] Spec renders cleanly — TODO appears as a markdown callout + fenced code block between `## ACL Matrix` heading and the matrix sentinel

Closes #1395

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`