### PR TITLE
chore(tooling): auto-refresh ccc index in worktree-setup.sh

### DIFF
--- a/tools/worktree-setup.sh
+++ b/tools/worktree-setup.sh
@@ -1,28 +1,53 @@
 #!/usr/bin/env bash
 # Post-worktree-create hook invoked by dev-core /implement.
-# Symlinks the main repo's .venv into the new worktree so Pyright/uv resolve
-# third-party imports immediately. Branches share uv.lock, so this is safe;
-# if a branch bumps deps, `rm .venv && uv sync` inside the worktree.
+# 1. Symlinks the main repo's .venv into the new worktree so Pyright/uv resolve
+#    third-party imports immediately. Branches share uv.lock, so this is safe;
+#    if a branch bumps deps, `rm .venv && uv sync` inside the worktree.
+# 2. Refreshes the cocoindex-code (ccc) index so retrieval-ladder step-3
+#    (semantic search) reflects the current tree in the new worktree.
 set -euo pipefail
 
-MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+link_venv() {
+  local main_repo
+  main_repo=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
 
-if [ -z "${MAIN_REPO:-}" ] || [ ! -d "${MAIN_REPO}/.venv" ]; then
-  echo "worktree-setup: main repo .venv not found at ${MAIN_REPO:-?} — skipping" >&2
-  exit 0
-fi
+  if [ -z "${main_repo:-}" ] || [ ! -d "${main_repo}/.venv" ]; then
+    echo "worktree-setup: main repo .venv not found at ${main_repo:-?} — skipping" >&2
+    return 0
+  fi
 
-if [ "${PWD}" = "${MAIN_REPO}" ]; then
-  echo "worktree-setup: running inside main repo, refusing to symlink .venv onto itself" >&2
-  exit 0
-fi
+  if [ "${PWD}" = "${main_repo}" ]; then
+    echo "worktree-setup: running inside main repo, refusing to symlink .venv onto itself" >&2
+    return 0
+  fi
 
-if [ -L .venv ]; then
-  rm .venv
-elif [ -d .venv ]; then
-  echo "worktree-setup: .venv already exists as a real directory — leaving it untouched" >&2
-  exit 0
-fi
+  if [ -L .venv ]; then
+    rm .venv
+  elif [ -d .venv ]; then
+    echo "worktree-setup: .venv already exists as a real directory — leaving it untouched" >&2
+    return 0
+  fi
 
-ln -s "${MAIN_REPO}/.venv" .venv
-echo "worktree-setup: linked .venv → ${MAIN_REPO}/.venv"
+  ln -s "${main_repo}/.venv" .venv
+  echo "worktree-setup: linked .venv → ${main_repo}/.venv"
+}
+
+# ccc resolves the project to the shared main-repo root, so a single incremental
+# index keeps semantic search current for the new worktree. ccc is an optional,
+# user-local tool; a missing binary or a failed index must never block worktree
+# creation, so both cases are non-fatal.
+refresh_ccc_index() {
+  if ! command -v ccc >/dev/null 2>&1; then
+    echo "worktree-setup: ccc not found — skipping index refresh" >&2
+    return 0
+  fi
+
+  if ccc index >/dev/null 2>&1; then
+    echo "worktree-setup: refreshed ccc index"
+  else
+    echo "worktree-setup: ccc index failed — continuing" >&2
+  fi
+}
+
+link_venv
+refresh_ccc_index

--- a/tools/worktree-setup.sh
+++ b/tools/worktree-setup.sh
@@ -29,23 +29,29 @@ link_venv() {
   fi
 
   ln -s "${main_repo}/.venv" .venv
-  echo "worktree-setup: linked .venv → ${main_repo}/.venv"
+  echo "worktree-setup: linked .venv → ${main_repo}/.venv" >&2
 }
 
 # ccc resolves the project to the shared main-repo root, so a single incremental
-# index keeps semantic search current for the new worktree. ccc is an optional,
-# user-local tool; a missing binary or a failed index must never block worktree
-# creation, so both cases are non-fatal.
+# index (~1.6s) keeps semantic search current for the new worktree. ccc is an
+# optional, user-local tool; a missing binary, a failed index, or a slow cold
+# rebuild must never block worktree creation, so all cases are non-fatal and the
+# run is bounded by a timeout.
 refresh_ccc_index() {
   if ! command -v ccc >/dev/null 2>&1; then
     echo "worktree-setup: ccc not found — skipping index refresh" >&2
     return 0
   fi
 
-  if ccc index >/dev/null 2>&1; then
-    echo "worktree-setup: refreshed ccc index"
+  # Capture output so a failure is debuggable without a re-run; bound the run so
+  # a cold/corrupted index can't stall the hook indefinitely (timeout exits
+  # non-zero → handled by the same non-fatal else branch).
+  local ccc_out
+  if ccc_out=$(timeout 30 ccc index 2>&1); then
+    echo "worktree-setup: refreshed ccc index" >&2
   else
     echo "worktree-setup: ccc index failed — continuing" >&2
+    echo "${ccc_out}" >&2
   fi
 }
 


### PR DESCRIPTION
## Summary
- Add `ccc index` to the post-worktree-create hook (`tools/worktree-setup.sh`) so every new worktree gets a fresh cocoindex-code index — keeps retrieval-ladder step-3 (semantic search) current.
- ccc resolves the project to the shared main-repo root, so a single **incremental** index (~1.6s) suffices.
- ccc is an optional, user-local tool: a missing binary or a failed index is **non-fatal** and never blocks worktree creation.
- Refactored the `.venv` symlink logic into `link_venv()` so the index refresh runs **independently** of the venv branch (early-returns no longer skip indexing).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1534: chore(tooling): auto-refresh ccc index in worktree-setup.sh | OPEN |
| Implementation | 1 commit on `feat/1534-auto-refresh-ccc-index` | Complete |
| Verification | Lint ✅ Typecheck ✅ pre-commit hooks ✅ (shell change — no unit tests) | Passed |

## Test Plan
- [x] `bash -n tools/worktree-setup.sh` — syntax OK
- [x] Run hook in worktree → `worktree-setup: refreshed ccc index`, exit 0
- [x] Index refresh runs even when `.venv` branch early-returns (real-dir case verified)
- [ ] `command -v ccc` false path → prints skip message, exit 0 (non-fatal)

Closes #1534

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`