### PR TITLE
feat(render-events): populate RunErrorRenderEvent.code from KNOWN_CODES

### DIFF
--- a/artifacts/frames/1113-render-events-code-taxonomy-frame.mdx
+++ b/artifacts/frames/1113-render-events-code-taxonomy-frame.mdx
@@ -1,0 +1,73 @@
+---
+title: Define RunErrorRenderEvent.code taxonomy
+issue: 1113
+status: approved
+tier: F-lite
+date: 2026-05-28
+---
+
+## Problem
+
+`RunErrorRenderEvent.code: str | None = None` exists in the render-events contract
+(`src/lyra/core/messaging/render_events.py`) but is **always emitted as `None`**. It was
+added in Slice 1 of #1096 (#1098, PR #1109) as a carry-over from #1097 review N1, with a
+docstring note deferring the taxonomy to "future" work.
+
+A field that is structurally always `None` is a contract lie: clients cannot rely on it,
+readers cannot infer intent from it. Today — before any UI consumer — a populated `code`
+already pays off in logs and debugging (filter/group infra failures by category). Once a
+consumer (dashboard, AG-UI HTTP/SSE adapter, structured-error filtering) arrives, historical
+events will already be tagged. This is hygiene debt, schedulable independently of any
+downstream consumer.
+
+## Who
+
+- **Primary:** operators / developers reading logs and debugging run failures — gain a
+  categorized `code` for filtering and triage.
+- **Secondary:** future observability consumers (roxabi-dashboard, AG-UI adapter,
+  structured-error filtering) — inherit historically-tagged data with no backfill.
+
+## Constraints
+
+- Single domain: render-events messaging contract + `StreamProcessor` emit sites.
+- Finite, enumerated taxonomy (enum or `Literal`), not free-form `str`.
+- ~5–10 emit sites to propagate categorization (start: `stream_processor.py` `RunErrorRenderEvent(...)` constructors).
+- Forward-compatible wire schema must be preserved (current consumers ignore the field).
+- If the contract schema is mirrored in `roxabi-contracts`, that mirror must stay in sync.
+
+## Out of Scope
+
+- Building any consumer of the field (dashboard, AG-UI adapter, error-filtering UI).
+- Changing the wire/SCHEMA_VERSION semantics beyond populating the existing field.
+- Reworking error handling/propagation logic itself — only categorize what is already raised.
+
+## Premise Validity
+
+**Success in 6 months:** `RunErrorRenderEvent.code` emits a real value drawn from a finite
+taxonomy at every emit site; logs and debugging can filter/group by code; the "future
+taxonomy" docstring note is removed; the contract no longer lies (`code` is never `None`
+in production).
+
+**Failure in 6 months:** ≥1 production emit site still constructs
+`RunErrorRenderEvent(code=None)` after merge — observable via grep / a test assertion that
+fails if any emit path leaves `code` unset.
+
+**Simplest alternative:** Delete the `code` field outright and remove the dead weight.
+**Why not simplest:** the field is SCHEMA-version-stable and forward-valuable — populated
+today it aids debugging with no UI, and historical events get tagged before a consumer
+arrives. Deleting forfeits both the debugging value now and the zero-backfill benefit later.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (render-events messaging), no new architecture;
+design fork + ~5–10 emit sites + per-category mapping tests.
+
+Signals observed:
+- `size:F-lite` label on the issue.
+- One domain (`core/messaging` + `core/processors`), no cross-cutting changes.
+- One genuine design decision (taxonomy location) → resolved in /spec, not an unknown.
+
+## Open Design Question (→ /spec)
+
+Taxonomy home: `roxabi_contracts.errors` (alongside `KNOWN_CODES`) **vs.** `core/messaging/`.
+Drives whether `roxabi-contracts` needs a coordinated bump.

--- a/artifacts/plans/1113-render-events-code-taxonomy-plan.mdx
+++ b/artifacts/plans/1113-render-events-code-taxonomy-plan.mdx
@@ -1,0 +1,219 @@
+---
+title: "Plan: Define RunErrorRenderEvent.code taxonomy"
+issue: 1113
+spec: artifacts/specs/1113-render-events-code-taxonomy-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-05-28
+---
+
+## Summary
+
+Stop discarding `err.code` in the `StreamProcessor` error translator and register the one
+unregistered code (`stream.error`) in the canonical `KNOWN_CODES` registry, so
+`RunErrorRenderEvent.code` is populated from the existing taxonomy instead of always `None`.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph contracts[packages/roxabi-contracts]
+        KC[KNOWN_CODES dict<br/>+ stream.error] --> GEN[check_codes_sync.py --write]
+        GEN --> DOC[error-codes.md<br/>+ stream.* section]
+    end
+    subgraph proc[src/lyra/core/processors/stream_processor.py]
+        SA[Site A: SanitizedError code=stream.error] --> TR
+        SB[Site B: SanitizedError code=_we.code / from_message] --> TR
+        TR[error_translator lambda<br/>code=err.code]
+    end
+    subgraph res[src/lyra/transport/_result.py]
+        FM[SanitizedError.from_message<br/>default code=stream.error]
+    end
+    KC -.governs.-> SA
+    KC -.governs.-> FM
+    TR --> RE[RunErrorRenderEvent code populated]
+    RE --> CODEC[render_event_codec NATS wire<br/>pass-through, no edit]
+    CODEC -.future.-> DASH[dashboard / AG-UI / logs]
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph errors[roxabi_contracts/errors.py]
+        K[KNOWN_CODES]
+    end
+    subgraph rev[core/messaging/render_events.py]
+        RC[RunErrorRenderEvent<br/>docstring]
+    end
+    subgraph sp[core/processors/stream_processor.py]
+        L[error_translator]
+    end
+    subgraph rs[transport/_result.py]
+        F[from_message]
+    end
+    subgraph tests[tests/]
+        T1[core/test_stream_processor.py]
+        T2[nats/test_render_event_codec.py]
+        T3[core/messaging/test_render_events.py]
+    end
+    K --> L
+    L --> T1
+    RC --> T3
+    K --> T3
+    L --> T2
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|----------------|-------|-------|
+| backend-dev-A | T1, T2, T3 | `errors.py`, `error-codes.md`, `render_events.py`, `docs/architecture/messaging.md` |
+| tester-A | T4, T5 | `tests/core/test_stream_processor.py`, `tests/nats/test_render_event_codec.py`, `tests/core/messaging/test_render_events.py` |
+| backend-dev-B | T6 | `stream_processor.py`, `transport/_result.py` |
+
+## Wave Structure
+
+3 waves, max 2 parallel agents. Elapsed ~½ day vs ~1 day sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | backend-dev-A: T1 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-A: T2→T3 · tester-A: T4, T5 (RED) |
+| 3 | Wave 2 done | 1 | backend-dev-B: T6 (GREEN) → RED-GATE: full suite |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 register stream.error | 1 | bounded | 3 | — |
+| T2 regen error-codes.md | 1 | trivial | 2 | — |
+| T3 docstring + messaging.md | 2 | bounded | 5 | — |
+| T4 emit-path tests (RED) | 3 | judgmental | 8 | — |
+| T5 codec + membership tests (RED) | 2 | judgmental | 7 | — |
+| T6 translator + comment (GREEN) | 2 | bounded | 5 | — |
+
+**Total estimated ops: 30**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3 | 10 | taxonomy, docs | — |
+| tester-A | T4, T5 | 15 | emit, codec | — |
+| backend-dev-B | T6 | 5 | emit | — |
+
+All instances under caps (≤4 tasks, ≤50 ops, ≤2 subjects).
+
+## Consistency Report
+
+Spec criteria covered: 8/8.
+
+| SC | Task |
+|----|------|
+| SC-1 translator builds code=err.code, no code=None | T6 |
+| SC-2 stream.error registered + doc regen + codes-sync passes | T1, T2 |
+| SC-3 Site A → code=="stream.error" | T4 |
+| SC-4 Site B + WorkerError → code==we.code | T4 |
+| SC-5 Site B no WorkerError → code=="stream.error" | T4 |
+| SC-6 emittable codes ⊆ KNOWN_CODES | T5 |
+| SC-7 docstring refs KNOWN_CODES + messaging.md note | T3 |
+| SC-8 codec round-trips non-None and None code | T5 |
+
+Untraced tasks: none. Exemptions: none.
+
+## Micro-Tasks
+
+### Slice S1 — register taxonomy + docs
+
+**T1 — Register `stream.error` in KNOWN_CODES** · backend-dev-A · subject: taxonomy · GREEN · diff 2 · SC-2
+- File: `packages/roxabi-contracts/src/roxabi_contracts/errors.py`
+- Add a `# --- stream ---` section with:
+  ```python
+  "stream.error": CodeMeta(
+      domain="stream",
+      default_retryable=False,
+      description="Unhandled exception during hub-side stream processing "
+      "(StreamProcessor), or an un-categorized soft error.",
+  ),
+  ```
+- Verify: `grep -q '"stream.error"' packages/roxabi-contracts/src/roxabi_contracts/errors.py`
+- Expected: match.
+
+**T2 — Regenerate `error-codes.md`** · backend-dev-A · subject: taxonomy · GREEN · diff 1 · SC-2 · blockedBy T1
+- File: `packages/roxabi-contracts/docs/error-codes.md` (generated)
+- Verify: `uv run python packages/roxabi-contracts/scripts/check_codes_sync.py --write && grep -q '## stream' packages/roxabi-contracts/docs/error-codes.md`
+- Expected: `## stream.*` section present; codes-sync clean.
+
+**T3 — Docstring + messaging.md note** · backend-dev-A · subject: docs · REFACTOR · diff 2 · SC-7 · blockedBy T1
+- Files: `src/lyra/core/messaging/render_events.py` (RunErrorRenderEvent docstring ~172-178), `docs/architecture/messaging.md`
+- render_events.py: replace the "reserved for a future taxonomy … Slice 1 always passes `None`" lines with: `code` is a key from `roxabi_contracts.errors.KNOWN_CODES` (e.g. `stream.error`, `cli.auth`); `None` only for historical/pre-taxonomy events.
+- messaging.md: one sentence under the NATS render-event / Registered event families section that `run_error` events carry a populated `code` from `KNOWN_CODES`.
+- Verify: `! grep -q 'future taxonomy' src/lyra/core/messaging/render_events.py && grep -qi 'KNOWN_CODES' docs/architecture/messaging.md`
+- Expected: both true.
+
+**RED-GATE S1:** `uv run python packages/roxabi-contracts/scripts/check_codes_sync.py` exits 0.
+
+### Slice S2 — propagate code + tests
+
+**T4 — Emit-path tests (RED)** · tester-A · subject: emit · RED · diff 3 · SC-3,4,5 · blockedBy T1
+- File: `tests/core/test_stream_processor.py`
+- Add tests driving `StreamProcessor.process`:
+  - infra exception → terminal `RunErrorRenderEvent.code == "stream.error"`.
+  - soft error with `WorkerError(code=...)` (e.g. `cli.auth`) → `code == "cli.auth"`.
+  - soft error, no WorkerError (error_text only → `from_message`) → `code == "stream.error"`.
+- Verify: `uv run pytest tests/core/test_stream_processor.py -k code -q` (expect FAIL pre-T6)
+- Expected: tests collected, fail on `code is None` (RED).
+
+**T5 — Codec round-trip + membership tests (RED)** · tester-A · subject: codec · RED · diff 3 · SC-6,8 · blockedBy T1
+- Files: `tests/nats/test_render_event_codec.py`, `tests/core/messaging/test_render_events.py`
+- codec: encode→decode a `RunErrorRenderEvent(code="stream.error")` preserves `code`; a `code=None` event decodes without error.
+- membership: assert the set of codes the translator can emit (`stream.error` + representative WorkerError codes) ⊆ `KNOWN_CODES`.
+- Verify: `uv run pytest tests/nats/test_render_event_codec.py tests/core/messaging/test_render_events.py -k 'code or known_codes' -q`
+- Expected: collected; codec non-None case fails pre-T6 only if it asserts populated emit (membership passes immediately after T1).
+
+**T6 — Propagate `err.code` (GREEN)** · backend-dev-B · subject: emit · GREEN · diff 2 · SC-1 · blockedBy T4, T5
+- Files: `src/lyra/core/processors/stream_processor.py` (translator lambda ~224), `src/lyra/transport/_result.py` (~42)
+- stream_processor.py: `RunErrorRenderEvent(run_id=run_id, message=err.message, code=err.code)`.
+- _result.py: brief comment at `from_message` default noting `stream.error` is its registry-valid fallback (ref KNOWN_CODES).
+- Verify: `! grep -n 'code=None' src/lyra/core/processors/stream_processor.py && uv run pytest tests/core/test_stream_processor.py tests/nats/test_render_event_codec.py -q`
+- Expected: no `code=None` at emit site; T4/T5 tests now GREEN.
+
+**RED-GATE S2:** `uv run pytest tests/core tests/nats packages/roxabi-contracts -q` green.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T{n} | agent-instance | blockedBy | subject. -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | taxonomy |
+
+### Wave 2 — after T1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | taxonomy |
+| T3 | backend-dev-A | T1 | docs |
+| T4 | tester-A | T1 | emit |
+| T5 | tester-A | T1 | codec |
+
+### Wave 3 — after T4, T5, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | backend-dev-B | T4, T5 | emit |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — taxonomy
+- T2: 13 — taxonomy
+- T3: 14 — docs
+- T4: 15 — emit
+- T5: 16 — codec
+- T6: 17 — emit

--- a/artifacts/specs/1113-render-events-code-taxonomy-spec.mdx
+++ b/artifacts/specs/1113-render-events-code-taxonomy-spec.mdx
@@ -1,0 +1,179 @@
+---
+title: Define RunErrorRenderEvent.code taxonomy
+issue: 1113
+status: approved
+tier: F-lite
+date: 2026-05-28
+promoted_from: artifacts/frames/1113-render-events-code-taxonomy-frame.mdx
+---
+
+## Context
+
+Source: [frame](../frames/1113-render-events-code-taxonomy-frame.mdx) (analysis skipped — F-lite).
+
+`RunErrorRenderEvent.code: str | None = None` (`src/lyra/core/messaging/render_events.py:154`)
+is always emitted as `None`. The field was added in Slice 1 of #1096 with a docstring note
+deferring the taxonomy to "future" work.
+
+**Investigation overturned the issue's stale action plan.** The issue body (line refs already
+drifted: it cites `:381,402`; the real emit site is now `stream_processor.py:224`) proposed
+*inventing* a new enum (`timeout`, `agent_crash`, `llm_failure`, …) under `core/messaging`.
+Reading the code shows a canonical taxonomy **already exists**:
+
+- `roxabi_contracts.errors.KNOWN_CODES` — a registry of 26 dotted codes across 7 domains
+  (`transport`, `pool`, `worker`, `cli`, `llm`, `voice`, `image`), defined in ADR-066, with
+  `CodeMeta` (domain, default_retryable, description).
+- It is the single source of truth: `error-codes.md` is auto-generated from it and the
+  `codes-sync` pre-commit hook + CI enforce the doc stays in sync.
+- Both `RunErrorRenderEvent` emit paths **already carry a code** they then throw away:
+  - **Site A — infra exception** (`stream_processor.py:254`): `SanitizedError(code="stream.error", …)`.
+  - **Site B — soft error** (`stream_processor.py:281`): `SanitizedError(code=_we.code, …)` where
+    `_we` is a `WorkerError` whose `code` is registry-valid; or `SanitizedError.from_message()`
+    which defaults `code="stream.error"`.
+  - The translator lambda (`stream_processor.py:224`) then builds
+    `RunErrorRenderEvent(run_id=run_id, message=err.message, code=None)` — **discarding `err.code`.**
+
+**This resolves the issue's open design fork decisively:** the taxonomy lives in
+`roxabi_contracts.errors` (reuse `KNOWN_CODES`). Minting a parallel enum under `core/messaging`
+would duplicate the registry and split the source of truth — rejected.
+
+The fix is therefore far smaller and lower-risk than the issue assumed: stop discarding the
+code that already flows, and close the one taxonomy gap (`stream.error` is emitted but
+unregistered).
+
+## Goal
+
+Populate `RunErrorRenderEvent.code` at every emit site with a value from the canonical
+`KNOWN_CODES` registry, so the field stops lying and infra-run-error events are filterable by code.
+
+## Users
+
+- **Primary:** operators/developers reading logs & debugging run failures — gain a categorized
+  `code` for filtering/triage today, no UI required.
+- **Secondary (out of scope to build):** future observability consumers (roxabi-dashboard,
+  AG-UI HTTP/SSE adapter, structured-error filtering) — inherit historically-tagged data with
+  zero backfill. The wire field must be accessible to them; this issue only populates it.
+
+## Expected Behavior
+
+Narrative walkthrough of `StreamProcessor.process()`:
+
+1. A run begins → `RunStartedRenderEvent`.
+2. **Infra exception** escapes the inner loop → `_emitter.emit_terminal(SanitizedError(code="stream.error", …))`.
+   The translator now emits `RunErrorRenderEvent(code="stream.error")` (was `code=None`).
+3. **Soft error** (`ResultLlmEvent.is_error=True`):
+   - With a `WorkerError` → `SanitizedError(code=_we.code)` → `RunErrorRenderEvent(code=_we.code)`
+     (e.g. `cli.auth`, `llm.rate_limit`, `worker.crash`).
+   - Without one → `SanitizedError.from_message()` defaults to `code="stream.error"` →
+     `RunErrorRenderEvent(code="stream.error")`.
+4. The event is encoded by `render_event_codec` onto the NATS bus (std codec already serializes
+   all dataclass fields → `code` round-trips with no codec change), and the outbound dispatch
+   ladder still flags the turn with an `❌` prefix (behavior unchanged; it reads the event type,
+   not `code`).
+
+Invariants preserved:
+- `message` remains `type(exc).__name__` / curated text — **never** `str(exc)` (NATS-bus safety).
+- `SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT` stays `1` — populating an existing optional field is
+  forward-compatible; consumers that ignore `code` are unaffected.
+- `code: str | None` keeps the `| None` arm: historical/in-flight events decode with `code=None`,
+  and `None` remains the explicit "pre-taxonomy / unknown" sentinel. The field is *always*
+  populated going forward, but the type is not tightened (avoids breaking decode of older events).
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class RunErrorRenderEvent {
+        +str run_id
+        +str message
+        +str|None code  «from KNOWN_CODES keys»
+        +int schema_version
+        «frozen»
+    }
+    class SanitizedError {
+        +str code
+        +str message
+        +bool retryable
+        «frozen»
+    }
+    class WorkerError {
+        +str code  «pattern ^[a-z][a-z0-9._-]*$»
+        +str message
+        +bool retryable
+        +str|None detail
+    }
+    class CodeMeta {
+        +str domain
+        +bool default_retryable
+        +str description
+    }
+    SanitizedError --> RunErrorRenderEvent : error_translator (code passthrough)
+    WorkerError --> SanitizedError : Site B (code=_we.code)
+    CodeMeta --> RunErrorRenderEvent : code ∈ KNOWN_CODES.keys()
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    SP[StreamProcessor.process] -->|RunErrorRenderEvent code populated| CODEC[render_event_codec NATS wire]
+    CODEC --> OUT[outbound/emitter dispatch ladder]
+    OUT -->|reads event TYPE, not code| MSG[rendered ❌ message]
+    CODEC -.->|reads code for filtering| DASH[future: roxabi-dashboard / AG-UI]
+    CODEC -.->|group/filter by code| LOG[logs / debugging]
+```
+
+Solid = this issue. Dashed = future consumers (out of scope; field must be accessible).
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `outbound/emitter.py` dispatch ladder | event type (isinstance) | per terminal event | existing — unchanged |
+| `render_event_codec` (NATS) | pass-through serialise/deserialise of all fields (not a semantic `code` consumer) | encode/decode on bus | existing — `code` now non-None on wire, no codec edit |
+| logs / debugging | `code` | on error | **this issue** |
+| roxabi-dashboard / AG-UI adapter | `code` | future | future (out of scope) |
+
+## Breadboard
+
+Backend-only change; affordances are code seams, not UI.
+
+| ID | Affordance (seam) | Handler | Data |
+|----|-------------------|---------|------|
+| N1 | `KNOWN_CODES` registry entry `stream.error` | `roxabi_contracts/errors.py` | `CodeMeta(domain="stream", default_retryable=False, description=…)` |
+| N2 | `error-codes.md` regeneration | `check_codes_sync.py --write` (codes-sync hook) | generated doc + new `## stream.*` section |
+| N3 | `error_translator` lambda | `stream_processor.py:224` | `RunErrorRenderEvent(run_id=run_id, message=err.message, code=err.code)`; add a brief comment at the `SanitizedError.from_message` default (`_result.py:42`) noting `stream.error` is its registry-valid fallback |
+| N4 | `RunErrorRenderEvent` docstring + `messaging.md` note | `render_events.py:172-178`; `docs/architecture/messaging.md` (NATS codec / Registered event families) | replace "future taxonomy" note with KNOWN_CODES reference; add one sentence that `run_error` events carry a populated `code` from `KNOWN_CODES` |
+| N5 | registry-membership test | `tests/.../test_render_events*` | assert emitted codes ⊆ `KNOWN_CODES` |
+| N6 | codec round-trip test | `tests/.../test_render_event_codec*` | encode→decode preserves a non-`None` `code`, and a historical `code=None` event decodes without error (forward-compat) |
+
+Wiring: N1→N2 (registry drives doc) · N3 consumes N1 codes · N4 documents N3 · N5 guards N1+N3 · N6 guards wire forward-compat.
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|-------|-------------|------|
+| S1 | Register `stream.error` + regenerate doc + update docstring & messaging.md | N1, N2, N4 | `codes-sync` passes; `error-codes.md` shows `## stream.*`; docstring + messaging.md reference registry |
+| S2 | Propagate `err.code` through translator + tests (both paths + codec) | N3, N5, N6 | infra-exception → `code="stream.error"`; soft-error+WorkerError → `code=_we.code`; all emitted codes ∈ KNOWN_CODES; codec round-trips non-None and None code |
+
+S1 before S2: the translator (S2) emits `stream.error`, which must be a registered code first (S1).
+
+## Success Criteria
+
+- [ ] `error_translator` in `stream_processor.py` builds `RunErrorRenderEvent(code=err.code)`; no `code=None` literal remains at the emit site.
+- [ ] `stream.error` is registered in `KNOWN_CODES` with a `CodeMeta`; `error-codes.md` is regenerated and the `codes-sync` hook/CI passes.
+- [ ] Infra-exception path (Site A) emits `RunErrorRenderEvent.code == "stream.error"` (asserted by test).
+- [ ] Soft-error path with a `WorkerError` (Site B) emits `code == worker_error.code` for a representative code (asserted by test).
+- [ ] Soft-error path without a `WorkerError` (`from_message`) emits `code == "stream.error"` (asserted by test).
+- [ ] A test asserts every code `RunErrorRenderEvent` can emit is a key in `KNOWN_CODES`.
+- [ ] `RunErrorRenderEvent` docstring no longer says `code` is "reserved for a future taxonomy" (references `KNOWN_CODES` instead), and `docs/architecture/messaging.md` notes `run_error` events carry a populated `code` from `KNOWN_CODES`.
+- [ ] NATS `render_event_codec` round-trips both a non-`None` `code` (unchanged) and a historical `code=None` event (decodes without error) — asserted by test.
+
+## Out of Scope
+
+- Building any consumer of `code` (dashboard, AG-UI, error-filtering UI).
+- Tightening `code: str | None` → `str` or a `Literal`/enum — would duplicate the `KNOWN_CODES` SSoT and break decode of historical `None`-coded events.
+- Reworking error propagation/classification logic — only categorize what is already raised.
+- Bumping `SCHEMA_VERSION_RUN_ERROR_RENDER_EVENT` — not required (forward-compatible).

--- a/docs/architecture/messaging.md
+++ b/docs/architecture/messaging.md
@@ -210,6 +210,11 @@ Both maps are built once in `__init__` and are immutable thereafter. `decode()` 
 | ToolCall lifecycle | `tool_call_start`, `tool_call_args`, `tool_call_end`, `tool_call_result` |
 | Reasoning lifecycle | `reasoning_start`, `reasoning_delta`, `reasoning_end` |
 
+`run_error` events carry a populated `code` drawn from the canonical
+`roxabi_contracts.errors.KNOWN_CODES` registry (e.g. `stream.error`, `cli.auth`,
+`llm.rate_limit`) — see [error-codes.md](../../packages/roxabi-contracts/docs/error-codes.md)
+(issue #1113). `code` is `None` only for events serialized before the taxonomy landed.
+
 The v1 events `TextRenderEvent` (`event_type="text"`) and `ToolSummaryRenderEvent`
 (`event_type="tool_summary"`) have been removed from `src/lyra/core/messaging/render_events.py`
 and from the registry (issue #1192, Slice 3). All consumer paths and dual-emit sites have been

--- a/packages/roxabi-contracts/docs/error-codes.md
+++ b/packages/roxabi-contracts/docs/error-codes.md
@@ -65,4 +65,10 @@
 | image.engine_unavailable | true | Image generation engine is not reachable or has not started. |
 | image.prompt_rejected | false | Image prompt was rejected by the engine's content policy. |
 
+## stream.*
+
+| code | retryable | description |
+|------|-----------|-------------|
+| stream.error | false | Unhandled exception during hub-side stream processing (StreamProcessor), or an un-categorized soft error surfaced via SanitizedError.from_message. |
+
 See ADR-066 for design rationale.

--- a/packages/roxabi-contracts/src/roxabi_contracts/errors.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/errors.py
@@ -142,7 +142,7 @@ class CodeMeta(BaseModel):
 # ---------------------------------------------------------------------------
 # KNOWN_CODES — canonical registry (ADR-066 § "The code namespace")
 # ---------------------------------------------------------------------------
-# Domains: transport | pool | worker | cli | llm | voice | image
+# Domains: transport | pool | worker | cli | llm | voice | image | stream
 # ---------------------------------------------------------------------------
 
 KNOWN_CODES: dict[str, CodeMeta] = {
@@ -282,5 +282,11 @@ KNOWN_CODES: dict[str, CodeMeta] = {
         domain="image",
         default_retryable=False,
         description="Image prompt was rejected by the engine's content policy.",
+    ),
+    # --- stream --------------------------------------------------------------
+    "stream.error": CodeMeta(
+        domain="stream",
+        default_retryable=False,
+        description="Unhandled exception during hub-side stream processing (StreamProcessor), or an un-categorized soft error surfaced via SanitizedError.from_message.",  # noqa: E501
     ),
 }

--- a/src/lyra/core/messaging/render_events.py
+++ b/src/lyra/core/messaging/render_events.py
@@ -169,8 +169,12 @@ class RunErrorRenderEvent:
     In both cases, the adapter dispatch ladder flags the turn as error so the
     final rendered message gets an ``❌`` prefix.
 
-    ``code`` is reserved for a future taxonomy (carry-over from #1097 review);
-    Slice 1 always passes ``None``.
+    ``code`` is a key from the canonical ``roxabi_contracts.errors.KNOWN_CODES``
+    registry (e.g. ``stream.error`` for an infrastructure exception, or a
+    ``WorkerError`` code such as ``cli.auth`` / ``llm.rate_limit`` for soft
+    errors). It is populated from the originating ``SanitizedError.code`` at
+    both emit sites. ``None`` is retained only as the historical / pre-taxonomy
+    sentinel for events serialized before #1113.
     """
 
     run_id: str

--- a/src/lyra/core/processors/stream_processor.py
+++ b/src/lyra/core/processors/stream_processor.py
@@ -220,9 +220,13 @@ class StreamProcessor:
         #
         # RenderEvent is a TypeAlias (Union[...]), not a concrete class, so the
         # Generic bound is left inferred by the translator return type.
+        # #1113: propagate the originating SanitizedError.code (a KNOWN_CODES
+        # key, e.g. ``stream.error`` for infra exceptions or a WorkerError code
+        # such as ``cli.auth`` for soft errors) onto RunErrorRenderEvent.code,
+        # rather than discarding it as ``None``.
         _emitter: EventEmitter[RunErrorRenderEvent] = EventEmitter(
             error_translator=lambda err: RunErrorRenderEvent(
-                run_id=run_id, message=err.message, code=None
+                run_id=run_id, message=err.message, code=err.code
             )
         )
         yield RunStartedRenderEvent(run_id=run_id)

--- a/src/lyra/transport/_result.py
+++ b/src/lyra/transport/_result.py
@@ -47,6 +47,11 @@ class SanitizedError:
         (mirrors ``_scrub_cli_error_text`` in cli_streaming_parser — same
         security boundary: untrusted upstream content must not reach the NATS
         bus raw). Falls back to ``"model_error"`` when ``message`` is empty.
+
+        The default ``code="stream.error"`` is a registry-valid key in
+        ``roxabi_contracts.errors.KNOWN_CODES`` (#1113); it flows through to
+        ``RunErrorRenderEvent.code`` for soft errors that lack a structured
+        ``WorkerError``.
         """
         if not message:
             return cls(code=code, message="model_error", retryable=False)

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -37,6 +37,7 @@ from lyra.core.messaging.render_events import (
 )
 from lyra.core.processors.stream_processor import StreamProcessor
 from lyra.core.trace import TraceContext
+from roxabi_contracts.errors import KNOWN_CODES, WorkerError
 
 _RUN_LIFECYCLE_TYPES = (
     RunStartedRenderEvent,
@@ -834,10 +835,10 @@ class TestRunLifecycle:
         # can leak file paths, hostnames, auth tokens onto the wire.
         assert seen[-1].message == "_Boom"
         assert "input died" not in seen[-1].message
-        # code is intentionally None per RunErrorRenderEvent docstring
-        # ("reserved for a future taxonomy" — #1097 carry-over). The EventEmitter
-        # translator deliberately drops SanitizedError.code on the wire.
-        assert seen[-1].code is None
+        # #1113: the EventEmitter translator now propagates SanitizedError.code
+        # onto the wire. Site A (infra exception) sources "stream.error", a key
+        # in roxabi_contracts.errors.KNOWN_CODES.
+        assert seen[-1].code == "stream.error"
         assert seen[-1].run_id == seen[0].run_id
         # Position-aware: no RunFinished must appear before RunError, and
         # exactly two lifecycle events should be present (started + error).
@@ -1788,3 +1789,76 @@ class TestTextTriplet:
         assert text_end_idx < run_finished_idx, (
             "TextEnd must be emitted before RunFinished on truncation path"
         )
+
+
+# ---------------------------------------------------------------------------
+# #1113 — RunErrorRenderEvent.code taxonomy (KNOWN_CODES)
+# ---------------------------------------------------------------------------
+
+
+async def _raise_events() -> AsyncIterator:
+    """Async iterator that raises mid-stream — drives the Site A infra path."""
+    raise RuntimeError("kaboom")
+    yield  # pragma: no cover — unreachable, makes this an async generator
+
+
+class TestRunErrorCode:
+    """RunErrorRenderEvent.code is populated from SanitizedError.code (#1113).
+
+    Three emit paths, all sourced from roxabi_contracts.errors.KNOWN_CODES:
+      - Site A: infrastructure exception → ``stream.error``.
+      - Site B with a WorkerError → the worker's registry code.
+      - Site B without a WorkerError (error_text → from_message) → ``stream.error``.
+    """
+
+    async def test_infra_exception_code_is_stream_error(self) -> None:
+        """Site A: an exception escaping process() emits code='stream.error'."""
+        processor = StreamProcessor()
+        collected: list = []
+        with pytest.raises(RuntimeError):
+            async for ev in processor.process(_raise_events()):
+                collected.append(ev)
+
+        run_errors = [e for e in collected if isinstance(e, RunErrorRenderEvent)]
+        assert run_errors, "expected a RunErrorRenderEvent before the re-raise"
+        assert run_errors[-1].code == "stream.error"
+
+    async def test_soft_error_with_worker_error_propagates_code(self) -> None:
+        """Site B: a WorkerError code (e.g. cli.auth) reaches RunError.code."""
+        processor = StreamProcessor()
+        events = async_events(
+            ResultLlmEvent(
+                is_error=True,
+                duration_ms=0,
+                error_text="Not logged in",
+                worker_error=WorkerError(
+                    code="cli.auth", message="auth failed", retryable=False
+                ),
+            ),
+        )
+        all_events = await collect(processor.process(events))
+
+        run_errors = [e for e in all_events if isinstance(e, RunErrorRenderEvent)]
+        assert len(run_errors) == 1
+        assert run_errors[0].code == "cli.auth"
+
+    async def test_soft_error_without_worker_error_code_is_stream_error(self) -> None:
+        """Site B: error_text only (no WorkerError) falls back to stream.error."""
+        processor = StreamProcessor()
+        events = async_events(
+            ResultLlmEvent(is_error=True, duration_ms=0, error_text="boom"),
+        )
+        all_events = await collect(processor.process(events))
+
+        run_errors = [e for e in all_events if isinstance(e, RunErrorRenderEvent)]
+        assert len(run_errors) == 1
+        assert run_errors[0].code == "stream.error"
+
+    def test_emittable_codes_are_registered(self) -> None:
+        """SC-6: every code RunErrorRenderEvent can emit is a KNOWN_CODES key."""
+        # The translator emits either "stream.error" (Site A + from_message default)
+        # or a WorkerError.code (Site B). WorkerError.code is validated against the
+        # registry at its own boundaries; the only literal this issue introduces is
+        # "stream.error", which must be registered.
+        assert "stream.error" in KNOWN_CODES
+        assert KNOWN_CODES["stream.error"].domain == "stream"

--- a/tests/core/test_stream_processor.py
+++ b/tests/core/test_stream_processor.py
@@ -1821,18 +1821,28 @@ class TestRunErrorCode:
 
         run_errors = [e for e in collected if isinstance(e, RunErrorRenderEvent)]
         assert run_errors, "expected a RunErrorRenderEvent before the re-raise"
+        # Ordering: the RunError must be the LAST event emitted before the
+        # re-raise — guards against a refactor that re-raises before yielding it.
+        assert isinstance(collected[-1], RunErrorRenderEvent)
         assert run_errors[-1].code == "stream.error"
 
-    async def test_soft_error_with_worker_error_propagates_code(self) -> None:
-        """Site B: a WorkerError code (e.g. cli.auth) reaches RunError.code."""
+    @pytest.mark.parametrize(
+        "code,retryable",
+        [("cli.auth", False), ("llm.rate_limit", True)],
+        ids=["non_retryable", "retryable"],
+    )
+    async def test_soft_error_with_worker_error_propagates_code(
+        self, code: str, retryable: bool
+    ) -> None:
+        """Site B: a WorkerError code reaches RunError.code (both retryable values)."""
         processor = StreamProcessor()
         events = async_events(
             ResultLlmEvent(
                 is_error=True,
                 duration_ms=0,
-                error_text="Not logged in",
+                error_text="upstream error",
                 worker_error=WorkerError(
-                    code="cli.auth", message="auth failed", retryable=False
+                    code=code, message="worker said no", retryable=retryable
                 ),
             ),
         )
@@ -1840,7 +1850,7 @@ class TestRunErrorCode:
 
         run_errors = [e for e in all_events if isinstance(e, RunErrorRenderEvent)]
         assert len(run_errors) == 1
-        assert run_errors[0].code == "cli.auth"
+        assert run_errors[0].code == code
 
     async def test_soft_error_without_worker_error_code_is_stream_error(self) -> None:
         """Site B: error_text only (no WorkerError) falls back to stream.error."""
@@ -1854,11 +1864,49 @@ class TestRunErrorCode:
         assert len(run_errors) == 1
         assert run_errors[0].code == "stream.error"
 
-    def test_emittable_codes_are_registered(self) -> None:
-        """SC-6: every code RunErrorRenderEvent can emit is a KNOWN_CODES key."""
-        # The translator emits either "stream.error" (Site A + from_message default)
-        # or a WorkerError.code (Site B). WorkerError.code is validated against the
-        # registry at its own boundaries; the only literal this issue introduces is
-        # "stream.error", which must be registered.
-        assert "stream.error" in KNOWN_CODES
+    async def test_soft_error_empty_error_text_falls_back_to_model_error(self) -> None:
+        """Site B: empty error_text → from_message → message='model_error'."""
+        processor = StreamProcessor()
+        events = async_events(
+            ResultLlmEvent(is_error=True, duration_ms=0, error_text=""),
+        )
+        all_events = await collect(processor.process(events))
+
+        run_errors = [e for e in all_events if isinstance(e, RunErrorRenderEvent)]
+        assert len(run_errors) == 1
+        assert run_errors[0].message == "model_error"
+        assert run_errors[0].code == "stream.error"
+
+    async def test_emitted_codes_are_registered(self) -> None:
+        """SC-6: every code the processor actually emits is a KNOWN_CODES key.
+
+        Connects the emit sites to the registry (not a static dict membership
+        check): drives all three paths and asserts each emitted, non-None code
+        is registered.
+        """
+        emitted: list[str] = []
+
+        # Site A — infra exception.
+        with pytest.raises(RuntimeError):
+            async for ev in StreamProcessor().process(_raise_events()):
+                if isinstance(ev, RunErrorRenderEvent) and ev.code is not None:
+                    emitted.append(ev.code)
+
+        # Site B — WorkerError code, and from_message fallback.
+        for evt in (
+            ResultLlmEvent(
+                is_error=True,
+                duration_ms=0,
+                worker_error=WorkerError(
+                    code="cli.auth", message="x", retryable=False
+                ),
+            ),
+            ResultLlmEvent(is_error=True, duration_ms=0, error_text="boom"),
+        ):
+            for ev in await collect(StreamProcessor().process(async_events(evt))):
+                if isinstance(ev, RunErrorRenderEvent) and ev.code is not None:
+                    emitted.append(ev.code)
+
+        assert emitted, "expected at least one populated code across the emit paths"
+        assert all(code in KNOWN_CODES for code in emitted), emitted
         assert KNOWN_CODES["stream.error"].domain == "stream"

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -706,8 +706,8 @@ class TestRunErrorCodeRoundTrip:
 
         assert is_done is True
         decoded = codec.decode(event_type, payload)
+        # decoded == original (frozen dataclass) already pins code fidelity.
         assert decoded == original
-        assert decoded.code == "stream.error"  # type: ignore[union-attr]
 
     def test_worker_error_code_round_trips(self) -> None:
         codec = NatsRenderEventCodec()
@@ -717,7 +717,6 @@ class TestRunErrorCodeRoundTrip:
         event_type, payload, _ = codec.encode(original)
         decoded = codec.decode(event_type, payload)
         assert decoded == original
-        assert decoded.code == "cli.auth"  # type: ignore[union-attr]
 
     def test_historical_none_code_decodes(self) -> None:
         """Forward-compat: an event serialized before #1113 (code=None) decodes."""

--- a/tests/nats/test_render_event_codec.py
+++ b/tests/nats/test_render_event_codec.py
@@ -33,6 +33,7 @@ from lyra.core.messaging.render_events import (
     ReasoningEndRenderEvent,
     ReasoningStartRenderEvent,
     RenderEvent,
+    RunErrorRenderEvent,
     TextChunkRenderEvent,
     TextDeltaRenderEvent,
     TextEndRenderEvent,
@@ -687,3 +688,42 @@ def test_decode_synthetic_sentinel_no_warning(
         f"Unexpected 'unknown event_type' warning(s) for synthetic sentinels: "
         f"{[r.getMessage() for r in unknown_warnings]}"
     )
+
+
+class TestRunErrorCodeRoundTrip:
+    """#1113 — RunErrorRenderEvent.code survives the NATS codec round-trip.
+
+    The codec is a pass-through serialiser; populating ``code`` from KNOWN_CODES
+    must reach the wire, and historical ``code=None`` events must still decode.
+    """
+
+    def test_populated_code_round_trips(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = RunErrorRenderEvent(
+            run_id="run-1", message="ValueError", code="stream.error"
+        )
+        event_type, payload, is_done = codec.encode(original)
+
+        assert is_done is True
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+        assert decoded.code == "stream.error"  # type: ignore[union-attr]
+
+    def test_worker_error_code_round_trips(self) -> None:
+        codec = NatsRenderEventCodec()
+        original = RunErrorRenderEvent(
+            run_id="run-2", message="auth failed", code="cli.auth"
+        )
+        event_type, payload, _ = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+        assert decoded.code == "cli.auth"  # type: ignore[union-attr]
+
+    def test_historical_none_code_decodes(self) -> None:
+        """Forward-compat: an event serialized before #1113 (code=None) decodes."""
+        codec = NatsRenderEventCodec()
+        original = RunErrorRenderEvent(run_id="run-3", message="boom", code=None)
+        event_type, payload, _ = codec.encode(original)
+        decoded = codec.decode(event_type, payload)
+        assert decoded == original
+        assert decoded.code is None  # type: ignore[union-attr]

--- a/tests/transport/test_result_types.py
+++ b/tests/transport/test_result_types.py
@@ -9,6 +9,7 @@ import pytest
 
 from lyra.transport import SanitizedError
 from lyra.transport._result import Err, InboxStream, Ok, Result
+from roxabi_contracts.errors import KNOWN_CODES
 
 
 def test_ok_isinstance() -> None:
@@ -100,6 +101,17 @@ class TestSanitizedErrorFromMessage:
         assert result.message == "model_error"
         assert result.code == "stream.error"
         assert result.retryable is False
+
+    def test_default_code_is_registered(self) -> None:
+        """#1113: the default code flows to RunErrorRenderEvent.code, so the
+        from_message default must be a registry-valid KNOWN_CODES key.
+
+        Transport is intentionally roxabi_contracts-free at runtime, so the
+        literal default has no import-time guard — this test is its guard.
+        """
+        default_code = SanitizedError.from_message("anything").code
+        assert default_code in KNOWN_CODES
+        assert default_code == "stream.error"
 
     def test_control_chars_are_stripped(self) -> None:
         """Non-printable control chars (NUL, BEL, newline, CR) become spaces."""


### PR DESCRIPTION
## Summary
- `RunErrorRenderEvent.code` was always emitted as `None` — a contract lie. The `StreamProcessor` error translator discarded `SanitizedError.code`, which already carries a registry code at both emit sites.
- **Root cause, not a new enum:** the canonical taxonomy already exists as `roxabi_contracts.errors.KNOWN_CODES` (ADR-066). The translator now propagates `err.code` instead of hardcoding `None`. Infra exceptions → `stream.error`; soft errors → the `WorkerError` code (e.g. `cli.auth`, `llm.rate_limit`) or `stream.error` fallback.
- Registered the one unregistered code (`stream.error`, new `stream` domain — additive-minor per ADR-049), regenerated `error-codes.md`, updated the docstring + `messaging.md`.
- No SCHEMA_VERSION bump, no codec change: populating an existing optional field is forward-compatible; `code=None` historical events still decode.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1113: define RunErrorRenderEvent.code taxonomy | OPEN |
| Frame | [1113-…-frame.mdx](artifacts/frames/1113-render-events-code-taxonomy-frame.mdx) | Present |
| Spec | [1113-…-spec.mdx](artifacts/specs/1113-render-events-code-taxonomy-spec.mdx) | Present |
| Plan | [1113-…-plan.mdx](artifacts/plans/1113-render-events-code-taxonomy-plan.mdx) | Present |
| Implementation | 5 commits on `feat/1113-render-events-code-taxonomy` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (8 new) | Passed |

## Test Plan
- [ ] `pytest tests/core/test_stream_processor.py::TestRunErrorCode` — 3 emit paths (infra → `stream.error`, WorkerError → its code, no-WorkerError → `stream.error`).
- [ ] `pytest tests/nats/test_render_event_codec.py::TestRunErrorCodeRoundTrip` — codec preserves a populated `code` and still decodes historical `code=None`.
- [ ] `check_codes_sync.py` passes (`error-codes.md` ↔ `KNOWN_CODES`).

> Note: 2 unrelated `tests/core/test_agent_refiner_cli.py` failures are **pre-existing** on `staging` (a typer `_get_command` env issue) — untouched by this PR.

Closes #1113

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/dev`
