### PR TITLE
sec(typing): #1393 WorkScope NATS subject-injection allowlist

### DIFF
--- a/src/lyra/transport/CLAUDE.md
+++ b/src/lyra/transport/CLAUDE.md
@@ -37,6 +37,17 @@ Sanitization rules:
 
 Security boundary semantics UNCHANGED: `SanitizedError.message` still never carries `str(exc)` — `from_message` accepts only callee-controlled strings and applies guardrails on top.
 
+## WorkScope (#1393)
+
+`WorkScope` is a frozen dataclass whose `platform` and `bot_id` fields are
+interpolated directly into NATS subjects (e.g. `lyra.typing.{platform}.{bot_id}`).
+Both MUST match `^[A-Za-z0-9_-]{1,48}$`; `trace_id` MUST match
+`^[A-Za-z0-9_-]{1,128}$`. Enforced in `__post_init__` — `ValueError` on violation.
+Callers MUST NOT catch-and-ignore: a violation indicates a bug or an inbound
+attack and the publish must abort, not silently downgrade.
+
+`scope_id` is `int` and is not subject-interpolated; not validated here.
+
 ## TurnPublisher (#1331)
 
 `TurnPublisher` (transport-level) publishes `TurnWriteEvent` to JetStream

--- a/src/lyra/transport/work_scope.py
+++ b/src/lyra/transport/work_scope.py
@@ -1,4 +1,10 @@
+import re
 from dataclasses import dataclass
+
+# NATS subject special chars (`.`, `*`, `>`) flow from these fields into
+# `lyra.typing.{platform}.{bot_id}` (and other subjects); reject anything
+# outside the allowlist so a caller can never publish to a wildcard match.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -7,3 +13,10 @@ class WorkScope:
     bot_id: str
     scope_id: int
     trace_id: str
+
+    def __post_init__(self) -> None:
+        for field, value in (("platform", self.platform), ("bot_id", self.bot_id)):
+            if not _TOKEN_RE.fullmatch(value):
+                raise ValueError(
+                    f"WorkScope.{field} must match {_TOKEN_RE.pattern}; got {value!r}"
+                )

--- a/src/lyra/transport/work_scope.py
+++ b/src/lyra/transport/work_scope.py
@@ -1,22 +1,44 @@
 import re
 from dataclasses import dataclass
 
-# NATS subject special chars (`.`, `*`, `>`) flow from these fields into
-# `lyra.typing.{platform}.{bot_id}` (and other subjects); reject anything
-# outside the allowlist so a caller can never publish to a wildcard match.
-_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# `platform` and `bot_id` flow into NATS subjects (`lyra.typing.{platform}.{bot_id}`
+# and others). NATS specials `.`, `*`, `>` would create wildcard-matching subjects;
+# the length cap bounds subject size and the error-message log line.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{1,48}$")
+
+# `trace_id` flows to wire payloads (`TypingEvent`/`ContractEnvelope`) and logs.
+# Wider charset (hex/UUID conventions) but still bounded against log pollution
+# and CRLF injection in structured-log sinks.
+_TRACE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
 @dataclass(frozen=True, slots=True)
 class WorkScope:
+    """Scope identifier for a single conversation turn.
+
+    `platform` and `bot_id` are interpolated directly into NATS subjects;
+    both MUST match `^[A-Za-z0-9_-]{1,48}$` (no NATS specials, bounded length)
+    so a caller can never publish to a wildcard-matching subject.
+
+    `trace_id` is not injected into subjects but flows to wire payloads and
+    structured logs; it MUST match `^[A-Za-z0-9_-]{1,128}$`.
+
+    `scope_id` is `int` and is not interpolated into any subject — not
+    validated here.
+    """
+
     platform: str
     bot_id: str
     scope_id: int
     trace_id: str
 
     def __post_init__(self) -> None:
-        for field, value in (("platform", self.platform), ("bot_id", self.bot_id)):
-            if not _TOKEN_RE.fullmatch(value):
+        for field, value, pattern in (
+            ("platform", self.platform, _TOKEN_RE),
+            ("bot_id", self.bot_id, _TOKEN_RE),
+            ("trace_id", self.trace_id, _TRACE_ID_RE),
+        ):
+            if not pattern.fullmatch(value):
                 raise ValueError(
-                    f"WorkScope.{field} must match {_TOKEN_RE.pattern}; got {value!r}"
+                    f"WorkScope.{field} must match {pattern.pattern}; got {value!r}"
                 )

--- a/tests/transport/test_work_scope.py
+++ b/tests/transport/test_work_scope.py
@@ -3,6 +3,7 @@
 The platform/bot_id fields flow into `lyra.typing.{platform}.{bot_id}` (and other
 future subjects); NATS special chars (`.`, `*`, `>`) MUST be rejected at the
 dataclass boundary so callers can never publish to a wildcard-matching subject.
+trace_id flows to wire payloads and logs and is bounded similarly (wider charset).
 """
 
 from __future__ import annotations
@@ -10,6 +11,24 @@ from __future__ import annotations
 import pytest
 
 from lyra.transport.work_scope import WorkScope
+
+# Values shared by platform + bot_id (same allowlist + bound).
+SUBJECT_FIELD_REJECTED = [
+    "tele.gram",  # NATS token separator
+    "*",  # NATS single-token wildcard
+    ">",  # NATS multi-token wildcard
+    "x.>",  # explicit wildcard injection (from issue body)
+    "a b",  # space
+    "",  # empty
+    "a/b",  # path separator
+    "héllo",  # non-ASCII
+    "a\nb",  # newline
+    "a\tb",  # tab
+    "a;b",  # punctuation
+    "a\x00b",  # null byte (log-truncation vector)
+    "a\rb",  # carriage return (line-override vector)
+    "a" * 49,  # over length cap (48)
+]
 
 
 def _make(**overrides: object) -> WorkScope:
@@ -24,53 +43,58 @@ def _make(**overrides: object) -> WorkScope:
 
 
 class TestAllowed:
-    """Values matching ^[A-Za-z0-9_-]+$ must construct cleanly."""
+    """Values matching the allowlist + length bound must construct cleanly."""
 
     @pytest.mark.parametrize(
         "value",
-        ["telegram", "discord", "x", "bot-1", "bot_2", "ABC", "0", "a-b_c-9"],
+        ["telegram", "discord", "x", "bot-1", "bot_2", "ABC", "0", "a-b_c-9", "a" * 48],
     )
     def test_platform_allowed(self, value: str) -> None:
         assert _make(platform=value).platform == value
 
     @pytest.mark.parametrize(
         "value",
-        ["x", "bot-1", "bot_2", "AlphaBot", "123", "a-b_c-9"],
+        ["x", "bot-1", "bot_2", "AlphaBot", "123", "a-b_c-9", "a" * 48],
     )
     def test_bot_id_allowed(self, value: str) -> None:
         assert _make(bot_id=value).bot_id == value
 
-
-class TestRejected:
-    """NATS special chars and other unsafe inputs MUST raise at construction."""
-
     @pytest.mark.parametrize(
         "value",
-        [
-            "tele.gram",  # NATS token separator
-            "*",  # NATS single-token wildcard
-            ">",  # NATS multi-token wildcard
-            "x.>",  # explicit wildcard injection (from issue body)
-            "a b",  # space
-            "",  # empty
-            "a/b",  # path separator
-            "héllo",  # non-ASCII
-            "a\nb",  # newline
-            "a\tb",  # tab
-            "a;b",  # punctuation
-        ],
+        ["t", "abc123", "550e8400-e29b-41d4-a716-446655440000", "a" * 128],
     )
+    def test_trace_id_allowed(self, value: str) -> None:
+        assert _make(trace_id=value).trace_id == value
+
+
+class TestRejected:
+    """NATS special chars, control chars, and over-length inputs MUST raise."""
+
+    @pytest.mark.parametrize("value", SUBJECT_FIELD_REJECTED)
     def test_platform_rejected(self, value: str) -> None:
         with pytest.raises(ValueError, match="platform"):
             _make(platform=value)
 
-    @pytest.mark.parametrize(
-        "value",
-        ["x.y", "*", ">", "x.>", "a b", "", "a/b", "a\nb"],
-    )
+    @pytest.mark.parametrize("value", SUBJECT_FIELD_REJECTED)
     def test_bot_id_rejected(self, value: str) -> None:
         with pytest.raises(ValueError, match="bot_id"):
             _make(bot_id=value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",  # empty
+            "a b",  # space
+            "a.b",  # dot — rejected for trace_id same as for platform/bot_id
+            "a\nb",  # newline (log-injection)
+            "a\rb",  # carriage return
+            "a\x00b",  # null byte
+            "a" * 129,  # over length cap (128)
+        ],
+    )
+    def test_trace_id_rejected(self, value: str) -> None:
+        with pytest.raises(ValueError, match="trace_id"):
+            _make(trace_id=value)
 
     def test_error_message_includes_offending_value(self) -> None:
         """The ValueError MUST cite the offending value to aid debugging."""

--- a/tests/transport/test_work_scope.py
+++ b/tests/transport/test_work_scope.py
@@ -1,0 +1,78 @@
+"""Tests for WorkScope NATS subject-injection allowlist (#1393).
+
+The platform/bot_id fields flow into `lyra.typing.{platform}.{bot_id}` (and other
+future subjects); NATS special chars (`.`, `*`, `>`) MUST be rejected at the
+dataclass boundary so callers can never publish to a wildcard-matching subject.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lyra.transport.work_scope import WorkScope
+
+
+def _make(**overrides: object) -> WorkScope:
+    defaults: dict[str, object] = {
+        "platform": "telegram",
+        "bot_id": "x",
+        "scope_id": 1,
+        "trace_id": "t",
+    }
+    defaults.update(overrides)
+    return WorkScope(**defaults)  # type: ignore[arg-type]
+
+
+class TestAllowed:
+    """Values matching ^[A-Za-z0-9_-]+$ must construct cleanly."""
+
+    @pytest.mark.parametrize(
+        "value",
+        ["telegram", "discord", "x", "bot-1", "bot_2", "ABC", "0", "a-b_c-9"],
+    )
+    def test_platform_allowed(self, value: str) -> None:
+        assert _make(platform=value).platform == value
+
+    @pytest.mark.parametrize(
+        "value",
+        ["x", "bot-1", "bot_2", "AlphaBot", "123", "a-b_c-9"],
+    )
+    def test_bot_id_allowed(self, value: str) -> None:
+        assert _make(bot_id=value).bot_id == value
+
+
+class TestRejected:
+    """NATS special chars and other unsafe inputs MUST raise at construction."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "tele.gram",  # NATS token separator
+            "*",  # NATS single-token wildcard
+            ">",  # NATS multi-token wildcard
+            "x.>",  # explicit wildcard injection (from issue body)
+            "a b",  # space
+            "",  # empty
+            "a/b",  # path separator
+            "héllo",  # non-ASCII
+            "a\nb",  # newline
+            "a\tb",  # tab
+            "a;b",  # punctuation
+        ],
+    )
+    def test_platform_rejected(self, value: str) -> None:
+        with pytest.raises(ValueError, match="platform"):
+            _make(platform=value)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["x.y", "*", ">", "x.>", "a b", "", "a/b", "a\nb"],
+    )
+    def test_bot_id_rejected(self, value: str) -> None:
+        with pytest.raises(ValueError, match="bot_id"):
+            _make(bot_id=value)
+
+    def test_error_message_includes_offending_value(self) -> None:
+        """The ValueError MUST cite the offending value to aid debugging."""
+        with pytest.raises(ValueError, match=r"x\.>"):
+            _make(bot_id="x.>")


### PR DESCRIPTION
## Summary
- Add `__post_init__` allowlist (`^[A-Za-z0-9_-]+$`) on `WorkScope.platform` and `WorkScope.bot_id` so NATS special chars (`.`, `*`, `>`) and other unsafe inputs can never reach subject construction (`lyra.typing.{platform}.{bot_id}` and future subjects).
- Defensive — values are bootstrap-controlled today; T2 (Pool integration) will source them from less-controlled inbound messages.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1393: sec(typing): WorkScope.platform/bot_id NATS subject-injection allowlist (T2) | Open |
| Implementation | 1 commit on `worktree-1393-nats-injection-allowlist` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new file, 34 cases) | Passed |

## Test Plan
- [ ] `tests/transport/test_work_scope.py` — 34 parametrized cases (allowed/rejected for both fields)
- [ ] Regression: `tests/transport/` + `tests/typing/` — 93/93 ✓
- [ ] Reject confirmed: `.`, `*`, `>`, `x.>` (from issue body), space, empty, `/`, non-ASCII, control chars
- [ ] `ValueError` message cites field name + offending value

Closes #1393

Origin: PR #1389 review consensus — S3 deferred to T2.

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`