### PR TITLE
refactor(bootstrap): unify seed_auth_store + _seed_auth → seed_grants_from_bots (#1418)

### DIFF
--- a/src/lyra/bootstrap/auth_seeding.py
+++ b/src/lyra/bootstrap/auth_seeding.py
@@ -22,15 +22,21 @@ from lyra.infrastructure.stores.auth_store import AuthStore
 log = logging.getLogger(__name__)
 
 
-async def seed_auth_store(auth_store: AuthStore, raw_config: dict) -> None:
-    """Seed per-bot owner/trusted users as permanent grants into the auth store."""
-    auth_block: dict = raw_config.get("auth", {})
-    for entry in auth_block.get("telegram_bots", []):
-        synthetic = {"auth": {"telegram": entry}}
-        await auth_store.seed_from_config(synthetic, "telegram")
-    for entry in auth_block.get("discord_bots", []):
-        synthetic = {"auth": {"discord": entry}}
-        await auth_store.seed_from_config(synthetic, "discord")
+async def seed_grants_from_bots(
+    auth_store: AuthStore,
+    bot_store: BotStoreProtocol,
+) -> None:
+    """Single canonical: read bots from BotStore, seed permanent grants into auth.db."""
+    for bot in bot_store.get_all():
+        synthetic = {
+            "auth": {
+                bot.platform: {
+                    "owner_users": bot.owner_users,
+                    "trusted_users": bot.trusted_users,
+                }
+            }
+        }
+        await auth_store.seed_from_config(synthetic, bot.platform)
 
 
 def build_bot_auths(

--- a/src/lyra/bootstrap/factory/unified.py
+++ b/src/lyra/bootstrap/factory/unified.py
@@ -49,7 +49,7 @@ async def _bootstrap_unified(
 
         async with open_stores(vault_dir) as stores:
             await _prune_message_index(stores, raw_config)
-            await _seed_auth(stores, raw_config)
+            await _seed_auth(stores)
 
             bundle = await _init_bot_auths_and_agents(stores, raw_config)
             pm = await _init_pairing(

--- a/src/lyra/bootstrap/factory/wiring_helpers.py
+++ b/src/lyra/bootstrap/factory/wiring_helpers.py
@@ -104,15 +104,11 @@ async def _init_inbound_bus(
     )
 
 
-async def _seed_auth(stores: object, raw_config: dict) -> None:
-    """Seed auth store from config block."""
-    auth_block: dict = raw_config.get("auth", {})
-    for entry in auth_block.get("telegram_bots", []):
-        synthetic = {"auth": {"telegram": entry}}
-        await stores.auth.seed_from_config(synthetic, "telegram")
-    for entry in auth_block.get("discord_bots", []):
-        synthetic = {"auth": {"discord": entry}}
-        await stores.auth.seed_from_config(synthetic, "discord")
+async def _seed_auth(stores: object) -> None:
+    """Thin shim: delegate to canonical seed_grants_from_bots."""
+    from lyra.bootstrap.auth_seeding import seed_grants_from_bots
+
+    await seed_grants_from_bots(stores.auth, stores.bot)
 
 
 async def _prune_message_index(stores: object, raw_config: dict) -> None:

--- a/src/lyra/bootstrap/standalone/hub_standalone.py
+++ b/src/lyra/bootstrap/standalone/hub_standalone.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from lyra.bootstrap.auth_seeding import build_bot_auths, seed_auth_store
+from lyra.bootstrap.auth_seeding import build_bot_auths, seed_grants_from_bots
 from lyra.bootstrap.bootstrap_stores import open_stores
 from lyra.bootstrap.factory.agent_factory import _resolve_bot_agent_map
 from lyra.bootstrap.factory.config import MessageIndexConfig
@@ -104,7 +104,7 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
                 mi_cfg.retention_days,
             )
 
-        await seed_auth_store(stores.auth, raw_config)
+        await seed_grants_from_bots(stores.auth, stores.bot)
 
         try:
             circuit_registry, admin_user_ids, tg_bot_auths, dc_bot_auths = (

--- a/tests/bootstrap/test_auth_seeding.py
+++ b/tests/bootstrap/test_auth_seeding.py
@@ -1,4 +1,4 @@
-"""Tests for lyra.bootstrap.auth_seeding — seed_auth_store and build_bot_auths."""
+"""Tests for lyra.bootstrap.auth_seeding — seed_grants_from_bots and build_bot_auths."""
 
 from __future__ import annotations
 
@@ -10,34 +10,34 @@ from lyra.bootstrap.auth_seeding import build_bot_auths
 from lyra.infrastructure.stores.auth_store import AuthStore
 
 # ---------------------------------------------------------------------------
-# test_bootstrap_calls_seed_auth_store
+# test_bootstrap_calls_seed_grants_from_bots
 # ---------------------------------------------------------------------------
 
 
-class TestBootstrapCallsSeedAuthStore:
-    async def test_bootstrap_calls_seed_auth_store(
+class TestBootstrapCallsSeedGrantsFromBots:
+    async def test_bootstrap_calls_seed_grants_from_bots(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """_bootstrap_hub_standalone calls seed_auth_store once with an AuthStore.
+        """_bootstrap_hub_standalone calls seed_grants_from_bots once.
 
         Drives the bootstrap past the NATS_URL guard with a mock NATS connection,
-        then short-circuits just after seed_auth_store so no real DB is needed.
+        then short-circuits just after seed_grants_from_bots so no real DB is needed.
         """
         # Arrange
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         monkeypatch.setenv("LYRA_VAULT_DIR", str(tmp_path))
 
-        # Track the seed_auth_store call
+        # Track the seed_grants_from_bots call
         seed_calls: list[tuple] = []
 
-        async def fake_seed(auth_store, raw_config):
-            seed_calls.append((auth_store, raw_config))
+        async def fake_seed(auth_store, bot_store):
+            seed_calls.append((auth_store, bot_store))
             # Raise to abort further bootstrap — we only need to verify the call
             raise RuntimeError("test-sentinel: abort after seed")
 
         import lyra.bootstrap.standalone.hub_standalone as hub_standalone_mod
 
-        monkeypatch.setattr(hub_standalone_mod, "seed_auth_store", fake_seed)
+        monkeypatch.setattr(hub_standalone_mod, "seed_grants_from_bots", fake_seed)
 
         # Patch NATS connection so we never touch a real server
         fake_nc = AsyncMock()
@@ -84,12 +84,11 @@ class TestBootstrapCallsSeedAuthStore:
         with pytest.raises(RuntimeError, match="test-sentinel"):
             await _bootstrap_hub_standalone(raw_config)
 
-        # Assert — seed_auth_store was called once with an AuthStore instance
-        assert len(seed_calls) == 1, "seed_auth_store must be called exactly once"
-        passed_store, passed_config = seed_calls[0]
-        # The store passed must be the one from fake_stores.auth
+        # Assert — seed_grants_from_bots was called once with auth+bot stores
+        assert len(seed_calls) == 1, "seed_grants_from_bots must be called exactly once"
+        passed_store, passed_bot = seed_calls[0]
         assert passed_store is not None
-        assert passed_config == raw_config
+        assert passed_bot is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bootstrap/test_wiring_helpers.py
+++ b/tests/bootstrap/test_wiring_helpers.py
@@ -71,35 +71,32 @@ class TestInitInboundBus:
 
 class TestSeedAuth:
     @pytest.mark.asyncio
-    async def test_seed_auth_calls_seed_from_config_once_per_bot_entry(self) -> None:
+    async def test_seed_auth_delegates_to_seed_grants_from_bots(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Arrange
+        seed_calls: list[tuple] = []
+
+        async def fake_seed(auth_store, bot_store):
+            seed_calls.append((auth_store, bot_store))
+
+        monkeypatch.setattr(
+            "lyra.bootstrap.auth_seeding.seed_grants_from_bots",
+            fake_seed,
+        )
+
         stores = MagicMock()
-        stores.auth.seed_from_config = AsyncMock()
-        raw_config = {
-            "auth": {
-                "telegram_bots": [
-                    {"bot_id": "tg1", "default": "public"},
-                    {"bot_id": "tg2", "default": "public"},
-                ],
-                "discord_bots": [
-                    {"bot_id": "dc1", "default": "public"},
-                ],
-            }
-        }
+        stores.auth = MagicMock()
+        stores.bot = MagicMock()
 
         # Act
-        await _seed_auth(stores, raw_config)
+        await _seed_auth(stores)
 
-        # Assert
-        assert stores.auth.seed_from_config.call_count == 3
-        stores.auth.seed_from_config.assert_any_call(
-            {"auth": {"telegram": {"bot_id": "tg1", "default": "public"}}},
-            "telegram",
-        )
-        stores.auth.seed_from_config.assert_any_call(
-            {"auth": {"discord": {"bot_id": "dc1", "default": "public"}}},
-            "discord",
-        )
+        # Assert — delegates to canonical seed_grants_from_bots with auth+bot stores
+        assert len(seed_calls) == 1
+        passed_auth, passed_bot = seed_calls[0]
+        assert passed_auth is stores.auth
+        assert passed_bot is stores.bot
 
 
 class TestPruneMessageIndex:

--- a/tests/factories/bootstrap.py
+++ b/tests/factories/bootstrap.py
@@ -274,6 +274,19 @@ def patch_all(
     _fake_auth_store.close = AsyncMock()
     monkeypatch.setattr(stores_mod, "AuthStore", lambda **kwargs: _fake_auth_store)
 
+    from lyra.core.agent.bot_models import BotRow
+
+    _fake_bot_store = MagicMock()
+    _fake_bot_store.connect = AsyncMock()
+    _fake_bot_store.close = AsyncMock()
+    _fake_bot_store.get_all = MagicMock(
+        return_value=[
+            BotRow(platform="telegram", bot_id="main", agent="lyra_default"),
+            BotRow(platform="discord", bot_id="main", agent="lyra_default"),
+        ]
+    )
+    monkeypatch.setattr(stores_mod, "BotStore", lambda **kwargs: _fake_bot_store)
+
     _fake_agent_row = MagicMock()
     _fake_agent_row.name = "lyra_default"
     _fake_agent_store = MagicMock()


### PR DESCRIPTION
## Summary
- Replace two duplicate TOML-reading seed functions with a single canonical `seed_grants_from_bots(auth_store, bot_store)` that reads from BotStore.
- `auth_seeding.py`: `seed_auth_store` → `seed_grants_from_bots`
- `wiring_helpers.py`: `_seed_auth` → thin shim delegating to canonical function
- Callers updated to pass `stores.auth, stores.bot` instead of `raw_config`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1418: refactor(bootstrap): unify seed_auth_store + _seed_auth → single BotStore-reading function | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1418-unify-seed-auth-store` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3898 passed) | Passed |

## Test Plan
- [ ] Verify bootstrap still seeds grants correctly on staging boot
- [ ] Confirm no `auth_block.get("telegram_bots")` remains in `bootstrap/`

Closes #1418

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`