### PR TITLE
feat(core): extract TurnStoreProtocol — fix lyra.core ← infrastructure inversion

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -38,13 +38,12 @@ ignore_imports =
     lyra.core.hub.hub_shutdown -> lyra.infrastructure.stores.message_index
     lyra.core.pool.pool_observer -> lyra.infrastructure.stores.message_index
     # TurnStore moved to infrastructure per ADR-048 (#760 review fix f2) — DEBT:importlinter-adr048-transition
+    # pool.pool and pool.pool_observer fixed in #1079 (TurnStoreProtocol introduced)
     lyra.core.hub.hub -> lyra.infrastructure.stores.turn_store
     lyra.core.hub.hub_registration -> lyra.infrastructure.stores.turn_store
     lyra.core.hub.hub_shutdown -> lyra.infrastructure.stores.turn_store
     lyra.core.cli.cli_pool -> lyra.infrastructure.stores.turn_store
     lyra.core.cli.cli_pool_session -> lyra.infrastructure.stores.turn_store
-    lyra.core.pool.pool -> lyra.infrastructure.stores.turn_store
-    lyra.core.pool.pool_observer -> lyra.infrastructure.stores.turn_store
 
 [importlinter:contract:core-stores-no-sqlite]
 name = core/stores protocols must not import SQLite drivers

--- a/docs/architecture/adr/078-turn-store-protocol.mdx
+++ b/docs/architecture/adr/078-turn-store-protocol.mdx
@@ -1,0 +1,65 @@
+---
+title: "ADR-078: TurnStoreProtocol — decouple lyra.core from concrete TurnStore"
+description: Introduce TurnStoreProtocol in core/stores/ so pool and session_lifecycle depend on the protocol, not the SQLite implementation. Fixes the lyra.core ← lyra.infrastructure inversion.
+status: accepted
+date: 2026-05-28
+deciders: [Mickael]
+supersedes: []
+superseded_by: []
+related: [048, 075]
+---
+
+## Status
+
+Accepted — 2026-05-28
+
+## Context
+
+`TurnStore` (the L1 raw-turn SQLite store) lives in `lyra.infrastructure.stores`.
+Per ADR-048, persistence implementations belong in `infrastructure/`; protocols
+belong in `core/stores/`. Every other store already follows this pattern:
+`AgentStoreProtocol`, `BotStoreProtocol`, `ThreadStoreProtocol` are all defined
+in `core/stores/` and re-exported by `core/stores/__init__.py`.
+
+`TurnStore` was the only exception. Without a protocol:
+
+- `src/lyra/core/pool/pool.py` — `turn_store` property typed as `"TurnStore | None"` (TYPE_CHECKING import from infrastructure)
+- `src/lyra/core/pool/pool_observer.py` — `_turn_store` field and `register_turn_store` parameter typed as `TurnStore`
+
+Both invert the dependency arrow `lyra.core ← lyra.infrastructure`, violating the
+layering contract documented in `src/lyra/core/CLAUDE.md`.
+
+## Decision
+
+Introduce `TurnStoreProtocol` in `src/lyra/core/stores/turn_store_protocol.py`.
+
+The protocol covers the **read-path interface** used by `lyra.core` consumers:
+
+| Method | Consumer |
+|---|---|
+| `get_turns(pool_id, user_id, limit)` | `core/session_lifecycle.py` |
+| `list_sessions(pool_id, limit)` | `core/commands/session_commands.py` |
+| `get_cli_session(session_id)` | `core/commands/session_commands.py` |
+| `get_cli_session_by_pool(pool_id)` | future consumers |
+| `get_last_session(pool_id)` | future consumers |
+| `get_session_pool_id(session_id)` | future consumers |
+
+Write-path methods (`_log_turn`, `_start_session`, `_end_session`,
+`_set_cli_session`, `_increment_resume_count`) are intentionally excluded.
+They are private to the `TurnWriter` subscriber (ADR-075) and are never
+called by `core/` consumers directly.
+
+`Pool.turn_store` and `PoolObserver._turn_store` / `register_turn_store` are
+retyped to `TurnStoreProtocol | None`. The concrete `TurnStore` satisfies the
+protocol structurally (`@runtime_checkable`), so no call-site changes are needed.
+
+## Consequences
+
+**Positive:**
+- Layering inversion eliminated — `core/` no longer imports from `infrastructure/`
+- `TurnStoreProtocol` is now swappable for testing (in-memory stub, NATS-backed future impl)
+- Consistent with the existing `AgentStoreProtocol` / `BotStoreProtocol` / `ThreadStoreProtocol` pattern
+
+**Neutral:**
+- No behaviour change — `TurnStore` satisfies `TurnStoreProtocol` structurally
+- Pyright verifies structural compatibility at the wire-up site in `bootstrap/`

--- a/docs/architecture/adr/078-turn-store-protocol.mdx
+++ b/docs/architecture/adr/078-turn-store-protocol.mdx
@@ -56,7 +56,7 @@ protocol structurally (`@runtime_checkable`), so no call-site changes are needed
 ## Consequences
 
 **Positive:**
-- Layering inversion eliminated — `core/` no longer imports from `infrastructure/`
+- Layering inversion eliminated for `pool/` consumers — `pool.py` and `pool_observer.py` no longer import from `infrastructure/` (5 hub/cli TYPE_CHECKING exemptions remain in `.importlinter`; tracked separately)
 - `TurnStoreProtocol` is now swappable for testing (in-memory stub, NATS-backed future impl)
 - Consistent with the existing `AgentStoreProtocol` / `BotStoreProtocol` / `ThreadStoreProtocol` pattern
 

--- a/src/lyra/core/commands/session_commands.py
+++ b/src/lyra/core/commands/session_commands.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..stores.turn_store_protocol import SessionRow
 
 from ..messaging.message import InboundMessage, Response
 from ..pool import Pool
@@ -50,7 +54,7 @@ def _truncate(text: str | None, n: int = _TITLE_MAX) -> str:
     return first_line[: n - 1] + "…"
 
 
-def _format_list(rows: list[dict], current_cli: str | None) -> str:
+def _format_list(rows: list[SessionRow], current_cli: str | None) -> str:
     if not rows:
         return "No past sessions for this chat."
     lines = ["Recent sessions:"]

--- a/src/lyra/core/pool/pool.py
+++ b/src/lyra/core/pool/pool.py
@@ -10,14 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lyra.infrastructure.stores.turn_store import TurnStore
-
     from ..memory import SessionSnapshot
 
 from ..config import PoolConfig
 from ..debouncer import MessageDebouncer
 from ..messaging.message import InboundMessage, OutboundMessage
 from ..stores.pairing_protocol import PairingManagerProtocol
+from ..stores.turn_store_protocol import TurnStoreProtocol
 from .pool_context import PoolContext as PoolContext
 from .pool_observer import PoolObserver
 from .pool_processor import PoolProcessor
@@ -126,7 +125,7 @@ class Pool:
         self.pairing_manager: PairingManagerProtocol | None = None
 
     @property
-    def turn_store(self) -> "TurnStore | None":
+    def turn_store(self) -> TurnStoreProtocol | None:
         """Read-only access to the wired TurnStore (None if not configured)."""
         return self._observer._turn_store
 

--- a/src/lyra/core/pool/pool_observer.py
+++ b/src/lyra/core/pool/pool_observer.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from lyra.infrastructure.stores.message_index import MessageIndex
-    from lyra.infrastructure.stores.turn_store import TurnStore
     from lyra.transport.turn_publisher import TurnPublisher
 
     from ..messaging.message import InboundMessage
+
+from ..stores.turn_store_protocol import TurnStoreProtocol
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class PoolObserver:
         self._pool_id = pool_id
         self._session_id_fn = session_id_fn
 
-        self._turn_store: TurnStore | None = None
+        self._turn_store: TurnStoreProtocol | None = None
         self._turn_publisher: TurnPublisher | None = None
         self._message_index: MessageIndex | None = None
         self._turn_logger: Callable[[str, InboundMessage], Awaitable[None]] | None = (
@@ -45,7 +46,7 @@ class PoolObserver:
     # Registration helpers (replaces direct attribute assignment)
     # ------------------------------------------------------------------
 
-    def register_turn_store(self, store: TurnStore) -> None:
+    def register_turn_store(self, store: TurnStoreProtocol) -> None:
         """Wire the TurnStore for L1 raw turn logging (kept for read paths)."""
         self._turn_store = store
 

--- a/src/lyra/core/stores/__init__.py
+++ b/src/lyra/core/stores/__init__.py
@@ -7,9 +7,11 @@ This package re-exports only protocol-safe symbols for backward compatibility.
 from .agent_store_protocol import AgentStoreProtocol
 from .bot_store_protocol import BotStoreProtocol
 from .thread_store_protocol import ThreadStoreProtocol
+from .turn_store_protocol import TurnStoreProtocol
 
 __all__ = [
     "AgentStoreProtocol",
     "BotStoreProtocol",
     "ThreadStoreProtocol",
+    "TurnStoreProtocol",
 ]

--- a/src/lyra/core/stores/__init__.py
+++ b/src/lyra/core/stores/__init__.py
@@ -7,11 +7,13 @@ This package re-exports only protocol-safe symbols for backward compatibility.
 from .agent_store_protocol import AgentStoreProtocol
 from .bot_store_protocol import BotStoreProtocol
 from .thread_store_protocol import ThreadStoreProtocol
-from .turn_store_protocol import TurnStoreProtocol
+from .turn_store_protocol import SessionRow, TurnRow, TurnStoreProtocol
 
 __all__ = [
     "AgentStoreProtocol",
     "BotStoreProtocol",
+    "SessionRow",
     "ThreadStoreProtocol",
+    "TurnRow",
     "TurnStoreProtocol",
 ]

--- a/src/lyra/core/stores/turn_store_protocol.py
+++ b/src/lyra/core/stores/turn_store_protocol.py
@@ -1,0 +1,43 @@
+"""TurnStoreProtocol — structural interface for raw turn stores.
+
+Decouples lyra.core from the concrete SQLite TurnStore implementation
+(lyra.infrastructure.stores.turn_store). Fixes the layering inversion where
+core modules imported an infrastructure type directly (issue #1079).
+
+Factory: obtain a store via the bootstrap layer; type-annotate against this
+protocol so that any conforming implementation (SQLite, in-memory, NATS-backed)
+can be wired in transparently.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["TurnStoreProtocol"]
+
+
+@runtime_checkable
+class TurnStoreProtocol(Protocol):
+    """Read-path structural protocol for TurnStore consumers in lyra.core.
+
+    Covers the public interface used by core/ modules (session_lifecycle,
+    session_commands, pool, pool_observer).  Write-path methods (_log_turn,
+    _start_session, etc.) are internal to the TurnWriter subscriber and are
+    intentionally excluded — they are never called by core/ consumers directly.
+    """
+
+    async def get_turns(
+        self, pool_id: str, user_id: str, limit: int = 50
+    ) -> list[dict]: ...
+
+    async def list_sessions(
+        self, pool_id: str, limit: int = 5
+    ) -> list[dict]: ...
+
+    async def get_cli_session(self, session_id: str) -> str | None: ...
+
+    async def get_cli_session_by_pool(self, pool_id: str) -> str | None: ...
+
+    async def get_last_session(self, pool_id: str) -> str | None: ...
+
+    async def get_session_pool_id(self, session_id: str) -> str | None: ...

--- a/src/lyra/core/stores/turn_store_protocol.py
+++ b/src/lyra/core/stores/turn_store_protocol.py
@@ -11,9 +11,35 @@ can be wired in transparently.
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol, TypedDict, runtime_checkable
 
-__all__ = ["TurnStoreProtocol"]
+__all__ = ["SessionRow", "TurnRow", "TurnStoreProtocol"]
+
+
+class TurnRow(TypedDict):
+    """One row from the ``conversation_turns`` table."""
+
+    id: int
+    pool_id: str
+    session_id: str
+    role: str
+    platform: str
+    user_id: str
+    content: str
+    message_id: str | None
+    reply_message_id: str | None
+    timestamp: str
+    metadata: dict
+
+
+class SessionRow(TypedDict):
+    """One row from ``list_sessions`` — session summary with first message."""
+
+    session_id: str
+    cli_session_id: str | None
+    last_active_at: str
+    first_user_msg: str | None
+    turn_count: int
 
 
 @runtime_checkable
@@ -28,11 +54,11 @@ class TurnStoreProtocol(Protocol):
 
     async def get_turns(
         self, pool_id: str, user_id: str, limit: int = 50
-    ) -> list[dict]: ...
+    ) -> list[TurnRow]: ...
 
     async def list_sessions(
         self, pool_id: str, limit: int = 5
-    ) -> list[dict]: ...
+    ) -> list[SessionRow]: ...
 
     async def get_cli_session(self, session_id: str) -> str | None: ...
 

--- a/src/lyra/infrastructure/stores/turn_store.py
+++ b/src/lyra/infrastructure/stores/turn_store.py
@@ -14,7 +14,10 @@ import json
 import logging
 import sqlite3
 from datetime import UTC, datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from lyra.core.stores.turn_store_protocol import TurnRow
 
 from lyra.infrastructure.stores.sqlite_base import SqliteStore
 from lyra.infrastructure.stores.turn_store_session import TurnStoreSessionMixin
@@ -220,7 +223,7 @@ class TurnStore(SqliteStore, TurnStoreSessionMixin):
 
     async def get_turns(
         self, pool_id: str, user_id: str, limit: int = 50
-    ) -> list[dict]:
+    ) -> list[TurnRow]:
         """Return the last *limit* turns for *pool_id* and *user_id*, newest first.
 
         *limit* is silently capped at 500 to guard against runaway reads.

--- a/src/lyra/infrastructure/stores/turn_store.py
+++ b/src/lyra/infrastructure/stores/turn_store.py
@@ -14,11 +14,9 @@ import json
 import logging
 import sqlite3
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
-if TYPE_CHECKING:
-    from lyra.core.stores.turn_store_protocol import TurnRow
-
+from lyra.core.stores.turn_store_protocol import TurnRow
 from lyra.infrastructure.stores.sqlite_base import SqliteStore
 from lyra.infrastructure.stores.turn_store_session import TurnStoreSessionMixin
 

--- a/src/lyra/infrastructure/stores/turn_store_queries.py
+++ b/src/lyra/infrastructure/stores/turn_store_queries.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
 
+    from lyra.core.stores.turn_store_protocol import SessionRow, TurnRow
+
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -153,7 +155,7 @@ _LIST_SESSIONS_COLS = (
 
 async def list_sessions_for_pool(
     db: aiosqlite.Connection, pool_id: str, limit: int = 5
-) -> list[dict]:
+) -> list[SessionRow]:
     """Return up to *limit* recent sessions for *pool_id*, newest first.
 
     Each row pulls the first user message and total turn count via correlated
@@ -167,12 +169,12 @@ async def list_sessions_for_pool(
     except sqlite3.Error:
         log.exception("list_sessions_for_pool failed (pool=%s)", pool_id)
         return []
-    return [dict(zip(_LIST_SESSIONS_COLS, row)) for row in rows]
+    return [SessionRow(**dict(zip(_LIST_SESSIONS_COLS, row))) for row in rows]
 
 
 async def get_turns(
     db: aiosqlite.Connection, pool_id: str, user_id: str, limit: int = 50
-) -> list[dict]:
+) -> list[TurnRow]:
     """Return the last *limit* turns for *pool_id* and *user_id*, newest first.
 
     *limit* is silently capped at 500 to guard against runaway reads.
@@ -192,11 +194,11 @@ async def get_turns(
     limit = min(limit, 500)  # guard against runaway reads
     async with db.execute(_SELECT_BY_POOL, (pool_id, user_id, limit)) as cur:
         rows = await cur.fetchall()
-    result = []
+    result: list[TurnRow] = []
     for row in rows:
         d = dict(zip(_COLS, row))
         d["metadata"] = json.loads(d["metadata"] or "{}")
-        result.append(d)
+        result.append(TurnRow(**d))
     return result
 
 

--- a/src/lyra/infrastructure/stores/turn_store_queries.py
+++ b/src/lyra/infrastructure/stores/turn_store_queries.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+
+from lyra.core.stores.turn_store_protocol import SessionRow, TurnRow
 
 if TYPE_CHECKING:
     import aiosqlite
-
-    from lyra.core.stores.turn_store_protocol import SessionRow, TurnRow
 
 log = logging.getLogger(__name__)
 
@@ -169,7 +169,7 @@ async def list_sessions_for_pool(
     except sqlite3.Error:
         log.exception("list_sessions_for_pool failed (pool=%s)", pool_id)
         return []
-    return [SessionRow(**dict(zip(_LIST_SESSIONS_COLS, row))) for row in rows]
+    return cast(list[SessionRow], [dict(zip(_LIST_SESSIONS_COLS, row)) for row in rows])
 
 
 async def get_turns(
@@ -194,12 +194,12 @@ async def get_turns(
     limit = min(limit, 500)  # guard against runaway reads
     async with db.execute(_SELECT_BY_POOL, (pool_id, user_id, limit)) as cur:
         rows = await cur.fetchall()
-    result: list[TurnRow] = []
+    result = []
     for row in rows:
         d = dict(zip(_COLS, row))
         d["metadata"] = json.loads(d["metadata"] or "{}")
-        result.append(TurnRow(**d))
-    return result
+        result.append(d)
+    return cast(list[TurnRow], result)
 
 
 async def backfill_sessions(db: aiosqlite.Connection) -> None:

--- a/src/lyra/infrastructure/stores/turn_store_session.py
+++ b/src/lyra/infrastructure/stores/turn_store_session.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
 
+    from lyra.core.stores.turn_store_protocol import SessionRow
+
 from lyra.infrastructure.stores.turn_store_queries import (
     get_cli_session,
     get_cli_session_by_pool,
@@ -90,7 +92,7 @@ class TurnStoreSessionMixin:
         """
         return await get_cli_session_by_pool(self._db_or_raise(), pool_id)
 
-    async def list_sessions(self, pool_id: str, limit: int = 5) -> list[dict]:
+    async def list_sessions(self, pool_id: str, limit: int = 5) -> list[SessionRow]:
         """Return up to *limit* recent sessions for *pool_id*, newest first.
 
         Each row carries ``session_id``, ``cli_session_id``, ``last_active_at``,

--- a/src/lyra/infrastructure/stores/turn_store_session.py
+++ b/src/lyra/infrastructure/stores/turn_store_session.py
@@ -11,10 +11,10 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from lyra.core.stores.turn_store_protocol import SessionRow
+
 if TYPE_CHECKING:
     import aiosqlite
-
-    from lyra.core.stores.turn_store_protocol import SessionRow
 
 from lyra.infrastructure.stores.turn_store_queries import (
     get_cli_session,

--- a/tests/core/test_session_builtin.py
+++ b/tests/core/test_session_builtin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from lyra.core.commands import session_commands
 from lyra.core.messaging.message import Response
 from lyra.core.pool import Pool
+from lyra.core.stores.turn_store_protocol import SessionRow
 from lyra.infrastructure.stores.turn_store import TurnStore
 
 from .conftest import make_message
@@ -251,15 +253,18 @@ class TestFormatHelpers:
         )
 
     def test_format_list_marks_active_only(self) -> None:
-        rows = [
-            {**_ROW_PING, "session_id": "s1", "cli_session_id": "cli-1"},
-            {
-                **_ROW_PING,
-                "session_id": "s2",
-                "cli_session_id": "cli-2",
-                "first_user_msg": "older",
-            },
-        ]
+        rows = cast(
+            list[SessionRow],
+            [
+                {**_ROW_PING, "session_id": "s1", "cli_session_id": "cli-1"},
+                {
+                    **_ROW_PING,
+                    "session_id": "s2",
+                    "cli_session_id": "cli-2",
+                    "first_user_msg": "older",
+                },
+            ],
+        )
         body = session_commands._format_list(rows, current_cli="cli-2")
         assert "► 2." in body
         assert "► 1." not in body


### PR DESCRIPTION
## Summary

- Introduce \`TurnStoreProtocol\` in \`src/lyra/core/stores/\` (read-path: \`get_turns\`, \`list_sessions\`, \`get_cli_session\`, \`get_cli_session_by_pool\`, \`get_last_session\`, \`get_session_pool_id\`)
- Retype \`Pool.turn_store\` and \`PoolObserver._turn_store\` / \`register_turn_store\` to the protocol — drops the \`lyra.core ← lyra.infrastructure\` TYPE_CHECKING imports
- Remove the now-fixed \`ignore_imports\` entries in \`.importlinter\`
- Add ADR-078 documenting the decision

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1079: Extract TurnStoreProtocol in core/stores | Open |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 1 commit on `feat/1079-extract-turn-store-protocol` | Complete |
| Verification | Lint ✅ Typecheck ✅ Import-layers ✅ | Passed |

## Test Plan

- [ ] `uv run pyright src/lyra/core/stores/turn_store_protocol.py src/lyra/core/pool/pool.py src/lyra/core/pool/pool_observer.py` → 0 errors
- [ ] `uv run lint-imports` (import-layers contract) → Passed
- [ ] `TurnStore` satisfies `TurnStoreProtocol` structurally — no runtime behavior change

Closes #1079

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`