### PR TITLE
refactor(core): finish ADR-048 ownership for message_index store

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -31,12 +31,8 @@ ignore_imports =
     lyra.core.hub.hub -> lyra.infrastructure.stores.identity_alias_store
     lyra.core.hub.hub_registration -> lyra.infrastructure.stores.identity_alias_store
     # TYPE_CHECKING imports for migrated stores (#935) — DEBT:importlinter-adr048-transition
-    lyra.core.hub.hub -> lyra.infrastructure.stores.message_index
     lyra.core.hub.hub -> lyra.infrastructure.stores.pairing
     lyra.core.hub.hub -> lyra.infrastructure.stores.prefs_store
-    lyra.core.hub.hub_registration -> lyra.infrastructure.stores.message_index
-    lyra.core.hub.hub_shutdown -> lyra.infrastructure.stores.message_index
-    lyra.core.pool.pool_observer -> lyra.infrastructure.stores.message_index
 
 [importlinter:contract:core-stores-no-sqlite]
 name = core/stores protocols must not import SQLite drivers

--- a/artifacts/frames/1529-relocate-hub-shutdown-closes-frame.mdx
+++ b/artifacts/frames/1529-relocate-hub-shutdown-closes-frame.mdx
@@ -1,0 +1,92 @@
+---
+title: Relocate hub_shutdown memory/message_index closes to bootstrap (finish ADR-048 ownership)
+issue: 1529
+status: approved
+tier: F-lite
+date: 2026-05-30
+---
+
+## Problem
+
+`#1506` (PR #1523) established the ADR-078 lifecycle-ownership rule: store
+`connect()`/`close()` is owned **solely** by `bootstrap_stores.open_stores()`, whose
+`finally` block closes every store exactly once. It removed `hub_shutdown`'s redundant
+`turn_store.close()` and left the explanatory comment now at `hub_shutdown.py:107-109`.
+
+The **same redundant-close pattern remains for two more stores** in
+`HubShutdownMixin.shutdown()`:
+
+- `self._message_index.close()` (`hub_shutdown.py:111`) — `message_index` is already
+  closed by `open_stores`'s `finally` (`bootstrap_stores.py:305`). This is a **redundant
+  second close** *and* a `core → infrastructure` ownership inversion that still carries
+  `.importlinter` `DEBT:importlinter-adr048-transition` exemptions.
+- `self._memory.close()` (`hub_shutdown.py:106`) — `MemoryManager`. Ownership is **not
+  yet verified**: `MemoryManager` is not visibly in the `StoreBundle` that `open_stores`
+  manages, so removal is gated on confirming who actually owns its lifecycle.
+
+These are the last residue (for these stores) of the `lyra.core ← lyra.infrastructure`
+layering inversion that ADR-048/078 exist to remove.
+
+## Who
+
+- **Primary:** Lyra maintainers working in `core/` — every `hub_shutdown` /
+  `bootstrap_stores` edit reasons about store lifecycle; a redundant close is a latent
+  double-close / use-after-close trap and an architectural false signal.
+- **Secondary:** the import-layer gate (`.importlinter`) — each freed exemption removes a
+  sanctioned `core → infrastructure` edge, tightening the ADR-048 boundary for everyone.
+
+## Constraints
+
+- **Ownership-first (per #1506):** verify `open_stores` (or equivalent) owns `close` for
+  `message_index` **and** `memory` in **every** hub/adapter mode *before* removing any
+  close — same check applied to `turn_store` in #1506.
+- **No read-path protocol exists yet:** unlike `turn_store` (`TurnStoreProtocol` predated
+  #1506), there is **no** `MessageIndexProtocol` / `MemoryManagerProtocol`. Retyping fields
+  to a read-path protocol may require **protocol extraction first** — a prerequisite the
+  spec must size.
+- **Exemption removal is conditional:** drop a `.importlinter`
+  `DEBT:importlinter-adr048-transition` exemption only as each becomes eligible (i.e. once
+  the runtime import is gone and any residual is TYPE_CHECKING-only / removed).
+- **Pattern reference:** #1506 / PR #1523 — reuse its lifecycle-ownership approach verbatim.
+
+## Out of Scope
+
+- `turn_store` lifecycle — already relocated in #1506.
+- Any store **not** named here (identity/alias, audit, etc.) beyond exemptions directly
+  freed by this change.
+- Broader ADR-048 migration of unrelated `core → infrastructure` edges.
+- Behavioural change to shutdown ordering beyond removing the redundant close calls.
+
+## Premise Validity
+
+*Auto-derived from the issue body + #1506 precedent — correct any field on review.*
+
+**Success in 6 months:** `HubShutdownMixin.shutdown()` no longer calls `close()` on any
+store it does not own; `message_index` (and `memory`, if owned by bootstrap) are closed
+exactly once, by `open_stores`'s `finally`; the `message_index` `adr048-transition`
+exemptions in `.importlinter` are gone.
+
+**Failure in 6 months:** the `message_index` / `memory` `DEBT:importlinter-adr048-transition`
+exemptions still present in `.importlinter` (measurable: `grep` count unchanged), **or** a
+double-close / use-after-close regression observed in hub shutdown. Falsifiable boolean +
+exemption count.
+
+**Simplest alternative:** delete the two `close()` lines in `hub_shutdown.py` directly.
+
+**Why not simplest:** (1) `memory` ownership is unverified — blind removal risks leaking an
+unclosed DB or a use-after-close if bootstrap does *not* own it; (2) the `.importlinter`
+exemptions are bound to the `TYPE_CHECKING` import of the concrete store — they cannot be
+fully dropped without the read-path-protocol retype, which may need protocol extraction
+first. Deleting the calls alone neither verifies ownership nor frees all exemptions.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (store lifecycle + `core/infrastructure`
+layering), direct precedent in #1506; the only unknowns (memory ownership, protocol
+extraction) are narrow enough to resolve in spec rather than a full analysis pass.
+
+Signals observed:
+- Two stores, mechanical close-relocation following an established pattern (#1506).
+- Spans `core/hub`, `bootstrap`, `infrastructure/stores`, `.importlinter` — single concern.
+- One genuine unknown (memory ownership) + one conditional prerequisite (protocol extraction).
+- Label `P3-low`; no size label.

--- a/artifacts/plans/1529-relocate-hub-shutdown-closes-plan.mdx
+++ b/artifacts/plans/1529-relocate-hub-shutdown-closes-plan.mdx
@@ -1,0 +1,221 @@
+---
+title: "Plan: Relocate hub_shutdown message_index close + extract MessageIndexProtocol"
+issue: 1529
+spec: artifacts/specs/1529-relocate-hub-shutdown-closes-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-05-30
+---
+
+## Summary
+
+Finish ADR-048/078 ownership for the `message_index` store: remove `hub_shutdown`'s redundant
+`.close()`, extract a `MessageIndexProtocol` (`resolve` + `upsert`) in `core/stores/`, retype the
+3 core consumers, free all 4 `.importlinter` `adr048-transition` exemptions, and document
+`memory`'s correct hub-ownership (premise correction — no relocation).
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph core_stores [core/stores]
+        P[MessageIndexProtocol\nresolve + upsert]
+        INIT[__init__.py export]
+    end
+    subgraph core_consumers [core consumers — typed as protocol]
+        H[hub.py annotation]
+        HR[hub_registration.py set_message_index]
+        PO[pool_observer.py register + upsert]
+        PV[path_validation.py resolve — via hub attr]
+        PM[pool_manager.py passes — via hub attr]
+    end
+    subgraph infra [infrastructure/stores]
+        MI[MessageIndex concrete]
+    end
+    subgraph bootstrap [bootstrap]
+        OS[open_stores finally\nclose once]
+    end
+    P --> INIT
+    INIT --> H & HR & PO
+    H -.-> PV & PM
+    MI -. implements structural .-> P
+    OS -->|owns connect/close| MI
+    HS[hub_shutdown.py\nclose REMOVED] -.x.-> MI
+    style P fill:#d4edda
+    style HS fill:#f8d7da
+```
+
+### File × change map
+
+```mermaid
+flowchart LR
+    subgraph create [create]
+        MIP[core/stores/message_index_protocol.py]
+    end
+    subgraph modify [modify]
+        INIT2[core/stores/__init__.py]
+        HUB[hub.py]
+        HREG[hub_registration.py]
+        POBS[pool_observer.py]
+        HSHUT[hub_shutdown.py]
+        IL[.importlinter]
+    end
+    subgraph tests [tests]
+        TSHUT[test shutdown — close-once]
+        TCONF[test protocol conformance]
+    end
+    MIP --> INIT2 --> HUB & HREG & POBS
+    HSHUT --> IL
+    HUB & HREG & POBS --> IL
+    HSHUT --> TSHUT
+    MIP --> TCONF
+```
+
+## Agents
+
+| Agent | Instance | Tasks | Files |
+|-------|----------|-------|-------|
+| backend-dev | backend-dev-A | T1, T3, T4, T5 | hub_shutdown.py, core/stores/*, hub.py, hub_registration.py, pool_observer.py, .importlinter |
+| tester | tester-A | T2, T6 | tests/ (shutdown, protocol conformance) |
+
+architect/devops/doc-writer not assigned: protocol mirrors existing `TurnStoreProtocol` pattern
+(architect already reviewed spec); `.importlinter` edits are coupled to code (owned by backend-dev-A);
+no docs/API surface change.
+
+## Wave Structure
+
+4 waves, max 2 parallel agents. Elapsed ~½ day vs ~1 day sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 (backend-dev-A serial) | backend-dev-A: T1 → T3 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-A: T4 · tester-A: T2 |
+| 3 | T4 done | 1 | backend-dev-A: T5 |
+| 4 | T5 done | 1 | tester-A: T6 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 hub_shutdown decouple + exemption 38 + memory comment | 1 | judgmental | 5 | — |
+| T2 shutdown close-once test | 1 | judgmental | 5 | — |
+| T3 create protocol + export | 2 | bounded | 3 | — |
+| T4 retype 3 consumers | 3 | judgmental | 6 | — |
+| T5 remove exemptions 34/37/39 | 1 | trivial | 2 | — |
+| T6 conformance test + gates | 1 | judgmental | 6 | — |
+
+**Total estimated ops: ~27**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T3, T4, T5 | 16 | message-index | — |
+| tester-A | T2, T6 | 11 | message-index | — |
+
+All caps clear (≤4 tasks, ≤50 ops, 1 subject per instance).
+
+## Consistency Report
+
+8/8 spec success-criteria traced. 0 uncovered, 0 untraced.
+
+| SC | Criterion | Task(s) |
+|----|-----------|---------|
+| SC1 | hub_shutdown no close/import; memory comment | T1 |
+| SC2 | MessageIndexProtocol exists + exported, exact sigs | T3 |
+| SC3 | concrete MessageIndex satisfies protocol | T3, T6 |
+| SC4 | 3 consumers typed to protocol; transitive sites OK | T4 |
+| SC5 | 4 exemptions removed; import-layers green | T1 (38), T5 (34/37/39) |
+| SC6 | message_index closed exactly once | T1, T2 |
+| SC7 | ruff + pyright + pytest green | T6 |
+| SC8 | memory unchanged + premise recorded | T1 |
+
+## Micro-Tasks
+
+### V1 — hub_shutdown cleanup
+
+**T1 — Decouple hub_shutdown from message_index** · backend-dev-A · subject: message-index · SC1/SC5/SC6/SC8 · diff 2 · `[P:N]`
+- File: `src/lyra/core/hub/hub_shutdown.py`, `.importlinter`
+- Do: remove `await self._message_index.close()` (:111) + its `if self._message_index is not None` guard; remove TYPE_CHECKING `MessageIndex` import (:13) + `_message_index` annotation (:35). Retain `_memory.close()` (:105-106); add a comment mirroring the `_turn_store` comment (:107-109): `MemoryManager` is hub-owned (core class, never a bootstrap store) — close belongs here when `_memory` is populated. Remove `.importlinter` line 38 (`hub_shutdown -> message_index`).
+- Verify: `grep -n "_message_index" src/lyra/core/hub/hub_shutdown.py` → empty; `uv run lint-imports` (import-layers) → passes.
+
+**T2 — Shutdown close-once test** · tester-A · subject: message-index · SC6/SC7 · diff 3 · `[P:Y w/T3]` · dep: T1 · **RED-GATE V1**
+- File: `tests/` (extend existing hub_shutdown/shutdown test, or add)
+- Do: assert hub shutdown does NOT call `message_index.close()` (bootstrap owns it) and `open_stores` closes it once; assert `_memory.close()` still invoked when `_memory` set (guard intact).
+- Verify: `uv run pytest -k "shutdown" -q` → green.
+
+### V2 — MessageIndexProtocol
+
+**T3 — Create + export MessageIndexProtocol** · backend-dev-A · subject: message-index · SC2/SC3 · diff 2 · `[P:Y]`
+- File: `src/lyra/core/stores/message_index_protocol.py` (new), `src/lyra/core/stores/__init__.py`
+- Shape:
+  ```python
+  from typing import Literal, Protocol, runtime_checkable
+
+  @runtime_checkable
+  class MessageIndexProtocol(Protocol):
+      async def resolve(self, pool_id: str, platform_msg_id: str) -> str | None: ...
+      async def upsert(
+          self, pool_id: str, platform_msg_id: str | None,
+          session_id: str, role: Literal["user", "assistant"],
+      ) -> None: ...
+  ```
+  Mirror `turn_store_protocol.py`. Export `MessageIndexProtocol` from `core/stores/__init__.py`.
+- Verify: `uv run python -c "from lyra.core.stores import MessageIndexProtocol"` → no error.
+
+**T4 — Retype 3 core consumers** · backend-dev-A · subject: message-index · SC4 · diff 3 · `[P:N]` · dep: T3
+- Files: `src/lyra/core/hub/hub.py` (:36 import, :102 annotation), `src/lyra/core/hub/hub_registration.py` (:17 import, :87 param), `src/lyra/core/pool/pool_observer.py` (:8 import, :57 param, annotation)
+- Do: replace concrete `MessageIndex` import/annotation with `MessageIndexProtocol`. `path_validation.py` + `pool_manager.py` need NO change (reach via `hub._message_index`).
+- Verify: `grep -rn "infrastructure.stores.message_index" src/lyra/core/` → empty; `uv run pyright src/lyra/core` → 0 new errors.
+
+**T5 — Remove remaining exemptions** · backend-dev-A · subject: message-index · SC5 · diff 1 · `[P:N]` · dep: T4
+- File: `.importlinter`
+- Do: remove the 3 `message_index` exemption lines (hub, hub_registration, pool_observer — orig 34/37/39).
+- Verify: `grep -c "message_index" .importlinter` → 0; `uv run lint-imports` → passes.
+
+**T6 — Conformance test + full gates** · tester-A · subject: message-index · SC3/SC7 · diff 3 · `[P:N]` · dep: T4,T5 · **RED-GATE V2**
+- File: `tests/`
+- Do: test that concrete `MessageIndex` satisfies `MessageIndexProtocol` (`isinstance(MessageIndex(...), MessageIndexProtocol)` via `@runtime_checkable`, or a pyright-asserted assignment). Run full gates.
+- Verify: `uv run pytest -q && uv run pyright && uv run ruff check . && uv run lint-imports` → all green.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T-numbers ref this list, not session IDs. -->
+
+### Wave 1 — no deps
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | message-index |
+| T3 | backend-dev-A | — | message-index |
+
+### Wave 2 — after Wave 1
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | tester-A | T1 | message-index |
+| T4 | backend-dev-A | T3 | message-index |
+
+### Wave 3 — after T4
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | backend-dev-A | T4 | message-index |
+
+### Wave 4 — after T5
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | tester-A | T4, T5 | message-index |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — message-index (hub_shutdown decouple)
+- T2: 14 — message-index (shutdown close-once test)
+- T3: 15 — message-index (create MessageIndexProtocol)
+- T4: 16 — message-index (retype consumers)
+- T5: 17 — message-index (remove exemptions)
+- T6: 18 — message-index (conformance test + gates)

--- a/artifacts/specs/1529-relocate-hub-shutdown-closes-spec.mdx
+++ b/artifacts/specs/1529-relocate-hub-shutdown-closes-spec.mdx
@@ -1,0 +1,152 @@
+---
+title: Relocate hub_shutdown message_index close + extract MessageIndexProtocol (finish ADR-048 ownership)
+issue: 1529
+status: approved
+tier: F-lite
+date: 2026-05-30
+promoted_from: artifacts/frames/1529-relocate-hub-shutdown-closes-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1529-relocate-hub-shutdown-closes-frame.mdx` (approved).
+Precedent: #1506 / PR #1523 — relocated `turn_store.close()` to `open_stores`' finally and
+established the ADR-078 lifecycle-ownership rule. This spec applies the same rule to
+`message_index`, and **corrects the issue's premise for `memory`** based on investigation.
+
+Investigation findings (this branch):
+
+- **message_index** is a bootstrap-owned store: `StoreBundle.message_index`
+  (`bootstrap_stores.py:237`), closed once by `open_stores`' `finally`
+  (`bootstrap_stores.py:300`). `hub_shutdown.py:111` `self._message_index.close()` is a
+  **redundant second close** + a `core → infrastructure` inversion.
+- **4 concrete `MessageIndex` imports in core** (all `TYPE_CHECKING`) — exactly the 4
+  `.importlinter` `DEBT:importlinter-adr048-transition` exemptions (lines 34/37/38/39):
+  `hub.py:36`, `hub_registration.py:17`, `hub_shutdown.py:13`, `pool_observer.py:8`.
+- **2 further core consumers reach `message_index` via the hub attribute** (no own import,
+  no exemption): `path_validation.py:73` calls `.resolve()`; `pool_manager.py:73` passes it
+  to `register_message_index()`. Retyping `hub._message_index` covers them transitively.
+- Core's real method surface on `message_index` = **`resolve()`** (read, path_validation) +
+  **`upsert()`** (write, pool_observer). `connect()`/`close()` are bootstrap-owned;
+  `cleanup_older_than()` is not called from core.
+- **memory premise is WRONG.** `MemoryManager` is a **core** class (`core/memory/memory.py`),
+  **not** in `StoreBundle`, never connected/closed by bootstrap. `self._memory` is `None` in
+  every production path (`set_memory()` has zero prod call sites). hub's `_memory.close()` is
+  a hub-owned guarded call, **not** redundant-with-bootstrap, with **no exemption** attached.
+
+## Goal
+
+Eliminate the `message_index` `core → infrastructure` coupling: remove hub_shutdown's
+redundant close and retype core's `message_index` consumers to a `MessageIndexProtocol`,
+freeing all 4 `adr048-transition` exemptions — and document `memory`'s correct (hub-owned)
+ownership rather than wrongly "relocating" it.
+
+## Users
+
+- **Primary:** Lyra `core/` maintainers — shutdown path no longer double-closes a
+  bootstrap-owned store; `message_index` consumers depend on a core protocol, not a
+  concrete infra type.
+- **Secondary:** the `import-layers` gate — 4 sanctioned `core → infrastructure` edges removed.
+
+## Expected Behavior
+
+1. On hub shutdown, `message_index` is closed **exactly once** — by `open_stores`' `finally`,
+   not by `HubShutdownMixin.shutdown()`.
+2. Core modules referencing `message_index` are typed against
+   `lyra.core.stores.message_index_protocol.MessageIndexProtocol` (a driven-port-style
+   Protocol exposing `resolve()` + `upsert()`), mirroring `TurnStoreProtocol`
+   (`core/stores/turn_store_protocol.py`).
+3. The concrete `lyra.infrastructure.stores.message_index.MessageIndex` satisfies the
+   protocol structurally — no runtime/behavioral change to the implementation.
+4. `.importlinter` no longer needs the 4 `message_index` `adr048-transition` exemptions;
+   the `import-layers` gate passes without them.
+5. `memory`: behavior unchanged. `_memory.close()` is retained with a clarifying comment that
+   `MemoryManager` is **hub-owned** (a core class, never a bootstrap store), correcting the
+   issue's conflation with `message_index`.
+
+## Data Model & Consumers
+
+### Protocol + implementation
+
+```mermaid
+classDiagram
+    class MessageIndexProtocol {
+        <<Protocol — core/stores>>
+        +resolve(pool_id, platform_msg_id) str | None
+        +upsert(pool_id, platform_msg_id, session_id, role) None
+    }
+    class MessageIndex {
+        <<infrastructure/stores — concrete>>
+        +connect() None
+        +resolve(pool_id, platform_msg_id) str | None
+        +upsert(pool_id, platform_msg_id, session_id, role) None
+        +cleanup_older_than(days) int
+        +close() None
+    }
+    MessageIndex ..|> MessageIndexProtocol : implements (structural)
+```
+
+Lifecycle methods (`connect`/`close`) intentionally **excluded** from the protocol — owned by
+`bootstrap_stores.open_stores`, not core. `cleanup_older_than` excluded — not a core consumer.
+
+### Consumer map
+
+```mermaid
+flowchart TD
+    P[MessageIndexProtocol\ncore/stores]
+    H[hub.py\n_message_index annotation] -->|typed as| P
+    HR[hub_registration.py\nset_message_index param] -->|typed as| P
+    PO[pool_observer.py\nregister_message_index + .upsert] -->|typed as| P
+    PV[path_validation.py\nhub._message_index.resolve] -.->|via hub attr| P
+    PM[pool_manager.py\npasses hub._message_index| -.->|via hub attr| P
+    HS[hub_shutdown.py] -.->|close REMOVED| X[no message_index ref]
+    BS[bootstrap_stores.open_stores\nfinally: close once] -->|owns lifecycle| MI[MessageIndex concrete]
+    MI -. implements .-> P
+```
+
+### Consumer summary
+
+| Consumer | Uses | When | Change | Status |
+|---|---|---|---|---|
+| `hub.py:36,102` | annotation `_message_index` | — | import + annotate `MessageIndexProtocol` | this issue |
+| `hub_registration.py:17,87,90` | `set_message_index(store)` param + wire to observer | wiring | retype param → protocol | this issue |
+| `pool_observer.py:8,57,204` | `register_message_index` param + `.upsert()` | per turn (write) | retype → protocol | this issue |
+| `hub_shutdown.py:13,35,111` | `.close()` only | shutdown | **remove** call + import + annotation | this issue |
+| `path_validation.py:73` | `hub._message_index.resolve()` | reply-to-resume (read) | none (transitive via hub attr) | this issue |
+| `pool_manager.py:73` | passes `hub._message_index` | pool create | none (transitive via hub attr) | this issue |
+| `bootstrap_stores.py:300` | `connect()` + `close()` | startup/shutdown | none — already sole owner | done (#own) |
+
+## Breadboard
+
+| ID | Affordance | Handler / location | Wiring |
+|---|---|---|---|
+| N1 | `MessageIndexProtocol` | new `core/stores/message_index_protocol.py` | exported via `core/stores/__init__.py` |
+| N2 | `resolve(pool_id: str, platform_msg_id: str) -> str \| None` | protocol method | verbatim from `MessageIndex.resolve` (`message_index.py:59`) |
+| N3 | `upsert(pool_id: str, platform_msg_id: str \| None, session_id: str, role: Literal["user","assistant"]) -> None` | protocol method | verbatim from `MessageIndex.upsert` (`message_index.py:40`) — **`platform_msg_id` is `str \| None`**; protocol MUST match exactly or pyright structural check fails (input contravariance) |
+| N4 | concrete `MessageIndex` conforms | `infrastructure/stores/message_index.py` | structural; pyright verifies |
+| N5 | retype 3 core sites | `hub.py`, `hub_registration.py`, `pool_observer.py` | import N1, drop concrete import |
+| N6 | remove redundant close | `hub_shutdown.py:111` (+ import :13, annotation :35) | bootstrap owns close |
+| N7 | drop 4 exemptions | `.importlinter:34,37,38,39` | import-layers gate green |
+| N8 | memory ownership comment | `hub_shutdown.py:105-106` | retain close; document hub-ownership |
+
+## Slices
+
+| # | Slice | Affordances | Independently demo-able |
+|---|---|---|---|
+| 1 | **hub_shutdown cleanup** — remove `_message_index.close()` + concrete import + annotation; drop exemption line 38; add `memory` ownership comment (retain `_memory.close()`) | N6, N8, partial N7 | `import-layers` green w/o line 38; shutdown closes message_index once; `pytest` green |
+| 2 | **MessageIndexProtocol extraction** — create N1 (resolve+upsert), export, conform concrete `MessageIndex`; retype `hub.py`/`hub_registration.py`/`pool_observer.py`; drop exemptions 34/37/39 | N1–N5, rest of N7 | `import-layers` green w/ all 4 message_index exemptions gone; `pyright` green; `path_validation`/`pool_manager` typecheck via hub attr |
+
+No smart-split: single cohesive refactor, 2 natural increments, criteria are verification
+points (not separable deliverables). Slice 1 is shippable alone (frees 1 exemption); Slice 2
+completes the goal.
+
+## Success Criteria
+
+- [ ] `hub_shutdown.py` no longer calls `_message_index.close()` nor imports concrete `MessageIndex`; `_memory.close()` retained with a comment documenting hub-ownership (core class, not a bootstrap store).
+- [ ] `MessageIndexProtocol` exists in `core/stores/message_index_protocol.py` exposing `resolve()` + `upsert()` with signatures matching the concrete impl, exported from `core/stores/__init__.py`.
+- [ ] Concrete `infrastructure/stores/message_index.MessageIndex` satisfies `MessageIndexProtocol` (pyright structural check); no behavioral change to the implementation.
+- [ ] `hub.py`, `hub_registration.py`, `pool_observer.py` reference `MessageIndexProtocol`, not the concrete `MessageIndex`; `path_validation.py` + `pool_manager.py` typecheck unchanged (via hub attribute).
+- [ ] All 4 `message_index` `DEBT:importlinter-adr048-transition` exemptions (`.importlinter:34,37,38,39`) removed; `import-layers` gate passes.
+- [ ] `message_index` is closed exactly once (by `open_stores` finally) — no double-close; verified by an existing/added shutdown test or explicit inspection note.
+- [ ] No regression: `ruff` + `pyright` + `pytest` all green in the worktree.
+- [ ] `memory` left functionally unchanged and explicitly out of scope for relocation (premise correction recorded in spec + code comment).

--- a/src/lyra/core/hub/hub.py
+++ b/src/lyra/core/hub/hub.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from collections import deque
 
     from lyra.infrastructure.stores.identity_alias_store import IdentityAliasStore
-    from lyra.infrastructure.stores.message_index import MessageIndex
     from lyra.infrastructure.stores.pairing import PairingManager
     from lyra.infrastructure.stores.prefs_store import PrefsStore
     from lyra.transport.turn_publisher import TurnPublisher
@@ -47,7 +46,7 @@ if TYPE_CHECKING:
     from ..ports.resume_publisher import ResumePublisherPort
     from ..ports.stt import STTProtocol
     from ..ports.tts import TtsProtocol
-    from ..stores import TurnStoreProtocol
+    from ..stores import MessageIndexProtocol, TurnStoreProtocol
     from .event_bus import PipelineEventBus
     from .outbound import OutboundDispatcher
 
@@ -99,7 +98,7 @@ class Hub(
                 " — STT error replies will use hardcoded fallbacks"
             )
         self._pairing_manager = pairing_manager
-        self._message_index: MessageIndex | None = None
+        self._message_index: MessageIndexProtocol | None = None
         self._stt: STTProtocol | None = stt
         self._tts_value: TtsProtocol | None = tts
         self._pool_ttl = cfg.pool_ttl

--- a/src/lyra/core/hub/hub_registration.py
+++ b/src/lyra/core/hub/hub_registration.py
@@ -12,9 +12,8 @@ from ..messaging.message import InboundMessage, Platform
 from .hub_protocol import Binding, ChannelAdapter, RoutingKey
 
 if TYPE_CHECKING:
-    from lyra.core.stores import TurnStoreProtocol
+    from lyra.core.stores import MessageIndexProtocol, TurnStoreProtocol
     from lyra.infrastructure.stores.identity_alias_store import IdentityAliasStore
-    from lyra.infrastructure.stores.message_index import MessageIndex
     from lyra.transport.turn_publisher import TurnPublisher
     from lyra.transport.typing_publisher import TypingPublisher
 
@@ -39,7 +38,7 @@ class HubRegistrationMixin:
         _authenticators: dict[tuple[Platform, str], Authenticator]
         _memory: MemoryManager | None
         _memory_tasks: set
-        _message_index: MessageIndex | None
+        _message_index: MessageIndexProtocol | None
         _platform_queue_maxsize: int
         _turn_store: TurnStoreProtocol | None
         _turn_publisher: TurnPublisher | None
@@ -84,7 +83,7 @@ class HubRegistrationMixin:
         """Wire the TypingPublisher (called by bootstrap; consumed by T2)."""
         self._typing_publisher = publisher
 
-    def set_message_index(self, store: MessageIndex) -> None:
+    def set_message_index(self, store: MessageIndexProtocol) -> None:
         self._message_index = store
         for pool in self.pools.values():
             pool._observer.register_message_index(store)

--- a/src/lyra/core/hub/hub_shutdown.py
+++ b/src/lyra/core/hub/hub_shutdown.py
@@ -10,8 +10,6 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lyra.infrastructure.stores.message_index import MessageIndex
-
     from ..circuit_breaker import CircuitRegistry
     from ..memory import MemoryManager
     from ..messaging.message import Platform
@@ -32,7 +30,6 @@ class HubShutdownMixin:
         _pool_manager: PoolManager
         _memory_tasks: set[asyncio.Task]
         _memory: MemoryManager | None
-        _message_index: MessageIndex | None
         adapter_registry: dict[tuple[Platform, str], ChannelAdapter]
         outbound_dispatchers: dict[tuple[Platform, str], OutboundDispatcher]
         circuit_registry: CircuitRegistry | None
@@ -102,10 +99,10 @@ class HubShutdownMixin:
             await self._pool_manager.flush_pool(pool_id, "shutdown")
         if self._memory_tasks:
             await asyncio.gather(*self._memory_tasks, return_exceptions=True)
+        # _memory (MemoryManager) IS hub-owned: it is a core class, not a StoreBundle
+        # entry, and is never connected/closed by open_stores(). Closing here is correct.  # noqa: E501
         if self._memory is not None:
             await self._memory.close()
-        # _turn_store is intentionally NOT closed here: its lifecycle is owned by
-        # bootstrap_stores.open_stores(), which closes it once in its finally block
-        # (ADR-078). The hub is a read-path consumer (TurnStoreProtocol), not the owner.
-        if self._message_index is not None:
-            await self._message_index.close()
+        # _turn_store and _message_index are intentionally NOT closed here: their
+        # lifecycle is owned by bootstrap_stores.open_stores(), which closes each once
+        # in its finally block (ADR-078). The hub is a consumer, not the owner.

--- a/src/lyra/core/pool/pool_observer.py
+++ b/src/lyra/core/pool/pool_observer.py
@@ -4,13 +4,13 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Literal
 
+from ..stores.message_index_protocol import MessageIndexProtocol
+from ..stores.turn_store_protocol import TurnStoreProtocol
+
 if TYPE_CHECKING:
-    from lyra.infrastructure.stores.message_index import MessageIndex
     from lyra.transport.turn_publisher import TurnPublisher
 
     from ..messaging.message import InboundMessage
-
-from ..stores.turn_store_protocol import TurnStoreProtocol
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class PoolObserver:
 
         self._turn_store: TurnStoreProtocol | None = None
         self._turn_publisher: TurnPublisher | None = None
-        self._message_index: MessageIndex | None = None
+        self._message_index: MessageIndexProtocol | None = None
         self._turn_logger: Callable[[str, InboundMessage], Awaitable[None]] | None = (
             None
         )
@@ -54,7 +54,7 @@ class PoolObserver:
         """Wire the TurnPublisher for NATS-backed turn writes."""
         self._turn_publisher = publisher
 
-    def register_message_index(self, store: MessageIndex) -> None:
+    def register_message_index(self, store: MessageIndexProtocol) -> None:
         """Wire the MessageIndex for session routing on reply-to (#341)."""
         self._message_index = store
 

--- a/src/lyra/core/stores/__init__.py
+++ b/src/lyra/core/stores/__init__.py
@@ -6,12 +6,14 @@ This package re-exports only protocol-safe symbols for backward compatibility.
 
 from .agent_store_protocol import AgentStoreProtocol
 from .bot_store_protocol import BotStoreProtocol
+from .message_index_protocol import MessageIndexProtocol
 from .thread_store_protocol import ThreadStoreProtocol
 from .turn_store_protocol import SessionRow, TurnRow, TurnStoreProtocol
 
 __all__ = [
     "AgentStoreProtocol",
     "BotStoreProtocol",
+    "MessageIndexProtocol",
     "SessionRow",
     "ThreadStoreProtocol",
     "TurnRow",

--- a/src/lyra/core/stores/message_index_protocol.py
+++ b/src/lyra/core/stores/message_index_protocol.py
@@ -1,0 +1,41 @@
+"""MessageIndexProtocol — structural interface for the message-to-session index.
+
+Decouples lyra.core from the concrete SQLite MessageIndex implementation
+(lyra.infrastructure.stores.message_index). Fixes the layering inversion where
+core modules imported an infrastructure type directly (issue #1529).
+
+Factory: obtain a store via the bootstrap layer; type-annotate against this
+protocol so that any conforming implementation (SQLite, in-memory, …) can be
+wired in transparently.
+
+Lifecycle methods (connect/close) and cleanup_older_than are intentionally
+excluded — not core's concern; lifecycle is owned by bootstrap_stores.open_stores()
+per ADR-078.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol, runtime_checkable
+
+__all__ = ["MessageIndexProtocol"]
+
+
+@runtime_checkable
+class MessageIndexProtocol(Protocol):
+    """Read/write structural protocol for MessageIndex consumers in lyra.core.
+
+    Covers the public interface used by core/ modules (hub_registration,
+    pool_observer). Lifecycle methods (connect/close) and cleanup_older_than
+    are intentionally excluded — lifecycle is owned by bootstrap_stores.open_stores()
+    (ADR-078); the hub is a write-path consumer, not the owner.
+    """
+
+    async def resolve(self, pool_id: str, platform_msg_id: str) -> str | None: ...
+
+    async def upsert(
+        self,
+        pool_id: str,
+        platform_msg_id: str | None,
+        session_id: str,
+        role: Literal["user", "assistant"],
+    ) -> None: ...

--- a/tests/core/test_hub_lifecycle.py
+++ b/tests/core/test_hub_lifecycle.py
@@ -209,26 +209,60 @@ class TestHubEvictFlushTask:
 
 
 class TestHubShutdownStoreLifecycle:
-    """hub.shutdown() store-teardown invariants (#1506)."""
+    """hub.shutdown() store-teardown invariants (#1506, #1529)."""
 
     @pytest.mark.asyncio
-    async def test_shutdown_closes_message_index_but_not_turn_store(self) -> None:
-        """hub.shutdown() must close message_index but NOT turn_store.
+    async def test_shutdown_does_not_close_message_index_or_turn_store(self) -> None:
+        """hub.shutdown() must NOT close message_index or turn_store.
 
-        Turn-store lifecycle is owned by open_stores() whose finally block closes
-        it exactly once.  hub.shutdown() must never call turn_store.close() — doing
-        so would produce a double-close (#1506 regression guard).
+        Both stores' lifecycle is owned by open_stores() whose finally block closes
+        each exactly once.  hub.shutdown() must never call close() on either — doing
+        so would produce a double-close (#1529 regression guard; #1506 for turn_store).
         """
+        # Arrange
         hub = Hub()
         mock_turn = AsyncMock()
         mock_index = AsyncMock()
         hub.set_turn_store(mock_turn)
         hub.set_message_index(mock_index)
+
+        # Act
         await hub.shutdown()
-        # message_index: still closed by hub.shutdown()
-        mock_index.close.assert_awaited_once()
-        # turn_store: must NOT be closed here — open_stores.finally owns its lifecycle
+
+        # Assert — open_stores.finally owns both lifecycles; hub must not close them
+        mock_index.close.assert_not_called()
         mock_turn.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_memory_when_set(self) -> None:
+        """hub.shutdown() must close _memory when it is not None.
+
+        _memory (MemoryManager) is hub-owned: never connected/closed by open_stores().
+        Closing it in shutdown() is correct and intentional.
+        """
+        # Arrange
+        hub = Hub()
+        mock_memory = AsyncMock()
+        object.__setattr__(hub, "_memory", mock_memory)
+
+        # Act
+        await hub.shutdown()
+
+        # Assert — memory close IS hub's responsibility
+        mock_memory.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_does_not_raise_when_memory_is_none(self) -> None:
+        """hub.shutdown() with _memory=None must not raise.
+
+        Default Hub has no memory configured; guard branch must be safe.
+        """
+        # Arrange
+        hub = Hub()
+        assert hub._memory is None
+
+        # Act + Assert — must not raise
+        await hub.shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_message_index.py
+++ b/tests/core/test_message_index.py
@@ -118,3 +118,45 @@ class TestMessageIndexStartupPrune:
         assert await s.resolve("pool:tg:main", "msg-recent") == "sess-recent"
 
         await s.close()
+
+
+# ---------------------------------------------------------------------------
+# MessageIndexProtocol conformance (#1529)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageIndexProtocolConformance:
+    """MessageIndex satisfies MessageIndexProtocol (runtime_checkable guard).
+
+    Guards against silent protocol drift: if MessageIndex drops or renames any
+    method required by the protocol, this test fails immediately.
+    """
+
+    async def test_message_index_isinstance_check(self, tmp_path) -> None:
+        """MessageIndex satisfies MessageIndexProtocol (runtime_checkable check)."""
+        from lyra.core.stores.message_index_protocol import MessageIndexProtocol
+
+        # Arrange — minimal real instance (no connect needed for isinstance check)
+        store = MessageIndex(db_path=tmp_path / "conformance.db")
+
+        # Assert — structural conformance verified at runtime
+        assert isinstance(store, MessageIndexProtocol)
+
+    def test_message_index_protocol_exported_from_package(self) -> None:
+        """MessageIndexProtocol is importable from lyra.core.stores."""
+        from lyra.core.stores import MessageIndexProtocol as _MIP
+        from lyra.core.stores.message_index_protocol import MessageIndexProtocol
+
+        assert _MIP is MessageIndexProtocol
+
+    def test_message_index_protocol_has_no_close_method(self) -> None:
+        """ADR-078: close() is intentionally excluded from MessageIndexProtocol.
+
+        Lifecycle is owned by bootstrap_stores.open_stores() — re-adding close()
+        to the protocol would silently break teardown ownership.
+        """
+        from lyra.core.stores.message_index_protocol import MessageIndexProtocol
+
+        expected = {"resolve", "upsert"}
+        actual: set[str] = getattr(MessageIndexProtocol, "__protocol_attrs__", set())
+        assert actual == expected


### PR DESCRIPTION
## Summary
- Remove `HubShutdownMixin.shutdown()`'s redundant `message_index.close()` — `bootstrap_stores.open_stores()`'s `finally` is the sole owner and already closes it exactly once (ADR-048/078). The hub is a read-path consumer, not the owner.
- Extract `MessageIndexProtocol` (`resolve` + `upsert`) in `core/stores/` and retype `hub` / `hub_registration` / `pool_observer` to it (`path_validation` / `pool_manager` are covered transitively via the `hub._message_index` attribute, no change needed). This drops **all 4** `message_index` `DEBT:importlinter-adr048-transition` exemptions — the `import-layers` gate now passes without them.
- **`memory`: premise-corrected, left unchanged.** The issue asked to relocate `memory`'s close too, but investigation showed `MemoryManager` is a *core* class (never in `StoreBundle`, never connected/closed by bootstrap) — it is hub-owned, so `_memory.close()` is correct and stays, now with a clarifying comment.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1529 — relocate hub_shutdown memory/message_index closes to bootstrap | OPEN |
| Analysis | — (F-lite, analyze skipped) | Absent |
| Spec | [1529-…-spec.mdx](artifacts/specs/1529-relocate-hub-shutdown-closes-spec.mdx) | Present |
| Implementation | 1 code commit (+3 lifecycle artifacts) on `feat/1529-relocate-hub-shutdown-closes` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (pytest 5044 passed; +shutdown close-once, +protocol conformance) | Passed |

## Test Plan
- [ ] `uv run pytest -k shutdown` — shutdown does NOT close `message_index` (bootstrap owns it); `_memory.close()` still awaited when `_memory` set; safe when `None`
- [ ] `MessageIndex` satisfies `MessageIndexProtocol` (`@runtime_checkable` isinstance)
- [ ] `uv run lint-imports` — 0 `message_index` exemptions remain, 11 contracts kept / 0 broken
- [ ] `uv run pyright` — 0 errors

Closes #1529

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
