### PR TITLE
feat(outbound-audio): non-fatal audio stage via NullAudioConsumer sentinel (#1524)

### DIFF
--- a/src/lyra/adapters/nats/null_audio_consumer.py
+++ b/src/lyra/adapters/nats/null_audio_consumer.py
@@ -1,0 +1,26 @@
+"""NullAudioConsumer — no-op sentinel returned by start_audio_consumer on degraded boot.
+
+Satisfies the consumer interface (async stop()) so teardown calls .stop()
+unconditionally without if-guards.  No platform-axis guard code needed — the
+sentinel collapses N guard sites to zero (ADR-079 §c).
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class NullAudioConsumer:
+    """No-op sentinel returned by start_audio_consumer on audio-degraded boot.
+
+    Teardown in _close_tg_wired / _close_dc_wired calls consumer.stop()
+    unconditionally; this sentinel makes that safe regardless of whether audio
+    provisioning succeeded.  Audio messages accumulate on LYRA_OUTBOUND_AUDIO
+    (buffered by JetStream up to MaxAge=24h) and are delivered when the next
+    adapter restart succeeds.
+    """
+
+    async def stop(self) -> None:
+        """No-op: nothing to cancel or unsubscribe."""

--- a/src/lyra/bootstrap/standalone/audio_consumer_bootstrap.py
+++ b/src/lyra/bootstrap/standalone/audio_consumer_bootstrap.py
@@ -4,7 +4,8 @@ Called once per (platform, bot_id) pair from bootstrap_telegram_standalone /
 bootstrap_discord_standalone (via standalone_telegram.py / standalone_discord.py)
 after the adapter's astart() and typing-listener start() succeed.
 
-Ordering contract (mirrors turn_writer_standalone.py):
+Ordering contract (S2 state — ensure_stream/ensure_kv still here; S3 moves them
+to hub_standalone.py as sole-provisioner):
     js = nc.jetstream()          -- called once per bootstrap_*_standalone
     await ensure_stream(js)
     kv = await ensure_kv(js)     -- idempotent; KvSentSet wraps the handle
@@ -13,6 +14,9 @@ Ordering contract (mirrors turn_writer_standalone.py):
     await consumer.start()
     # ... running ...
     await consumer.stop()        -- called in _close_tg_wired / _close_dc_wired
+
+On any failure, returns NullAudioConsumer() instead of raising (ADR-079 §c).
+Teardown calls .stop() unconditionally on both real and null consumer.
 
 Consumer is per-bot (not per-platform): durable and filter_subject are scoped
 to (platform, bot_id) so each bot's consumer is bound to its own adapter send
@@ -29,6 +33,7 @@ from typing import TYPE_CHECKING
 
 from lyra.adapters.nats.jetstream_audio_consumer import JetStreamAudioConsumer
 from lyra.adapters.nats.jetstream_audio_dedup import KvSentSet
+from lyra.adapters.nats.null_audio_consumer import NullAudioConsumer
 from lyra.infrastructure.outbound_audio.stream_setup import (
     ensure_consumer,
     ensure_kv,
@@ -46,8 +51,13 @@ async def start_audio_consumer(
     platform: str,
     bot_id: str,
     adapter: object,
-) -> JetStreamAudioConsumer:
+) -> JetStreamAudioConsumer | NullAudioConsumer:
     """Provision stream/KV/consumer then construct and start a JetStreamAudioConsumer.
+
+    On any failure, logs at ERROR level and returns a NullAudioConsumer sentinel
+    instead of raising.  The adapter boots and serves text fully; audio messages
+    accumulate on LYRA_OUTBOUND_AUDIO (JetStream buffers up to MaxAge=24h) and
+    are delivered when the next adapter restart succeeds (ADR-079 §c).
 
     Args:
         js:       JetStreamContext bound to the live NATS connection.
@@ -57,33 +67,43 @@ async def start_audio_consumer(
                   ``send`` bound methods matching AudioSendFn / TextSendFn.
 
     Returns:
-        A started ``JetStreamAudioConsumer``.  The caller is responsible for
-        calling ``await consumer.stop()`` in teardown.
+        A started ``JetStreamAudioConsumer`` on success, or ``NullAudioConsumer``
+        on failure.  The caller MUST call ``await consumer.stop()`` in teardown
+        in either case — both types satisfy the async stop() contract.
     """
-    await ensure_stream(js)
-    kv = await ensure_kv(js)
+    try:
+        await ensure_stream(js)
+        kv = await ensure_kv(js)
 
-    durable = f"outbound-audio-{platform}-{bot_id}"
-    filter_subject = f"lyra.outbound.audio.{platform}.{bot_id}"
+        durable = f"outbound-audio-{platform}-{bot_id}"
+        filter_subject = f"lyra.outbound.audio.{platform}.{bot_id}"
 
-    await ensure_consumer(js, durable=durable, filter_subject=filter_subject)
+        await ensure_consumer(js, durable=durable, filter_subject=filter_subject)
 
-    consumer = JetStreamAudioConsumer(
-        js,
-        durable=durable,
-        filter_subject=filter_subject,
-        send_audio=adapter.render_audio,  # type: ignore[arg-type]
-        send_text=adapter.send,  # type: ignore[arg-type]
-        dedup=KvSentSet(kv),
-    )
-    await consumer.start()
+        consumer = JetStreamAudioConsumer(
+            js,
+            durable=durable,
+            filter_subject=filter_subject,
+            send_audio=adapter.render_audio,  # type: ignore[arg-type]
+            send_text=adapter.send,  # type: ignore[arg-type]
+            dedup=KvSentSet(kv),
+        )
+        await consumer.start()
 
-    log.info(
-        "audio_consumer_bootstrap: consumer started"
-        " (platform=%s bot_id=%s durable=%s filter=%s)",
-        platform,
-        bot_id,
-        durable,
-        filter_subject,
-    )
-    return consumer
+        log.info(
+            "audio_consumer_bootstrap: consumer started"
+            " (platform=%s bot_id=%s durable=%s filter=%s)",
+            platform,
+            bot_id,
+            durable,
+            filter_subject,
+        )
+        return consumer
+    except Exception:
+        log.exception(
+            "audio_consumer_bootstrap: audio consumer failed to start"
+            " (platform=%s bot_id=%s) — audio degraded, text unaffected",
+            platform,
+            bot_id,
+        )
+        return NullAudioConsumer()

--- a/tests/bootstrap/test_bootstrap_audio_consumer.py
+++ b/tests/bootstrap/test_bootstrap_audio_consumer.py
@@ -373,3 +373,155 @@ async def test_bootstrap_audio_consumer_discord_provisions_and_starts() -> None:
 
     mock_consumer_dc.start.assert_awaited_once()
     mock_consumer_dc.stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# S2 — NullAudioConsumer sentinel (ADR-079 §c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_audio_consumer_returns_null_on_ensure_stream_failure() -> None:
+    """Returns NullAudioConsumer (not None, no raise) when ensure_stream fails."""
+    import nats.errors
+
+    from lyra.adapters.nats.null_audio_consumer import NullAudioConsumer
+    from lyra.bootstrap.standalone.audio_consumer_bootstrap import start_audio_consumer
+
+    mock_js = MagicMock()
+
+    with patch(
+        "lyra.bootstrap.standalone.audio_consumer_bootstrap.ensure_stream",
+        new_callable=AsyncMock,
+        side_effect=nats.errors.Error("STREAM.CREATE denied"),
+    ):
+        result = await start_audio_consumer(mock_js, "telegram", "main", MagicMock())
+
+    assert isinstance(result, NullAudioConsumer)
+
+
+@pytest.mark.asyncio
+async def test_start_audio_consumer_returns_null_on_ensure_kv_failure() -> None:
+    """start_audio_consumer returns NullAudioConsumer when ensure_kv raises."""
+    from lyra.adapters.nats.null_audio_consumer import NullAudioConsumer
+    from lyra.bootstrap.standalone.audio_consumer_bootstrap import start_audio_consumer
+
+    mock_js = MagicMock()
+
+    with (
+        patch(
+            "lyra.bootstrap.standalone.audio_consumer_bootstrap.ensure_stream",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "lyra.bootstrap.standalone.audio_consumer_bootstrap.ensure_kv",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("KV create failed"),
+        ),
+    ):
+        result = await start_audio_consumer(mock_js, "discord", "main", MagicMock())
+
+    assert isinstance(result, NullAudioConsumer)
+
+
+@pytest.mark.asyncio
+async def test_start_audio_consumer_returns_real_consumer_on_success() -> None:
+    """start_audio_consumer returns the real JetStreamAudioConsumer on happy path."""
+    from lyra.adapters.nats.jetstream_audio_consumer import JetStreamAudioConsumer
+    from lyra.bootstrap.standalone.audio_consumer_bootstrap import start_audio_consumer
+
+    mock_js = MagicMock()
+    mock_kv = MagicMock()
+    mock_consumer = AsyncMock(spec=JetStreamAudioConsumer)
+    mock_adapter = MagicMock()
+    mock_adapter.render_audio = AsyncMock()
+    mock_adapter.send = AsyncMock()
+
+    with (
+        patch(
+            "lyra.bootstrap.standalone.audio_consumer_bootstrap.ensure_stream",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "lyra.bootstrap.standalone.audio_consumer_bootstrap.ensure_kv",
+            new_callable=AsyncMock,
+            return_value=mock_kv,
+        ),
+        patch(
+            "lyra.bootstrap.standalone.audio_consumer_bootstrap.ensure_consumer",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "lyra.bootstrap.standalone.audio_consumer_bootstrap.JetStreamAudioConsumer",
+            return_value=mock_consumer,
+        ),
+    ):
+        result = await start_audio_consumer(mock_js, "telegram", "main", mock_adapter)
+
+    assert result is mock_consumer
+    mock_consumer.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_null_audio_consumer_stop_is_awaitable_noop() -> None:
+    """NullAudioConsumer.stop() is awaitable and completes without error."""
+    from lyra.adapters.nats.null_audio_consumer import NullAudioConsumer
+
+    sentinel = NullAudioConsumer()
+    # Must not raise; return value is None.
+    result = await sentinel.stop()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_teardown_calls_stop_on_null_sentinel_without_error() -> None:
+    """Teardown calls .stop() on NullAudioConsumer — no if-guards, no error."""
+    from lyra.adapters.nats.null_audio_consumer import NullAudioConsumer
+    from lyra.bootstrap.standalone.adapter_standalone import (
+        _bootstrap_adapter_standalone,
+    )
+
+    stop = asyncio.Event()
+    stop.set()
+
+    mock_nc = _make_nc_mock()
+    mock_adapter = AsyncMock()
+    mock_adapter._bot_id = "main"
+    mock_adapter.resolve_identity = AsyncMock()
+    mock_adapter.astart = AsyncMock()
+    mock_adapter.close = AsyncMock()
+    mock_adapter.dp.start_polling = AsyncMock(return_value=None)
+    mock_adapter.dp.stop_polling = AsyncMock()
+    mock_adapter.render_audio = AsyncMock()
+    mock_adapter.send = AsyncMock()
+
+    mock_inbound_bus = AsyncMock()
+    mock_inbound_bus.register = MagicMock()
+
+    # Return a real NullAudioConsumer (not a mock) to verify the sentinel contract.
+    null_consumer = NullAudioConsumer()
+
+    (load_token,) = _cred_patch()
+    with (
+        patch("nats.connect", AsyncMock(return_value=mock_nc)),
+        patch("lyra.nats.nats_bus.NatsBus", return_value=mock_inbound_bus),
+        patch("lyra.adapters.telegram.TelegramAdapter", return_value=mock_adapter),
+        patch(
+            "lyra.bootstrap.wiring.standalone_telegram.NatsOutboundListener",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "lyra.bootstrap.wiring.standalone_telegram.wait_for_hub",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "lyra.bootstrap.wiring.standalone_telegram.start_audio_consumer",
+            AsyncMock(return_value=null_consumer),
+        ),
+        load_token,
+        patch.dict(os.environ, {"NATS_URL": "nats://localhost:4222"}),
+    ):
+        # Should complete without any AttributeError or TypeError from teardown.
+        await _bootstrap_adapter_standalone(
+            _make_raw_config("telegram"), "telegram", _stop=stop
+        )


### PR DESCRIPTION
## What

- New `NullAudioConsumer` sentinel in `src/lyra/adapters/nats/null_audio_consumer.py` — no-op async `stop()`, satisfies the teardown contract unconditionally.
- `start_audio_consumer` (`audio_consumer_bootstrap.py`) wraps its entire body in `try/except Exception`. On failure: logs `ERROR` with "audio degraded, text unaffected" and returns `NullAudioConsumer()`. On success: returns the real `JetStreamAudioConsumer`. Never returns `None`.
- Return type updated: `JetStreamAudioConsumer | NullAudioConsumer`.
- Teardown unchanged — `_close_tg_wired` / `_close_dc_wired` already call `consumer.stop()` unconditionally; the sentinel makes that safe with no per-platform if-guards.
- Ordering docstring updated to reflect S2 state (`ensure_stream`/`ensure_kv` still here; note that S3 moves them to hub).

## Why (degrade not crash)

Audio provisioning failures (missing ACL grants, JetStream not ready, transient network) previously raised unconditionally from `start_audio_consumer`, crashing the entire adapter and taking text messaging down with it. The sentinel collapses the crash to a degraded-audio boot. Audio messages buffer in JetStream (`MaxAge=24h`) and deliver automatically when the next restart succeeds. Single observability grep: `journalctl --user -u lyra-{discord,telegram} | grep "audio degraded"`.

ADR-079 §c explicitly prohibits per-platform `if consumer is not None` guards — the sentinel pattern is the structural fix.

## Tests

5 new tests in `tests/bootstrap/test_bootstrap_audio_consumer.py`:

- `test_start_audio_consumer_returns_null_on_ensure_stream_failure` — monkeypatches `ensure_stream` to raise `nats.errors.Error`; asserts `NullAudioConsumer` returned, no raise.
- `test_start_audio_consumer_returns_null_on_ensure_kv_failure` — monkeypatches `ensure_kv` to raise; asserts `NullAudioConsumer` returned.
- `test_start_audio_consumer_returns_real_consumer_on_success` — happy path; asserts real consumer returned and `start()` awaited.
- `test_null_audio_consumer_stop_is_awaitable_noop` — `await NullAudioConsumer().stop()` returns `None`, no error.
- `test_teardown_calls_stop_on_null_sentinel_without_error` — wires a real `NullAudioConsumer` through the Telegram bootstrap and confirms teardown completes without error.

All 9 tests in the file pass. Full suite: 5036 passed, 1 pre-existing NATS server e2e skip.

## Slice

S2 of #1521 (ADR-079). Ships before S3 (sole-provisioner) so the safety-net is live before ACL surface is restructured.

Closes #1524
Related: ADR-079 (`docs/architecture/adr/079-audio-nats-contract-axial-consolidation.mdx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)