### PR TITLE
fix(deploy): provision blobstore NATS identity

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -22,59 +22,60 @@ and is verified by `scripts/check-acl-matrix-spec.sh` on every CI run.
 The row will grant `subscribe: lyra.typing.>` to `code-worker` (it consumes typing events to throttle its own typing emission). Provisioning: `make nats-add-identity NAME=code-worker` when T3 worker fleet integration starts; the `_inbox.code-worker.>` grant is derived automatically from `request_reply_flows` per the renderer convention.
 
 <!-- acl-matrix:begin -->
-| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | llm-operator | image-worker | clipool-worker | dashboard-reader | voice-client | turn-writer |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| `$JS.API.>` | PUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — |
-| `$JS.API.CONSUMER.CREATE.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — |
-| `$JS.API.CONSUMER.CREATE.LYRA_TURNS.turn-writer-v1.>` | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `$JS.API.CONSUMER.INFO.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `$JS.API.CONSUMER.MSG.NEXT.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `$JS.API.DIRECT.GET.LYRA_STATE.hub.ready` | — | PUB | PUB | — | — | — | — | — | — | — | — | — |
-| `$JS.API.INFO` | — | PUB | PUB | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.CREATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `$JS.API.STREAM.INFO.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `$JS.API.STREAM.UPDATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `$KV.lyra-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | — | SUB | SUB | — | — | — |
-| `_inbox.clipool-worker.>` | — | — | — | — | — | — | — | — | SUB | — | — | — |
-| `_inbox.discord-adapter.*.*` | — | — | SUB | — | — | — | — | — | — | — | — | — |
-| `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — | — | — |
-| `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — |
-| `_inbox.image-worker.>` | — | — | — | — | — | — | — | SUB | — | — | — | — |
-| `_inbox.llm-operator.>` | — | — | — | — | — | — | SUB | — | — | — | — | — |
-| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — | — | — |
-| `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.turn-writer.>` | — | — | — | — | — | — | — | — | — | — | — | PUB+SUB |
-| `_inbox.voice-client.>` | — | — | — | PUB | PUB | — | — | — | — | — | SUB | — |
-| `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — | — |
-| `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — | — |
-| `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | SUB | — | — | — |
-| `lyra.clipool.control` | PUB | — | — | — | — | — | — | — | SUB | — | — | — |
-| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | PUB | — | — | — |
-| `lyra.event.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — |
-| `lyra.image.generate.request` | PUB | — | — | — | — | — | — | SUB | — | — | — | — |
-| `lyra.image.heartbeat` | SUB | — | — | — | — | — | — | PUB | — | — | — | — |
-| `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — | — | — | — |
-| `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.llm.generate.request` | PUB | — | — | — | — | SUB | — | — | — | — | — | — |
-| `lyra.llm.heartbeat` | SUB | — | — | — | — | PUB | — | — | — | — | — | — |
-| `lyra.llm.lifecycle.>` | — | — | — | — | — | SUB | PUB | — | — | — | — | — |
-| `lyra.metric.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — |
-| `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — | — | — | — |
-| `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.system.ready` | SUB | PUB | PUB | PUB | PUB | — | — | — | PUB | — | — | — |
-| `lyra.turns.>` | — | — | — | — | — | — | — | — | — | — | — | SUB |
-| `lyra.turns.write` | PUB | PUB | PUB | — | — | — | — | — | — | — | — | — |
-| `lyra.typing.>` | PUB | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.typing.discord.>` | — | — | SUB | — | — | — | — | — | — | — | — | — |
-| `lyra.typing.telegram.>` | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — | — | — | — | — | — |
-| `lyra.voice.stt.request` | PUB | — | — | — | SUB | — | — | — | — | — | PUB | — |
-| `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — | — | — |
-| `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — | — | — |
-| `lyra.voice.tts.request` | PUB | — | — | SUB | — | — | — | — | — | — | PUB | — |
-| `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — | — | — |
+| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | llm-operator | image-worker | clipool-worker | dashboard-reader | voice-client | turn-writer | blobstore |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| `$JS.API.>` | PUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — | PUB |
+| `$JS.API.CONSUMER.CREATE.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.CONSUMER.CREATE.LYRA_TURNS.turn-writer-v1.>` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `$JS.API.CONSUMER.INFO.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `$JS.API.CONSUMER.MSG.NEXT.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `$JS.API.DIRECT.GET.LYRA_STATE.hub.ready` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.INFO` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.CREATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `$JS.API.STREAM.INFO.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `$JS.API.STREAM.UPDATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `$KV.lyra-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | — | SUB | SUB | — | — | — | PUB |
+| `_inbox.blobstore.>` | — | — | — | — | — | — | — | — | — | — | — | — | SUB |
+| `_inbox.clipool-worker.>` | — | — | — | — | — | — | — | — | SUB | — | — | — | — |
+| `_inbox.discord-adapter.*.*` | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — | — |
+| `_inbox.image-worker.>` | — | — | — | — | — | — | — | SUB | — | — | — | — | — |
+| `_inbox.llm-operator.>` | — | — | — | — | — | — | SUB | — | — | — | — | — | — |
+| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — | — | — | — |
+| `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.turn-writer.>` | — | — | — | — | — | — | — | — | — | — | — | PUB+SUB | — |
+| `_inbox.voice-client.>` | — | — | — | PUB | PUB | — | — | — | — | — | SUB | — | — |
+| `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — | — | — |
+| `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — | — | — |
+| `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | PUB |
+| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | SUB | — | — | — | — |
+| `lyra.clipool.control` | PUB | — | — | — | — | — | — | — | SUB | — | — | — | — |
+| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | PUB | — | — | — | — |
+| `lyra.event.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — | — |
+| `lyra.image.generate.request` | PUB | — | — | — | — | — | — | SUB | — | — | — | — | — |
+| `lyra.image.heartbeat` | SUB | — | — | — | — | — | — | PUB | — | — | — | — | — |
+| `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.llm.generate.request` | PUB | — | — | — | — | SUB | — | — | — | — | — | — | — |
+| `lyra.llm.heartbeat` | SUB | — | — | — | — | PUB | — | — | — | — | — | — | — |
+| `lyra.llm.lifecycle.>` | — | — | — | — | — | SUB | PUB | — | — | — | — | — | — |
+| `lyra.metric.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — | — |
+| `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.system.ready` | SUB | PUB | PUB | PUB | PUB | — | — | — | PUB | — | — | — | — |
+| `lyra.turns.>` | — | — | — | — | — | — | — | — | — | — | — | SUB | — |
+| `lyra.turns.write` | PUB | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.typing.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.typing.discord.>` | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.typing.telegram.>` | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — | — | — | — | — | — | — |
+| `lyra.voice.stt.request` | PUB | — | — | — | SUB | — | — | — | — | — | PUB | — | — |
+| `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — | — | — | — |
+| `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — | — | — | — |
+| `lyra.voice.tts.request` | PUB | — | — | SUB | — | — | — | — | — | — | PUB | — | — |
+| `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — | — | — | — |
 <!-- acl-matrix:end -->
 
 [^ready]: `lyra.system.ready` — adapters and workers publish once on startup; hub subscribes to track liveness.

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -280,6 +280,23 @@
         "_inbox.turn-writer.>"
       ],
       "deploy": { "type": "container", "secret": "lyra-nats-turn-writer" }
+    },
+    "blobstore": {
+      "status": "active",
+      "created_at": "2026-05-28",
+      "owner": "lyra",
+      "description": "BlobStore HTTP service — publishes audit events to lyra.audit.blobs.> and announces readiness via lyra-state KV.",
+      "notes": "Publishes to lyra.audit.> for BlobAuditSink and uses $JS.API.> + $KV.lyra-state.> for KV readiness announce. allow_responses=true for JetStream API request-reply (js.create_key_value). No explicit subscription subjects.",
+      "allow_responses": true,
+      "publish": [
+        "lyra.audit.>",
+        "$JS.API.>",
+        "$KV.lyra-state.>"
+      ],
+      "subscribe": [
+        "_inbox.blobstore.>"
+      ],
+      "deploy": { "type": "container", "secret": "lyra-nats-blobstore" }
     }
   }
 }

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -117,5 +117,14 @@ authorization {
         allow_responses: true
       }
     }
+    {
+      nkey: "UDETBLOBSTORE"
+      # blobstore
+      permissions: {
+        publish:   { allow: ["lyra.audit.>","$JS.API.>","$KV.lyra-state.>"] }
+        subscribe: { allow: ["_inbox.blobstore.>"] }
+        allow_responses: true
+      }
+    }
   ]
 }

--- a/deploy/quadlet/lyra-blobstore.container
+++ b/deploy/quadlet/lyra-blobstore.container
@@ -27,6 +27,9 @@ UserNS=keep-id:uid=1500,gid=1500
 EnvironmentFile=%h/.lyra/env/blobstore.env
 # NATS target for audit sink + readiness KV; mirrors hub convention.
 Environment=NATS_URL=nats://lyra-nats:4222
+# ADR-054: nkey seed delivered as Podman secret for NATS nkey auth.
+Secret=lyra-nats-blobstore,type=mount,target=lyra-nats-blobstore.seed,uid=1500,gid=1500,mode=0400
+Environment=NATS_NKEY_SEED_PATH=/run/secrets/lyra-nats-blobstore.seed
 # D4: bearer token secret (type=mount, tmpfs-backed). Bootstrap: see docs/QUADLET-DEPLOYMENT.md.
 # Rotation: write new token → podman secret create --replace → systemctl --user restart
 # (type=mount files are bound at container init; restart is mandatory — ADR-054).


### PR DESCRIPTION
## Summary
- Add blobstore identity to acl-matrix.json with publish on lyra.audit.>, $JS.API.>, and $KV.lyra-state.> for audit sink + KV readiness announce.
- Add lyra-nats-blobstore secret + NATS_NKEY_SEED_PATH to blobstore Quadlet unit so the service authenticates with nkey auth instead of degrading to logger-only mode.
- Update 706-per-role-nkeys-acls-spec.mdx sentinel block to match.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1481: Provisionner identité blobstore pour audit NATS | OPEN |
| Implementation | 1 commit on `feat/1481-provisionner-identite-blobstore-pour-audit-nats` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests N/A (config-only) | Passed |

## Test Plan
- [ ] Verify blobstore connects to NATS without Authorization Violation after secret provisioning
- [ ] Verify audit events appear on lyra.audit.blobs.> in JetStream

Closes #1481

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`