### PR TITLE
feat(adapters): configure_tool_display setter on OutboundAdapterBase (#1468)

### DIFF
--- a/artifacts/frames/1468-tool-display-config-storage-frame.mdx
+++ b/artifacts/frames/1468-tool-display-config-storage-frame.mdx
@@ -1,0 +1,56 @@
+---
+title: "watch: 3rd OutboundAdapterBase subclass — design tool_display_config storage before adding"
+issue: 1468
+status: approved
+tier: F-lite
+date: 2026-05-28
+---
+
+## Problem
+
+`tool_display_config` is stored per-platform via a copy-pasted `__init__` kwarg + assignment:
+
+```python
+def __init__(self, ..., tool_display_config: ToolDisplayConfig | None = None):
+    self._tool_display_config = tool_display_config
+```
+
+This pattern is currently duplicated in EXACTLY 2 sibling adapter dirs — `src/lyra/adapters/telegram/telegram.py` and `src/lyra/adapters/discord/adapter.py`. ADR-073 RC-3 (target-axis-trap) fires at 3 sibling dirs: any new `OutboundAdapterBase` subclass (Slack, Matrix, …) would copy-paste the same kwarg + storage, crossing the threshold and re-introducing cross-cutting drift along the non-primary (platform) axis.
+
+A 3rd adapter is now imminent, so the storage mechanism must be designed and the 2 existing platforms refactored onto it **before** the 3rd is added.
+
+## Who
+
+- **Primary:** Lyra maintainers adding new outbound platform adapters — they should configure tool-display once, not re-implement storage.
+- **Secondary:** Reviewers / axial-adr-review (ADR-073 RC-3) — the mechanism removes the recurring target-axis-trap finding.
+
+## Constraints
+
+- `OutboundAdapterBase` has **NO `__init__`** (MRO with `discord.Client` — `DiscordAdapter(discord.Client, OutboundAdapterBase)`). A base-class `__init__` is forbidden. Verified: `_base_outbound.py:34` class def, no `__init__`; line 71 reads `getattr(self, "_tool_display_config", None) or ToolDisplayConfig()` defensively.
+- Single domain: `src/lyra/adapters/`. No new arch.
+- Must keep the existing read path working (`getattr(self, "_tool_display_config", None)` consumers in `_base_outbound.py`).
+- Refactor both existing adapters onto the new mechanism in the same change (no half-migrated state).
+
+## Out of Scope
+
+- Adding the actual 3rd adapter (Slack/Matrix) — separate issue once mechanism lands.
+- Changing `ToolDisplayConfig` shape or the bootstrap wiring that constructs the configs (`bootstrap/factory/config.py`, `bootstrap/wiring/bootstrap_wiring.py`).
+- The outbound emitter consumption of the config (`outbound/emitter.py`, `outbound/_tool_recap.py`).
+
+## Premise Validity
+
+**Success in 6 months:** A 3rd `OutboundAdapterBase` subclass is added WITHOUT copy-pasting the `tool_display_config` kwarg + storage; the storage mechanism is defined once and the 2 existing adapters use it.
+
+**Failure in 6 months:** The 3rd adapter ships still copy-pasting `self._tool_display_config = tool_display_config` (≥3 sibling dirs duplicate the pattern → ADR-073 RC-3 target-axis-trap fires), OR the new mechanism added net complexity (LOC of base mechanism > LOC saved across adapters). Falsifiable: measurable via sibling-dir duplication count and net LOC delta.
+
+**Simplest alternative:** Keep the class-attribute default + per-subclass `__init__` storage (current pattern).
+**Why not simplest:** Doesn't scale — every new adapter re-duplicates the kwarg + assignment; that re-duplication is exactly the drift that triggered this issue and ADR-073 RC-3.
+
+## Complexity
+
+**Tier: F-lite** — single domain (adapters), clear scope, no new architecture; bounded to a storage-mechanism design + 2-adapter refactor.
+
+Signals observed:
+- `size:F-lite` label on issue.
+- Single domain (`src/lyra/adapters/`), 2 files to refactor + 1 base mechanism.
+- No unknowns: the 3 candidate mechanisms are enumerated in the issue.

--- a/artifacts/plans/1468-tool-display-config-storage-plan.mdx
+++ b/artifacts/plans/1468-tool-display-config-storage-plan.mdx
@@ -1,0 +1,215 @@
+---
+title: "Plan: tool_display_config storage via configure_tool_display setter"
+issue: 1468
+spec: artifacts/specs/1468-tool-display-config-storage-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-05-28
+---
+
+## Summary
+
+Lift per-instance `tool_display_config` storage from copy-pasted adapter constructors into a single `configure_tool_display(cfg)` setter on `OutboundAdapterBase`; strip the kwarg/import/assignment from both adapters; route the 4 construction sites through the setter and drop the now-dead `_tdc` normalization; update the tests that locked in the old kwarg API.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph cfg[config]
+      CB[config_bundle.tool_display]
+    end
+    subgraph wiring[bootstrap/]
+      WH[wiring_helpers: *WiringDeps tool_display_config field — KEPT]
+      WT[wire_telegram_adapters]
+      WD[wire_discord_adapters]
+      AS[adapter_standalone ×2]
+    end
+    subgraph adapters[adapters/]
+      OAB[OutboundAdapterBase.configure_tool_display]
+      TA[TelegramAdapter]
+      DA[DiscordAdapter]
+      SS[send_streaming: getattr ... or ToolDisplayConfig defaults]
+    end
+    CB --> WH --> WT & WD
+    CB --> AS
+    WT -- "configure_tool_display(deps.tdc)" --> TA
+    WD -- "configure_tool_display(deps.tdc)" --> DA
+    AS -- "configure_tool_display(config_bundle.tool_display)" --> TA & DA
+    TA --> OAB
+    DA --> OAB
+    OAB -. "stores _tool_display_config" .-> SS
+    style OAB stroke-width:3px
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph base[adapters/shared/_base_outbound.py]
+      F1[configure_tool_display NEW]
+      F2[send_streaming UNCHANGED logic]
+    end
+    subgraph tg[adapters/telegram/telegram.py]
+      F3[TelegramAdapter.__init__ −kwarg −import −assign]
+    end
+    subgraph dc[adapters/discord/adapter.py]
+      F4[DiscordAdapter.__init__ −kwarg −import −assign]
+    end
+    subgraph bw[bootstrap/wiring/bootstrap_wiring.py]
+      F5[wire_telegram_adapters −_tdc +setter]
+      F6[wire_discord_adapters −_tdc +setter]
+    end
+    subgraph st[bootstrap/standalone/adapter_standalone.py]
+      F7[tg construct +setter]
+      F8[dc construct +setter]
+    end
+    subgraph tests[tests/]
+      T1[test_emitter_config_threading.py]
+      T2[test_tool_display_wiring.py]
+      T3[base setter unit test NEW]
+    end
+    F5 --> F3
+    F6 --> F4
+    F7 --> F3
+    F8 --> F4
+    F3 --> F1
+    F4 --> F1
+    T1 -.-> F1
+    T2 -.-> F5 & F6
+    T3 -.-> F1
+```
+
+## Agents
+
+| Agent | Task count | Files |
+|-------|-----------|-------|
+| backend-dev-A | 4 | `_base_outbound.py`, `telegram.py`, `discord/adapter.py`, `bootstrap_wiring.py`, `adapter_standalone.py`, `adapters/CLAUDE.md` |
+| tester-A | 1 | `test_emitter_config_threading.py`, `test_tool_display_wiring.py`, new base setter test |
+
+Single subject surface (`tool-display-storage`) across all impl tasks → no instance split required.
+
+## Micro-Tasks
+
+### Slice 1 — base setter
+
+**T1** — Add `configure_tool_display` setter to `OutboundAdapterBase`
+- File: `src/lyra/adapters/shared/_base_outbound.py`
+- Snippet:
+  ```python
+  def configure_tool_display(self, config: ToolDisplayConfig | None) -> None:
+      """Store the per-instance tool-display config (post-construction setter).
+
+      OutboundAdapterBase has no __init__ (Discord MRO); this is the single
+      permitted per-instance write point. Stores None as-is — defaulting to
+      ToolDisplayConfig() happens only in send_streaming's read path.
+      """
+      self._tool_display_config = config
+  ```
+  Also reword the `:69` comment: `# Single site propagating tool_display_config to the emitter — see ADR-073.`
+- Verify: `grep -n "def configure_tool_display" src/lyra/adapters/shared/_base_outbound.py`
+- Expected: 1 match
+- Agent: backend-dev-A · Subject: tool-display-storage · Spec trace: SC-1, SC-6(comment) · Slice V1 · Phase GREEN · Difficulty 1
+
+### Slice 2 — refactor adapters + call sites + docs + tests
+
+**T2** — Strip kwarg/import/assignment from both adapters
+- Files: `src/lyra/adapters/telegram/telegram.py` (drop `:53` import, `:95` kwarg, `:98` assignment; keep `:97` `super().__init__()`), `src/lyra/adapters/discord/adapter.py` (drop `:57` import, `:99` kwarg, `:105` assignment)
+- Verify: `grep -rn "self._tool_display_config" src/lyra/adapters/ | grep -v _base_outbound`
+- Expected: no output
+- Agent: backend-dev-A · Subject: tool-display-storage · Spec trace: SC-2, SC-3 · Slice V2 · Phase GREEN · Difficulty 2 · blockedBy T1
+
+**T3** — Route 4 construction sites through setter; drop `_tdc` normalization
+- Files: `src/lyra/bootstrap/wiring/bootstrap_wiring.py` (`wire_telegram_adapters`: drop `:90-93` `_tdc`, drop `tool_display_config=` kwarg at `:119`, add `adapter.configure_tool_display(deps.tool_display_config)` after construct; `wire_discord_adapters`: same at `:169-172`/`:232`), `src/lyra/bootstrap/standalone/adapter_standalone.py` (`:103-109` tg, `:261-269` dc: drop kwarg, add setter call after construct)
+- Verify: `grep -rn "_tdc" src/lyra/bootstrap/wiring/bootstrap_wiring.py; grep -rn "configure_tool_display" src/lyra/bootstrap/`
+- Expected: no `_tdc` matches; 4 `configure_tool_display` call sites
+- Agent: backend-dev-A · Subject: tool-display-storage · Spec trace: SC-4, SC-5 · Slice V2 · Phase GREEN · Difficulty 3 · blockedBy T2
+
+**T4** — Update `adapters/CLAUDE.md`
+- File: `src/lyra/adapters/CLAUDE.md`
+- Update the `OutboundAdapterBase` section: name `configure_tool_display` as the single per-instance write point; note it is a **post-construction setter, NOT `__init__`** (so the "do NOT add `__init__`" constraint is not conflated); mirror the `make_typing_factory` "define once" framing.
+- Verify: `grep -n "configure_tool_display" src/lyra/adapters/CLAUDE.md`
+- Expected: ≥1 match
+- Agent: backend-dev-A · Subject: tool-display-storage · Spec trace: SC-8 · Slice V2 · Phase REFACTOR · Difficulty 1 · blockedBy T1
+
+**T5** — Update + add tests for setter API
+- Files: `tests/outbound/test_emitter_config_threading.py` (update `_make_tg_adapter`/`_make_dc_adapter` helpers to construct then `configure_tool_display(...)`; revise the SC-2 "accepts kwarg" assertion to "setter stores config"), `tests/bootstrap/test_tool_display_wiring.py` (flip assertions: 4 callsites call `configure_tool_display` instead of passing the kwarg), new unit test asserting `configure_tool_display` sets `_tool_display_config` and `None` stays `None` while `send_streaming` defaults.
+- Verify: `uv run pytest tests/outbound/test_emitter_config_threading.py tests/bootstrap/test_tool_display_wiring.py tests/bootstrap/test_wiring_helpers.py tests/test_tool_display_config.py -q`
+- Expected: all green
+- Agent: tester-A · Subject: tool-display-storage · Spec trace: SC-1..SC-7 · Slice V2 · Phase RED-GATE · Difficulty 3 · blockedBy T3
+
+## Wave Structure
+
+4 waves, mostly sequential (single cohesive refactor, 1 impl instance + 1 tester). Elapsed ~same as sequential — parallelism limited by the atomic API change.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | backend-dev-A: T1 |
+| 2 | T1 done | 1 | backend-dev-A: T2→T4 (T4 ∥-safe after T1) |
+| 3 | T2 done | 1 | backend-dev-A: T3 |
+| 4 | T3 done | 1 | tester-A: T5 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 setter | 1 | bounded | 3 | — |
+| T2 strip adapters | 2 files | judgmental | 6 | — |
+| T3 call sites | 4 sites | judgmental | 8 | — |
+| T4 CLAUDE.md | 1 | bounded | 3 | — |
+| T5 tests | 3 files | judgmental | 10 | — |
+
+**Total estimated ops: ~30**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3, T4 | 20 | tool-display-storage | — (4 tasks ≤ 4; 1 subject) |
+| tester-A | T5 | 10 | tool-display-storage | — |
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | tool-display-storage |
+
+### Wave 2 — after T1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | tool-display-storage |
+| T4 | backend-dev-A | T1 | tool-display-storage |
+
+### Wave 3 — after T2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T2 | tool-display-storage |
+
+### Wave 4 — after T3, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | tester-A | T3 | tool-display-storage |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 11 — tool-display-storage (setter)
+- T2: 12 — tool-display-storage (strip adapters)
+- T3: 13 — tool-display-storage (call sites + dead-norm)
+- T4: 14 — tool-display-storage (CLAUDE.md)
+- T5: 15 — tool-display-storage (tests)
+
+## Consistency Report
+
+- Success criteria covered: 8/8 (SC-1→T1, SC-2/3→T2, SC-4/5→T3, SC-6 grep→T2, SC-7 toolchain→T5+validate, SC-8→T4).
+- Uncovered: none.
+- Untraced tasks: none.
+- Exemptions: `*WiringDeps.tool_display_config` fields kept by design (spec scope note).

--- a/artifacts/specs/1468-tool-display-config-storage-spec.mdx
+++ b/artifacts/specs/1468-tool-display-config-storage-spec.mdx
@@ -1,0 +1,133 @@
+---
+title: "tool_display_config storage mechanism for OutboundAdapterBase"
+issue: 1468
+status: approved
+tier: F-lite
+date: 2026-05-28
+promoted_from: artifacts/frames/1468-tool-display-config-storage-frame.mdx
+---
+
+## Context
+
+Source: [frame](../frames/1468-tool-display-config-storage-frame.mdx). Pre-emptive design tracker (#1468) before a 3rd `OutboundAdapterBase` subclass is added.
+
+`tool_display_config` is a **per-instance** (per-bot) value, currently stored via a copy-pasted constructor kwarg + assignment in each adapter dir:
+
+```python
+def __init__(self, ..., tool_display_config: ToolDisplayConfig | None = None):
+    self._tool_display_config = tool_display_config
+```
+
+Duplicated in `adapters/telegram/telegram.py` and `adapters/discord/adapter.py`. `OutboundAdapterBase` (`adapters/shared/_base_outbound.py`) has **no `__init__`** (Discord MRO with `discord.Client`), so a base constructor is forbidden. ADR-073 RC-3 (target-axis-trap) fires at a 3rd sibling dir.
+
+The **read** path is already centralized on the base (`send_streaming`, `_base_outbound.py:70-72`):
+
+```python
+emitter.tool_display_config = (
+    getattr(self, "_tool_display_config", None) or ToolDisplayConfig()
+)
+```
+
+Only the **write** (storage) is duplicated.
+
+## Goal
+
+Define the storage write ONCE on `OutboundAdapterBase` via a `configure_tool_display(cfg)` setter, so a future 3rd adapter inherits storage with zero new per-dir code; refactor the 2 existing adapters and their 4 construction sites onto it.
+
+## Users
+
+- **Primary:** Lyra maintainers adding outbound platform adapters — inherit storage, never re-implement it.
+- **Secondary:** axial-adr-review / ADR-073 RC-3 — recurring target-axis-trap finding removed.
+
+## Expected Behavior
+
+1. `OutboundAdapterBase` exposes a concrete `configure_tool_display(self, config: ToolDisplayConfig | None) -> None` that assigns `self._tool_display_config = config`. It accepts `None` and stores it as-is — normalization to a default lives **only** in the read path.
+2. `TelegramAdapter` / `DiscordAdapter` no longer declare the `tool_display_config` kwarg, the assignment, or the now-unused `ToolDisplayConfig` import.
+3. The 4 adapter construction sites build the adapter, then call `adapter.configure_tool_display(<config>)` immediately after instantiation (before the adapter is registered / serves traffic). The redundant `_tdc = … or ToolDisplayConfig()` normalization in `wire_telegram_adapters` / `wire_discord_adapters` is removed — the value is passed straight to the setter.
+4. `send_streaming` read path keeps its defensive `getattr(..., None) or ToolDisplayConfig()` — the **sole** default site — so an un-configured adapter (e.g. a unit test that bypasses bootstrap) still defaults correctly.
+5. Behavior is identical at runtime: same config value reaches the emitter; no observable change for any platform.
+6. The `TelegramAdapter` `super().__init__()` no-op call (`telegram.py:97`) is untouched; the `_base_outbound.py:69` `# Single WRITE site …` comment is clarified to name the emitter-propagation site (it is no longer the only place `tool_display_config` is written, now that the setter exists).
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class OutboundAdapterBase {
+        <<abstract, no __init__>>
+        -_tool_display_config: ToolDisplayConfig | None
+        +configure_tool_display(config) None
+        +send_streaming(...) None
+    }
+    class TelegramAdapter {
+        +__init__(bot_id, token, ...)
+    }
+    class DiscordAdapter {
+        +__init__(bot_id, *, intents, ...)
+    }
+    class ToolDisplayConfig {
+        <<config>>
+    }
+    OutboundAdapterBase <|-- TelegramAdapter
+    OutboundAdapterBase <|-- DiscordAdapter
+    OutboundAdapterBase ..> ToolDisplayConfig : stores per-instance
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    BW[bootstrap_wiring.py] -- configure_tool_display(tdc) --> TA[TelegramAdapter]
+    BW -- configure_tool_display(tdc) --> DA[DiscordAdapter]
+    AS[adapter_standalone.py] -- configure_tool_display(tdc) --> TA
+    AS -- configure_tool_display(tdc) --> DA
+    TA -- getattr _tool_display_config --> SS[send_streaming → emitter]
+    DA -- getattr _tool_display_config --> SS
+    SLACK[future 3rd adapter]:::future -. inherits configure_tool_display .-> OAB[OutboundAdapterBase]
+    classDef future stroke-dasharray: 4 4
+```
+
+### Consumer summary
+
+| Consumer | Field | When | Status |
+|---|---|---|---|
+| `bootstrap_wiring.py` `wire_telegram_adapters` / `wire_discord_adapters` (×2) | sets `_tool_display_config` via setter; drops `_tdc` normalization | post-construction, pre-register | this issue |
+| `adapter_standalone.py` (×2) | sets `_tool_display_config` via setter | post-construction, pre-register | this issue |
+| `send_streaming` (base) | reads `_tool_display_config` (sole default site) | per streamed reply | logic unchanged |
+| `wiring_helpers.py` `*WiringDeps(tool_display_config=…)` (×2) | DI field carries config into the wiring layer | construct-time | **kept** — not a construction/storage site; lives in `bootstrap/`, axial-confirmed not drift |
+| future 3rd adapter | inherits setter | n/a | future (must require 0 new storage code) |
+
+> **Scope note:** `TelegramWiringDeps.tool_display_config` / `DiscordWiringDeps.tool_display_config` (`bootstrap_wiring.py:52,65`) are intentionally **kept** — they are DI plumbing carrying the config from `wiring_helpers` into the wire-functions, not per-adapter-dir storage. axial-adr-review confirmed they are not axis drift (bootstrap layer, single file, no three-strikes threshold). Removing them is out of scope.
+
+## Breadboard
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `OutboundAdapterBase.configure_tool_display(config)` | assigns `self._tool_display_config = config` | `ToolDisplayConfig \| None` |
+| N2 | `TelegramAdapter.__init__` | drop kwarg + assignment + import | — |
+| N3 | `DiscordAdapter.__init__` | drop kwarg + assignment + import | — |
+| N4 | 4 construction sites (`wire_telegram_adapters`, `wire_discord_adapters`, `adapter_standalone` ×2) | `adapter.configure_tool_display(<config>)` after instantiation; drop `_tdc` normalization in the two wire-functions | `deps.tool_display_config` / `config_bundle.tool_display` |
+
+Wiring: N1 defines storage → N2/N3 remove duplicated storage → N4 calls N1 at each site (and removes dead `_tdc` default). `send_streaming` read/propagation logic untouched.
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|---|---|---|
+| 1 | Add setter to base | N1 | `configure_tool_display` exists on base; unit test sets + reads `_tool_display_config` |
+| 2 | Refactor both adapters + call sites | N2, N3, N4 | both adapters drop the kwarg; 4 call sites use setter; full suite green, config still reaches emitter |
+
+Slices are sequenced (2 depends on 1) but ship as one PR (F-lite).
+
+## Success Criteria
+
+- [ ] `OutboundAdapterBase.configure_tool_display(config: ToolDisplayConfig | None) -> None` exists, assigns `self._tool_display_config = config`, and stores `None` as-is (no normalization in the setter).
+- [ ] `TelegramAdapter.__init__` no longer declares `tool_display_config`; the `ToolDisplayConfig` import is removed from `telegram.py`.
+- [ ] `DiscordAdapter.__init__` no longer declares `tool_display_config`; the `ToolDisplayConfig` import is removed from `adapter.py`.
+- [ ] All 4 construction sites (`wire_telegram_adapters`, `wire_discord_adapters` in `bootstrap_wiring.py`; `adapter_standalone.py` ×2) call `configure_tool_display(...)` after instantiation.
+- [ ] The `_tdc = … or ToolDisplayConfig()` normalization in `wire_telegram_adapters` (`bootstrap_wiring.py:90-93`) and `wire_discord_adapters` (`:169-172`) is removed; `send_streaming`'s `or ToolDisplayConfig()` is the sole default site.
+- [ ] `send_streaming` read/propagation **logic** is unchanged (the `_base_outbound.py:69` comment may be reworded to disambiguate the emitter-write site; no behavioral change).
+- [ ] No sibling adapter dir (`adapters/telegram/`, `adapters/discord/`) contains a `self._tool_display_config = ...` assignment — grep across `src/lyra/adapters/` returns only `_base_outbound.py`.
+- [ ] `uv run pytest` green; `uv run pyright` clean; `uv run ruff check .` clean.
+- [ ] `adapters/CLAUDE.md` `OutboundAdapterBase` section names `configure_tool_display` as the single permitted per-instance write point, explicitly noting it is a **post-construction setter, not `__init__`** (so the "do NOT add `__init__`" constraint is not conflated), mirroring the `make_typing_factory` "define once" note.

--- a/src/lyra/adapters/CLAUDE.md
+++ b/src/lyra/adapters/CLAUDE.md
@@ -62,6 +62,16 @@ formatter/typing-indicator implementations under `outbound/`.
 `OutboundAdapterBase` has no `__init__` intentionally. Do NOT add one — it breaks
 cooperative MRO with `discord.Client`.
 
+`configure_tool_display(config: ToolDisplayConfig | None)` is the **single permitted
+per-instance write point** for `tool_display_config` (stored as
+`self._tool_display_config`). It is a **post-construction setter** — bootstrap calls
+it after construction, keeping per-instance config storage off `__init__`. Every
+adapter inherits it. A new platform adapter MUST NOT re-declare a
+`tool_display_config` constructor kwarg or a bare
+`self._tool_display_config = ...` assignment. Same "define once on the base, never
+per-adapter-dir" rationale as `make_typing_factory` — avoids N×M drift per
+ADR-073.
+
 ## MRO constraint (Discord only)
 
 `discord.Client` must be first:

--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -54,8 +54,6 @@ from lyra.core.messaging.message import (
     OutboundMessage,
 )
 from lyra.core.messaging.messages import MessageManager
-from lyra.core.messaging.tool_display_config import ToolDisplayConfig
-
 log = logging.getLogger(__name__)
 
 
@@ -96,13 +94,11 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         thread_store: ThreadStoreProtocol | None = None,
         watch_channels: frozenset[int] = frozenset(),
         turn_store: "TurnStore | None" = None,
-        tool_display_config: ToolDisplayConfig | None = None,
     ) -> None:
         if intents is None:
             intents = discord.Intents.default()
             intents.message_content = True
         super().__init__(intents=intents)
-        self._tool_display_config = tool_display_config
         self.tree = discord.app_commands.CommandTree(self)
         _register_voice_app_commands(self.tree, self)
         self._inbound_bus = inbound_bus

--- a/src/lyra/adapters/shared/_base_outbound.py
+++ b/src/lyra/adapters/shared/_base_outbound.py
@@ -66,11 +66,20 @@ class OutboundAdapterBase(ABC):
     ) -> None:
         """Stream reply using the shared OutboundEmitter algorithm."""
         emitter = self._make_emitter(original_msg, outbound)
-        # Single WRITE site for tool_display_config — see ADR-073.
+        # Single site propagating tool_display_config to the emitter — see ADR-073.
         emitter.tool_display_config = (
             getattr(self, "_tool_display_config", None) or ToolDisplayConfig()
         )
         await emitter.run(events)
+
+    def configure_tool_display(self, config: ToolDisplayConfig | None) -> None:
+        """Store the per-instance tool-display config (post-construction setter).
+
+        OutboundAdapterBase has no __init__ (Discord MRO); this is the single
+        permitted per-instance write point. Stores None as-is — defaulting to
+        ToolDisplayConfig() happens only in send_streaming's read path.
+        """
+        self._tool_display_config = config
 
     @abstractmethod
     def _make_emitter(

--- a/src/lyra/adapters/telegram/telegram.py
+++ b/src/lyra/adapters/telegram/telegram.py
@@ -50,8 +50,6 @@ from lyra.core.messaging.message import (
     OutboundMessage,
 )
 from lyra.core.messaging.messages import MessageManager
-from lyra.core.messaging.tool_display_config import ToolDisplayConfig
-
 log = logging.getLogger(__name__)
 
 
@@ -92,10 +90,8 @@ class TelegramAdapter(OutboundAdapterBase):
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
         turn_store: "TurnStore | None" = None,
-        tool_display_config: ToolDisplayConfig | None = None,
     ) -> None:
         super().__init__()  # no-op today, future-proofs cooperative chain
-        self._tool_display_config = tool_display_config
         self._bot_id = bot_id
         self._token = token
         self._webhook_secret = webhook_secret

--- a/src/lyra/bootstrap/wiring/bootstrap_wiring.py
+++ b/src/lyra/bootstrap/wiring/bootstrap_wiring.py
@@ -87,11 +87,6 @@ async def wire_telegram_adapters(
 
     Returns (adapters, dispatchers) lists.
     """
-    _tdc = (
-        deps.tool_display_config
-        if deps.tool_display_config is not None
-        else ToolDisplayConfig()
-    )
     adapters: list[TelegramAdapter] = []
     dispatchers: list[OutboundDispatcher] = []
 
@@ -116,8 +111,8 @@ async def wire_telegram_adapters(
             circuit_registry=deps.circuit_registry,
             msg_manager=deps.msg_manager,
             turn_store=deps.hub._turn_store,
-            tool_display_config=_tdc,
         )
+        adapter.configure_tool_display(deps.tool_display_config)
         await adapter.resolve_identity()
         # C3: Hub is the trust authority — register authenticator here, not on adapter.
         deps.hub.register_authenticator(Platform.TELEGRAM, bot_cfg.bot_id, auth)
@@ -166,11 +161,6 @@ async def wire_discord_adapters(
     Returns (adapters_with_config, dispatchers) where each adapter entry is
     (adapter, bot_cfg, token) — the token is needed later for ``adapter.start()``.
     """
-    _tdc = (
-        deps.tool_display_config
-        if deps.tool_display_config is not None
-        else ToolDisplayConfig()
-    )
     adapters: list[tuple[DiscordAdapter, DiscordBotConfig, str]] = []
     dispatchers: list[OutboundDispatcher] = []
 
@@ -229,8 +219,8 @@ async def wire_discord_adapters(
                 thread_store=thread_store,
                 watch_channels=watch_channels,
                 turn_store=deps.hub._turn_store,
-                tool_display_config=_tdc,
             )
+            adapter.configure_tool_display(deps.tool_display_config)
             # Wire identity resolver for slash command trust (voice commands).
             adapter._resolve_identity_fn = deps.hub.resolve_identity
             # C3: Hub is the trust authority — register here, not on adapter.

--- a/src/lyra/bootstrap/wiring/standalone_discord.py
+++ b/src/lyra/bootstrap/wiring/standalone_discord.py
@@ -158,8 +158,8 @@ async def bootstrap_discord_standalone(
             thread_store=dc_thread_store,
             watch_channels=dc_bot_watch_channels.get(bot_id, frozenset()),
             turn_store=dc_turn_store,
-            tool_display_config=config_bundle.tool_display,
         )
+        adapter_dc.configure_tool_display(config_bundle.tool_display)
 
         listener_dc = NatsOutboundListener(
             nc,

--- a/src/lyra/bootstrap/wiring/standalone_telegram.py
+++ b/src/lyra/bootstrap/wiring/standalone_telegram.py
@@ -118,8 +118,8 @@ async def bootstrap_telegram_standalone(
             inbound_bus=inbound_bus,
             webhook_secret=webhook_secret or "",
             turn_store=tg_turn_store,
-            tool_display_config=config_bundle.tool_display,
         )
+        adapter.configure_tool_display(config_bundle.tool_display)
         await adapter.resolve_identity()
 
         listener = NatsOutboundListener(

--- a/tests/adapters/test_outbound_base_tool_display.py
+++ b/tests/adapters/test_outbound_base_tool_display.py
@@ -1,0 +1,149 @@
+# pyright: reportAttributeAccessIssue=false
+"""Unit tests for OutboundAdapterBase.configure_tool_display() setter (#1468).
+
+Covers:
+1. Setter stores the given config on the instance as _tool_display_config.
+2. Setter stores None as-is — no defaulting at write time.
+3. An adapter that never had the setter called still defaults correctly in the
+   read path (mirrors send_streaming's getattr fallback).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from lyra.adapters.shared._base_outbound import OutboundAdapterBase
+from lyra.core.messaging.tool_display_config import ToolDisplayConfig
+from lyra.outbound.emitter import OutboundEmitter, PlatformCallbacks
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass (OutboundAdapterBase is abstract)
+# ---------------------------------------------------------------------------
+
+
+class _MinimalAdapter(OutboundAdapterBase):
+    """Minimal concrete subclass implementing all abstract methods."""
+
+    async def send(self, original_msg, outbound) -> None:
+        pass
+
+    def _make_streaming_callbacks(self, original_msg, outbound) -> PlatformCallbacks:
+        return PlatformCallbacks(
+            send_placeholder=AsyncMock(return_value=(MagicMock(), 42)),
+            edit_placeholder_text=AsyncMock(),
+            send_trace_placeholder=AsyncMock(return_value=(object(), 42)),
+            send_message=AsyncMock(return_value=99),
+            send_fallback=AsyncMock(return_value=77),
+            chunk_text=lambda text: [text],
+            start_typing=MagicMock(),
+            cancel_typing=MagicMock(),
+            get_msg=MagicMock(side_effect=lambda key, fb: fb),
+            placeholder_text="…",
+        )
+
+    def _make_emitter(self, original_msg, outbound) -> OutboundEmitter:
+        return OutboundEmitter(
+            self._make_streaming_callbacks(original_msg, outbound), outbound
+        )
+
+    def _start_typing(self, scope_id: int) -> None:
+        pass
+
+    def _cancel_typing(self, scope_id: int) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureToolDisplay:
+    def test_setter_stores_config_on_instance(self) -> None:
+        """configure_tool_display(cfg) stores cfg as _tool_display_config."""
+        # Arrange
+        adapter = _MinimalAdapter()
+        cfg = ToolDisplayConfig(bash_max_len=200)
+
+        # Act
+        adapter.configure_tool_display(cfg)
+
+        # Assert
+        assert adapter._tool_display_config is cfg
+
+    def test_setter_stores_none_as_is(self) -> None:
+        """configure_tool_display(None) stores None — no defaulting at write time."""
+        # Arrange
+        adapter = _MinimalAdapter()
+
+        # Act
+        adapter.configure_tool_display(None)
+
+        # Assert — None is stored verbatim; defaulting happens only in send_streaming
+        assert adapter._tool_display_config is None
+
+    def test_setter_overwrites_previous_value(self) -> None:
+        """A second configure_tool_display() call replaces the previous config."""
+        # Arrange
+        adapter = _MinimalAdapter()
+        first_cfg = ToolDisplayConfig(bash_max_len=100)
+        second_cfg = ToolDisplayConfig(bash_max_len=200)
+
+        # Act
+        adapter.configure_tool_display(first_cfg)
+        adapter.configure_tool_display(second_cfg)
+
+        # Assert
+        assert adapter._tool_display_config is second_cfg
+
+    def test_read_path_defaults_when_setter_never_called(self) -> None:
+        """Adapter with no setter call gets ToolDisplayConfig() defaults.
+
+        Mirrors send_streaming's read path:
+            getattr(self, "_tool_display_config", None) or ToolDisplayConfig()
+        """
+        # Arrange — fresh adapter, setter never called
+        adapter = _MinimalAdapter()
+
+        # Act — replicate send_streaming's read path
+        resolved = getattr(adapter, "_tool_display_config", None) or ToolDisplayConfig()
+
+        # Assert — falls back to default ToolDisplayConfig()
+        assert isinstance(resolved, ToolDisplayConfig)
+        assert resolved.bash_max_len == ToolDisplayConfig().bash_max_len
+
+    def test_read_path_uses_stored_config_when_setter_was_called(self) -> None:
+        """When configure_tool_display(cfg) was called, the read path returns cfg.
+
+        Negative guard: if the setter is removed, _tool_display_config is missing
+        and getattr returns None, so the read path falls back to ToolDisplayConfig()
+        defaults — making the bash_max_len assertion below fail.
+        """
+        # Arrange
+        adapter = _MinimalAdapter()
+        cfg = ToolDisplayConfig(bash_max_len=300)
+        adapter.configure_tool_display(cfg)
+
+        # Act — replicate send_streaming's read path
+        resolved = getattr(adapter, "_tool_display_config", None) or ToolDisplayConfig()
+
+        # Assert — stored config is returned, not the default
+        assert resolved is cfg
+        assert resolved.bash_max_len == 300
+
+    def test_read_path_falls_back_to_default_when_none_stored(self) -> None:
+        """configure_tool_display(None) → read path falls back to ToolDisplayConfig().
+
+        None stored as-is at write time, but the `or ToolDisplayConfig()` in
+        send_streaming's read path then substitutes the default.
+        """
+        # Arrange
+        adapter = _MinimalAdapter()
+        adapter.configure_tool_display(None)
+
+        # Act — replicate send_streaming's read path
+        resolved = getattr(adapter, "_tool_display_config", None) or ToolDisplayConfig()
+
+        # Assert — None triggers fallback to defaults
+        assert isinstance(resolved, ToolDisplayConfig)
+        assert resolved.bash_max_len == ToolDisplayConfig().bash_max_len

--- a/tests/bootstrap/test_tool_display_wiring.py
+++ b/tests/bootstrap/test_tool_display_wiring.py
@@ -1,15 +1,14 @@
-"""Slice 3 RED tests — tool_display_config threading from raw_config to adapters.
+"""tool_display_config threading from raw_config to adapters — post-#1468.
 
 Tests assert that the [tool_display] section in raw_config is loaded and threaded
 through both the wired bootstrap path (bootstrap_wiring.py) and the standalone
-adapter path (adapter_standalone.py) to TelegramAdapter._tool_display_config and
-DiscordAdapter._tool_display_config.
-
-These tests are intentionally RED until T20 (wired path) + T21 (standalone path)
-implement the loader call + kwarg threading in the respective bootstrap modules.
+adapter path (adapter_standalone.py) via configure_tool_display() (post-construction
+setter), NOT via a constructor kwarg.
 
 SC-5: absent [tool_display] section → ToolDisplayConfig() defaults (integration level).
-SC-6: all 4 bootstrap callsites pass tool_display_config= to adapter constructors.
+SC-6: all 4 bootstrap callsites call adapter.configure_tool_display(config) after
+      construction (kwarg was removed from both TelegramAdapter and DiscordAdapter
+      __init__ in #1468).
 """
 
 from __future__ import annotations
@@ -54,10 +53,11 @@ def _dc_raw_config(tool_display: dict | None = None) -> dict:
 
 @pytest.mark.asyncio
 async def test_wired_path_threads_tool_display_config_to_telegram() -> None:
-    """wire_telegram_adapters must pass tool_display_config= to TelegramAdapter.
+    """wire_telegram_adapters must call adapter.configure_tool_display() post-build.
 
-    RED trigger: wire_telegram_adapters currently does NOT pass tool_display_config=.
-    T20 implements the wiring at bootstrap_wiring.py L64.
+    #1468 removed tool_display_config= from TelegramAdapter.__init__. The wiring
+    contract is now: construct without the kwarg, then call configure_tool_display()
+    on the returned instance.
     """
     from lyra.bootstrap.wiring.bootstrap_wiring import (
         TelegramWiringDeps,
@@ -71,7 +71,7 @@ async def test_wired_path_threads_tool_display_config_to_telegram() -> None:
 
     raw_config = {"tool_display": {"bash_max_len": 200, "show": {"web_fetch": False}}}
 
-    # Arrange — loader parses the section correctly (loader itself is already done)
+    # Arrange — loader parses the section correctly
     tool_display_cfg = _load_tool_display_config(raw_config)
     assert tool_display_cfg.bash_max_len == 200
     assert tool_display_cfg.show["web_fetch"] is False
@@ -80,12 +80,15 @@ async def test_wired_path_threads_tool_display_config_to_telegram() -> None:
     bot_cfg = TelegramBotConfig(bot_id="main")
     auth = Authenticator(store=None, role_map={}, default=TrustLevel.PUBLIC)
 
-    captured_kwargs: dict = {}
+    captured_constructor_kwargs: dict = {}
+    captured_adapter_instance: MagicMock | None = None
 
     def _capture_adapter(**kwargs):
-        captured_kwargs.update(kwargs)
+        captured_constructor_kwargs.update(kwargs)
         mock = MagicMock()
         mock.resolve_identity = AsyncMock()
+        nonlocal captured_adapter_instance
+        captured_adapter_instance = mock
         return mock
 
     with (
@@ -109,15 +112,17 @@ async def test_wired_path_threads_tool_display_config_to_telegram() -> None:
             )
         )
 
-    # T20 contract: wire_telegram_adapters threads tool_display_config kwarg
-    # through to the TelegramAdapter constructor. Loader call lives one layer
-    # up in wiring_helpers._wire_adapters (where raw_config is in scope).
-    assert "tool_display_config" in captured_kwargs, (
-        "wire_telegram_adapters must forward tool_display_config= to "
-        "TelegramAdapter constructor"
+    # #1468 contract: constructor must NOT receive tool_display_config= kwarg.
+    assert "tool_display_config" not in captured_constructor_kwargs, (
+        "TelegramAdapter constructor must NOT receive tool_display_config= "
+        "after #1468 (setter replaces kwarg)"
     )
-    assert captured_kwargs["tool_display_config"].bash_max_len == 200
-    assert captured_kwargs["tool_display_config"].show["web_fetch"] is False
+
+    # Post-construction setter must be called with the correct config.
+    assert captured_adapter_instance is not None
+    captured_adapter_instance.configure_tool_display.assert_called_once_with(
+        tool_display_cfg
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -127,10 +132,11 @@ async def test_wired_path_threads_tool_display_config_to_telegram() -> None:
 
 @pytest.mark.asyncio
 async def test_wired_path_threads_tool_display_config_to_discord() -> None:
-    """wire_discord_adapters must pass tool_display_config= to DiscordAdapter.
+    """wire_discord_adapters must call adapter.configure_tool_display() post-build.
 
-    RED until T20 adds the kwarg to the DiscordAdapter callsite in
-    bootstrap_wiring.py (L170).
+    #1468 removed tool_display_config= from DiscordAdapter.__init__. The wiring
+    contract is now: construct without the kwarg, then call configure_tool_display()
+    on the returned instance.
     """
     from lyra.bootstrap.wiring.bootstrap_wiring import (
         DiscordWiringDeps,
@@ -152,12 +158,15 @@ async def test_wired_path_threads_tool_display_config_to_discord() -> None:
     bot_cfg = DiscordBotConfig(bot_id="main", auto_thread=False, thread_hot_hours=4)
     auth = Authenticator(store=None, role_map={}, default=TrustLevel.PUBLIC)
 
-    captured_kwargs: dict = {}
+    captured_constructor_kwargs: dict = {}
+    captured_adapter_instance: MagicMock | None = None
 
     def _capture_discord_adapter(**kwargs):
-        captured_kwargs.update(kwargs)
+        captured_constructor_kwargs.update(kwargs)
         mock = MagicMock()
         mock._resolve_identity_fn = None
+        nonlocal captured_adapter_instance
+        captured_adapter_instance = mock
         return mock
 
     mock_thread_store = AsyncMock()
@@ -190,15 +199,17 @@ async def test_wired_path_threads_tool_display_config_to_discord() -> None:
             )
         )
 
-    # T20 contract: wire_discord_adapters threads tool_display_config kwarg
-    # through to the DiscordAdapter constructor. Loader call lives one layer
-    # up in wiring_helpers._wire_adapters (where raw_config is in scope).
-    assert "tool_display_config" in captured_kwargs, (
-        "wire_discord_adapters must forward tool_display_config= to "
-        "DiscordAdapter constructor"
+    # #1468 contract: constructor must NOT receive tool_display_config= kwarg.
+    assert "tool_display_config" not in captured_constructor_kwargs, (
+        "DiscordAdapter constructor must NOT receive tool_display_config= "
+        "after #1468 (setter replaces kwarg)"
     )
-    assert captured_kwargs["tool_display_config"].bash_max_len == 200
-    assert captured_kwargs["tool_display_config"].show["web_fetch"] is False
+
+    # Post-construction setter must be called with the correct config.
+    assert captured_adapter_instance is not None
+    captured_adapter_instance.configure_tool_display.assert_called_once_with(
+        loader_result
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -208,14 +219,16 @@ async def test_wired_path_threads_tool_display_config_to_discord() -> None:
 
 @pytest.mark.asyncio
 async def test_wired_path_with_absent_tool_display_section_uses_defaults() -> None:
-    """raw_config={} (no [tool_display]) → TelegramAdapter receives default config.
+    """raw_config={} (no [tool_display]) → configure_tool_display() receives defaults.
 
     SC-5: integration-level default parity — absent section must produce
-    ToolDisplayConfig() defaults (bash_max_len=80, names_threshold=5) threaded
-    through to the adapter, not None.
+    ToolDisplayConfig() defaults (bash_max_len=80) threaded through to the adapter
+    via configure_tool_display(), not None.
 
-    RED until T20 wires the loader into wire_telegram_adapters so the kwarg is
-    always populated.
+    When tool_display_config is None in TelegramWiringDeps (absent section),
+    configure_tool_display(None) is called and send_streaming falls back to
+    ToolDisplayConfig() defaults — both paths are acceptable. This test verifies
+    the wiring_helpers path which passes a default ToolDisplayConfig(), not None.
     """
     from lyra.bootstrap.wiring.bootstrap_wiring import (
         TelegramWiringDeps,
@@ -227,20 +240,23 @@ async def test_wired_path_with_absent_tool_display_section_uses_defaults() -> No
     from lyra.core.circuit_breaker import CircuitRegistry
     from lyra.core.hub.hub import Hub
 
-    # No [tool_display] section
+    # No [tool_display] section — loader returns defaults
     tool_display_cfg = _load_tool_display_config({})
-    assert tool_display_cfg.bash_max_len == 80  # default after Slice 1
+    assert tool_display_cfg.bash_max_len == 80  # default
 
     hub = Hub()
     bot_cfg = TelegramBotConfig(bot_id="main")
     auth = Authenticator(store=None, role_map={}, default=TrustLevel.PUBLIC)
 
-    captured_kwargs: dict = {}
+    captured_constructor_kwargs: dict = {}
+    captured_adapter_instance: MagicMock | None = None
 
     def _capture_adapter(**kwargs):
-        captured_kwargs.update(kwargs)
+        captured_constructor_kwargs.update(kwargs)
         mock = MagicMock()
         mock.resolve_identity = AsyncMock()
+        nonlocal captured_adapter_instance
+        captured_adapter_instance = mock
         return mock
 
     with (
@@ -260,18 +276,22 @@ async def test_wired_path_with_absent_tool_display_section_uses_defaults() -> No
                 bot_agent_map={("telegram", "main"): "lyra_default"},
                 circuit_registry=CircuitRegistry(),
                 msg_manager=MagicMock(),
+                tool_display_config=tool_display_cfg,
             )
         )
 
-    # RED: T20 must thread tool_display_cfg (default) to TelegramAdapter.
-    # Until then: key absent → KeyError / assertion fails.
-    assert "tool_display_config" in captured_kwargs, (
-        "RED: wire_telegram_adapters does not pass tool_display_config= "
-        "when [tool_display] section is absent (T20 implements this)"
+    # #1468 contract: constructor must NOT receive tool_display_config= kwarg.
+    assert "tool_display_config" not in captured_constructor_kwargs, (
+        "TelegramAdapter constructor must NOT receive tool_display_config= "
+        "after #1468 (setter replaces kwarg)"
     )
-    adapter_cfg = captured_kwargs["tool_display_config"]
-    assert adapter_cfg.bash_max_len == 80, (
-        f"Expected default bash_max_len=80, got {adapter_cfg.bash_max_len}"
+
+    # configure_tool_display() must be called with the default config.
+    assert captured_adapter_instance is not None
+    captured_adapter_instance.configure_tool_display.assert_called_once()
+    call_arg = captured_adapter_instance.configure_tool_display.call_args[0][0]
+    assert call_arg.bash_max_len == 80, (
+        f"Expected default bash_max_len=80, got {call_arg.bash_max_len}"
     )
 
 
@@ -282,10 +302,11 @@ async def test_wired_path_with_absent_tool_display_section_uses_defaults() -> No
 
 @pytest.mark.asyncio
 async def test_standalone_path_threads_tool_display_config_to_telegram() -> None:
-    """_bootstrap_adapter_standalone must pass tool_display_config= to TelegramAdapter.
+    """Standalone bootstrap must call adapter.configure_tool_display() post-construct.
 
-    RED until T21 adds the _load_tool_display_config call + kwarg threading in
-    adapter_standalone.py (L101 callsite).
+    #1468 removed tool_display_config= from TelegramAdapter.__init__. The standalone
+    bootstrap contract is now: construct without the kwarg, then call
+    configure_tool_display() on the returned instance with the parsed config.
     """
     from lyra.bootstrap.standalone.adapter_standalone import (
         _bootstrap_adapter_standalone,
@@ -301,10 +322,11 @@ async def test_standalone_path_threads_tool_display_config_to_telegram() -> None
     mock_nc = AsyncMock()
     mock_nc.subscribe = AsyncMock(return_value=AsyncMock())
 
-    captured_kwargs: dict = {}
+    captured_constructor_kwargs: dict = {}
+    captured_tg_adapter_instance: MagicMock | None = None
 
     def _capture_tg_adapter(**kwargs):
-        captured_kwargs.update(kwargs)
+        captured_constructor_kwargs.update(kwargs)
         mock = MagicMock()
         mock._bot_id = "main"
         mock.resolve_identity = AsyncMock()
@@ -314,6 +336,8 @@ async def test_standalone_path_threads_tool_display_config_to_telegram() -> None
         mock.dp.start_polling = AsyncMock(return_value=None)
         mock.dp.stop_polling = AsyncMock(return_value=None)
         mock._typing = MagicMock()
+        nonlocal captured_tg_adapter_instance
+        captured_tg_adapter_instance = mock
         return mock
 
     mock_inbound_bus = AsyncMock()
@@ -368,23 +392,27 @@ async def test_standalone_path_threads_tool_display_config_to_telegram() -> None
     ):
         await _bootstrap_adapter_standalone(raw_config, "telegram", _stop=stop)
 
-    # RED: T21 must add _load_tool_display_config(raw_config) call and pass
-    # tool_display_config= kwarg to TelegramAdapter at L101 in adapter_standalone.py.
-    assert "tool_display_config" in captured_kwargs, (
-        "RED: _bootstrap_adapter_standalone does not yet pass tool_display_config= "
-        "to TelegramAdapter constructor (T21 implements this)"
+    # #1468 contract: constructor must NOT receive tool_display_config= kwarg.
+    assert "tool_display_config" not in captured_constructor_kwargs, (
+        "TelegramAdapter constructor must NOT receive tool_display_config= "
+        "after #1468 (setter replaces kwarg)"
     )
-    adapter_cfg = captured_kwargs["tool_display_config"]
+
+    # configure_tool_display() must be called post-construction with the parsed config.
+    assert captured_tg_adapter_instance is not None
+    captured_tg_adapter_instance.configure_tool_display.assert_called_once()
+    adapter_cfg = captured_tg_adapter_instance.configure_tool_display.call_args[0][0]
     assert adapter_cfg.bash_max_len == 200
     assert adapter_cfg.show["web_fetch"] is False
 
 
 @pytest.mark.asyncio
 async def test_standalone_path_threads_tool_display_config_to_discord() -> None:
-    """_bootstrap_adapter_standalone must pass tool_display_config= to DiscordAdapter.
+    """Standalone bootstrap must call Discord configure_tool_display() post-construct.
 
-    Symmetric to the Telegram standalone test; closes the SC-6 coverage gap on
-    the Discord standalone bootstrap callsite (adapter_standalone.py:269).
+    Symmetric to the Telegram standalone test. #1468 removed tool_display_config=
+    from DiscordAdapter.__init__; the standalone bootstrap must call the setter
+    after construction (adapter_standalone.py callsite).
     """
     from lyra.bootstrap.standalone.adapter_standalone import (
         _bootstrap_adapter_standalone,
@@ -400,10 +428,11 @@ async def test_standalone_path_threads_tool_display_config_to_discord() -> None:
     mock_nc = AsyncMock()
     mock_nc.subscribe = AsyncMock(return_value=AsyncMock())
 
-    captured_kwargs: dict = {}
+    captured_constructor_kwargs_dc: dict = {}
+    captured_dc_adapter_instance: MagicMock | None = None
 
     def _capture_dc_adapter(**kwargs):
-        captured_kwargs.update(kwargs)
+        captured_constructor_kwargs_dc.update(kwargs)
         mock = MagicMock()
         mock._bot_id = "main"
         mock.resolve_identity = AsyncMock()
@@ -413,6 +442,8 @@ async def test_standalone_path_threads_tool_display_config_to_discord() -> None:
         mock._typing = MagicMock()
         mock._resolve_identity_fn = None
         mock._resolve_channel = MagicMock()
+        nonlocal captured_dc_adapter_instance
+        captured_dc_adapter_instance = mock
         return mock
 
     mock_inbound_bus = AsyncMock()
@@ -464,10 +495,15 @@ async def test_standalone_path_threads_tool_display_config_to_discord() -> None:
     ):
         await _bootstrap_adapter_standalone(raw_config, "discord", _stop=stop)
 
-    assert "tool_display_config" in captured_kwargs, (
-        "_bootstrap_adapter_standalone must pass tool_display_config= "
-        "to DiscordAdapter constructor (SC-6 standalone half)"
+    # #1468 contract: constructor must NOT receive tool_display_config= kwarg.
+    assert "tool_display_config" not in captured_constructor_kwargs_dc, (
+        "DiscordAdapter constructor must NOT receive tool_display_config= "
+        "after #1468 (setter replaces kwarg)"
     )
-    adapter_cfg = captured_kwargs["tool_display_config"]
+
+    # configure_tool_display() must be called post-construction with the parsed config.
+    assert captured_dc_adapter_instance is not None
+    captured_dc_adapter_instance.configure_tool_display.assert_called_once()
+    adapter_cfg = captured_dc_adapter_instance.configure_tool_display.call_args[0][0]
     assert adapter_cfg.bash_max_len == 200
     assert adapter_cfg.show["web_fetch"] is False

--- a/tests/factories/bootstrap.py
+++ b/tests/factories/bootstrap.py
@@ -69,6 +69,9 @@ class _FakeTgAdapter:
         self._bot_id = kwargs.get("bot_id", "main")
         self.dp = _FakeDp(shutdown_event)
 
+    def configure_tool_display(self, config: object) -> None:
+        self._tool_display_config = config
+
     async def send(self, msg: object, response: object) -> None:
         pass
 
@@ -86,6 +89,9 @@ class _FakeDcAdapter:
         self, shutdown_event: asyncio.Event | None = None, **kwargs: object
     ) -> None:
         self._shutdown = shutdown_event if shutdown_event else asyncio.Event()
+
+    def configure_tool_display(self, config: object) -> None:
+        self._tool_display_config = config
 
     async def start(self, token: str) -> None:
         await self._shutdown.wait()  # explicit: wait for teardown signal

--- a/tests/outbound/test_emitter_config_threading.py
+++ b/tests/outbound/test_emitter_config_threading.py
@@ -83,16 +83,21 @@ def _capture_recap_lines(edit_tool_recap_mock: AsyncMock) -> list[str]:
 
 
 def _make_tg_adapter(tool_display_config: ToolDisplayConfig | None = None):
-    """Build a TelegramAdapter with the given tool_display_config."""
+    """Build a TelegramAdapter with the given tool_display_config.
+
+    Constructs the adapter WITHOUT the kwarg (removed in #1468), then calls
+    configure_tool_display() post-construction. Passing None skips the setter
+    call so send_streaming falls back to ToolDisplayConfig() defaults.
+    """
     from lyra.adapters.telegram import TelegramAdapter
 
-    # Wave 4 adds tool_display_config kwarg — RED until then
     adapter = TelegramAdapter(
         bot_id="main",
         token="test-token",
         inbound_bus=MagicMock(),
-        tool_display_config=tool_display_config,
     )
+    if tool_display_config is not None:
+        adapter.configure_tool_display(tool_display_config)
     placeholder_msg = SimpleNamespace(message_id=100)
     bot = AsyncMock()
     bot.send_message = AsyncMock(return_value=placeholder_msg)
@@ -134,16 +139,21 @@ def _make_tg_inbound(chat_id: int = 42, message_id: int = 10) -> InboundMessage:
 
 
 def _make_dc_adapter(tool_display_config: ToolDisplayConfig | None = None):
-    """Build a DiscordAdapter with the given tool_display_config."""
+    """Build a DiscordAdapter with the given tool_display_config.
+
+    Constructs the adapter WITHOUT the kwarg (removed in #1468), then calls
+    configure_tool_display() post-construction. Passing None skips the setter
+    call so send_streaming falls back to ToolDisplayConfig() defaults.
+    """
     from lyra.adapters.discord import DiscordAdapter
 
-    # Wave 4 adds tool_display_config kwarg — RED until then
     adapter = DiscordAdapter(
         bot_id="main",
         inbound_bus=MagicMock(),
         intents=discord.Intents.none(),
-        tool_display_config=tool_display_config,
     )
+    if tool_display_config is not None:
+        adapter.configure_tool_display(tool_display_config)
     placeholder = AsyncMock()
     placeholder.id = 200
     placeholder.edit = AsyncMock()


### PR DESCRIPTION
## Summary
- Define per-instance `tool_display_config` storage **once** on `OutboundAdapterBase` via a post-construction `configure_tool_display(config)` setter — a future 3rd adapter inherits storage with zero new per-dir code, closing the ADR-073 RC-3 target-axis-trap *before* the 3rd platform lands.
- `TelegramAdapter` / `DiscordAdapter` drop the `tool_display_config` kwarg, the assignment, and the now-unused `ToolDisplayConfig` import. No `__init__` added to the base (Discord MRO preserved).
- The 4 construction sites (`bootstrap_wiring` ×2, `adapter_standalone` ×2) route through the setter; dead `_tdc` normalization removed — the lone default now lives in `send_streaming`'s read path. `*WiringDeps.tool_display_config` fields kept (DI plumbing, axial-confirmed not drift).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1468: watch — design tool_display_config storage before 3rd adapter | OPEN |
| Frame | [1468-…-frame.mdx](artifacts/frames/1468-tool-display-config-storage-frame.mdx) | Present |
| Spec | [1468-…-spec.mdx](artifacts/specs/1468-tool-display-config-storage-spec.mdx) | Present |
| Plan | [1468-…-plan.mdx](artifacts/plans/1468-tool-display-config-storage-plan.mdx) | Present |
| Implementation | 1 impl commit on `feat/1468-tool-display-config-storage` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4869 passed; 1 new test file) | Passed |

## Test Plan
- [ ] `configure_tool_display(cfg)` stores `cfg`; `configure_tool_display(None)` stores `None` as-is.
- [ ] An un-configured adapter still defaults via `send_streaming`'s `getattr(...) or ToolDisplayConfig()`.
- [ ] All 4 wiring/standalone sites call the setter post-construction; no constructor receives the kwarg.
- [ ] `grep -rn "self._tool_display_config" src/lyra/adapters/ | grep -v _base_outbound` → empty (single-write invariant; enforced by pre-push gate).

Closes #1468

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`