### PR TITLE
test(infra): centralize load_bot_token patch path into _LOAD_BOT_TOKEN_PATH constant (#1305)

### DIFF
--- a/tests/bootstrap/test_adapter_standalone.py
+++ b/tests/bootstrap/test_adapter_standalone.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.conftest import _LOAD_BOT_TOKEN_PATH
+
 
 def _make_raw_config(platform: str) -> dict:
     if platform == "telegram":
@@ -24,7 +26,7 @@ def _cred_store_patches(token: str, webhook_secret: str = "") -> tuple:
     webhook: str | None = webhook_secret if webhook_secret else None
     return (
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=(token, webhook),
         ),
     )

--- a/tests/bootstrap/test_bootstrap_audio_consumer.py
+++ b/tests/bootstrap/test_bootstrap_audio_consumer.py
@@ -21,6 +21,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.conftest import _LOAD_BOT_TOKEN_PATH
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -39,7 +41,7 @@ def _make_raw_config(platform: str) -> dict:
 def _cred_patch(token: str = "tok", webhook: str = "") -> tuple:
     return (
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=(token, webhook or None),
         ),
     )

--- a/tests/bootstrap/test_bootstrap_wiring.py
+++ b/tests/bootstrap/test_bootstrap_wiring.py
@@ -14,6 +14,7 @@ from lyra.core.auth.trust import (
 )
 from lyra.core.hub.hub import Hub
 from lyra.core.messaging.message import Platform
+from tests.conftest import _LOAD_BOT_TOKEN_PATH
 
 # ---------------------------------------------------------------------------
 # Finding I: wire_telegram_adapters registers the authenticator on the hub
@@ -53,7 +54,7 @@ async def test_wire_telegram_adapters_registers_authenticator() -> None:
             return_value=mock_adapter_instance,
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("fake-token", "fake-secret"),
         ),
     ):
@@ -100,7 +101,7 @@ async def test_wire_telegram_no_nats_listener_in_dev_mode() -> None:
             return_value=mock_adapter_instance,
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("fake-token", "fake-secret"),
         ),
     ):

--- a/tests/bootstrap/test_tool_display_wiring.py
+++ b/tests/bootstrap/test_tool_display_wiring.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lyra.bootstrap.factory.config import _load_tool_display_config
+from tests.conftest import _LOAD_BOT_TOKEN_PATH
 
 # ---------------------------------------------------------------------------
 # Helper — minimal raw_config dicts
@@ -97,7 +98,7 @@ async def test_wired_path_threads_tool_display_config_to_telegram() -> None:
             side_effect=_capture_adapter,
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("fake-token", None),
         ),
     ):
@@ -179,7 +180,7 @@ async def test_wired_path_threads_tool_display_config_to_discord() -> None:
             side_effect=_capture_discord_adapter,
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("dc-token", None),
         ),
         patch(
@@ -265,7 +266,7 @@ async def test_wired_path_with_absent_tool_display_section_uses_defaults() -> No
             side_effect=_capture_adapter,
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("fake-token", None),
         ),
     ):
@@ -365,7 +366,7 @@ async def test_standalone_path_threads_tool_display_config_to_telegram() -> None
             AsyncMock(return_value=True),
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("test-token", None),
         ),
         patch(
@@ -472,7 +473,7 @@ async def test_standalone_path_threads_tool_display_config_to_discord() -> None:
             AsyncMock(return_value=True),
         ),
         patch(
-            "lyra.bootstrap.credentials.load_bot_token",
+            _LOAD_BOT_TOKEN_PATH,
             return_value=("test-token", None),
         ),
         patch(

--- a/tests/cli/test_cli_setup.py
+++ b/tests/cli/test_cli_setup.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.conftest import _LOAD_BOT_TOKEN_PATH
+
 
 @pytest.fixture()
 def config_file(tmp_path: Path) -> Path:
@@ -56,7 +58,7 @@ class TestRegisterAll:
 
         with (
             patch(
-                "lyra.bootstrap.credentials.load_bot_token",
+                _LOAD_BOT_TOKEN_PATH,
                 return_value=("fake_token", "fake_secret"),
             ),
             patch(
@@ -87,7 +89,7 @@ class TestRegisterAll:
         # Should not raise — prints message and returns
         with (
             patch(
-                "lyra.bootstrap.credentials.load_bot_token",
+                _LOAD_BOT_TOKEN_PATH,
                 return_value=(MagicMock(), None),
             ),
             patch(
@@ -112,7 +114,7 @@ class TestRegisterAll:
 
         with (
             patch(
-                "lyra.bootstrap.credentials.load_bot_token",
+                _LOAD_BOT_TOKEN_PATH,
                 side_effect=MissingCredentialsError("telegram", "test_bot"),
             ),
             patch(
@@ -134,7 +136,7 @@ class TestRegisterAll:
 
         with (
             patch(
-                "lyra.bootstrap.credentials.load_bot_token",
+                _LOAD_BOT_TOKEN_PATH,
                 return_value=("fake_token", "fake_secret"),
             ),
             patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ __all__ = [
     "_FakeDcAdapter",
     "_FakeDp",
     "_FakeTgAdapter",
+    "_LOAD_BOT_TOKEN_PATH",
     "_patch_nats_stubs",
     "_reset_version_check_log_state",
     "make_fake_stores",
@@ -38,6 +39,13 @@ __all__ = [
     "patch_auth_config_test",
     "patch_bootstrap_common",
 ]
+
+# ---------------------------------------------------------------------------
+# Patch-path constants — centralised so a future relocation of load_bot_token
+# is a one-line change here rather than a grep-across-13-files exercise.
+# ---------------------------------------------------------------------------
+
+_LOAD_BOT_TOKEN_PATH = "lyra.bootstrap.credentials.load_bot_token"
 
 # ---------------------------------------------------------------------------
 # Health endpoint shared constants


### PR DESCRIPTION
## Summary

The patch-target string `"lyra.bootstrap.credentials.load_bot_token"` was duplicated across the test suite (13 literals in 5 consumer files). Centralized into a single `_LOAD_BOT_TOKEN_PATH` constant in `tests/conftest.py` (exported via `__all__`), so a future relocation of `load_bot_token` is a one-line change.

- **`tests/conftest.py`** — new `_LOAD_BOT_TOKEN_PATH` constant (placed alongside existing shared constants like `HEALTH_SECRET`, `_AUDIO_CONSUMER_PATCH_TARGETS`; `from tests.conftest import` is already the established pattern in this suite).
- 13 literals replaced across `test_cli_setup.py`, `test_bootstrap_wiring.py`, `test_tool_display_wiring.py`, `test_adapter_standalone.py`, `test_bootstrap_audio_consumer.py`.
- Pure string→constant substitution; no test behavior/assertion/patched-symbol changes.

## Verification

- `grep -rn '"lyra.bootstrap.credentials.load_bot_token"' tests/` → **1** (the constant definition only).
- Affected suites: **28 passed, 0 failed**. `ruff check`/`format` clean.

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)