### PR TITLE
feat(config)!: migrate runtime bot roster TOML→BotStore, deprecate TOML bot sections

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -72,3 +72,7 @@ quality_gates:
     enabled: true
     stage: pre-push
     config: .importlinter
+
+  no_runtime_toml_bots:
+    enabled: true
+    script: tools/check_no_runtime_toml_bots.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,13 @@ repos:
     pass_filenames: false
     stages:
     - pre-push
+  - id: check-no-runtime-toml-bots
+    name: check-no-runtime-toml-bots
+    entry: tools/check_no_runtime_toml_bots.sh
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push
   - id: license
     name: license check
     entry: uv run tools/license_check.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Entries are generated automatically by `/promote` and committed to staging befor
 
 ## [Unreleased]
 
+### Deprecated
+
+- Runtime-read of the four TOML bot sections (`[[telegram.bots]]`, `[[discord.bots]]`,
+  `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`) is deprecated and now seed-only. The
+  runtime bot roster is sourced from BotStore (`~/.lyra/config.db`); these sections are
+  consumed only by `lyra bot init`. A one-time `DeprecationWarning` is logged at config load
+  if they are present. Scheduled for removal in the next major release (v1.0.0). (#1420)
+
 ### Changed
 
 - Migrated 7 consumer paths and 5 dual-emit sites from v1 to v2 RenderEvents: text triplet

--- a/artifacts/frames/1420-deprecate-runtime-toml-bots-frame.mdx
+++ b/artifacts/frames/1420-deprecate-runtime-toml-bots-frame.mdx
@@ -1,0 +1,67 @@
+---
+title: deprecate runtime-read of [[telegram.bots]] + [[auth.*_bots]] (TOML → seed-only)
+issue: 1420
+status: approved
+tier: F-lite
+date: 2026-05-28
+---
+
+## Problem
+
+Closing step of epic #1413 (BotStore SQLite + `lyra bot` CLI — drop TOML runtime). All
+consumer migrations are complete and merged: #1415 (CLI verbs), #1416 (Authenticator →
+BotStore), #1417 (render_quadlet → BotStore), #1418 (unified seed function), #1412 (shared
+Pydantic BotConfig). BotStore is now the runtime source of truth for bot identity.
+
+The four legacy TOML sections — `[[telegram.bots]]`, `[[discord.bots]]`,
+`[[auth.telegram_bots]]`, `[[auth.discord_bots]]` — are no longer needed at runtime, but
+nothing tells an operator that. A `config.toml` carrying stale bot definitions loads
+silently with zero output, inviting drift between TOML and BotStore. The TOML must become
+**seed-only** (consumed solely by `lyra bot init`) and emit a one-time `DeprecationWarning`
+at config load so operators know to migrate. Also closes #1412's G18 finding (the
+`webhook_enabled` typo trap) by having the Pydantic seed validator catch it at init time.
+
+## Who
+
+- **Primary:** Operators deploying/configuring Lyra — need a clear signal that TOML bot
+  sections are seed-only, plus a migration path (`lyra bot init` → remove sections).
+- **Secondary:** Developers — `Deprecated[...]` Pydantic field markers surface the status
+  in-IDE and prevent accidental new runtime reads.
+
+## Constraints
+
+- Sections must remain **parsable** (no schema error) — `lyra bot init` still consumes them
+  as seed source for backward-compat.
+- DeprecationWarning fires **once** (deduplicated), not per-load-spam.
+- No removal of the sections from config parsing — that is next-major (out of scope here).
+- Single domain: `src/lyra/config.py` + docs + CHANGELOG.
+
+## Out of Scope
+
+- **Removal** of the 4 sections from config parsing (next major version, TBD).
+- Migration tooling beyond `lyra bot init` (operators run init manually).
+
+## Premise Validity
+
+**Success in 6 months:** TOML bot sections are never read at runtime — all bot identity
+flows from BotStore. Grep guardrails return 0 matches. A legacy `config.toml` emits exactly
+one `DeprecationWarning` at load. `lyra bot init` still consumes the sections as seed. The
+G18 `webhook_enabled` typo is caught at seed time by the Pydantic validator.
+
+**Failure in 6 months:** Grep guardrails return >0 matches (runtime reads survive the
+deprecation), OR a `config.toml` containing `[[telegram.bots]]` loads with zero deprecation
+output. Both are observable: a grep count and a boolean "warning fired".
+
+**Simplest alternative:** Hard-delete the 4 sections from config parsing now.
+**Why not simplest:** It breaks `lyra bot init`, which consumes the sections as its seed
+source, and gives operators no migration window. Deprecate-now / remove-next-major with a
+warning is the safe path.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (config), no new architecture; depends on
+already-merged consumer migrations.
+
+- Touches `src/lyra/config.py` (detect + warn), Pydantic models (`Deprecated[...]` markers),
+  `docs/bot-management.md` (deprecation timeline), CHANGELOG.
+- No multi-domain coordination, no unknowns — guardrails are deterministic greps.

--- a/artifacts/plans/1420-deprecate-runtime-toml-bots-plan.mdx
+++ b/artifacts/plans/1420-deprecate-runtime-toml-bots-plan.mdx
@@ -1,0 +1,312 @@
+---
+title: "Plan: deprecate runtime-read of TOML bot sections (seed-only)"
+issue: 1420
+spec: artifacts/specs/1420-deprecate-runtime-toml-bots-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-05-28
+---
+
+## Summary
+
+Migrate the runtime bot roster from TOML (`load_multibot_config(raw_config)`) to
+`bot_store.get_all()` in both boot paths, then ship a truthful one-time `DeprecationWarning`,
+`Deprecated[...]` markers, a `lyra bot init` seed validator (G18), docs, CHANGELOG, and a
+tightened guardrail. After this, the four TOML bot sections are read only by `lyra bot init`.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph cfg["src/lyra/config.py"]
+        N2["multibot_config_from_store(bot_store)"]
+        Multi["TelegramMultiConfig / DiscordMultiConfig (Deprecated[...])"]
+        LMC["load_multibot_config(raw) — seed-only now"]
+    end
+    subgraph fac["bootstrap/factory/config.py"]
+        Raw["_load_raw_config()"]
+        Warn["warn_deprecated_bot_sections(raw)"]
+    end
+    subgraph wire["bootstrap wiring"]
+        AS["auth_seeding.build_bot_auths"]
+        WH["wiring_helpers._init_bot_auths_and_agents"]
+        BBA["bootstrap_wiring._build_bot_auths"]
+    end
+    subgraph init["agent_cmd/bots/init.py"]
+        Merge["_merge_bots (Pydantic extra=forbid)"]
+    end
+    Store[("BotStore (bots table)")]
+    TOML[["config.toml 4 sections"]]
+
+    TOML -->|seed-only| Merge --> Store
+    TOML -.->|presence| Raw --> Warn
+    Store ==> N2 --> Multi
+    Multi --> AS --> BBA
+    Multi --> WH --> BBA
+    BBA ==>|roster| Store
+    LMC -.->|config validate / bot init only| TOML
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph S1["config.py"]
+        f_n2["multibot_config_from_store()"]
+        f_marker["Multi models @deprecated"]
+    end
+    subgraph S2["factory/config.py"]
+        f_warn["warn_deprecated_bot_sections()"]
+        f_raw["_load_raw_config()"]
+    end
+    subgraph S3["auth_seeding.py"]
+        f_bba["build_bot_auths()"]
+    end
+    subgraph S4["wiring_helpers.py"]
+        f_init["_init_bot_auths_and_agents()"]
+    end
+    subgraph S5["bots/init.py"]
+        f_merge["_merge_bots()"]
+    end
+    subgraph T["tests + tools"]
+        t1["test_auth_seeding.py"]
+        t2["test_config.py"]
+        t3["test bot init seed"]
+        g["tools/check_no_runtime_toml_bots.sh"]
+    end
+    f_raw --> f_warn
+    f_bba --> f_n2
+    f_init --> f_n2
+    t1 --> f_bba
+    t2 --> f_n2 & f_warn & f_marker
+    t3 --> f_merge
+    g --> f_bba & f_init
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T2, T3, T4 | `config.py`, `auth_seeding.py`, `wiring_helpers.py`, `bootstrap_wiring.py` |
+| backend-dev-B | T7, T10, T11 | `factory/config.py`, `bots/init.py`, `config.py` (markers) |
+| tester-A | T1, T5 | `tests/bootstrap/test_auth_seeding.py` |
+| tester-B | T6, T8, T9, T12 | `tests/bootstrap/`, `tests/cli/` |
+| devops-A | T13 | `tools/check_no_runtime_toml_bots.sh`, `.claude/stack.yml` |
+| doc-writer-A | T14, T15 | `docs/bot-management.md`, `CHANGELOG.md`, issue #1420 |
+
+## Wave Structure
+
+3 waves, max 6 parallel agents. Elapsed ~1 day vs ~2.5 days sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 5 ∥ | tester-A: T1 · backend-dev-A: T2 · backend-dev-B: T7→T10→T11 · tester-B: T6→T9 · doc-writer-A: T14→T15 |
+| 2 | T2 done | 1 | backend-dev-A: T3→T4 |
+| 3 | T3,T4 done | 3 ∥ | devops-A: T13 · tester-A: T5 · tester-B: T8, T12 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 RED roster test | 1 | judgmental | 5 | — |
+| T2 multibot_config_from_store | 1 | judgmental | 5 | — |
+| T3 auth_seeding swap + error text | 1 | bounded | 3 | — |
+| T4 wiring_helpers swap + error text | 1 | bounded | 3 | — |
+| T5 RED-GATE roster verify | 1 | bounded | 2 | — |
+| T6 RED warning test | 1 | bounded | 3 | — |
+| T7 warn_deprecated_bot_sections | 1 | judgmental | 5 | — |
+| T8 RED-GATE warning verify | 1 | trivial | 2 | — |
+| T9 RED seed-validator test | 1 | bounded | 3 | — |
+| T10 _merge_bots extra=forbid | 1 | judgmental | 5 | — |
+| T11 Deprecated[...] markers | 1 | bounded | 3 | — |
+| T12 RED-GATE seed verify | 1 | trivial | 2 | — |
+| T13 guardrail script + stack wire | 1 | judgmental | 5 | — |
+| T14 docs Deprecation Timeline | 1 | bounded | 3 | — |
+| T15 CHANGELOG + issue update | 1 | bounded | 3 | — |
+
+**Total estimated ops: 52**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|---|---|---|---|---|
+| backend-dev-A | T2, T3, T4 | 11 | roster | — |
+| backend-dev-B | T7, T10, T11 | 13 | deprecation, seed-validation | — |
+| tester-A | T1, T5 | 7 | roster | — |
+| tester-B | T6, T8, T9, T12 | 10 | deprecation, seed-validation | — |
+| devops-A | T13 | 5 | guardrail | — |
+| doc-writer-A | T14, T15 | 6 | docs | — |
+
+No instance exceeds caps (≤4 tasks, ≤2 subjects, Σ ops ≤50).
+
+## Consistency Report
+
+Covered: 12/12 success criteria. Untraced tasks: 0. Exemptions: none.
+
+| SC | Tasks |
+|---|---|
+| roster from BotStore (no load_multibot_config) | T2, T3, T4 |
+| integration: empty TOML + seeded store → bot wired | T1, T5 |
+| empty-roster error text retargeted | T3, T4, T5 |
+| DeprecationWarning once | T6, T7, T8 |
+| no warning on clean config | T6, T8 |
+| bot init still seeds | T9, T10 (regression-guarded) |
+| webhook_enabled typo raises (G18) | T9, T10, T12 |
+| Multi models Deprecated[...] | T11 |
+| original 2 guardrail greps = 0 | T13 |
+| new load_multibot_config guardrail = 0 | T4, T13 |
+| docs Deprecation Timeline (next major/v1.0.0/4 names) | T14 |
+| CHANGELOG entry | T15 |
+
+## Micro-Tasks
+
+### Slice 1 — Roster from BotStore
+
+**T1 [RED] tester-A · roster** — failing integration test.
+- File: `tests/bootstrap/test_auth_seeding.py`
+- Build a BotStore with one telegram bot row; pass `raw_config` with **no** `[[telegram.bots]]`. Assert `build_bot_auths` returns non-empty `tg_bot_auths` whose `bot_cfg.bot_id == seeded.bot_id`.
+- Verify: `uv run pytest tests/bootstrap/test_auth_seeding.py -k roster_from_store` → fails (RED).
+- Spec trace: SC#2 · Difficulty 3
+
+**T2 [GREEN] backend-dev-A · roster** — store-sourced builder.
+- File: `src/lyra/config.py`
+- Add `multibot_config_from_store(bot_store) -> tuple[TelegramMultiConfig, DiscordMultiConfig]`: iterate `bot_store.get_all()`, partition by `platform`, build `TelegramBotConfig(bot_id, agent)` / `DiscordBotConfig(bot_id, auto_thread, agent, thread_hot_hours)`.
+- Import `BotStoreProtocol`/`BotRow` from `lyra.core` (importlinter-clean per spec note).
+- Verify: `uv run pytest tests/test_config.py -k from_store` (T-paired) + `uv run pyright src/lyra/config.py`.
+- Spec trace: N2 / SC#1 · Difficulty 3
+
+**T3 [GREEN] backend-dev-A · roster** — swap hub path + error text. blockedBy T2.
+- File: `src/lyra/bootstrap/auth_seeding.py`
+- Replace `load_multibot_config(raw_config)` (line 59) with `multibot_config_from_store(bot_store)`. Retarget the empty-roster `ValueError` (line ~74) to instruct `lyra bot init` / seed BotStore (drop `[[telegram.bots]]` wording). Drop now-unused `load_multibot_config` import if unused.
+- Verify: `grep -c 'load_multibot_config' src/lyra/bootstrap/auth_seeding.py` → 0.
+- Spec trace: N3 / SC#1, SC#3(err) · Difficulty 2
+
+**T4 [GREEN] backend-dev-A · roster** — swap unified path + error text. blockedBy T2.
+- File: `src/lyra/bootstrap/factory/wiring_helpers.py`
+- Replace `load_multibot_config(raw_config)` (line 171) with `multibot_config_from_store(stores.bot)`. Retarget the empty-roster `SystemExit` (line ~193). Note: `_init_bot_auths_and_agents` already has `stores.bot`.
+- Verify: `grep -c 'load_multibot_config' src/lyra/bootstrap/factory/wiring_helpers.py` → 0.
+- Spec trace: N4 / SC#1, SC#3(err) · Difficulty 2
+
+**T5 [RED-GATE] tester-A · roster** — verify slice green. blockedBy T3, T4.
+- Run T1 test (now GREEN) + add empty-store assertion: empty BotStore + no TOML → error message contains `lyra bot init`.
+- Verify: `uv run pytest tests/bootstrap/test_auth_seeding.py tests/bootstrap/test_wiring_helpers.py` → all pass.
+- Spec trace: SC#2, SC#3(err) · Difficulty 2
+
+### Slice 2 — Truthful deprecation warning
+
+**T6 [RED] tester-B · deprecation** — failing warning test.
+- File: `tests/bootstrap/test_config_deprecation.py` (new, unique basename)
+- caplog: `_load_raw_config` on a config with `[[telegram.bots]]` → exactly one `DeprecationWarning`-level record; clean config → zero.
+- Verify: `uv run pytest tests/bootstrap/test_config_deprecation.py` → fails (RED).
+- Spec trace: SC#3, SC#4 · Difficulty 2
+
+**T7 [GREEN] backend-dev-B · deprecation** — emit warning.
+- File: `src/lyra/bootstrap/factory/config.py`
+- Add `warn_deprecated_bot_sections(raw)` checking the 4 keys (`telegram.bots`, `discord.bots`, `auth.telegram_bots`, `auth.discord_bots`); module-level dedup flag → log once via `log.warning` with the issue's message text. Call from `_load_raw_config` after `tomllib.load` (line ~166).
+- Verify: `uv run pytest tests/bootstrap/test_config_deprecation.py` → pass.
+- Spec trace: N1 / SC#3, SC#4 · Difficulty 3
+
+**T8 [RED-GATE] tester-B · deprecation** — verify. blockedBy T7.
+- Run T6 + assert dedup across two `_load_raw_config` calls = still one record (reset flag fixture).
+- Verify: `uv run pytest tests/bootstrap/test_config_deprecation.py -v` → pass.
+- Spec trace: SC#3 · Difficulty 1
+
+### Slice 3 — Seed safety + discoverability
+
+**T9 [RED] tester-B · seed-validation** — failing typo test.
+- File: `tests/cli/test_bot_init_seed_validation.py` (new)
+- TOML with a `[[telegram.bots]]` entry containing `webhook_enabled = true` typo (unknown key for the seed model) → `lyra bot init` / `_merge_bots` raises a validation error naming the bad key.
+- Verify: `uv run pytest tests/cli/test_bot_init_seed_validation.py` → fails (RED).
+- Spec trace: SC#6 · Difficulty 2
+
+**T10 [GREEN] backend-dev-B · seed-validation** — extra=forbid seed model.
+- File: `src/lyra/agent_cmd/bots/init.py`
+- In `_merge_bots`, validate each bot entry through a Pydantic model with `model_config = ConfigDict(extra="forbid")` mapping the legal seed keys (bot_id, agent, webhook_enabled, default_trust, owner_users, trusted_users, trusted_roles, auto_thread, thread_hot_hours). Surface unknown keys as a clear init error (added to existing `errors` list / typer.echo).
+- Verify: `uv run pytest tests/cli/test_bot_init_seed_validation.py` → pass; `lyra bot init` happy-path regression still seeds.
+- Spec trace: N6 / SC#5, SC#6 · Difficulty 3
+
+**T11 [GREEN] backend-dev-B · deprecation** — Deprecated markers.
+- File: `src/lyra/config.py`
+- Mark `TelegramMultiConfig` and `DiscordMultiConfig` (and/or `.bots` field) with `typing_extensions.deprecated("...seed-only; see docs/bot-management.md")`.
+- Verify: `uv run pyright src/lyra/config.py` clean; `grep -c 'deprecated' src/lyra/config.py` ≥ 1.
+- Spec trace: N5 / SC#7 · Difficulty 2
+
+**T12 [RED-GATE] tester-B · seed-validation** — verify. blockedBy T10.
+- Run T9 green + assert a valid entry still seeds (no false positive on legal keys).
+- Verify: `uv run pytest tests/cli/test_bot_init_seed_validation.py -v` → pass.
+- Spec trace: SC#5, SC#6 · Difficulty 1
+
+### Slice 4 — Docs + guardrails
+
+**T13 [GREEN] devops-A · guardrail** — guardrail script. blockedBy T3, T4.
+- Files: `tools/check_no_runtime_toml_bots.sh` (model on `tools/check_single_write_tool_display_config.sh`), `.claude/stack.yml`
+- Script runs the original 2 issue greps **+** `grep -n 'load_multibot_config(' src/lyra/bootstrap/auth_seeding.py src/lyra/bootstrap/factory/wiring_helpers.py`; exit 1 on any match. Wire into `quality_gates` in `.claude/stack.yml`.
+- Verify: `bash tools/check_no_runtime_toml_bots.sh; echo $?` → 0.
+- Spec trace: N7 / SC#8, SC#9 · Difficulty 3
+
+**T14 [GREEN] doc-writer-A · docs** — Deprecation Timeline section.
+- File: `docs/bot-management.md`
+- Add `## Deprecation Timeline` (between `## Bot Configuration` and `## CLI Commands`): literal phrase `next major`, target `v1.0.0` (current `0.2.1`), name all 4 sections, point to `lyra bot init`.
+- Verify: `grep -q 'next major' docs/bot-management.md && grep -q 'v1.0.0' docs/bot-management.md && grep -q 'auth.telegram_bots' docs/bot-management.md`.
+- Spec trace: SC#10 · Difficulty 2
+
+**T15 [GREEN] doc-writer-A · docs** — CHANGELOG + issue hygiene.
+- Files: `CHANGELOG.md`, issue #1420 (gh)
+- Add CHANGELOG entry (Deprecated: TOML bot sections runtime-read; seed-only). Update issue body AC to record corrected premise (roster migration) and bump `<!-- complexity: 2 -->` → `5`.
+- Verify: `grep -qi 'seed-only\|deprecat' CHANGELOG.md`.
+- Spec trace: SC#11 · Difficulty 2
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T-numbers ref this list. -->
+
+### Wave 1 — no deps, 5 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | tester-A | — | roster |
+| T2 | backend-dev-A | — | roster |
+| T6 | tester-B | — | deprecation |
+| T7 | backend-dev-B | — | deprecation |
+| T9 | tester-B | T6 | seed-validation |
+| T10 | backend-dev-B | T7 | seed-validation |
+| T11 | backend-dev-B | T10 | deprecation |
+| T14 | doc-writer-A | — | docs |
+| T15 | doc-writer-A | T14 | docs |
+
+### Wave 2 — after T2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T3 | backend-dev-A | T2 | roster |
+| T4 | backend-dev-A | T3 | roster |
+
+### Wave 3 — after T3,T4, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T5 | tester-A | T3, T4 | roster |
+| T8 | tester-B | T7 | deprecation |
+| T12 | tester-B | T10 | seed-validation |
+| T13 | devops-A | T3, T4 | guardrail |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — roster (RED test)
+- T2: 13 — roster (builder)
+- T3: 14 — roster (auth_seeding swap)
+- T4: 15 — roster (wiring_helpers swap)
+- T5: 16 — roster (RED-GATE)
+- T6: 17 — deprecation (RED test)
+- T7: 18 — deprecation (warn fn)
+- T8: 19 — deprecation (RED-GATE)
+- T9: 20 — seed-validation (RED test)
+- T10: 21 — seed-validation (extra=forbid)
+- T11: 22 — deprecation (Deprecated markers)
+- T12: 23 — seed-validation (RED-GATE)
+- T13: 24 — guardrail (check script)
+- T14: 25 — docs (timeline)
+- T15: 26 — docs (CHANGELOG + issue)

--- a/artifacts/specs/1420-deprecate-runtime-toml-bots-spec.mdx
+++ b/artifacts/specs/1420-deprecate-runtime-toml-bots-spec.mdx
@@ -1,0 +1,174 @@
+---
+title: deprecate runtime-read of TOML bot sections (seed-only)
+issue: 1420
+status: approved
+tier: F-lite
+date: 2026-05-28
+promoted_from: artifacts/frames/1420-deprecate-runtime-toml-bots-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1420-deprecate-runtime-toml-bots-frame.mdx`. Closing step of
+epic #1413. During framing, a falsification check revealed the issue's premise was **not**
+met by the code: the original guardrail greps match only a narrow bracket pattern
+(`raw["telegram"]["bots"]`) and returned 0, but **both production boot paths still read the
+TOML bot roster at runtime** via `load_multibot_config(raw_config)`:
+
+| Path | Call site | Reads |
+|---|---|---|
+| NATS hub | `bootstrap/standalone/hub_standalone.py:113` → `auth_seeding.build_bot_auths` | `load_multibot_config(raw_config)` → roster |
+| Unified | `bootstrap/factory/unified.py:57` → `wiring_helpers._init_bot_auths_and_agents` | `load_multibot_config(raw_config)` → roster |
+
+Both feed `bootstrap/wiring/bootstrap_wiring.py::_build_bot_auths`, which iterates
+`tg_multi_cfg.bots` / `dc_multi_cfg.bots` (the TOML roster) to decide *which* bots exist,
+then pulls per-bot auth from BotStore. #1416 migrated the auth *data*; the **roster** is
+still TOML-sourced. So the intended `DeprecationWarning` ("no longer read at runtime")
+would be false until the roster is migrated too.
+
+`BotRow` already carries every field the runtime needs (`platform, bot_id, agent,
+webhook_enabled, auto_thread, thread_hot_hours`) and `seed_grants_from_bots` already reads
+from `bot_store.get_all()`, so nothing blocks sourcing the roster from BotStore.
+
+## Goal
+
+Make TOML bot sections genuinely seed-only: the runtime bot roster comes from BotStore,
+the four legacy sections are read only by `lyra bot init`, and a one-time `DeprecationWarning`
+truthfully tells operators to migrate.
+
+## Users
+
+- **Primary:** Operators — see a truthful one-time deprecation warning + a migration path.
+- **Secondary:** Developers — `Deprecated[...]` markers in-IDE; a `lyra bot init` seed
+  validator that rejects typos (G18 `webhook_enabled`) instead of silently dropping them.
+
+## Expected Behavior
+
+1. **Runtime boot (hub / adapter / unified):** `_load_raw_config()` parses `config.toml`.
+   If any of `[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`,
+   `[[auth.discord_bots]]` is present, it logs **one** `DeprecationWarning` (deduplicated).
+   Bot-auth wiring builds its roster from `bot_store.get_all()` — `load_multibot_config`
+   is no longer called on `raw_config` in either runtime path.
+2. **`lyra bot init`:** unchanged behavior — still parses the four TOML sections as seed
+   source (`tomllib.load` + `_merge_bots`), now through a Pydantic seed model that rejects
+   unknown keys (`extra="forbid"`) so a `webhook_enabled` typo raises at init time (G18).
+3. **`lyra config validate`:** still parses sections (no schema error).
+4. A `config.toml` with **no** legacy sections produces **no** warning.
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class BotRow {
+        +str platform
+        +str bot_id
+        +str agent
+        +bool webhook_enabled
+        +str default_trust
+        +bool auto_thread
+        +int thread_hot_hours
+        +list owner_users
+        +list trusted_users
+        +list trusted_roles
+    }
+    class TelegramBotConfig {
+        <<frozen>>
+        +str bot_id
+        +str agent
+    }
+    class DiscordBotConfig {
+        <<frozen>>
+        +str bot_id
+        +bool auto_thread
+        +str agent
+        +int thread_hot_hours
+    }
+    BotRow ..> TelegramBotConfig : built-from (platform==telegram)
+    BotRow ..> DiscordBotConfig : built-from (platform==discord)
+```
+
+### Consumer map
+
+```mermaid
+flowchart TD
+    TOML["config.toml sections"]
+    Store["BotStore (bots table)"]
+    Init["lyra bot init (_merge_bots)"]
+    Validate["lyra config validate"]
+    Raw["_load_raw_config()"]
+    Roster["_build_bot_auths roster"]
+
+    TOML -->|seed-only| Init
+    Init -->|writes| Store
+    TOML -->|parse, no schema err| Validate
+    TOML -.->|presence detected → 1x DeprecationWarning| Raw
+    Store ==>|get_all by platform| Roster
+    TOML -. "REMOVED runtime read (this issue)" .-> Roster
+```
+
+### Consumer summary
+
+| Consumer | Reads | When | Status |
+|---|---|---|---|
+| `lyra bot init` (`_merge_bots`) | 4 TOML sections | manual seed | seed-only (kept) |
+| `lyra config validate` | TOML sections | CLI inspect | kept (parsable) |
+| `_load_raw_config` | section *presence* only | runtime boot | new: emit DeprecationWarning |
+| `_build_bot_auths` roster | `bot_store.get_all()` | runtime boot | **migrated TOML→BotStore (this issue)** |
+
+## Breadboard
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `_load_raw_config()` warning hook | new `warn_deprecated_bot_sections(raw)` in `bootstrap/factory/config.py` | reads section keys, logs once |
+| N2 | store-sourced roster builder | new `multibot_config_from_store(bot_store)` in `lyra/config.py` (or bootstrap helper) | `bot_store.get_all()` → `TelegramMultiConfig`/`DiscordMultiConfig` |
+| N3 | runtime call swap (hub path) | `auth_seeding.build_bot_auths` | N2 instead of `load_multibot_config(raw_config)`; **also** retarget the empty-roster `ValueError` text (`auth_seeding.py:74`) at `lyra bot init` / BotStore, not `[[telegram.bots]]` |
+| N4 | runtime call swap (unified path) | `wiring_helpers._init_bot_auths_and_agents` | N2 instead of `load_multibot_config(raw_config)`; **also** retarget the empty-roster `SystemExit` text (`wiring_helpers.py:193`) at `lyra bot init` / BotStore |
+| N5 | `Deprecated[...]` markers | `TelegramMultiConfig` / `DiscordMultiConfig` (and `.bots`) in `lyra/config.py` | `typing_extensions.deprecated` |
+| N6 | seed validator (G18) | `agent_cmd/bots/init.py::_merge_bots` | Pydantic model w/ `extra="forbid"` |
+| N7 | guardrail tightening | new check script `tools/check_no_runtime_toml_bots.sh` (or inline in existing guardrail) wired into `/validate`: original 2 issue greps **+** `load_multibot_config(` in `auth_seeding.py`/`wiring_helpers.py` | CI/validate |
+
+Wiring: N2 feeds N3 + N4 (incl. error-text retarget). N1 independent (presence warning). N5/N6 discoverability + safety. N7 verifies N3/N4.
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|---|---|---|
+| 1 | **Roster from BotStore** | N2, N3, N4 | hub boots with empty `[[telegram.bots]]` + seeded store → bot still wired; empty store → error tells operator to run `lyra bot init` |
+| 2 | **Truthful deprecation warning** | N1 | legacy `config.toml` boot logs exactly one `DeprecationWarning`; clean config logs none |
+| 3 | **Seed safety + discoverability** | N5, N6 | `webhook_enabled` typo in a bot entry raises at `lyra bot init`; IDE shows Deprecated |
+| 4 | **Docs + guardrails** | N7 | `docs/bot-management.md` timeline + CHANGELOG; all guardrail greps green |
+
+## Success Criteria
+
+- [ ] Neither `auth_seeding.py` nor `wiring_helpers.py` calls `load_multibot_config(raw_config)`; roster built from `bot_store.get_all()`
+- [ ] Integration test: with a `config.toml` containing **no** `[[telegram.bots]]`/`[[discord.bots]]` and a BotStore seeded with one telegram bot, `build_bot_auths` returns a non-empty `tg_bot_auths` list whose `bot_cfg.bot_id` equals the seeded row's `bot_id` (no `KeyError`, no `ValueError`)
+- [ ] Empty-roster error text in `auth_seeding.py` and `wiring_helpers.py` instructs the operator to run `lyra bot init` / seed the BotStore — it no longer says "add a `[[telegram.bots]]` entry"
+- [ ] DeprecationWarning fires **exactly once** at `_load_raw_config` when ≥1 of the 4 sections is present
+- [ ] **No** warning fires when none of the 4 sections is present
+- [ ] `lyra bot init` still seeds BotStore from the 4 TOML sections (sections remain parsable)
+- [ ] A `webhook_enabled` (or any unknown-key) typo in a bot entry raises at `lyra bot init` (Pydantic `extra="forbid"`) — G18 closed
+- [ ] `TelegramMultiConfig` / `DiscordMultiConfig` marked `Deprecated[...]`
+- [ ] Original 2 issue guardrail greps return 0
+- [ ] New guardrail: `grep -rn 'load_multibot_config(' src/lyra/bootstrap/auth_seeding.py src/lyra/bootstrap/factory/wiring_helpers.py` returns 0
+- [ ] `docs/bot-management.md` has a `## Deprecation Timeline` section that contains the literal phrase `next major`, names a target version (`v1.0.0`, current is `0.2.1`), and names all 4 deprecated section identifiers
+- [ ] CHANGELOG entry added
+
+## Notes
+
+- **Smart-splitting considered, rejected:** 12 criteria / 4 slices trip the Gate 2.5
+  threshold, but the slices are a single cohesive closing step (roster migration is the
+  precondition that makes the warning truthful). Splitting would create artificial
+  cross-issue ordering with no independent value.
+- `seed_grants_from_bots` already reads BotStore — no change.
+- Warning lives at `_load_raw_config` (single runtime chokepoint), **not** in
+  `lyra bot init`'s independent loader — init must stay quiet (it *is* the seed consumer).
+- **Issue hygiene (out-of-band):** issue #1420's `<!-- complexity: 2 -->` annotation predates
+  the falsification finding; true scope ≈ 5. Update on the GitHub issue, and amend the issue
+  body's AC to record the corrected premise (roster migration), so auditors don't see AC
+  narrower than the spec. Done as part of the PR.
+- **Import layer (verified):** `multibot_config_from_store` in `lyra/config.py` may import
+  `BotStoreProtocol` (`lyra.core.stores`) + `BotRow` (`lyra.core.agent`) — `.importlinter`
+  `shared-modules-upper-boundary` bans only `bootstrap`/`adapters`/`infrastructure`, not
+  `lyra.core`; `config.py` already imports `lyra.core.config`.

--- a/docs/bot-management.md
+++ b/docs/bot-management.md
@@ -25,6 +25,27 @@ lyra bot secret install <platform> <bot_id>-webhook
 
 **Rule:** `lyra bot init` is idempotent. Run it after every `config.toml` edit that changes bot definitions.
 
+## Deprecation Timeline
+
+As of this release, the four TOML bot sections are **deprecated and seed-only**. The runtime bot roster is read from BotStore (`~/.lyra/config.db`), not from `config.toml`.
+
+| Deprecated section | Replacement |
+|---|---|
+| `[[telegram.bots]]` | BotStore via `lyra bot init` |
+| `[[discord.bots]]` | BotStore via `lyra bot init` |
+| `[[auth.telegram_bots]]` | BotStore via `lyra bot init` |
+| `[[auth.discord_bots]]` | BotStore via `lyra bot init` |
+
+At runtime, presence of any of these sections logs a one-time `DeprecationWarning`.
+
+**Migration path:**
+
+1. Run `lyra bot init` to seed BotStore from your existing TOML sections.
+2. Verify with `lyra bot list`.
+3. Remove the four deprecated sections from `config.toml`.
+
+**Removal schedule:** The four sections will be removed in the `next major` release (`v1.0.0`; current is `0.2.1`). Until then they remain parsable and are consumed only by `lyra bot init`.
+
 ## CLI Commands (per platform)
 
 Bot management commands are grouped under `lyra agent <platform>` (`telegram` or `discord`). Each platform exposes the same 9 verbs.

--- a/src/lyra/agent_cmd/bots/init.py
+++ b/src/lyra/agent_cmd/bots/init.py
@@ -7,7 +7,7 @@ import os
 import re
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 import typer
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -29,12 +29,22 @@ class _BotSeedEntry(BaseModel):
     bot_id: str = "main"
     agent: str = "lyra_default"
     webhook_enabled: bool = False
-    default_trust: str = DEFAULT_TRUST
+    default_trust: Literal["owner", "trusted", "public", "blocked"] = cast(
+        Literal["owner", "trusted", "public", "blocked"], DEFAULT_TRUST
+    )
     owner_users: list[str] = []
     trusted_users: list[str] = []
     trusted_roles: list[str] = []
     auto_thread: bool = DEFAULT_AUTO_THREAD
     thread_hot_hours: int = DEFAULT_THREAD_HOT_HOURS
+    # Real config.toml keys that appear in [[telegram.bots]] / [[discord.bots]]
+    # and [[auth.telegram_bots]] / [[auth.discord_bots]]; listed here so
+    # extra="forbid" doesn't reject them. They are NOT stored in BotRow —
+    # credentials are resolved from secrets at runtime, and `default` is the
+    # legacy trust alias handled by the auth section.
+    token: str | None = None
+    webhook_secret: str | None = None
+    default: str | None = None
 
 
 def _find_config_toml() -> Path | None:

--- a/src/lyra/agent_cmd/bots/init.py
+++ b/src/lyra/agent_cmd/bots/init.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import typer
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from lyra.cli_bot import _connect_bot_store, bot_app
 from lyra.core.agent.bot_models import (
@@ -18,6 +19,22 @@ from lyra.core.agent.bot_models import (
     DEFAULT_TRUST,
     BotRow,
 )
+
+
+class _BotSeedEntry(BaseModel):
+    """Validates one raw TOML bot entry; rejects unknown keys (G18 typo trap)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bot_id: str = "main"
+    agent: str = "lyra_default"
+    webhook_enabled: bool = False
+    default_trust: str = DEFAULT_TRUST
+    owner_users: list[str] = []
+    trusted_users: list[str] = []
+    trusted_roles: list[str] = []
+    auto_thread: bool = DEFAULT_AUTO_THREAD
+    thread_hot_hours: int = DEFAULT_THREAD_HOT_HOURS
 
 
 def _find_config_toml() -> Path | None:
@@ -121,6 +138,15 @@ def _merge_bots(raw: dict[str, Any]) -> tuple[list[BotRow], int]:  # noqa: C901 
             if not _BOT_ID_RE.match(bot_id) or not _PLATFORM_RE.match(platform):
                 typer.echo(
                     f"  error: invalid platform/bot_id ({platform}/{bot_id}) — skipped",
+                    err=True,
+                )
+                validation_errors += 1
+                continue
+            try:
+                _BotSeedEntry.model_validate(entry)
+            except ValidationError as exc:
+                typer.echo(
+                    f"  error: invalid bot entry ({platform}/{bot_id}): {exc}",
                     err=True,
                 )
                 validation_errors += 1

--- a/src/lyra/bootstrap/auth_seeding.py
+++ b/src/lyra/bootstrap/auth_seeding.py
@@ -12,7 +12,7 @@ from lyra.bootstrap.wiring.bootstrap_wiring import BotAuthDeps, _build_bot_auths
 from lyra.config import (
     DiscordBotConfig,
     TelegramBotConfig,
-    load_multibot_config,
+    multibot_config_from_store,
 )
 from lyra.core.auth.authenticator import Authenticator
 from lyra.core.circuit_breaker import CircuitRegistry
@@ -56,7 +56,7 @@ def build_bot_auths(
     """
     circuit_registry, admin_user_ids = _load_circuit_config(raw_config)
 
-    tg_multi_cfg, dc_multi_cfg = load_multibot_config(raw_config)
+    tg_multi_cfg, dc_multi_cfg = multibot_config_from_store(bot_store)
 
     tg_bot_auths, dc_bot_auths = _build_bot_auths(
         BotAuthDeps(
@@ -71,8 +71,9 @@ def build_bot_auths(
 
     if not tg_bot_auths and not dc_bot_auths:
         raise ValueError(
-            "No adapters configured — add at least one [[telegram.bots]] or"
-            " [[discord.bots]] entry and run 'lyra bot init' to seed the bot store"
+            "No bots configured — the runtime roster is sourced from BotStore."
+            " Run 'lyra bot init' to seed it from config.toml,"
+            " then 'lyra bot list' to verify."
         )
 
     return circuit_registry, admin_user_ids, tg_bot_auths, dc_bot_auths

--- a/src/lyra/bootstrap/factory/agent_factory.py
+++ b/src/lyra/bootstrap/factory/agent_factory.py
@@ -20,7 +20,7 @@ from lyra.bootstrap.factory.config import (
 )
 from lyra.bootstrap.types import BotAuthBundle
 from lyra.bootstrap.wiring.bootstrap_wiring import BotAuthDeps, _build_bot_auths
-from lyra.config import load_multibot_config
+from lyra.config import multibot_config_from_store
 from lyra.core.agent import Agent, AgentBase
 from lyra.core.agent.agent_loader import agent_row_to_config
 from lyra.core.circuit_breaker import CircuitRegistry
@@ -100,7 +100,7 @@ async def _init_bot_auths_and_agents(
     """Resolve multibot config, build authenticators, load agent configs."""
     circuit_registry, admin_user_ids = _load_circuit_config(raw_config)
 
-    tg_multi_cfg, dc_multi_cfg = load_multibot_config(raw_config)
+    tg_multi_cfg, dc_multi_cfg = multibot_config_from_store(stores.bot)
 
     tg_bot_auths, dc_bot_auths = _build_bot_auths(
         BotAuthDeps(
@@ -119,9 +119,9 @@ async def _init_bot_auths_and_agents(
 
     if not tg_bot_auths and not dc_bot_auths:
         raise ValueError(
-            "No adapters configured — add at least one"
-            " [[telegram.bots]] or [[discord.bots]] entry"
-            " and run 'lyra bot init' to seed the bot store"
+            "No bots configured — the runtime roster is sourced from BotStore."
+            " Run 'lyra bot init' to seed it from config.toml,"
+            " then 'lyra bot list' to verify."
         )
 
     bot_agent_map = await _resolve_bot_agent_map(

--- a/src/lyra/bootstrap/factory/config.py
+++ b/src/lyra/bootstrap/factory/config.py
@@ -19,6 +19,45 @@ from lyra.core.stores.pairing_config import PairingConfig
 
 log = logging.getLogger(__name__)
 
+_bot_sections_deprecation_warned: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Deprecation helpers
+# ---------------------------------------------------------------------------
+
+
+def warn_deprecated_bot_sections(raw: dict[str, Any]) -> None:
+    """Log a one-time DeprecationWarning if any legacy TOML bot section is present.
+
+    The runtime bot roster now comes from BotStore (`lyra bot init`); these four
+    sections are seed-only. Detected sections:
+    [[telegram.bots]], [[discord.bots]], [[auth.telegram_bots]], [[auth.discord_bots]].
+    """
+    global _bot_sections_deprecation_warned
+    if _bot_sections_deprecation_warned:
+        return
+    present = [
+        name
+        for name, value in (
+            ("[[telegram.bots]]", (raw.get("telegram") or {}).get("bots")),
+            ("[[discord.bots]]", (raw.get("discord") or {}).get("bots")),
+            ("[[auth.telegram_bots]]", (raw.get("auth") or {}).get("telegram_bots")),
+            ("[[auth.discord_bots]]", (raw.get("auth") or {}).get("discord_bots")),
+        )
+        if value
+    ]
+    if not present:
+        return
+    _bot_sections_deprecation_warned = True
+    log.warning(
+        "TOML bot sections are deprecated and seed-only: %s. "
+        "The runtime roster now comes from BotStore — seed it with `lyra bot init` "
+        "and remove these sections from config.toml. "
+        "See docs/bot-management.md (Deprecation Timeline).",
+        ", ".join(present),
+    )
+
 
 # ---------------------------------------------------------------------------
 # Pydantic config section models (#411)
@@ -164,6 +203,7 @@ def _load_raw_config(config_path: str | None = None) -> dict[str, Any]:
         try:
             with open(path, "rb") as f:
                 raw = tomllib.load(f)
+            warn_deprecated_bot_sections(raw)
             log.info("Loaded config from %s", path)
             return raw
         except FileNotFoundError:

--- a/src/lyra/config.py
+++ b/src/lyra/config.py
@@ -12,6 +12,12 @@ And the legacy flat schema (backward compat, treated as single bot with bot_id="
     ...
 
 Re-exports legacy single-bot dataclasses for callers that still use them.
+
+Deprecated classes
+------------------
+TelegramMultiConfig, DiscordMultiConfig — TOML-sourced bot roster is seed-only.
+The runtime roster comes from BotStore via multibot_config_from_store().
+See docs/bot-management.md (Deprecation Timeline).
 """
 
 from __future__ import annotations
@@ -28,6 +34,7 @@ from lyra.core.config import (
     load_discord_config,
     load_telegram_config,
 )
+from lyra.core.stores import BotStoreProtocol
 
 # Backward-compat alias: callers using load_config get the Telegram loader.
 load_config = load_telegram_config
@@ -43,6 +50,7 @@ __all__ = [
     "TelegramMultiConfig",
     "DiscordMultiConfig",
     "load_multibot_config",
+    "multibot_config_from_store",
 ]
 
 log = logging.getLogger(__name__)
@@ -95,13 +103,23 @@ class DiscordBotConfig(BaseModel):
 
 
 class TelegramMultiConfig(BaseModel):
-    """Parsed [telegram] section: list of bot configs."""
+    """Parsed [telegram] section: list of bot configs.
+
+    .. deprecated::
+        TOML-sourced bot roster is seed-only; runtime roster comes from BotStore
+        via multibot_config_from_store(). See docs/bot-management.md.
+    """
 
     bots: list[TelegramBotConfig] = []
 
 
 class DiscordMultiConfig(BaseModel):
-    """Parsed [discord] section: list of bot configs."""
+    """Parsed [discord] section: list of bot configs.
+
+    .. deprecated::
+        TOML-sourced bot roster is seed-only; runtime roster comes from BotStore
+        via multibot_config_from_store(). See docs/bot-management.md.
+    """
 
     bots: list[DiscordBotConfig] = []
 
@@ -215,4 +233,30 @@ def load_multibot_config(
             )
         ]
 
+    return TelegramMultiConfig(bots=tg_bots), DiscordMultiConfig(bots=dc_bots)
+
+
+def multibot_config_from_store(
+    bot_store: BotStoreProtocol,
+) -> tuple[TelegramMultiConfig, DiscordMultiConfig]:
+    """Build the runtime bot roster from BotStore (SSoT), not TOML.
+
+    Partitions bot_store.get_all() by platform. Telegram rows become
+    TelegramBotConfig(bot_id, agent); Discord rows become
+    DiscordBotConfig(bot_id, auto_thread, agent, thread_hot_hours).
+    """
+    tg_bots: list[TelegramBotConfig] = []
+    dc_bots: list[DiscordBotConfig] = []
+    for row in bot_store.get_all():
+        if row.platform == "telegram":
+            tg_bots.append(TelegramBotConfig(bot_id=row.bot_id, agent=row.agent))
+        elif row.platform == "discord":
+            dc_bots.append(
+                DiscordBotConfig(
+                    bot_id=row.bot_id,
+                    auto_thread=row.auto_thread,
+                    agent=row.agent,
+                    thread_hot_hours=row.thread_hot_hours,
+                )
+            )
     return TelegramMultiConfig(bots=tg_bots), DiscordMultiConfig(bots=dc_bots)

--- a/tests/bootstrap/test_auth_seeding.py
+++ b/tests/bootstrap/test_auth_seeding.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from lyra.bootstrap.auth_seeding import build_bot_auths
+from lyra.core.agent.bot_models import BotRow
 from lyra.infrastructure.stores.auth_store import AuthStore
+from tests.factories.stores import make_auth_store
+from tests.helpers.bot_store import make_bot_store
 
 # ---------------------------------------------------------------------------
 # test_bootstrap_calls_seed_grants_from_bots
@@ -99,16 +103,93 @@ class TestBootstrapCallsSeedGrantsFromBots:
 
 class TestBuildBotAuthsRaisesWithoutAdapters:
     def test_build_bot_auths_raises_without_adapters(self) -> None:
-        """build_bot_auths raises ValueError when no telegram AND no discord bots."""
-        # Arrange
-        raw_config: dict = {
-            "telegram": {"bots": []},
-            "discord": {"bots": []},
-            "auth": {"telegram_bots": [], "discord_bots": []},
-        }
+        """build_bot_auths raises ValueError when BotStore is empty (no roster).
+
+        Old contract raised "No adapters configured" from TOML parsing.
+        New contract: the roster comes from bot_store.get_all(); an empty
+        store raises ValueError with the new migration-hint message.
+        """
+        # Arrange — empty BotStore (roster is store-sourced, not TOML)
+        raw_config: dict = {}
         fake_auth_store = MagicMock(spec=AuthStore)
         fake_bot_store = MagicMock()
+        fake_bot_store.get_all.return_value = []  # empty roster
+
+        # Act / Assert — new message guides operator to run 'lyra bot init'
+        with pytest.raises(ValueError, match="No bots configured"):
+            build_bot_auths(raw_config, fake_auth_store, fake_bot_store)
+
+    def test_build_bot_auths_error_message_contains_lyra_bot_init(self) -> None:
+        """SC#3 — the ValueError message contains 'lyra bot init' so operators know
+        how to recover from an empty roster.
+
+        Negative gate: deleting the guard in build_bot_auths would suppress the
+        raise entirely, causing this test to fail (no exception raised at all).
+        """
+        # Arrange
+        fake_auth_store = MagicMock(spec=AuthStore)
+        fake_bot_store = MagicMock()
+        fake_bot_store.get_all.return_value = []  # empty roster
 
         # Act / Assert
-        with pytest.raises(ValueError, match="No adapters configured"):
-            build_bot_auths(raw_config, fake_auth_store, fake_bot_store)
+        with pytest.raises(ValueError) as exc_info:
+            build_bot_auths({}, fake_auth_store, fake_bot_store)
+
+        assert "lyra bot init" in str(exc_info.value), (
+            f"Expected 'lyra bot init' in error message, got: {exc_info.value!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# test_roster_from_store  [RED — post-T3 behavior, fails until T3 is implemented]
+# ---------------------------------------------------------------------------
+
+
+class TestRosterFromStore:
+    async def test_roster_from_store(self, tmp_path: Path) -> None:
+        """build_bot_auths reads the bot roster from BotStore, not from TOML.
+
+        RED: currently build_bot_auths calls load_multibot_config(raw_config) and
+        ignores bot_store for roster construction.  After T3 swaps the roster source
+        to bot_store.get_all(), a bot present in the store but absent from TOML must
+        appear in tg_bot_auths.
+
+        Failure until T3: ValueError("No adapters configured") because TOML is empty
+        and the current implementation never reads bot_store for the roster.
+        """
+        # Arrange — real stores backed by a tmp SQLite DB
+        bot_store = await make_bot_store(tmp_path)
+        auth_store = await make_auth_store(tmp_path)
+
+        try:
+            # Seed exactly one Telegram bot into BotStore (not in TOML)
+            seeded_row = BotRow(
+                platform="telegram",
+                bot_id="seeded_tg",
+                agent="lyra_default",
+                default_trust="public",
+            )
+            await bot_store.upsert(seeded_row)
+
+            # raw_config has NO [[telegram.bots]] and NO [[discord.bots]]
+            # — TOML roster empty
+            raw_config: dict = {}
+
+            # Act — post-T3 this must succeed and return the seeded bot
+            _circuit_registry, _admin_ids, tg_bot_auths, _dc_bot_auths = (
+                build_bot_auths(raw_config, auth_store, bot_store)
+            )
+
+            # Assert — seeded_tg must appear in the telegram bot-auth list
+            assert len(tg_bot_auths) >= 1, (
+                "Expected at least one telegram bot-auth from BotStore, got none. "
+                "build_bot_auths still reads roster from TOML instead of bot_store."
+            )
+            bot_cfg, _auth = tg_bot_auths[0]
+            assert bot_cfg.bot_id == "seeded_tg", (
+                f"Expected bot_id='seeded_tg', got {bot_cfg.bot_id!r}. "
+                "Roster is not sourced from BotStore."
+            )
+        finally:
+            await bot_store.close()
+            await auth_store.close()

--- a/tests/bootstrap/test_auth_seeding.py
+++ b/tests/bootstrap/test_auth_seeding.py
@@ -141,7 +141,7 @@ class TestBuildBotAuthsRaisesWithoutAdapters:
 
 
 # ---------------------------------------------------------------------------
-# test_roster_from_store  [RED — post-T3 behavior, fails until T3 is implemented]
+# test_roster_from_store
 # ---------------------------------------------------------------------------
 
 
@@ -149,13 +149,9 @@ class TestRosterFromStore:
     async def test_roster_from_store(self, tmp_path: Path) -> None:
         """build_bot_auths reads the bot roster from BotStore, not from TOML.
 
-        RED: currently build_bot_auths calls load_multibot_config(raw_config) and
-        ignores bot_store for roster construction.  After T3 swaps the roster source
-        to bot_store.get_all(), a bot present in the store but absent from TOML must
-        appear in tg_bot_auths.
-
-        Failure until T3: ValueError("No adapters configured") because TOML is empty
-        and the current implementation never reads bot_store for the roster.
+        Verifies that a bot seeded into BotStore appears in tg_bot_auths even
+        when the raw_config contains no [[telegram.bots]] section.  The roster
+        is sourced exclusively from bot_store.get_all().
         """
         # Arrange — real stores backed by a tmp SQLite DB
         bot_store = await make_bot_store(tmp_path)

--- a/tests/bootstrap/test_config_deprecation.py
+++ b/tests/bootstrap/test_config_deprecation.py
@@ -1,0 +1,128 @@
+"""RED tests — warn_deprecated_bot_sections + _load_raw_config deprecation call.
+
+These tests are intentionally FAILING until T7 implements:
+  - warn_deprecated_bot_sections(raw: dict) in src/lyra/bootstrap/factory/config.py
+  - _load_raw_config calling it right after tomllib.load(f)
+
+Contract (agreed with T7):
+  - Function: warn_deprecated_bot_sections(raw: dict)
+  - Module: lyra.bootstrap.factory.config
+  - Logger: lyra.bootstrap.factory.config (module-level `log`)
+  - Dedup flag: _bot_sections_deprecation_warned (module-level bool, initially False)
+  - Log level: WARNING
+  - Message substring: "TOML bot sections are deprecated"
+  - Detected sections: telegram.bots, discord.bots, auth.telegram_bots,
+    auth.discord_bots
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+LOGGER_NAME = "lyra.bootstrap.factory.config"
+DEPRECATED_SUBSTRING = "TOML bot sections are deprecated"
+FLAG_PATH = "lyra.bootstrap.factory.config._bot_sections_deprecation_warned"
+
+
+class TestWarnOnLegacyBotSections:
+    """_load_raw_config emits exactly one WARNING when legacy bot sections are
+    present."""
+
+    def test_warns_on_legacy_telegram_bots_section(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Exactly one WARNING containing the deprecation substring when
+        [[telegram.bots]] exists."""
+        # Arrange
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[telegram]\n[[telegram.bots]]\ntoken = "fake-token"\n',
+            encoding="utf-8",
+        )
+        # Reset dedup flag so the warning fires even if another test ran first
+        monkeypatch.setattr(FLAG_PATH, False, raising=False)
+
+        from lyra.bootstrap.factory.config import _load_raw_config
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            _load_raw_config(str(config_file))
+
+        # Assert — exactly one record with the deprecation substring
+        matching = [r for r in caplog.records if DEPRECATED_SUBSTRING in r.getMessage()]
+        assert len(matching) == 1, (
+            f"Expected exactly 1 deprecation WARNING, got {len(matching)}. "
+            f"Records: {[r.getMessage() for r in caplog.records]}"
+        )
+        assert matching[0].levelno == logging.WARNING
+
+    def test_no_warning_on_clean_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No deprecation WARNING when the config contains no legacy bot sections."""
+        # Arrange
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[some]\nkey = "value"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(FLAG_PATH, False, raising=False)
+
+        from lyra.bootstrap.factory.config import _load_raw_config
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            _load_raw_config(str(config_file))
+
+        # Assert — zero records with the deprecation substring
+        matching = [r for r in caplog.records if DEPRECATED_SUBSTRING in r.getMessage()]
+        assert len(matching) == 0, (
+            f"Expected 0 deprecation WARNINGs on clean config, got {len(matching)}. "
+            f"Records: {[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_warns_only_once_across_two_loads(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Deprecation WARNING fires exactly once even when _load_raw_config is
+        called twice.
+
+        The module-global _bot_sections_deprecation_warned flag must suppress the
+        second emission.  If the flag logic is removed the count becomes 2 and this
+        test fails — proving the dedup is load-bearing.
+        """
+        # Arrange
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[telegram]\n[[telegram.bots]]\ntoken = "fake-token"\n',
+            encoding="utf-8",
+        )
+        # Reset dedup flag to False so the first call fires the warning
+        monkeypatch.setattr(FLAG_PATH, False, raising=False)
+
+        from lyra.bootstrap.factory.config import _load_raw_config
+
+        # Act — call TWICE with the same path; module flag persists between calls
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            _load_raw_config(str(config_file))
+            _load_raw_config(str(config_file))
+
+        # Assert — exactly 1 record, not 2
+        matching = [r for r in caplog.records if DEPRECATED_SUBSTRING in r.getMessage()]
+        assert len(matching) == 1, (
+            f"Expected exactly 1 deprecation WARNING across two loads,"
+            f" got {len(matching)}. "
+            f"Records: {[r.getMessage() for r in caplog.records]}"
+        )

--- a/tests/bootstrap/test_config_deprecation.py
+++ b/tests/bootstrap/test_config_deprecation.py
@@ -1,10 +1,9 @@
-"""RED tests — warn_deprecated_bot_sections + _load_raw_config deprecation call.
+"""Tests for warn_deprecated_bot_sections + _load_raw_config deprecation call.
 
-These tests are intentionally FAILING until T7 implements:
-  - warn_deprecated_bot_sections(raw: dict) in src/lyra/bootstrap/factory/config.py
-  - _load_raw_config calling it right after tomllib.load(f)
+Verifies that _load_raw_config emits a single WARNING when legacy TOML bot
+sections are present and stays silent on clean configs.
 
-Contract (agreed with T7):
+Contract:
   - Function: warn_deprecated_bot_sections(raw: dict)
   - Module: lyra.bootstrap.factory.config
   - Logger: lyra.bootstrap.factory.config (module-level `log`)

--- a/tests/bootstrap/test_wiring_helpers.py
+++ b/tests/bootstrap/test_wiring_helpers.py
@@ -290,10 +290,11 @@ class TestInitBotAuthsAndAgents:
         tg_cfg.bots = [MagicMock(bot_id="main")]
         dc_cfg = MagicMock()
         dc_cfg.bots = []
+        # Roster now comes from multibot_config_from_store(stores.bot), not TOML
         monkeypatch.setattr(
             agent_factory_mod,
-            "load_multibot_config",
-            lambda raw: (tg_cfg, dc_cfg),
+            "multibot_config_from_store",
+            lambda bot_store: (tg_cfg, dc_cfg),
         )
 
         mock_tg_auth = MagicMock()
@@ -355,15 +356,21 @@ class TestInitBotAuthsAndAgents:
     async def test_init_bot_auths_exits_when_no_bots_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """SC#3 — empty BotStore roster raises SystemExit with 'lyra bot init' hint.
+
+        Negative gate: deleting the empty-roster guard in _init_bot_auths_and_agents
+        means no SystemExit is raised and the test fails.
+        """
         monkeypatch.setattr(
             agent_factory_mod,
             "_load_circuit_config",
             lambda raw: (MagicMock(), frozenset()),
         )
+        # Roster sourced from store — return empty configs (no bots in BotStore)
         monkeypatch.setattr(
             agent_factory_mod,
-            "load_multibot_config",
-            lambda raw: (MagicMock(bots=[]), MagicMock(bots=[])),
+            "multibot_config_from_store",
+            lambda bot_store: (MagicMock(bots=[]), MagicMock(bots=[])),
         )
         monkeypatch.setattr(
             agent_factory_mod,
@@ -371,8 +378,12 @@ class TestInitBotAuthsAndAgents:
             lambda *a, **kw: ([], []),
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exc_info:
             await _init_bot_auths_and_agents(MagicMock(), {})
+
+        assert "lyra bot init" in str(exc_info.value), (
+            f"Expected 'lyra bot init' in error message, got: {exc_info.value!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_init_bot_auths_exits_when_no_agent_configs_loaded(
@@ -383,10 +394,11 @@ class TestInitBotAuthsAndAgents:
             "_load_circuit_config",
             lambda raw: (MagicMock(), frozenset()),
         )
+        # Roster sourced from store — one telegram bot present
         monkeypatch.setattr(
             agent_factory_mod,
-            "load_multibot_config",
-            lambda raw: (MagicMock(bots=[MagicMock()]), MagicMock(bots=[])),
+            "multibot_config_from_store",
+            lambda bot_store: (MagicMock(bots=[MagicMock()]), MagicMock(bots=[])),
         )
         monkeypatch.setattr(
             agent_factory_mod,
@@ -408,18 +420,32 @@ class TestInitBotAuthsAndAgents:
     async def test_init_bot_auths_exits_on_bad_multibot_config(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Old behavior: ValueError from load_multibot_config (TOML parsing) was wrapped
+        into SystemExit. That wrapping is GONE — the store builder does not parse TOML.
+
+        Repurposed: assert that BotStore.get_all() raising propagates unhandled through
+        _init_bot_auths_and_agents. This tests the boundary between the store and the
+        factory: a broken store is an infrastructure failure, not a configuration error,
+        so we expect the exception to surface (not be silently swallowed).
+
+        Choice rationale: option (a) — BotStore raising on get_all() propagates — is
+        preferred over merging with the empty-store test (#3) because it exercises a
+        distinct failure mode (store error vs. empty store) and keeps the negative-test
+        guard distinct and non-redundant.
+        """
         monkeypatch.setattr(
             agent_factory_mod,
             "_load_circuit_config",
             lambda raw: (MagicMock(), frozenset()),
         )
+        # Simulate a broken BotStore that raises on get_all()
         monkeypatch.setattr(
             agent_factory_mod,
-            "load_multibot_config",
-            MagicMock(side_effect=ValueError("bad config")),
+            "multibot_config_from_store",
+            MagicMock(side_effect=RuntimeError("store unavailable")),
         )
 
-        with pytest.raises(ValueError, match="bad config"):
+        with pytest.raises(RuntimeError, match="store unavailable"):
             await _init_bot_auths_and_agents(MagicMock(), {})
 
 

--- a/tests/cli/test_bot_init_seed_validation.py
+++ b/tests/cli/test_bot_init_seed_validation.py
@@ -1,14 +1,13 @@
-"""RED tests for G18 trap: unknown/typo keys in bot seed entries (issue #1420 T9).
+"""Tests for G18 trap: unknown/typo keys in bot seed entries (issue #1420).
 
-T10 will add a Pydantic model with extra="forbid" to _merge_bots so that
-unknown keys (e.g. webhook_enabel) are rejected, skip the entry, increment
-validation_errors, and emit the offending key name to stderr.
-
-Contract (pinned, T10 implements to match):
+Contract:
   - _merge_bots(raw) -> tuple[list[BotRow], int] = (rows, validation_errors)
   - Entry with unknown key: skipped, validation_errors += 1, stderr names key
+  - Known real-config keys (token, webhook_secret, default) are accepted but
+    not stored in BotRow — they must NOT be rejected.
   - Legal seed keys: bot_id, agent, webhook_enabled, default_trust,
-    owner_users, trusted_users, trusted_roles, auto_thread, thread_hot_hours
+    owner_users, trusted_users, trusted_roles, auto_thread, thread_hot_hours,
+    token, webhook_secret, default
 """
 
 from __future__ import annotations
@@ -29,7 +28,6 @@ class TestMergeBotsUnknownKey:
         rows, errors = _merge_bots(raw)
 
         # Assert — entry is skipped, error counted, offending key named on stderr
-        # RED: today errors == 0 and rows has one BotRow (typo silently dropped)
         assert errors == 1, (
             f"Expected 1 validation error for typo key 'webhook_enabel', got {errors}. "
             "T10 must add Pydantic seed model with extra='forbid' to catch this."
@@ -126,3 +124,41 @@ class TestMergeBotsUnknownKey:
             f"Expected offending key 'unknwon_key' named in stderr,"
             f" got: {captured.err!r}"
         )
+
+    def test_real_config_keys_accepted(self) -> None:
+        """Keys present in config.toml.example must not be rejected by extra='forbid'.
+
+        token, webhook_secret, default are real TOML keys in shipped configs;
+        they are accepted by _BotSeedEntry but not stored in BotRow.
+        """
+        # Mirrors config.toml.example [[telegram.bots]] + [[auth.telegram_bots]]
+        raw = {
+            "telegram": {
+                "bots": [
+                    {
+                        "bot_id": "lyra",
+                        "token": "env:TELEGRAM_TOKEN",
+                        "webhook_secret": "env:WH",
+                    }
+                ]
+            },
+            "auth": {
+                "telegram_bots": [
+                    {
+                        "bot_id": "lyra",
+                        "default": "blocked",
+                        "owner_users": [],
+                    }
+                ]
+            },
+        }
+
+        rows, errors = _merge_bots(raw)
+
+        assert errors == 0, (
+            f"Expected 0 errors for real config.toml.example keys, got {errors}. "
+            "token/webhook_secret/default must be accepted (not stored in BotRow)."
+        )
+        assert len(rows) == 1, f"Expected 1 row, got {len(rows)}."
+        assert rows[0].bot_id == "lyra"
+        assert rows[0].platform == "telegram"

--- a/tests/cli/test_bot_init_seed_validation.py
+++ b/tests/cli/test_bot_init_seed_validation.py
@@ -1,0 +1,128 @@
+"""RED tests for G18 trap: unknown/typo keys in bot seed entries (issue #1420 T9).
+
+T10 will add a Pydantic model with extra="forbid" to _merge_bots so that
+unknown keys (e.g. webhook_enabel) are rejected, skip the entry, increment
+validation_errors, and emit the offending key name to stderr.
+
+Contract (pinned, T10 implements to match):
+  - _merge_bots(raw) -> tuple[list[BotRow], int] = (rows, validation_errors)
+  - Entry with unknown key: skipped, validation_errors += 1, stderr names key
+  - Legal seed keys: bot_id, agent, webhook_enabled, default_trust,
+    owner_users, trusted_users, trusted_roles, auto_thread, thread_hot_hours
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lyra.agent_cmd.bots.init import _merge_bots
+
+
+class TestMergeBotsUnknownKey:
+    """_merge_bots seed validation: unknown keys must be rejected (G18)."""
+
+    def test_unknown_key_rejected(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # Arrange — typo key webhook_enabel (misspelling of webhook_enabled)
+        raw = {"telegram": {"bots": [{"bot_id": "lyra", "webhook_enabel": True}]}}
+
+        # Act
+        rows, errors = _merge_bots(raw)
+
+        # Assert — entry is skipped, error counted, offending key named on stderr
+        # RED: today errors == 0 and rows has one BotRow (typo silently dropped)
+        assert errors == 1, (
+            f"Expected 1 validation error for typo key 'webhook_enabel', got {errors}. "
+            "T10 must add Pydantic seed model with extra='forbid' to catch this."
+        )
+        assert rows == [], (
+            f"Expected entry with typo key to be skipped (rows=[]), got {rows}."
+        )
+        captured = capsys.readouterr()
+        assert "webhook_enabel" in captured.err, (
+            f"Expected offending key 'webhook_enabel' named in stderr,"
+            f" got: {captured.err!r}"
+        )
+
+    def test_valid_entry_still_seeds(self) -> None:
+        # Arrange — all legal keys, no unknown keys
+        raw = {
+            "telegram": {
+                "bots": [{"bot_id": "lyra", "agent": "x", "webhook_enabled": True}]
+            }
+        }
+
+        # Act
+        rows, errors = _merge_bots(raw)
+
+        # Assert — valid entry seeds normally, no errors
+        assert errors == 0, f"Expected 0 errors for valid entry, got {errors}."
+        assert len(rows) == 1, f"Expected 1 row, got {len(rows)}."
+        assert rows[0].bot_id == "lyra"
+        assert rows[0].webhook_enabled is True
+
+    def test_mixed_batch_skips_only_bad_entry(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Arrange — two entries: one valid, one with typo key thread_hot_hours
+        # (thread_hot_hours is the correct spelling; here we use a misspelling to
+        # simulate a typo)
+        raw = {
+            "telegram": {
+                "bots": [
+                    {"bot_id": "good", "agent": "a"},
+                    {"bot_id": "bad", "thread_hot_hourss": 5},  # typo: extra 's'
+                ]
+            }
+        }
+
+        # Act
+        rows, errors = _merge_bots(raw)
+
+        # Assert — only the bad entry is skipped; good entry seeds normally
+        assert errors == 1, (
+            f"Expected 1 validation error for typo key, got {errors}. "
+            "Validator must be per-entry, not abort the whole batch."
+        )
+        assert len(rows) == 1, (
+            f"Expected 1 row (only 'good' entry), got {len(rows)}. "
+            "The valid entry must still seed when a sibling entry is invalid."
+        )
+        assert rows[0].bot_id == "good", (
+            f"Expected rows[0].bot_id == 'good', got {rows[0].bot_id!r}."
+        )
+        captured = capsys.readouterr()
+        assert "thread_hot_hourss" in captured.err, (
+            f"Expected offending key 'thread_hot_hourss' named in stderr,"
+            f" got: {captured.err!r}"
+        )
+
+    def test_auth_section_entry_also_validated(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Arrange — unknown key in [[auth.telegram_bots]] section
+        raw = {
+            "auth": {
+                "telegram_bots": [
+                    {"bot_id": "lyra", "unknwon_key": "oops"}  # typo key
+                ]
+            }
+        }
+
+        # Act
+        rows, errors = _merge_bots(raw)
+
+        # Assert — auth section entries go through the same validator
+        # (G18 covers all 4 sections)
+        assert errors == 1, (
+            f"Expected 1 validation error for typo key in auth.telegram_bots,"
+            f" got {errors}. "
+            "All four config sections must pass through _BotSeedEntry validation."
+        )
+        assert rows == [], (
+            f"Expected entry with typo key to be skipped (rows=[]), got {rows}."
+        )
+        captured = capsys.readouterr()
+        assert "unknwon_key" in captured.err, (
+            f"Expected offending key 'unknwon_key' named in stderr,"
+            f" got: {captured.err!r}"
+        )

--- a/tests/factories/bootstrap.py
+++ b/tests/factories/bootstrap.py
@@ -365,6 +365,16 @@ def patch_auth_config_test(monkeypatch: pytest.MonkeyPatch) -> None:
             else None
         )
     )
+    _fake_bot_store.get_all = MagicMock(
+        return_value=[
+            BotRow(
+                platform="telegram",
+                bot_id="main",
+                agent="lyra_default",
+                default_trust="public",
+            )
+        ]
+    )
     monkeypatch.setattr(stores_mod, "BotStore", lambda **kwargs: _fake_bot_store)
     monkeypatch.setattr(
         agent_factory_mod,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,9 @@ from lyra.config import (
     _parse_telegram_bots,
     _resolve_value,
     load_multibot_config,
+    multibot_config_from_store,
 )
+from lyra.core.agent.bot_models import BotRow
 
 # ---------------------------------------------------------------------------
 # TestResolveValue
@@ -228,3 +230,121 @@ class TestLoadMultibotConfig:
         # Assert — only the new-style bot is present; no legacy "main" bot synthesized
         assert len(tg.bots) == 1
         assert tg.bots[0].bot_id == "new_bot"
+
+
+# ---------------------------------------------------------------------------
+# TestMultibotConfigFromStore
+# ---------------------------------------------------------------------------
+
+
+class _FakeBotStore:
+    """Minimal in-memory BotStore stub for testing multibot_config_from_store.
+
+    Implements the full BotStoreProtocol surface so it type-checks where the
+    protocol is expected; only ``get_all`` carries behaviour for these tests.
+    """
+
+    def __init__(self, rows: list[BotRow]) -> None:
+        self._rows = rows
+
+    def get_all(self) -> list[BotRow]:
+        return list(self._rows)
+
+    def get(self, platform: str, bot_id: str) -> BotRow | None:
+        return next(
+            (r for r in self._rows if r.platform == platform and r.bot_id == bot_id),
+            None,
+        )
+
+    async def connect(self) -> None:  # pragma: no cover - stub
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - stub
+        return None
+
+    async def upsert(self, row: BotRow) -> None:  # pragma: no cover - stub
+        self._rows.append(row)
+
+    async def delete(
+        self, platform: str, bot_id: str
+    ) -> None:  # pragma: no cover - stub
+        self._rows = [
+            r for r in self._rows if not (r.platform == platform and r.bot_id == bot_id)
+        ]
+
+
+class TestMultibotConfigFromStore:
+    def _tg_row(self, bot_id: str = "tg_bot", agent: str = "lyra_default") -> BotRow:
+        return BotRow(platform="telegram", bot_id=bot_id, agent=agent)
+
+    def _dc_row(
+        self,
+        bot_id: str = "dc_bot",
+        agent: str = "lyra_default",
+        auto_thread: bool = True,
+        thread_hot_hours: int = 36,
+    ) -> BotRow:
+        return BotRow(
+            platform="discord",
+            bot_id=bot_id,
+            agent=agent,
+            auto_thread=auto_thread,
+            thread_hot_hours=thread_hot_hours,
+        )
+
+    def test_from_store_one_telegram_one_discord(self) -> None:
+        # Arrange
+        store = _FakeBotStore([self._tg_row("tg_bot"), self._dc_row("dc_bot")])
+        # Act
+        tg, dc = multibot_config_from_store(store)
+        # Assert
+        assert isinstance(tg, TelegramMultiConfig)
+        assert isinstance(dc, DiscordMultiConfig)
+        assert len(tg.bots) == 1
+        assert len(dc.bots) == 1
+        assert tg.bots[0].bot_id == "tg_bot"
+        assert dc.bots[0].bot_id == "dc_bot"
+
+    def test_from_store_telegram_bot_fields_round_trip(self) -> None:
+        # Arrange
+        store = _FakeBotStore([self._tg_row(bot_id="lyra", agent="my_agent")])
+        # Act
+        tg, _ = multibot_config_from_store(store)
+        # Assert
+        bot = tg.bots[0]
+        assert isinstance(bot, TelegramBotConfig)
+        assert bot.bot_id == "lyra"
+        assert bot.agent == "my_agent"
+
+    def test_from_store_discord_bot_fields_round_trip(self) -> None:
+        # Arrange
+        store = _FakeBotStore(
+            [self._dc_row(bot_id="dc1", auto_thread=False, thread_hot_hours=48)]
+        )
+        # Act
+        _, dc = multibot_config_from_store(store)
+        # Assert
+        bot = dc.bots[0]
+        assert isinstance(bot, DiscordBotConfig)
+        assert bot.bot_id == "dc1"
+        assert bot.auto_thread is False
+        assert bot.thread_hot_hours == 48
+
+    def test_from_store_empty_store_returns_empty_lists(self) -> None:
+        # Arrange
+        store = _FakeBotStore([])
+        # Act
+        tg, dc = multibot_config_from_store(store)
+        # Assert
+        assert tg.bots == []
+        assert dc.bots == []
+
+    def test_from_store_unknown_platform_ignored(self) -> None:
+        # Arrange — a row with an unrecognised platform is silently skipped
+        unknown = BotRow(platform="slack", bot_id="slack_bot", agent="lyra_default")
+        store = _FakeBotStore([self._tg_row(), unknown])
+        # Act
+        tg, dc = multibot_config_from_store(store)
+        # Assert
+        assert len(tg.bots) == 1
+        assert dc.bots == []

--- a/tests/test_main_auth.py
+++ b/tests/test_main_auth.py
@@ -77,10 +77,21 @@ class TestAuthConfig:
         """No bot config at all causes ValueError when _main() runs."""
         patch_auth_config_test(monkeypatch)
         monkeypatch.setattr(main_mod, "_load_raw_config", lambda: {})
+        # Override BotStore so get_all returns empty roster — no bots in DB.
+        import lyra.bootstrap.bootstrap_stores as stores_mod_local
+
+        _empty_bot_store = MagicMock()
+        _empty_bot_store.connect = AsyncMock()
+        _empty_bot_store.close = AsyncMock()
+        _empty_bot_store.get = MagicMock(return_value=None)
+        _empty_bot_store.get_all = MagicMock(return_value=[])
+        monkeypatch.setattr(
+            stores_mod_local, "BotStore", lambda **kwargs: _empty_bot_store
+        )
         stop = asyncio.Event()
         stop.set()
-        # With no config, _bootstrap_unified raises ValueError.
-        with pytest.raises(ValueError, match="No adapters configured"):
+        # With no bots in BotStore, _init_bot_auths_and_agents raises ValueError.
+        with pytest.raises(ValueError, match="No bots configured"):
             await main_mod._main(_stop=stop)
 
     async def test_discord_section_optional_when_telegram_present(
@@ -133,11 +144,24 @@ class TestAuthConfig:
         from unittest.mock import MagicMock
 
         import lyra.bootstrap.bootstrap_stores as stores_mod_local
+        from lyra.core.agent.bot_models import BotRow
 
         patch_auth_config_test(monkeypatch)
         _fake_bot_store = MagicMock()
         _fake_bot_store.connect = AsyncMock()
         _fake_bot_store.close = AsyncMock()
+        # get_all provides the roster (telegram "main" bot present).
+        _fake_bot_store.get_all = MagicMock(
+            return_value=[
+                BotRow(
+                    platform="telegram",
+                    bot_id="main",
+                    agent="lyra_default",
+                    default_trust="public",
+                )
+            ]
+        )
+        # Per-bot get returns a row with invalid trust — this triggers SystemExit.
         _fake_bot_store.get = MagicMock(
             return_value=MagicMock(default_trust="invalid_level", trusted_roles=[])
         )
@@ -147,9 +171,7 @@ class TestAuthConfig:
         monkeypatch.setattr(
             main_mod,
             "_load_raw_config",
-            lambda: {
-                "telegram": {"bots": [{"bot_id": "main"}]},
-            },
+            lambda: {},
         )
         stop = asyncio.Event()
         stop.set()

--- a/tools/check_no_runtime_toml_bots.sh
+++ b/tools/check_no_runtime_toml_bots.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# #1420 guardrail — TOML bot sections are seed-only; no runtime roster reads allowed.
+#
+# Three checks (SC#7a, SC#7b, SC#9):
+#   (SC#7a) No raw dict-index reads of [[telegram.bots]] / [[discord.bots]] at runtime
+#           Pattern: raw["telegram"]["bots"], raw["discord"]["bots"],
+#                    auth_block.get("telegram_bots", auth_block.get("discord_bots"
+#   (SC#7b) No raw dict-index reads of [[auth.telegram_bots]] / [[auth.discord_bots]]
+#           Pattern: raw_config["auth"]["telegram_bots"], raw_config["auth"]["discord_bots"]
+#   (SC#9)  load_multibot_config() must not be called from boot paths
+#           (auth_seeding.py, factory/agent_factory.py) — replaced by BotStore.get_all()
+#
+# Exclusions:
+#   src/lyra/agent_cmd/bots/init.py    — sanctioned seed consumer (lyra bot init)
+#   src/lyra/config.py                 — parser internals (sections are still parsed for compat)
+#
+# Run locally: bash tools/check_no_runtime_toml_bots.sh
+# Run in CI:   quality gate (no_runtime_toml_bots in .claude/stack.yml)
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail=0
+
+# ── SC#7a: no runtime roster reads of [[telegram.bots]] / [[discord.bots]] ───
+# Guards against re-introducing raw["telegram"]["bots"] / raw["discord"]["bots"]
+# or .get("telegram_bots") / .get("discord_bots") outside the seed-only consumer.
+violations_7a=$(grep -rn \
+    'raw\["telegram"\]\["bots"\]\|raw\["discord"\]\["bots"\]\|auth_block\.get("telegram_bots"\|auth_block\.get("discord_bots"' \
+    src/lyra/ \
+    --include="*.py" \
+    | grep -v 'src/lyra/agent_cmd/bots/init\.py:' \
+    | grep -v 'src/lyra/config\.py:' \
+    || true)
+if [ -n "$violations_7a" ]; then
+    echo "FAIL (SC#7a): runtime TOML bot roster read detected — [[telegram.bots]] / [[discord.bots]] are seed-only (#1420)." >&2
+    echo "  Use BotStore.get_all() at runtime instead." >&2
+    printf '%s\n' "$violations_7a" | sed 's/^/  /' >&2
+    fail=1
+fi
+
+# ── SC#7b: no runtime roster reads of [[auth.telegram_bots]] / [[auth.discord_bots]] ──
+# Guards against raw_config["auth"]["telegram_bots"] / raw_config["auth"]["discord_bots"]
+# outside the seed-only consumer.
+violations_7b=$(grep -rn \
+    'raw_config\["auth"\]\["telegram_bots"\]\|raw_config\["auth"\]\["discord_bots"\]' \
+    src/lyra/ \
+    --include="*.py" \
+    | grep -v 'src/lyra/agent_cmd/bots/init\.py:' \
+    | grep -v 'src/lyra/config\.py:' \
+    || true)
+if [ -n "$violations_7b" ]; then
+    echo "FAIL (SC#7b): runtime TOML bot roster read detected — [[auth.telegram_bots]] / [[auth.discord_bots]] are seed-only (#1420)." >&2
+    echo "  Use BotStore.get_all() at runtime instead." >&2
+    printf '%s\n' "$violations_7b" | sed 's/^/  /' >&2
+    fail=1
+fi
+
+# ── SC#9: load_multibot_config() must not be called from boot paths ───────────
+# Hub standalone (auth_seeding.py) and unified (factory/agent_factory.py, which owns
+# _init_bot_auths_and_agents after #1283 Phase 6) must source the bot roster from
+# BotStore.get_all(), not load_multibot_config(raw_config).
+violations_9=$(grep -n 'load_multibot_config(' \
+    src/lyra/bootstrap/auth_seeding.py \
+    src/lyra/bootstrap/factory/agent_factory.py \
+    2>/dev/null || true)
+if [ -n "$violations_9" ]; then
+    echo "FAIL (SC#9): load_multibot_config() called in boot path — boot paths must use BotStore.get_all() (#1420)." >&2
+    echo "  Files: src/lyra/bootstrap/auth_seeding.py, src/lyra/bootstrap/factory/agent_factory.py" >&2
+    printf '%s\n' "$violations_9" | sed 's/^/  /' >&2
+    fail=1
+fi
+
+exit $fail

--- a/tools/check_no_runtime_toml_bots.sh
+++ b/tools/check_no_runtime_toml_bots.sh
@@ -3,16 +3,21 @@
 #
 # Three checks (SC#7a, SC#7b, SC#9):
 #   (SC#7a) No raw dict-index reads of [[telegram.bots]] / [[discord.bots]] at runtime
-#           Pattern: raw["telegram"]["bots"], raw["discord"]["bots"],
+#           Pattern: raw["telegram"]["bots"], raw['telegram']['bots'],
+#                    raw["discord"]["bots"], raw['discord']['bots'],
 #                    auth_block.get("telegram_bots", auth_block.get("discord_bots"
 #   (SC#7b) No raw dict-index reads of [[auth.telegram_bots]] / [[auth.discord_bots]]
-#           Pattern: raw_config["auth"]["telegram_bots"], raw_config["auth"]["discord_bots"]
+#           Pattern: raw_config["auth"]["telegram_bots"], raw_config['auth']['telegram_bots'],
+#                    raw_config["auth"]["discord_bots"], raw_config['auth']['discord_bots']
 #   (SC#9)  load_multibot_config() must not be called from boot paths
 #           (auth_seeding.py, factory/agent_factory.py) — replaced by BotStore.get_all()
 #
 # Exclusions:
 #   src/lyra/agent_cmd/bots/init.py    — sanctioned seed consumer (lyra bot init)
 #   src/lyra/config.py                 — parser internals (sections are still parsed for compat)
+#
+# Sanctioned load_multibot_config() caller NOT in SC#9 target list:
+#   src/lyra/cli.py                    — `lyra config validate` CLI introspection only (¬boot path)
 #
 # Run locally: bash tools/check_no_runtime_toml_bots.sh
 # Run in CI:   quality gate (no_runtime_toml_bots in .claude/stack.yml)
@@ -27,7 +32,7 @@ fail=0
 # Guards against re-introducing raw["telegram"]["bots"] / raw["discord"]["bots"]
 # or .get("telegram_bots") / .get("discord_bots") outside the seed-only consumer.
 violations_7a=$(grep -rn \
-    'raw\["telegram"\]\["bots"\]\|raw\["discord"\]\["bots"\]\|auth_block\.get("telegram_bots"\|auth_block\.get("discord_bots"' \
+    'raw\[["'"'"']\(telegram\|discord\)["'"'"']\]\[["'"'"']bots["'"'"']\]\|auth_block\.get("telegram_bots"\|auth_block\.get("discord_bots"' \
     src/lyra/ \
     --include="*.py" \
     | grep -v 'src/lyra/agent_cmd/bots/init\.py:' \
@@ -44,7 +49,7 @@ fi
 # Guards against raw_config["auth"]["telegram_bots"] / raw_config["auth"]["discord_bots"]
 # outside the seed-only consumer.
 violations_7b=$(grep -rn \
-    'raw_config\["auth"\]\["telegram_bots"\]\|raw_config\["auth"\]\["discord_bots"\]' \
+    'raw_config\[["'"'"']auth["'"'"']\]\[["'"'"']\(telegram_bots\|discord_bots\)["'"'"']\]' \
     src/lyra/ \
     --include="*.py" \
     | grep -v 'src/lyra/agent_cmd/bots/init\.py:' \

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -1,5 +1,5 @@
 # File size exemptions (≤300 lines per file)
-src/lyra/bootstrap/factory/config.py  # 313 lines — DEBT:file-exemptions — #1467 +23 lines (AdapterConfigBundle dataclass + build_adapter_config_bundle factory); config loader aggregator — all _load_* helpers live here
+src/lyra/bootstrap/factory/config.py  # 353 lines — DEBT:file-exemptions — #1467 +23 lines (AdapterConfigBundle dataclass + build_adapter_config_bundle factory); #1420 +43 lines (warn_deprecated_bot_sections + _bot_sections_deprecation_warned flag + call site); config loader aggregator — all _load_* helpers live here
 # Each entry must have a tracking issue.
 # Format: <path>  # <lines> lines — <issue> <description>
 tests/core/conftest.py  # 314 lines — DEBT:file-exemptions — backward-compatible re-exports after factory extraction (#1417)


### PR DESCRIPTION
## Summary
- Closing step of epic #1413. The runtime bot **roster** now comes from BotStore (`bot_store.get_all()`) in both boot paths (NATS hub via `auth_seeding.build_bot_auths`, unified via `wiring_helpers._init_bot_auths_and_agents`) — no longer from the TOML `load_multibot_config(raw_config)` read.
- With the roster migrated, the four legacy TOML sections (`[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`) are genuinely **seed-only**; `_load_raw_config` logs a one-time `DeprecationWarning` when any is present.
- `lyra bot init` seed parsing now validates each entry through a Pydantic `extra="forbid"` model — unknown/typo keys raise instead of being silently dropped (**closes G18**, the `webhook_enabled` typo trap).
- New guardrail `tools/check_no_runtime_toml_bots.sh` (wired into `stack.yml` quality_gates) fails CI if the bracket-pattern runtime reads or `load_multibot_config(` in the two boot paths ever return.

> **Note for review — deprecation marker:** `TelegramMultiConfig`/`DiscordMultiConfig` use `.. deprecated::` docstrings rather than the `typing_extensions.@deprecated` decorator. The decorator mis-flags the **new** `multibot_config_from_store` builder, which legitimately reuses these classes as its return type (it would emit `reportDeprecated` on the non-deprecated path and break the typecheck gate). The actual runtime-read enforcement is the guardrail script, not the marker.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1420: deprecate runtime-read of TOML bot sections | OPEN |
| Frame | [1420-…-frame.mdx](artifacts/frames/1420-deprecate-runtime-toml-bots-frame.mdx) | Present |
| Analysis | — (F-lite, skipped) | Absent |
| Spec | [1420-…-spec.mdx](artifacts/specs/1420-deprecate-runtime-toml-bots-spec.mdx) | Present |
| Plan | [1420-…-plan.mdx](artifacts/plans/1420-deprecate-runtime-toml-bots-plan.mdx) | Present |
| Implementation | 15 micro-tasks (4 slices, 3 waves) on `feat/1420-deprecate-runtime-toml-bots` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4877 passed; +5 new test modules) | Passed |

## Test Plan
- [ ] Boot with a seeded BotStore + `config.toml` containing **no** `[[telegram.bots]]` → bot still wired (roster from store).
- [ ] Boot with an empty BotStore → exits with guidance pointing at `lyra bot init` (not "[[telegram.bots]]").
- [ ] Boot with a legacy `config.toml` containing the sections → exactly one `DeprecationWarning` logged; clean config → none.
- [ ] `lyra bot init` with a typo'd key (e.g. `webhook_enabel`) → rejected naming the bad key; valid entries still seed.
- [ ] `bash tools/check_no_runtime_toml_bots.sh` → exit 0.

## Breaking change
The runtime bot roster is read from BotStore, not `config.toml`. Operators must run `lyra bot init` to seed BotStore before boot; an unseeded store now exits with guidance instead of reading bots from TOML.

Closes #1420

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`