### PR TITLE
refactor(runtime_config): extract set_param parser helpers

### DIFF
--- a/src/lyra/core/runtime_config.py
+++ b/src/lyra/core/runtime_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import tomllib
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -173,7 +174,93 @@ def _write_flat_toml(data: dict[str, object]) -> str:
     return "\n".join(lines) + "\n" if lines else ""
 
 
-def set_param(rc: RuntimeConfig, key: str, value: str) -> RuntimeConfig:  # noqa: C901, PLR0915 — DEBT:complexity-residual
+def _parse_style(value: str) -> str:
+    if value not in _STYLES:
+        raise ValueError(f"Invalid style {value!r}. Valid: {sorted(_STYLES)}")
+    return value
+
+
+def _parse_temperature(value: str) -> float:
+    try:
+        fval = float(value)
+    except (ValueError, TypeError):
+        raise ValueError(f"temperature must be a float between 0 and 1, got {value!r}")
+    if not 0.0 <= fval <= 1.0:
+        raise ValueError(f"temperature must be between 0 and 1, got {fval}")
+    return fval
+
+
+def _parse_max_steps(value: str) -> int:
+    try:
+        iv = int(value)
+    except (ValueError, TypeError):
+        raise ValueError(f"max_steps must be a positive integer, got {value!r}")
+    if iv <= 0:
+        raise ValueError(f"max_steps must be a positive integer (≥1), got {iv}")
+    if iv > 50:
+        raise ValueError(f"max_steps too large ({iv}). Maximum is 50.")
+    return iv
+
+
+def _parse_model(value: str) -> str | None:
+    if value.lower() in ("", "none"):
+        return None
+    if not re.match(r"^[a-zA-Z0-9_.:-]+$", value):
+        raise ValueError(
+            f"Invalid model ID {value!r}. "
+            "Only alphanumerics, '.', '_', ':', '-' are allowed."
+        )
+    return value
+
+
+def _parse_language(value: str) -> str:
+    if value != "auto" and not re.match(r"^[a-z]{2,8}$", value):
+        raise ValueError(
+            f"Invalid language {value!r}. "
+            "Use 'auto' or a 2-8 char lowercase code (e.g. 'fr', 'en')."
+        )
+    return value
+
+
+def _parse_debounce_ms(value: str) -> int:
+    try:
+        iv = int(value)
+    except (ValueError, TypeError):
+        raise ValueError(f"debounce_ms must be an integer (0–5000), got {value!r}")
+    if iv < 0 or iv > 5000:
+        raise ValueError(f"debounce_ms must be between 0 and 5000, got {iv}")
+    return iv
+
+
+def _parse_cancel_on_new_message(value: str) -> bool:
+    if value.lower() in ("true", "1", "yes", "on"):
+        return True
+    if value.lower() in ("false", "0", "no", "off"):
+        return False
+    raise ValueError(f"cancel_on_new_message must be true or false, got {value!r}")
+
+
+def _parse_extra_instructions(value: str) -> str:
+    if len(value) > 500:
+        raise ValueError(
+            f"extra_instructions too long ({len(value)} chars). Max is 500."
+        )
+    return value
+
+
+_PARSERS: dict[str, Callable[[str], object]] = {
+    "style": _parse_style,
+    "temperature": _parse_temperature,
+    "max_steps": _parse_max_steps,
+    "model": _parse_model,
+    "language": _parse_language,
+    "debounce_ms": _parse_debounce_ms,
+    "cancel_on_new_message": _parse_cancel_on_new_message,
+    "extra_instructions": _parse_extra_instructions,
+}
+
+
+def set_param(rc: RuntimeConfig, key: str, value: str) -> RuntimeConfig:
     """Validate and apply a single key=value update to RuntimeConfig.
 
     Returns a new RuntimeConfig instance via model_copy().
@@ -182,81 +269,8 @@ def set_param(rc: RuntimeConfig, key: str, value: str) -> RuntimeConfig:  # noqa
     if key not in _VALID_PARAMS:
         raise ValueError(f"Unknown config key: {key!r}. Valid: {sorted(_VALID_PARAMS)}")
 
-    parsed: object
-
-    if key == "style":
-        if value not in _STYLES:
-            raise ValueError(f"Invalid style {value!r}. Valid: {sorted(_STYLES)}")
-        parsed = value
-
-    elif key == "temperature":
-        try:
-            fval = float(value)
-        except (ValueError, TypeError):
-            raise ValueError(
-                f"temperature must be a float between 0 and 1, got {value!r}"
-            )
-        if not 0.0 <= fval <= 1.0:
-            raise ValueError(f"temperature must be between 0 and 1, got {fval}")
-        parsed = fval
-
-    elif key == "max_steps":
-        try:
-            iv = int(value)
-        except (ValueError, TypeError):
-            raise ValueError(f"max_steps must be a positive integer, got {value!r}")
-        if iv <= 0:
-            raise ValueError(f"max_steps must be a positive integer (≥1), got {iv}")
-        if iv > 50:
-            raise ValueError(f"max_steps too large ({iv}). Maximum is 50.")
-        parsed = iv
-
-    elif key == "model":
-        if value.lower() in ("", "none"):
-            parsed = None
-        else:
-            if not re.match(r"^[a-zA-Z0-9_.:-]+$", value):
-                raise ValueError(
-                    f"Invalid model ID {value!r}. "
-                    "Only alphanumerics, '.', '_', ':', '-' are allowed."
-                )
-            parsed = value
-
-    elif key == "language":
-        if value != "auto" and not re.match(r"^[a-z]{2,8}$", value):
-            raise ValueError(
-                f"Invalid language {value!r}. "
-                "Use 'auto' or a 2-8 char lowercase code (e.g. 'fr', 'en')."
-            )
-        parsed = value
-
-    elif key == "debounce_ms":
-        try:
-            iv = int(value)
-        except (ValueError, TypeError):
-            raise ValueError(f"debounce_ms must be an integer (0–5000), got {value!r}")
-        if iv < 0 or iv > 5000:
-            raise ValueError(f"debounce_ms must be between 0 and 5000, got {iv}")
-        parsed = iv
-
-    elif key == "cancel_on_new_message":
-        if value.lower() in ("true", "1", "yes", "on"):
-            parsed = True
-        elif value.lower() in ("false", "0", "no", "off"):
-            parsed = False
-        else:
-            raise ValueError(
-                f"cancel_on_new_message must be true or false, got {value!r}"
-            )
-
-    else:
-        # extra_instructions — accept as-is, but cap length to avoid bloating context
-        if len(value) > 500:
-            raise ValueError(
-                f"extra_instructions too long ({len(value)} chars). Max is 500."
-            )
-        parsed = value
-
+    parser = _PARSERS[key]
+    parsed = parser(value)
     return rc.model_copy(update={key: parsed})
 
 

--- a/tests/core/test_runtime_config_set_param.py
+++ b/tests/core/test_runtime_config_set_param.py
@@ -10,6 +10,14 @@ import pytest
 
 from lyra.core.runtime_config import (
     RuntimeConfig,
+    _parse_cancel_on_new_message,
+    _parse_debounce_ms,
+    _parse_extra_instructions,
+    _parse_language,
+    _parse_max_steps,
+    _parse_model,
+    _parse_style,
+    _parse_temperature,
     set_param,
 )
 
@@ -246,3 +254,215 @@ class TestSetParam:
         # Act / Assert
         with pytest.raises(ValueError):
             set_param(rc, "language", "FR")
+
+    def test_valid_debounce_ms(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "debounce_ms", "1000")
+        assert updated.debounce_ms == 1000
+
+    def test_debounce_ms_min_boundary(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "debounce_ms", "0")
+        assert updated.debounce_ms == 0
+
+    def test_debounce_ms_max_boundary(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "debounce_ms", "5000")
+        assert updated.debounce_ms == 5000
+
+    def test_debounce_ms_negative_raises(self) -> None:
+        rc = RuntimeConfig()
+        with pytest.raises(ValueError):
+            set_param(rc, "debounce_ms", "-1")
+
+    def test_debounce_ms_above_max_raises(self) -> None:
+        rc = RuntimeConfig()
+        with pytest.raises(ValueError):
+            set_param(rc, "debounce_ms", "5001")
+
+    def test_debounce_ms_non_int_raises(self) -> None:
+        rc = RuntimeConfig()
+        with pytest.raises(ValueError):
+            set_param(rc, "debounce_ms", "abc")
+
+    def test_cancel_on_new_message_true(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "cancel_on_new_message", "true")
+        assert updated.cancel_on_new_message is True
+
+    def test_cancel_on_new_message_yes(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "cancel_on_new_message", "yes")
+        assert updated.cancel_on_new_message is True
+
+    def test_cancel_on_new_message_false(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "cancel_on_new_message", "false")
+        assert updated.cancel_on_new_message is False
+
+    def test_cancel_on_new_message_off(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "cancel_on_new_message", "off")
+        assert updated.cancel_on_new_message is False
+
+    def test_cancel_on_new_message_invalid_raises(self) -> None:
+        rc = RuntimeConfig()
+        with pytest.raises(ValueError):
+            set_param(rc, "cancel_on_new_message", "maybe")
+
+    def test_extra_instructions_accepted(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "extra_instructions", "Be concise.")
+        assert updated.extra_instructions == "Be concise."
+
+    def test_extra_instructions_too_long_raises(self) -> None:
+        rc = RuntimeConfig()
+        with pytest.raises(ValueError):
+            set_param(rc, "extra_instructions", "x" * 501)
+
+    def test_model_valid_value(self) -> None:
+        rc = RuntimeConfig()
+        updated = set_param(rc, "model", "claude-sonnet-4-6")
+        assert updated.model == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Parser helpers (_parse_*)
+# ---------------------------------------------------------------------------
+
+
+class TestParseStyle:
+    def test_valid(self) -> None:
+        assert _parse_style("detailed") == "detailed"
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid style"):
+            _parse_style("bogus")
+
+
+class TestParseTemperature:
+    def test_valid_float(self) -> None:
+        assert _parse_temperature("0.3") == pytest.approx(0.3)
+
+    def test_boundary_min(self) -> None:
+        assert _parse_temperature("0.0") == pytest.approx(0.0)
+
+    def test_boundary_max(self) -> None:
+        assert _parse_temperature("1.0") == pytest.approx(1.0)
+
+    def test_below_min_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_temperature("-0.1")
+
+    def test_above_max_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_temperature("1.1")
+
+    def test_non_float_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_temperature("abc")
+
+
+class TestParseMaxSteps:
+    def test_valid(self) -> None:
+        assert _parse_max_steps("5") == 5
+
+    def test_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_max_steps("0")
+
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_max_steps("-1")
+
+    def test_above_max_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_max_steps("51")
+
+    def test_non_int_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_max_steps("3.5")
+
+
+class TestParseModel:
+    def test_none_lowercase(self) -> None:
+        assert _parse_model("none") is None
+
+    def test_none_uppercase(self) -> None:
+        assert _parse_model("None") is None
+
+    def test_valid(self) -> None:
+        assert _parse_model("claude-haiku") == "claude-haiku"
+
+    def test_invalid_chars_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_model("model@id")
+
+
+class TestParseLanguage:
+    def test_two_char(self) -> None:
+        assert _parse_language("fr") == "fr"
+
+    def test_eight_char(self) -> None:
+        assert _parse_language("zhtwblah") == "zhtwblah"
+
+    def test_one_char_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_language("f")
+
+    def test_nine_char_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_language("abcdefghi")
+
+    def test_auto(self) -> None:
+        assert _parse_language("auto") == "auto"
+
+    def test_uppercase_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_language("FR")
+
+
+class TestParseDebounceMs:
+    def test_valid(self) -> None:
+        assert _parse_debounce_ms("1000") == 1000
+
+    def test_boundary_min(self) -> None:
+        assert _parse_debounce_ms("0") == 0
+
+    def test_boundary_max(self) -> None:
+        assert _parse_debounce_ms("5000") == 5000
+
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_debounce_ms("-1")
+
+    def test_above_max_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_debounce_ms("5001")
+
+    def test_non_int_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_debounce_ms("abc")
+
+
+class TestParseCancelOnNewMessage:
+    def test_true_variants(self) -> None:
+        for v in ("true", "1", "yes", "on"):
+            assert _parse_cancel_on_new_message(v) is True
+
+    def test_false_variants(self) -> None:
+        for v in ("false", "0", "no", "off"):
+            assert _parse_cancel_on_new_message(v) is False
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_cancel_on_new_message("maybe")
+
+
+class TestParseExtraInstructions:
+    def test_valid(self) -> None:
+        assert _parse_extra_instructions("Be concise.") == "Be concise."
+
+    def test_too_long_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_extra_instructions("x" * 501)


### PR DESCRIPTION
## Summary
- Replace the monolithic if/elif ladder in `set_param()` with eight focused `_parse_XXX()` helpers and a `_PARSERS` dispatch table.
- Add 40+ unit tests for previously uncovered keys (debounce_ms, cancel_on_new_message, extra_instructions) and direct parser tests.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1425: [P0] Cognitive-complexity critical hotspot in `runtime_config.set_param` | OPEN |
| Implementation | 1 commit on `feat/1425-runtime-config-set-param` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (40+ new) | Passed |

## Test Plan
- [ ] Verify `set_param` still works for all 8 config keys via existing + new tests.
- [ ] Verify parser helper unit tests cover edge cases (boundaries, invalid inputs).

Closes #1425

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`