### PR TITLE
refactor(config): name DISCORD_DEFAULT_AUTO_THREAD/THREAD_HOT_HOURS, document intentional divergence (#1514)

### DIFF
--- a/src/lyra/config.py
+++ b/src/lyra/config.py
@@ -51,12 +51,22 @@ __all__ = [
     "DiscordMultiConfig",
     "load_multibot_config",
     "multibot_config_from_store",
+    # Discord-specific defaults (#1514)
+    "DISCORD_DEFAULT_AUTO_THREAD",
+    "DISCORD_DEFAULT_THREAD_HOT_HOURS",
 ]
 
 log = logging.getLogger(__name__)
 
 _ENV_PREFIX = "env:"
 _AUTO_THREAD_TRUE = frozenset({"1", "true", "yes", "on"})
+
+# Discord-specific defaults — intentionally diverge from the generic bot_models defaults
+# (DEFAULT_AUTO_THREAD=False / DEFAULT_THREAD_HOT_HOURS=24).
+# Discord threads conversations by default; the generic store default is False for
+# non-threading platforms (e.g. Telegram). See #1514. Keep the divergence deliberate.
+DISCORD_DEFAULT_AUTO_THREAD: bool = True
+DISCORD_DEFAULT_THREAD_HOT_HOURS: int = 36
 
 
 def _resolve_value(value: str) -> str:
@@ -97,9 +107,9 @@ class DiscordBotConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     bot_id: str
-    auto_thread: bool = True
+    auto_thread: bool = DISCORD_DEFAULT_AUTO_THREAD
     agent: str = "lyra_default"
-    thread_hot_hours: int = 36
+    thread_hot_hours: int = DISCORD_DEFAULT_THREAD_HOT_HOURS
 
 
 class TelegramMultiConfig(BaseModel):
@@ -154,7 +164,8 @@ def _parse_discord_bots(raw: dict[str, Any]) -> list[DiscordBotConfig]:
     """Parse [[discord.bots]] array from raw config.
 
     Each entry requires: bot_id.
-    Optional: auto_thread (default True), agent (default "lyra_default").
+    Optional: auto_thread (default DISCORD_DEFAULT_AUTO_THREAD),
+    agent (default "lyra_default").
 
     Credentials (token) are resolved at bootstrap time from
     /run/secrets/bot_token-<bot_id> and are not read here.
@@ -165,9 +176,11 @@ def _parse_discord_bots(raw: dict[str, Any]) -> list[DiscordBotConfig]:
     bots: list[DiscordBotConfig] = []
     for entry in bots_raw:
         bot_id: str = entry.get("bot_id", "main")
-        auto_thread: bool = entry.get("auto_thread", True)
+        auto_thread: bool = entry.get("auto_thread", DISCORD_DEFAULT_AUTO_THREAD)
         agent: str = entry.get("agent", "lyra_default")
-        thread_hot_hours: int = int(entry.get("thread_hot_hours", 36))
+        thread_hot_hours: int = int(
+            entry.get("thread_hot_hours", DISCORD_DEFAULT_THREAD_HOT_HOURS)
+        )
 
         bots.append(
             DiscordBotConfig(
@@ -220,7 +233,11 @@ def load_multibot_config(
     dc_has_bots_key = "bots" in raw.get("discord", {})
     if not dc_bots and not dc_has_bots_key and raw.get("auth", {}).get("discord"):
         auto_thread_str = os.environ.get("DISCORD_AUTO_THREAD", "").strip().lower()
-        auto_thread = auto_thread_str in _AUTO_THREAD_TRUE if auto_thread_str else True
+        auto_thread = (
+            auto_thread_str in _AUTO_THREAD_TRUE
+            if auto_thread_str
+            else DISCORD_DEFAULT_AUTO_THREAD
+        )
         log.info(
             "discord: no [[discord.bots]] found; "
             "falling back to legacy single-bot path (bot_id='main')"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,10 @@ import logging
 
 import pytest
 
+import lyra.core.agent.bot_models as bot_models
 from lyra.config import (
+    DISCORD_DEFAULT_AUTO_THREAD,
+    DISCORD_DEFAULT_THREAD_HOT_HOURS,
     DiscordBotConfig,
     DiscordMultiConfig,
     TelegramBotConfig,
@@ -348,3 +351,47 @@ class TestMultibotConfigFromStore:
         # Assert
         assert len(tg.bots) == 1
         assert dc.bots == []
+
+
+# ---------------------------------------------------------------------------
+# TestDiscordDefaultConstants — guard test for #1514
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordDefaultConstants:
+    """Guard that the Discord-specific defaults are named, valued, and deliberately
+    diverge from the generic platform-agnostic defaults in bot_models.
+
+    If a future "alignment" refactor changes these values, this test will trip and
+    force re-reading the decision documented in #1514 before proceeding.
+    """
+
+    def test_discord_default_auto_thread_is_true(self) -> None:
+        # Discord threads every conversation by default.
+        assert DISCORD_DEFAULT_AUTO_THREAD is True
+
+    def test_discord_default_thread_hot_hours_is_36(self) -> None:
+        assert DISCORD_DEFAULT_THREAD_HOT_HOURS == 36
+
+    def test_discord_bot_config_default_auto_thread(self) -> None:
+        # DiscordBotConfig() with no explicit auto_thread must use the named constant.
+        cfg = DiscordBotConfig(bot_id="test")
+        assert cfg.auto_thread is DISCORD_DEFAULT_AUTO_THREAD
+        assert cfg.auto_thread is True
+
+    def test_discord_bot_config_default_thread_hot_hours(self) -> None:
+        # DiscordBotConfig() with no explicit thread_hot_hours must use the constant.
+        cfg = DiscordBotConfig(bot_id="test")
+        assert cfg.thread_hot_hours == DISCORD_DEFAULT_THREAD_HOT_HOURS
+        assert cfg.thread_hot_hours == 36
+
+    def test_intentional_divergence_from_generic_auto_thread(self) -> None:
+        # DELIBERATE: Discord default (True) != generic default (False).
+        # bot_models.DEFAULT_AUTO_THREAD is False for non-threading platforms
+        # (e.g. Telegram). Discord is the exception.
+        # See #1514. Do NOT "fix" this divergence without re-reading that decision.
+        assert DISCORD_DEFAULT_AUTO_THREAD != bot_models.DEFAULT_AUTO_THREAD
+
+    def test_intentional_divergence_from_generic_thread_hot_hours(self) -> None:
+        # DELIBERATE: Discord default (36 h) != generic default (24 h). See #1514.
+        assert DISCORD_DEFAULT_THREAD_HOT_HOURS != bot_models.DEFAULT_THREAD_HOT_HOURS


### PR DESCRIPTION
## Summary

Maintainer decision (#1514): the `DiscordBotConfig` `auto_thread=True`/`thread_hot_hours=36` defaults **intentionally** diverge from the generic `bot_models.DEFAULT_AUTO_THREAD=False`/`DEFAULT_THREAD_HOT_HOURS=24` — Discord threads conversations by default; the generic store default is False for non-threading platforms (Telegram). **Keep the divergence, give it a named home + document it.** No behavior change.

## Change (`src/lyra/config.py`)

- New constants `DISCORD_DEFAULT_AUTO_THREAD = True`, `DISCORD_DEFAULT_THREAD_HOT_HOURS = 36` with a comment explaining the deliberate divergence (#1514).
- Replaced the magic `True`/`36` literals at all 5 sites: `DiscordBotConfig` field defaults, `_parse_discord_bots` `entry.get(...)` fallbacks, and the env-path `else` fallback.
- No new cross-layer import (constants are local to `config.py`).

## Test (`tests/test_config.py::TestDiscordDefaultConstants`)

- Constant values + `DiscordBotConfig()` default round-trip.
- **Guard assertions** that the constants deliberately differ from `bot_models.DEFAULT_*` (bot_models imported in the test only) — so a future "alignment" refactor trips this test and re-reads the #1514 decision.

## Verification

29/29 pass · ruff clean (changed files) · pyright 0 errors · lint-imports 11 kept / 0 broken (no new import).

Closes #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)