### PR TITLE
feat(contracts): add lyra.event.* and lyra.metric.* schemas (#1181)

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/event/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/event/__init__.py
@@ -1,0 +1,23 @@
+"""Event/metric NATS contract surface.
+
+Public API: SUBJECTS namespace + LyraEvent + LyraMetric envelope models.
+The `fixtures` submodule is test-only — import explicitly as
+``from roxabi_contracts.event.fixtures import ...``.
+"""
+
+from __future__ import annotations
+
+from roxabi_contracts.event.models import LyraEvent, LyraMetric
+from roxabi_contracts.event.subjects import (
+    SUBJECTS,
+    per_service_event,
+    per_service_metric,
+)
+
+__all__ = [
+    "LyraEvent",
+    "LyraMetric",
+    "SUBJECTS",
+    "per_service_event",
+    "per_service_metric",
+]

--- a/packages/roxabi-contracts/src/roxabi_contracts/event/fixtures.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/event/fixtures.py
@@ -1,0 +1,88 @@
+"""Test fixtures for roxabi_contracts.event.
+
+Pure synthesized data. No runtime dependencies beyond the package itself.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+_ENV: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "evt-trace-001",
+    "issued_at": datetime(2026, 5, 27, tzinfo=timezone.utc),
+}
+
+
+# --- LyraEvent fixtures ---
+
+
+event_hub_startup: dict[str, Any] = {
+    **_ENV,
+    "service": "hub",
+    "kind": "startup",
+    "level": "info",
+    "message": "Hub process started",
+    "payload": {"pid": 1234, "version": "2.1.0"},
+}
+"""Synthetic hub startup event payload."""
+
+
+event_hub_error: dict[str, Any] = {
+    **_ENV,
+    "service": "hub",
+    "kind": "error",
+    "level": "error",
+    "message": "Unhandled exception in dispatcher",
+    "payload": {"exception": "ValueError", "route": "telegram.inbound"},
+}
+"""Synthetic hub error event payload."""
+
+
+event_telegram_lifecycle: dict[str, Any] = {
+    **_ENV,
+    "service": "telegram",
+    "kind": "lifecycle.connected",
+    "level": "info",
+    "message": "Telegram adapter connected",
+}
+"""Synthetic telegram lifecycle event payload."""
+
+
+# --- LyraMetric fixtures ---
+
+
+metric_hub_request_count: dict[str, Any] = {
+    **_ENV,
+    "service": "hub",
+    "name": "request.count",
+    "metric_type": "counter",
+    "value": 1.0,
+    "unit": "count",
+    "labels": {"platform": "telegram"},
+}
+"""Synthetic hub request counter metric payload."""
+
+
+metric_hub_latency: dict[str, Any] = {
+    **_ENV,
+    "service": "hub",
+    "name": "request.latency",
+    "metric_type": "histogram",
+    "value": 42.5,
+    "unit": "ms",
+    "labels": {"platform": "telegram", "route": "inbound"},
+}
+"""Synthetic hub latency histogram metric payload."""
+
+
+metric_llm_queue_depth: dict[str, Any] = {
+    **_ENV,
+    "service": "llm",
+    "name": "queue.depth",
+    "metric_type": "gauge",
+    "value": 3.0,
+    "unit": "count",
+}
+"""Synthetic LLM queue depth gauge metric payload."""

--- a/packages/roxabi-contracts/src/roxabi_contracts/event/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/event/models.py
@@ -1,0 +1,47 @@
+"""Event and metric contract models for the observability bus.
+
+Two envelope models:
+  LyraEvent  — structured operational events (lifecycle, errors, alerts)
+  LyraMetric — typed metrics (counters, gauges, histograms)
+
+Canonical subject patterns:
+  lyra.event.<service>.<kind>
+  lyra.metric.<service>.<name>
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import StringConstraints, model_validator
+
+from roxabi_contracts.envelope import ContractEnvelope
+
+
+class LyraEvent(ContractEnvelope):
+    """Structured operational event. Published to ``lyra.event.<service>.<kind>``."""
+
+    service: Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9_-]*$")]
+    kind: Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9._-]*$")]
+    level: Literal["debug", "info", "warn", "error", "critical"]
+    message: str | None = None
+    payload: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _error_level_requires_message(self) -> Self:
+        if self.level in ("error", "critical") and not self.message:
+            raise ValueError(
+                "LyraEvent with level='error' or 'critical' must carry a message"
+            )
+        return self
+
+
+class LyraMetric(ContractEnvelope):
+    """Typed metric. Published to ``lyra.metric.<service>.<name>``."""
+
+    service: Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9_-]*$")]
+    name: Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9._-]*$")]
+    metric_type: Literal["counter", "gauge", "histogram"]
+    value: float
+    unit: str | None = None
+    labels: dict[str, str] | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/event/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/event/subjects.py
@@ -1,0 +1,77 @@
+"""Event/metric NATS subject strings and per-service helpers.
+
+Canonical values — literal strings (no f-strings, no derivation) so grep
+can locate every reference across the monorepo.
+
+Subject hierarchy:
+  lyra.event.<service>.<kind>   — operational events
+  lyra.metric.<service>.<name>  — typed metrics
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from roxabi_contracts._nats_utils import _SAFE_SUBJECT_SEGMENT_RE
+
+__all__ = ["SUBJECTS", "per_service_event", "per_service_metric"]
+
+# Namespaced tokens (e.g. "lifecycle.swap", "request.count") are valid
+# multi-segment NATS subject suffixes. Dots are allowed for namespacing,
+# but leading/trailing/consecutive dots and wildcards are rejected.
+_SAFE_NAMESPACED_RE = re.compile(r"[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*")
+
+
+@dataclass(frozen=True, slots=True)
+class _Subjects:
+    """Frozen namespace of event/metric subject strings.
+
+    Attribute access is pyright-checked: typos fail at type-check time
+    rather than silently returning None.
+    """
+
+    event_all: Literal["lyra.event.>"] = "lyra.event.>"
+    metric_all: Literal["lyra.metric.>"] = "lyra.metric.>"
+
+
+SUBJECTS = _Subjects()
+
+
+def _validate_segment(segment: str) -> None:
+    if not _SAFE_SUBJECT_SEGMENT_RE.fullmatch(segment):
+        raise ValueError(
+            f"NATS subject segment must match [A-Za-z0-9_-]+ (got {segment!r}); "
+            "dots, wildcards (* >) and empty segments are rejected"
+        )
+
+
+def _validate_namespaced(token: str) -> None:
+    if not _SAFE_NAMESPACED_RE.fullmatch(token):
+        raise ValueError(
+            f"NATS namespaced token must match [A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)* "
+            f"(got {token!r}); wildcards (* >) and dot-boundary violations are rejected"
+        )
+
+
+def per_service_event(service: str, kind: str) -> str:
+    """Per-service event subject: ``lyra.event.{service}.{kind}``.
+
+    Raises ``ValueError`` if ``service`` contains characters outside
+    ``[A-Za-z0-9_-]`` or if ``kind`` is not a valid namespaced token.
+    """
+    _validate_segment(service)
+    _validate_namespaced(kind)
+    return f"lyra.event.{service}.{kind}"
+
+
+def per_service_metric(service: str, name: str) -> str:
+    """Per-service metric subject: ``lyra.metric.{service}.{name}``.
+
+    Raises ``ValueError`` if ``service`` contains characters outside
+    ``[A-Za-z0-9_-]`` or if ``name`` is not a valid namespaced token.
+    """
+    _validate_segment(service)
+    _validate_namespaced(name)
+    return f"lyra.metric.{service}.{name}"

--- a/packages/roxabi-contracts/tests/test_event_models.py
+++ b/packages/roxabi-contracts/tests/test_event_models.py
@@ -70,7 +70,14 @@ def test_event_invalid_kind() -> None:
 
 def test_event_invalid_level() -> None:
     with pytest.raises(ValidationError):
-        LyraEvent(**_ENV, service="hub", kind="startup", level="verbose")
+        LyraEvent.model_validate(
+            {
+                **_ENV,
+                "service": "hub",
+                "kind": "startup",
+                "level": "verbose",
+            }
+        )
 
 
 def test_event_extra_fields_ignored() -> None:
@@ -145,8 +152,14 @@ def test_metric_invalid_name() -> None:
 
 def test_metric_invalid_type() -> None:
     with pytest.raises(ValidationError):
-        LyraMetric(
-            **_ENV, service="hub", name="count", metric_type="summary", value=1.0
+        LyraMetric.model_validate(
+            {
+                **_ENV,
+                "service": "hub",
+                "name": "count",
+                "metric_type": "summary",
+                "value": 1.0,
+            }
         )
 
 

--- a/packages/roxabi-contracts/tests/test_event_models.py
+++ b/packages/roxabi-contracts/tests/test_event_models.py
@@ -1,0 +1,164 @@
+"""Roundtrip + invariant tests for event/metric contract models."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from roxabi_contracts.event import LyraEvent, LyraMetric
+
+_ENV: dict[str, Any] = {
+    "contract_version": "1",
+    "trace_id": "tst-trace",
+    "issued_at": datetime(2026, 5, 27, tzinfo=timezone.utc),
+}
+
+
+# --- LyraEvent ---
+
+
+def test_event_roundtrip() -> None:
+    evt = LyraEvent(
+        **_ENV,
+        service="hub",
+        kind="startup",
+        level="info",
+        message="Hub started",
+        payload={"pid": 1234},
+    )
+    restored = LyraEvent.model_validate_json(evt.model_dump_json())
+    assert restored.service == "hub"
+    assert restored.kind == "startup"
+    assert restored.level == "info"
+    assert restored.message == "Hub started"
+    assert restored.payload == {"pid": 1234}
+
+
+def test_event_minimal() -> None:
+    evt = LyraEvent(**_ENV, service="hub", kind="heartbeat", level="debug")
+    assert evt.message is None
+    assert evt.payload is None
+
+
+def test_event_error_level_requires_message() -> None:
+    with pytest.raises(ValidationError, match="must carry a message"):
+        LyraEvent(**_ENV, service="hub", kind="crash", level="error", message=None)
+
+
+def test_event_critical_level_requires_message() -> None:
+    with pytest.raises(ValidationError, match="must carry a message"):
+        LyraEvent(**_ENV, service="hub", kind="alert", level="critical", message=None)
+
+
+def test_event_warn_without_message_ok() -> None:
+    evt = LyraEvent(**_ENV, service="hub", kind="degraded", level="warn")
+    assert evt.message is None
+
+
+def test_event_invalid_service() -> None:
+    with pytest.raises(ValidationError):
+        LyraEvent(**_ENV, service="Hub", kind="startup", level="info")
+
+
+def test_event_invalid_kind() -> None:
+    with pytest.raises(ValidationError):
+        LyraEvent(**_ENV, service="hub", kind="Startup!", level="info")
+
+
+def test_event_invalid_level() -> None:
+    with pytest.raises(ValidationError):
+        LyraEvent(**_ENV, service="hub", kind="startup", level="verbose")
+
+
+def test_event_extra_fields_ignored() -> None:
+    evt = LyraEvent.model_validate(
+        {
+            **_ENV,
+            "service": "hub",
+            "kind": "startup",
+            "level": "info",
+            "unknown_field": "x",
+        }
+    )
+    assert not hasattr(evt, "unknown_field")
+
+
+# --- LyraMetric ---
+
+
+def test_metric_counter_roundtrip() -> None:
+    m = LyraMetric(
+        **_ENV,
+        service="hub",
+        name="request.count",
+        metric_type="counter",
+        value=1.0,
+        unit="count",
+        labels={"platform": "telegram"},
+    )
+    restored = LyraMetric.model_validate_json(m.model_dump_json())
+    assert restored.service == "hub"
+    assert restored.name == "request.count"
+    assert restored.metric_type == "counter"
+    assert restored.value == 1.0
+    assert restored.unit == "count"
+    assert restored.labels == {"platform": "telegram"}
+
+
+def test_metric_gauge_minimal() -> None:
+    m = LyraMetric(
+        **_ENV, service="llm", name="queue.depth", metric_type="gauge", value=3.0
+    )
+    assert m.unit is None
+    assert m.labels is None
+
+
+def test_metric_histogram_no_labels() -> None:
+    m = LyraMetric(
+        **_ENV,
+        service="hub",
+        name="request.latency",
+        metric_type="histogram",
+        value=42.5,
+        unit="ms",
+    )
+    assert m.labels is None
+    assert m.value == 42.5
+
+
+def test_metric_invalid_service() -> None:
+    with pytest.raises(ValidationError):
+        LyraMetric(
+            **_ENV, service="HUB", name="count", metric_type="counter", value=1.0
+        )
+
+
+def test_metric_invalid_name() -> None:
+    with pytest.raises(ValidationError):
+        LyraMetric(
+            **_ENV, service="hub", name="Count!", metric_type="counter", value=1.0
+        )
+
+
+def test_metric_invalid_type() -> None:
+    with pytest.raises(ValidationError):
+        LyraMetric(
+            **_ENV, service="hub", name="count", metric_type="summary", value=1.0
+        )
+
+
+def test_metric_extra_fields_ignored() -> None:
+    m = LyraMetric.model_validate(
+        {
+            **_ENV,
+            "service": "hub",
+            "name": "count",
+            "metric_type": "counter",
+            "value": 1.0,
+            "unknown_field": "x",
+        }
+    )
+    assert not hasattr(m, "unknown_field")

--- a/packages/roxabi-contracts/tests/test_event_subjects.py
+++ b/packages/roxabi-contracts/tests/test_event_subjects.py
@@ -1,0 +1,51 @@
+"""Tests locking event/metric subject strings and helpers."""
+
+import pytest
+
+from roxabi_contracts.event import SUBJECTS
+from roxabi_contracts.event.subjects import per_service_event, per_service_metric
+
+
+def test_event_all_subject() -> None:
+    assert SUBJECTS.event_all == "lyra.event.>"
+
+
+def test_metric_all_subject() -> None:
+    assert SUBJECTS.metric_all == "lyra.metric.>"
+
+
+def test_per_service_event() -> None:
+    assert per_service_event("hub", "startup") == "lyra.event.hub.startup"
+
+
+def test_per_service_event_nested_kind() -> None:
+    assert per_service_event("llm", "lifecycle.swap") == "lyra.event.llm.lifecycle.swap"
+
+
+def test_per_service_metric() -> None:
+    assert per_service_metric("hub", "request.count") == "lyra.metric.hub.request.count"
+
+
+def test_per_service_event_rejects_dot_in_service() -> None:
+    with pytest.raises(ValueError, match="segment"):
+        per_service_event("hub.prod", "startup")
+
+
+def test_per_service_event_rejects_wildcard() -> None:
+    with pytest.raises(ValueError, match="segment"):
+        per_service_event("hub*", "startup")
+
+
+def test_per_service_metric_rejects_wildcard_in_name() -> None:
+    with pytest.raises(ValueError, match="token"):
+        per_service_metric("hub", "request*count")
+
+
+def test_per_service_metric_rejects_consecutive_dots() -> None:
+    with pytest.raises(ValueError, match="token"):
+        per_service_metric("hub", "request..count")
+
+
+def test_per_service_metric_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="token"):
+        per_service_metric("hub", "")


### PR DESCRIPTION
## Summary
- New `packages/roxabi-contracts/event/` domain with `LyraEvent` + `LyraMetric` envelopes
- Subject helpers with NATS-safe validation (`per_service_event`, `per_service_metric`)
- Fixtures + 26 roundtrip/validation tests

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1181 | Open |
| Implementation | `worktree-1181-event-metric-schemas` | Complete |
| Verification | Lint, Typecheck, Tests | Passed |

## Test Plan
- [ ] `uv run pytest packages/roxabi-contracts/tests/test_event_models.py` — 17 tests
- [ ] `uv run pytest packages/roxabi-contracts/tests/test_event_subjects.py` — 9 tests

Closes #1181

---
Generated with [Claude Code](https://claude.com/claude-code)