### PR TITLE
fix(tests): deflake keepalive test — increase idle sleep margin

### DIFF
--- a/tests/nats/test_keepalive.py
+++ b/tests/nats/test_keepalive.py
@@ -119,10 +119,10 @@ class TestPublishesKeepaliveDuringIdle:
         proxy = NatsChannelProxy(nc=nc, platform=Platform.TELEGRAM, bot_id="main")
         inbound = _make_inbound("msg-idle")
 
-        # Events iterator that sleeps for 5 * interval before yielding anything,
+        # Events iterator that sleeps for 10 * interval before yielding anything,
         # simulating an LLM tool-call that takes a while.
         async def _slow_events() -> AsyncIterator:
-            await asyncio.sleep(5 * fast_interval)
+            await asyncio.sleep(10 * fast_interval)
             # Yield nothing — keepalives should have fired before this returns
             return
             yield  # make it an async generator


### PR DESCRIPTION
## Summary
- `test_publishes_keepalive_during_idle` flaked in CI with `Expected >=3 keepalive envelopes, got 1`
- Increase idle sleep from 5× to 10× the fast interval (250 ms → 500 ms) to give the keepalive loop enough wall-clock time under xdist CPU contention

## Lifecycle
| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | Fix flaky CI test | ad-hoc |
| Implementation | 1 commit | Complete |
| Verification | Test passed locally | ✅ |

## Test Plan
- [ ] CI passes on this PR
- [ ] `test_publishes_keepalive_during_idle` passes consistently

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>