### PR TITLE
feat(voice): #1067 BlobRef wiring for STT/TTS workers

### DIFF
--- a/src/lyra/core/hub/middleware/middleware_stt.py
+++ b/src/lyra/core/hub/middleware/middleware_stt.py
@@ -113,8 +113,7 @@ class SttMiddleware:
 
         try:
             result = await asyncio.wait_for(
-                # blob_ref → bytes resolution lands in #1067; transitional placeholder.
-                hub._stt.transcribe(b"", msg.audio.mime_type),
+                hub._stt.transcribe(msg.audio.blob_ref, msg.audio.mime_type),
                 timeout=timeout_s,
             )
         except asyncio.TimeoutError:

--- a/src/lyra/core/ports/stt.py
+++ b/src/lyra/core/ports/stt.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
+from roxabi_contracts import BlobRef
+
 
 @runtime_checkable
 class STTProtocol(Protocol):
-    async def transcribe(self, audio: bytes, mime: str) -> "TranscriptionResult": ...
+    async def transcribe(
+        self, audio: BlobRef | bytes, mime: str
+    ) -> "TranscriptionResult": ...
 
 
 @dataclass

--- a/src/lyra/core/ports/tts.py
+++ b/src/lyra/core/ports/tts.py
@@ -30,11 +30,10 @@ class TtsProtocol(Protocol):
 
 @dataclass
 class SynthesisResult:
-    audio_bytes: bytes
+    blob_ref: BlobRef
     mime_type: str
     duration_ms: int | None  # None if WAV header unreadable
     waveform_b64: str | None = field(default=None)  # 256-byte amplitude array, base64
-    blob_ref: BlobRef | None = field(default=None)
     error: str = field(default="")  # non-empty on codec decode failure
 
 

--- a/src/lyra/core/tts_dispatch.py
+++ b/src/lyra/core/tts_dispatch.py
@@ -245,12 +245,6 @@ class AudioPipeline:
                 voice=voice,
                 fallback_language=fallback_language,
             )
-            if result.blob_ref is None:
-                log.warning(
-                    "TTS result missing blob_ref for msg id=%s — dropping audio",
-                    msg.id,
-                )
-                return
             audio = OutboundAudio(
                 blob_ref=result.blob_ref,
                 mime_type=result.mime_type,

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from lyra.core.ports.stt import STTNoiseError, STTUnavailableError, TranscriptionResult
 from lyra.nats.nats_stt_codec import SttEncodeParams
 from lyra.nats.stt_helpers import is_whisper_noise
+from roxabi_contracts import BlobRef
 from roxabi_contracts.voice import per_worker_stt
 
 if TYPE_CHECKING:
@@ -49,9 +50,21 @@ class NatsSttClient:
     def is_available(self) -> bool:
         return self._pool.is_pool_alive()
 
-    async def transcribe(self, audio: bytes, mime: str) -> TranscriptionResult:
+    async def transcribe(
+        self, audio: BlobRef | bytes, mime: str
+    ) -> TranscriptionResult:
         params = SttEncodeParams(model=self._model)
-        payload = self._codec.encode(audio, mime, params)
+        if isinstance(audio, bytes):
+            blob_ref = BlobRef(
+                store_key="",
+                content_hash="",
+                mime=mime,
+                size=len(audio),
+                source="lyra-hub",
+            )
+        else:
+            blob_ref = audio
+        payload = self._codec.encode(blob_ref, mime, params)
         result = await self._pool.request_with_routing(
             per_worker_stt, payload, max_attempts=None
         )

--- a/src/lyra/nats/nats_stt_client.py
+++ b/src/lyra/nats/nats_stt_client.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from lyra.core.ports.stt import STTNoiseError, STTUnavailableError, TranscriptionResult
 from lyra.nats.nats_stt_codec import SttEncodeParams
 from lyra.nats.stt_helpers import is_whisper_noise
-from roxabi_contracts import BlobRef
+from roxabi_contracts import PENDING_STORE_KEY, BlobRef
 from roxabi_contracts.voice import per_worker_stt
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ class NatsSttClient:
         params = SttEncodeParams(model=self._model)
         if isinstance(audio, bytes):
             blob_ref = BlobRef(
-                store_key="",
+                store_key=PENDING_STORE_KEY,
                 content_hash="",
                 mime=mime,
                 size=len(audio),

--- a/src/lyra/nats/nats_stt_codec.py
+++ b/src/lyra/nats/nats_stt_codec.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 
 from lyra.core.ports.stt import TranscriptionResult
 from lyra.transport._result import Err, Result, SanitizedError
-from roxabi_contracts import PENDING_STORE_KEY, BlobRef
+from roxabi_contracts import BlobRef
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.voice import SttRequest, SttResponse
 
@@ -41,7 +41,7 @@ class SttCodec:
     decode: maps Result[bytes, SanitizedError] → TranscriptionResult; never raises.
     """
 
-    def encode(self, audio: bytes, mime: str, params: SttEncodeParams) -> bytes:
+    def encode(self, blob_ref: BlobRef, mime: str, params: SttEncodeParams) -> bytes:
         """Build canonical SttRequest payload bytes.
 
         Mirrors NatsSttClient.transcribe() payload-builder exactly so the wire
@@ -52,13 +52,7 @@ class SttCodec:
             trace_id=str(uuid4()),
             issued_at=datetime.now(timezone.utc),
             request_id=str(uuid4()),
-            blob_ref=BlobRef(
-                store_key=PENDING_STORE_KEY,
-                content_hash="",
-                mime=mime,
-                size=len(audio),
-                source="lyra-hub",
-            ),
+            blob_ref=blob_ref,
             mime_type=mime,
             model=params.model,
             language_detection_threshold=params.language_detection_threshold,

--- a/src/lyra/nats/nats_tts_codec.py
+++ b/src/lyra/nats/nats_tts_codec.py
@@ -17,6 +17,8 @@ from pydantic import ValidationError
 
 from lyra.core.ports.tts import SynthesisResult
 from lyra.transport._result import Err, Result, SanitizedError
+from roxabi_contracts import BlobRef
+from roxabi_contracts.blob_ref import PENDING_STORE_KEY
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.voice import TtsRequest, TtsResponse
 from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS
@@ -25,6 +27,15 @@ if TYPE_CHECKING:
     from lyra.core.agent.agent_config import AgentTTSConfig
 
 log = logging.getLogger(__name__)
+
+# Sentinel BlobRef for error paths where no real blob was produced.
+_SENTINEL_BLOB_REF = BlobRef(
+    store_key=PENDING_STORE_KEY,
+    content_hash="",
+    mime="",
+    size=0,
+    source="",
+)
 
 
 class TtsCodec:
@@ -76,7 +87,7 @@ class TtsCodec:
         if isinstance(result, Err):
             err = result.error
             return SynthesisResult(
-                audio_bytes=b"",
+                blob_ref=_SENTINEL_BLOB_REF,
                 mime_type="",
                 duration_ms=None,
                 error=err.code,
@@ -86,22 +97,21 @@ class TtsCodec:
         except (ValidationError, ValueError) as exc:
             log.warning("TtsCodec.decode: validation error: %r", exc)
             return SynthesisResult(
-                audio_bytes=b"",
+                blob_ref=_SENTINEL_BLOB_REF,
                 mime_type="",
                 duration_ms=None,
                 error="decode.validation_error",
             )
         if not resp.ok:
             return SynthesisResult(
-                audio_bytes=b"",
+                blob_ref=_SENTINEL_BLOB_REF,
                 mime_type="",
                 duration_ms=None,
                 error=resp.error or "tts.worker_error",
             )
         return SynthesisResult(
-            audio_bytes=b"",
+            blob_ref=resp.blob_ref,  # type: ignore[arg-type]
             mime_type=resp.mime_type,  # type: ignore[arg-type]
             duration_ms=resp.duration_ms,  # type: ignore[arg-type]
             waveform_b64=resp.waveform_b64,
-            blob_ref=resp.blob_ref,
         )

--- a/src/lyra/nats/stt_helpers.py
+++ b/src/lyra/nats/stt_helpers.py
@@ -16,7 +16,7 @@ def mime_from_suffix(suffix: str) -> str:
     """Map a file extension (with leading dot) to its audio MIME type.
 
     Callers that receive audio as a file path (e.g. attachment handlers) use this
-    to derive the MIME type before calling STTProtocol.transcribe(audio, mime).
+    to derive the MIME type before calling STTProtocol.transcribe(blob_ref, mime).
     """
     return {
         ".ogg": "audio/ogg",

--- a/tests/adapters/test_telegram_voice.py
+++ b/tests/adapters/test_telegram_voice.py
@@ -237,6 +237,7 @@ def test_normalize_audio_voice_fields() -> None:
     assert result.audio.file_id == "F1"
     from roxabi_contracts import PENDING_STORE_KEY
 
+    assert result.audio.blob_ref is not None
     assert result.audio.blob_ref.store_key == PENDING_STORE_KEY
     assert result.audio.blob_ref.size == len(b"data")
     assert result.audio.blob_ref.source == "telegram"

--- a/tests/core/test_audio_pipeline_tts.py
+++ b/tests/core/test_audio_pipeline_tts.py
@@ -52,10 +52,9 @@ class TestSynthesizeDispatchAgentTTS:
         mock_tts = MagicMock()
         mock_tts.synthesize = AsyncMock(
             return_value=SynthesisResult(
-                audio_bytes=b"fake",
+                blob_ref=make_test_blobref(b"fake"),
                 mime_type="audio/ogg",
                 duration_ms=100,
-                blob_ref=make_test_blobref(b"fake"),
             )
         )
 
@@ -93,10 +92,9 @@ class TestSynthesizeDispatchAgentTTS:
         mock_tts = MagicMock()
         mock_tts.synthesize = AsyncMock(
             return_value=SynthesisResult(
-                audio_bytes=b"fake",
+                blob_ref=make_test_blobref(b"fake"),
                 mime_type="audio/ogg",
                 duration_ms=100,
-                blob_ref=make_test_blobref(b"fake"),
             )
         )
 
@@ -262,10 +260,9 @@ class TestDispatchResponseAgentTTSE2E:
         mock_tts = MagicMock()
         mock_tts.synthesize = AsyncMock(
             return_value=SynthesisResult(
-                audio_bytes=b"audio",
+                blob_ref=make_test_blobref(b"audio"),
                 mime_type="audio/ogg",
                 duration_ms=100,
-                blob_ref=make_test_blobref(b"audio"),
             )
         )
         hub._tts = mock_tts

--- a/tests/fixtures/fake_drivers.py
+++ b/tests/fixtures/fake_drivers.py
@@ -48,9 +48,6 @@ class FakeTts:
             raise self.raise_on_synthesize
 
         return SynthesisResult(
-            audio_bytes=self._audio_bytes,
-            mime_type="audio/wav",
-            duration_ms=100,
             blob_ref=BlobRef(
                 store_key="test-blob",
                 content_hash="deadbeef",
@@ -58,6 +55,8 @@ class FakeTts:
                 size=len(self._audio_bytes),
                 source="test",
             ),
+            mime_type="audio/wav",
+            duration_ms=100,
         )
 
 
@@ -71,11 +70,13 @@ class FakeStt:
 
     preset_transcript: str = "Hello world"
     called: bool = False
-    last_audio: bytes = field(default_factory=bytes)
+    last_audio: BlobRef | bytes = field(default_factory=bytes)
     last_mime: str = ""
     raise_on_transcribe: Exception | None = None
 
-    async def transcribe(self, audio: bytes, mime: str) -> TranscriptionResult:
+    async def transcribe(
+        self, audio: BlobRef | bytes, mime: str
+    ) -> TranscriptionResult:
         """Return preset transcript or raise if configured."""
         self.called = True
         self.last_audio = audio

--- a/tests/fixtures/test_fake_drivers.py
+++ b/tests/fixtures/test_fake_drivers.py
@@ -11,6 +11,14 @@ from lyra.core.agent.agent_config import ModelConfig
 from lyra.core.messaging.events import ResultLlmEvent, TextLlmEvent
 from lyra.core.ports.stt import TranscriptionResult
 from lyra.core.ports.tts import SynthesisResult
+from roxabi_contracts import BlobRef
+
+_FAKE_BLOB = BlobRef(
+    store_key="test", content_hash="deadbeef", mime="audio/wav", size=0, source="test"
+)
+_FAKE_BLOB_OGG = BlobRef(
+    store_key="test", content_hash="deadbeef", mime="audio/ogg", size=0, source="test"
+)
 
 
 class TestFakeTts:
@@ -35,7 +43,8 @@ class TestFakeTts:
         assert tts.last_text == "Test text"
         assert tts.last_voice == "alloy"
         assert isinstance(result, SynthesisResult)
-        assert result.audio_bytes == tts._audio_bytes
+        assert result.blob_ref is not None
+        assert result.blob_ref.size == len(tts._audio_bytes)
 
     @pytest.mark.asyncio
     async def test_fake_tts_returns_synthesis_result(self) -> None:
@@ -77,7 +86,8 @@ class TestFakeTts:
 
         assert tts.called is True
         assert tts.last_text == ""
-        assert result.audio_bytes == tts._audio_bytes
+        assert result.blob_ref is not None
+        assert result.blob_ref.size == len(tts._audio_bytes)
 
     @pytest.mark.asyncio
     async def test_fake_tts_handles_none_voice(self) -> None:
@@ -87,7 +97,8 @@ class TestFakeTts:
         result = await tts.synthesize("Test text", voice=None)
 
         assert tts.last_voice == ""
-        assert result.audio_bytes == tts._audio_bytes
+        assert result.blob_ref is not None
+        assert result.blob_ref.size == len(tts._audio_bytes)
 
 
 class TestFakeStt:
@@ -105,7 +116,7 @@ class TestFakeStt:
         """Should return configured preset transcript."""
         stt = FakeStt(preset_transcript="Custom transcript")
 
-        result = await stt.transcribe(b"fake audio", "audio/wav")
+        result = await stt.transcribe(_FAKE_BLOB, "audio/wav")
 
         assert isinstance(result, TranscriptionResult)
         assert result.text == "Custom transcript"
@@ -116,27 +127,27 @@ class TestFakeStt:
         """Should record audio and mime from transcribe call."""
         stt = FakeStt()
 
-        await stt.transcribe(b"audio data", "audio/wav")
+        await stt.transcribe(_FAKE_BLOB, "audio/wav")
 
         assert stt.called is True
-        assert stt.last_audio == b"audio data"
+        assert stt.last_audio == _FAKE_BLOB
         assert stt.last_mime == "audio/wav"
 
     @pytest.mark.asyncio
-    async def test_fake_stt_records_audio_bytes(self) -> None:
-        """Should record audio bytes passed directly."""
+    async def test_fake_stt_records_audio_blob(self) -> None:
+        """Should record audio BlobRef passed directly."""
         stt = FakeStt()
 
-        await stt.transcribe(b"fake audio data here", "audio/wav")
+        await stt.transcribe(_FAKE_BLOB, "audio/wav")
 
-        assert stt.last_audio == b"fake audio data here"
+        assert stt.last_audio == _FAKE_BLOB
 
     @pytest.mark.asyncio
     async def test_fake_stt_records_mime(self) -> None:
         """Should record the mime type passed to transcribe."""
         stt = FakeStt()
 
-        await stt.transcribe(b"\x00" * 16, "audio/ogg")
+        await stt.transcribe(_FAKE_BLOB_OGG, "audio/ogg")
 
         assert stt.last_mime == "audio/ogg"
 
@@ -146,7 +157,7 @@ class TestFakeStt:
         stt = FakeStt(raise_on_transcribe=RuntimeError("STT unavailable"))
 
         with pytest.raises(RuntimeError, match="STT unavailable"):
-            await stt.transcribe(b"fake audio", "audio/wav")
+            await stt.transcribe(_FAKE_BLOB, "audio/wav")
 
         assert stt.called is True  # Call was recorded before raise
 
@@ -155,7 +166,7 @@ class TestFakeStt:
         """Should accept any mime type string."""
         stt = FakeStt(preset_transcript="mime test")
 
-        result = await stt.transcribe(b"ogg data", "audio/ogg")
+        result = await stt.transcribe(_FAKE_BLOB_OGG, "audio/ogg")
 
         assert result.text == "mime test"
         assert stt.last_mime == "audio/ogg"

--- a/tests/nats/test_nats_stt_client.py
+++ b/tests/nats/test_nats_stt_client.py
@@ -9,6 +9,7 @@ import pytest
 from lyra.core.ports.stt import STTNoiseError, STTUnavailableError, TranscriptionResult
 from lyra.nats.nats_stt_client import NatsSttClient
 from lyra.transport._result import Err, Ok, SanitizedError
+from roxabi_contracts import BlobRef
 
 
 def _make_pool(*, alive: bool = True) -> MagicMock:
@@ -27,6 +28,9 @@ def _make_codec(tr: TranscriptionResult) -> MagicMock:
 
 
 WAV_BYTES = b"RIFF$\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x00\x00"
+WAV_BLOB = BlobRef(
+    store_key="test", content_hash="abc123", mime="audio/wav", size=36, source="test"
+)
 
 
 class TestNatsSttClientAvailability:
@@ -51,7 +55,7 @@ class TestNatsSttClientTranscribe:
         pool.request_with_routing = AsyncMock(return_value=Ok(b"raw"))
         codec = _make_codec(expected)
         client = NatsSttClient(pool, codec)
-        result = await client.transcribe(WAV_BYTES, "audio/wav")
+        result = await client.transcribe(WAV_BLOB, "audio/wav")
         assert result.text == "hello"
         assert result.language == "en"
 
@@ -65,7 +69,7 @@ class TestNatsSttClientTranscribe:
         codec = _make_codec(err_tr)
         client = NatsSttClient(pool, codec)
         with pytest.raises(STTUnavailableError, match="stt.worker_error"):
-            await client.transcribe(WAV_BYTES, "audio/wav")
+            await client.transcribe(WAV_BLOB, "audio/wav")
 
     @pytest.mark.asyncio
     async def test_pool_err_propagates_via_codec_decode(self) -> None:
@@ -82,7 +86,7 @@ class TestNatsSttClientTranscribe:
         codec = _make_codec(err_tr)
         client = NatsSttClient(pool, codec)
         with pytest.raises(STTUnavailableError, match="pool.no_live_workers"):
-            await client.transcribe(WAV_BYTES, "audio/wav")
+            await client.transcribe(WAV_BLOB, "audio/wav")
 
     @pytest.mark.asyncio
     async def test_noise_transcript_raises_noise_error(self) -> None:
@@ -94,7 +98,7 @@ class TestNatsSttClientTranscribe:
         codec = _make_codec(noise_tr)
         client = NatsSttClient(pool, codec)
         with pytest.raises(STTNoiseError):
-            await client.transcribe(WAV_BYTES, "audio/wav")
+            await client.transcribe(WAV_BLOB, "audio/wav")
 
     @pytest.mark.asyncio
     async def test_model_passed_to_encode_via_params(self) -> None:
@@ -103,9 +107,9 @@ class TestNatsSttClientTranscribe:
         pool.request_with_routing = AsyncMock(return_value=Ok(b"raw"))
         codec = _make_codec(ok_tr)
         client = NatsSttClient(pool, codec, model="tiny")
-        await client.transcribe(WAV_BYTES, "audio/wav")
+        await client.transcribe(WAV_BLOB, "audio/wav")
         call_args = codec.encode.call_args
-        assert call_args.args[0] == WAV_BYTES  # audio
+        assert call_args.args[0] == WAV_BLOB  # audio
         assert call_args.args[1] == "audio/wav"  # mime
         params = call_args.args[2]
         assert params.model == "tiny"

--- a/tests/nats/test_nats_tts_client.py
+++ b/tests/nats/test_nats_tts_client.py
@@ -9,6 +9,11 @@ import pytest
 from lyra.core.ports.tts import SynthesisResult, TtsUnavailableError
 from lyra.nats.nats_tts_client import NatsTtsClient
 from lyra.transport._result import Err, Ok, SanitizedError
+from roxabi_contracts import BlobRef
+
+_FAKE_BLOB = BlobRef(
+    store_key="test", content_hash="deadbeef", mime="audio/ogg", size=4, source="test"
+)
 
 
 def _make_pool(*, alive: bool = True) -> MagicMock:
@@ -42,20 +47,23 @@ class TestNatsTtsClientSynthesize:
     @pytest.mark.asyncio
     async def test_success_returns_synth_result(self) -> None:
         expected = SynthesisResult(
-            audio_bytes=b"audio", mime_type="audio/ogg", duration_ms=100
+            blob_ref=_FAKE_BLOB, mime_type="audio/ogg", duration_ms=100
         )
         pool = _make_pool()
         pool.request_with_routing = AsyncMock(return_value=Ok(b"raw"))
         codec = _make_codec(expected)
         client = NatsTtsClient(pool, codec)
         result = await client.synthesize("hello")
-        assert result.audio_bytes == b"audio"
+        assert result.blob_ref == _FAKE_BLOB
         assert result.mime_type == "audio/ogg"
 
     @pytest.mark.asyncio
     async def test_codec_error_raises_tts_unavailable(self) -> None:
         err_synth = SynthesisResult(
-            audio_bytes=b"", mime_type="", duration_ms=None, error="tts.worker_error"
+            blob_ref=_FAKE_BLOB,
+            mime_type="",
+            duration_ms=None,
+            error="tts.worker_error",
         )
         pool = _make_pool()
         pool.request_with_routing = AsyncMock(return_value=Ok(b"raw"))
@@ -72,7 +80,7 @@ class TestNatsTtsClientSynthesize:
             )
         )
         err_synth = SynthesisResult(
-            audio_bytes=b"",
+            blob_ref=_FAKE_BLOB,
             mime_type="",
             duration_ms=None,
             error="pool.no_live_workers",
@@ -87,7 +95,7 @@ class TestNatsTtsClientSynthesize:
     @pytest.mark.asyncio
     async def test_encode_called_with_correct_args(self) -> None:
         ok_synth = SynthesisResult(
-            audio_bytes=b"x", mime_type="audio/ogg", duration_ms=10
+            blob_ref=_FAKE_BLOB, mime_type="audio/ogg", duration_ms=10
         )
         pool = _make_pool()
         pool.request_with_routing = AsyncMock(return_value=Ok(b"raw"))


### PR DESCRIPTION
## Summary
- STT/TTS ports now exchange audio via BlobRef instead of inline bytes
- SttMiddleware passes msg.audio.blob_ref to STT (line 117 placeholder removed)
- SynthesisResult removes audio_bytes; blob_ref is now required
- Backward-compatible bytes overload preserved for attachment path

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1067: feat(voice): STT/TTS workers consume/produce BlobRef — cross-repo coord | OPEN |
| Spec | [1067-voice-blobref-workers-spec.mdx](artifacts/specs/1067-voice-blobref-workers-spec.mdx) | Present |
| Implementation | 1 commit on `feat/1067-voice-blobref-workers` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4671 passed) | Passed |

## Test Plan
- [ ] STT voice messages flow through pipeline with BlobRef
- [ ] TTS synthesis returns SynthesisResult with blob_ref
- [ ] Attachment path (simple_agent_prompts) still works with bytes overload
- [ ] All existing tests pass (4671 passed, 14 skipped)

Closes #1067

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`