### PR TITLE
refactor(config): split ToolDisplayConfig.group_threshold into bash+files thresholds (#1464)

### DIFF
--- a/src/lyra/core/messaging/tool_display_config.py
+++ b/src/lyra/core/messaging/tool_display_config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 # Canonical show-key names (lowercase).  StreamProcessor normalises tool_name
 # to lowercase before lookup.
@@ -34,7 +34,10 @@ class ToolDisplayConfig(BaseModel):
     names_threshold:
         Number of individual file-edit names to show per file before switching
         to count-only mode (e.g. "5 edits").  Default: 5.
-    group_threshold:
+    bash_group_threshold:
+        Number of bash commands before switching from per-command display to a
+        grouped summary (e.g. "4 commands").  Default: 3.
+    files_group_threshold:
         Number of distinct files before switching from per-file display to a
         grouped summary (e.g. "4 files edited").  Default: 3.
     bash_max_len:
@@ -58,7 +61,8 @@ class ToolDisplayConfig(BaseModel):
     model_config = ConfigDict(frozen=True, extra="ignore")
 
     names_threshold: int = 5
-    group_threshold: int = 3
+    bash_group_threshold: int = 3
+    files_group_threshold: int = 3
     bash_max_len: int = 80
     throttle_ms: int = 2000
     """Min ms between streaming edits. Future consumers must wire through
@@ -67,6 +71,17 @@ class ToolDisplayConfig(BaseModel):
     # Stored as dict[str, bool] for Pydantic compatibility; exposed as
     # MappingProxyType via the .show property to preserve read-only semantics.
     _show: dict[str, bool] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_group_threshold(cls, data: Any) -> Any:
+        """Deprecated alias: group_threshold sets both bash and files thresholds."""
+        if isinstance(data, dict) and data.get("group_threshold") is not None:
+            data = dict(data)
+            gt = data.pop("group_threshold")
+            data.setdefault("bash_group_threshold", gt)
+            data.setdefault("files_group_threshold", gt)
+        return data
 
     def __init__(self, **data: Any) -> None:
         show_raw: Any = data.pop("show", None)
@@ -92,11 +107,18 @@ class ToolDisplayConfig(BaseModel):
             raise ValueError(f"names_threshold must be >= 1, got {v}")
         return v
 
-    @field_validator("group_threshold")
+    @field_validator("bash_group_threshold")
     @classmethod
-    def _validate_group_threshold(cls, v: int) -> int:
+    def _validate_bash_group_threshold(cls, v: int) -> int:
         if v < 1:
-            raise ValueError(f"group_threshold must be >= 1, got {v}")
+            raise ValueError(f"bash_group_threshold must be >= 1, got {v}")
+        return v
+
+    @field_validator("files_group_threshold")
+    @classmethod
+    def _validate_files_group_threshold(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"files_group_threshold must be >= 1, got {v}")
         return v
 
     @field_validator("bash_max_len")
@@ -118,7 +140,8 @@ class ToolDisplayConfig(BaseModel):
             return NotImplemented
         return (
             self.names_threshold == other.names_threshold
-            and self.group_threshold == other.group_threshold
+            and self.bash_group_threshold == other.bash_group_threshold
+            and self.files_group_threshold == other.files_group_threshold
             and self.bash_max_len == other.bash_max_len
             and self.throttle_ms == other.throttle_ms
             and self._show == other._show
@@ -128,7 +151,8 @@ class ToolDisplayConfig(BaseModel):
         return hash(
             (
                 self.names_threshold,
-                self.group_threshold,
+                self.bash_group_threshold,
+                self.files_group_threshold,
                 self.bash_max_len,
                 self.throttle_ms,
                 tuple(sorted(self._show.items())),

--- a/src/lyra/outbound/_tool_recap.py
+++ b/src/lyra/outbound/_tool_recap.py
@@ -199,7 +199,7 @@ def _format_files(accum: ToolRecapAccumulator) -> list[str]:
     """Build lines for the file-edit section."""
     if not accum.files:
         return []
-    if len(accum.files) >= accum.config.group_threshold:
+    if len(accum.files) >= accum.config.files_group_threshold:
         total = sum(f.count for f in accum.files.values())
         return [f"✏️ {len(accum.files)} files · {total} edits"]
     lines: list[str] = []
@@ -215,7 +215,7 @@ def _format_bash(accum: ToolRecapAccumulator) -> list[str]:
     cmds = [c for c in (s.strip() for s in accum.bash_commands) if c]
     if not cmds:
         return []
-    if len(cmds) >= accum.config.group_threshold:
+    if len(cmds) >= accum.config.bash_group_threshold:
         return [f"\U0001f4bb {_plural(len(cmds), 'command')}"]
     max_len = accum.config.bash_max_len
     return [f"\U0001f4bb `{_sanitize(_truncate(c, max_len))}`" for c in cmds]

--- a/tests/outbound/test_tool_recap.py
+++ b/tests/outbound/test_tool_recap.py
@@ -121,13 +121,13 @@ def test_accumulator_uses_default_bash_max_len_when_no_config() -> None:
 
 
 # ---------------------------------------------------------------------------
-# SC-1: group_threshold config
+# SC-1: bash_group_threshold / files_group_threshold config
 # ---------------------------------------------------------------------------
 
 
-def test_accumulator_respects_group_threshold() -> None:
-    """config.group_threshold controls when bash cmds collapse to a summary."""
-    config = ToolDisplayConfig(group_threshold=10)
+def test_accumulator_respects_bash_group_threshold() -> None:
+    """config.bash_group_threshold controls when bash cmds collapse to a summary."""
+    config = ToolDisplayConfig(bash_group_threshold=10)
 
     # 9 commands — below threshold → individual lines, no grouping
     accum_below = ToolRecapAccumulator(config=config)
@@ -136,7 +136,7 @@ def test_accumulator_respects_group_threshold() -> None:
     lines_below = format_recap_lines(accum_below, done=True)
     blines_below = _bash_lines(lines_below)
     assert not any("commands" in ln for ln in blines_below), (
-        "9 commands below group_threshold=10 must not be grouped"
+        "9 commands below bash_group_threshold=10 must not be grouped"
     )
 
     # 11 commands — above threshold → grouped summary
@@ -146,8 +146,43 @@ def test_accumulator_respects_group_threshold() -> None:
     lines_above = format_recap_lines(accum_above, done=True)
     blines_above = _bash_lines(lines_above)
     assert any("commands" in ln for ln in blines_above), (
-        "11 commands above group_threshold=10 must be grouped"
+        "11 commands above bash_group_threshold=10 must be grouped"
     )
+
+
+def test_accumulator_respects_files_group_threshold() -> None:
+    """config.files_group_threshold controls when file edits collapse to a summary."""
+    config = ToolDisplayConfig(files_group_threshold=5)
+
+    def _file_lines(lines: list[str]) -> list[str]:
+        return [ln for ln in lines if "✏️" in ln]
+
+    # 4 files — below threshold → individual lines
+    accum_below = ToolRecapAccumulator(config=config)
+    for idx in range(4):
+        _feed_file(accum_below, f"f{idx}", f"edit{idx}")
+    lines_below = format_recap_lines(accum_below, done=True)
+    flines_below = _file_lines(lines_below)
+    assert not any("files" in ln for ln in flines_below), (
+        "4 files below files_group_threshold=5 must not be grouped"
+    )
+
+    # 6 files — above threshold → grouped summary
+    accum_above = ToolRecapAccumulator(config=config)
+    for idx in range(6):
+        _feed_file(accum_above, f"g{idx}", f"edit{idx}")
+    lines_above = format_recap_lines(accum_above, done=True)
+    flines_above = _file_lines(lines_above)
+    assert any("files" in ln for ln in flines_above), (
+        "6 files above files_group_threshold=5 must be grouped"
+    )
+
+
+def test_deprecated_group_threshold_alias_sets_both() -> None:
+    """Deprecated group_threshold sets both bash and files thresholds."""
+    config = ToolDisplayConfig(group_threshold=10)
+    assert config.bash_group_threshold == 10
+    assert config.files_group_threshold == 10
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_display_config.py
+++ b/tests/test_tool_display_config.py
@@ -27,7 +27,8 @@ class TestToolDisplayConfigDefaults:
         cfg = ToolDisplayConfig()
         # Assert
         assert cfg.names_threshold == 5
-        assert cfg.group_threshold == 3
+        assert cfg.bash_group_threshold == 3
+        assert cfg.files_group_threshold == 3
         assert cfg.bash_max_len == 80
         assert cfg.throttle_ms == 2000
 
@@ -110,7 +111,8 @@ class TestToolDisplayConfigFromDict:
         cfg = ToolDisplayConfig.model_validate(data)
         # Assert
         assert cfg.names_threshold == 5
-        assert cfg.group_threshold == 3  # default preserved
+        assert cfg.bash_group_threshold == 3  # default preserved
+        assert cfg.files_group_threshold == 3  # default preserved
         assert cfg.bash_max_len == 80  # default preserved
         assert cfg.throttle_ms == 2000  # default preserved
 
@@ -118,7 +120,8 @@ class TestToolDisplayConfigFromDict:
         # Arrange
         data = {
             "names_threshold": 10,
-            "group_threshold": 7,
+            "bash_group_threshold": 7,
+            "files_group_threshold": 4,
             "bash_max_len": 120,
             "throttle_ms": 500,
         }
@@ -126,7 +129,8 @@ class TestToolDisplayConfigFromDict:
         cfg = ToolDisplayConfig.model_validate(data)
         # Assert
         assert cfg.names_threshold == 10
-        assert cfg.group_threshold == 7
+        assert cfg.bash_group_threshold == 7
+        assert cfg.files_group_threshold == 4
         assert cfg.bash_max_len == 120
         assert cfg.throttle_ms == 500
 
@@ -247,7 +251,8 @@ class TestLoadToolDisplayConfig:
         # Assert
         assert cfg.names_threshold == 6
         assert cfg.throttle_ms == 1000
-        assert cfg.group_threshold == 3  # default preserved
+        assert cfg.bash_group_threshold == 3  # default preserved
+        assert cfg.files_group_threshold == 3  # default preserved
 
     def test_show_subsection_parsed(self) -> None:
         # Arrange


### PR DESCRIPTION
## Summary
- Replace single `group_threshold` with two independent fields:
  - `bash_group_threshold`: controls bash command collapse
  - `files_group_threshold`: controls file edit collapse
- Keep deprecated `group_threshold` alias via model_validator (sets both).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1464: refactor(config): split ToolDisplayConfig.group_threshold into bash_group_threshold + files_group_threshold | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1464-split-tooldisplayconfig-group-threshold` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3903 passed) | Passed |

## Test Plan
- [ ] Verify backward compat: `group_threshold=5` still sets both thresholds
- [ ] Verify forward paths: `bash_group_threshold` and `files_group_threshold` work independently

Closes #1464

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`