### PR TITLE
feat(tools): add check_single_write_tool_display_config.sh pre-push gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,13 @@ repos:
     pass_filenames: false
     stages:
     - pre-push
+  - id: check-single-write-tool-display-config
+    name: check-single-write-tool-display-config
+    entry: tools/check_single_write_tool_display_config.sh
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push
   - id: license
     name: license check
     entry: uv run tools/license_check.py

--- a/tools/check_single_write_tool_display_config.sh
+++ b/tools/check_single_write_tool_display_config.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# ADR-073: emitter.tool_display_config must only be written in _base_outbound.py
+# Pre-push gate — analogous to check_outbound_str_exc.sh
+
+hits=$(grep -rn "\.tool_display_config\s*=" src/ --include="*.py" | grep -v "_base_outbound.py:")
+if [ -n "$hits" ]; then
+    echo "ADR-073 violation: emitter.tool_display_config = … must only appear in _base_outbound.py"
+    echo "$hits"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `tools/check_single_write_tool_display_config.sh` to enforce ADR-073 single-WRITE-site invariant for `emitter.tool_display_config`.
- Wire into `.pre-commit-config.yaml` as a `pre-push` hook.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1466: tools: add check_single_write_tool_display_config.sh pre-push gate | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1466-tools-add-check_single_write_tool_display_configsh-pre-push-gate` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests N/A (0 new) | Passed |

## Test Plan
- [ ] Run `tools/check_single_write_tool_display_config.sh` locally — should pass with current code.
- [ ] Verify `.pre-commit-config.yaml` syntax is valid (`pre-commit` hooks pass).
- [ ] Introduce a fake `.tool_display_config =` in a non-`_base_outbound.py` file and confirm the script fails.

Closes #1466

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`