### PR TITLE
docs(bots): add docs/bot-management.md + update deploy refs for DB-first flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Let:
 | `docs/ARCHITECTURE.md` | Architecture + decisions |
 | `docs/CONFIGURATION.md` | Config files, load order |
 | `docs/agent-management.md` | Agent seed flow + CLI |
+| `docs/bot-management.md` | Bot seed flow + CLI |
 | `docs/ops/container-publishing.md` | CI → GHCR → Quadlet pattern |
 | `deploy/quadlet/lyra-nats.container` | NATS Quadlet unit — `type=mount` secret anchor (restart-not-HUP for ACL changes) |
 | `packages/roxabi-nats/` | NATS transport SDK (ADR-045) |

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -73,6 +73,8 @@ Who runs it: operator (Mickael) — ¬automated, ¬CI. Idempotent for most steps
 `systemctl --user daemon-reload`.
 
 Secrets bootstrap: `make quadlet-secrets-install` (installs Podman secrets from host key files).
+BotStore bootstrap: `make quadlet-install` runs `lyra bot init` as its first step (seeds
+`~/.lyra/config.db` from `config.toml` — idempotent, skip-existing). Required since #1416.
 Operator scripts: `scripts/rotate-claude-oauth.sh`, `scripts/rotate-gh-key.sh` — run manually
 on rotation events.
 

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -139,7 +139,13 @@ The tracked files `deploy/quadlet/lyra-{telegram,discord}.container.tmpl` are **
 
 End-to-end flow for adding a new bot:
 
-1. Install the Podman secret for the bot token (host-local):
+1. Add the bot to the DB (DB-first since #1415):
+   ```bash
+   lyra agent <platform> add <bot_id> --agent <agent>
+   ```
+   (Replace `<platform>` with `telegram` or `discord`.)
+
+2. Install the Podman secret for the bot token (host-local):
    ```bash
    lyra bot secret install <platform> <bot_id>
    ```
@@ -148,25 +154,13 @@ End-to-end flow for adding a new bot:
    lyra bot secret install <platform> <bot_id>-webhook
    ```
 
-2. Add the bot to `~/.lyra/config.toml`:
-   ```toml
-   [[auth.<platform>_bots]]
-   bot_id = "<bot_id>"
-   ```
-   (Replace `<platform>` with `telegram` or `discord`.)
-
-3. Seed the bot database from `config.toml` (idempotent — skips existing rows):
-   ```bash
-   lyra bot init
-   ```
-
-4. Render and restart:
+3. Render and restart:
    ```bash
    make quadlet-install
    ```
-   The target runs `lyra bot init` (re-syncs `config.toml` → `BotStore`), then `render_quadlet.py` reads from `BotStore`, generates the `Secret=` directives, writes the new Quadlet atomically, runs `systemctl --user daemon-reload`, then restarts the adapter container.
+   The target runs `lyra bot init` (idempotent re-sync of `config.toml` → `BotStore`), then `render_quadlet.py` reads from `BotStore`, generates the `Secret=` directives, writes the new Quadlet atomically, runs `systemctl --user daemon-reload`, then restarts the adapter container.
 
-5. Verify the adapter is healthy:
+4. Verify the adapter is healthy:
    ```bash
    systemctl --user status lyra-<platform>
    ```

--- a/docs/bot-management.md
+++ b/docs/bot-management.md
@@ -1,0 +1,130 @@
+# Bot Management
+
+Bots are stored in **`~/.lyra/config.db`** (SQLite, table `bots`). TOML files are seed sources only — run `lyra bot init` to import them into the DB before use.
+
+## Database Tables
+
+| Table | Purpose |
+|-------|---------|
+| `bots` | Bot configurations (11 columns — see schema below) |
+| `bot_agent_map` | Maps `(platform, bot_id)` → `agent_name` |
+
+## Bot Configuration
+
+Bots are configured in `~/.lyra/config.toml` (`[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`). The hub reads bot metadata from `BotStore` (table `bots`), not from `config.toml` directly.
+
+```bash
+# Seeding (required before first hub boot since #1416)
+lyra bot init                     # import config.toml → BotStore (skip existing)
+lyra bot init --force             # overwrite existing rows
+
+# Secret management
+lyra bot secret install <platform> <bot_id>   # create Podman secret for bot token
+lyra bot secret install <platform> <bot_id>-webhook
+```
+
+**Rule:** `lyra bot init` is idempotent. Run it after every `config.toml` edit that changes bot definitions.
+
+## CLI Commands (per platform)
+
+Bot management commands are grouped under `lyra agent <platform>` (`telegram` or `discord`). Each platform exposes the same 9 verbs.
+
+```bash
+# Listing & inspection
+lyra agent telegram list                     # all Telegram bots in DB
+lyra agent discord list                      # all Discord bots in DB
+lyra agent telegram show <bot_id>            # full bot record
+lyra agent discord show <bot_id>             # full bot record
+
+# Creation & editing
+lyra agent telegram add <bot_id> --agent foo --webhook-enabled
+lyra agent telegram edit <bot_id>            # interactive field editor
+lyra agent telegram patch <bot_id> --webhook-enabled true
+lyra agent telegram patch <bot_id> --agent foo
+lyra agent telegram patch <bot_id> --owner-users "123,456"
+lyra agent telegram remove <bot_id>          # delete + cascade bot_agent_map cleanup
+lyra agent telegram remove <bot_id> --yes    # skip confirmation
+
+# Agent assignment
+lyra agent telegram assign <bot_id> --agent foo
+lyra agent telegram unassign <bot_id>        # revert to empty agent
+
+# Validation
+lyra agent telegram validate <bot_id>        # check agent exists, owners non-empty, secret present
+```
+
+**Valid trust levels:** `owner`, `trusted`, `public`, `blocked` (default: `blocked`).
+
+**Patchable fields:** `agent`, `webhook_enabled`, `default_trust`, `owner_users`, `trusted_users`, `trusted_roles`, `auto_thread`, `thread_hot_hours`. Typer rejects unknown flags (`--webhook-enabel` → shell error).
+
+## DB Schema Reference
+
+**bots table** (11 columns):
+
+| Column | Type | Default |
+|--------|------|---------|
+| `platform` | TEXT (PK part) | — |
+| `bot_id` | TEXT (PK part) | — |
+| `agent` | TEXT | `""` |
+| `webhook_enabled` | INTEGER | `0` |
+| `default_trust` | TEXT | `"blocked"` |
+| `owner_users` | TEXT | `'[]'` |
+| `trusted_users` | TEXT | `'[]'` |
+| `trusted_roles` | TEXT | `'[]'` |
+| `auto_thread` | INTEGER | `0` |
+| `thread_hot_hours` | INTEGER | `24` |
+| `updated_at` | TEXT | `datetime('now')` |
+
+## Workflows
+
+### First-time deploy
+
+```bash
+# 1. Seed BotStore from config.toml (idempotent — skips existing rows)
+lyra bot init
+
+# 2. Render adapter templates + daemon-reload
+make quadlet-install
+```
+
+### Add a new bot
+
+```bash
+lyra agent discord add newbot --agent foo
+lyra bot secret install discord newbot
+make quadlet-install
+```
+
+### Update a bot
+
+```bash
+lyra agent telegram patch main --webhook-enabled true
+make quadlet-install   # restart adapter so Quadlet picks up Secret= changes
+```
+
+### Remove a bot
+
+```bash
+lyra agent discord remove oldbot
+make quadlet-install   # re-renders Quadlet without the removed bot's Secret= line
+```
+
+## Migration runbook
+
+Existing deployments that already have bots in `config.toml`:
+
+```bash
+lyra bot init
+```
+
+This is a **no-op** if rows already exist (idempotent skip). No data loss. Run once per host after upgrading to the BotStore-based flow (#1416).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `lyra agent <platform> show <bot_id>` returns "not found" | Bot not seeded | `lyra bot init` |
+| `lyra agent <platform> validate <bot_id>` fails on secret | Podman secret missing | `lyra bot secret install <platform> <bot_id>` |
+| `lyra agent <platform> patch` fails with "no fields provided" | All flag values are `None` | Provide at least one `--field value` |
+| Adapter fails to start after adding bot | Quadlet not re-rendered | `make quadlet-install` (re-renders templates + restarts adapter) |
+| `lyra bot init` reports 0 seeded, N skipped | Rows already exist | Use `--force` to overwrite, or this is expected |


### PR DESCRIPTION
## Summary
- Add `docs/bot-management.md` as the bot-management analogue to `docs/agent-management.md`
- Update `docs/QUADLET-DEPLOYMENT.md` §Bot onboarding to use the DB-first `lyra agent <platform> add` flow instead of manual TOML edits
- Update `deploy/CLAUDE.md` to mention `lyra bot init` as a Makefile step
- Register `docs/bot-management.md` in root `CLAUDE.md` Key files table

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1419: docs(bots): docs/bot-management.md + QUADLET-DEPLOYMENT/deploy CLAUDE.md updates | OPEN |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 1 commit on `feat/1419-docs-bot-management` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Verify `docs/bot-management.md` renders correctly and links resolve
- [ ] Verify `docs/QUADLET-DEPLOYMENT.md` no longer references `[[telegram.bots]]` TOML edits
- [ ] Verify `deploy/CLAUDE.md` mentions `lyra bot init` step
- [ ] Verify root `CLAUDE.md` lists `docs/bot-management.md` in Key files

Closes #1419

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`