### PR TITLE
docs(adr): ADR-083 central inbound attachment-ingest stage + #1537 design

### DIFF
--- a/artifacts/analyses/1537-central-inbound-ingestion-design.md
+++ b/artifacts/analyses/1537-central-inbound-ingestion-design.md
@@ -1,0 +1,437 @@
+---
+title: "Central Inbound Ingestion Stage — Design Analysis"
+description: "Architecture design for absorbing adapter-side attachment ingest (#1065, #1066, #1067) into the stage axis per Epic #1277 §11."
+issue: 1537
+tier: F-lite
+date: 2026-05-30
+---
+
+## 1. Current State
+
+### Where ingest happens today (cited)
+
+**Voice / audio path — Telegram**
+
+`src/lyra/adapters/telegram/telegram_inbound.py:119-174` — `handle_voice_message()`:
+1. Calls `_download_audio()` (telegram_audio.py) which uses `adapter.bot.get_file()` + `adapter.bot.download()` to write a tmp file.
+2. Reads bytes from tmp file, then calls `normalize_audio()`.
+3. `telegram_normalize.py:275-290` — `normalize_audio()` stamps `BlobRef(store_key=PENDING_STORE_KEY, content_hash="", ...)` — bytes are **dropped** after this call. The `audio_bytes` parameter is used only for `size=len(audio_bytes)`.
+
+**Non-audio attachments — Telegram**
+
+`src/lyra/adapters/telegram/telegram_normalize.py:26-81` — `_extract_attachments()` builds `Attachment` objects with `url_or_path_or_bytes=f"tg:file_id:{file_id}"` strings. No download, no store. The platform reference is kept as an opaque string.
+
+**Voice / audio path — Discord**
+
+`src/lyra/adapters/discord/discord_audio.py:128-260` — `handle_audio()`:
+1. Pre-download size check, then `await audio_attachment.read()` (signed CDN URL fetch).
+2. Magic-byte validation (`is_valid_audio_magic`).
+3. Calls `normalize_audio()` at line 240.
+4. `discord_audio.py:61-125` — `normalize_audio()` stamps `BlobRef(store_key=PENDING_STORE_KEY, content_hash="", platform_ref=None, ...)`. Bytes are **dropped** — used only for `size=len(audio_bytes)`.
+
+**Non-audio attachments — Discord**
+
+`src/lyra/adapters/discord/discord_normalize.py:83` — `extract_attachments()` (delegated to `discord_formatting.py`). Discord CDN URLs are placed in `Attachment.url_or_path_or_bytes`. No download, no store.
+
+**STT worker side (#1067)**
+
+`src/lyra/nats/nats_stt_client.py:53-77` — `transcribe()` accepts `BlobRef | bytes`. When given a `BlobRef` with `store_key=PENDING_STORE_KEY`, the codec currently sends it as-is; the STT worker (voiceCLI) must fall back to `platform_ref` (Telegram `file_id`) or inline bytes to obtain the audio. The `PENDING_STORE_KEY` sentinel is defined in `packages/roxabi-contracts/src/roxabi_contracts/blob_ref.py:16` with an explicit removal note.
+
+### Why this is the N×M trap
+
+The attachment-ingest concern is implemented per-platform (N=2, Telegram + Discord) × per-type (voice, image, document, video, animation, sticker). That is N × M implementation points with identical logic: download bytes → compute hash → store → emit `BlobRef`. Per ADR-073's pattern: each new platform must re-implement all M type handlers; each new type requires edits in all N platform files. The `ingest_bytes_to_blob_ref()` helper in `packages/roxabi-blobs/ingest.py` was written explicitly to close this trap (its module docstring says "prevent N×M adapter duplication (ADR-073 three-strikes)") but was never wired in — confirmed by `git log -S ingest_bytes_to_blob_ref -- src/lyra/adapters/` returning no hits.
+
+---
+
+## 2. Stage Placement
+
+### Decision
+
+Ingestion is a **new dedicated stage** inserted into the inbound pipeline between `parse` and `pre_route_hook`. Call it `AttachmentIngestStage`.
+
+### Before / after pipeline diagram
+
+**Before (current)**:
+
+```
+[Telegram adapter]                          [Discord adapter]
+  handle_voice_message()                      handle_audio()
+    download bytes                              .read() bytes
+    normalize_audio()                           normalize_audio()
+      → BlobRef(PENDING_STORE_KEY)               → BlobRef(PENDING_STORE_KEY)
+    push_to_hub_guarded()                     push_to_hub_guarded()
+                                                        ↓
+                                             [Bus → Hub → SttMiddleware]
+                                               transcribe(BlobRef)
+                                               BlobRef.store_key == PENDING  → fallback to platform_ref
+                                               STT failure → bytes already dropped → LOST
+```
+
+**After (proposed)**:
+
+```
+[Telegram adapter]                          [Discord adapter]
+  handle_voice_message()                      handle_audio()
+    _download_audio() → bytes                   .read() → bytes
+    → InboundMessage(                           → InboundMessage(
+        audio=AudioPayload(                         audio=AudioPayload(
+          blob_ref=BlobRef(PENDING),                  blob_ref=BlobRef(PENDING),
+          ...),                                        ...),
+        attachments=[                               attachments=[
+          PendingAttachment(fetch_closure)])          PendingAttachment(fetch_closure)])
+
+InboundPipeline.run()
+    parse()    ← unchanged
+       ↓
+    AttachmentIngestStage.run(msg, ctx)   ← NEW
+       for each PendingAttachment:
+         bytes = await fetch_closure()
+         ref = await ingest_bytes_to_blob_ref(store, bytes, ...)
+         → replaces PendingAttachment with real BlobRef in Attachment
+       for audio (modality==voice):
+         ref = await ingest_bytes_to_blob_ref(store, bytes, ...)
+         → replaces blob_ref in AudioPayload (PENDING → real)
+       ↓
+    pre_route_hook(opt)
+       ↓
+    Router → [DROP|PROCESS]
+       ↓
+    pre_session_hook(opt) → SessionBuilder → Dispatcher
+       ↓
+                                             [Bus → Hub → SttMiddleware]
+                                               transcribe(BlobRef)
+                                               BlobRef.store_key is REAL → store.get()
+                                               STT failure → blob already in store → preserved
+```
+
+### Rationale
+
+**Not fold-into-parse:** `WireParser.parse()` is sync and pure (`wire_parser.py:21`). Ingest is async I/O — structural mismatch. The WireParser Protocol cannot be widened without breaking all implementations.
+
+**Not a pre_route_hook:** Hooks are optional and platform-specific (bound via `functools.partial` with adapter reference). Ingest is a universal concern, not platform-specific. Using a hook would require both adapters to independently supply it — recreating the N×M pattern.
+
+**Not post-dispatch:** Ingest must complete before the message reaches the bus and `SttMiddleware`, to guarantee blob durability before STT runs.
+
+**A new stage (chosen):** `InboundPipeline.run()` inserts `AttachmentIngestStage` as a mandatory step after `parse` and before `pre_route_hook`. It receives an `IngestCtx` (contains the `BlobStore` reference) and the `InboundMessage`. The stage is stateless; the `BlobStore` reference lives in `InboundContext`. Stage modules in `src/lyra/inbound/` contain no platform-library imports — the fetch closure is the only platform bit crossing the boundary.
+
+**Audio path inversion:** Currently `handle_voice_message` (Telegram) and `handle_audio` (Discord) download bytes, then create an `InboundMessage` with `PENDING_STORE_KEY`. They bypass the pipeline entirely, calling `push_to_hub_guarded()` directly. Post-design: adapters create a light `InboundMessage` with the audio bytes captured in a fetch closure, run it through the pipeline, and let `AttachmentIngestStage` perform the store write. The `handle_voice_message`/`handle_audio` functions are reduced to parsing + closure construction, then delegating to `InboundPipeline.run()` (same pattern as `handle_message`).
+
+---
+
+## 3. Attachment Descriptor + Fetch Closure Contract
+
+### Platform-agnostic types (adapter emits, stage consumes)
+
+```python
+# src/lyra/inbound/attachment_ingest.py
+
+from __future__ import annotations
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+
+# A closure that fetches raw bytes for one attachment unit.
+# Supplied by the adapter; contains no platform types.
+FetchFn = Callable[[], Awaitable[bytes]]
+
+
+@dataclass(frozen=True)
+class PendingAttachment:
+    """Platform-agnostic descriptor for an attachment pending ingest.
+
+    Emitted by wire parsers; consumed by AttachmentIngestStage.
+    Contains no discord/aiogram types — only stdlib + callable.
+    """
+    fetch: FetchFn                # async closure: () -> bytes
+    mime: str                     # MIME type (trusted from platform or sniffed)
+    source: str                   # "telegram" | "discord" | ...
+    platform_ref: str | None      # opaque: "tg:file_id:{id}" or Discord URL
+    platform_message_id: str | None
+    filename: str | None = None
+
+
+@dataclass(frozen=True)
+class IngestCtx:
+    """Ingest-stage context — injected into InboundContext."""
+    store: "BlobStorePort | None"  # lyra.core.ports.blobstore — Protocol, never concrete infrastructure type
+    # Rationale: the stage imports the core/ports Protocol (BlobStorePort), never infrastructure/roxabi_blobs
+    # concrete types — satisfies the import-layer contract. Ref: ADR-082.
+
+
+class AttachmentIngestStage:
+    """Resolves all PendingAttachment descriptors into real BlobRefs.
+
+    For each PendingAttachment in msg.attachments:
+      1. Awaits fetch() closure to get raw bytes.
+      2. Calls ingest_bytes_to_blob_ref(store, bytes, ...).
+      3. Replaces the Attachment.url_or_path_or_bytes with the BlobRef store_key
+         (or stores the BlobRef inline if InboundMessage.Attachment gains a blob_ref field).
+
+    For voice messages (modality=="voice"):
+      4. Awaits AudioPayload's associated fetch closure.
+      5. Replaces AudioPayload.blob_ref (PENDING → real BlobRef).
+
+    On store=None or fetch failure: falls back gracefully (keeps PENDING / logs warning).
+    """
+
+    async def run(
+        self,
+        msg: "InboundMessage",
+        ctx: "InboundContext",
+    ) -> "InboundMessage":
+        """Returns an InboundMessage with all BlobRefs resolved."""
+        ...
+```
+
+### How it satisfies `inbound-no-adapters`
+
+The `.importlinter` contract `inbound-no-adapters` forbids `lyra.inbound` → `lyra.adapters` imports. The fetch closure (`FetchFn = Callable[[], Awaitable[bytes]]`) is a plain Python callable — it captures adapter-specific state (aiogram Bot, aiohttp session, Discord attachment proxy) inside the adapter before being injected into the descriptor. The descriptor type `PendingAttachment` imports only stdlib and `roxabi_blobs`/`roxabi_contracts`. `AttachmentIngestStage` imports `ingest_bytes_to_blob_ref` from `roxabi_blobs` and `BlobStore` from `roxabi_blobs.protocol` — neither is in `lyra.adapters`.
+
+**Pattern precedent:** This is identical to how `pre_route_hook` and `pre_session_hook` work: adapter-side closures bound via `functools.partial` are injected into the pipeline call, carrying platform-specific context without polluting generic stage modules. The `FetchFn` is a closure, not a method on an adapter-typed argument.
+
+### Injection mechanism
+
+The fetch closure is constructed in the adapter's `handle_voice_message` / `handle_audio` / `handle_message` (for attachment messages), captured with a lambda or partial, and placed in `PendingAttachment`. Example for Telegram voice:
+
+```python
+# adapter side (telegram_inbound.py) — sketch only
+async def _make_voice_fetch(adapter, file_id: str) -> FetchFn:
+    async def _fetch() -> bytes:
+        tmp_path, _ = await _download_audio(adapter, file_id)
+        try:
+            return tmp_path.read_bytes()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    return _fetch
+
+# PendingAttachment(fetch=await _make_voice_fetch(adapter, file_id), mime="audio/ogg", ...)
+```
+
+The `IngestCtx` is added to `InboundContext` as a new field:
+
+```python
+@dataclass(frozen=True)
+class InboundContext:
+    router: RouterCtx
+    session: SessionCtx
+    dispatch: DispatchCtx
+    ingest: IngestCtx           # NEW — None-safe: ingest skipped when store=None
+    # IngestCtx.store is typed BlobStorePort | None (lyra.core.ports.blobstore), per ADR-082.
+```
+
+`InboundPipeline.run()` signature gains an `ingest_stage` optional parameter (defaulting to `None` for backward compat until the context field lands):
+
+```python
+async def run(
+    self, raw, ctx, parser, *,
+    pre_route_hook=None,
+    pre_session_hook=None,
+    send_backpressure,
+    on_drop=None,
+) -> None:
+    msg = parser.parse(raw, ctx)
+    if msg is None:
+        return
+    if self._ingest_stage is not None and ctx.ingest.store is not None:
+        msg = await self._ingest_stage.run(msg, ctx)
+    ...  # existing pipeline continues unchanged
+```
+
+---
+
+## 4. Attachment-Type Coverage
+
+| Type | Telegram source | Discord source | Mime (representative) | Current handling | Post-design handling |
+|------|----------------|----------------|----------------------|-----------------|---------------------|
+| Voice/audio | `voice`, `audio`, `video_note` — `file_id` via `bot.get_file()` + `bot.download()` | `attachment.content_type in AUDIO_MIME_TYPES`, signed CDN URL, `attachment.read()` | `audio/ogg`, `audio/mpeg` | Downloaded in `handle_voice_message`/`handle_audio`; PENDING_STORE_KEY; bytes dropped | `PendingAttachment` with fetch closure; `AttachmentIngestStage` stores + stamps real `BlobRef` in `AudioPayload` |
+| Image/photo | `msg.photo[-1].file_id` → `tg:file_id:{id}` | `attachment.url` (CDN URL) | `image/jpeg`, `image/png` | `url_or_path_or_bytes=f"tg:file_id:{id}"` string; no download; no store | Fetch closure wraps `bot.get_file()` + download (Telegram) or `aiohttp.get(url)` (Discord); stage stores + `Attachment.blob_ref` set |
+| Document | `msg.document.file_id` → `tg:file_id:{id}` | `attachment.url`, `attachment.content_type` | `application/pdf`, `application/octet-stream`, etc. | Same as image — opaque string ref only | Same as image |
+| Video | `msg.video.file_id` → `tg:file_id:{id}` | `attachment.url` | `video/mp4` | Same — string ref | Same as image |
+| Animation/GIF | `msg.animation.file_id` | `attachment.url` with `.gif`/`.mp4` | `image/gif` | `type="image"`, string ref | Same as image |
+| Sticker (static) | `msg.sticker.file_id` (only non-animated, non-video) | Not detected today | `image/webp` | String ref; animated/video stickers skipped | Static stickers: fetch closure. Animated (`.tgs`) and video (`.webm`) continue to be skipped — out of scope for V1 |
+| Sticker (animated/video) | Skipped (`is_animated=True` or `is_video=True`) | — | `application/x-tgsticker`, `video/webm` | Not handled | Not handled (unchanged) |
+
+---
+
+## 5. Contract Changes
+
+### AudioPayload — no generalization needed
+
+`AudioPayload` (`src/lyra/core/audio_payload.py`) remains voice-only. Non-audio attachment types are handled through `InboundMessage.attachments: list[Attachment]`. This avoids widening `AudioPayload`'s semantics.
+
+**Required change to `Attachment`:** The current `Attachment.url_or_path_or_bytes: str | bytes` field is a platform-specific opaque value. Post-ingest it needs to carry a resolved `BlobRef`. Two options:
+
+- Option A: Add `blob_ref: BlobRef | None = None` field to `Attachment`. After ingest, `blob_ref` is set and `url_or_path_or_bytes` retains the original reference for debugging / fallback.
+- Option B: Encode the `store_key` in `url_or_path_or_bytes` with a sentinel prefix (`"blob:{store_key}"`).
+
+Option A is cleaner (typed, explicit) and consistent with `AudioPayload.blob_ref`. Recommended.
+
+### BlobRef flow
+
+```
+[Adapter] construct PendingAttachment(fetch_closure, mime, source, platform_ref)
+    ↓
+[AttachmentIngestStage]
+    bytes = await fetch_closure()
+    ref: roxabi_blobs.BlobRef = await ingest_bytes_to_blob_ref(store, bytes, ...)
+    # Convert to wire-side BlobRef (roxabi_contracts) using the factory method:
+    wire_ref: roxabi_contracts.BlobRef = roxabi_contracts.BlobRef.from_store_ref(ref)
+    # Note: the manual 7-field copy above was the provenance-loss anti-pattern eliminated by ADR-082.
+    # It silently dropped filename, platform_ref, platform_message_id, and created_at.
+    # from_store_ref() is the single correct conversion point. Ref: ADR-082.
+    # stamp into AudioPayload or Attachment.blob_ref
+    ↓
+[SttMiddleware] transcribe(msg.audio.blob_ref)
+    → store_key is real → store.get(store_key) succeeds
+```
+
+Note: `roxabi_blobs.BlobRef` and `roxabi_contracts.BlobRef` are parallel types (identical field shapes, different packages). Both are already present in the codebase. The stage ingests via `roxabi_blobs` (store access) and stamps `roxabi_contracts.BlobRef` on `InboundMessage` (cross-process wire type). See `roxabi_blobs/CLAUDE.md` §"BlobRef ownership" — this dual-type pattern is the documented design.
+
+Note: `IngestCtx.store: BlobStorePort | None` now consumes a real merged port — **#1540 (BlobStorePort) is DELIVERED** (PR #1546 merged 2026-05-30). The `BlobStorePort` interface in `lyra.core.ports.blobstore` is the type to import in the stage.
+
+### Transport & payload (validated 2026-05-30)
+
+- **Byte transport:** bytes flow via HTTP `BlobStorePort.put()` single-shot. NATS carries only the `BlobRef` (wire ref), never raw bytes. This is correct — the NATS message-size cap does not apply to blob content.
+- **`put_multipart` scope:** `put_multipart()` (#1334) is an additive, non-breaking Protocol extension. V1 uses single-shot `put()` only. Deferring multipart causes zero wire/contract churn — the `put()` path is entirely unaffected. `put_multipart` remains out-of-scope for this stage.
+- **Non-audio ceiling — GAP:** Non-audio attachments (images, documents, video, sticker) have **no size cap in code today** (`telegram_normalize.py:26-81` passes opaque `tg:file_id:{id}` strings; `discord_formatting.py:67-88` passes CDN URLs — zero download). The `AttachmentIngestStage` will be the **first site to download them**. It MUST impose an explicit ceiling before download:
+  - Recommended: `MAX_ATTACHMENT_INGEST_BYTES = 20 MiB` (= Telegram `getFile` cap). Reject + log + user-facing error before any `fetch()` call if `PendingAttachment.size` (if known) exceeds this, or abort mid-stream and raise immediately on byte count exceeded.
+  - Audio path: real cap is `LYRA_MAX_AUDIO_BYTES` (default **5 MiB** — `telegram.py:124-125`, `discord/adapter.py:113-114`), NOT the TG 50 MB / Discord 100 MB platform limits.
+- **HTTP 500 on oversize:** The blobstore HTTP service returns **500 (not 413)** on oversize payloads (`await request.body()` is unbounded in current server). The stage MUST catch HTTP 500 from `put()` and surface a user-facing error — do not propagate 500 silently.
+- **Write timeout:** `HttpBlobStore` write timeout is 5 s (`http_store.py:89`). If the stage streams CDN→PUT (Discord eager-ingest timing, CDN URLs expire within minutes), the 5 s idle window may be insufficient for large attachments over a slow link. Per-call timeout override should be assessed at implementation.
+- **Discord CDN URL expiry:** Discord CDN URLs expire within minutes. The stage must ingest eagerly on message receipt (not lazily). Timing of S4/S7 wiring must confirm the fetch happens within the pipeline, before the message is enqueued on the bus.
+
+### PENDING_STORE_KEY removal sequencing
+
+1. `AttachmentIngestStage` lands and is wired in both adapters' audio paths → voice `BlobRef` is always real before the bus.
+2. `SttMiddleware` (`middleware_stt.py:116`) calls `transcribe(msg.audio.blob_ref, ...)` — this already passes the `BlobRef` directly; no code change needed at the STT call site.
+3. `NatsSttClient.transcribe()` removes the `isinstance(audio, bytes)` branch and the inline `PENDING_STORE_KEY` construction (`nats_stt_client.py:57-64`).
+4. Non-audio `Attachment.blob_ref` is populated by the stage; consumers are updated to use it.
+5. `PENDING_STORE_KEY` sentinel and the `_require_content_hash_unless_sentinel` validator in `roxabi_contracts.blob_ref` are removed after all three adapters are confirmed producing real `BlobRef`s (guarded by a CI check).
+6. `BlobRef.platform_ref` field is retained as a permanent provenance field (original platform handle for audit), not a fallback mechanism.
+
+---
+
+## 6. Ingest-Before-STT Ordering
+
+The ordering guarantee is structural, not documented:
+
+```
+InboundPipeline.run() execution sequence:
+  1. parse()                   → InboundMessage with PendingAttachment + PENDING BlobRef
+  2. AttachmentIngestStage.run() → awaited; returns InboundMessage with real BlobRef
+  3. pre_route_hook (opt)
+  4. Router.decide()
+  5. pre_session_hook (opt)
+  6. SessionBuilder.build()
+  7. Dispatcher.dispatch()     → pushes to inbound bus
+                                       ↓
+                               Hub → SttMiddleware  ← receives real BlobRef
+```
+
+`AttachmentIngestStage.run()` is `await`-ed inline before `Dispatcher.dispatch()`. The dispatcher pushes to `inbound_bus` only after the stage completes. `SttMiddleware` runs inside the hub's middleware pipeline, which only fires after the message is dequeued from the bus. Since `AttachmentIngestStage` runs before the bus enqueue, blob durability is guaranteed before STT runs — no concurrency or ordering ambiguity.
+
+### STT-failure `_DROP` path
+
+Under the current design, STT failure (`_DROP` at `middleware_stt.py:97–153`) loses the audio bytes because they were already dropped after `normalize_audio()` stamped `PENDING_STORE_KEY`. After this design:
+
+- The blob is already in `BlobStore` when `SttMiddleware` runs.
+- STT failure drops the `InboundMessage` (the pipeline result is `_DROP`) but the blob persists in the store.
+- Recovery paths (replay, manual retranscription) can call `store.get(blob_ref.store_key)` using the `BlobRef` stored in the dropped message's `audio.blob_ref`.
+- No code change is required in `SttMiddleware` for this property — it falls out of the ordering guarantee.
+
+### Fetch closure failure handling
+
+If `fetch_closure()` raises (network error, size limit exceeded, magic-byte check fails), `AttachmentIngestStage` logs the failure and either:
+- Returns the original `InboundMessage` with `PENDING_STORE_KEY` (degraded mode, preserved backward compat with STT's `platform_ref` fallback path), OR
+- Returns `None` to signal the pipeline to drop the message (same as `WireParser.parse()` returning `None`).
+
+The recommended behavior is **degraded mode** for voice (allows STT `platform_ref` fallback path until fully cut over) and **drop + error reply** for non-audio attachments (the attachment is the content; without it the message has no value). This is a decision for implementation — flagged under §8.
+
+---
+
+## 7. Slice Decomposition
+
+Each slice is ≤F-lite. Ordered by dependency; can be executed sequentially.
+
+| # | Slice | Files affected | Falsifiable AC | Maps to |
+|---|-------|---------------|----------------|---------|
+| S1 | `PendingAttachment` descriptor + `FetchFn` type + `IngestCtx` | `src/lyra/inbound/attachment_ingest.py` (new), `src/lyra/inbound/context.py` | `ingest-no-adapters` importlinter contract passes; `PendingAttachment` can be constructed with a plain `async def` closure; no `discord`/`aiogram` import anywhere in `lyra.inbound` | New infrastructure |
+| S2 | `AttachmentIngestStage` — voice path only (audio/ogg, PENDING→real) | `src/lyra/inbound/attachment_ingest.py`, `src/lyra/inbound/pipeline.py` | Unit test: stage given `AudioPayload(PENDING_STORE_KEY)` + fetch closure → emits message with real `BlobRef`; `store_key != PENDING_STORE_KEY` | #1065 completion (Telegram voice ingest) |
+| S3 | Wire up Telegram voice path: `handle_voice_message` → fetch closure → pipeline | `src/lyra/adapters/telegram/telegram_inbound.py`, `src/lyra/adapters/telegram/telegram_normalize.py` | E2E test: Telegram voice message → `ingest_bytes_to_blob_ref` called once → `InboundMessage.audio.blob_ref.store_key != PENDING_STORE_KEY` before hub enqueue | #1065 completion |
+| S4 | Wire up Discord voice path: `handle_audio` → fetch closure → pipeline | `src/lyra/adapters/discord/discord_audio.py`, `src/lyra/adapters/discord/discord_inbound.py` | Same AC as S3 for Discord | #1066 supersede |
+| S5 | `AttachmentIngestStage` — non-audio attachment path (image/document/video/sticker/animation) | `src/lyra/inbound/attachment_ingest.py`, `src/lyra/core/messaging/message.py` (`Attachment.blob_ref` field) | Unit test: stage given `Attachment(url_or_path_or_bytes="tg:file_id:x")` + fetch closure → `Attachment.blob_ref` is a real `BlobRef`; `store_key != PENDING_STORE_KEY` | #1065 (all types), #1066 (Discord non-audio) |
+| S6 | Wire up Telegram non-audio attachments: `_extract_attachments` emits fetch closures | `src/lyra/adapters/telegram/telegram_normalize.py` | E2E test: Telegram image message → `Attachment.blob_ref` populated before hub | #1065 |
+| S7 | Wire up Discord non-audio attachments | `src/lyra/adapters/discord/discord_normalize.py`, `src/lyra/adapters/discord/discord_formatting.py` | Same AC as S6 for Discord | #1066 |
+| S8 | STT worker path cleanup: remove PENDING_STORE_KEY construction in `NatsSttClient.transcribe()` + verify `platform_ref` fallback can be removed | `src/lyra/nats/nats_stt_client.py` | CI: no remaining `PENDING_STORE_KEY` construction at adapter ingest sites; STT integration test passes with real BlobRef | #1067 coordination |
+| S9 | PENDING_STORE_KEY retirement: remove sentinel, validator, `cli_voice_smoke.py` usage | `packages/roxabi-contracts/src/roxabi_contracts/blob_ref.py`, `src/lyra/cli_voice_smoke.py`, `src/lyra/nats/nats_tts_codec.py` | CI: `grep -r PENDING_STORE_KEY src/` returns 0 hits | #1065 + #1066 completion |
+
+**Issue disposition:**
+- **#1065** (Telegram adapter eager-ingest) — S2, S3, S5, S6 collectively deliver its original scope. Mark closed-complete after S6.
+- **#1066** (Discord adapter eager-ingest) — S4, S7 deliver Discord symmetry. Mark closed-complete or superseded after S7.
+- **#1067** (workers consume BlobRef, drop platform_ref fallback) — S8 delivers the coordination requirement. Mark closed-complete after S8.
+
+---
+
+## 8. Risks / Open Questions
+
+### Decision A — Fetch failure behavior for non-audio attachments
+
+```
+── Decision: Attachment fetch failure disposition ──
+Context:     fetch_closure() can fail (network error, size limit). For non-audio
+             attachments the attachment IS the content. For voice the STT platform_ref
+             fallback exists as a temporary escape hatch.
+Target:      Clear, user-visible error behavior; no silent data loss.
+Path:        Implement chosen option in AttachmentIngestStage.run() error branch.
+
+Options:
+  1. Drop + error reply — pipeline returns None; adapter sends "attachment unavailable" error reply
+  2. Degraded mode — keep PENDING_STORE_KEY; let downstream consumer handle (STT platform_ref fallback, or agent sees empty attachment)   ← recommended for voice during transition
+Recommended: Option 2 for voice (preserves STT fallback during transition), Option 1 for non-audio (attachment IS the content; degraded is meaningless)
+```
+
+### Decision B — `Attachment` type evolution
+
+```
+── Decision: Add blob_ref field to Attachment ──
+Context:     Attachment.url_or_path_or_bytes carries opaque platform refs today.
+             After ingest, a typed BlobRef is available. Two ways to carry it.
+Target:      Typed access to BlobRef by downstream consumers (agents, hub outbound).
+Path:        Modify InboundMessage.Attachment in lyra.core.messaging.message.
+
+Options:
+  1. Add blob_ref: BlobRef | None = None field alongside url_or_path_or_bytes  ← recommended
+  2. Encode store_key in url_or_path_or_bytes with "blob:{key}" prefix sentinel
+Recommended: Option 1 — typed, explicit, consistent with AudioPayload.blob_ref pattern. Requires checking all existing Attachment consumers for the new field.
+```
+
+### Decision C — Ingest context availability in test/CLI mode
+
+```
+── Decision: BlobStore availability when store=None ──
+Context:     CLI mode and many tests have no BlobStore. IngestCtx.store=None
+             must be safe.
+Target:      Zero regressions in existing test suite.
+Path:        AttachmentIngestStage short-circuits when ctx.ingest.store is None (passthrough mode).
+
+Options:
+  1. Stage is no-op when store=None (PENDING_STORE_KEY preserved)   ← recommended
+  2. Stage raises if store=None (force explicit wiring)
+Recommended: Option 1 — matches existing optional-field patterns (turn_publisher=None, thread_store=None) in context.py.
+```
+
+### Open question — Animated/video sticker handling
+
+Telegram animated stickers (`.tgs`, Lottie JSON-based) and video stickers (`.webm`) are currently skipped in `_extract_attachments`. Should the stage handle them? Decision deferred to product — out of scope for S5/S6.
+
+---
+
+## 9. Non audité
+
+The following items from the read-list were not inspected:
+
+- `artifacts/specs/1061-blobstore-spec.mdx` N5/N6 nodes beyond the grep excerpt — full spec text not read; key identifiers (N5=TG ingest, N6=Discord ingest, V3/V4 slices) were found via grep.
+- `artifacts/analyses/1277-stage-axis-refactor-strategy.mdx` §6 (inbound) — the §6 subsection was not directly read; §11 references and the absorbed-issues table (lines 330, 382) were read.
+- `discord_formatting.py` `extract_attachments` — not read; inferred from `discord_normalize.py:83` call site.
+- `src/lyra/adapters/shared/` files beyond `_shared.py` (push_to_hub_guarded signature) — not read.
+- `src/lyra/core/hub/pipeline/message_pipeline.py` full content — only `_DROP` sentinel was checked.

--- a/docs/architecture/adr/083-central-inbound-attachment-ingest-stage.mdx
+++ b/docs/architecture/adr/083-central-inbound-attachment-ingest-stage.mdx
@@ -1,0 +1,113 @@
+---
+title: "ADR-083: Central Inbound Attachment Ingest Stage"
+description: Absorb per-adapter attachment ingest into a single stage-axis module, eliminating the N×M trap and guaranteeing blob durability before STT runs.
+related: [073, 067, 079, 082]
+---
+
+## Status
+
+Proposed
+
+## Context
+
+Inbound attachments (voice, image, document, video, sticker, animation, GIF) from Telegram and Discord are currently normalized adapter-side with `store_key=PENDING_STORE_KEY` — a sentinel indicating that no BlobStore write has occurred. The `ingest_bytes_to_blob_ref()` helper in `packages/roxabi-blobs/` was written to close this gap but was never wired in (`git log -S ingest_bytes_to_blob_ref -- src/lyra/adapters/` = empty). Consequences:
+
+1. **Audio loss on STT failure.** `handle_voice_message` (Telegram) and `handle_audio` (Discord) download audio bytes to construct a `PENDING_STORE_KEY` `BlobRef`, then discard the bytes. If `SttMiddleware` fails, the audio is permanently lost — the Bot API has no history to re-fetch from.
+2. **N×M implementation surface.** Ingest logic (download → hash → store → emit `BlobRef`) must be duplicated per platform × per attachment type. At N=2 platforms, M=7 types, that is up to 14 implementation points. Each new adapter or new attachment type amplifies this.
+3. **PENDING_STORE_KEY sentinel persists on the wire.** `SttRequest(blob_ref)` carries `store_key=PENDING_STORE_KEY`; STT workers must implement a `platform_ref` fallback path. This fallback adds complexity in `nats_stt_client.py`, is undocumented in the STT worker contract, and blocks `PENDING_STORE_KEY` removal.
+
+This is precisely the N×M duplication pattern ADR-073 identifies as the primary architectural anti-pattern. The `inbound-no-adapters` importlinter contract (#1287) already forbids `lyra.inbound` modules from importing `discord` or `aiogram`, establishing the boundary this ADR formalizes.
+
+Epic #1277 §11 explicitly absorbs issues #1065 (Telegram adapter eager-ingest), #1066 (Discord adapter eager-ingest), and #1067 (workers consume real `BlobRef`) into the stage axis. Issue #1537 is the delivery issue for this ADR.
+
+Reference analysis: `artifacts/analyses/1537-central-inbound-ingestion-design.md`.
+
+## Options Considered
+
+### Option A: Per-adapter eager ingest (platform-axis)
+
+Each adapter implements its own ingest path: Telegram `handle_voice_message` calls `ingest_bytes_to_blob_ref()` before `normalize_audio()`; Discord `handle_audio` does the same. Non-audio attachments follow per-adapter download + ingest logic.
+
+- **Pros:** Minimal pipeline changes; each adapter owns its full ingest path; no new stage type needed.
+- **Cons:** N×M growth preserved — each new adapter must re-implement ingest for all M types. Ingest cannot be tested independently of adapter platform libraries. Contradicts ADR-073 primary-axis decision. This is also precisely the approach `#1065` was designed to take, and it was never completed — evidence that per-adapter implementation has high friction.
+
+### Option B: Central ingest stage + fetch-closure injection (stage-axis, chosen)
+
+A single `AttachmentIngestStage` module in `src/lyra/inbound/` receives a platform-agnostic `PendingAttachment` descriptor (containing a `FetchFn: Callable[[], Awaitable[bytes]]` closure) produced by adapters during normalization. The stage calls `ingest_bytes_to_blob_ref()` once per attachment, stamping a real `BlobRef` before the message reaches the bus.
+
+- **Pros:** Single ingest implementation regardless of N or M. Importlinter contract satisfied — no platform types in `lyra.inbound`. Fetch failure handling is centralized. Blob durability guaranteed before `SttMiddleware` runs — STT failure no longer loses audio. Fetch closures follow the established `functools.partial` hook pattern already used by `pre_route_hook` / `pre_session_hook`.
+- **Cons:** Adapters must be refactored to emit `PendingAttachment` descriptors rather than stamping `PENDING_STORE_KEY` inline. `InboundContext` gains an `IngestCtx` field. `InboundPipeline.run()` gains one new stage insertion. `Attachment` dataclass gains a `blob_ref` field.
+
+## Decision
+
+**Option B — central ingest stage with fetch-closure injection.**
+
+**Primary axis:** `stage` (per ADR-073). The ingest concern is a pipeline stage, not a per-platform concern. Platform variation is confined to the `FetchFn` closure constructed by the adapter (e.g. Telegram `bot.get_file()` + `bot.download()` vs Discord CDN HTTP GET), which is the only platform-specific bit crossing the adapter→stage boundary.
+
+**Stage placement:** `AttachmentIngestStage` is inserted into `InboundPipeline.run()` between `parse()` and `pre_route_hook`, as the first async operation on the parsed message. This placement guarantees:
+
+1. The stage sees the normalized `InboundMessage` with all `PendingAttachment` descriptors.
+2. The stage runs before `Dispatcher.dispatch()` pushes the message to the inbound bus.
+3. `SttMiddleware` (downstream of the bus, inside the hub pipeline) always receives a real `BlobRef`.
+
+**Fetch closure protocol:**
+
+```python
+FetchFn = Callable[[], Awaitable[bytes]]
+
+@dataclass(frozen=True)
+class PendingAttachment:
+    fetch: FetchFn
+    mime: str
+    source: str
+    platform_ref: str | None
+    platform_message_id: str | None
+    filename: str | None = None
+```
+
+**Context extension:** `InboundContext` gains `ingest: IngestCtx` where `IngestCtx.store: BlobStorePort | None` (Protocol from `lyra.core.ports.blobstore`, per ADR-082 — never a concrete infrastructure type). When `store=None` (test/CLI mode), the stage is a no-op — `PENDING_STORE_KEY` is preserved and the pipeline continues unchanged (backward compatible).
+
+**Blob write protocol:** Blob bytes flow via HTTP `BlobStorePort.put()` single-shot in V1. `put_multipart()` (#1334) is deferred — it is an additive, non-breaking Protocol extension; HTTP transport already bypasses the NATS size cap. Multipart is out-of-scope for this stage.
+
+**Converter:** The `roxabi_blobs.BlobRef` → `roxabi_contracts.BlobRef` conversion uses `roxabi_contracts.BlobRef.from_store_ref(ref)` exclusively (per ADR-082). Manual field-copy is forbidden — it silently drops `filename`, `platform_ref`, `platform_message_id`, and `created_at`.
+
+**AudioPayload path:** Audio bytes are captured in a `FetchFn` closure by the adapter (Telegram `handle_voice_message`, Discord `handle_audio`). The stage resolves `AudioPayload.blob_ref` from `PENDING_STORE_KEY` to a real `BlobRef` before the message is enqueued.
+
+**Non-audio attachment path:** `Attachment` gains `blob_ref: BlobRef | None = None`. After the stage, `blob_ref` is populated; `url_or_path_or_bytes` retains the original platform reference for provenance / debugging.
+
+## Consequences
+
+### Positive
+
+- **Blob durability before STT.** STT failure no longer loses audio. The blob is in the store before `SttMiddleware` runs; replay and manual retranscription become possible.
+- **N×M trap closed.** Ingest is a single module. New platform → 1 adapter-side fetch closure per attachment type. New attachment type → 1 new `FetchFn` constructor in the adapter + stage coverage extended. No stage duplication.
+- **PENDING_STORE_KEY retirement path.** Once S2–S4 (voice path) and S5–S7 (non-audio path) are merged, `PENDING_STORE_KEY` construction at adapter ingest sites drops to zero and the sentinel can be removed from `roxabi_contracts.blob_ref`.
+- **STT worker simplification (#1067).** `NatsSttClient.transcribe()` can remove the `isinstance(audio, bytes)` branch and the inline `PENDING_STORE_KEY` construction. The `platform_ref` fallback path in the STT worker contract is retired.
+- **Importlinter contract respected.** `AttachmentIngestStage` imports only `roxabi_blobs`, `roxabi_contracts`, and `lyra.core` types. The `inbound-no-adapters` contract requires no new `ignore_imports` entries.
+
+### Negative
+
+- **Adapter refactor cost.** `handle_voice_message` and `handle_audio` must be refactored to emit `PendingAttachment` and route through `InboundPipeline.run()` instead of calling `push_to_hub_guarded()` directly. Estimated: 9 slices (see design analysis §7).
+- **BlobStore required in production wiring.** `IngestCtx.store` must be non-None in all production bootstrap paths. This must be wired in `bootstrap/wiring.py` or equivalent. Bootstrap MUST assert `ctx.ingest.store is not None` — a missed wiring is silent (stage no-ops) with no user-visible error.
+- **`Attachment` dataclass change.** Adding `blob_ref: BlobRef | None = None` to `Attachment` is additive (default None) but all Attachment construction sites must be audited for completeness.
+- **Non-audio attachment ceiling (open).** Non-audio attachments have no size cap in code today (`telegram_normalize.py:26-81`, `discord_formatting.py:67-88` pass by opaque ref / CDN URL — zero download). The stage is the first download site. Implementation MUST enforce `MAX_ATTACHMENT_INGEST_BYTES` (recommended 20 MiB = Telegram `getFile` cap) before download — reject + log + user-facing error on oversize. Audio cap is `LYRA_MAX_AUDIO_BYTES` (default 5 MiB), not the platform-advertised limits.
+- **HTTP 500 on oversize.** The blobstore HTTP service returns 500 (not 413) on oversize payloads. The stage must map HTTP 500 from `put()` to a user-facing error; do not propagate silently.
+- **Discord CDN URL expiry.** Discord CDN URLs expire within minutes. Ingest must be eager (within the pipeline, before bus enqueue). Confirm timing in S4/S7.
+
+### Neutral
+
+- The `FetchFn` closure pattern adds a small allocation per attachment per message. At typical Lyra message volumes this is not a performance concern.
+- `BlobRef` dual-type mapping (from `roxabi_blobs.BlobRef` returned by `ingest_bytes_to_blob_ref()` to `roxabi_contracts.BlobRef` embedded in `InboundMessage`) is already the documented pattern in `roxabi_blobs/CLAUDE.md §BlobRef ownership`. The stage performs this conversion once per attachment.
+
+## Trail
+
+- Issue: #1537 — central inbound attachment-ingest stage (delivery)
+- Epic: #1277 §11 — stage-axis decomposition (absorbed issues)
+- Absorbed: #1065 (Telegram adapter eager-ingest), #1066 (Discord adapter eager-ingest), #1067 (workers consume real BlobRef)
+- Enables: BlobStore epic #1061 V3/V4 slices (adapter-side ingest)
+- ADR-073: `axial: true` — stage as primary axis; this ADR implements that choice for the attachment-ingest concern
+- ADR-067: BlobStore abstraction (FsBlobStore + `ingest_bytes_to_blob_ref` contract)
+- ADR-079: Audio NATS contract axial consolidation (NATS plane complement to this inbound-pipeline decision)
+- ADR-082: BlobStorePort driven-port (delivered PR #1546, 2026-05-30) — `IngestCtx.store: BlobStorePort | None`; converter = `BlobRef.from_store_ref()`
+- Contract: `.importlinter` → `inbound-no-adapters` (#1287)
+- Design analysis: `artifacts/analyses/1537-central-inbound-ingestion-design.md`


### PR DESCRIPTION
## What

Two companion docs for the central inbound attachment-ingest stage (#1537):

- **ADR-083** (`Proposed`) — `AttachmentIngestStage` on the stage axis: one ingest module absorbing per-adapter eager-ingest (#1065 Telegram, #1066 Discord, #1067 workers) per epic #1277 §11 — closes the N×M trap and guarantees blob durability before STT.
- **Design analysis** (`artifacts/analyses/1537-…`) — stage placement, fetch-closure contract, attachment-type coverage, slice decomposition S1–S9.

## Key decisions (architect + devops validated, 2026-05-30)

- **Single-shot `put()` in V1.** `put_multipart()` (#1334, P3) deferred — additive/non-breaking Protocol extension, and HTTP blob transport already bypasses the NATS cap, so the multipart rationale doesn't apply. Zero wire/contract churn from deferring.
- **`IngestCtx.store: BlobStorePort | None`** consuming the merged port (ADR-082, #1540 / PR #1546); conversion via `BlobRef.from_store_ref()`, not a hand-rolled converter.
- **Non-audio gap:** non-audio attachments are uncapped in code today (passed by file_id / CDN-URL, never downloaded). The stage is the first downloader → must enforce `MAX_ATTACHMENT_INGEST_BYTES` (reco 20 MiB = TG getFile cap) before download. (Old #1066's "TG ≤50MB / Discord ≤100MB" is refuted by code: audio cap is `LYRA_MAX_AUDIO_BYTES`, default 5 MiB.)

## Scope

Docs only — no code. Does **not** close #1537 (implementation pending; ACs added to the issue). ADR-083 stays `Proposed` until the stage lands.

Refs #1537 · ADR-082 (#1540, merged) · epic #1277 §11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
