### PR TITLE
chore(arch): enforce lyra.inbound→adapters boundary via .importlinter forbidden contract (#1287)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -142,6 +142,25 @@ forbidden_modules =
     lyra.infrastructure.stores.bot_store
 allow_indirect_imports = true
 
+[importlinter:contract:inbound-no-adapters]
+name = inbound stages must not import adapters (stage-axis invariant, ADR-073 / #1287)
+type = forbidden
+source_modules =
+    lyra.inbound
+forbidden_modules =
+    lyra.adapters
+allow_indirect_imports = true
+ignore_imports =
+    # DEBT:inbound-adapters-transition (#1287) — stage→shared coupling pending relocation
+    # of push_to_hub_guarded + shared types to lyra.core/lyra.shared (deferred; see #1283 Phase 6).
+    lyra.inbound.dispatcher -> lyra.adapters.shared._shared
+    lyra.inbound.context -> lyra.adapters.shared._shared
+    lyra.inbound.context -> lyra.adapters.shared.outbound_listener
+    # DEBT:inbound-adapters-wireparser (#1287) — wire parsers reference concrete adapter
+    # classes under TYPE_CHECKING only (platform-parser coupling, separate concern).
+    lyra.inbound.wire_parser_telegram -> lyra.adapters.telegram.telegram
+    lyra.inbound.wire_parser_discord -> lyra.adapters.discord.adapter
+
 [importlinter:contract:tests-fakes-isolation]
 name = Production code must not import tests.fakes
 type = forbidden

--- a/src/lyra/inbound/CLAUDE.md
+++ b/src/lyra/inbound/CLAUDE.md
@@ -21,7 +21,7 @@ parse → pre_route_hook(opt) → Router → [DROP|PROCESS] → pre_session_hook
 ## Layer invariants
 
 - `router.py`, `session_builder.py`, `dispatcher.py`, `pipeline.py` must NOT import `discord` or `aiogram`. Platform isolation lives in `wire_parser_telegram.py` / `wire_parser_discord.py` and adapter-side hooks.
-- Stages depend on `lyra.core` only — never `lyra.adapters`. Enforced by importlinter.
+- Stages depend on `lyra.core` only — never `lyra.adapters`. Enforced by `.importlinter` (`inbound-no-adapters` contract, #1287). Known violations are tagged `DEBT:inbound-adapters-transition` / `DEBT:inbound-adapters-wireparser` and listed as `ignore_imports` in that contract pending relocation to `lyra.core`/`lyra.shared` (deferred to #1283 Phase 6).
 - `InboundContext`, `RouterCtx`, `SessionCtx`, `DispatchCtx` are `@dataclass(frozen=True)`. The container references are frozen; the mutable collections they carry (`RouterCtx.owned_threads: set`, `SessionCtx.thread_sessions_cache: dict`) are mutated in place by hooks and `SessionBuilder`. Document this contract on `context.py` module docstring.
 - Hook signatures (verified post-Phase-3):
   - `pre_route_hook(InboundMessage, InboundContext) -> Awaitable[None]` — may mutate


### PR DESCRIPTION
## Summary

`src/lyra/inbound/CLAUDE.md` documented "inbound stages depend on `lyra.core` only — never `lyra.adapters`" but `.importlinter` did not enforce it (trust-documentation). This adds a dedicated `forbidden` contract (`inbound-no-adapters`) so any **new** `lyra.inbound → lyra.adapters` import fails the pre-push gate, while the 5 existing edges are documented as tagged DEBT `ignore_imports`.

## Design decision — forbidden contract (not layers reorder)

Chosen over inserting `lyra.inbound` into the existing 9-entry `clean-architecture-layers` ordering. The layers contract encodes order-as-direction semantics; inserting `inbound` would force repositioning relative to `outbound`/`adapters`/`core` with lateral effects on every adjacent layer's allowed import set. The forbidden contract is surgical — one directional constraint, zero perturbation of other contracts.

## DEBT exceptions (empirically verified, exactly the broken edges — no dead config)

- `lyra.inbound.dispatcher -> lyra.adapters.shared._shared` (runtime `push_to_hub_guarded`)
- `lyra.inbound.context -> lyra.adapters.shared._shared` (TYPE_CHECKING `TypingTaskManager`)
- `lyra.inbound.context -> lyra.adapters.shared.outbound_listener` (TYPE_CHECKING)
- `lyra.inbound.wire_parser_telegram -> lyra.adapters.telegram.telegram` (TYPE_CHECKING)
- `lyra.inbound.wire_parser_discord -> lyra.adapters.discord.adapter` (TYPE_CHECKING)

Relocation of `push_to_hub_guarded` + shared types to `lyra.core`/`lyra.shared` remains deferred (per #1283 Phase 6 reasoning in the issue).

## Verification

`uv run lint-imports` → **Contracts: 11 kept, 0 broken** (was 10). Config + CLAUDE.md only; no `.py` import changed.

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)