### PR TITLE
fix(config): honor 'default' trust alias in [[auth.*_bots]] seeding (#1498)

### DIFF
--- a/src/lyra/agent_cmd/bots/init.py
+++ b/src/lyra/agent_cmd/bots/init.py
@@ -191,7 +191,11 @@ def _merge_bots(raw: dict[str, Any]) -> tuple[list[BotRow], int]:  # noqa: C901 
                 bot_id=bot_id,
                 agent=data.get("agent", "lyra_default"),
                 webhook_enabled=data.get("webhook_enabled", False),
-                default_trust=data.get("default_trust", DEFAULT_TRUST),
+                # [[auth.*_bots]] sections use `default` (per config.toml.example);
+                # `default_trust` is the canonical CLI key. Both must reach BotRow.
+                default_trust=data.get(
+                    "default_trust", data.get("default", DEFAULT_TRUST)
+                ),
                 owner_users=data.get("owner_users", []),
                 trusted_users=data.get("trusted_users", []),
                 trusted_roles=data.get("trusted_roles", []),

--- a/tests/cli/test_bot_init_seed_validation.py
+++ b/tests/cli/test_bot_init_seed_validation.py
@@ -125,6 +125,53 @@ class TestMergeBotsUnknownKey:
             f" got: {captured.err!r}"
         )
 
+    def test_default_alias_sets_trust(self) -> None:
+        """[[auth.*_bots]] `default` key must reach BotRow.default_trust (#1498).
+
+        Old code: data.get("default_trust", DEFAULT_TRUST) — ignored `default` key.
+        New code: data.get("default_trust", data.get("default", DEFAULT_TRUST)).
+        Without the fix this asserts "trusted" but receives "blocked".
+        """
+        raw = {
+            "auth": {
+                "telegram_bots": [
+                    {"bot_id": "main", "default": "trusted"},
+                ]
+            }
+        }
+
+        rows, errors = _merge_bots(raw)
+
+        assert errors == 0, f"Expected 0 errors, got {errors}."
+        assert len(rows) == 1
+        assert rows[0].default_trust == "trusted", (
+            f"Expected default_trust='trusted' via 'default' alias, "
+            f"got {rows[0].default_trust!r}. Fix: read 'default' as fallback."
+        )
+
+    def test_default_trust_wins_over_default_alias(self) -> None:
+        """Explicit `default_trust` must take precedence over `default` alias (#1498).
+
+        Both keys present in the merged dict — canonical key wins (last-wins
+        semantics are irrelevant here; `default_trust` is authoritative).
+        """
+        raw = {
+            "auth": {
+                "telegram_bots": [
+                    {"bot_id": "main", "default_trust": "owner", "default": "trusted"},
+                ]
+            }
+        }
+
+        rows, errors = _merge_bots(raw)
+
+        assert errors == 0, f"Expected 0 errors, got {errors}."
+        assert len(rows) == 1
+        assert rows[0].default_trust == "owner", (
+            f"Expected default_trust='owner' (canonical key wins), "
+            f"got {rows[0].default_trust!r}."
+        )
+
     def test_real_config_keys_accepted(self) -> None:
         """Keys present in config.toml.example must not be rejected by extra='forbid'.
 


### PR DESCRIPTION
## Summary

`config.toml.example` ships `default = "blocked"` in `[[auth.telegram_bots]]`/`[[auth.discord_bots]]`, but `_merge_bots` read only `default_trust` → the `default` value was silently dropped and every seeded bot fell back to `DEFAULT_TRUST` regardless of what the operator wrote.

**Fix** (`src/lyra/agent_cmd/bots/init.py`):
```python
default_trust=data.get("default_trust", data.get("default", DEFAULT_TRUST)),
```
`[[auth.*_bots]]` sections use `default` (per the shipped example); the CLI/`default_trust` key is canonical and takes precedence. Both now reach `BotRow.default_trust`. No change to `config.toml.example`.

**Invalid-value safety:** the `default` alias field is `str | None` (bypasses `_BotSeedEntry`'s `Literal` guard), but `BotRow.__post_init__` validates `default_trust ∈ _VALID_TRUST_LEVELS` and raises `ValueError` before any DB write — caught by `init_bots` and counted as a validation error (+ exit 1). No silent pass-through of garbage.

## Test (`tests/cli/test_bot_init_seed_validation.py`)
- `test_default_alias_sets_trust` — `default="trusted"` → `BotRow.default_trust == "trusted"`. **Fails without the fix** (was "blocked").
- `test_default_trust_wins_over_default_alias` — both keys present → canonical `default_trust` wins.

## Deferred (filed separately)
The issue's secondary item (align `DiscordBotConfig` defaults `auto_thread=True`/`thread_hot_hours=36` with `DEFAULT_*` `False`/`24`) is **not** included: investigation showed `config.py::from_config` uses `True`/`36` as deliberate parse-time defaults for Discord, so changing them is a behavior change (not the cosmetic fix the issue assumed) and needs its own decision. → follow-up sibling issue.

## Verification
18/18 affected tests pass · ruff clean · pyright 0 errors · lint-imports 11 kept / 0 broken.

Closes #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)