### PR TITLE
fix(tests): pytest.skip → pytest.fail on missing acl-matrix.json

### DIFF
--- a/tests/nats/test_ops_verify_matrix_drift.py
+++ b/tests/nats/test_ops_verify_matrix_drift.py
@@ -159,7 +159,10 @@ def test_real_matrix_has_no_drift() -> None:
     all lyra-owned identities.  Failing this test means a regression was
     introduced into deploy/nats/acl-matrix.json."""
     if not _MATRIX_PATH.exists():
-        pytest.skip(f"matrix file not found: {_MATRIX_PATH}")
+        pytest.fail(
+            f"matrix file not found: {_MATRIX_PATH}"
+            " — committed artefact, absence is a regression"
+        )
     identities = _load_matrix(_MATRIX_PATH)
     findings = audit_matrix_inbox_drift(identities)
     assert findings == [], (


### PR DESCRIPTION
## Summary
- Replace `pytest.skip` with `pytest.fail` in `test_real_matrix_has_no_drift` when the committed `acl-matrix.json` is missing.
- Prevents silent passes of the NATS ACL audit if the file is ever deleted or moved.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1275: test(nats): pytest.skip → pytest.fail on missing acl-matrix.json | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1275-test-nats-pytestskip-pytestfail-on-missing-acl-matrixjson-same-silent-skip-pattern-as-1262` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (8/8 passed) | Passed |

## Test Plan
- [ ] `test_real_matrix_has_no_drift` passes when `deploy/nats/acl-matrix.json` exists.
- [ ] Temporarily rename the matrix file and confirm the test fails with the expected message.

Closes #1275

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`