### PR TITLE
feat(deploy): auto-converge Quadlet changes via systemd timer (#1380)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ define require_machine1
 	@case "$(DEPLOY_DIR)" in *[\'\"\$$\\\;\&\|\`]*) echo "Error: DEPLOY_DIR contains shell metacharacters"; exit 1 ;; esac
 endef
 
-.PHONY: build push lyra telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy remote nats-setup nats-regen-authconf nats-add-identity test test-integration voice-smoke lint typecheck format quality-debt-report quality-debt-classify
+.PHONY: build push lyra telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy remote nats-setup nats-regen-authconf nats-add-identity test test-integration voice-smoke lint typecheck format quality-debt-report quality-debt-classify
 
 # ── Container image build + transfer ─────────────────────────────────────────
 
@@ -180,6 +180,18 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 	else \
 		bash deploy/quadlet-install-verify.sh; \
 	fi
+
+QUADLET_SYNC_SRC := deploy/systemd
+QUADLET_SYNC_DST := $(HOME)/.config/systemd/user
+
+quadlet-sync-install:  ## install lyra-quadlet-sync timer + service → daemon-reload + enable
+	@mkdir -p "$(QUADLET_SYNC_DST)"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-quadlet-sync.service" "$(QUADLET_SYNC_DST)/"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-quadlet-sync.timer"   "$(QUADLET_SYNC_DST)/"
+	@echo "Sync units copied to $(QUADLET_SYNC_DST)"
+	@systemctl --user daemon-reload
+	@systemctl --user enable lyra-quadlet-sync.timer
+	@echo "[ok] lyra-quadlet-sync.timer enabled."
 
 quadlet-authconf-merged:  ## render merged auth.conf (lyra + voicecli identities) → ~/.lyra/nkeys/auth.conf
 	@lyra-acl genkeys --emit-merged-authconf

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -186,3 +186,8 @@ run systemctl --user daemon-reload
 echo "  [ok]   daemon-reload"
 
 log "Done. Services NOT restarted — run: systemctl --user start lyra-nats lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-gh-helper lyra-turn-writer lyra-blobstore"
+
+# ── 6. Install sync timer + service (idempotent) ───────────────────────────
+
+log "Installing lyra-quadlet-sync timer + service ..."
+run make quadlet-sync-install

--- a/deploy/lyra-quadlet-sync.sh
+++ b/deploy/lyra-quadlet-sync.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# deploy/lyra-quadlet-sync.sh — auto-pull staging and conditional quadlet-install
+#
+# Called by lyra-quadlet-sync.service (systemd user unit).
+# Guard: only runs make quadlet-install when deploy/quadlet/**, Makefile, or
+# tools/render_quadlet.py changed.
+set -euo pipefail
+
+cd ~/projects/lyra || {
+    echo "ERROR: ~/projects/lyra not found" >&2
+    exit 1
+}
+
+git fetch origin staging || {
+    echo "ERROR: git fetch origin staging failed" >&2
+    exit 1
+}
+
+if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/staging)" ]; then
+    echo "Already at origin/staging — nothing to do."
+    exit 0
+fi
+
+PRE_SHA=$(git rev-parse HEAD)
+git pull --ff-only origin staging || {
+    echo "ERROR: git pull --ff-only failed" >&2
+    exit 1
+}
+
+if git diff --name-only "$PRE_SHA" HEAD | grep -qE '^(deploy/quadlet/|Makefile|tools/render_quadlet\.py)'; then
+    echo "Quadlet-relevant files changed — running make quadlet-install ..."
+    export PATH="$HOME/.local/bin:$PATH"
+    make quadlet-install
+else
+    echo "No Quadlet-relevant changes — skipping make quadlet-install."
+fi

--- a/deploy/systemd/lyra-quadlet-sync.service
+++ b/deploy/systemd/lyra-quadlet-sync.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Lyra Quadlet sync — pull staging and conditional install
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/projects/lyra/deploy/lyra-quadlet-sync.sh
+WorkingDirectory=%h/projects/lyra
+Environment="PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
+StandardOutput=journal
+StandardError=journal

--- a/deploy/systemd/lyra-quadlet-sync.timer
+++ b/deploy/systemd/lyra-quadlet-sync.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Lyra Quadlet sync timer — every 5 minutes
+
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -53,6 +53,41 @@ make quadlet-install    # copy units + daemon-reload
 systemctl --user restart lyra-hub lyra-telegram lyra-discord lyra-clipool
 ```
 
+## Auto-sync for Quadlet file changes
+
+Tracked Quadlet files (`deploy/quadlet/**`, `Makefile`, `tools/render_quadlet.py`) are
+auto-converged on M₁ by `lyra-quadlet-sync.timer`:
+
+| Path | Cadence | What it does |
+|---|---|---|
+| **Auto** (`lyra-quadlet-sync.timer`) | Every 5 min | `git fetch` → `ff-only pull` → diff-guard → conditional `make quadlet-install` |
+| **Manual** (`make quadlet-install`) | Operator-driven | Immediate — use when you need a change NOW or the timer is disabled |
+
+### First-time enable
+
+Run once (idempotent):
+```bash
+cd ~/projects/lyra
+make quadlet-sync-install
+```
+
+### Checking sync status
+
+```bash
+# Last run output
+journalctl --user -u lyra-quadlet-sync -n 20
+
+# Timer next trigger
+systemctl --user list-timers lyra-quadlet-sync.timer
+```
+
+### When to use manual `make quadlet-install`
+
+- You need a Quadlet change applied **immediately** (timer max latency = 5 min).
+- You are debugging a unit and want to iterate fast.
+- The auto-sync service is temporarily stopped for maintenance.
+- The change is a hot-fix and you cannot wait for the next timer firing.
+
 ## Secret layout
 
 | Podman secret | Source file | Mounted at |


### PR DESCRIPTION
## Summary
- Add `lyra-quadlet-sync.timer` + `.service` that pull `origin/staging` every 5 min and conditionally run `make quadlet-install` when `deploy/quadlet/**`, `Makefile`, or `tools/render_quadlet.py` changed.
- Add `make quadlet-sync-install` target for idempotent install of the sync units.
- Update `deploy/install.sh` to call `make quadlet-sync-install` on first-time setup.
- Document auto-sync vs manual escape hatch in `docs/QUADLET-DEPLOYMENT.md`.

Mirrors the existing `podman-auto-update.timer` mental model. Manual `make quadlet-install` remains available as escape hatch.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1380: ops(deploy): auto-converge Quadlet file changes on lyra-hub via systemd-timer pull-loop | OPEN |
| Analysis | — | Absent (F-lite, frame sufficient) |
| Spec | [1380-auto-converge-quadlet-changes-spec.mdx](artifacts/specs/1380-auto-converge-quadlet-changes-spec.mdx) | Present |
| Implementation | 1 commit on `worktree-1380-auto-converge-quadlet-changes` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4521 passed, 1 pre-existing NATS infra failure) | Passed |

## Test Plan
- [ ] Run `make -n quadlet-sync-install` on M₁ — verify dry-run output shows cp + daemon-reload + enable
- [ ] Run `make quadlet-sync-install` on M₁ — verify units copied to `~/.config/systemd/user/` and timer enabled
- [ ] Check `systemctl --user list-timers lyra-quadlet-sync.timer` shows next trigger
- [ ] Check `journalctl --user -u lyra-quadlet-sync -n 20` shows "Already at origin/staging — nothing to do." when up-to-date
- [ ] Merge a test PR touching `deploy/quadlet/lyra-hub.container` — verify timer fires and `make quadlet-install` runs within 5 min

Closes #1380

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`