### PR TITLE
feat(ci): check_subject_literals.py — lyra.* literals resolve via oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check inbox_prefix uses identity_name API
         run: uv run python scripts/check_inbox_prefix.py
 
+      - name: Check subject literals resolve (acl-matrix + contracts)
+        run: uv run python scripts/check_subject_literals.py
+
       - name: Check docs drift — removed symbols must not reappear
         run: |
           set -euo pipefail

--- a/scripts/check_subject_literals.py
+++ b/scripts/check_subject_literals.py
@@ -143,14 +143,26 @@ def _looks_like_filename(literal: str) -> bool:
     return literal.rsplit(".", 1)[-1].lower() in _FILE_EXTENSIONS
 
 
-def _extract_subject_literals(path: Path) -> dict[str, list[int]]:
+def _extract_subject_literals(
+    path: Path,
+    parse_errors: list[tuple[Path, str]],
+) -> dict[str, list[int]]:
     """Map each candidate ``lyra.*`` literal in *path* to its line numbers.
 
     Excludes f-string fragments, getLogger() arguments, and filenames.
+    On SyntaxError/UnicodeDecodeError/OSError, appends ``(path, reason)`` to
+    *parse_errors* and returns ``{}`` so the caller can surface the failure.
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
-    except (SyntaxError, UnicodeDecodeError, OSError):
+    except SyntaxError as exc:
+        parse_errors.append((path, f"SyntaxError: {exc}"))
+        return {}
+    except UnicodeDecodeError as exc:
+        parse_errors.append((path, f"UnicodeDecodeError: {exc}"))
+        return {}
+    except OSError as exc:
+        parse_errors.append((path, f"OSError: {exc}"))
         return {}
 
     skip = _fstring_fragment_ids(tree) | _getlogger_arg_ids(tree)
@@ -195,11 +207,15 @@ def _scan(
     inventory: CodeInventory,
     files: list[Path],
     allowlist: set[str],
+    parse_errors: list[tuple[Path, str]],
 ) -> dict[str, list[str]]:
-    """Return ``{orphan_subject: [<file>:<line>, ...]}`` over *files*."""
+    """Return ``{orphan_subject: [<file>:<line>, ...]}`` over *files*.
+
+    Files that cannot be parsed are recorded in *parse_errors*.
+    """
     orphans: dict[str, list[str]] = {}
     for path in files:
-        for literal, linenos in _extract_subject_literals(path).items():
+        for literal, linenos in _extract_subject_literals(path, parse_errors).items():
             if literal in allowlist:
                 continue
             verdict = inventory.resolve(literal)
@@ -264,7 +280,18 @@ def main() -> None:
         sys.exit(2)
 
     allowlist = _load_allowlist(args.allowlist)
-    orphans = _scan(inventory, _iter_source_files(src_dirs), allowlist)
+    parse_errors: list[tuple[Path, str]] = []
+    orphans = _scan(inventory, _iter_source_files(src_dirs), allowlist, parse_errors)
+
+    if parse_errors:
+        print(
+            f"ERROR: scanner failed to parse {len(parse_errors)} file(s) — "
+            "subject inventory for those files is incomplete:",
+            file=sys.stderr,
+        )
+        for path, reason in parse_errors:
+            print(f"  {path}: {reason}", file=sys.stderr)
+        sys.exit(2)
 
     if orphans:
         print(

--- a/scripts/check_subject_literals.py
+++ b/scripts/check_subject_literals.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""check_subject_literals.py — every raw lyra.* subject literal in src/ resolves.
+
+Scans src/ for raw ``lyra.*`` NATS subject string literals and verifies each one
+against the semantic CodeInventory oracle (tools/code_inventory.py), whose
+``subjects`` set is sourced from deploy/nats/acl-matrix.json + roxabi-contracts
+SUBJECTS. A literal that the oracle classifies as a subject but cannot resolve
+(``kind == "subject" and not exists``) is an *orphan*: a subject used in code but
+declared nowhere. Orphans fail CI — unless baselined in the allowlist.
+
+Re-scoped per ADR-081 (#1530): resolution goes through ``oracle.resolve(token)``,
+NOT a bespoke acl-matrix/contracts resolver. The oracle owns subject knowledge.
+
+Module/logger names (``lyra.adapters.telegram``) resolve as ``kind == "module"``
+and are never flagged. Three classes of subject-shaped non-subjects are filtered
+out before resolution to avoid false positives:
+  - f-string fragments  (``f"lyra.outbound.{bot}"`` → fragment ``"lyra.outbound."``)
+  - logging.getLogger() arguments (logger names, e.g. ``"lyra.security"``)
+  - filenames           (final segment is a file extension, e.g. ``"lyra.toml"``)
+
+Exit codes (mirror the sibling src/ scanners, e.g. check_inbox_prefix.py):
+  0 — scan ran, no orphan subjects found
+  1 — orphan subject(s) found, OR scanner failure (bad --src path, I/O error)
+  2 — oracle scanned source with SyntaxError(s) (the inventory is unreliable)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+# Ensure repo root is on sys.path when executed directly as a script.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    from tools.code_inventory import CodeInventory
+except ModuleNotFoundError:  # pragma: no cover - standalone import fallback
+    _tools_dir = _REPO_ROOT / "tools"
+    if str(_tools_dir) not in sys.path:
+        sys.path.insert(0, str(_tools_dir))
+    from code_inventory import CodeInventory  # type: ignore[no-redef]
+
+_DEFAULT_ALLOWLIST = _REPO_ROOT / "scripts" / "subject_literals_allowlist.txt"
+
+# Final dotted segments that mark a filename, not a NATS subject (lyra.toml, …).
+_FILE_EXTENSIONS = frozenset(
+    {
+        "toml",
+        "json",
+        "yaml",
+        "yml",
+        "ini",
+        "cfg",
+        "conf",
+        "env",
+        "lock",
+        "py",
+        "pyi",
+        "sh",
+        "sql",
+        "db",
+        "log",
+        "txt",
+        "md",
+        "csv",
+        "html",
+        "css",
+        "js",
+        "ts",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Source discovery
+# ---------------------------------------------------------------------------
+
+
+def _iter_source_files(src_dirs: list[Path]) -> list[Path]:
+    """Return all .py source files under *src_dirs*, excluding test files."""
+    files: list[Path] = []
+    for d in src_dirs:
+        for p in d.rglob("*.py"):
+            parts = p.parts
+            if "tests" in parts:
+                continue
+            if p.name.startswith("test_") or p.name == "conftest.py":
+                continue
+            files.append(p)
+    return sorted(files)
+
+
+# ---------------------------------------------------------------------------
+# Literal extraction (AST — ignores comments and docstrings by construction)
+# ---------------------------------------------------------------------------
+
+
+def _fstring_fragment_ids(tree: ast.AST) -> set[int]:
+    """id()s of Constant nodes that are static fragments of an f-string.
+
+    ``f"lyra.outbound.{bot}"`` yields the fragment Constant ``"lyra.outbound."`` —
+    an incomplete subject that must not be resolved as a standalone literal.
+    """
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.JoinedStr):
+            for value in node.values:
+                if isinstance(value, ast.Constant):
+                    ids.add(id(value))
+    return ids
+
+
+def _getlogger_arg_ids(tree: ast.AST) -> set[int]:
+    """id()s of Constant nodes passed as the first arg to ``getLogger(...)``.
+
+    Logger names share the dotted ``lyra.*`` shape but are never NATS subjects.
+    """
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = (
+            func.attr
+            if isinstance(func, ast.Attribute)
+            else func.id
+            if isinstance(func, ast.Name)
+            else None
+        )
+        if name == "getLogger" and node.args:
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                ids.add(id(first))
+    return ids
+
+
+def _looks_like_filename(literal: str) -> bool:
+    """True if the final dotted segment is a known file extension (lyra.toml)."""
+    return literal.rsplit(".", 1)[-1].lower() in _FILE_EXTENSIONS
+
+
+def _extract_subject_literals(path: Path) -> dict[str, list[int]]:
+    """Map each candidate ``lyra.*`` literal in *path* to its line numbers.
+
+    Excludes f-string fragments, getLogger() arguments, and filenames.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return {}
+
+    skip = _fstring_fragment_ids(tree) | _getlogger_arg_ids(tree)
+    found: dict[str, list[int]] = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+            continue
+        if id(node) in skip:
+            continue
+        value = node.value
+        if not value.lower().startswith("lyra."):
+            continue
+        if " " in value or _looks_like_filename(value):
+            continue
+        found.setdefault(value, []).append(node.lineno)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+def _load_allowlist(path: Path) -> set[str]:
+    """Load baselined orphan subjects. Missing file → empty allowlist."""
+    if not path.exists():
+        return set()
+    entries: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.split("#", 1)[0].strip()
+        if stripped:
+            entries.add(stripped)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+
+def _scan(
+    inventory: CodeInventory,
+    files: list[Path],
+    allowlist: set[str],
+) -> dict[str, list[str]]:
+    """Return ``{orphan_subject: [<file>:<line>, ...]}`` over *files*."""
+    orphans: dict[str, list[str]] = {}
+    for path in files:
+        for literal, linenos in _extract_subject_literals(path).items():
+            if literal in allowlist:
+                continue
+            verdict = inventory.resolve(literal)
+            if verdict.kind == "subject" and not verdict.exists:
+                orphans.setdefault(literal, []).extend(
+                    f"{path}:{lineno}" for lineno in linenos
+                )
+    return orphans
+
+
+def _resolve_src_dirs(src_dirs: list[Path] | None) -> list[Path]:
+    """Return the effective source directories to scan."""
+    if src_dirs:
+        return src_dirs
+    return [d for d in [_REPO_ROOT / "src"] if d.is_dir()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check that every raw lyra.* subject literal in src/ resolves to the "
+            "CodeInventory oracle (acl-matrix.json + roxabi-contracts SUBJECTS)."
+        )
+    )
+    parser.add_argument(
+        "--src",
+        type=Path,
+        action="append",
+        dest="src_dirs",
+        metavar="DIR",
+        help="Source directory to scan (repeatable). Defaults to src/.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="Repo root the oracle builds its subject inventory from.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=_DEFAULT_ALLOWLIST,
+        help="File of baselined orphan subjects to ignore.",
+    )
+    args = parser.parse_args()
+
+    src_dirs = _resolve_src_dirs(args.src_dirs)
+    for d in src_dirs:
+        if not d.is_dir():
+            print(f"ERROR: source directory not found: {d}", file=sys.stderr)
+            sys.exit(1)
+
+    inventory = CodeInventory.build(args.root)
+    if inventory.syntax_errors:
+        print(
+            f"ERROR: oracle hit {len(inventory.syntax_errors)} syntax error(s) while "
+            "scanning source — subject inventory is unreliable:",
+            file=sys.stderr,
+        )
+        for path, msg in inventory.syntax_errors:
+            print(f"  {path}: {msg}", file=sys.stderr)
+        sys.exit(2)
+
+    allowlist = _load_allowlist(args.allowlist)
+    orphans = _scan(inventory, _iter_source_files(src_dirs), allowlist)
+
+    if orphans:
+        print(
+            f"FAIL: {len(orphans)} orphan subject literal(s) in src/ "
+            "not declared in acl-matrix.json or roxabi-contracts SUBJECTS:"
+        )
+        for subject in sorted(orphans):
+            print(f"  {subject}")
+            for location in orphans[subject]:
+                print(f"    {location}")
+        print(
+            "\nDeclare each subject (acl-matrix publish/subscribe grant or contracts "
+            "SUBJECTS), or baseline it in scripts/subject_literals_allowlist.txt."
+        )
+        sys.exit(1)
+
+    print("check-subject-literals: OK (all lyra.* literals in src/ resolve)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/subject_literals_allowlist.txt
+++ b/scripts/subject_literals_allowlist.txt
@@ -1,0 +1,19 @@
+# subject_literals_allowlist.txt — pre-existing orphan NATS subjects.
+#
+# Each line is a raw `lyra.*` subject literal that appears in src/ but is NOT
+# yet declared in deploy/nats/acl-matrix.json or roxabi-contracts SUBJECTS.
+# check_subject_literals.py treats these as baselined debt (gate stays green)
+# instead of failing CI on day one — mirrors the baseline-then-prevent pattern
+# of the other src/ scanners in this directory.
+#
+# Format: one subject literal per line. `#` comments and blank lines ignored.
+#
+# DO NOT add new entries to silence the gate. The correct fix for a new orphan
+# is to declare the subject in acl-matrix.json (publish/subscribe grant) or in
+# roxabi-contracts SUBJECTS. This list should only shrink.
+#
+# Retirement tracked in the follow-up issue (blocked-by #1533): declare both
+# subjects in acl-matrix, then delete them here and the gate goes fully strict.
+
+lyra.verify.deny
+lyra.gh.mint_failure.>

--- a/tests/scripts/test_check_subject_literals.py
+++ b/tests/scripts/test_check_subject_literals.py
@@ -39,6 +39,7 @@ DECLARED = "lyra.turns.write"
 def _run(
     src_dirs: list[Path] | None = None,
     allowlist: Path | None = None,
+    root: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run the CLI, optionally scoped to explicit --src dirs and an allowlist."""
     cmd = [sys.executable, str(CLI)]
@@ -47,6 +48,8 @@ def _run(
             cmd += ["--src", str(d)]
     if allowlist is not None:
         cmd += ["--allowlist", str(allowlist)]
+    if root is not None:
+        cmd += ["--root", str(root)]
     return subprocess.run(
         cmd,
         capture_output=True,
@@ -174,20 +177,34 @@ class TestFalsePositiveFilters:
         result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
         assert result.returncode == 0, result.stdout
 
-    def test_comment_and_docstring_not_flagged(self, tmp_path: Path) -> None:
-        """AST extraction ignores comments and docstrings."""
+    def test_comment_not_flagged(self, tmp_path: Path) -> None:
+        """Comments are not AST nodes — an orphan in a comment is not flagged."""
         _write_py(
             tmp_path,
-            "doc.py",
-            f'''\
-            # "{ORPHAN}" mentioned in a comment
+            "comment.py",
+            f"""\
+            # {ORPHAN} mentioned in a comment only
             def f():
-                """Docstring mentions {ORPHAN} too."""
                 return 1
-            ''',
+            """,
         )
         result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
         assert result.returncode == 0, result.stdout
+
+    def test_docstring_literal_is_flagged(self, tmp_path: Path) -> None:
+        """A bare orphan string literal used as a docstring IS an AST Constant and
+        IS scanned — the scanner does not special-case docstrings."""
+        _write_py(
+            tmp_path,
+            "docstring.py",
+            f'''\
+            def f():
+                "{ORPHAN}"
+            ''',
+        )
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 1, result.stdout
+        assert ORPHAN in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +248,31 @@ class TestExclusion:
         _write_py(tests_dir, "helper.py", f'SUBJECT = "{ORPHAN}"\n')
         result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
         assert result.returncode == 0
+
+    def test_conftest_excluded(self, tmp_path: Path) -> None:
+        """conftest.py is excluded from scanning — orphan inside it is not flagged."""
+        _write_py(tmp_path, "conftest.py", f'SUBJECT = "{ORPHAN}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0
+        assert "FAIL" not in result.stdout
+
+
+class TestSyntaxError:
+    def test_unparseable_file_exits_2(self, tmp_path: Path) -> None:
+        """A .py file with invalid syntax causes the scanner to exit 2."""
+        broken = tmp_path / "broken.py"
+        broken.write_text("def broken(:\n    pass\n")
+        result = _run(
+            [tmp_path],
+            allowlist=_empty_allowlist(tmp_path),
+            root=tmp_path,
+        )
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert (
+            "ERROR" in result.stderr
+            or "syntax" in result.stderr.lower()
+            or "parse" in result.stderr.lower()
+        )
 
 
 class TestMissingSrcTarget:

--- a/tests/scripts/test_check_subject_literals.py
+++ b/tests/scripts/test_check_subject_literals.py
@@ -1,0 +1,243 @@
+"""Tests for scripts/check_subject_literals.py — #1533.
+
+Covers:
+  - Happy path: clean source (declared subjects + module/logger names) exits 0
+  - Orphan path: an undeclared lyra.* subject literal exits 1 and is listed
+  - Falsification pair: clean exits 0, known-orphan exits 1 (detection alive)
+  - False-positive filters: f-string fragments, getLogger() args, filenames
+  - Module/logger names that resolve via the oracle are not flagged
+  - Allowlist suppresses a baselined orphan
+  - Test files are excluded from scanning
+  - Missing --src directory exits 1 (scanner failure, not a violation)
+
+Exit-code contract (mirrors sibling scanners):
+  Exit 0 = scan ran, no orphan subjects
+  Exit 1 = orphan subject(s) found OR scanner failure (bad path)
+  Exit 2 = oracle hit a SyntaxError in scanned source
+
+The oracle builds its subject inventory from the real repo root (default --root),
+so declared subjects like ``lyra.turns.write`` resolve live while fabricated ones
+like ``lyra.totally.fake.orphan`` are orphans.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "scripts" / "check_subject_literals.py"
+
+# A fabricated subject the oracle cannot resolve (kind=subject, exists=False).
+ORPHAN = "lyra.totally.fake.orphan"
+# A subject that IS declared in acl-matrix.json (resolves live).
+DECLARED = "lyra.turns.write"
+
+
+def _run(
+    src_dirs: list[Path] | None = None,
+    allowlist: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the CLI, optionally scoped to explicit --src dirs and an allowlist."""
+    cmd = [sys.executable, str(CLI)]
+    if src_dirs is not None:
+        for d in src_dirs:
+            cmd += ["--src", str(d)]
+    if allowlist is not None:
+        cmd += ["--allowlist", str(allowlist)]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+
+def _write_py(directory: Path, name: str, content: str) -> Path:
+    """Write a dedented Python source file inside *directory*."""
+    p = directory / name
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+def _empty_allowlist(tmp_path: Path) -> Path:
+    """Return an allowlist file with no entries (isolate from the repo default)."""
+    p = tmp_path / "empty_allowlist.txt"
+    p.write_text("# none\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_clean_file_exits_0(self, tmp_path: Path) -> None:
+        """Only a declared subject → exit 0, OK message."""
+        _write_py(tmp_path, "clean.py", f'SUBJECT = "{DECLARED}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "OK" in result.stdout
+
+    def test_empty_directory_exits_0(self, tmp_path: Path) -> None:
+        """No source files → exit 0."""
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0
+        assert "OK" in result.stdout
+
+    def test_repo_src_passes_with_default_allowlist(self) -> None:
+        """The real src/ tree passes with the committed allowlist (gate is green)."""
+        result = _run()
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Orphan detection + falsification pair
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanDetection:
+    def test_orphan_exits_1(self, tmp_path: Path) -> None:
+        _write_py(tmp_path, "bad.py", f'SUBJECT = "{ORPHAN}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 1, result.stdout
+
+    def test_orphan_listed_in_output(self, tmp_path: Path) -> None:
+        _write_py(tmp_path, "bad.py", f'SUBJECT = "{ORPHAN}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert ORPHAN in result.stdout
+        assert "FAIL" in result.stdout
+
+    def test_orphan_names_file_and_line(self, tmp_path: Path) -> None:
+        src = _write_py(tmp_path, "named.py", f'\nSUBJECT = "{ORPHAN}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert f"{src}:2" in result.stdout
+
+    def test_falsification_pair(self, tmp_path: Path) -> None:
+        """Clean fixture exits 0, known-orphan fixture exits 1 — detection alive."""
+        clean = tmp_path / "clean"
+        bad = tmp_path / "bad"
+        clean.mkdir()
+        bad.mkdir()
+        allow = _empty_allowlist(tmp_path)
+        _write_py(clean, "ok.py", f'SUBJECT = "{DECLARED}"\n')
+        _write_py(bad, "violation.py", f'SUBJECT = "{ORPHAN}"\n')
+
+        assert _run([clean], allowlist=allow).returncode == 0
+        assert _run([bad], allowlist=allow).returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# False-positive filters
+# ---------------------------------------------------------------------------
+
+
+class TestFalsePositiveFilters:
+    def test_fstring_fragment_not_flagged(self, tmp_path: Path) -> None:
+        """A dynamic f-string subject yields a fragment that must not be flagged."""
+        _write_py(
+            tmp_path,
+            "fstr.py",
+            """\
+            def subject(bot):
+                return f"lyra.nonexistent.{bot}.tail"
+            """,
+        )
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0, result.stdout
+
+    def test_getlogger_arg_not_flagged(self, tmp_path: Path) -> None:
+        """A logger name passed to getLogger() must not be flagged as a subject."""
+        _write_py(
+            tmp_path,
+            "log.py",
+            """\
+            import logging
+            log = logging.getLogger("lyra.nonexistent.logger")
+            """,
+        )
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0, result.stdout
+
+    def test_filename_literal_not_flagged(self, tmp_path: Path) -> None:
+        """A filename-shaped literal (lyra.<ext>) must not be flagged."""
+        _write_py(tmp_path, "fname.py", 'PATH = "lyra.toml"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0, result.stdout
+
+    def test_module_path_not_flagged(self, tmp_path: Path) -> None:
+        """A real module path resolves as kind=module, never an orphan subject."""
+        _write_py(tmp_path, "mod.py", 'NAME = "lyra.commands"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0, result.stdout
+
+    def test_comment_and_docstring_not_flagged(self, tmp_path: Path) -> None:
+        """AST extraction ignores comments and docstrings."""
+        _write_py(
+            tmp_path,
+            "doc.py",
+            f'''\
+            # "{ORPHAN}" mentioned in a comment
+            def f():
+                """Docstring mentions {ORPHAN} too."""
+                return 1
+            ''',
+        )
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    def test_allowlisted_orphan_suppressed(self, tmp_path: Path) -> None:
+        """An orphan present in the allowlist must not fail the gate."""
+        _write_py(tmp_path, "bad.py", f'SUBJECT = "{ORPHAN}"\n')
+        allow = tmp_path / "allow.txt"
+        allow.write_text(f"# baselined\n{ORPHAN}\n")
+        result = _run([tmp_path], allowlist=allow)
+        assert result.returncode == 0, result.stdout
+
+    def test_allowlist_comments_ignored(self, tmp_path: Path) -> None:
+        """Inline comments and blank lines in the allowlist are ignored."""
+        _write_py(tmp_path, "bad.py", f'SUBJECT = "{ORPHAN}"\n')
+        allow = tmp_path / "allow.txt"
+        allow.write_text(f"\n  {ORPHAN}  # keep until declared\n\n")
+        result = _run([tmp_path], allowlist=allow)
+        assert result.returncode == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Exclusion + scanner-failure
+# ---------------------------------------------------------------------------
+
+
+class TestExclusion:
+    def test_test_files_excluded(self, tmp_path: Path) -> None:
+        _write_py(tmp_path, "test_thing.py", f'SUBJECT = "{ORPHAN}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0
+        assert "FAIL" not in result.stdout
+
+    def test_tests_subdir_excluded(self, tmp_path: Path) -> None:
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        _write_py(tests_dir, "helper.py", f'SUBJECT = "{ORPHAN}"\n')
+        result = _run([tmp_path], allowlist=_empty_allowlist(tmp_path))
+        assert result.returncode == 0
+
+
+class TestMissingSrcTarget:
+    def test_nonexistent_src_exits_1(self, tmp_path: Path) -> None:
+        result = _run([tmp_path / "does_not_exist"])
+        assert result.returncode == 1
+
+    def test_nonexistent_src_error_on_stderr(self, tmp_path: Path) -> None:
+        result = _run([tmp_path / "does_not_exist"])
+        assert "ERROR" in result.stderr or "not found" in result.stderr


### PR DESCRIPTION
## Summary
- New CI gate `scripts/check_subject_literals.py`: scans `src/` for raw `lyra.*` NATS subject string literals and verifies each against the semantic **CodeInventory oracle** (`tools/code_inventory.py`), whose `subjects` set is sourced from `deploy/nats/acl-matrix.json` + roxabi-contracts `SUBJECTS`. An undeclared subject (oracle `kind=subject, exists=False`) fails CI.
- Per **ADR-081** (#1530): resolution goes through `oracle.resolve(token)`, not a bespoke resolver. The oracle's module/symbol disambiguation means logger/module names like `lyra.adapters.telegram` resolve as `kind=module` and are never flagged.
- Three subject-shaped non-subjects are filtered before resolution to avoid false positives: **f-string fragments**, **`logging.getLogger()` arguments**, and **filenames** (final segment is a file extension, e.g. `lyra.toml`).
- Two pre-existing orphans (`lyra.verify.deny`, `lyra.gh.mint_failure.>`) are baselined in `scripts/subject_literals_allowlist.txt` so the gate ships **green** and blocks new drift. Retirement (declaring them in acl-matrix) tracked in a follow-up issue.
- Registered in `.github/workflows/ci.yml` alongside the sibling `check_inbox_prefix.py` gate.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1533: check_subject_literals.py | OPEN |
| Implementation | 1 commit on `feat/1533-check-subject-literals` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (18 new) | Passed |

## Test Plan
- [ ] `uv run python scripts/check_subject_literals.py` → exits 0 (OK) on current tree
- [ ] `uv run python scripts/check_subject_literals.py --allowlist /dev/null` → exits 1, lists the 2 baselined orphans
- [ ] `uv run pytest tests/scripts/test_check_subject_literals.py` → 18 passed
- [ ] Adding a new raw `lyra.fake.subject` literal to `src/` fails CI; declaring it in acl-matrix/contracts (or allowlist) clears it

Closes #1533

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`