### PR TITLE
feat(contracts): add LlmHeartbeat model and fixture (#1038)

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/llm/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/llm/__init__.py
@@ -5,6 +5,7 @@ from roxabi_contracts.llm.models import (
     LifecycleRequest,
     LifecycleResponse,
     LlmChunkEvent,
+    LlmHeartbeat,
     LlmRequest,
     LlmResponse,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "LifecycleRequest",
     "LifecycleResponse",
     "LlmChunkEvent",
+    "LlmHeartbeat",
     "LlmRequest",
     "LlmResponse",
     "build_llm_chunk",

--- a/packages/roxabi-contracts/src/roxabi_contracts/llm/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/llm/fixtures.py
@@ -1,0 +1,28 @@
+"""Test fixtures for roxabi_contracts.llm.
+
+Pure dicts — no NATS imports, no model imports (avoids circular deps).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+ENV_BASE: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "tst-llm-trace",
+    "issued_at": datetime(2026, 5, 27, tzinfo=timezone.utc),
+}
+
+sample_llm_heartbeat: dict[str, Any] = {
+    **ENV_BASE,
+    "worker_id": "llm-worker-1",
+    "model_name": "mistral-7b",
+    "status": "idle",
+    "latency_ms": 42,
+    "last_heartbeat_ts": 1716816000.0,
+}
+"""Canonical LLM heartbeat payload. Round-trips cleanly through ``LlmHeartbeat``.
+
+Fields per issue #1038: model name, status, latency, last-heartbeat-ts.
+"""

--- a/packages/roxabi-contracts/src/roxabi_contracts/llm/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/llm/models.py
@@ -2,10 +2,11 @@
 
 Pure Pydantic. No NATS imports. No transport logic.
 
-Three envelope models:
+Four envelope models:
   LlmRequest    — hub → worker (generate_request subject)
   LlmChunkEvent — worker → hub (streaming chunks, published to reply inbox)
   LlmResponse   — worker → hub (non-streaming reply, published to reply inbox)
+  LlmHeartbeat  — worker → hub (periodic heartbeat, lyra.llm.heartbeat)
 """
 
 from __future__ import annotations
@@ -65,6 +66,21 @@ class LlmResponse(ContractEnvelope):
         if self.ok and self.text is None:
             raise ValueError("LlmResponse with ok=True must carry text")
         return self
+
+
+class LlmHeartbeat(ContractEnvelope):
+    """Inbound heartbeat from an LLM worker satellite.
+
+    Canonical subject: ``lyra.llm.heartbeat``. Consumers populate a
+    worker registry keyed by ``worker_id`` and prune stale entries via
+    ``last_heartbeat_ts``.
+    """
+
+    worker_id: Annotated[str, StringConstraints(min_length=1)]
+    model_name: Annotated[str, StringConstraints(min_length=1)]
+    status: str
+    latency_ms: int
+    last_heartbeat_ts: float
 
 
 class LifecycleRequest(ContractEnvelope):

--- a/packages/roxabi-contracts/tests/test_llm_fixtures.py
+++ b/packages/roxabi-contracts/tests/test_llm_fixtures.py
@@ -1,0 +1,14 @@
+"""Roundtrip tests for LLM-domain fixtures."""
+
+from __future__ import annotations
+
+from roxabi_contracts.llm import LlmHeartbeat
+from roxabi_contracts.llm import fixtures as llm_fixtures
+
+
+def test_llm_heartbeat_fixture_roundtrip() -> None:
+    """model_validate(sample) → model_dump() is a fixed point."""
+    sample = llm_fixtures.sample_llm_heartbeat
+    inst = LlmHeartbeat.model_validate(sample)
+    dumped = inst.model_dump()
+    assert dumped == sample


### PR DESCRIPTION
## Summary
- Add `LlmHeartbeat` envelope model to `roxabi_contracts.llm` with canonical heartbeat fields (worker_id, model_name, status, latency_ms, last_heartbeat_ts) — prerequisite for hub/worker heartbeat consumption
- Create `llm/fixtures.py` with `sample_llm_heartbeat` dict and roundtrip fixed-point test

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1038 | Active |
| Implementation | 1 commit on `worktree-1038-llm-heartbeat-fixture` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new) | Passed |

## Test Plan
- [ ] `uv run pytest packages/roxabi-contracts/tests/test_llm_fixtures.py` passes
- [ ] `uv run pytest packages/roxabi-contracts/tests/` full suite passes (338)

Closes #1038