### PR TITLE
fix(agent_refiner): make run_session and apply_patch async to prevent event-loop blocking

### DIFF
--- a/src/lyra/agent_cmd/agents/edit_cmd.py
+++ b/src/lyra/agent_cmd/agents/edit_cmd.py
@@ -261,7 +261,7 @@ def refine(name: str = typer.Argument(..., help="Agent name to refine.")) -> Non
             io = TerminalIO()
             before_row = store.get(name)
             try:
-                patch = refiner.run_session(io)
+                patch = await refiner.run_session(io)
             except RefinementCancelled:
                 typer.echo("\nRefinement session cancelled.")
                 raise typer.Exit(0)

--- a/src/lyra/core/agent/agent_refiner.py
+++ b/src/lyra/core/agent/agent_refiner.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
 import shutil
-import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -107,8 +107,8 @@ class RefinementPatch:
 class TerminalIO:
     """Simple terminal I/O wrapper (injectable for tests)."""
 
-    def prompt(self, text: str) -> str:
-        return input(text)
+    async def prompt(self, text: str) -> str:
+        return await asyncio.to_thread(input, text)
 
     def print(self, text: str) -> None:
         print(text)
@@ -117,7 +117,7 @@ class TerminalIO:
 class LlmProvider(Protocol):
     """Protocol for any LLM backend used by AgentRefiner."""
 
-    def chat(self, system: str, messages: list[dict[str, Any]]) -> str:
+    async def chat(self, system: str, messages: list[dict[str, Any]]) -> str:
         """Single LLM call returning assistant response text."""
         ...
 
@@ -125,7 +125,7 @@ class LlmProvider(Protocol):
 class CliLlmProvider:
     """LlmProvider backed by the Claude CLI (`claude --print`)."""
 
-    def chat(self, system: str, messages: list[dict[str, Any]]) -> str:
+    async def chat(self, system: str, messages: list[dict[str, Any]]) -> str:
         """Shell out to `claude --print` and return stdout."""
         parts = [system] if system else []
         for msg in messages:
@@ -134,16 +134,19 @@ class CliLlmProvider:
             parts.append(f"{role}: {content}" if role else content)
         prompt = "\n\n".join(parts)
 
-        result = subprocess.run(
-            ["claude", "--print", prompt],
-            capture_output=True,
-            text=True,
+        proc = await asyncio.create_subprocess_exec(
+            "claude",
+            "--print",
+            prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        if result.returncode != 0:
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
             raise RuntimeError(
-                f"claude CLI exited {result.returncode}: {result.stderr.strip()}"
+                f"claude CLI exited {proc.returncode}: {stderr.decode().strip()}"
             )
-        return result.stdout.strip()
+        return stdout.decode().strip()
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +199,9 @@ class AgentRefiner:
     # Interactive session
     # ------------------------------------------------------------------
 
-    def run_session(self, io: TerminalIO, *, max_turns: int = 20) -> RefinementPatch:
+    async def run_session(
+        self, io: TerminalIO, *, max_turns: int = 20
+    ) -> RefinementPatch:
         """LLM-driven Q&A loop. Returns patch on user confirmation.
 
         Flow:
@@ -219,7 +224,7 @@ class AgentRefiner:
 
         # Initial greeting
         initial_msg = "Hello, I'd like to refine this agent's profile."
-        initial_response = driver.chat(
+        initial_response = await driver.chat(
             system, [{"role": "user", "content": initial_msg}]
         )
         io.print(initial_response)
@@ -229,7 +234,7 @@ class AgentRefiner:
         turn = 0
         while turn < max_turns:
             turn += 1
-            user_input = io.prompt("\nYou: ").strip()
+            user_input = (await io.prompt("\nYou: ")).strip()
             if not user_input:
                 turn -= 1  # don't count empty prompts against the limit
                 continue
@@ -239,7 +244,7 @@ class AgentRefiner:
             waiting_for_confirmation = user_input.lower().strip(".!") in _CONFIRM_WORDS
 
             messages.append({"role": "user", "content": user_input})
-            response = driver.chat(system, messages)
+            response = await driver.chat(system, messages)
             io.print(f"\nAssistant: {response}")
             messages.append({"role": "assistant", "content": response})
 
@@ -258,22 +263,14 @@ class AgentRefiner:
     # Patch apply
     # ------------------------------------------------------------------
 
-    def apply_patch(self, patch: RefinementPatch) -> "AgentRow":
-        """Apply patch to agent row and upsert to DB. Returns updated AgentRow.
-
-        Internally calls asyncio.run() — consistent with the sync CLI pattern.
-        """
-        import asyncio
-
-        async def _apply() -> "AgentRow":
-            row = self._store.get(self._name)
-            if row is None:
-                raise ValueError(f"Agent {self._name!r} not found in DB")
-            updated = patch.to_agent_row(row)
-            await self._store.upsert(updated)
-            return updated
-
-        return asyncio.run(_apply())
+    async def apply_patch(self, patch: RefinementPatch) -> "AgentRow":
+        """Apply patch to agent row and upsert to DB. Returns updated AgentRow."""
+        row = self._store.get(self._name)
+        if row is None:
+            raise ValueError(f"Agent {self._name!r} not found in DB")
+        updated = patch.to_agent_row(row)
+        await self._store.upsert(updated)
+        return updated
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/tests/core/test_agent_refiner_cli.py
+++ b/tests/core/test_agent_refiner_cli.py
@@ -212,7 +212,7 @@ class TestRunSession:
         row = make_row()
         store = make_store(row)
 
-        mock_driver = MagicMock()
+        mock_driver = AsyncMock()
         mock_driver.chat.side_effect = [
             # First call: initial greeting
             "Here is your profile. What would you like to change?",
@@ -222,14 +222,14 @@ class TestRunSession:
             'I\'ll update the model.\n<<PATCH>>\n{"model": "new-model"}\n<<END_PATCH>>',
         ]
 
-        mock_io = MagicMock(spec=TerminalIO)
+        mock_io = AsyncMock(spec=TerminalIO)
         # First prompt: describe what to change; second prompt: confirm
         mock_io.prompt.side_effect = ["change the model", "confirm"]
 
         refiner = AgentRefiner("lyra_default", store, driver=mock_driver)
 
         # Act
-        result = refiner.run_session(mock_io)
+        result = asyncio.run(refiner.run_session(mock_io))
 
         # Assert
         assert isinstance(result, RefinementPatch)
@@ -240,7 +240,7 @@ class TestRunSession:
         row = make_row()
         store = make_store(row)
 
-        mock_driver = MagicMock()
+        mock_driver = AsyncMock()
         mock_driver.chat.side_effect = [
             # First call: initial greeting (before loop)
             "Hello! Here's your current profile. What would you like to change?",
@@ -252,53 +252,53 @@ class TestRunSession:
             "\n<<END_PATCH>>",
         ]
 
-        mock_io = MagicMock(spec=TerminalIO)
+        mock_io = AsyncMock(spec=TerminalIO)
         mock_io.prompt.side_effect = ["change the model first", "confirm"]
 
         refiner = AgentRefiner("lyra_default", store, driver=mock_driver)
 
         # Act
-        result = refiner.run_session(mock_io)
+        result = asyncio.run(refiner.run_session(mock_io))
 
         # Assert
         assert result.fields == {
             "persona_json": '{"identity": {"display_name": "Aryl"}}'
         }
         # Assert driver was called for greeting + the 2 loop turns
-        assert mock_driver.chat.call_count == 3
-        assert mock_io.prompt.call_count == 2
+        assert mock_driver.chat.await_count == 3
+        assert mock_io.prompt.await_count == 2
 
     def test_run_session_raises_on_abort(self) -> None:
         # Arrange
         row = make_row()
         store = make_store(row)
 
-        mock_driver = MagicMock()
+        mock_driver = AsyncMock()
         mock_driver.chat.return_value = (
             "Here is your profile. What would you like to change?"
         )
 
-        mock_io = MagicMock(spec=TerminalIO)
+        mock_io = AsyncMock(spec=TerminalIO)
         mock_io.prompt.return_value = "quit"
 
         refiner = AgentRefiner("lyra_default", store, driver=mock_driver)
 
         # Act + Assert
         with pytest.raises(RefinementCancelled):
-            refiner.run_session(mock_io)
+            asyncio.run(refiner.run_session(mock_io))
 
         # Assert driver was called only for the greeting, not again after abort
-        mock_driver.chat.assert_called_once()
+        mock_driver.chat.assert_awaited_once()
 
     def test_run_session_skips_empty_input(self) -> None:
         # Arrange — first prompt returns empty (skipped), second returns abort
         row = make_row()
         store = make_store(row)
 
-        mock_driver = MagicMock()
+        mock_driver = AsyncMock()
         mock_driver.chat.return_value = "Profile loaded. What to change?"
 
-        mock_io = MagicMock(spec=TerminalIO)
+        mock_io = AsyncMock(spec=TerminalIO)
         # Empty string is skipped; second call returns abort
         mock_io.prompt.side_effect = ["", "exit"]
 
@@ -306,7 +306,7 @@ class TestRunSession:
 
         # Act + Assert
         with pytest.raises(RefinementCancelled):
-            refiner.run_session(mock_io)
+            asyncio.run(refiner.run_session(mock_io))
 
 
 # ---------------------------------------------------------------------------
@@ -340,6 +340,7 @@ class TestRefineCommand:
             ),
             mock_patch(
                 "lyra.core.agent.agent_refiner.AgentRefiner.run_session",
+                new_callable=AsyncMock,
                 return_value=RefinementPatch(fields={"model": "claude-opus-4-6"}),
             ),
         ):
@@ -373,6 +374,7 @@ class TestRefineCommand:
             ),
             mock_patch(
                 "lyra.core.agent.agent_refiner.AgentRefiner.run_session",
+                new_callable=AsyncMock,
                 side_effect=RefinementCancelled(),
             ),
         ):

--- a/tests/core/test_agent_refiner_profile.py
+++ b/tests/core/test_agent_refiner_profile.py
@@ -227,7 +227,7 @@ class TestRefineUnknownAgent:
 
         # Act + Assert
         with pytest.raises(ValueError, match="not found"):
-            refiner.apply_patch(patch)
+            asyncio.run(refiner.apply_patch(patch))
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +246,7 @@ class TestApplyPatch:
         patch = RefinementPatch(fields={"model": "claude-opus-4-6"})
 
         # Act
-        updated = refiner.apply_patch(patch)
+        updated = asyncio.run(refiner.apply_patch(patch))
 
         # Assert
         assert updated.model == "claude-opus-4-6"
@@ -261,7 +261,7 @@ class TestApplyPatch:
 
         # Act + Assert
         with pytest.raises(ValueError, match="not found"):
-            refiner.apply_patch(patch)
+            asyncio.run(refiner.apply_patch(patch))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Convert `AgentRefiner.run_session()` and `apply_patch()` from sync to async to prevent blocking the asyncio event loop.
- Replace `subprocess.run()` with `asyncio.create_subprocess_exec()` in `CliLlmProvider`.
- Replace `input()` with `asyncio.to_thread(input, text)` in `TerminalIO`.
- Remove nested `asyncio.run()` in `apply_patch()`.
- Update `lyra agent refine` CLI to await async refiner methods.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1424: [P0] Blocking event-loop bug in `lyra agent refine` | OPEN |
| Implementation | 1 commit on `feat/1424-blocking-event-loop-bug-in-lyra-agent-refine` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 updated) | Passed |

## Test Plan
- [ ] Run `lyra agent refine <agent>` from an existing asyncio runtime
- [ ] Verify the event loop does not freeze during interactive prompts

Closes #1424

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`