### PR TITLE
feat(bots): add PRAGMA user_version guard to bot_store_migrations (#1454)

### DIFF
--- a/src/lyra/infrastructure/stores/bot_store_migrations.py
+++ b/src/lyra/infrastructure/stores/bot_store_migrations.py
@@ -11,6 +11,16 @@ log = logging.getLogger(__name__)
 __all__ = ["run_bot_migrations"]
 
 
+async def _get_user_version(db: aiosqlite.Connection) -> int:
+    cur = await db.execute("PRAGMA user_version")
+    row = await cur.fetchone()
+    return row[0] if row else 0
+
+
+async def _set_user_version(db: aiosqlite.Connection, version: int) -> None:
+    await db.execute(f"PRAGMA user_version = {version}")
+
+
 async def run_bot_migrations(db: aiosqlite.Connection) -> None:
     """Run additive schema migrations for the bots table.
 
@@ -22,11 +32,16 @@ async def run_bot_migrations(db: aiosqlite.Connection) -> None:
     Args:
         db: An open aiosqlite connection.
     """
-    # Migration: add trusted_roles_json column for #1416
-    cur = await db.execute(
-        "SELECT 1 FROM pragma_table_info('bots') WHERE name = 'trusted_roles_json'"
-    )
-    if await cur.fetchone() is None:
-        await db.execute(
-            "ALTER TABLE bots ADD COLUMN trusted_roles_json TEXT NOT NULL DEFAULT '[]'"
+    version = await _get_user_version(db)
+
+    if version < 1:
+        # Migration 1: add trusted_roles_json column for #1416
+        cur = await db.execute(
+            "SELECT 1 FROM pragma_table_info('bots') WHERE name = 'trusted_roles_json'"
         )
+        if await cur.fetchone() is None:
+            await db.execute(
+                "ALTER TABLE bots ADD COLUMN trusted_roles_json"
+                " TEXT NOT NULL DEFAULT '[]'"
+            )
+        await _set_user_version(db, 1)

--- a/tests/infrastructure/test_bot_store_migration.py
+++ b/tests/infrastructure/test_bot_store_migration.py
@@ -1,0 +1,142 @@
+"""Tests for BotStore migrations.
+
+Covers: PRAGMA user_version guard for ALTER TABLE migration (#1454).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from lyra.core.agent.bot_schema import _CREATE_BOTS
+from lyra.infrastructure.stores.bot_store_migrations import (
+    _get_user_version,
+    _set_user_version,
+    run_bot_migrations,
+)
+
+# Legacy DDL without trusted_roles_json (pre-#1416 schema)
+_DDL_LEGACY_BOTS = """
+CREATE TABLE IF NOT EXISTS bots (
+    platform TEXT NOT NULL,
+    bot_id TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    webhook_enabled INTEGER NOT NULL DEFAULT 0,
+    default_trust TEXT NOT NULL DEFAULT 'blocked',
+    owner_users_json TEXT NOT NULL DEFAULT '[]',
+    trusted_users_json TEXT NOT NULL DEFAULT '[]',
+    auto_thread INTEGER NOT NULL DEFAULT 0,
+    thread_hot_hours INTEGER NOT NULL DEFAULT 24,
+    updated_at TEXT,
+    PRIMARY KEY (platform, bot_id)
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# T1 — Fresh DB: migration runs and sets user_version
+# ---------------------------------------------------------------------------
+
+
+class TestFreshDbMigration:
+    @pytest.mark.asyncio
+    async def test_migration_adds_column_and_sets_version(self) -> None:
+        """Fresh DB: migration adds trusted_roles_json and sets user_version=1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "bots.db"
+            async with aiosqlite.connect(str(db_path)) as db:
+                await db.execute(_CREATE_BOTS)
+                await db.commit()
+
+                version_before = await _get_user_version(db)
+                assert version_before == 0
+
+                await run_bot_migrations(db)
+
+                version_after = await _get_user_version(db)
+                assert version_after == 1
+
+                async with db.execute("PRAGMA table_info('bots')") as cur:
+                    rows = await cur.fetchall()
+                cols = {row[1] for row in rows}
+                assert "trusted_roles_json" in cols
+
+
+# ---------------------------------------------------------------------------
+# T2 — Idempotency: second run is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationIdempotency:
+    @pytest.mark.asyncio
+    async def test_second_run_is_noop(self) -> None:
+        """Running migration twice on a fresh DB is a no-op (no exception)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "bots.db"
+            async with aiosqlite.connect(str(db_path)) as db:
+                await db.execute(_CREATE_BOTS)
+                await db.commit()
+
+                await run_bot_migrations(db)
+                version_first = await _get_user_version(db)
+                assert version_first == 1
+
+                # Second run must not raise
+                await run_bot_migrations(db)
+                version_second = await _get_user_version(db)
+                assert version_second == 1
+
+    @pytest.mark.asyncio
+    async def test_migration_skips_when_version_already_set(self) -> None:
+        """Migration skips ALTER TABLE when user_version >= 1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "bots.db"
+            async with aiosqlite.connect(str(db_path)) as db:
+                await db.execute(_DDL_LEGACY_BOTS)
+                await db.commit()
+
+                # Manually set version to 1 before running migration
+                await _set_user_version(db, 1)
+
+                # Migration must skip because version >= 1
+                await run_bot_migrations(db)
+
+                # Column should NOT be added because version guard skipped
+                async with db.execute("PRAGMA table_info('bots')") as cur:
+                    rows = await cur.fetchall()
+                cols = {row[1] for row in rows}
+                assert "trusted_roles_json" not in cols
+
+
+# ---------------------------------------------------------------------------
+# T3 — Legacy DB without user_version: migration applies
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyDbMigration:
+    @pytest.mark.asyncio
+    async def test_legacy_db_gets_migration_and_version(self) -> None:
+        """Pre-existing DB without user_version gets migrated and version set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "bots.db"
+            async with aiosqlite.connect(str(db_path)) as db:
+                # Create legacy schema without trusted_roles_json
+                await db.execute(_DDL_LEGACY_BOTS)
+                await db.commit()
+
+                # Verify user_version starts at 0
+                version = await _get_user_version(db)
+                assert version == 0
+
+                await run_bot_migrations(db)
+
+                version_after = await _get_user_version(db)
+                assert version_after == 1
+
+                async with db.execute("PRAGMA table_info('bots')") as cur:
+                    rows = await cur.fetchall()
+                cols = {row[1] for row in rows}
+                assert "trusted_roles_json" in cols


### PR DESCRIPTION
## Summary
Add `PRAGMA user_version` read/write guard to `bot_store_migrations.py` before the first `ALTER TABLE` migration.

## Changes
- `_get_user_version()` / `_set_user_version()` helpers
- Migration runs only when `user_version < 1`
- After applying, sets `user_version = 1`
- Keeps `pragma_table_info` safety check as defense in depth
- 4 new tests: fresh DB, idempotency, version skip, legacy DB

## Test plan
- [x] `uv run pytest tests/infrastructure/test_bot_store_migration.py` — 4/4 pass
- [x] `uv run pytest tests/core/test_bot_store_crud.py` — 17/17 pass
- [x] `uv run ruff check .` — clean
- [x] pre-commit hooks — all pass

Closes #1454

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)