### PR TITLE
fix(streaming): propagate clipool tool input to live recap accumulator (#1348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ Entries are generated automatically by `/promote` and committed to staging befor
   new `_ensure_trace_obj` helper, so the trace placeholder is sent at most once per turn
   regardless of which path fires first. Unknown tools (`todowrite`, `ls`, …) render as
   `🔧 N toolname` (lost feature from PR #1209). Adjacent v2-cutover context: #1102. (#1214)
+- Clipool NATS path now forwards the full tool-input dict through
+  `ToolCallStartRenderEvent.input`, fixing the bare "🔧 Done ✅" recap card on
+  clipool turns. `StreamProcessor` maps `ToolUseLlmEvent.input` → the new optional
+  `input` field; `ToolRecapAccumulator.observe_start` routes immediately when `input`
+  is present, skipping the buffered `_in_flight` path. Empty-dict (`{}`) inputs
+  (SDK streamed-delta default) map to `None` so the existing Args+End buffering
+  path is preserved. Old adapters tolerate the new field because
+  `roxabi_nats._decode_dataclass` ignores unknown payload keys. (#1348)
 
 ## [0.2.0](https://github.com/Roxabi/lyra/compare/lyra-v0.1.0...lyra-v0.2.0) (2026-04-17)
 

--- a/src/lyra/adapters/shared/_tool_recap.py
+++ b/src/lyra/adapters/shared/_tool_recap.py
@@ -81,6 +81,11 @@ class ToolRecapAccumulator:
 
     def observe_start(self, ev: ToolCallStartRenderEvent) -> None:
         """Register a new in-flight tool call."""
+        if ev.input:
+            self._route(
+                ev.tool_call_id, ev.tool_name.lower(), ev.tool_name, ev.input
+            )
+            return
         self._in_flight[ev.tool_call_id] = _PartialCall(tool_name=ev.tool_name)
 
     def observe_args(self, ev: ToolCallArgsRenderEvent) -> None:

--- a/src/lyra/core/messaging/events.py
+++ b/src/lyra/core/messaging/events.py
@@ -51,8 +51,9 @@ class ToolUseLlmEvent:
     """Emitted when the LLM calls a tool.
 
     ``input`` is empty at ``ContentBlockStart`` time (SDK); the full input dict
-    is populated via ``InputJsonDelta`` events but V1 only tracks tool name/id
-    for real-time visibility.
+    is populated via ``InputJsonDelta`` events. The clipool NATS path sends the
+    full input dict in a single ``tool_use`` chunk, so ``input`` may already be
+    complete when this event is emitted.
     """
 
     tool_name: str

--- a/src/lyra/core/messaging/render_events.py
+++ b/src/lyra/core/messaging/render_events.py
@@ -18,7 +18,7 @@ accumulator reference with an already-emitted event.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 SCHEMA_VERSION_TEXT_START_RENDER_EVENT = 1
 SCHEMA_VERSION_TEXT_DELTA_RENDER_EVENT = 1
@@ -191,6 +191,7 @@ class ToolCallStartRenderEvent:
 
     tool_call_id: str
     tool_name: str
+    input: dict[str, Any] | None = None
     schema_version: int = SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT
 
 

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -396,7 +396,9 @@ class StreamProcessor:
         self._sm_tool.open(event.tool_id, event.tool_name)
         self._tool_id_to_name[event.tool_id] = event.tool_name
         yield ToolCallStartRenderEvent(
-            tool_call_id=event.tool_id, tool_name=event.tool_name
+            tool_call_id=event.tool_id,
+            tool_name=event.tool_name,
+            input=event.input if event.input else None,
         )
         if self._show_intermediate:
             self._pending_text = ""

--- a/tests/adapters/test_tool_recap.py
+++ b/tests/adapters/test_tool_recap.py
@@ -210,3 +210,39 @@ def test_done_true_emits_done_header_else_working() -> None:
 
     assert working_lines[0] == "🔧 Working…"
     assert done_lines[0] == "🔧 Done ✅"
+
+
+def test_pre_routed_observe_start_skips_in_flight() -> None:
+    """observe_start with input routes immediately and skips _in_flight.
+
+    Clipool path: ToolCallStartRenderEvent carries the full args dict.
+    The accumulator routes immediately and does NOT add to _in_flight,
+    so a subsequent observe_end naturally no-ops (partial is None).
+    """
+    accum = ToolRecapAccumulator()
+    accum.observe_start(
+        ToolCallStartRenderEvent(
+            tool_call_id="tc-1",
+            tool_name="Bash",
+            input={"command": "git status"},
+        )
+    )
+    # observe_end should be a no-op because the call was never buffered
+    accum.observe_end(ToolCallEndRenderEvent(tool_call_id="tc-1"))
+
+    assert accum.bash_commands == ["git status"]
+    assert not accum._in_flight
+
+
+def test_pre_routed_observe_start_file_edit() -> None:
+    """Pre-routed Edit call with input accumulates into files dict."""
+    accum = ToolRecapAccumulator()
+    accum.observe_start(
+        ToolCallStartRenderEvent(
+            tool_call_id="tc-2",
+            tool_name="Edit",
+            input={"path": "/a.py", "old_string": "x", "new_string": "y"},
+        )
+    )
+    assert len(accum.files) == 1
+    assert accum.files["/a.py"].count == 1

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -95,7 +95,6 @@ async def async_events(*evts) -> AsyncIterator:
         yield e
 
 
-
 # ---------------------------------------------------------------------------
 # T9 — T24: StreamProcessor integration tests
 # ---------------------------------------------------------------------------
@@ -1386,6 +1385,44 @@ class TestToolCallLifecycle:
         # If the bare-else regressed, the delta would crash on event.is_error
         # access. Successful dispatch surfaces a ToolCallArgsRenderEvent.
         assert any(isinstance(e, ToolCallArgsRenderEvent) for e in result)
+
+    async def test_clipool_input_forwarding(self) -> None:
+        """ToolUseLlmEvent with non-empty input → ToolCallStartRenderEvent carries it.
+
+        Clipool NATS path sends the full input dict in a single tool_use chunk.
+        StreamProcessor must forward it so the recap accumulator can route
+        immediately without waiting for ToolCallArgs deltas.
+        """
+        processor = StreamProcessor()
+        events = async_events(
+            ToolUseLlmEvent(
+                tool_name="Bash", tool_id="tc-1", input={"command": "git log"}
+            ),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        starts = [e for e in result if isinstance(e, ToolCallStartRenderEvent)]
+        assert len(starts) == 1
+        assert starts[0].input == {"command": "git log"}
+
+    async def test_empty_input_maps_to_none(self) -> None:
+        """SDK path: ToolUseLlmEvent.input defaults to {} → mapped to None.
+
+        Empty dict is falsy; StreamProcessor must pass None so the accumulator
+        falls back to the buffered _in_flight path (Args + End) rather than
+        premature routing on an empty dict.
+        """
+        processor = StreamProcessor()
+        events = async_events(
+            ToolUseLlmEvent(tool_name="Read", tool_id="r1", input={}),
+            ResultLlmEvent(is_error=False, duration_ms=10),
+        )
+
+        result = await collect(processor.process(events))
+        starts = [e for e in result if isinstance(e, ToolCallStartRenderEvent)]
+        assert len(starts) == 1
+        assert starts[0].input is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_session_clear.py
+++ b/tests/integration/test_session_clear.py
@@ -1,5 +1,4 @@
-"""Integration test — /clear rotates Pool session UUID and publishes via TurnPublisher.
-"""
+"""Integration test — /clear rotates session UUID and publishes via TurnPublisher."""
 
 from __future__ import annotations
 

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -153,6 +153,25 @@ class TestToolCallCodecRoundTrip:
         decoded = codec.decode(event_type, payload)
         assert decoded == original
 
+    def test_tool_call_start_with_input_round_trip(self) -> None:
+        """Clipool path: input dict is encoded, decoded, and preserved."""
+        codec = NatsRenderEventCodec()
+        original = ToolCallStartRenderEvent(
+            tool_call_id="toolu_AB",
+            tool_name="Bash",
+            input={"command": "git log"},
+        )
+
+        event_type, payload, is_done = codec.encode(original)
+
+        assert event_type == "tool_call_start"
+        assert is_done is False
+        assert payload["input"] == {"command": "git log"}
+
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+        assert decoded.input == {"command": "git log"}  # type: ignore[union-attr]
+
     def test_tool_call_args_round_trip(self) -> None:
         codec = NatsRenderEventCodec()
         original = ToolCallArgsRenderEvent(tool_call_id="toolu_AB", delta='{"foo":')


### PR DESCRIPTION
## Summary

Clipool NATS path sends the full tool-input dict in a single `tool_use` chunk, but `StreamProcessor._handle_tool_use` ignored `ToolUseLlmEvent.input`, leaving the live recap card as a bare "🔧 Done ✅" with empty body.

## Changes

- `ToolCallStartRenderEvent` — new optional `input: dict[str, Any] | None = None`
- `StreamProcessor._handle_tool_use` — forwards `input`, mapping empty dict `{}` → `None`
- `ToolRecapAccumulator.observe_start` — routes immediately when `ev.input` present, skipping `_in_flight`
- `NatsRenderEventCodec` — no code change needed; generic dataclass serialization handles the new field
- Old adapters tolerate the new field (`roxabi_nats._decode_dataclass` ignores unknown payload keys)

## Test plan

- [x] `test_clipool_input_forwarding` — asserts input dict forwarded
- [x] `test_empty_input_maps_to_none` — asserts `{}` → `None` for SDK path
- [x] `test_pre_routed_observe_start_skips_in_flight` — no-op observe_end
- [x] `test_pre_routed_observe_start_file_edit` — Edit accumulates into files dict
- [x] `test_tool_call_start_with_input_round_trip` — codec encode/decode preserves input

## Coordinated deploy

No schema-floor bump. `SCHEMA_VERSION_TOOL_CALL_START_RENDER_EVENT` stays at 1. Old adapters silently ignore the new `input` key in the payload.

Closes #1348