### PR TITLE
refactor(core): complete #1506 — eliminate residual hub_shutdown TurnStore coupling

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -37,11 +37,6 @@ ignore_imports =
     lyra.core.hub.hub_registration -> lyra.infrastructure.stores.message_index
     lyra.core.hub.hub_shutdown -> lyra.infrastructure.stores.message_index
     lyra.core.pool.pool_observer -> lyra.infrastructure.stores.message_index
-    # TurnStore moved to infrastructure per ADR-048 (#760 review fix f2) — DEBT:importlinter-adr048-transition
-    # pool.pool and pool.pool_observer fixed in #1079 (TurnStoreProtocol introduced)
-    # hub, hub_registration, cli_pool, cli_pool_session fixed in #1506 (widened to TurnStoreProtocol)
-    # hub_shutdown retained: calls self._turn_store.close() — lifecycle method not in TurnStoreProtocol
-    lyra.core.hub.hub_shutdown -> lyra.infrastructure.stores.turn_store
 
 [importlinter:contract:core-stores-no-sqlite]
 name = core/stores protocols must not import SQLite drivers

--- a/artifacts/frames/1506-widen-turnstore-wiring-protocol-frame.mdx
+++ b/artifacts/frames/1506-widen-turnstore-wiring-protocol-frame.mdx
@@ -1,0 +1,90 @@
+---
+title: Eliminate core→infrastructure TurnStore coupling (protocol + lifecycle ownership)
+issue: 1506
+status: approved
+tier: F-lite
+date: 2026-05-29
+---
+
+## Problem
+
+`TurnStoreProtocol` (ADR-078, #1079) decoupled `pool/` consumers from the concrete
+SQLite `TurnStore`, but **5 `.importlinter` TYPE_CHECKING exemptions remain** in the
+hub/cli wiring sites — `lyra.core.*  ->  lyra.infrastructure.stores.turn_store` (lines
+42–46), tagged `DEBT:importlinter-adr048-transition`. They are the last residue of the
+`lyra.core ← lyra.infrastructure` layering inversion that ADR-048/078 exist to remove.
+
+The original issue framed this as a 2-signature widening. Investigation during
+implement-prep found the real shape is **lifecycle ownership**, not type annotation:
+
+- `bootstrap_stores.open_stores()` already creates → `connect()` → **closes** every
+  store, including `turn_store`, in its `finally` block (line 305). It is the canonical
+  lifecycle owner. Both hub entrypoints run inside it (`hub_standalone.py:82`,
+  `unified.py:54`).
+- `hub_shutdown.shutdown()` *also* calls `await self._turn_store.close()` — a
+  **redundant second close** on a store the hub received via `set_turn_store()` but
+  never created. This is the ownership inversion in miniature, and it is the reason
+  `hub_shutdown` cannot drop the concrete type (`close()` ∉ read-path `TurnStoreProtocol`).
+
+Widening only the two `set_turn_store` signatures clears just 2 of 5 exemptions and
+leaves a heterogeneous residue (some siblings on protocol, some on concrete) =
+**parallel-path drift**.
+
+## Who
+
+- **Primary:** Lyra core maintainers — the layering contract in `src/lyra/core/CLAUDE.md`
+  and the import-linter gate are theirs to keep clean.
+- **Secondary:** Future authors of alternative TurnStore impls (in-memory stub for tests,
+  NATS-backed) — uniform protocol dependency makes the store swappable.
+
+## Constraints
+
+- No behavior regression: store must still be closed exactly once on shutdown (no leaked
+  SQLite handles, no double-close error). Safety rests on `open_stores`' `finally`.
+- `TurnStoreProtocol` stays **read-path only** (ADR-078) — do NOT add `close()` to it;
+  lifecycle is an infrastructure/bootstrap concern.
+- `import-linter` (`lint-imports`) is the objective gate — every exemption removed must be
+  proven unused, not assumed.
+- Stage-axis (ADR-073) is untouched — this is the orthogonal layering axis.
+
+## Out of Scope
+
+- `hub_shutdown` also redundantly closes `memory` + `message_index` (same `open_stores`
+  ownership). Same fix pattern, different DEBT lines → **sibling follow-up issue**, not
+  this PR.
+- No change to `pool.py` / `pool_observer.py` (already on the protocol since #1079).
+- No new TurnStore implementation.
+
+## Premise Validity
+
+**Success in 6 months:** Zero `turn_store` core→infra exemptions in `.importlinter`;
+ADR-078 marked fully discharged (no "exemptions remain" caveat); new `core/` code that
+reads turns depends on `TurnStoreProtocol` by default; store shutdown still closes exactly
+once.
+
+**Failure in 6 months (falsifiable):** the `turn_store` ignore_imports count in
+`.importlinter` is still > 0, OR a shutdown regression is observed (SQLite connection
+leak / double-close exception in any hub or adapter mode), OR the exemption count creeps
+back up because new core code re-imported the concrete `TurnStore`.
+
+**Simplest alternative:** Widen only the two `set_turn_store` signatures + their field
+annotations (the original S), remove the 2 exemptions that clear, keep `hub_shutdown` on
+the concrete type with a clarifying comment.
+**Why not simplest:** leaves 1–3 exemptions = the same logical dependency expressed two
+ways across sibling modules (parallel-path drift), preserves the lifecycle ownership
+inversion, and leaves ADR-078's debt formally open. It does not reach the stated goal.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (core layering), but ~5 source files +
+`.importlinter` + ADR-078, and includes one behavioral deletion (the redundant close) that
+warrants spec/plan gates and a tester verifying shutdown still closes once.
+
+Signals observed:
+- Files touched: `hub.py`, `hub_registration.py`, `hub_shutdown.py`, `cli_pool.py`,
+  `cli_pool_session.py`, `.importlinter`, ADR-078 (~7) → above S's ≤3.
+- Technical risk: low (mechanical annotation swaps) except the 1 behavioral deletion.
+- Architectural impact: single layering axis; restores ADR-048/078 contract.
+- Unknowns: ~1 (confirm no non-`open_stores` hub mode owns the close — preliminarily
+  verified for hub_standalone + unified).
+- Domain breadth: 1 (core).

--- a/artifacts/plans/1506-widen-turnstore-wiring-protocol-plan.mdx
+++ b/artifacts/plans/1506-widen-turnstore-wiring-protocol-plan.mdx
@@ -1,0 +1,169 @@
+---
+title: "Plan: Eliminate core→infrastructure TurnStore coupling"
+issue: 1506
+spec: artifacts/specs/1506-widen-turnstore-wiring-protocol-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-05-29
+---
+
+## Summary
+
+Retype the 4 `lyra.core` read-path consumers of `TurnStore` to `TurnStoreProtocol`, delete
+the redundant `hub_shutdown` close (bootstrap owns lifecycle), remove all 5 `.importlinter`
+turn_store exemptions, and discharge ADR-078.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph infra["lyra.infrastructure"]
+        TS["TurnStore (SqliteStore)"]
+    end
+    subgraph boot["lyra.bootstrap"]
+        OS["open_stores() — connect/close (owner)"]
+        OS -->|set_turn_store| HR
+        OS -->|set_turn_store| CPS
+        OS -. creates/closes .-> TS
+    end
+    subgraph core["lyra.core (protocol-only)"]
+        TSP["TurnStoreProtocol (read-path)"]
+        HUB["hub.hub._turn_store: TurnStoreProtocol"]
+        HR["hub_registration.set_turn_store"]
+        SHUT["hub_shutdown (close REMOVED)"]
+        CP["cli_pool (get_cli_session*)"]
+        CPS["cli_pool_session.set_turn_store"]
+    end
+    HUB -.-> TSP
+    HR -.-> TSP
+    CP -.-> TSP
+    CPS -.-> TSP
+    TSP -. structural .-> TS
+```
+
+**Coupling constraint:** `hub.py` / `hub_registration.py` / `hub_shutdown.py` all reference
+the single `Hub._turn_store` field. Retyping it to `TurnStoreProtocol` (no `close()`) while
+`hub_shutdown` still calls `.close()` breaks pyright. → the hub trio (T1+T2+T3) is **one
+atomic edit group**. The cli pair (T4) is independent (separate `_turn_store` field).
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1–T6 | hub.py, hub_registration.py, hub_shutdown.py, cli_pool.py, cli_pool_session.py, .importlinter |
+| tester-A | T7 | tests for bootstrap→shutdown close-once |
+| doc-writer-A | T8 | docs/architecture/adr/078-turn-store-protocol.mdx |
+
+## Micro-Tasks
+
+### Slice S1 + S2 — hub trio (atomic) · backend-dev-A
+
+- **T1** — `hub.py`: change `self._turn_store: TurnStore | None` → `TurnStoreProtocol | None`;
+  swap TYPE_CHECKING import `...stores.turn_store import TurnStore` → `core.stores.turn_store_protocol import TurnStoreProtocol`.
+  Verify: `grep -n TurnStoreProtocol src/lyra/core/hub/hub.py`. Difficulty 2. Subject: turn-store-typing.
+- **T2** — `hub_registration.py`: `set_turn_store(store: TurnStoreProtocol)` + field annotation
+  `_turn_store: TurnStoreProtocol | None`; swap import. (forwards to `register_turn_store`, already protocol).
+  Verify: `grep -n "def set_turn_store" src/lyra/core/hub/hub_registration.py`. Difficulty 2. Subject: turn-store-typing.
+- **T3** — `hub_shutdown.py`: **delete** `if self._turn_store is not None: await self._turn_store.close()`;
+  drop the `_turn_store` TYPE_CHECKING import + field annotation (if now unused). Leave `_message_index`/`_memory` closes untouched (out of scope).
+  Verify: `! grep -n "_turn_store.close" src/lyra/core/hub/hub_shutdown.py`. Difficulty 2. Subject: lifecycle.
+
+### Slice S1 — cli pair (independent) · backend-dev-A
+
+- **T4** — `cli_pool.py` + `cli_pool_session.py`: retype `_turn_store` field + `set_turn_store`
+  param → `TurnStoreProtocol`; swap imports. Read calls (`get_cli_session`, `get_cli_session_by_pool`) already protocol.
+  Verify: `grep -rn TurnStoreProtocol src/lyra/core/cli/`. Difficulty 2. Subject: turn-store-typing.
+
+### Slice S1 + S2 — exemption removal · backend-dev-A
+
+- **T5** — `.importlinter`: remove all 5 turn_store `ignore_imports` (hub, hub_registration, hub_shutdown, cli_pool, cli_pool_session). blockedBy T1–T4.
+  Verify: `! grep -E 'turn_store' .importlinter` (in ignore block). Difficulty 1. Subject: import-linter.
+- **T6** — Run gates: `uv run lint-imports && uv run pyright`. blockedBy T5.
+  Verify: both exit 0. Difficulty 1. Subject: import-linter.
+
+### Slice S2 — regression test · tester-A
+
+- **T7** — Add test asserting the turn store is closed **exactly once** across a full
+  `open_stores`→hub-shutdown cycle (spy/mock `TurnStore.close`; assert call_count == 1; hub no longer double-closes).
+  Place near existing bootstrap/shutdown tests. blockedBy T3.
+  Verify: `uv run pytest -k "turn_store and (close or shutdown)"`. Difficulty 3. Subject: lifecycle.
+
+### Slice S3 — ADR · doc-writer-A
+
+- **T8** — `078-turn-store-protocol.mdx`: in Consequences, flip "5 hub/cli TYPE_CHECKING
+  exemptions remain… tracked separately" → eliminated (#1506); add a sentence: lifecycle
+  (connect/close) owned by `bootstrap.open_stores`, core consumers depend on read-path protocol only.
+  Verify: `! grep -n "exemptions remain" docs/architecture/adr/078-turn-store-protocol.mdx`. Difficulty 2. Subject: docs.
+
+## Wave Structure
+
+2 waves, max 2 parallel agents. Elapsed ~0.5 day vs ~1 day sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | backend-dev-A: T1→T2→T3→T4→T5→T6 · doc-writer-A: T8 |
+| 2 | T3 done | 1 | tester-A: T7 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 | 1 | bounded | 3 | — |
+| T2 | 1 | bounded | 3 | — |
+| T3 | 1 | judgmental | 5 | — |
+| T4 | 2 | bounded | 4 | — |
+| T5 | 1 | trivial | 2 | — |
+| T6 | 1 | bounded | 3 | — |
+| T7 | 1 | judgmental | 6 | — |
+| T8 | 1 | bounded | 3 | — |
+
+**Total estimated ops: 29**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1–T6 | 20 | turn-store-typing, lifecycle, import-linter | — (3 subjects but tightly-coupled single concern; ops≪50, tasks=6 mechanical) |
+| tester-A | T7 | 6 | lifecycle | — |
+| doc-writer-A | T8 | 3 | docs | — |
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. blockedBy refs T-numbers. -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | turn-store-typing |
+| T2 | backend-dev-A | T1 | turn-store-typing |
+| T3 | backend-dev-A | T2 | lifecycle |
+| T4 | backend-dev-A | — | turn-store-typing |
+| T5 | backend-dev-A | T1,T2,T3,T4 | import-linter |
+| T6 | backend-dev-A | T5 | import-linter |
+| T8 | doc-writer-A | — | docs |
+
+### Wave 2 — after T3, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | tester-A | T3 | lifecycle |
+
+## Consistency Report
+
+- Success criteria covered: 8/8 (SC-exemptions→T5,T6 · SC-lint/pyright→T6 · SC-no-core-import→T1-T4 · SC-close-once→T3,T7 · SC-protocol-unchanged→(none touch protocol) · SC-ADR→T8 · SC-pytest→T7)
+- Uncovered: none
+- Untraced tasks: none
+- Exemptions: out-of-scope memory/message_index closes (documented in spec) → sibling follow-up issue at ship time
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — turn-store-typing (hub.py)
+- T2: 13 — turn-store-typing (hub_registration)
+- T3: 14 — lifecycle (hub_shutdown close delete)
+- T4: 15 — turn-store-typing (cli pair)
+- T5: 16 — import-linter (remove 5 exemptions)
+- T6: 17 — import-linter (lint-imports + pyright)
+- T7: 18 — lifecycle (close-once test)
+- T8: 19 — docs (ADR-078)

--- a/artifacts/specs/1506-widen-turnstore-wiring-protocol-spec.mdx
+++ b/artifacts/specs/1506-widen-turnstore-wiring-protocol-spec.mdx
@@ -1,0 +1,153 @@
+---
+title: Eliminate core→infrastructure TurnStore coupling (protocol + lifecycle ownership)
+issue: 1506
+status: approved
+tier: F-lite
+date: 2026-05-29
+promoted_from: artifacts/frames/1506-widen-turnstore-wiring-protocol-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1506-widen-turnstore-wiring-protocol-frame.mdx` (approved).
+Closes the ADR-078 residue: 5 `lyra.core.* -> lyra.infrastructure.stores.turn_store`
+TYPE_CHECKING exemptions in `.importlinter` (lines 42–46), tagged
+`DEBT:importlinter-adr048-transition`.
+
+## Goal
+
+Remove all 5 turn_store layering exemptions by making every `lyra.core` consumer depend on
+the read-path `TurnStoreProtocol` and relocating the store's `close()` to its sole rightful
+owner — the bootstrap layer.
+
+## Users
+
+- **Primary:** Lyra core maintainers (own the import-linter gate + `core/CLAUDE.md` layering contract).
+- **Secondary:** Future alternative `TurnStore` implementors (in-memory test stub, NATS-backed) — uniform protocol dependency makes the store swappable.
+
+## Expected Behavior
+
+1. `Hub` and `CliPool` continue to read turns through the same methods (`get_turns`,
+   `get_cli_session`, `get_cli_session_by_pool`, …) — now typed against `TurnStoreProtocol`.
+2. On shutdown the turn store is closed **exactly once**, by `open_stores()`'s `finally`
+   block — unchanged externally; the hub no longer issues a second close.
+3. `lint-imports` passes with zero turn_store exemptions in `.importlinter`.
+4. No runtime behavior change observable to adapters or users.
+
+## Data Model & Consumers
+
+### Type relationship
+
+```mermaid
+classDiagram
+    class TurnStoreProtocol {
+        <<Protocol, runtime_checkable>>
+        +get_turns(pool_id, user_id, limit) list~TurnRow~
+        +list_sessions(pool_id, limit) list~SessionRow~
+        +get_cli_session(session_id) str?
+        +get_cli_session_by_pool(pool_id) str?
+        +get_last_session(pool_id) str?
+        +get_session_pool_id(session_id) str?
+    }
+    class SqliteStore {
+        <<infrastructure>>
+        +connect()
+        +close()
+    }
+    class TurnStore {
+        <<infrastructure>>
+    }
+    SqliteStore <|-- TurnStore
+    TurnStoreSessionMixin <|-- TurnStore
+    TurnStoreProtocol <|.. TurnStore : structural (satisfies)
+```
+
+`close()` lives on `SqliteStore` (infrastructure) and is intentionally **absent** from the
+read-path protocol — lifecycle is not a core concern.
+
+### Consumer map
+
+```mermaid
+flowchart TD
+    OS["bootstrap.open_stores()<br/>creates · connect · close"] -->|owns lifecycle| TS[(TurnStore concrete)]
+    OS -->|wires via set_turn_store| HUB
+    OS -->|wires via set_turn_store| CLI
+
+    subgraph core["lyra.core (depends on protocol only)"]
+        HUB["hub_registration / hub.hub"] -.read-path.-> TSP[TurnStoreProtocol]
+        SHUT["hub_shutdown"]
+        CLI["cli_pool / cli_pool_session"] -.read-path.-> TSP
+    end
+
+    TSP -. structural .-> TS
+    SHUT -. "close() REMOVED<br/>(was 2nd close)" .-x TS
+```
+
+### Consumer summary
+
+| Consumer | Methods used | Typed as (after) | Exemption | Status |
+|---|---|---|---|---|
+| `hub_registration` | `set_turn_store` wiring → `register_turn_store` | `TurnStoreProtocol` | line 43 removed | this issue |
+| `hub.hub` | field declaration only (0 calls) | `TurnStoreProtocol` | line 42 removed | this issue |
+| `cli_pool` | `get_cli_session`, `get_cli_session_by_pool` | `TurnStoreProtocol` | line 45 removed | this issue |
+| `cli_pool_session` | `set_turn_store` wiring | `TurnStoreProtocol` | line 46 removed | this issue |
+| `hub_shutdown` | `close()` → **deleted** | (no turn_store ref) | line 44 removed | this issue |
+| `bootstrap.open_stores` | `connect`, `close` (lifecycle) | concrete `TurnStore` | n/a (infra layer) | unchanged |
+| `pool` / `pool_observer` | read-path | `TurnStoreProtocol` | n/a | done (#1079) |
+
+## Breadboard
+
+| ID | Affordance (site) | Wiring / handler | Data |
+|---|---|---|---|
+| N1 | `hub_registration.set_turn_store(store)` | retype param + `_turn_store` field → `TurnStoreProtocol`; forwards to `pool._observer.register_turn_store(store)` (already protocol) | protocol ref |
+| N2 | `hub.hub` `self._turn_store` field decl | retype `TurnStoreProtocol | None`; drop concrete import | annotation only |
+| N3 | `cli_pool_session.set_turn_store(store)` | retype param + `_turn_store` field → `TurnStoreProtocol` | protocol ref |
+| N4 | `cli_pool` `_turn_store` field + read calls | retype field → `TurnStoreProtocol`; calls already protocol methods | protocol ref |
+| N5 | `hub_shutdown.shutdown()` | **delete** `if self._turn_store is not None: await self._turn_store.close()`; drop concrete import; drop field annotation if now unused | none |
+| N6 | `.importlinter` lines 42–46 | remove all 5 turn_store `ignore_imports`; `lint-imports` proves unused | config |
+| N7 | ADR-078 Consequences | flip "5 exemptions remain, tracked separately" → eliminated; add lifecycle-ownership note | docs |
+
+## Slices
+
+| # | Slice | Affordances | Independently demoable |
+|---|---|---|---|
+| S1 | Retype read-path consumers + drop their imports + drop their 4 exemptions | N1, N2, N3, N4, N6 (lines 42,43,45,46) | `lint-imports` green; pyright green; no behavior change |
+| S2 | Delete redundant `hub_shutdown` close + drop import + drop 5th exemption | N5, N6 (line 44) | `lint-imports` green; test asserts store closed exactly once on shutdown |
+| S3 | Discharge ADR-078 | N7 | doc reflects zero exemptions + ownership rule |
+
+## Out of Scope — Surviving exemptions (pre-existing ADR-048 debt)
+
+This PR makes the **turn_store** dimension fully uniform (0 residue). It does **not** make
+`hub.hub` / `hub_registration` / `hub_shutdown` protocol-clean overall — they retain
+concrete-infra references to *other* stores with no protocol extracted yet. These
+exemptions are neither introduced nor removed here (EXPECTED_DEBT per ADR-073); listed so a
+reviewer does not misread S2 as "hub_shutdown fully clean":
+
+| Module | Surviving `.importlinter` exemptions (other stores) |
+|---|---|
+| `hub.hub` | `identity_alias_store`, `message_index`, `pairing`, `prefs_store` |
+| `hub_registration` | `identity_alias_store`, `message_index` |
+| `hub_shutdown` | `message_index` (import + `_message_index.close()` — same redundant-close pattern, deferred with the sibling follow-up) |
+| `memory.memory` | `identity_alias_store` |
+
+After S2, `hub_shutdown` is **partially** cleaned: turn_store ref gone, but it still imports
++ closes `message_index`. Each surviving store awaits its own `*StoreProtocol` extraction.
+
+## Success Criteria
+
+- [ ] `grep -E 'turn_store' .importlinter` returns **0** lines inside the `ignore_imports` block.
+- [ ] `uv run lint-imports` exits 0.
+- [ ] `uv run pyright` exits 0 (structural compatibility holds at bootstrap wiring sites).
+- [ ] No `lyra.core.*` module imports `lyra.infrastructure.stores.turn_store` (verified by grep + import-linter).
+- [ ] `hub_shutdown.shutdown()` no longer calls `_turn_store.close()`; a test asserts the turn store is closed exactly once across a full bootstrap→shutdown cycle (closed by `open_stores`, not double-closed).
+- [ ] `TurnStoreProtocol` is unchanged — no `close()`/lifecycle method added.
+- [ ] ADR-078 Consequences section states the exemptions are eliminated and documents bootstrap as the lifecycle owner.
+- [ ] `uv run pytest` passes (no shutdown/teardown regression).
+
+## Edge Cases
+
+| Edge | Handling |
+|---|---|
+| A hub mode closes turn store ONLY via `hub_shutdown` (not `open_stores`) | Verified none: `hub_standalone.py:82` + `unified.py:54` both wrap in `open_stores`; adapters (`standalone_telegram/discord`) create + close their own. Test covers the standalone hub path. |
+| `close()` is idempotent → removal "harmless" either way | Removal still required: the goal is the layering boundary, not just avoiding double-close. |
+| Future core code needs a write/lifecycle method | Out of scope; would be a separate protocol decision, not a read-path protocol change. |

--- a/docs/architecture/adr/078-turn-store-protocol.mdx
+++ b/docs/architecture/adr/078-turn-store-protocol.mdx
@@ -66,14 +66,15 @@ protocol structurally (`@runtime_checkable`), so no call-site changes are needed
 - No behaviour change — `TurnStore` satisfies `TurnStoreProtocol` structurally
 - Pyright verifies structural compatibility at the wire-up site in `bootstrap/`
 
-## Remaining DEBT
+## DEBT resolution (#1506)
 
-`hub_shutdown.py` retains the concrete `TurnStore` import and its `.importlinter` exemption.
-`HubShutdownMixin.shutdown()` calls `self._turn_store.close()`, which is a lifecycle method
-intentionally absent from `TurnStoreProtocol` (the protocol covers the read/session surface only).
+The interim residue — `hub_shutdown.py` retaining the concrete `TurnStore` import + a
+`.importlinter` exemption because `HubShutdownMixin.shutdown()` called `self._turn_store.close()`
+— was resolved in #1506 by taking the **"relocate teardown to bootstrap"** option:
+`bootstrap_stores.open_stores()` is the sole lifecycle owner (its `finally` closes every store
+exactly once), so the hub's redundant `close()` call was removed. `hub_shutdown.py` no longer
+imports `TurnStore`, and `.importlinter` carries **zero** `turn_store` exemptions.
 
-**Options for follow-up:**
-- Add a `Closeable` / `LifecycleStore` protocol to `core/ports/` and narrow the shutdown mixin to that
-- Or relocate shutdown teardown to the bootstrap layer, where concrete types are in scope
-
-Until then the exemption is load-bearing and annotated in `.importlinter` with a rationale comment.
+`close()` remains intentionally absent from `TurnStoreProtocol` (read-path only) — adding a
+`Closeable`/`LifecycleStore` protocol proved unnecessary once lifecycle ownership was correctly
+placed in the bootstrap layer.

--- a/docs/architecture/adr/078-turn-store-protocol.mdx
+++ b/docs/architecture/adr/078-turn-store-protocol.mdx
@@ -56,10 +56,11 @@ protocol structurally (`@runtime_checkable`), so no call-site changes are needed
 ## Consequences
 
 **Positive:**
-- Layering inversion eliminated for `pool/` consumers — `pool.py` and `pool_observer.py` no longer import from `infrastructure/`
-- 4 of 5 hub/cli `.importlinter` exemptions removed in #1506: `hub.hub`, `hub.hub_registration`, `cli.cli_pool`, `cli.cli_pool_session` all widened to `TurnStoreProtocol`
+- Layering inversion eliminated for ALL `turn_store` consumers (`pool/`, `hub/`, `cli/`, adapters, inbound) — `.importlinter` carries no `turn_store` exemptions as of #1506
 - `TurnStoreProtocol` is now swappable for testing (in-memory stub, NATS-backed future impl)
 - Consistent with the existing `AgentStoreProtocol` / `BotStoreProtocol` / `ThreadStoreProtocol` pattern
+- **Lifecycle ownership rule** (#1506): the store's lifecycle (`connect` / `close`) is owned solely by the bootstrap layer (`bootstrap_stores.open_stores()`, which closes every store in its `finally` block); `lyra.core` consumers depend on the read-path `TurnStoreProtocol` only and must NOT call lifecycle methods — the previously-redundant `hub_shutdown` `close()` call was removed for this reason
+- `close()` is intentionally excluded from `TurnStoreProtocol`; the protocol is read-path only
 
 **Neutral:**
 - No behaviour change — `TurnStore` satisfies `TurnStoreProtocol` structurally

--- a/src/lyra/adapters/discord/adapter.py
+++ b/src/lyra/adapters/discord/adapter.py
@@ -15,8 +15,8 @@ from lyra.core.stores.thread_store_protocol import ThreadSession
 if TYPE_CHECKING:
     from lyra.adapters.shared.outbound_listener import OutboundListener
     from lyra.core.messaging.bus import Bus
+    from lyra.core.stores import TurnStoreProtocol
     from lyra.core.stores.thread_store_protocol import ThreadStoreProtocol
-    from lyra.infrastructure.stores.turn_store import TurnStore
     from lyra.outbound.emitter import OutboundEmitter
 
 from lyra.adapters.discord import discord_audio  # noqa: I001 — DEBT:module-level-patch-fixtures
@@ -93,7 +93,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         thread_hot_hours: int = 36,
         thread_store: ThreadStoreProtocol | None = None,
         watch_channels: frozenset[int] = frozenset(),
-        turn_store: "TurnStore | None" = None,
+        turn_store: "TurnStoreProtocol | None" = None,
     ) -> None:
         if intents is None:
             intents = discord.Intents.default()
@@ -119,7 +119,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         self._mention_re: re.Pattern[str] | None = None  # compiled on on_ready
         self._owned_threads: set[int] = set()  # populated from ThreadStore on on_ready
         self._thread_store: ThreadStoreProtocol | None = thread_store
-        self._turn_store: "TurnStore | None" = turn_store
+        self._turn_store: "TurnStoreProtocol | None" = turn_store
         self._watch_channels: frozenset[int] = watch_channels
         self._thread_sessions: dict[str, ThreadSession] = {}
         self._vsm: VoiceSessionManager = VoiceSessionManager()

--- a/src/lyra/adapters/telegram/telegram.py
+++ b/src/lyra/adapters/telegram/telegram.py
@@ -16,7 +16,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 if TYPE_CHECKING:
     from lyra.adapters.shared.outbound_listener import OutboundListener
     from lyra.core.messaging.bus import Bus
-    from lyra.infrastructure.stores.turn_store import TurnStore
+    from lyra.core.stores import TurnStoreProtocol
     from lyra.outbound.emitter import OutboundEmitter
 
 from lyra.adapters.telegram import telegram_audio  # noqa: I001 — DEBT:lint-residual
@@ -89,7 +89,7 @@ class TelegramAdapter(OutboundAdapterBase):
         webhook_secret: str = "",
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
-        turn_store: "TurnStore | None" = None,
+        turn_store: "TurnStoreProtocol | None" = None,
     ) -> None:
         super().__init__()  # no-op today, future-proofs cooperative chain
         self._bot_id = bot_id
@@ -104,7 +104,7 @@ class TelegramAdapter(OutboundAdapterBase):
         self._circuit_registry = circuit_registry
         self._msg_manager = msg_manager
         self._guard_chain: GuardChain = GuardChain([BlockedGuard()])
-        self._turn_store: "TurnStore | None" = turn_store
+        self._turn_store: "TurnStoreProtocol | None" = turn_store
         _raw_tmp = os.environ.get("LYRA_AUDIO_TMP") or None
         if _raw_tmp is not None:
             _tmp_path = Path(_raw_tmp)

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from ..ports.resume_publisher import ResumePublisherPort
     from ..ports.stt import STTProtocol
     from ..ports.tts import TtsProtocol
+    from ..stores import TurnStoreProtocol
     from .event_bus import PipelineEventBus
     from .outbound import OutboundDispatcher
 
@@ -108,8 +109,7 @@ class Hub(
         self._start_time: float = time.monotonic()
         self._memory: MemoryManager | None = None
         self._memory_tasks: set[asyncio.Task] = set()
-        # _turn_store: TurnStoreProtocol | None — declared by HubShutdownMixin
-        self._turn_store = None
+        self._turn_store: TurnStoreProtocol | None = None
         self._turn_publisher: TurnPublisher | None = None
         self._resume_publisher: ResumePublisherPort | None = resume_publisher
         # T1 — typing-plane publisher; wired by bootstrap, consumed by T2.

--- a/src/lyra/core/hub/hub_registration.py
+++ b/src/lyra/core/hub/hub_registration.py
@@ -41,7 +41,7 @@ class HubRegistrationMixin:
         _memory_tasks: set
         _message_index: MessageIndex | None
         _platform_queue_maxsize: int
-        # _turn_store: typed by HubShutdownMixin (concrete TurnStore; close() needed)
+        _turn_store: TurnStoreProtocol | None
         _turn_publisher: TurnPublisher | None
         _typing_publisher: TypingPublisher | None
 

--- a/src/lyra/core/hub/hub_shutdown.py
+++ b/src/lyra/core/hub/hub_shutdown.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lyra.infrastructure.stores.message_index import MessageIndex
-    from lyra.infrastructure.stores.turn_store import TurnStore
 
     from ..circuit_breaker import CircuitRegistry
     from ..memory import MemoryManager
@@ -33,7 +32,6 @@ class HubShutdownMixin:
         _pool_manager: PoolManager
         _memory_tasks: set[asyncio.Task]
         _memory: MemoryManager | None
-        _turn_store: TurnStore | None
         _message_index: MessageIndex | None
         adapter_registry: dict[tuple[Platform, str], ChannelAdapter]
         outbound_dispatchers: dict[tuple[Platform, str], OutboundDispatcher]
@@ -106,7 +104,5 @@ class HubShutdownMixin:
             await asyncio.gather(*self._memory_tasks, return_exceptions=True)
         if self._memory is not None:
             await self._memory.close()
-        if self._turn_store is not None:
-            await self._turn_store.close()
         if self._message_index is not None:
             await self._message_index.close()

--- a/src/lyra/core/hub/hub_shutdown.py
+++ b/src/lyra/core/hub/hub_shutdown.py
@@ -104,5 +104,8 @@ class HubShutdownMixin:
             await asyncio.gather(*self._memory_tasks, return_exceptions=True)
         if self._memory is not None:
             await self._memory.close()
+        # _turn_store is intentionally NOT closed here: its lifecycle is owned by
+        # bootstrap_stores.open_stores(), which closes it once in its finally block
+        # (ADR-078). The hub is a read-path consumer (TurnStoreProtocol), not the owner.
         if self._message_index is not None:
             await self._message_index.close()

--- a/src/lyra/inbound/context.py
+++ b/src/lyra/inbound/context.py
@@ -33,11 +33,11 @@ if TYPE_CHECKING:
     from lyra.core.circuit_breaker import CircuitRegistry
     from lyra.core.messaging.bus import Bus
     from lyra.core.messaging.messages import MessageManager
+    from lyra.core.stores import TurnStoreProtocol
     from lyra.core.stores.thread_store_protocol import (
         ThreadSession,
         ThreadStoreProtocol,
     )
-    from lyra.infrastructure.stores.turn_store import TurnStore
     from lyra.transport.turn_publisher import TurnPublisher
 
 
@@ -69,7 +69,7 @@ class SessionCtx:
     When ``None`` (test/CLI mode), session persistence is skipped.
     """
 
-    turn_store: TurnStore | None
+    turn_store: TurnStoreProtocol | None
     thread_store: ThreadStoreProtocol | None
     turn_publisher: TurnPublisher | None = None
     thread_sessions_cache: dict[str, ThreadSession] = field(default_factory=dict)

--- a/tests/bootstrap/test_bootstrap_stores.py
+++ b/tests/bootstrap/test_bootstrap_stores.py
@@ -388,7 +388,8 @@ class TestOpenStoresLifecycle:
                 # hub.shutdown() must NOT close the turn store
                 await hub.shutdown()
 
-        # Assert — turn_store.close() called exactly once (by open_stores.finally)
+        # Assert — full lifecycle: connect on entry, close exactly once on exit
+        mock_turn.connect.assert_awaited_once()
         assert mock_turn.close.await_count == 1, (
             f"Expected turn_store.close() to be called exactly once "
             f"(by open_stores.finally), got {mock_turn.close.await_count} call(s). "

--- a/tests/bootstrap/test_bootstrap_stores.py
+++ b/tests/bootstrap/test_bootstrap_stores.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from lyra.bootstrap.bootstrap_stores import (
     _atomic_table_copy,
     _ensure_config_db,
     _ensure_discord_db,
     _has_sentinel,
+    open_stores,
 )
 
 # ---------------------------------------------------------------------------
@@ -295,3 +299,119 @@ class TestEnsureDiscordDb:
         _ensure_discord_db(tmp_path)
         # Assert — untouched
         assert discord_path.stat().st_mtime == mtime_before
+
+
+# ---------------------------------------------------------------------------
+# open_stores lifecycle — turn_store closed exactly once (#1506 regression)
+# ---------------------------------------------------------------------------
+
+
+def _make_store_mock() -> AsyncMock:
+    """Return an AsyncMock that satisfies SqliteStore's connect/close protocol."""
+    mock = AsyncMock()
+    mock.connect = AsyncMock()
+    mock.close = AsyncMock()
+    return mock
+
+
+class TestOpenStoresLifecycle:
+    """open_stores finally block closes TurnStore exactly once (#1506).
+
+    Regression guard: hub.shutdown() previously called turn_store.close() as
+    well as the open_stores finally block, resulting in a double-close.  After
+    #1506 the close responsibility belongs ONLY to open_stores.
+    """
+
+    @pytest.mark.asyncio
+    async def test_turn_store_closed_exactly_once_across_open_stores_and_hub_shutdown(
+        self, tmp_path: Path
+    ) -> None:
+        """turn_store.close() is invoked exactly once: by open_stores.finally.
+
+        Simulates the full lifecycle:
+          1. open_stores enters and connects all stores
+          2. hub.set_turn_store() wires the store into the hub
+          3. hub.shutdown() is called (must NOT close turn_store)
+          4. open_stores context exits — finally block must close turn_store once
+        """
+        from lyra.core.hub import Hub
+
+        # Arrange — one mock per store that open_stores constructs
+        mock_turn = _make_store_mock()
+        mock_auth = _make_store_mock()
+        mock_agent = _make_store_mock()
+        mock_bot = _make_store_mock()
+        mock_prefs = _make_store_mock()
+        mock_index = _make_store_mock()
+        mock_alias = _make_store_mock()
+
+        hub = Hub()
+
+        # Patch all store constructors so open_stores never touches real SQLite.
+        # The mocks' connect() and close() are async no-ops by default.
+        with (
+            patch(
+                "lyra.bootstrap.bootstrap_stores.AuthStore",
+                return_value=mock_auth,
+            ),
+            patch(
+                "lyra.bootstrap.bootstrap_stores.IdentityAliasStore",
+                return_value=mock_alias,
+            ),
+            patch(
+                "lyra.bootstrap.bootstrap_stores.AgentStore",
+                return_value=mock_agent,
+            ),
+            patch(
+                "lyra.bootstrap.bootstrap_stores.TurnStore",
+                return_value=mock_turn,
+            ),
+            patch(
+                "lyra.bootstrap.bootstrap_stores.BotStore",
+                return_value=mock_bot,
+            ),
+            patch(
+                "lyra.bootstrap.bootstrap_stores.PrefsStore",
+                return_value=mock_prefs,
+            ),
+            patch(
+                "lyra.bootstrap.bootstrap_stores.MessageIndex",
+                return_value=mock_index,
+            ),
+            # Migration guards touch the filesystem; bypass them for lifecycle tests.
+            patch("lyra.bootstrap.bootstrap_stores._ensure_config_db"),
+            patch("lyra.bootstrap.bootstrap_stores._ensure_discord_db"),
+        ):
+            # Act — enter open_stores, wire hub, call hub.shutdown(), then exit
+            async with open_stores(tmp_path) as stores:
+                hub.set_turn_store(stores.turn)
+                # hub.shutdown() must NOT close the turn store
+                await hub.shutdown()
+
+        # Assert — turn_store.close() called exactly once (by open_stores.finally)
+        assert mock_turn.close.await_count == 1, (
+            f"Expected turn_store.close() to be called exactly once "
+            f"(by open_stores.finally), got {mock_turn.close.await_count} call(s). "
+            "A call count > 1 means hub.shutdown() is still closing the store — "
+            "the double-close regression from #1506 has been reintroduced."
+        )
+
+    @pytest.mark.asyncio
+    async def test_hub_shutdown_does_not_close_turn_store(self, tmp_path: Path) -> None:
+        """hub.shutdown() alone must not invoke turn_store.close().
+
+        This is the negative half of the regression: if hub.shutdown() is called
+        WITHOUT the open_stores context exiting, close() must not be called at all.
+        """
+        from lyra.core.hub import Hub
+
+        # Arrange
+        mock_turn = _make_store_mock()
+        hub = Hub()
+        hub.set_turn_store(mock_turn)
+
+        # Act — only hub.shutdown(); no open_stores context
+        await hub.shutdown()
+
+        # Assert — turn_store.close() must not have been called
+        mock_turn.close.assert_not_called()

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -208,16 +208,23 @@ class TestHubEvictFlushTask:
         assert len(hub._memory_tasks) >= 1
 
     @pytest.mark.asyncio
-    async def test_shutdown_closes_injected_stores(self) -> None:
-        """hub.shutdown() must close turn_store and message_index when injected."""
+    async def test_shutdown_closes_message_index_but_not_turn_store(self) -> None:
+        """hub.shutdown() must close message_index but NOT turn_store.
+
+        Turn-store lifecycle is owned by open_stores() whose finally block closes
+        it exactly once.  hub.shutdown() must never call turn_store.close() — doing
+        so would produce a double-close (#1506 regression guard).
+        """
         hub = Hub()
         mock_turn = AsyncMock()
         mock_index = AsyncMock()
         hub.set_turn_store(mock_turn)
         hub.set_message_index(mock_index)
         await hub.shutdown()
-        mock_turn.close.assert_awaited_once()
+        # message_index: still closed by hub.shutdown()
         mock_index.close.assert_awaited_once()
+        # turn_store: must NOT be closed here — open_stores.finally owns its lifecycle
+        mock_turn.close.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -207,6 +207,10 @@ class TestHubEvictFlushTask:
         # Eviction must schedule a flush task for the pool with messages
         assert len(hub._memory_tasks) >= 1
 
+
+class TestHubShutdownStoreLifecycle:
+    """hub.shutdown() store-teardown invariants (#1506)."""
+
     @pytest.mark.asyncio
     async def test_shutdown_closes_message_index_but_not_turn_store(self) -> None:
         """hub.shutdown() must close message_index but NOT turn_store.


### PR DESCRIPTION
## Summary

**Completes #1506.** PR #1519 already merged the partial widening (4 of 5 `turn_store` `.importlinter` exemptions removed) but **kept `hub_shutdown` on the concrete `TurnStore`** because it called `self._turn_store.close()` — leaving the last exemption and the `core → infrastructure` ownership inversion intact. This PR closes that gap.

- **Delete** `hub_shutdown`'s redundant `await self._turn_store.close()`. Lifecycle (connect/close) is owned solely by `bootstrap_stores.open_stores()`, whose `finally` already closes every store exactly once — both hub entrypoints (`hub_standalone.py`, `unified.py`) run inside it. The hub is a *consumer*, not the lifecycle owner; closing a store it received via `set_turn_store()` but never created was the inversion ADR-048/078 target.
- Retype the shared `Hub._turn_store` field (`hub.py`, `hub_registration`, `hub_shutdown`) uniformly to `TurnStoreProtocol | None`.
- Also retype the remaining read-path consumers #1519 left concrete: **discord/telegram adapters** + **inbound `SessionCtx`**.
- Remove the **last** `turn_store` exemption (`hub_shutdown → turn_store`) from `.importlinter` — now **zero** turn_store exemptions remain.
- Discharge **ADR-078**: "4 of 5 removed" → full elimination across all consumers + documented lifecycle-ownership rule. `TurnStoreProtocol` stays read-path only (no `close()` added).

### Out of scope (pre-existing ADR-048 debt → sibling follow-up)
`hub_shutdown` still redundantly closes `memory` + `message_index` (same `open_stores` ownership); those stores have no protocol extracted yet.

## Verification
- `uv run lint-imports` → 11 kept, 0 broken; **0** `turn_store` exemptions.
- `uv run pyright` → 0 errors/warnings.
- `uv run pytest tests/bootstrap/test_bootstrap_stores.py tests/core/test_hub_lifecycle.py` → 33 passed. New tests assert the turn store is closed **exactly once** across `open_stores`→hub-shutdown and that `hub.shutdown()` no longer closes it.

## Lifecycle
| Phase | Artifact |
|-------|----------|
| Frame | [frame](artifacts/frames/1506-widen-turnstore-wiring-protocol-frame.mdx) |
| Spec | [spec](artifacts/specs/1506-widen-turnstore-wiring-protocol-spec.mdx) (architect + axial-adr-review: good) |
| Plan | [plan](artifacts/plans/1506-widen-turnstore-wiring-protocol-plan.mdx) |

Closes #1506

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/dev\`