### PR TITLE
chore(deps): upgrade idna/starlette/urllib3 for flagged CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ override-dependencies = [
     "pynacl>=1.6.2",  # CVE-2025-69277 — discord.py 2.7.1 pins <1.6 but 1.6.x is API-compatible (discord.py master confirmed)
     "aiohttp>=3.13.4",  # CVE-2026-34520 + 9 others fixed in 3.13.4 (transitive via aiogram); drop-in, no API changes
     "pygments>=2.20.0",  # CVE-2026-4539 ReDoS fixed in 2.20.0 (dev-only, transitive via rich/pytest)
+    "idna>=3.15",  # CVE-2026-45409 ReDoS (incomplete 2024 fix) — transitive via anyio/httpx/requests/yarl
+    "starlette>=1.0.1",  # PYSEC-2026-161 Host-header path-prepend auth-bypass — via fastapi (0.136.3 accepts any starlette)
+    "urllib3>=2.7.0",  # PYSEC-2026-141/142 (proxy-auth on cross-origin redirect + brotli OOM) — dev-only, transitive via requests→pip-audit
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -16,15 +16,18 @@ members = [
 ]
 overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "ml-dtypes", specifier = ">=0.5" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "onnx", specifier = ">=1.20" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pynacl", specifier = ">=1.6.2" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "torch", specifier = ">=2.7" },
     { name = "torchaudio", specifier = ">=2.7" },
     { name = "transformers", specifier = ">=4.57.3,<5" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -568,11 +571,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -1483,15 +1486,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]
@@ -1580,11 +1583,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Verified all three flagged CVEs still apply (project `pip-audit`), then bumped each via the existing `[tool.uv] override-dependencies` security-floor pattern — matching the `pynacl`/`aiohttp`/`pygments` precedent, which keeps transitive deps out of the direct dependency list.
- idna `3.11→3.17` (CVE-2026-45409 ReDoS), starlette `0.52.1→1.2.0` (PYSEC-2026-161 Host-header auth-bypass), urllib3 `2.6.3→2.7.0` (PYSEC-2026-141/142).

## CVE verification

| Dep | Was | Now | Advisory | Lyra surface |
|---|---|---|---|---|
| idna | 3.11 | 3.17 | CVE-2026-45409 (ReDoS) | transitive — anyio/httpx/requests/yarl |
| starlette | 0.52.1 | 1.2.0 | PYSEC-2026-161 (Host-header) | fastapi → BlobStore + lyra-send |
| urllib3 | 2.6.3 | 2.7.0 | PYSEC-2026-141/142 | dev-only — requests→pip-audit |

`pip-audit`: **6 vulns / 4 pkgs → 2 vulns / 1 pkg**. The 2 remaining are `pip 26.0.1` itself (CVE-2026-3219/6357, fix 26.1) — out of scope for this issue.

## starlette major bump (0.52 → 1.x)
- fastapi 0.136.3 imposes **no upper bound** on starlette → resolver accepts 1.2.0.
- Full suite **5173 passed, 14 skipped, 1 xfailed** — no API breakage on the FastAPI surface (BlobStore `serve`, lyra-send).
- Only new artifact: `StarletteDeprecationWarning` (TestClient prefers `httpx2`) — non-fatal; pytest `filterwarnings` does not escalate warnings to errors.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1541: verify & upgrade idna/starlette/urllib3 CVEs | OPEN |
| Implementation | 1 commit on `feat/1541-deps-cve-upgrade-idna-starlette-urllib3` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5173 passed) | Passed |

## Test Plan
- [x] `uv sync --frozen` resolves green
- [x] `uv run pip-audit` no longer flags idna/starlette/urllib3
- [x] Full `uv run pytest` suite green (BlobStore serve + lyra-send FastAPI paths covered)

Closes #1541

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`