### PR TITLE
docs(outbound): document OutboundFormatter format-vs-IO two-axis split (S7a decision) (#1508)

### DIFF
--- a/src/lyra/adapters/CLAUDE.md
+++ b/src/lyra/adapters/CLAUDE.md
@@ -100,6 +100,14 @@ Send-mechanics (send_placeholder, edit_placeholder_text, send_trace_placeholder,
 send_message, send_fallback) and get_msg are part of `OutboundFormatter` — the
 formatter is the single platform-I/O surface consumed by `OutboundEmitter`.
 
+**Format-vs-I/O split (S7a decision, #1508):** `OutboundFormatter` intentionally
+owns two axes — (a) pure formatting (`chunk`, `render_text`, `render_buttons`,
+`dim_italic`, `placeholder_text`) and (b) platform-I/O mechanics (everything else).
+This is a deliberate SRP trade-off accepted at N=2 platforms to keep `_make_emitter`
+arity low.  Any new method added to `OutboundFormatter` MUST be consciously placed
+in axis (a) or (b).  Re-evaluate extracting an `OutboundSender` Protocol when a
+third platform adapter lands (#1508).
+
 ## Clipool adapter (`clipool/`)
 
 Not a platform adapter — the **NATS worker** that hosts `CliPool` in a separate

--- a/src/lyra/outbound/formatter.py
+++ b/src/lyra/outbound/formatter.py
@@ -39,7 +39,35 @@ async def default_no_op_edit_tool_recap(
 
 
 class OutboundFormatter(Protocol):
-    """Per-platform formatting stage for OutboundEmitter."""
+    """Per-platform formatting stage for OutboundEmitter.
+
+    This Protocol deliberately spans two responsibility axes (S7a decision, #1508):
+
+    **(a) Pure formatting** — no platform I/O, fully synchronous:
+        ``chunk``, ``render_text``, ``render_buttons``, ``dim_italic``,
+        ``placeholder_text``
+
+    **(b) Platform-I/O mechanics** — talk to the platform SDK (all async):
+        ``get_msg``, ``send_placeholder``, ``edit_placeholder_text``,
+        ``send_trace_placeholder``, ``send_message``, ``send_fallback``,
+        ``edit_reasoning``, ``edit_tool_recap``
+
+    **Why one Protocol?** S7a explicitly chose Option 1 (extend the formatter
+    to own both axes) over Option 2 (a separate ``OutboundSender`` Protocol)
+    to keep ``_make_emitter`` injection arity low — a single object is injected
+    instead of two, and the emitter has one call-site surface.  The SRP cost is
+    accepted at N=2 platforms (Telegram + Discord).
+
+    **Re-evaluate at N≥3.** If a third platform adapter lands, the arity
+    argument weakens (one extra param is cheap) while the SRP win grows
+    (formatting logic is genuinely platform-agnostic).  At that point, extract
+    an ``OutboundSender`` Protocol and split the implementations accordingly.
+
+    **Guard for new methods:** every addition to this Protocol must be
+    consciously placed in axis (a) or (b).  A method that touches the platform
+    SDK belongs in (b); one that only transforms text/data belongs in (a).
+    Mixing the two inside a single method is the boundary to avoid.
+    """
 
     def placeholder_text(self) -> str: ...
     def chunk(self, text: str) -> list[str]: ...


### PR DESCRIPTION
## Summary

Documents the deliberate S7a decision (#1505 review) that `OutboundFormatter` owns two responsibility axes, so future method additions are consciously categorised rather than drifting.

- **`OutboundFormatter` docstring** (`src/lyra/outbound/formatter.py`) — names the two axes:
  - (a) **pure formatting**: `chunk`, `render_text`, `render_buttons`, `dim_italic`, `placeholder_text`
  - (b) **platform-I/O mechanics**: `send_placeholder`, `edit_placeholder_text`, `send_trace_placeholder`, `send_message`, `send_fallback`, `get_msg`
  - records that S7a chose Option 1 (extend formatter) over Option 2 (`OutboundSender` Protocol) to keep `_make_emitter` arity low, and to revisit extraction at a 3rd platform (N≥3).
- **`src/lyra/adapters/CLAUDE.md`** — guard note: any new `OutboundFormatter` method must be placed in axis (a) or (b).

Docs-only; no code/behaviour change. `formatter.py` = 153 lines.

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)