### PR TITLE
refactor(deploy): migrate render_quadlet to BotStore + Makefile bot init sequence (#1417)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,14 +159,15 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 	@chmod 0700 "$(HOME)/.lyra/nats/jetstream"
 	@cp deploy/quadlet/lyra-nats.container             "$(QUADLET_DIR)/lyra-nats.container"
 	@cp deploy/quadlet/lyra-hub.container              "$(QUADLET_DIR)/lyra-hub.container"
+	@uv run lyra bot init
 	@uv run python tools/render_quadlet.py \
 		--platform telegram \
-		--config "$(HOME)/.lyra/config.toml" \
+		--db "$(HOME)/.lyra/config.db" \
 		--tmpl deploy/quadlet/lyra-telegram.container.tmpl \
 		--dest "$(QUADLET_DIR)/lyra-telegram.container"
 	@uv run python tools/render_quadlet.py \
 		--platform discord \
-		--config "$(HOME)/.lyra/config.toml" \
+		--db "$(HOME)/.lyra/config.db" \
 		--tmpl deploy/quadlet/lyra-discord.container.tmpl \
 		--dest "$(QUADLET_DIR)/lyra-discord.container"
 	@cp deploy/quadlet/lyra-gh.pod                     "$(QUADLET_DIR)/lyra-gh.pod"

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -109,7 +109,7 @@ the auth middleware and never re-read until the container restarts (ADR-054).
 
 ### (a) No manual splicing
 
-The tracked files `deploy/quadlet/lyra-{telegram,discord}.container.tmpl` are **pure templates** — they contain a `{{bot_secrets}}` marker and zero `Secret=lyra-bot-*` lines. Per-bot `Secret=lyra-bot-<platform>-<bot_id>,…` directives are generated at install time by `tools/render_quadlet.py`, which reads `[[auth.<platform>_bots]]` entries from `~/.lyra/config.toml` and substitutes the rendered block into each template before writing the live Quadlet to `~/.config/containers/systemd/`.
+The tracked files `deploy/quadlet/lyra-{telegram,discord}.container.tmpl` are **pure templates** — they contain a `{{bot_secrets}}` marker and zero `Secret=lyra-bot-*` lines. Per-bot `Secret=lyra-bot-<platform>-<bot_id>,…` directives are generated at install time by `tools/render_quadlet.py`, which reads bot rows from `BotStore` (`~/.lyra/config.db`) and substitutes the rendered block into each template before writing the live Quadlet to `~/.config/containers/systemd/`.
 
 **Never edit `~/.config/containers/systemd/lyra-{telegram,discord}.container` directly.** Any manual change is silently overwritten on the next `make quadlet-install`. This replaces the prior fragment-paste workflow that caused the 2026-05-26 crash-loop cascade (#1369): a `git pull --ff-only` during the #1331 deploy discarded an operator-spliced `BEGIN/END` block, stranding 4 bot-token mounts and forcing 6.5 h of adapter crash-loop before re-splice. Use the onboarding flow in (b) instead.
 
@@ -133,13 +133,18 @@ End-to-end flow for adding a new bot:
    ```
    (Replace `<platform>` with `telegram` or `discord`.)
 
-3. Render and restart:
+3. Seed the bot database from `config.toml` (idempotent — skips existing rows):
+   ```bash
+   lyra bot init
+   ```
+
+4. Render and restart:
    ```bash
    make quadlet-install
    ```
-   The render step reads the updated `config.toml`, generates the `Secret=` directive, writes the new Quadlet atomically, runs `systemctl --user daemon-reload`, then restarts the adapter container.
+   The target runs `lyra bot init` (re-syncs `config.toml` → `BotStore`), then `render_quadlet.py` reads from `BotStore`, generates the `Secret=` directives, writes the new Quadlet atomically, runs `systemctl --user daemon-reload`, then restarts the adapter container.
 
-4. Verify the adapter is healthy:
+5. Verify the adapter is healthy:
    ```bash
    systemctl --user status lyra-<platform>
    ```
@@ -157,7 +162,7 @@ Three artefacts prevent re-introduction of the manual-splice pattern:
 
 ### (d) Multi-host caveat
 
-`~/.lyra/config.toml` is Syncthing-synced across M₁, M₂, and laptop. That means `[[auth.telegram_bots]]` and `[[auth.discord_bots]]` enumerate **all bots across all hosts** in one shared file. The render step reads this file on whichever host runs `make quadlet-install` — so the rendered Quadlet on every host includes `Secret=` lines for every configured bot.
+`~/.lyra/config.toml` is Syncthing-synced across M₁, M₂, and laptop. That means `[[auth.telegram_bots]]` and `[[auth.discord_bots]]` enumerate **all bots across all hosts** in one shared file. `make quadlet-install` runs `lyra bot init` first (seeds `BotStore` from `config.toml`), then `render_quadlet.py` reads from `BotStore` — so the rendered Quadlet on every host includes `Secret=` lines for every configured bot.
 
 However, Podman secrets (`lyra-bot-<platform>-<bot_id>`) are **host-local** and must be installed per host. A mismatch — `config.toml` lists a bot but its Podman secret is absent — causes `systemctl --user start lyra-<platform>` to fail immediately:
 

--- a/tests/scripts/test_render_quadlet.py
+++ b/tests/scripts/test_render_quadlet.py
@@ -1,26 +1,26 @@
-"""RED tests for tools/render_quadlet.py — #1369 T1.
-
-These tests FAIL at collection or execution time because tools/render_quadlet.py
-does not exist yet.  That is the intended RED state.
+"""Tests for tools/render_quadlet.py — BotStore-backed (#1417).
 
 Tests invoke the script as a subprocess:
   python tools/render_quadlet.py --platform <telegram|discord>
-                                  --config <path>
+                                  --db <path>
                                   --tmpl <path>
                                   --dest <path>
 
-No mocking of TOML parsing or filesystem — real tmp_path throughout.
+No mocking of store internals — real tmp_path + BotStore throughout.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import subprocess
 import sys
 import textwrap
 from pathlib import Path
 
-import pytest
+from lyra.core.agent.bot_models import BotRow
+from lyra.infrastructure.stores.bot_store import BotStore
+from tests.helpers.bot_store import db_upsert
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "tools" / "render_quadlet.py"
@@ -28,23 +28,25 @@ SCRIPT = REPO_ROOT / "tools" / "render_quadlet.py"
 # ── fixture helpers ────────────────────────────────────────────────────────────
 
 
-def make_config(tmp_path: Path, bots: list[str] | None = None) -> Path:
-    """Write a minimal config.toml with [[auth.telegram_bots]] entries.
+def make_bot_db(tmp_path: Path, bots: list[BotRow]) -> Path:
+    """Create a BotStore database at tmp_path/config.db and seed it with *bots*."""
+    db_path = tmp_path / "config.db"
+    # Ensure the schema exists even when *bots* is empty
+    _ensure_bot_db(db_path)
+    for bot in bots:
+        db_upsert(db_path, bot)
+    return db_path
 
-    bots: list of bot_id strings.  None → omit the key entirely (no section).
-    Empty list → write an empty inline array (auth.telegram_bots = []).
-    """
-    path = tmp_path / "config.toml"
-    if bots is None:
-        path.write_text("[auth]\n")
-    elif len(bots) == 0:
-        path.write_text("[auth]\ntelegram_bots = []\n")
-    else:
-        lines = ["[auth]\n"]
-        for bot_id in bots:
-            lines.append(f'[[auth.telegram_bots]]\nbot_id = "{bot_id}"\n\n')
-        path.write_text("".join(lines))
-    return path
+
+def _ensure_bot_db(db_path: Path) -> None:
+    """Create an empty BotStore database file with schema."""
+
+    async def _run() -> None:
+        store = BotStore(db_path=str(db_path))
+        await store.connect()
+        await store.close()
+
+    asyncio.run(_run())
 
 
 def make_tmpl(tmp_path: Path, *, with_marker: bool = True) -> Path:
@@ -92,15 +94,18 @@ def test_happy_path(tmp_path: Path) -> None:
 
     Spec trace: A6(a)
     Negative sentinel: if sort_bots is deleted, aryl would appear AFTER lyra
-    (TOML order), breaking the sorted-order assertion.
+    (insertion order), breaking the sorted-order assertion.
     If the marker substitution is skipped, {{bot_secrets}} remains in output,
     breaking the marker-absence assertion.
     """
-    # Arrange
-    # bots listed deliberately out of alphabetical order — lyra before aryl — so that a
-    # missing sort_bots() call would produce out-of-order output and fail the
-    # sort assertion.
-    config = make_config(tmp_path, bots=["lyra", "aryl"])
+    # Arrange — bots deliberately out of alphabetical order (lyra before aryl)
+    db = make_bot_db(
+        tmp_path,
+        bots=[
+            BotRow(platform="telegram", bot_id="lyra", agent="lyra_default"),
+            BotRow(platform="telegram", bot_id="aryl", agent="lyra_default"),
+        ],
+    )
     tmpl = make_tmpl(tmp_path, with_marker=True)
     dest = tmp_path / "lyra-telegram.container"
 
@@ -109,8 +114,8 @@ def test_happy_path(tmp_path: Path) -> None:
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -167,8 +172,8 @@ def test_happy_path(tmp_path: Path) -> None:
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -183,24 +188,22 @@ def test_happy_path(tmp_path: Path) -> None:
 
 
 def test_empty_bots(tmp_path: Path) -> None:
-    """No [[auth.telegram_bots]] entries → marker replaced by empty string, exit 0.
+    """No bots in BotStore → marker replaced by empty string, exit 0.
 
     Spec trace: A6(b)
     Negative sentinel: if the empty-list path is not handled, the renderer might
     leave {{bot_secrets}} in the output or crash with a KeyError/AttributeError.
     """
-    # Arrange — config.toml with empty bot list
-    config = make_config(tmp_path, bots=[])
+    db = make_bot_db(tmp_path, bots=[])
     tmpl = make_tmpl(tmp_path, with_marker=True)
     dest = tmp_path / "lyra-telegram.container"
 
-    # Act
     result = _run_render(
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -208,7 +211,6 @@ def test_empty_bots(tmp_path: Path) -> None:
         ]
     )
 
-    # Assert exit 0
     assert result.returncode == 0, (
         f"Expected exit 0 for empty bot list; got {result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -233,41 +235,6 @@ def test_empty_bots(tmp_path: Path) -> None:
     )
 
 
-def test_missing_bots_key(tmp_path: Path) -> None:
-    """[[auth.telegram_bots]] key absent entirely → same as empty list (exit 0).
-
-    No Secret= lines produced when the key is missing.
-
-    Spec trace: implicit — auth.get(key, []) contract.
-    """
-    # writes [auth]\n only, no telegram_bots key
-    config = make_config(tmp_path, bots=None)
-    tmpl = make_tmpl(tmp_path, with_marker=True)
-    dest = tmp_path / "lyra-telegram.container"
-
-    result = _run_render(
-        [
-            "--platform",
-            "telegram",
-            "--config",
-            str(config),
-            "--tmpl",
-            str(tmpl),
-            "--dest",
-            str(dest),
-        ]
-    )
-
-    assert result.returncode == 0, (
-        f"Expected exit 0 when [[auth.telegram_bots]] key absent; "
-        f"got {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-    assert dest.exists()
-    content = dest.read_text()
-    assert "{{bot_secrets}}" not in content
-    assert "Secret=lyra-bot-telegram-" not in content
-
-
 def test_missing_marker(tmp_path: Path) -> None:
     """Template without {{bot_secrets}} marker → non-zero exit with error message.
 
@@ -276,18 +243,19 @@ def test_missing_marker(tmp_path: Path) -> None:
     silently emit an unchanged template (no bot secrets injected), exit 0, and
     the operator would deploy a broken Quadlet without any signal.
     """
-    # Arrange — template deliberately lacks the marker
-    config = make_config(tmp_path, bots=["lyra"])
+    db = make_bot_db(
+        tmp_path,
+        bots=[BotRow(platform="telegram", bot_id="lyra", agent="lyra_default")],
+    )
     tmpl = make_tmpl(tmp_path, with_marker=False)
     dest = tmp_path / "lyra-telegram.container"
 
-    # Act
     result = _run_render(
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -312,28 +280,24 @@ def test_missing_marker(tmp_path: Path) -> None:
     )
 
 
-def test_missing_config(tmp_path: Path) -> None:
-    """config.toml path that does not exist → non-zero exit with error message.
+def test_missing_db(tmp_path: Path) -> None:
+    """DB path that does not exist → non-zero exit with error message.
 
-    Spec trace: A6(d)
-    Negative sentinel: if the config-not-found guard is deleted, tomllib.load
-    would raise an unhandled FileNotFoundError/OSError, producing an ugly
-    traceback with exit 1 — but the spec requires a CLEAR error message.
-    Removing the guard would still fail this test because we assert on message
-    content, not just exit code.
+    Spec trace: A6(d) — migrated from config.toml to BotStore.
+    Negative sentinel: if the db-not-found guard is deleted, aiosqlite would
+    raise an unhandled error, producing an ugly traceback with exit 1 — but the
+    spec requires a CLEAR error message.
     """
-    # Arrange — point config at a path that does not exist
-    config = tmp_path / "nonexistent-config.toml"
+    db = tmp_path / "nonexistent-config.db"
     tmpl = make_tmpl(tmp_path, with_marker=True)
     dest = tmp_path / "lyra-telegram.container"
 
-    # Act
     result = _run_render(
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -343,7 +307,7 @@ def test_missing_config(tmp_path: Path) -> None:
 
     # Assert non-zero exit
     assert result.returncode != 0, (
-        f"Expected non-zero exit for missing config; got {result.returncode}\n"
+        f"Expected non-zero exit for missing db; got {result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
@@ -352,50 +316,10 @@ def test_missing_config(tmp_path: Path) -> None:
     assert "Traceback" not in combined, (
         f"Expected clean error message; got Python traceback.\nCombined: {combined!r}"
     )
-    assert "config" in combined.lower() or "not found" in combined.lower(), (
-        "Error message must reference the missing config path.\n"
+    assert "database" in combined.lower() or "not found" in combined.lower(), (
+        "Error message must reference the missing db path.\n"
         f"Combined output: {combined!r}"
     )
-
-
-def make_config_with_webhook(
-    tmp_path: Path,
-    bots: list[dict],
-    filename: str = "config.toml",
-    raw_webhook_value: str | None = None,
-    platform: str = "telegram",
-) -> Path:
-    """Write a config.toml supporting arbitrary per-bot fields (e.g. webhook_enabled).
-
-    bots: list of dicts with at least 'bot_id'; may include 'webhook_enabled'.
-    raw_webhook_value: if provided, write this literal TOML text for webhook_enabled
-        on every bot that lacks an explicit 'webhook_enabled' key (e.g. '"yes"', '1',
-        'false', 'true'). Use this for non-bool TOML variants that cannot be
-        represented as Python bool without truthy-coercion.
-    platform: 'telegram' or 'discord' — determines the section name used.
-
-    Raises ValueError if a bot dict provides 'webhook_enabled' with a non-bool value
-    and raw_webhook_value is not set — callers MUST use raw_webhook_value for non-bool
-    TOML literals.
-    """
-    path = tmp_path / filename
-    section = f"auth.{platform}_bots"
-    lines = ["[auth]\n"]
-    for bot in bots:
-        lines.append(f'[[{section}]]\nbot_id = "{bot["bot_id"]}"\n')
-        if raw_webhook_value is not None:
-            lines.append(f"webhook_enabled = {raw_webhook_value}\n")
-        elif "webhook_enabled" in bot:
-            val = bot["webhook_enabled"]
-            if not isinstance(val, bool):
-                raise ValueError(
-                    f"webhook_enabled must be a bool; got {type(val).__name__!r}. "
-                    "Use raw_webhook_value= for non-bool TOML literals."
-                )
-            lines.append(f"webhook_enabled = {'true' if val else 'false'}\n")
-        lines.append("\n")
-    path.write_text("".join(lines))
-    return path
 
 
 def test_webhook_enabled_happy_path(tmp_path: Path) -> None:
@@ -405,8 +329,16 @@ def test_webhook_enabled_happy_path(tmp_path: Path) -> None:
     Negative sentinel: if the webhook branch is absent, only the token line appears
     and the bot_webhook- assertion fails.
     """
-    config = make_config_with_webhook(
-        tmp_path, bots=[{"bot_id": "lyra", "webhook_enabled": True}]
+    db = make_bot_db(
+        tmp_path,
+        bots=[
+            BotRow(
+                platform="telegram",
+                bot_id="lyra",
+                agent="lyra_default",
+                webhook_enabled=True,
+            )
+        ],
     )
     tmpl = make_tmpl(tmp_path, with_marker=True)
     dest = tmp_path / "lyra-telegram.container"
@@ -415,8 +347,8 @@ def test_webhook_enabled_happy_path(tmp_path: Path) -> None:
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -460,15 +392,24 @@ def test_webhook_enabled_happy_path(tmp_path: Path) -> None:
     )
 
 
-def test_webhook_key_absent_no_webhook_line(tmp_path: Path) -> None:
-    """Bot without webhook_enabled key (default false) → only bot_token- line emitted.
+def test_webhook_enabled_false_no_webhook_line(tmp_path: Path) -> None:
+    """Bot with webhook_enabled = False → only bot_token- line emitted.
 
     Spec trace: #1373 regression — default false
     Negative sentinel: if webhook_enabled defaults to True, this test fails on the
     no-webhook-line assertion.
     """
-    # webhook_enabled absent → default false
-    config = make_config(tmp_path, bots=["lyra"])
+    db = make_bot_db(
+        tmp_path,
+        bots=[
+            BotRow(
+                platform="telegram",
+                bot_id="lyra",
+                agent="lyra_default",
+                webhook_enabled=False,
+            )
+        ],
+    )
     tmpl = make_tmpl(tmp_path, with_marker=True)
     dest = tmp_path / "lyra-telegram.container"
 
@@ -476,8 +417,8 @@ def test_webhook_key_absent_no_webhook_line(tmp_path: Path) -> None:
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -492,22 +433,32 @@ def test_webhook_key_absent_no_webhook_line(tmp_path: Path) -> None:
 
     assert "bot_token-lyra" in content, "bot_token- line must be present"
     assert "bot_webhook-lyra" not in content, (
-        "bot_webhook- line must NOT appear when webhook_enabled is false/absent"
+        "bot_webhook- line must NOT appear when webhook_enabled is False"
     )
 
 
 def test_webhook_mixed_bots(tmp_path: Path) -> None:
-    """Bot A (webhook_enabled=true) + Bot B (default false) → webhook only for A.
+    """Bot A (webhook=True) + Bot B (webhook=False) → webhook only for A.
 
     Spec trace: #1373 mixed bots
     Negative sentinel: if webhook_enabled is ignored and always emitted, bot_webhook-b
     appears and the assertion fails.
     """
-    config = make_config_with_webhook(
+    db = make_bot_db(
         tmp_path,
         bots=[
-            {"bot_id": "a", "webhook_enabled": True},
-            {"bot_id": "b"},
+            BotRow(
+                platform="telegram",
+                bot_id="a",
+                agent="lyra_default",
+                webhook_enabled=True,
+            ),
+            BotRow(
+                platform="telegram",
+                bot_id="b",
+                agent="lyra_default",
+                webhook_enabled=False,
+            ),
         ],
     )
     tmpl = make_tmpl(tmp_path, with_marker=True)
@@ -517,8 +468,8 @@ def test_webhook_mixed_bots(tmp_path: Path) -> None:
         [
             "--platform",
             "telegram",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl),
             "--dest",
@@ -542,198 +493,6 @@ def test_webhook_mixed_bots(tmp_path: Path) -> None:
     assert "bot_token-b" in content
 
 
-@pytest.mark.parametrize("string_value", ["yes", "true", "false"])
-def test_webhook_string_value_does_not_emit(tmp_path: Path, string_value: str) -> None:
-    """webhook_enabled = <string> (TOML string, not bool) must NOT emit webhook line.
-
-    Defensive: tomllib produces a str for quoted values; strict `is True` check
-    in render_secrets() must reject non-bool to avoid silent misconfig.
-    Covers "yes", "true", and "false" — all are truthy-ish strings that a
-    loose check would mishandle.
-
-    Spec trace: #1373 F5 follow-on (G16: parametrized)
-    Negative sentinel: if the check were truthy (e.g. `if b.get(...):`), strings
-    "yes" and "true" would incorrectly emit a bot_webhook- line.
-    """
-    config = make_config_with_webhook(
-        tmp_path,
-        bots=[{"bot_id": "lyra"}],
-        raw_webhook_value=f'"{string_value}"',
-        filename=f"config-str-{string_value}.toml",
-    )
-    tmpl = make_tmpl(tmp_path, with_marker=True)
-    dest = tmp_path / f"lyra-telegram-str-{string_value}.container"
-
-    result = _run_render(
-        [
-            "--platform",
-            "telegram",
-            "--config",
-            str(config),
-            "--tmpl",
-            str(tmpl),
-            "--dest",
-            str(dest),
-        ]
-    )
-
-    assert result.returncode == 0, (
-        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
-    )
-    content = dest.read_text()
-
-    # String value must NOT trigger webhook line emission
-    assert "target=bot_webhook-" not in content, (
-        f'webhook_enabled = "{string_value}" (string) must NOT emit a bot_webhook- '
-        f"Secret= line; got:\n{content}"
-    )
-    # Token line must still be emitted normally
-    assert "target=bot_token-lyra" in content, (
-        "bot_token- line must still appear even when webhook_enabled is a string"
-    )
-
-
-def test_toml_syntax_error(tmp_path: Path) -> None:
-    """config.toml with TOML syntax error → non-zero exit, parser error on output.
-
-    Spec trace: A6(e)
-    Negative sentinel: if the TOML parse error is silently swallowed (e.g.
-    bare except: pass), the renderer would produce garbage output and exit 0.
-    Removing the guard causes this test to fail on the returncode assertion.
-    """
-    # Arrange — write a deliberately malformed TOML file (unclosed section header)
-    config = tmp_path / "bad-config.toml"
-    config.write_text(
-        '[auth]\n[[auth.telegram_bots\nbot_id = "lyra"\n'
-    )  # missing closing ]
-    tmpl = make_tmpl(tmp_path, with_marker=True)
-    dest = tmp_path / "lyra-telegram.container"
-
-    # Act
-    result = _run_render(
-        [
-            "--platform",
-            "telegram",
-            "--config",
-            str(config),
-            "--tmpl",
-            str(tmpl),
-            "--dest",
-            str(dest),
-        ]
-    )
-
-    # Assert non-zero exit
-    assert result.returncode != 0, (
-        f"Expected non-zero exit for TOML syntax error; got {result.returncode}\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-
-    # Error output must propagate the underlying TOML parser exception text — clean
-    # message, no raw traceback.
-    combined = result.stdout + result.stderr
-    assert "Traceback" not in combined, (
-        f"Expected clean error message; got Python traceback.\nCombined: {combined!r}"
-    )
-    toml_error_signals = ("TOMLDecodeError", "Invalid", "Expected", "toml", "parse")
-    assert any(sig.lower() in combined.lower() for sig in toml_error_signals), (
-        f"Error output must include TOML parser exception text.\n"
-        f"Combined output: {combined!r}"
-    )
-
-
-def test_webhook_enabled_false_bool_no_emit(tmp_path: Path) -> None:
-    """webhook_enabled = false (explicit bool) → no webhook line, token line present.
-
-    Distinct from test_webhook_key_absent_no_webhook_line: here the key IS present
-    with value false (bool), exercising the explicit-false TOML path separately
-    from the absent-key path.
-
-    Spec trace: #1398 G10
-    Negative sentinel: if the check uses truthiness instead of `is True`, explicit
-    false (bool) still passes (since bool False is falsy), so the test would pass
-    vacuously — but the intent is to confirm the strict-is-True branch handles both
-    absent and explicit-false correctly.
-    """
-    config = make_config_with_webhook(
-        tmp_path, bots=[{"bot_id": "lyra", "webhook_enabled": False}]
-    )
-    tmpl = make_tmpl(tmp_path, with_marker=True)
-    dest = tmp_path / "lyra-telegram.container"
-
-    result = _run_render(
-        [
-            "--platform",
-            "telegram",
-            "--config",
-            str(config),
-            "--tmpl",
-            str(tmpl),
-            "--dest",
-            str(dest),
-        ]
-    )
-
-    assert result.returncode == 0, (
-        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
-    )
-    content = dest.read_text()
-
-    assert "target=bot_webhook-" not in content, (
-        "webhook_enabled = false (explicit bool) must NOT emit a bot_webhook- line;\n"
-        f"got:\n{content}"
-    )
-    assert "target=bot_token-lyra" in content, (
-        "bot_token- line must still be present when webhook_enabled = false"
-    )
-
-
-def test_webhook_enabled_int_does_not_emit(tmp_path: Path) -> None:
-    """webhook_enabled = 1 (TOML integer, not bool) must NOT emit webhook line.
-
-    tomllib distinguishes int from bool: `1` is an int, not True. The strict
-    `is True` check must reject it.
-
-    Spec trace: #1398 G11
-    Negative sentinel: if the check were truthy (`if b.get("webhook_enabled"):`),
-    integer 1 is truthy and would incorrectly emit a bot_webhook- line.
-    """
-    config = make_config_with_webhook(
-        tmp_path,
-        bots=[{"bot_id": "lyra"}],
-        raw_webhook_value="1",
-    )
-    tmpl = make_tmpl(tmp_path, with_marker=True)
-    dest = tmp_path / "lyra-telegram.container"
-
-    result = _run_render(
-        [
-            "--platform",
-            "telegram",
-            "--config",
-            str(config),
-            "--tmpl",
-            str(tmpl),
-            "--dest",
-            str(dest),
-        ]
-    )
-
-    assert result.returncode == 0, (
-        f"Expected exit 0; got {result.returncode}\nstderr: {result.stderr}"
-    )
-    content = dest.read_text()
-
-    assert "target=bot_webhook-" not in content, (
-        "webhook_enabled = 1 (int) must NOT emit a bot_webhook- Secret= line "
-        "(strict `is True` must reject non-bool);\n"
-        f"got:\n{content}"
-    )
-    assert "target=bot_token-lyra" in content, (
-        "bot_token- line must still appear even when webhook_enabled is an int"
-    )
-
-
 def test_webhook_enabled_discord(tmp_path: Path) -> None:
     """Discord bot with webhook_enabled = true → emits bot_webhook- for discord.
 
@@ -746,12 +505,17 @@ def test_webhook_enabled_discord(tmp_path: Path) -> None:
     the platform variable, the discord secret name would contain 'telegram' and the
     expected_webhook assertion would fail.
     """
-    config = make_config_with_webhook(
+    db = make_bot_db(
         tmp_path,
-        bots=[{"bot_id": "lyra", "webhook_enabled": True}],
-        platform="discord",
+        bots=[
+            BotRow(
+                platform="discord",
+                bot_id="lyra",
+                agent="lyra_default",
+                webhook_enabled=True,
+            )
+        ],
     )
-    # Use a discord-named template file (name is cosmetic for the test)
     tmpl_path = tmp_path / "lyra-discord.container.tmpl"
     tmpl_path.write_text(
         "[Unit]\nDescription=lyra-discord adapter\n\n[Container]\n{{bot_secrets}}\n"
@@ -762,8 +526,8 @@ def test_webhook_enabled_discord(tmp_path: Path) -> None:
         [
             "--platform",
             "discord",
-            "--config",
-            str(config),
+            "--db",
+            str(db),
             "--tmpl",
             str(tmpl_path),
             "--dest",

--- a/tools/render_quadlet.py
+++ b/tools/render_quadlet.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
-"""Render Quadlet .container files from .tmpl + ~/.lyra/config.toml.
+"""Render Quadlet .container files from .tmpl + BotStore.
 
 Token in template: {{bot_secrets}}  →  one `Secret=` line per bot.
-Bots come from config.toml [[auth.<platform>_bots]]; sorted by bot_id.
+Bots come from BotStore (~/.lyra/config.db); sorted by bot_id.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import os
 import re
+import sqlite3
 import sys
 import tempfile
-import tomllib
 from pathlib import Path
+
+from lyra.infrastructure.stores.bot_store import BotStore
 
 MARKER = "{{bot_secrets}}"
 _BOT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -29,34 +32,14 @@ def validate_bot_id(bot_id: str, platform: str) -> None:
         sys.exit(1)
 
 
-def load_config(path: Path) -> dict:
-    try:
-        with path.open("rb") as f:
-            return tomllib.load(f)
-    except FileNotFoundError:
-        print(
-            f"config file not found: {path}\n"
-            "Run `lyra agent init` to bootstrap config.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    except tomllib.TOMLDecodeError as exc:
-        print(
-            f"TOML parse error in {path}:\n  {exc}\n"
-            "Fix the syntax error in the config file.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+def sort_bots(bots: list) -> list:
+    return sorted(bots, key=lambda b: b.bot_id)
 
 
-def sort_bots(bots: list[dict]) -> list[dict]:
-    return sorted(bots, key=lambda b: b["bot_id"])
-
-
-def render_secrets(platform: str, bots: list[dict]) -> str:
+def render_secrets(platform: str, bots: list) -> str:
     lines: list[str] = []
-    for b in bots:
-        bot_id = b["bot_id"]
+    for bot in bots:
+        bot_id = bot.bot_id
         lines.append(
             f"Secret=lyra-bot-{platform}-{bot_id},"
             f"type=mount,"
@@ -65,7 +48,7 @@ def render_secrets(platform: str, bots: list[dict]) -> str:
             f"uid=1500,"
             f"gid=1500"
         )
-        if b.get("webhook_enabled") is True:
+        if bot.webhook_enabled is True:
             lines.append(
                 f"Secret=lyra-bot-{platform}-{bot_id}-webhook,"
                 f"type=mount,"
@@ -103,34 +86,48 @@ def atomic_write(dest: Path, content: str) -> None:
         raise
 
 
+async def _load_bots(db_path: Path, platform: str) -> list:
+    try:
+        store = BotStore(db_path=str(db_path))
+        await store.connect()
+    except (OSError, sqlite3.Error) as exc:
+        print(
+            f"Failed to open BotStore at {db_path}:\n  {exc}\n"
+            "Run `lyra bot init` to seed the bot database.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    all_bots = store.get_all()
+    platform_bots = [b for b in all_bots if b.platform == platform]
+    await store.close()
+    return platform_bots
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Render a Quadlet .container file from a template."
     )
     parser.add_argument("--platform", required=True, choices=["telegram", "discord"])
-    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--db", required=True, type=Path)
     parser.add_argument("--tmpl", required=True, type=Path)
     parser.add_argument("--dest", required=True, type=Path)
     args = parser.parse_args(argv)
 
-    config = load_config(args.config)
+    if not args.db.exists():
+        print(
+            f"bot database not found: {args.db}\n"
+            "Run `lyra bot init` to seed the bot database.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    auth = config.get("auth", {})
-    key = f"{args.platform}_bots"
-    raw_bots = auth.get(key, [])
+    bots = asyncio.run(_load_bots(args.db, args.platform))
 
-    for entry in raw_bots:
-        if not isinstance(entry, dict) or "bot_id" not in entry:
-            print(
-                f"config entry under [[auth.{key}]] missing 'bot_id' key: {entry!r}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    for bot in bots:
+        validate_bot_id(bot.bot_id, args.platform)
 
-    for entry in raw_bots:
-        validate_bot_id(entry["bot_id"], args.platform)
-
-    bots = sort_bots(raw_bots)
+    bots = sort_bots(bots)
 
     secrets_block = render_secrets(args.platform, bots)
 


### PR DESCRIPTION
## Summary
- `tools/render_quadlet.py`: reads from BotStore (`--db`) instead of raw TOML (`--config`); typed access to `bot.webhook_enabled`; async `_load_bots()` with clean error messages.
- `Makefile quadlet-install`: inserts `uv run lyra bot init` before `render_quadlet.py` calls to re-sync `config.toml` → `BotStore` before each install.
- `tests/scripts/test_render_quadlet.py`: migrated to BotStore fixture (`make_bot_db` + `db_upsert`); removed obsolete TOML edge-case tests; added `test_missing_db`.
- `docs/QUADLET-DEPLOYMENT.md`: updated bot onboarding flow and multi-host caveat to reflect BotStore as the render data source.

## Idempotency
First prod `make quadlet-install` after merge will run `lyra bot init`, seeding existing `config.toml` bots into `~/.lyra/config.db`, then render from BotStore — zero manual intervention.

## Test plan
- [x] `tests/scripts/test_render_quadlet.py` — 8/8 passed
- [x] `tests/cli/test_bot_secret.py::TestE2EV1RedGate` — passed
- [x] `tests/cli/` — 108/108 passed
- [x] `ruff check` clean on all modified files

Closes #1417