### PR TITLE
test(typing): make typing e2e NATS test deterministic (#1543)

### DIFF
--- a/tests/typing/test_integration_nats.py
+++ b/tests/typing/test_integration_nats.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +14,22 @@ from lyra.transport.typing_publisher import TypingPublisher
 from lyra.transport.work_scope import WorkScope
 from lyra.typing.listener import TypingListener
 from tests.nats.conftest import requires_nats_server
+
+
+async def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
+    """Poll ``predicate`` until true or ``timeout`` elapses.
+
+    Deterministic replacement for a fixed ``asyncio.sleep`` when waiting on an
+    async round-trip (publish -> NATS Core -> listener callback): returns as
+    soon as the condition holds, and tolerates a slow runner up to ``timeout``.
+    On timeout it simply returns so the caller's assertion produces the failure.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            return
+        await asyncio.sleep(0.01)
 
 
 @requires_nats_server
@@ -42,17 +59,23 @@ async def test_publisher_to_listener_e2e_discord(nats_server_url: str) -> None:
         enabled=True,
     )
     await listener.start()
+    # NATS Core drops messages with no registered subscriber. subscribe() only
+    # buffers the SUB locally; flush round-trips PING/PONG so the server has
+    # registered it before the publisher (separate connection) emits anything.
+    await nc_sub.flush()
 
     pub = TypingPublisher(nc_pub, enabled=True)
     scope = WorkScope(platform="discord", bot_id="x", scope_id=42, trace_id="t")
 
     await pub.publish_started(scope)
-    await asyncio.sleep(0.1)
+    await nc_pub.flush()  # publish() buffers locally; flush forces it to the server
+    await _wait_until(lambda: mgr.start.called)
     mgr.start.assert_called_once()
     assert mgr.start.call_args[0][0] == 42
 
     await pub.publish_ended(scope)
-    await asyncio.sleep(0.1)
+    await nc_pub.flush()
+    await _wait_until(lambda: mgr.cancel.called)
     mgr.cancel.assert_called_once_with(42)
 
     await listener.stop()


### PR DESCRIPTION
## Summary
- `test_publisher_to_listener_e2e_discord` flaked under parallel-runner load (~1–4 in 8). Issue framed it as fixed-sleep latency; the real race is wider: **NATS Core drops messages with no registered subscriber**, and both `subscribe()` and `publish()` only buffer locally — so the SUB or the message could miss the server entirely (`mgr.start` called **0** times even after a generous 5s wait, not just late).
- Made deterministic on three fronts:
  - `await nc_sub.flush()` after `listener.start()` → SUB registered on the server before any publish
  - `await nc_pub.flush()` after each publish → message reaches the server, not just the local write buffer
  - replaced the two fixed `asyncio.sleep(0.1)` with a bounded `_wait_until` poll on `mgr.start.called` / `mgr.cancel.called` for residual callback-dispatch latency

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1543: test(flaky) fixed-sleep race | OPEN |
| Implementation | 1 commit on `feat/1543-test-publisher-to-listener-e2e-discord-flaky` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (20/20 under `pytest -n2`) | Passed |

## Test Plan
- [x] `pytest tests/typing/test_integration_nats.py::test_publisher_to_listener_e2e_discord` — looped 20× under `-n2`, 0 failures
- [x] Full `tests/typing/` module green
- [x] Production code untouched — test-only determinism fix

Closes #1543

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`