### PR TITLE
fix(bootstrap): thread alias_store through hub-path build_bot_auths for identity-alias parity (#1497)

### DIFF
--- a/src/lyra/bootstrap/auth_seeding.py
+++ b/src/lyra/bootstrap/auth_seeding.py
@@ -18,6 +18,7 @@ from lyra.core.auth.authenticator import Authenticator
 from lyra.core.circuit_breaker import CircuitRegistry
 from lyra.core.stores.bot_store_protocol import BotStoreProtocol
 from lyra.infrastructure.stores.auth_store import AuthStore
+from lyra.infrastructure.stores.identity_alias_store import IdentityAliasStore
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ def build_bot_auths(
     raw_config: dict,
     auth_store: AuthStore,
     bot_store: BotStoreProtocol,
+    alias_store: IdentityAliasStore | None = None,
 ) -> tuple[
     CircuitRegistry,
     frozenset[str],
@@ -65,6 +67,7 @@ def build_bot_auths(
             dc_multi_cfg=dc_multi_cfg,
             auth_store=auth_store,
             admin_user_ids=admin_user_ids,
+            alias_store=alias_store,
         )
     )
     log.info("Authenticator: %d admin_user_id(s) configured", len(admin_user_ids))

--- a/src/lyra/bootstrap/standalone/hub_standalone.py
+++ b/src/lyra/bootstrap/standalone/hub_standalone.py
@@ -94,7 +94,9 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
 
         try:
             circuit_registry, admin_user_ids, tg_bot_auths, dc_bot_auths = (
-                build_bot_auths(raw_config, stores.auth, stores.bot)
+                build_bot_auths(
+                    raw_config, stores.auth, stores.bot, stores.identity_alias
+                )
             )
         except ValueError as exc:
             log.error("Configuration error: %s", exc)

--- a/tests/bootstrap/test_auth_seeding.py
+++ b/tests/bootstrap/test_auth_seeding.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lyra.bootstrap.auth_seeding import build_bot_auths
+from lyra.bootstrap.wiring.bootstrap_wiring import BotAuthDeps
 from lyra.core.agent.bot_models import BotRow
 from lyra.infrastructure.stores.auth_store import AuthStore
+from lyra.infrastructure.stores.identity_alias_store import IdentityAliasStore
 from tests.factories.stores import make_auth_store
 from tests.helpers.bot_store import make_bot_store
 
@@ -189,3 +191,93 @@ class TestRosterFromStore:
         finally:
             await bot_store.close()
             await auth_store.close()
+
+
+# ---------------------------------------------------------------------------
+# test_alias_store_parity — hub-path threads alias_store into BotAuthDeps
+# ---------------------------------------------------------------------------
+
+
+class TestAliasStoreParity:
+    def test_build_bot_auths_threads_alias_store_into_deps(self) -> None:
+        """build_bot_auths passes alias_store into BotAuthDeps when provided.
+
+        Parity gate: the hub-standalone path must forward its alias_store arg
+        into the BotAuthDeps so Authenticator.from_bot_store receives it.
+        Without the fix, alias_store defaults to None and identity-alias
+        resolution is silently skipped for all bots in hub-standalone mode.
+
+        This test fails if build_bot_auths ignores the alias_store parameter
+        (i.e., still constructs BotAuthDeps without forwarding it).
+        """
+        fake_auth_store = MagicMock(spec=AuthStore)
+        fake_bot_store = MagicMock()
+        fake_bot_store.get_all.return_value = []
+        fake_alias_store = MagicMock(spec=IdentityAliasStore)
+
+        captured_deps: list[BotAuthDeps] = []
+
+        def fake_build_bot_auths(deps: BotAuthDeps):
+            captured_deps.append(deps)
+            return [], []
+
+        with (
+            patch(
+                "lyra.bootstrap.auth_seeding._build_bot_auths",
+                side_effect=fake_build_bot_auths,
+            ),
+            patch("lyra.bootstrap.auth_seeding._load_circuit_config") as mock_circuit,
+            patch(
+                "lyra.bootstrap.auth_seeding.multibot_config_from_store"
+            ) as mock_multi,
+        ):
+            mock_circuit.return_value = (MagicMock(), frozenset())
+            mock_multi.return_value = (MagicMock(bots=[]), MagicMock(bots=[]))
+
+            with pytest.raises(ValueError, match="No bots configured"):
+                build_bot_auths(
+                    {},
+                    fake_auth_store,
+                    fake_bot_store,
+                    fake_alias_store,
+                )
+
+        assert len(captured_deps) == 1, "Expected _build_bot_auths to be called once"
+        assert captured_deps[0].alias_store is fake_alias_store, (
+            "build_bot_auths did not forward alias_store into BotAuthDeps. "
+            "Hub-standalone path will silently skip identity-alias resolution."
+        )
+
+    def test_build_bot_auths_alias_store_defaults_to_none(self) -> None:
+        """build_bot_auths preserves None default when alias_store is omitted.
+
+        Ensures backward-compatibility for callers that do not pass alias_store.
+        """
+        fake_auth_store = MagicMock(spec=AuthStore)
+        fake_bot_store = MagicMock()
+        fake_bot_store.get_all.return_value = []
+
+        captured_deps: list[BotAuthDeps] = []
+
+        def fake_build_bot_auths(deps: BotAuthDeps):
+            captured_deps.append(deps)
+            return [], []
+
+        with (
+            patch(
+                "lyra.bootstrap.auth_seeding._build_bot_auths",
+                side_effect=fake_build_bot_auths,
+            ),
+            patch("lyra.bootstrap.auth_seeding._load_circuit_config") as mock_circuit,
+            patch(
+                "lyra.bootstrap.auth_seeding.multibot_config_from_store"
+            ) as mock_multi,
+        ):
+            mock_circuit.return_value = (MagicMock(), frozenset())
+            mock_multi.return_value = (MagicMock(bots=[]), MagicMock(bots=[]))
+
+            with pytest.raises(ValueError, match="No bots configured"):
+                build_bot_auths({}, fake_auth_store, fake_bot_store)
+
+        assert len(captured_deps) == 1
+        assert captured_deps[0].alias_store is None


### PR DESCRIPTION
## Summary

Fixes a parallel-path drift: the hub-standalone boot path silently skipped identity-alias resolution for all bots.

`BotAuthDeps` has `alias_store: IdentityAliasStore | None = None`. The **unified path** (`agent_factory`) passes `alias_store=stores.identity_alias`, but the **hub-standalone path** (`auth_seeding.build_bot_auths`) constructed `BotAuthDeps(...)` without it → defaulted to `None` → `Authenticator.from_bot_store(..., alias_store=None)` → identity-alias resolution silently disabled in the hub process.

## Fix

- `auth_seeding.build_bot_auths` — new `alias_store: IdentityAliasStore | None = None` param, threaded into `BotAuthDeps`.
- `hub_standalone` — call site now passes `stores.identity_alias`, matching the unified path.
- No change to `_build_bot_auths` / `BotAuthDeps` / unified path (already correct).

## Test

`tests/bootstrap/test_auth_seeding.py::TestAliasStoreParity`:
- `test_build_bot_auths_threads_alias_store_into_deps` — captures the `BotAuthDeps` reaching `_build_bot_auths` and asserts `alias_store is` the store passed in. **Fails without the fix** (old code → `alias_store=None`).
- `test_build_bot_auths_alias_store_defaults_to_none` — backward-compat guard.

## Verification

- `pytest tests/bootstrap/` → **171 passed**
- `lint-imports` → 11 kept, 0 broken · `pyright` → 0 errors · ruff clean

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)