### PR TITLE
fix(nats): grant voice-client publish to lyra.voice.tts.request

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -42,7 +42,7 @@ The row will grant `subscribe: lyra.typing.>` to `code-worker` (it consumes typi
 | `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — |
 | `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — |
 | `_inbox.turn-writer.>` | — | — | — | — | — | — | — | — | — | — | PUB+SUB |
-| `_inbox.voice-client.>` | — | — | — | — | PUB | — | — | — | — | SUB | — |
+| `_inbox.voice-client.>` | — | — | — | PUB | PUB | — | — | — | — | SUB | — |
 | `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — |
 | `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — |
 | `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — | — |
@@ -68,7 +68,7 @@ The row will grant `subscribe: lyra.typing.>` to `code-worker` (it consumes typi
 | `lyra.voice.stt.request` | — | — | — | — | SUB | — | — | — | — | PUB | — |
 | `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — | — |
 | `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — | — |
-| `lyra.voice.tts.request` | — | — | — | SUB | — | — | — | — | — | — | — |
+| `lyra.voice.tts.request` | — | — | — | SUB | — | — | — | — | — | PUB | — |
 | `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — | — |
 <!-- acl-matrix:end -->
 

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -6,7 +6,8 @@
     { "requester": "hub", "responder": "voice-stt",      "subject": "lyra.voice.stt.request.>" },
     { "requester": "hub", "responder": "llm-worker",     "subject": "lyra.llm.generate.request" },
     { "requester": "hub", "responder": "image-worker",   "subject": "lyra.image.generate.request" },
-    { "requester": "voice-client", "responder": "voice-stt", "subject": "lyra.voice.stt.request" }
+    { "requester": "voice-client", "responder": "voice-stt", "subject": "lyra.voice.stt.request" },
+    { "requester": "voice-client", "responder": "voice-tts", "subject": "lyra.voice.tts.request" }
   ],
   "identities": {
     "hub": {
@@ -219,10 +220,11 @@
       "status": "active",
       "created_at": "2026-04-29",
       "owner": "voicecli",
-      "description": "VoiceCLI dictate client — sends STT requests from local mic to remote voice-stt worker. Inbox normalized to _inbox.voice-client.> (ADR-051). Inbox grant derived from request_reply_flows.",
+      "description": "VoiceCLI dictate (STT) and generate --via-nats (TTS) client — sends requests from local host to remote voice-stt / voice-tts workers. Inbox normalized to _inbox.voice-client.> (ADR-051). Inbox grant derived from request_reply_flows. TTS publish added 2026-05-27 (#1462) to unblock voiceCLI #178.",
       "allow_responses": true,
       "publish": [
-        "lyra.voice.stt.request"
+        "lyra.voice.stt.request",
+        "lyra.voice.tts.request"
       ],
       "subscribe": [
         "_inbox.voice-client.>"

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -44,7 +44,7 @@ authorization {
       nkey: "UDETVOICETTS"
       # voice-tts
       permissions: {
-        publish:   { allow: ["lyra.voice.tts.heartbeat","lyra.system.ready","$JS.API.>","_inbox.hub.>"] }
+        publish:   { allow: ["lyra.voice.tts.heartbeat","lyra.system.ready","$JS.API.>","_inbox.hub.>","_inbox.voice-client.>"] }
         subscribe: { allow: ["lyra.voice.tts.request","lyra.voice.tts.request.>","_inbox.voice-tts.>","$KV.lyra-state.>"] }
         allow_responses: true
       }
@@ -104,7 +104,7 @@ authorization {
       nkey: "UDETVOICECLIENT"
       # voice-client
       permissions: {
-        publish:   { allow: ["lyra.voice.stt.request"] }
+        publish:   { allow: ["lyra.voice.stt.request","lyra.voice.tts.request"] }
         subscribe: { allow: ["_inbox.voice-client.>"] }
         allow_responses: true
       }


### PR DESCRIPTION
## Summary
- Mirror the existing STT flow for TTS: the `voice-client` NKey was provisioned at #689 for `voicecli dictate nats` (STT only), but the new TTS NATS client landed in voiceCLI #178 needs the same publish access on the TTS request subject. Without this, `voicecli generate --via-nats` fails with `permissions violation for publish to "lyra.voice.tts.request"`.
- Edit `deploy/nats/acl-matrix.json` SSoT (1 new flow entry + 1 publish line) and regenerate `deploy/nats/auth.conf` to match.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1462: fix(nats): grant voice-client publish to lyra.voice.tts.request + inbox reply path | Open |
| Implementation | 1 commit on `fix/1462-voice-client-tts-acl` | Complete |
| Verification | `lyra-acl check flows` ✅ (7 flows) · `lyra-acl check retired` ✅ · `lyra-acl genkeys --template-only` matches expected delta | Passed |

S-tier — no spec/plan artifacts.

## What changed

| File | Change |
|---|---|
| `deploy/nats/acl-matrix.json` | +1 `request_reply_flows` entry (`voice-client → voice-tts`); `voice-client.publish` gains `lyra.voice.tts.request`; description updated to mention TTS path |
| `deploy/nats/auth.conf` | regenerated — `voice-client.publish` adds `lyra.voice.tts.request`; `voice-tts.publish` auto-derives `_inbox.voice-client.>` from the new flow (same pattern as `voice-stt.publish`) |

Diff size: +7 / −5 lines across 2 files.

## Why this is minimal

Inbox grants are auto-derived from `request_reply_flows` by the generator (`lyra-acl genkeys`). Adding the single flow entry covers:
- `voice-client.publish += lyra.voice.tts.request` (explicit, matches the STT-side pattern)
- `voice-tts.publish += _inbox.voice-client.>` (auto-derived for reply path)
- `voice-stt` untouched (existing STT flow preserved)

## Test Plan
- [x] `uv run lyra-acl check flows` → `OK (7 flows)`
- [x] `uv run lyra-acl check retired` → `ok — acl-matrix lifecycle fields valid`
- [x] `uv run lyra-acl genkeys --template-only` → diff matches expected
- [x] Pre-commit hooks (lint/typecheck/file-length/import-layers/etc.) all pass
- [ ] CI green on this PR
- [ ] After merge → `make nats-regen-authconf` on M₁ (refresh secret + restart NATS + clients)
- [ ] Smoke: `voicecli generate --via-nats "Bonjour"` from M₂ → WAV lands in `~/.voicecli/TTS/voices_out/`
- [ ] No STT regression: `voicecli dictate nats` still works

## Pre-existing test note

`tests/nats/test_gen_nkeys_acls.sh` fails `FAIL (a): expected 10 identity blocks, got 7` — this is a stale hardcoded expectation on `origin/staging` HEAD (test uses old identity names like `tts-adapter`, `stt-adapter` that have been renamed to `voice-tts`, `voice-stt`). Verified by running the same test on a clean staging checkout — same failure. Not introduced by this PR.

## Deploy

After merge to staging → after promote to main → on M₁:

```bash
make nats-regen-authconf  # refreshes lyra-nats-auth secret + restarts lyra-nats + clients
```

## Unblocks

- voiceCLI PR #178 (TTS NATS client) — code is correct and merged on staging, but blocked by this ACL gap from end-to-end functioning.

Closes #1462

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`