### PR TITLE
feat(inbound): central attachment ingest — non-audio S5–S7

### DIFF
--- a/artifacts/plans/1552-central-ingest-non-audio-plan.mdx
+++ b/artifacts/plans/1552-central-ingest-non-audio-plan.mdx
@@ -1,0 +1,324 @@
+---
+title: "Plan: central attachment ingest — non-audio (S5–S7)"
+issue: 1552
+spec: artifacts/specs/1552-central-ingest-non-audio-spec.mdx
+parent_spec: artifacts/specs/1537-central-attachment-ingestion-stage-spec.mdx
+complexity: 6/10
+tier: F-lite
+generated: 2026-05-31
+---
+
+## Summary
+
+Extend the central `AttachmentIngestStage` (#1551) to non-audio attachments
+(image/document/video/sticker/animation/GIF) on Telegram + Discord. Today the stage's
+non-audio branch (`attachment_ingest.py:95-97`) **stores the blob but discards the
+returned `wire_ref`**, and `normalize()` never sets a pending descriptor → the branch is
+dead for real traffic. This plan adds the `Attachment.blob_ref` wire field, a
+multi-attachment pending carrier, a pre-download size guard, an HTTP-500→user-error map,
+and wires both adapters to emit fetch closures.
+
+## Design decisions (resolved at plan gate, 2026-05-31)
+
+| # | Decision | Resolution |
+|---|---|---|
+| D1 | attachment multiplicity | **Full multi.** Add `InboundMessage.pending_attachments: list[Any]` (transient, `repr=False`, NATS-cleared), index-aligned with `attachments`. Stage iterates + stamps each `attachments[i].blob_ref`. Voice singular `pending_attachment` untouched (no regression). |
+| D2 | size-guard + user-error placement | **Stage-owns + raise-to-boundary.** Declared `size` rides on `PendingAttachment`; stage enforces `MAX_ATTACHMENT_INGEST_BYTES` **before** fetch + catches typed 500; signals via `raise AttachmentIngestError(user_message)`; each adapter's `pipeline.run()` call-site catches → replies via its existing reply helper. Stage stays platform-agnostic. V1 limitation: a mixed text+oversize message is dropped wholesale (rare; follow-up). |
+| D3 | typed 500 at infra seam | `HttpBlobStoreAdapter.put` catches `httpx.HTTPStatusError` 5xx → raises `roxabi_contracts.BlobStoreServerError` (mirrors its existing 404→`BlobNotFoundError`), so `lyra.inbound` never imports httpx. |
+| D4 | write timeout (parent Open-Q1) | **Construction-time knob** (corrected from per-call): `HttpBlobStore` write timeout reads `LYRA_BLOBSTORE_WRITE_TIMEOUT_S` (default raised 5→30 s) — sufficient for 20 MiB over slow CDN→PUT. No `BlobStorePort` signature change (ADR-067 locked). A higher ceiling is harmless for small audio uploads. |
+
+**Axial guard (carried from parent spec §Slices):** `PendingAttachment.source` is metadata
+only — it must never drive a branch in `AttachmentIngestStage.run()`. Stage logic stays
+platform-agnostic; only the adapters differ.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph ADAPT["adapters/{telegram,discord}/*_normalize.py"]
+    EX["_extract_attachments / extract_attachments<br/>build Attachment[] + closure + declared size"]
+    PA["pending_attachments: list[PendingAttachment]<br/>(fetch, mime, source, size, ...)"]
+    EX --> PA
+  end
+  subgraph CORE["core/messaging/message.py"]
+    IM["InboundMessage<br/>+attachments[]  +pending_attachments[]"]
+  end
+  subgraph STAGE["inbound/attachment_ingest.py"]
+    GUARD{"declared size ><br/>MAX_ATTACHMENT_INGEST_BYTES?"}
+    PUT["ctx.store.put(bytes) → wire BlobRef"]
+    STAMP["attachments[i] = replace(blob_ref=wire_ref)"]
+    ERR["raise AttachmentIngestError(user_msg)"]
+  end
+  subgraph INFRA["infrastructure/blobstore_adapter.py"]
+    MAP["catch httpx 5xx → BlobStoreServerError"]
+  end
+  PA --> IM --> GUARD
+  GUARD -- "oversize" --> ERR
+  GUARD -- "ok" --> PUT --> STAMP
+  PUT -. "500" .-> MAP -. "BlobStoreServerError" .-> ERR
+  ERR -. "propagates out of pipeline.run()" .-> REPLY["adapter boundary → user reply"]
+  STAMP --> NEXT["router → session → dispatch"]
+
+  classDef new fill:#cfe,stroke:#393;
+  class PA,GUARD,STAMP,ERR,MAP new;
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+  subgraph msg["core/messaging/message.py"]
+    A["class Attachment +blob_ref"]
+    I["class InboundMessage +pending_attachments"]
+  end
+  subgraph stg["inbound/attachment_ingest.py"]
+    PAcls["PendingAttachment +size"]
+    CONST["MAX_ATTACHMENT_INGEST_BYTES"]
+    EXC["AttachmentIngestError"]
+    RUN["AttachmentIngestStage.run (non-audio loop)"]
+  end
+  subgraph tg["adapters/telegram"]
+    TN["telegram_normalize._extract_attachments"]
+    TI["telegram_inbound (pipeline.run boundary)"]
+  end
+  subgraph dc["adapters/discord"]
+    DF["discord_formatting.extract_attachments"]
+    DN["discord_normalize.normalize"]
+    DI["discord_inbound (pipeline.run boundary)"]
+  end
+  subgraph infra["infrastructure + roxabi pkgs"]
+    ADP["blobstore_adapter.put (500 map)"]
+    HS["roxabi_blobs http_store.put (timeout knob)"]
+    CE["roxabi_contracts BlobStoreServerError"]
+  end
+  TN --> PAcls --> I
+  DF --> PAcls
+  DN --> DF
+  RUN --> A
+  RUN --> EXC
+  RUN --> CONST
+  TI -.catch.-> EXC
+  DI -.catch.-> EXC
+  ADP --> CE
+  RUN --> ADP --> HS
+  TST["tests/{inbound,adapters}"] -.consumes.-> RUN
+```
+
+## Agents
+
+| Agent instance | Tasks | Files | Subjects |
+|---|---|---|---|
+| backend-dev-A | T4, T5 | `inbound/attachment_ingest.py`, `packages/roxabi-blobs/.../http_store.py` | stage, blobs |
+| backend-dev-B | T2, T3, T15 | `core/messaging/message.py`, `infrastructure/blobstore_adapter.py`, `packages/roxabi-contracts/...`, audit | model, infra |
+| backend-dev-C | T8, T9, T12, T13 | `adapters/telegram/{telegram_normalize,telegram_inbound}.py`, `adapters/discord/{discord_formatting,discord_normalize,discord_inbound}.py` | telegram, discord |
+| tester-A | T1, T6 | `tests/inbound/test_attachment_ingest_nonaudio.py` | stage |
+| tester-B | T7, T10, T11, T14 | `tests/adapters/{telegram,discord}/test_*_nonaudio_ingest.py` | telegram, discord |
+
+## Wave Structure
+
+4 waves, max 4 parallel agents. Elapsed ~4 sequential-equivalent units vs ~15 fully serial.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 4 ∥ | tester-A: T1 · tester-B: T7→T11 · backend-dev-B: T2→T3 · backend-dev-A: T5 |
+| 2 | Wave 1 done | 1 | backend-dev-A: T4 (stage loop — needs T2 model + T3 typed-500) |
+| 3 | Wave 2 done | 1 | backend-dev-C: T8→T9→T12→T13 (adapter wiring — needs T4 + T5) |
+| 4 | Wave 3 done | 3 ∥ | tester-A: T6 (S5 gate) · tester-B: T10,T14 (S6/S7 gates) · backend-dev-B: T15 (audit + validate) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 unit tests (S5) | 1 | judgmental | 5 | — |
+| T2 model fields | 2 | bounded | 3 | — |
+| T3 typed-500 seam | 2 | judgmental | 5 | — |
+| T4 stage non-audio loop | 1 | judgmental | 6 | — |
+| T5 blobs timeout knob | 1 | bounded | 3 | — |
+| T6 S5 RED-GATE | 1 | bounded | 2 | — |
+| T7 TG e2e tests | 1 | judgmental | 5 | — |
+| T8 TG closures | 1 | judgmental | 5 | — |
+| T9 TG boundary reply | 1 | bounded | 3 | — |
+| T10 S6 RED-GATE | 1 | bounded | 2 | — |
+| T11 DC e2e tests | 1 | judgmental | 5 | — |
+| T12 DC closures | 1 | judgmental | 5 | — |
+| T13 DC boundary reply | 1 | bounded | 3 | — |
+| T14 S7 RED-GATE + #1066 note | 1 | bounded | 3 | — |
+| T15 audit sites + validate | ~8 sites | judgmental | 6 | — |
+
+**Total estimated ops: ~64** (across 5 instances, no single task > 50).
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|---|---|---|---|---|
+| backend-dev-A | T4, T5 | 9 | stage, blobs | — |
+| backend-dev-B | T2, T3, T15 | 14 | model, infra | — |
+| backend-dev-C | T8, T9, T12, T13 | 16 | telegram, discord | — (4 tasks = cap, 2 subjects) |
+| tester-A | T1, T6 | 7 | stage | — |
+| tester-B | T7, T10, T11, T14 | 15 | telegram, discord | — (4 tasks = cap, 2 subjects) |
+
+## Consistency Report
+
+Spec success-criteria (1552 spec) → task coverage:
+
+| SC | Covered by |
+|---|---|
+| real `BlobRef` into `Attachment.blob_ref`, all non-audio types, both platforms | T2, T4, T8, T12 |
+| `MAX_ATTACHMENT_INGEST_BYTES` enforced **before** download; reject + log + user error | T4 (guard + raise), T9/T13 (reply) |
+| stage catches HTTP 500 → user-facing error (no silent propagation) | T3 (typed seam), T4 (catch+raise), T9/T13 (reply) |
+| zero ingest duplication; `source` never branches in stage | T4 (single loop, source = metadata only) |
+| all `Attachment` construction sites audited for new field | T15 |
+| #1066 closed-as-superseded on merge | T14 (note) + PR linkage |
+
+Untraced tasks: none. Exemptions: D4 timeout (parent Open-Q1, folded into T5).
+
+## Micro-Tasks
+
+### Slice S5 — `Attachment.blob_ref` + stage non-audio + size guard + 500-map (N7,N8)
+
+**T1 [RED] [P] — tester-A — unit tests for non-audio stage**
+- File: `tests/inbound/test_attachment_ingest_nonaudio.py`
+- Cover: (a) `Attachment.blob_ref` defaults `None`; (b) stage stamps real `blob_ref` for a non-audio pending; (c) oversize declared size → `AttachmentIngestError` raised **and** `fetch` never awaited; (d) `put()` raising `BlobStoreServerError` → `AttachmentIngestError`; (e) N attachments → each `blob_ref` stamped; (f) voice path (`msg.audio` set) unchanged; (g) `pending_attachments` cleared on return (NATS safety).
+- Verify: `uv run pytest tests/inbound/test_attachment_ingest_nonaudio.py -q` (RED — fails until T2–T4).
+- Spec trace: S5 / SC1-3. Difficulty 3.
+
+**T2 [GREEN] — backend-dev-B — model fields**
+- File: `src/lyra/core/messaging/message.py`
+- `Attachment`: add `blob_ref: BlobRef | None = None` (import `from roxabi_contracts import BlobRef`). `InboundMessage`: add `pending_attachments: list[Any] = field(default_factory=list, repr=False)` with the same "transient, never serialized, cleared by stage" docstring as `pending_attachment`.
+- Verify: `uv run python -c "from lyra.core.messaging.message import Attachment, InboundMessage; a=Attachment(type='image', url_or_path_or_bytes='x', mime_type='image/png'); assert a.blob_ref is None"`
+- Spec trace: N7 / S5. Difficulty 2.
+
+**T3 [GREEN] — backend-dev-B — typed 500 at infra seam (D3)**
+- Files: `packages/roxabi-contracts/src/roxabi_contracts/` (add `BlobStoreServerError` beside `BlobNotFoundError`, export in `__init__`), `src/lyra/infrastructure/blobstore_adapter.py` (wrap `put` body: `except httpx.HTTPStatusError as e: if e.response.status_code >= 500: raise BlobStoreServerError(...) from e; raise`).
+- Verify: `uv run python -c "from roxabi_contracts import BlobStoreServerError"` + `uv run pytest tests/ -k blobstore_adapter -q`
+- Spec trace: parent §4, SC "no silent propagation". Difficulty 3.
+
+**T4 [GREEN] — backend-dev-A — stage non-audio loop + const + size + error (N8)**
+- File: `src/lyra/inbound/attachment_ingest.py`
+- Add module const `MAX_ATTACHMENT_INGEST_BYTES = int(os.environ.get("LYRA_MAX_ATTACHMENT_INGEST_BYTES", 20 * 1024 * 1024))` (mirror `LYRA_MAX_AUDIO_BYTES`). Add `size: int | None = None` to `PendingAttachment`. Add `class AttachmentIngestError(Exception)` carrying `user_message: str`. Implement non-audio path: iterate `msg.pending_attachments`; per item — if `size is not None and size > MAX` → log + `raise AttachmentIngestError("…too large…")` (**before** `fetch`); else `data = await p.fetch()`; `try: ref = await ctx.store.put(...)` `except BlobStoreServerError: raise AttachmentIngestError("…couldn't store…")`; rebuild `attachments[i] = replace(att, blob_ref=ref)`. Always return with `pending_attachments=()`/`[]` cleared. Keep the audio branch as-is. `source` must NOT branch logic.
+- Verify: `uv run pytest tests/inbound/test_attachment_ingest_nonaudio.py -q` (now GREEN) + `uv run python -m pytest --co -q tests/inbound >/dev/null`
+- Spec trace: N8 / SC1-4. Difficulty 4.
+
+**T5 [GREEN] [P] — backend-dev-A — write-timeout knob (D4, parent Open-Q1)**
+- File: `packages/roxabi-blobs/src/roxabi_blobs/http_store.py`
+- Make the client write timeout configurable: read `LYRA_BLOBSTORE_WRITE_TIMEOUT_S` (default `30.0`) at client construction (`httpx.Timeout(write=<env>, connect=5.0, read=5.0, pool=5.0)` or equivalent). Document the 20 MiB CDN→PUT rationale.
+- Verify: `uv run pytest packages/roxabi-blobs -q`
+- Spec trace: parent Open-Q1. Difficulty 2.
+
+**T6 [RED-GATE S5] — tester-A — S5 green + layer clean**
+- Verify: `uv run pytest tests/inbound -q` green; `uv run lint-imports` (importlinter) green — **`lyra.inbound` imports neither `httpx` nor `discord`/`aiogram`**; `bash tools/check_file_length.sh` for touched files ≤300.
+- Spec trace: SC "import-layers green". Difficulty 2.
+
+### Slice S6 — Wire Telegram non-audio (N9)
+
+**T7 [RED] [P] — tester-B — Telegram e2e**
+- File: `tests/adapters/telegram/test_telegram_nonaudio_ingest.py`
+- Cover: photo/document update → `normalize()` sets `pending_attachments` (closure + declared `size`); through pipeline → `attachments[0].blob_ref` real before hub; oversize file_size → `AttachmentIngestError` → `bot.send_message` "too large" reply, no hub push.
+- Verify: `uv run pytest tests/adapters/telegram/test_telegram_nonaudio_ingest.py -q` (RED).
+- Spec trace: S6. Difficulty 3.
+
+**T8 [GREEN] — backend-dev-C — Telegram closures**
+- File: `src/lyra/adapters/telegram/telegram_normalize.py`
+- `_extract_attachments(adapter, msg)` (add `adapter` param): for each media, build a `PendingAttachment(fetch=<closure: adapter.bot.get_file + download by file_id>, mime=…, source="telegram", size=<media.file_size>, platform_ref=file_id, filename=…)`. `normalize()` sets both `attachments=` and `pending_attachments=`. Keep `lyra.inbound` import of `PendingAttachment` under `TYPE_CHECKING` already present.
+- Verify: `uv run pytest tests/adapters/telegram -q -k "attachment or nonaudio"`
+- Spec trace: N9 / S6. Difficulty 3.
+
+**T9 [GREEN] — backend-dev-C — Telegram boundary reply**
+- File: `src/lyra/adapters/telegram/telegram_inbound.py` (the `pipeline.run(...)` call site in `handle_message`)
+- Wrap the pipeline call: `except AttachmentIngestError as e:` → reply with `adapter._msg("attachment_too_large", e.user_message)` via `adapter.bot.send_message(**_make_send_kwargs(...))` (mirror audio-too-large at `:133`), then return.
+- Verify: `uv run pytest tests/adapters/telegram -q`
+- Spec trace: S6 / D2. Difficulty 2.
+
+**T10 [RED-GATE S6] — tester-B — Telegram green**
+- Verify: `uv run pytest tests/adapters/telegram -q` green.
+- Spec trace: S6 AC. Difficulty 1.
+
+### Slice S7 — Wire Discord non-audio (N10) — closes #1066
+
+**T11 [RED] [P] — tester-B — Discord e2e**
+- File: `tests/adapters/discord/test_discord_nonaudio_ingest.py`
+- Cover: message with **multiple** attachments → each `blob_ref` stamped before hub; oversize (`attachment.size`) → `AttachmentIngestError` → channel reply, no hub push.
+- Verify: `uv run pytest tests/adapters/discord/test_discord_nonaudio_ingest.py -q` (RED).
+- Spec trace: S7 (multi-attachment is the Discord-specific AC). Difficulty 3.
+
+**T12 [GREEN] — backend-dev-C — Discord closures**
+- Files: `src/lyra/adapters/discord/discord_formatting.py` (`extract_attachments` → also return paired `PendingAttachment`s: `fetch=<a.read>`, `size=a.size`), `src/lyra/adapters/discord/discord_normalize.py` (set `pending_attachments`). Keep `discord` imports out of `lyra.inbound`.
+- Verify: `uv run pytest tests/adapters/discord -q -k "attachment or nonaudio"`
+- Spec trace: N10 / S7. Difficulty 3.
+
+**T13 [GREEN] — backend-dev-C — Discord boundary reply**
+- File: `src/lyra/adapters/discord/discord_inbound.py` (the `pipeline.run(...)` call site)
+- `except AttachmentIngestError as e:` → reply in-channel with `e.user_message`, then return.
+- Verify: `uv run pytest tests/adapters/discord -q`
+- Spec trace: S7 / D2. Difficulty 2.
+
+**T14 [RED-GATE S7] — tester-B — Discord green + #1066 note**
+- Verify: `uv run pytest tests/adapters/discord -q` green. Add PR body line `Closes #1066 as superseded` (linkage at /pr).
+- Spec trace: S7 AC + #1066 disposition. Difficulty 1.
+
+### Cross-cutting
+
+**T15 [REFACTOR] — backend-dev-B — audit construction sites + full validate**
+- Audit every `Attachment(` construction site (`git grep -n "Attachment("` in `src/` + `tests/`) — additive default means none must change, but confirm. Run full gate suite.
+- Verify: `uv run ruff format . && uv run ruff check . && uv run pyright && uv run pytest -q && uv run lint-imports`
+- Spec trace: SC "all construction sites audited". Difficulty 3.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T-numbers ref within this list. -->
+
+### Wave 1 — no deps, 4 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | tester-A | — | stage |
+| T2 | backend-dev-B | — | model |
+| T3 | backend-dev-B | T2 | infra |
+| T5 | backend-dev-A | — | blobs |
+| T7 | tester-B | — | telegram |
+| T11 | tester-B | T7 | discord |
+
+### Wave 2 — after T2,T3,T5
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T4 | backend-dev-A | T2, T3, T5 | stage |
+
+### Wave 3 — after T4
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T8 | backend-dev-C | T4 | telegram |
+| T9 | backend-dev-C | T8 | telegram |
+| T12 | backend-dev-C | T4 | discord |
+| T13 | backend-dev-C | T12 | discord |
+
+### Wave 4 — gates + audit
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T6 | tester-A | T1, T4 | stage |
+| T10 | tester-B | T7, T9 | telegram |
+| T14 | tester-B | T11, T13 | discord |
+| T15 | backend-dev-B | T4, T9, T13 | model |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — stage (RED unit)
+- T2: 13 — model
+- T3: 14 — infra (typed 500)
+- T4: 15 — stage (non-audio loop)
+- T5: 16 — blobs (timeout knob)
+- T6: 17 — stage (S5 RED-GATE)
+- T7: 18 — telegram (RED e2e)
+- T8: 19 — telegram (closures)
+- T9: 20 — telegram (boundary reply)
+- T10: 21 — telegram (S6 RED-GATE)
+- T11: 22 — discord (RED e2e)
+- T12: 23 — discord (closures)
+- T13: 24 — discord (boundary reply)
+- T14: 25 — discord (S7 RED-GATE + #1066)
+- T15: 26 — model (audit + validate)

--- a/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
@@ -15,9 +15,15 @@ from .models import BlobRef
 # Default write (and overall/read) timeout raised from 5 s to 30 s to accommodate
 # 20 MiB non-audio CDN→PUT transfers (#1552 / parent Open-Q1).  connect stays at
 # 5 s — it is unaffected by payload size.
-_DEFAULT_WRITE_TIMEOUT_S: float = float(
-    os.environ.get("LYRA_BLOBSTORE_WRITE_TIMEOUT_S", "30.0")
-)
+_raw_write_timeout = os.environ.get("LYRA_BLOBSTORE_WRITE_TIMEOUT_S")
+try:
+    _DEFAULT_WRITE_TIMEOUT_S: float = (
+        float(_raw_write_timeout) if _raw_write_timeout else 30.0
+    )
+except ValueError:
+    raise ValueError(
+        f"LYRA_BLOBSTORE_WRITE_TIMEOUT_S must be a float, got {_raw_write_timeout!r}"
+    ) from None
 
 
 class HttpBlobStore:

--- a/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/http_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import UTC, datetime
 from typing import Any
 
@@ -11,11 +12,19 @@ import httpx
 from .errors import BlobNotFoundError
 from .models import BlobRef
 
+# Default write (and overall/read) timeout raised from 5 s to 30 s to accommodate
+# 20 MiB non-audio CDN→PUT transfers (#1552 / parent Open-Q1).  connect stays at
+# 5 s — it is unaffected by payload size.
+_DEFAULT_WRITE_TIMEOUT_S: float = float(
+    os.environ.get("LYRA_BLOBSTORE_WRITE_TIMEOUT_S", "30.0")
+)
+
 
 class HttpBlobStore:
     """HTTP client for a remote `lyra blobstore serve` service.
 
-    Per-request timeout = 5 s connect / 5 s read.
+    Per-request timeout: connect=5 s, write/read/pool=``timeout`` seconds
+    (default 30 s, overridable via ``LYRA_BLOBSTORE_WRITE_TIMEOUT_S`` env var).
     """
 
     def __init__(
@@ -23,10 +32,12 @@ class HttpBlobStore:
         base_url: str,
         token: str,
         *,
+        timeout: float = _DEFAULT_WRITE_TIMEOUT_S,
         _transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._token = token
+        self._timeout = timeout
         self._transport = _transport
         self._client: httpx.AsyncClient | None = None
         # ASGI lifespan support (test seam only — production uses real HTTP)
@@ -86,7 +97,7 @@ class HttpBlobStore:
                 base_url=self._base_url,
                 headers={"Authorization": f"Bearer {self._token}"},
                 transport=self._transport,  # None → default network transport
-                timeout=httpx.Timeout(5.0, connect=5.0),
+                timeout=httpx.Timeout(self._timeout, connect=5.0),
             )
         return self._client
 

--- a/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
@@ -10,7 +10,7 @@ per-domain submodules (voice, image, memory, llm) arrive in later tags.
 from importlib.metadata import PackageNotFoundError, version
 
 from .audit import SecurityEvent
-from .blob_errors import BlobNotFoundError
+from .blob_errors import BlobNotFoundError, BlobStoreServerError
 from .blob_ref import PENDING_STORE_KEY, BlobRef
 from .envelope import CONTRACT_VERSION, ContractEnvelope
 
@@ -22,6 +22,7 @@ except PackageNotFoundError:
 __all__ = [
     "BlobNotFoundError",
     "BlobRef",
+    "BlobStoreServerError",
     "CONTRACT_VERSION",
     "ContractEnvelope",
     "PENDING_STORE_KEY",

--- a/packages/roxabi-contracts/src/roxabi_contracts/blob_errors.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/blob_errors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["BlobNotFoundError"]
+__all__ = ["BlobNotFoundError", "BlobStoreServerError"]
 
 
 def _redact_key(key: str) -> str:
@@ -24,3 +24,28 @@ class BlobNotFoundError(Exception):
     def __init__(self, key: str) -> None:
         self.key = key
         super().__init__(_redact_key(key))
+
+
+class BlobStoreServerError(Exception):
+    """Raised by BlobStorePort.put when the backing store returns an HTTP 5xx.
+
+    Callers import this from ``roxabi_contracts`` (not ``roxabi_blobs`` or
+    ``httpx``); the adapter layer translates the HTTP error at the seam.
+    Infrastructure is the only layer permitted to inspect HTTP status codes.
+
+    ``.status_code`` carries the HTTP status (e.g. 500, 502, 503) when
+    available; None when the error predates HTTP (e.g. connection failure
+    surfaced as a 5xx-family escalation). ``.message`` is a human-readable
+    description for logging.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.message = message
+        suffix = f" (HTTP {status_code})" if status_code is not None else ""
+        super().__init__(f"{message}{suffix}")

--- a/src/lyra/adapters/discord/discord_formatting.py
+++ b/src/lyra/adapters/discord/discord_formatting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
 from typing import Any
@@ -101,7 +102,9 @@ def extract_attachments(
         )
         # Per-item factory avoids late-binding: each closure captures its own
         # ``_read`` bound method, not the loop variable ``a``.
-        _read = a.read
+        # use_cached=True fetches via proxy_url (longer-lived than the direct CDN
+        # URL, which expires before the stage can fetch post-queue).
+        _read = functools.partial(a.read, use_cached=True)
         pendings.append(
             PendingAttachment(
                 fetch=_read,

--- a/src/lyra/adapters/discord/discord_formatting.py
+++ b/src/lyra/adapters/discord/discord_formatting.py
@@ -16,6 +16,7 @@ from lyra.core.messaging.message import (
     InboundMessage,
     Platform,
 )
+from lyra.inbound.attachment_ingest import PendingAttachment
 
 log = logging.getLogger("lyra.adapters.discord")
 
@@ -64,9 +65,21 @@ def make_thread_name(content: str, fallback: str) -> str:
     return name[:100]
 
 
-def extract_attachments(raw_attachments: list[Any]) -> list[Attachment]:
-    """Extract non-audio Attachment objects from Discord message.attachments."""
-    result: list[Attachment] = []
+def extract_attachments(
+    raw_attachments: list[Any],
+) -> tuple[list[Attachment], list[PendingAttachment]]:
+    """Extract non-audio Attachment objects and PendingAttachment closures.
+
+    Returns a tuple (attachments, pending_attachments), index-aligned.
+    Audio attachments (content_type in AUDIO_MIME_TYPES) are skipped entirely —
+    they are handled by the audio short-circuit path in discord_inbound.
+
+    For each non-audio attachment the PendingAttachment closure captures
+    ``a.read`` by per-item binding (no late-binding loop bug) so the stage
+    can ``await fetch()`` without touching any discord type.
+    """
+    attachments: list[Attachment] = []
+    pendings: list[PendingAttachment] = []
     for a in raw_attachments:
         ct = getattr(a, "content_type", None) or ""
         if ct in AUDIO_MIME_TYPES:
@@ -77,15 +90,29 @@ def extract_attachments(raw_attachments: list[Any]) -> list[Attachment]:
             att_type = "video"
         else:
             att_type = "file"
-        result.append(
+        mime = ct or "application/octet-stream"
+        attachments.append(
             Attachment(
                 type=att_type,
                 url_or_path_or_bytes=a.url,
-                mime_type=ct or "application/octet-stream",
+                mime_type=mime,
                 filename=getattr(a, "filename", None),
             )
         )
-    return result
+        # Per-item factory avoids late-binding: each closure captures its own
+        # ``_read`` bound method, not the loop variable ``a``.
+        _read = a.read
+        pendings.append(
+            PendingAttachment(
+                fetch=_read,
+                mime=mime,
+                source="discord",
+                platform_ref=a.url,
+                filename=getattr(a, "filename", None),
+                size=getattr(a, "size", None),
+            )
+        )
+    return attachments, pendings
 
 
 def render_text(text: str, max_length: int = 2000) -> list[str]:

--- a/src/lyra/adapters/discord/discord_inbound.py
+++ b/src/lyra/adapters/discord/discord_inbound.py
@@ -16,7 +16,7 @@ from lyra.adapters.discord.discord_threads import persist_thread_claim
 from lyra.adapters.shared._shared import AUDIO_MIME_TYPES
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import DiscordMeta, InboundMessage
-from lyra.inbound.attachment_ingest import AttachmentIngestStage
+from lyra.inbound.attachment_ingest import AttachmentIngestError, AttachmentIngestStage
 from lyra.inbound.context import DispatchCtx, InboundContext, RouterCtx, SessionCtx
 from lyra.inbound.dispatcher import Dispatcher
 from lyra.inbound.pipeline import InboundPipeline
@@ -241,8 +241,7 @@ async def _discord_pre_session_hook(
 async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:
     """Handle incoming Gateway message.
 
-    Filters own/bot messages, dispatches audio/voice short-circuits,
-    then delegates to InboundPipeline for the text path.
+    Bot filter → audio/voice short-circuits → InboundPipeline (text path).
     """
     # Discard bot messages early — before normalization to avoid waste.
     if message.author.bot:
@@ -266,8 +265,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:
         if await adapter._handle_voice_command(message, TrustLevel.PUBLIC):
             return
 
-    # _cancel_typing is keyed by id — use channel.id (what was started); never
-    # thread.id (auto-thread is created later by pre_session_hook, after typing starts).
+    # Use channel.id (not thread.id — auto-thread is created later by pre_session_hook).
     send_to_id = message.channel.id
     adapter._start_typing(send_to_id)
 
@@ -277,7 +275,8 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:
         parser = DiscordWireParser(adapter)
         _parser_cache[id(adapter)] = parser
 
-    inbound_ctx = build_discord_inbound_ctx(adapter)
+    _ingest = getattr(adapter, "_ingest_ctx", None)
+    inbound_ctx = build_discord_inbound_ctx(adapter, ingest=_ingest)
 
     pre_route = functools.partial(_discord_pre_route_hook, adapter=adapter)
     pre_session = functools.partial(
@@ -287,12 +286,15 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:
     async def _dc_backpressure(text: str) -> None:
         await message.reply(text)
 
-    await _pipeline.run(
-        message,
-        inbound_ctx,
-        parser,
-        pre_route_hook=pre_route,
-        pre_session_hook=pre_session,
-        send_backpressure=_dc_backpressure,
-        on_drop=lambda: adapter._cancel_typing(send_to_id),
-    )
+    try:
+        await _pipeline.run(
+            message,
+            inbound_ctx,
+            parser,
+            pre_route_hook=pre_route,
+            pre_session_hook=pre_session,
+            send_backpressure=_dc_backpressure,
+            on_drop=lambda: adapter._cancel_typing(send_to_id),
+        )
+    except AttachmentIngestError as e:
+        await message.reply(e.user_message)

--- a/src/lyra/adapters/discord/discord_normalize.py
+++ b/src/lyra/adapters/discord/discord_normalize.py
@@ -80,7 +80,8 @@ def normalize(  # noqa: PLR0913 — DEBT:wiring-bootstrap-deps
 
     _display_name = getattr(raw.author, "display_name", None)
     roles = tuple(str(r.id) for r in getattr(raw.author, "roles", []) or [])
-    attachments = extract_attachments(getattr(raw, "attachments", None) or [])
+    raw_atts = getattr(raw, "attachments", None) or []
+    attachments, _pendings = extract_attachments(raw_atts)
     _reference = getattr(raw, "reference", None)
     reply_to_id: str | None = (
         str(_reference.message_id)
@@ -114,6 +115,7 @@ def normalize(  # noqa: PLR0913 — DEBT:wiring-bootstrap-deps
         text=text,
         text_raw=raw.content,
         attachments=attachments,
+        pending_attachments=_pendings,
         timestamp=timestamp,
         trust_level=trust_level,
         is_admin=is_admin,

--- a/src/lyra/adapters/telegram/telegram_attachments.py
+++ b/src/lyra/adapters/telegram/telegram_attachments.py
@@ -1,0 +1,175 @@
+"""Telegram non-audio attachment helpers (T8, #1552).
+
+Extracted from ``telegram_normalize.py`` to keep that module ≤300 lines.
+
+``_make_fetch_closure`` builds the async download closure for a single file_id.
+``_extract_attachments`` returns index-aligned (Attachment, PendingAttachment) pairs
+for every non-audio media object on a Telegram message.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lyra.core.messaging.message import Attachment
+from lyra.inbound.attachment_ingest import PendingAttachment
+
+if TYPE_CHECKING:
+    from lyra.adapters.telegram import TelegramAdapter
+
+
+def _make_fetch_closure(adapter: "TelegramAdapter", file_id: str) -> Any:
+    """Return an async closure that downloads ``file_id`` bytes via the bot.
+
+    Binds ``file_id`` eagerly (default-arg pattern) to avoid the loop
+    late-binding bug when called from a comprehension.
+    """
+
+    async def _fetch(
+        _adapter: "TelegramAdapter" = adapter,
+        _file_id: str = file_id,
+    ) -> bytes:
+        file_ = await _adapter.bot.get_file(_file_id)
+        buf = await _adapter.bot.download(file=file_.file_id)
+        if isinstance(buf, (bytes, bytearray)):
+            return bytes(buf)
+        # BytesIO / file-like
+        return buf.read()
+
+    return _fetch
+
+
+def _extract_attachments(
+    adapter: "TelegramAdapter", msg: Any
+) -> tuple[list[Attachment], list[PendingAttachment]]:
+    """Extract non-audio Attachment + PendingAttachment pairs from a Telegram message.
+
+    Returns two index-aligned lists: (attachments, pending_attachments).
+    Each PendingAttachment carries an async fetch closure bound to the adapter
+    and the platform file_id, plus declared size metadata for the oversize guard.
+    """
+    attachments: list[Attachment] = []
+    pendings: list[PendingAttachment] = []
+    message_id: int | None = getattr(msg, "message_id", None)
+    platform_message_id = str(message_id) if message_id is not None else None
+
+    # photo: list of PhotoSize, take largest (last)
+    photo = getattr(msg, "photo", None)
+    if photo:
+        largest = photo[-1]
+        file_id: str = largest.file_id
+        mime = "image/jpeg"
+        attachments.append(
+            Attachment(
+                type="image",
+                url_or_path_or_bytes=f"tg:file_id:{file_id}",
+                mime_type=mime,
+            )
+        )
+        pendings.append(
+            PendingAttachment(
+                fetch=_make_fetch_closure(adapter, file_id),
+                mime=mime,
+                source="telegram",
+                platform_ref=file_id,
+                platform_message_id=platform_message_id,
+                size=getattr(largest, "file_size", None),
+            )
+        )
+
+    doc = getattr(msg, "document", None)
+    if doc:
+        file_id = doc.file_id
+        mime = getattr(doc, "mime_type", None) or "application/octet-stream"
+        filename = getattr(doc, "file_name", None)
+        attachments.append(
+            Attachment(
+                type="file",
+                url_or_path_or_bytes=f"tg:file_id:{file_id}",
+                mime_type=mime,
+                filename=filename,
+            )
+        )
+        pendings.append(
+            PendingAttachment(
+                fetch=_make_fetch_closure(adapter, file_id),
+                mime=mime,
+                source="telegram",
+                platform_ref=file_id,
+                platform_message_id=platform_message_id,
+                filename=filename,
+                size=getattr(doc, "file_size", None),
+            )
+        )
+
+    video = getattr(msg, "video", None)
+    if video:
+        file_id = video.file_id
+        mime = getattr(video, "mime_type", None) or "video/mp4"
+        attachments.append(
+            Attachment(
+                type="video",
+                url_or_path_or_bytes=f"tg:file_id:{file_id}",
+                mime_type=mime,
+            )
+        )
+        pendings.append(
+            PendingAttachment(
+                fetch=_make_fetch_closure(adapter, file_id),
+                mime=mime,
+                source="telegram",
+                platform_ref=file_id,
+                platform_message_id=platform_message_id,
+                size=getattr(video, "file_size", None),
+            )
+        )
+
+    anim = getattr(msg, "animation", None)
+    if anim:
+        file_id = anim.file_id
+        mime = "image/gif"
+        attachments.append(
+            Attachment(
+                type="image",
+                url_or_path_or_bytes=f"tg:file_id:{file_id}",
+                mime_type=mime,
+            )
+        )
+        pendings.append(
+            PendingAttachment(
+                fetch=_make_fetch_closure(adapter, file_id),
+                mime=mime,
+                source="telegram",
+                platform_ref=file_id,
+                platform_message_id=platform_message_id,
+                size=getattr(anim, "file_size", None),
+            )
+        )
+
+    sticker = getattr(msg, "sticker", None)
+    if sticker:
+        # Only static WebP stickers; skip animated (.tgs) and video (.webm)
+        if not getattr(sticker, "is_animated", False) and not getattr(
+            sticker, "is_video", False
+        ):
+            file_id = sticker.file_id
+            mime = "image/webp"
+            attachments.append(
+                Attachment(
+                    type="image",
+                    url_or_path_or_bytes=f"tg:file_id:{file_id}",
+                    mime_type=mime,
+                )
+            )
+            pendings.append(
+                PendingAttachment(
+                    fetch=_make_fetch_closure(adapter, file_id),
+                    mime=mime,
+                    source="telegram",
+                    platform_ref=file_id,
+                    platform_message_id=platform_message_id,
+                    size=getattr(sticker, "file_size", None),
+                )
+            )
+
+    return attachments, pendings

--- a/src/lyra/adapters/telegram/telegram_attachments.py
+++ b/src/lyra/adapters/telegram/telegram_attachments.py
@@ -30,7 +30,7 @@ def _make_fetch_closure(adapter: "TelegramAdapter", file_id: str) -> Any:
         _file_id: str = file_id,
     ) -> bytes:
         file_ = await _adapter.bot.get_file(_file_id)
-        buf = await _adapter.bot.download(file=file_.file_id)
+        buf = await _adapter.bot.download_file(file_.file_path)
         if isinstance(buf, (bytes, bytearray)):
             return bytes(buf)
         # BytesIO / file-like

--- a/src/lyra/adapters/telegram/telegram_inbound.py
+++ b/src/lyra/adapters/telegram/telegram_inbound.py
@@ -78,7 +78,7 @@ async def handle_message(adapter: "TelegramAdapter", msg: Any) -> None:
             typing=adapter._typing,
             msg_catalog=adapter._msg_manager,
         ),
-        ingest=getattr(adapter, "_ingest_ctx", None),
+        ingest=adapter._ingest_ctx,
     )
 
     async def _tg_backpressure(text: str) -> None:
@@ -232,7 +232,7 @@ async def handle_voice_message(adapter: "TelegramAdapter", msg: Any) -> None:  #
             typing=adapter._typing,
             msg_catalog=adapter._msg_manager,
         ),
-        ingest=getattr(adapter, "_ingest_ctx", None),
+        ingest=adapter._ingest_ctx,
     )
 
     async def _send_bp(text: str) -> None:

--- a/src/lyra/adapters/telegram/telegram_inbound.py
+++ b/src/lyra/adapters/telegram/telegram_inbound.py
@@ -11,7 +11,11 @@ from lyra.adapters.telegram.telegram_audio import _download_audio
 from lyra.adapters.telegram.telegram_formatting import _make_send_kwargs
 from lyra.adapters.telegram.telegram_normalize import _make_scope_id, normalize_audio
 from lyra.core.auth.trust import TrustLevel
-from lyra.inbound.attachment_ingest import AttachmentIngestStage, PendingAttachment
+from lyra.inbound.attachment_ingest import (
+    AttachmentIngestError,
+    AttachmentIngestStage,
+    PendingAttachment,
+)
 from lyra.inbound.context import DispatchCtx, InboundContext, RouterCtx, SessionCtx
 from lyra.inbound.dispatcher import Dispatcher
 from lyra.inbound.pipeline import InboundPipeline
@@ -74,18 +78,31 @@ async def handle_message(adapter: "TelegramAdapter", msg: Any) -> None:
             typing=adapter._typing,
             msg_catalog=adapter._msg_manager,
         ),
+        ingest=getattr(adapter, "_ingest_ctx", None),
     )
 
     async def _tg_backpressure(text: str) -> None:
         await adapter.bot.send_message(msg.chat.id, text)
 
-    await _pipeline.run(
-        msg,
-        inbound_ctx,
-        parser,
-        send_backpressure=_tg_backpressure,
-        on_drop=lambda: adapter._cancel_typing(msg.chat.id),
-    )
+    try:
+        await _pipeline.run(
+            msg,
+            inbound_ctx,
+            parser,
+            send_backpressure=_tg_backpressure,
+            on_drop=lambda: adapter._cancel_typing(msg.chat.id),
+        )
+    except AttachmentIngestError as e:
+        try:
+            await adapter.bot.send_message(
+                **_make_send_kwargs(msg.chat.id, e.user_message, msg.message_id)
+            )
+        except TelegramAPIError:
+            log.warning(
+                "Failed to send attachment-too-large reply for chat_id=%s",
+                msg.chat.id,
+            )
+        return
 
 
 async def handle_voice_message(adapter: "TelegramAdapter", msg: Any) -> None:  # noqa: C901

--- a/src/lyra/adapters/telegram/telegram_normalize.py
+++ b/src/lyra/adapters/telegram/telegram_normalize.py
@@ -6,80 +6,22 @@ import logging
 from datetime import timezone
 from typing import TYPE_CHECKING, Any
 
+from lyra.adapters.telegram.telegram_attachments import _extract_attachments
 from lyra.core.audio_payload import AudioPayload
 from lyra.core.auth.trust import TrustLevel
 from lyra.core.messaging.message import (
-    Attachment,
     InboundMessage,
     Platform,
     RoutingContext,
     TelegramMeta,
 )
+from lyra.inbound.attachment_ingest import PendingAttachment
 from roxabi_contracts import PENDING_STORE_KEY, BlobRef
 
 if TYPE_CHECKING:
     from lyra.adapters.telegram import TelegramAdapter
-    from lyra.inbound.attachment_ingest import PendingAttachment
 
 log = logging.getLogger("lyra.adapters.telegram")
-
-
-def _extract_attachments(msg: Any) -> list[Attachment]:
-    """Extract non-audio Attachment objects from a Telegram message."""
-    result: list[Attachment] = []
-    # photo: list of PhotoSize, take largest (last)
-    photo = getattr(msg, "photo", None)
-    if photo:
-        largest = photo[-1]
-        result.append(
-            Attachment(
-                type="image",
-                url_or_path_or_bytes=f"tg:file_id:{largest.file_id}",
-                mime_type="image/jpeg",
-            )
-        )
-    doc = getattr(msg, "document", None)
-    if doc:
-        result.append(
-            Attachment(
-                type="file",
-                url_or_path_or_bytes=f"tg:file_id:{doc.file_id}",
-                mime_type=getattr(doc, "mime_type", None) or "application/octet-stream",
-                filename=getattr(doc, "file_name", None),
-            )
-        )
-    video = getattr(msg, "video", None)
-    if video:
-        result.append(
-            Attachment(
-                type="video",
-                url_or_path_or_bytes=f"tg:file_id:{video.file_id}",
-                mime_type=getattr(video, "mime_type", None) or "video/mp4",
-            )
-        )
-    anim = getattr(msg, "animation", None)
-    if anim:
-        result.append(
-            Attachment(
-                type="image",
-                url_or_path_or_bytes=f"tg:file_id:{anim.file_id}",
-                mime_type="image/gif",
-            )
-        )
-    sticker = getattr(msg, "sticker", None)
-    if sticker:
-        # Only static WebP stickers; skip animated (.tgs) and video (.webm)
-        if not getattr(sticker, "is_animated", False) and not getattr(
-            sticker, "is_video", False
-        ):
-            result.append(
-                Attachment(
-                    type="image",
-                    url_or_path_or_bytes=f"tg:file_id:{sticker.file_id}",
-                    mime_type="image/webp",
-                )
-            )
-    return result
 
 
 def _make_scope_id(
@@ -187,7 +129,7 @@ def normalize(  # noqa: C901 — DEBT:wiring-bootstrap-deps
         chat_id,
     )
 
-    attachments = _extract_attachments(raw)
+    attachments, pendings = _extract_attachments(adapter, raw)
     message_id = getattr(raw, "message_id", None)
     reply_to_message = getattr(raw, "reply_to_message", None)
     reply_to_id = (
@@ -207,6 +149,7 @@ def normalize(  # noqa: C901 — DEBT:wiring-bootstrap-deps
         text=text,
         text_raw=text,
         attachments=attachments,
+        pending_attachments=pendings,
         timestamp=timestamp,
         trust_level=trust_level,
         is_admin=is_admin,
@@ -223,7 +166,7 @@ def normalize_audio(  # noqa: PLR0913 — ChannelAdapter protocol; pending is ad
     mime_type: str,
     *,
     trust_level: TrustLevel,
-    pending: "PendingAttachment | None" = None,
+    pending: PendingAttachment | None = None,
 ) -> InboundMessage:
     """Build a voice InboundMessage from a Telegram audio/voice/video_note update.
 

--- a/src/lyra/core/messaging/message.py
+++ b/src/lyra/core/messaging/message.py
@@ -80,20 +80,19 @@ class RoutingContext:
 class Attachment:
     """A file or media attachment on an InboundMessage.
 
-    url_or_path_or_bytes stores platform-specific references:
+    url_or_path_or_bytes stores a platform-specific reference:
     - Discord: direct CDN URL (str) — fetchable with HTTP GET.
-    - Telegram: prefixed file_id (str, ``"tg:file_id:{id}"``) — resolve via
-      Bot API ``getFile``. Detect with
-      ``url_or_path_or_bytes.startswith("tg:file_id:")``.
-    - Local filesystem path (str, e.g. ``"/tmp/tmpXXX.ogg"``) — for audio
-      downloaded by adapters before normalization.
-    - Raw bytes (bytes) — for pre-downloaded media (future).
+    - Telegram: prefixed file_id (``"tg:file_id:{id}"``) — resolve via Bot API
+      ``getFile``; detect with ``.startswith("tg:file_id:")``.
+    - Local path (str) for pre-download audio, or raw bytes (future).
     """
 
     type: str  # "image" | "audio" | "video" | "file"
     url_or_path_or_bytes: str | bytes  # URL, local path, or raw bytes
     mime_type: str
     filename: str | None = None
+    # content-addressed ref; stamped by AttachmentIngestStage (#1552)
+    blob_ref: BlobRef | None = None
 
 
 @dataclass(frozen=True)
@@ -139,9 +138,11 @@ class InboundMessage:
     # Callback set by adapters to persist session ID after a turn starts (#853).
     # Not serialized over NATS (callable cannot cross process boundary).
     session_update_fn: SessionUpdateFn | None = field(default=None, repr=False)
-    # Transient adapter→stage carrier for PendingAttachment. Typed Any to avoid
-    # core→inbound cycle; never serialized; cleared by AttachmentIngestStage (#1551).
+    # Transient adapter→stage carriers (Typed Any → avoid core→inbound cycle; never
+    # serialized; cleared by AttachmentIngestStage). Singular = audio (#1551); plural =
+    # non-audio, index-aligned with `attachments` (#1552).
     pending_attachment: Any = field(default=None, repr=False)
+    pending_attachments: list[Any] = field(default_factory=list, repr=False)
 
 
 @dataclass

--- a/src/lyra/inbound/attachment_ingest.py
+++ b/src/lyra/inbound/attachment_ingest.py
@@ -34,9 +34,15 @@ if TYPE_CHECKING:
 # Maximum bytes for a non-audio attachment before download is refused.
 # Mirrors LYRA_MAX_AUDIO_BYTES (TG getFile 20 MiB cap) — raised via env for
 # large CDN→PUT transfers (#1552 / parent Open-Q1).
-MAX_ATTACHMENT_INGEST_BYTES: int = int(
-    os.environ.get("LYRA_MAX_ATTACHMENT_INGEST_BYTES", 20 * 1024 * 1024)
-)
+_raw_max_ingest = os.environ.get("LYRA_MAX_ATTACHMENT_INGEST_BYTES")
+try:
+    MAX_ATTACHMENT_INGEST_BYTES: int = (
+        int(_raw_max_ingest) if _raw_max_ingest else 20 * 1024 * 1024
+    )
+except ValueError:
+    raise ValueError(
+        f"LYRA_MAX_ATTACHMENT_INGEST_BYTES must be an int, got {_raw_max_ingest!r}"
+    ) from None
 
 FetchFn = Callable[[], Awaitable[bytes]]
 log = logging.getLogger(__name__)
@@ -181,6 +187,14 @@ class AttachmentIngestStage:
                 )
                 raise AttachmentIngestError("That file is too large to process.")
             data = await p.fetch()
+            if len(data) > MAX_ATTACHMENT_INGEST_BYTES:
+                log.warning(
+                    "attachment exceeded cap after fetch: %s > %s (source=%s)",
+                    len(data),
+                    MAX_ATTACHMENT_INGEST_BYTES,
+                    p.source,
+                )
+                raise AttachmentIngestError("That file is too large to process.")
             try:
                 ref = await store.put(
                     data,

--- a/src/lyra/inbound/attachment_ingest.py
+++ b/src/lyra/inbound/attachment_ingest.py
@@ -2,8 +2,12 @@
 
 Voice path (#1551): fetches a pending attachment via its closure, stores the
 bytes in BlobStore, and stamps the returned real BlobRef onto
-``InboundMessage.audio.blob_ref``.  Non-audio attachments (P2, #1552) are
-passed through with ``pending_attachment`` cleared.
+``InboundMessage.audio.blob_ref``.
+
+Non-audio path (#1552): iterates ``pending_attachments``, enforces a per-item
+size cap before fetching, stores each item, stamps the returned real BlobRef
+onto the matching ``InboundMessage.attachments[i].blob_ref``, and clears
+``pending_attachments`` so the message is safe to serialise over NATS.
 
 Layer invariant: this module MUST NOT import ``discord``, ``aiogram``, or
 ``lyra.adapters``.  BlobStorePort is imported from ``lyra.core.ports.blobstore``
@@ -16,13 +20,23 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from roxabi_contracts import BlobStoreServerError
+
 if TYPE_CHECKING:
     from lyra.core.messaging.message import InboundMessage
     from lyra.core.ports.blobstore import BlobStorePort
+
+# Maximum bytes for a non-audio attachment before download is refused.
+# Mirrors LYRA_MAX_AUDIO_BYTES (TG getFile 20 MiB cap) — raised via env for
+# large CDN→PUT transfers (#1552 / parent Open-Q1).
+MAX_ATTACHMENT_INGEST_BYTES: int = int(
+    os.environ.get("LYRA_MAX_ATTACHMENT_INGEST_BYTES", 20 * 1024 * 1024)
+)
 
 FetchFn = Callable[[], Awaitable[bytes]]
 log = logging.getLogger(__name__)
@@ -44,6 +58,20 @@ class PendingAttachment:
     platform_ref: str | None = None
     platform_message_id: str | None = None
     filename: str | None = None
+    # Declared byte count supplied by the platform before download; used for
+    # the oversize guard in _ingest_non_audio (#1552).
+    size: int | None = None
+
+
+class AttachmentIngestError(Exception):
+    """Non-audio ingest failed (oversize before download, or BlobStore 5xx).
+
+    Carries a user-facing message the adapter boundary surfaces as a reply (#1552).
+    """
+
+    def __init__(self, user_message: str) -> None:
+        self.user_message = user_message
+        super().__init__(user_message)
 
 
 @dataclass(frozen=True)
@@ -54,33 +82,65 @@ class IngestCtx:
 
 
 class AttachmentIngestStage:
-    """Central inbound attachment ingest (ADR-083, epic #1537). Voice path (#1551)."""
+    """Central inbound attachment ingest (ADR-083, epic #1537).
+
+    Handles both carriers:
+    - Voice / audio path (#1551): singular ``pending_attachment`` → stamps
+      ``msg.audio.blob_ref`` with the real BlobRef; degrades gracefully on error.
+    - Non-audio path (#1552): list ``pending_attachments`` → stamps each
+      ``msg.attachments[i].blob_ref``; clears ``pending_attachments``; raises
+      ``AttachmentIngestError`` on oversize or BlobStore 5xx.
+    """
 
     async def run(self, msg: "InboundMessage", ctx: IngestCtx) -> "InboundMessage":
-        """Resolve a pending attachment and stamp the real BlobRef onto the message.
+        """Resolve pending attachments and stamp real BlobRefs onto the message.
 
         Contract:
-        - No pending_attachment or no store → no-op passthrough (msg returned
-          unchanged, including any PENDING sentinel on audio.blob_ref).
-        - Fetch failure → degraded: ``pending_attachment`` cleared, audio
-          blob_ref preserved as-is (still PENDING — downstream STT will degrade
-          gracefully).
-        - Success (audio path) → real BlobRef stamped on ``msg.audio.blob_ref``;
+        - ``ctx.store is None`` → no-op passthrough (CLI/test; leaves carriers
+          intact, unchanged contract).
+        - Non-audio path (``msg.pending_attachments`` non-empty):
+          each item size-checked before fetch; on success stamps
+          ``attachments[i].blob_ref``; clears ``pending_attachments``.
+          Raises ``AttachmentIngestError`` on oversize or BlobStore 5xx.
+        - Audio path (``msg.pending_attachment`` set):
+          fetch failure or put failure → degraded: ``pending_attachment``
+          cleared, ``audio.blob_ref`` preserved as PENDING.
+          Success → real BlobRef stamped on ``msg.audio.blob_ref``;
           ``pending_attachment`` cleared.
-        - Success (non-audio path, P2 #1552) → ``pending_attachment`` cleared;
-          audio untouched.
 
-        CRITICAL: both degraded and success paths set ``pending_attachment=None``
-        before returning.  The NATS serialiser recurses into dataclasses and
-        would encounter the fetch closure, producing an undecodable dict.
+        CRITICAL: both degraded and success audio paths set
+        ``pending_attachment=None`` before returning.  The NATS serialiser
+        recurses into dataclasses and would encounter the fetch closure,
+        producing an undecodable dict.
+
+        AXIAL GUARD: ``source`` is never inspected to branch logic — it is
+        only forwarded to ``store.put``.
         """
-        pending = cast("PendingAttachment | None", msg.pending_attachment)
-        if pending is None or ctx.store is None:
-            return msg  # no-op passthrough
+        if ctx.store is None:
+            return msg  # no-op passthrough (CLI/test; leaves carriers intact)
 
+        if msg.pending_attachments:  # non-audio (P2 #1552)
+            msg = await self._ingest_non_audio(msg, ctx.store)
+
+        pending = cast("PendingAttachment | None", msg.pending_attachment)
+        if pending is not None:  # audio (#1551) — UNCHANGED policy
+            msg = await self._ingest_audio(msg, pending, ctx.store)
+
+        return msg
+
+    async def _ingest_audio(
+        self,
+        msg: "InboundMessage",
+        pending: "PendingAttachment",
+        store: "BlobStorePort",
+    ) -> "InboundMessage":
+        """Voice ingest: fetch → store.put → stamp audio.blob_ref.
+
+        Degrades gracefully on any error (PENDING preserved, closure cleared).
+        """
         try:
             data = await pending.fetch()
-            wire_ref = await ctx.store.put(
+            wire_ref = await store.put(
                 data,
                 mime=pending.mime,
                 source=pending.source,
@@ -93,7 +153,48 @@ class AttachmentIngestStage:
             return dataclasses.replace(msg, pending_attachment=None)
 
         if msg.audio is None:
-            # non-audio = P2 (#1552)
+            # Non-audio message that somehow had a singular pending_attachment;
+            # clear the closure without touching attachments.
             return dataclasses.replace(msg, pending_attachment=None)
         new_audio = dataclasses.replace(msg.audio, blob_ref=wire_ref)
         return dataclasses.replace(msg, audio=new_audio, pending_attachment=None)
+
+    async def _ingest_non_audio(
+        self,
+        msg: "InboundMessage",
+        store: "BlobStorePort",
+    ) -> "InboundMessage":
+        """Non-audio ingest: size-guard → fetch → store.put.
+
+        Stamps each ``attachments[i].blob_ref`` with the returned BlobRef.
+        Raises ``AttachmentIngestError`` on oversize or BlobStore 5xx.
+        """
+        new_atts = list(msg.attachments)
+        pending_attachments = cast("list[PendingAttachment]", msg.pending_attachments)
+        for i, p in enumerate(pending_attachments):
+            if p.size is not None and p.size > MAX_ATTACHMENT_INGEST_BYTES:
+                log.warning(
+                    "attachment too large: %s > %s (source=%s)",
+                    p.size,
+                    MAX_ATTACHMENT_INGEST_BYTES,
+                    p.source,
+                )
+                raise AttachmentIngestError("That file is too large to process.")
+            data = await p.fetch()
+            try:
+                ref = await store.put(
+                    data,
+                    mime=p.mime,
+                    source=p.source,
+                    filename=p.filename,
+                    platform_ref=p.platform_ref,
+                    platform_message_id=p.platform_message_id,
+                )
+            except BlobStoreServerError:
+                log.exception("blobstore rejected attachment (source=%s)", p.source)
+                raise AttachmentIngestError(
+                    "Couldn't store your attachment — please try again."
+                ) from None
+            if i < len(new_atts):
+                new_atts[i] = dataclasses.replace(new_atts[i], blob_ref=ref)
+        return dataclasses.replace(msg, attachments=new_atts, pending_attachments=[])

--- a/src/lyra/inbound/pipeline.py
+++ b/src/lyra/inbound/pipeline.py
@@ -89,12 +89,14 @@ class InboundPipeline:
             and ctx.ingest.store is not None
         ):
             msg = await self._ingest_stage.run(msg, ctx.ingest)
-        elif msg.pending_attachment is not None:
-            # No-store path: the stage did not run. Clear the fetch closure so the
-            # message is safe to serialise over NATS (a PendingAttachment must never
-            # cross the process boundary). Transport-boundary invariant.
-            # (#1551, ADR-083)
-            msg = dataclasses.replace(msg, pending_attachment=None)
+        elif msg.pending_attachment is not None or msg.pending_attachments:
+            # No-store path: the stage did not run. Clear fetch closures (singular
+            # audio #1551 + plural non-audio #1552) so the message is NATS-safe —
+            # a PendingAttachment closure must never cross the process boundary.
+            # Transport-boundary invariant. (ADR-083)
+            msg = dataclasses.replace(
+                msg, pending_attachment=None, pending_attachments=[]
+            )
         if pre_route_hook is not None:
             await pre_route_hook(msg, ctx)
         if self._router.decide(msg, ctx.router) is RouteDecision.DROP:

--- a/src/lyra/infrastructure/blobstore_adapter.py
+++ b/src/lyra/infrastructure/blobstore_adapter.py
@@ -66,10 +66,15 @@ class HttpBlobStoreAdapter:
         except httpx.HTTPStatusError as e:
             if e.response.status_code >= 500:
                 raise BlobStoreServerError(
-                    str(e),
+                    f"BlobStore returned HTTP {e.response.status_code}",
                     status_code=e.response.status_code,
                 ) from e
             raise
+        except httpx.RequestError as e:
+            raise BlobStoreServerError(
+                f"BlobStore request failed: {type(e).__name__}",
+                status_code=503,
+            ) from e
         wire = BlobRef.from_store_ref(storage_ref)
         if wire.store_key == PENDING_STORE_KEY:
             raise ValueError(

--- a/src/lyra/infrastructure/blobstore_adapter.py
+++ b/src/lyra/infrastructure/blobstore_adapter.py
@@ -13,10 +13,17 @@ See ADR-082 (driven-port) and ADR-067 (BlobStore abstraction).
 
 from __future__ import annotations
 
+import httpx
+
 import roxabi_blobs
 from roxabi_blobs import HttpBlobStore
 from roxabi_blobs.models import BlobRef as StorageBlobRef
-from roxabi_contracts import PENDING_STORE_KEY, BlobNotFoundError, BlobRef
+from roxabi_contracts import (
+    PENDING_STORE_KEY,
+    BlobNotFoundError,
+    BlobRef,
+    BlobStoreServerError,
+)
 
 
 class HttpBlobStoreAdapter:
@@ -47,14 +54,22 @@ class HttpBlobStoreAdapter:
         real ingest indicates a storage contract violation and raises
         ``ValueError`` immediately (store_key is opaque — no sha256 regex).
         """
-        storage_ref: StorageBlobRef = await self._http_store.put(
-            data,
-            mime=mime,
-            source=source,
-            filename=filename,
-            platform_ref=platform_ref,
-            platform_message_id=platform_message_id,
-        )
+        try:
+            storage_ref: StorageBlobRef = await self._http_store.put(
+                data,
+                mime=mime,
+                source=source,
+                filename=filename,
+                platform_ref=platform_ref,
+                platform_message_id=platform_message_id,
+            )
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500:
+                raise BlobStoreServerError(
+                    str(e),
+                    status_code=e.response.status_code,
+                ) from e
+            raise
         wire = BlobRef.from_store_ref(storage_ref)
         if wire.store_key == PENDING_STORE_KEY:
             raise ValueError(

--- a/tests/adapters/discord/test_discord_nonaudio_ingest.py
+++ b/tests/adapters/discord/test_discord_nonaudio_ingest.py
@@ -1,0 +1,308 @@
+"""RED tests — Discord non-audio attachment ingest (T11, #1552).
+
+Covers:
+1. Message with multiple attachments → discord_normalize.normalize() sets
+   pending_attachments index-aligned with attachments; each PendingAttachment has
+   fetch (wraps a.read), size==a.size, source=="discord", mime==content_type.
+2. Through pipeline with fake store → EACH attachments[i].blob_ref is stamped.
+3. Oversize (attachment.size > cap) → AttachmentIngestError → in-channel reply
+   via adapter boundary; no hub push.
+
+These tests are RED until T12 (discord closures) + T13 (discord boundary reply) land.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from lyra.adapters.discord import DiscordAdapter
+from lyra.adapters.discord.discord_normalize import normalize
+from lyra.inbound.attachment_ingest import PendingAttachment
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> DiscordAdapter:
+    """Minimal DiscordAdapter — no real gateway connection."""
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        intents=discord.Intents.none(),
+    )
+    return adapter
+
+
+def _make_discord_message(
+    attachments: list[Any] | None = None,
+) -> SimpleNamespace:
+    """Discord-like message in a DM (guild=None)."""
+    import datetime
+
+    return SimpleNamespace(
+        guild=None,
+        channel=SimpleNamespace(id=555),
+        author=SimpleNamespace(
+            id=77,
+            name="Bob",
+            display_name="Bob",
+            bot=False,
+            roles=[],
+        ),
+        id=888,
+        content="",
+        mentions=[],
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+        reply=AsyncMock(),
+        reference=None,
+        attachments=attachments or [],
+    )
+
+
+def _make_discord_attachment(
+    url: str = "https://cdn.discord.com/file.png",
+    size: int = 1024,
+    content_type: str = "image/png",
+    filename: str = "file.png",
+) -> SimpleNamespace:
+    """discord.Attachment-like stub with async .read()."""
+    data = b"\x89PNG" + b"\x00" * 20  # PNG magic
+    return SimpleNamespace(
+        url=url,
+        size=size,
+        content_type=content_type,
+        filename=filename,
+        read=AsyncMock(return_value=data),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: multiple attachments → pending_attachments index-aligned
+# ---------------------------------------------------------------------------
+
+
+def test_dc_multi_attachment_normalize_sets_pending_attachments() -> None:
+    """normalize() with 3 attachments sets pending_attachments index-aligned.
+
+    Each PendingAttachment must have:
+    - fetch: wraps a.read (async callable)
+    - size: == a.size
+    - source: "discord"
+    - mime: == a.content_type
+    """
+    adapter = _make_adapter()
+
+    att1 = _make_discord_attachment(
+        url="https://cdn/img1.png",
+        size=1000,
+        content_type="image/png",
+        filename="img1.png",
+    )
+    att2 = _make_discord_attachment(
+        url="https://cdn/doc.pdf",
+        size=2000,
+        content_type="application/pdf",
+        filename="doc.pdf",
+    )
+    att3 = _make_discord_attachment(
+        url="https://cdn/vid.mp4",
+        size=3000,
+        content_type="video/mp4",
+        filename="vid.mp4",
+    )
+    raw = _make_discord_message(attachments=[att1, att2, att3])
+
+    msg = normalize(adapter, raw)
+
+    assert len(msg.attachments) == 3
+    assert len(msg.pending_attachments) == 3
+
+    for i, (_att, pa) in enumerate(zip(msg.attachments, msg.pending_attachments)):
+        assert isinstance(pa, PendingAttachment), (
+            f"pending_attachments[{i}] must be PendingAttachment"
+        )
+        assert callable(pa.fetch), f"pending_attachments[{i}].fetch must be callable"
+        assert pa.source == "discord", (
+            f"pending_attachments[{i}].source must be 'discord'"
+        )
+
+    # Index 0 — image
+    assert msg.pending_attachments[0].size == 1000
+    assert msg.pending_attachments[0].mime == "image/png"
+
+    # Index 1 — document
+    assert msg.pending_attachments[1].size == 2000
+    assert msg.pending_attachments[1].mime == "application/pdf"
+
+    # Index 2 — video
+    assert msg.pending_attachments[2].size == 3000
+    assert msg.pending_attachments[2].mime == "video/mp4"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: through pipeline + fake store → each blob_ref stamped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dc_multi_attachment_pipeline_stamps_all_blob_refs() -> None:
+    """3 attachments through the full inbound pipeline → each blob_ref stamped.
+
+    The fake store.put() returns a distinct BlobRef per call.
+    After pipeline.run(), every dispatched msg.attachments[i].blob_ref is real.
+
+    Negative-test contract: if the non-audio loop in AttachmentIngestStage is
+    deleted (P2 dead branch), all blob_refs remain None — assertion fails.
+    """
+    from lyra.adapters.discord.discord_inbound import handle_message
+    from lyra.inbound.attachment_ingest import IngestCtx
+    from roxabi_contracts import BlobRef
+
+    adapter = _make_adapter()
+
+    att1 = _make_discord_attachment(
+        url="https://cdn/a.png", size=500, content_type="image/png"
+    )
+    att2 = _make_discord_attachment(
+        url="https://cdn/b.pdf", size=600, content_type="application/pdf"
+    )
+    att3 = _make_discord_attachment(
+        url="https://cdn/c.mp4", size=700, content_type="video/mp4"
+    )
+    raw = _make_discord_message(attachments=[att1, att2, att3])
+
+    # Distinct BlobRefs per put() call
+    fake_refs = [
+        BlobRef(
+            store_key=f"s3://bucket/att{i}",
+            content_hash=f"hash{i}",
+            mime="image/png",
+            size=100,
+            source="discord",
+        )
+        for i in range(3)
+    ]
+    call_count = [0]
+
+    async def _fake_put(*args: Any, **kwargs: Any) -> BlobRef:
+        ref = fake_refs[call_count[0]]
+        call_count[0] += 1
+        return ref
+
+    fake_store = AsyncMock()
+    fake_store.put = _fake_put
+    fake_ingest_ctx = IngestCtx(store=fake_store)
+    adapter._ingest_ctx = fake_ingest_ctx  # type: ignore[attr-defined]
+
+    captured: list[Any] = []
+
+    async def _capture_dispatch(msg: Any, ctx: Any, send_bp: Any, on_drop: Any) -> None:
+        captured.append(msg)
+
+    mock_dispatcher = MagicMock()
+    mock_dispatcher.dispatch = _capture_dispatch
+
+    with patch("lyra.adapters.discord.discord_inbound._pipeline") as mock_pipeline:
+        from lyra.inbound.attachment_ingest import AttachmentIngestStage
+        from lyra.inbound.pipeline import InboundPipeline
+        from lyra.inbound.router import Router
+        from lyra.inbound.session_builder import SessionBuilder
+
+        real_pipeline = InboundPipeline(
+            router=Router(),
+            session_builder=SessionBuilder(),
+            dispatcher=mock_dispatcher,  # type: ignore[arg-type]
+            ingest_stage=AttachmentIngestStage(),
+        )
+        mock_pipeline.run = real_pipeline.run
+
+        await handle_message(adapter, raw)
+
+    assert len(captured) == 1, "Dispatcher must be called exactly once"
+    dispatched_msg = captured[0]
+    assert len(dispatched_msg.attachments) == 3
+
+    for i in range(3):
+        assert dispatched_msg.attachments[i].blob_ref is not None, (
+            f"attachments[{i}].blob_ref must be set after pipeline"
+        )
+        assert dispatched_msg.attachments[i].blob_ref == fake_refs[i]
+
+
+# ---------------------------------------------------------------------------
+# Test 3: oversize → AttachmentIngestError → in-channel reply; no hub push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dc_oversize_attachment_reply_no_hub_push() -> None:
+    """attachment.size > cap → AttachmentIngestError caught at boundary.
+
+    The adapter must:
+    (a) await message.reply() with the "too large" user-facing text
+    (b) NOT push to the hub (no dispatcher call)
+
+    Negative-test contract: if the AttachmentIngestError catch in handle_message
+    is removed, the error propagates uncaught and message.reply is never called —
+    assertion fails.
+    """
+    from lyra.adapters.discord.discord_inbound import handle_message
+    from lyra.inbound.attachment_ingest import MAX_ATTACHMENT_INGEST_BYTES, IngestCtx
+
+    adapter = _make_adapter()
+
+    # One oversized attachment
+    big_att = _make_discord_attachment(
+        url="https://cdn/big.zip",
+        size=MAX_ATTACHMENT_INGEST_BYTES + 1,
+        content_type="application/zip",
+        filename="big.zip",
+    )
+    raw = _make_discord_message(attachments=[big_att])
+
+    fake_store = AsyncMock()
+    fake_store.put = AsyncMock()  # must never be called
+    fake_ingest_ctx = IngestCtx(store=fake_store)
+    adapter._ingest_ctx = fake_ingest_ctx  # type: ignore[attr-defined]
+
+    captured_dispatches: list[Any] = []
+
+    async def _capture_dispatch(msg: Any, ctx: Any, send_bp: Any, on_drop: Any) -> None:
+        captured_dispatches.append(msg)
+
+    mock_dispatcher = MagicMock()
+    mock_dispatcher.dispatch = _capture_dispatch
+
+    with patch("lyra.adapters.discord.discord_inbound._pipeline") as mock_pipeline:
+        from lyra.inbound.attachment_ingest import AttachmentIngestStage
+        from lyra.inbound.pipeline import InboundPipeline
+        from lyra.inbound.router import Router
+        from lyra.inbound.session_builder import SessionBuilder
+
+        real_pipeline = InboundPipeline(
+            router=Router(),
+            session_builder=SessionBuilder(),
+            dispatcher=mock_dispatcher,  # type: ignore[arg-type]
+            ingest_stage=AttachmentIngestStage(),
+        )
+        mock_pipeline.run = real_pipeline.run
+
+        await handle_message(adapter, raw)
+
+    # (a) In-channel reply was sent
+    raw.reply.assert_awaited_once()
+    reply_text: str = raw.reply.call_args.args[0]
+    assert "large" in reply_text.lower(), (
+        f"Expected 'large' in reply text, got: {reply_text!r}"
+    )
+
+    # (b) No hub push
+    assert len(captured_dispatches) == 0, (
+        "Hub must NOT be reached on oversize attachment"
+    )

--- a/tests/adapters/telegram/test_telegram_nonaudio_ingest.py
+++ b/tests/adapters/telegram/test_telegram_nonaudio_ingest.py
@@ -1,0 +1,298 @@
+"""RED tests — Telegram non-audio attachment ingest (T7, #1552).
+
+Covers:
+1. photo update → normalize() sets pending_attachments (PendingAttachment per
+   Attachment, index-aligned), with fetch closure, declared size, source="telegram",
+   platform_ref=file_id.
+2. document update → same; filename carried on PendingAttachment.
+3. Through pipeline with fake store → attachments[0].blob_ref is a real BlobRef
+   before hub enqueue.
+4. Oversize (declared file_size > MAX_ATTACHMENT_INGEST_BYTES) → AttachmentIngestError
+   raised; adapter sends "too large" reply via adapter.bot.send_message; no hub push.
+
+These tests are RED until T8 (telegram closures) + T9 (telegram boundary reply) land.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lyra.adapters.telegram import TelegramAdapter
+from lyra.adapters.telegram.telegram_normalize import normalize
+from lyra.inbound.attachment_ingest import PendingAttachment
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> TelegramAdapter:
+    """Minimal TelegramAdapter with mocked bot — no real HTTP."""
+    adapter = TelegramAdapter(
+        bot_id="main",
+        token="tok",
+        inbound_bus=MagicMock(),
+    )
+    bot_mock = AsyncMock()
+    bot_mock.get_file = AsyncMock()
+    bot_mock.send_message = AsyncMock()
+    adapter.bot = bot_mock
+    return adapter
+
+
+def _make_base_msg() -> SimpleNamespace:
+    """Base Telegram message skeleton (no media)."""
+    from datetime import datetime, timezone
+
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=100, type="private"),
+        from_user=SimpleNamespace(id=42, full_name="Alice", is_bot=False),
+        message_thread_id=None,
+        message_id=9,
+        date=datetime.now(timezone.utc),
+        voice=None,
+        audio=None,
+        video_note=None,
+        reply_to_message=None,
+        text="",
+        entities=None,
+        caption=None,
+        photo=None,
+        document=None,
+        video=None,
+        animation=None,
+        sticker=None,
+    )
+
+
+def _make_photo_msg(
+    file_id: str = "photo_001", file_size: int = 1024
+) -> SimpleNamespace:
+    """Telegram message carrying a photo (list of PhotoSize, largest last)."""
+    base = _make_base_msg()
+    photo_size = SimpleNamespace(
+        file_id=file_id, file_size=file_size, width=800, height=600
+    )
+    base.photo = [photo_size]
+    return base
+
+
+def _make_document_msg(
+    file_id: str = "doc_001",
+    file_size: int = 2048,
+    file_name: str = "report.pdf",
+    mime_type: str = "application/pdf",
+) -> SimpleNamespace:
+    """Telegram message carrying a document."""
+    base = _make_base_msg()
+    base.document = SimpleNamespace(
+        file_id=file_id,
+        file_size=file_size,
+        file_name=file_name,
+        mime_type=mime_type,
+    )
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Test 1: photo → pending_attachments set with correct PendingAttachment shape
+# ---------------------------------------------------------------------------
+
+
+def test_tg_photo_normalize_sets_pending_attachments() -> None:
+    """normalize() on a photo message sets pending_attachments index-aligned.
+
+    Each PendingAttachment must have:
+    - fetch: async callable
+    - mime: "image/jpeg" (photo default)
+    - source: "telegram"
+    - size: photo.file_size
+    - platform_ref: photo.file_id
+    """
+    adapter = _make_adapter()
+    raw = _make_photo_msg(file_id="photo_abc", file_size=5000)
+
+    msg = normalize(adapter, raw)
+
+    assert len(msg.attachments) == 1
+    assert len(msg.pending_attachments) == 1
+
+    pa: PendingAttachment = msg.pending_attachments[0]
+    assert isinstance(pa, PendingAttachment)
+    assert callable(pa.fetch)
+    assert pa.mime == "image/jpeg"
+    assert pa.source == "telegram"
+    assert pa.size == 5000
+    assert pa.platform_ref == "photo_abc"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: document → pending_attachments carries filename
+# ---------------------------------------------------------------------------
+
+
+def test_tg_document_normalize_carries_filename() -> None:
+    """normalize() on a document message carries filename in PendingAttachment."""
+    adapter = _make_adapter()
+    raw = _make_document_msg(
+        file_id="doc_xyz",
+        file_size=3000,
+        file_name="report.pdf",
+        mime_type="application/pdf",
+    )
+
+    msg = normalize(adapter, raw)
+
+    assert len(msg.attachments) == 1
+    assert len(msg.pending_attachments) == 1
+
+    pa: PendingAttachment = msg.pending_attachments[0]
+    assert pa.filename == "report.pdf"
+    assert pa.mime == "application/pdf"
+    assert pa.source == "telegram"
+    assert pa.size == 3000
+    assert pa.platform_ref == "doc_xyz"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: through pipeline + fake store → blob_ref stamped on attachments[0]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tg_photo_pipeline_stamps_blob_ref() -> None:
+    """Photo message through the full inbound pipeline stamps attachments[0].blob_ref.
+
+    The fake store.put() returns a real BlobRef. After pipeline.run(), the
+    InboundMessage dispatched to the hub has attachments[0].blob_ref set.
+
+    Negative-test contract: if the stage's non-audio loop is deleted (P2 dead branch),
+    blob_ref remains None and the assertion fails.
+    """
+    from lyra.adapters.telegram.telegram_inbound import handle_message
+    from lyra.inbound.attachment_ingest import IngestCtx
+    from roxabi_contracts import BlobRef
+
+    adapter = _make_adapter()
+    raw = _make_photo_msg(file_id="photo_pipeline", file_size=1024)
+
+    fake_blob_ref = BlobRef(
+        store_key="s3://bucket/photo_pipeline",
+        content_hash="abc123",
+        mime="image/jpeg",
+        size=1024,
+        source="telegram",
+        platform_ref="photo_pipeline",
+    )
+
+    fake_store = AsyncMock()
+    fake_store.put = AsyncMock(return_value=fake_blob_ref)
+    fake_ingest_ctx = IngestCtx(store=fake_store)
+
+    # Inject ingest_ctx so the stage runs
+    adapter._ingest_ctx = fake_ingest_ctx  # type: ignore[attr-defined]
+
+    # Capture the dispatched InboundMessage
+    captured: list[Any] = []
+
+    async def _capture_dispatch(msg: Any, ctx: Any, send_bp: Any, on_drop: Any) -> None:
+        captured.append(msg)
+
+    mock_dispatcher = MagicMock()
+    mock_dispatcher.dispatch = _capture_dispatch
+
+    with patch("lyra.adapters.telegram.telegram_inbound._pipeline") as mock_pipeline:
+        # Build a real InboundPipeline but intercept dispatcher
+        from lyra.inbound.attachment_ingest import AttachmentIngestStage
+        from lyra.inbound.pipeline import InboundPipeline
+        from lyra.inbound.router import Router
+        from lyra.inbound.session_builder import SessionBuilder
+
+        real_pipeline = InboundPipeline(
+            router=Router(),
+            session_builder=SessionBuilder(),
+            dispatcher=mock_dispatcher,  # type: ignore[arg-type]
+            ingest_stage=AttachmentIngestStage(),
+        )
+        mock_pipeline.run = real_pipeline.run
+
+        await handle_message(adapter, raw)
+
+    assert len(captured) == 1, "Dispatcher must have been called exactly once"
+    dispatched_msg = captured[0]
+    assert len(dispatched_msg.attachments) >= 1
+    assert dispatched_msg.attachments[0].blob_ref == fake_blob_ref
+
+
+# ---------------------------------------------------------------------------
+# Test 4: oversize → AttachmentIngestError → adapter replies; no hub push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tg_oversize_photo_reply_no_hub_push() -> None:
+    """Oversize declared file_size → AttachmentIngestError is caught at the boundary.
+
+    The adapter must:
+    (a) send_message with a "too large" user-facing message
+    (b) NOT push to the hub (no dispatcher call)
+
+    Negative-test contract: if the AttachmentIngestError catch in handle_message
+    is removed, the error propagates uncaught and no send_message is called —
+    the assertion on send_message fails.
+    """
+    from lyra.adapters.telegram.telegram_inbound import handle_message
+    from lyra.inbound.attachment_ingest import MAX_ATTACHMENT_INGEST_BYTES, IngestCtx
+
+    adapter = _make_adapter()
+    # file_size declared as one byte over the cap
+    raw = _make_photo_msg(
+        file_id="photo_big", file_size=MAX_ATTACHMENT_INGEST_BYTES + 1
+    )
+
+    fake_store = AsyncMock()
+    fake_store.put = AsyncMock()  # should never be called
+    fake_ingest_ctx = IngestCtx(store=fake_store)
+    adapter._ingest_ctx = fake_ingest_ctx  # type: ignore[attr-defined]
+
+    captured_dispatches: list[Any] = []
+
+    async def _capture_dispatch(msg: Any, ctx: Any, send_bp: Any, on_drop: Any) -> None:
+        captured_dispatches.append(msg)
+
+    mock_dispatcher = MagicMock()
+    mock_dispatcher.dispatch = _capture_dispatch
+
+    with patch("lyra.adapters.telegram.telegram_inbound._pipeline") as mock_pipeline:
+        from lyra.inbound.attachment_ingest import AttachmentIngestStage
+        from lyra.inbound.pipeline import InboundPipeline
+        from lyra.inbound.router import Router
+        from lyra.inbound.session_builder import SessionBuilder
+
+        real_pipeline = InboundPipeline(
+            router=Router(),
+            session_builder=SessionBuilder(),
+            dispatcher=mock_dispatcher,  # type: ignore[arg-type]
+            ingest_stage=AttachmentIngestStage(),
+        )
+        mock_pipeline.run = real_pipeline.run
+
+        await handle_message(adapter, raw)
+
+    # (a) Adapter sent a "too large" message to the user
+    adapter.bot.send_message.assert_called_once()
+    call_kwargs = adapter.bot.send_message.call_args
+    # send_message is called with keyword arguments via _make_send_kwargs (text=...)
+    text_sent: str = call_kwargs.kwargs.get("text", "") or str(call_kwargs)
+    assert "large" in text_sent.lower(), (
+        f"Expected 'large' in reply, got: {text_sent!r}"
+    )
+
+    # (b) No hub push — dispatcher was never called
+    assert len(captured_dispatches) == 0, (
+        "Hub must NOT be reached on oversize attachment"
+    )

--- a/tests/adapters/telegram/test_telegram_nonaudio_ingest.py
+++ b/tests/adapters/telegram/test_telegram_nonaudio_ingest.py
@@ -32,13 +32,19 @@ from lyra.inbound.attachment_ingest import PendingAttachment
 
 def _make_adapter() -> TelegramAdapter:
     """Minimal TelegramAdapter with mocked bot — no real HTTP."""
+    import io
+
     adapter = TelegramAdapter(
         bot_id="main",
         token="tok",
         inbound_bus=MagicMock(),
     )
     bot_mock = AsyncMock()
-    bot_mock.get_file = AsyncMock()
+    # get_file returns a File-like object with .file_path
+    file_stub = SimpleNamespace(file_id="file_id_stub", file_path="path/to/file")
+    bot_mock.get_file = AsyncMock(return_value=file_stub)
+    # download_file returns a BytesIO (matches aiogram's real return type)
+    bot_mock.download_file = AsyncMock(return_value=io.BytesIO(b"<fake-bytes>"))
     bot_mock.send_message = AsyncMock()
     adapter.bot = bot_mock
     return adapter
@@ -296,3 +302,63 @@ async def test_tg_oversize_photo_reply_no_hub_push() -> None:
     assert len(captured_dispatches) == 0, (
         "Hub must NOT be reached on oversize attachment"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: sticker exclusion — static included, animated + video excluded
+# ---------------------------------------------------------------------------
+
+
+def _make_sticker_msg(
+    file_id: str = "sticker_001",
+    file_size: int = 512,
+    *,
+    is_animated: bool = False,
+    is_video: bool = False,
+) -> SimpleNamespace:
+    """Telegram message carrying a sticker."""
+    base = _make_base_msg()
+    base.sticker = SimpleNamespace(
+        file_id=file_id,
+        file_size=file_size,
+        is_animated=is_animated,
+        is_video=is_video,
+    )
+    return base
+
+
+def test_tg_static_sticker_included() -> None:
+    """Static WebP sticker (is_animated=False, is_video=False) → included."""
+    adapter = _make_adapter()
+    raw = _make_sticker_msg(file_id="sticker_static", is_animated=False, is_video=False)
+
+    msg = normalize(adapter, raw)
+
+    assert len(msg.attachments) == 1
+    assert len(msg.pending_attachments) == 1
+    pa: PendingAttachment = msg.pending_attachments[0]
+    assert pa.mime == "image/webp"
+    assert pa.source == "telegram"
+    assert pa.platform_ref == "sticker_static"
+
+
+def test_tg_animated_sticker_excluded() -> None:
+    """Animated sticker (is_animated=True) → excluded (empty attachment lists)."""
+    adapter = _make_adapter()
+    raw = _make_sticker_msg(is_animated=True, is_video=False)
+
+    msg = normalize(adapter, raw)
+
+    assert len(msg.attachments) == 0
+    assert len(msg.pending_attachments) == 0
+
+
+def test_tg_video_sticker_excluded() -> None:
+    """Video sticker (is_video=True) → excluded (empty attachment lists)."""
+    adapter = _make_adapter()
+    raw = _make_sticker_msg(is_animated=False, is_video=True)
+
+    msg = normalize(adapter, raw)
+
+    assert len(msg.attachments) == 0
+    assert len(msg.pending_attachments) == 0

--- a/tests/adapters/test_discord_attachments.py
+++ b/tests/adapters/test_discord_attachments.py
@@ -47,6 +47,8 @@ class TestDiscordAttachments:
             content_type="image/png",
             url="https://cdn.discord.com/img.png",
             filename="img.png",
+            size=123,
+            read=AsyncMock(return_value=b"<bytes>"),
         )
         msg = adapter.normalize(
             self._make_msg(attachments=[att]),
@@ -65,6 +67,8 @@ class TestDiscordAttachments:
             content_type="application/pdf",
             url="https://cdn.discord.com/doc.pdf",
             filename="doc.pdf",
+            size=123,
+            read=AsyncMock(return_value=b"<bytes>"),
         )
         msg = adapter.normalize(
             self._make_msg(attachments=[att]),
@@ -83,11 +87,15 @@ class TestDiscordAttachments:
                 content_type="image/jpeg",
                 url="https://cdn/a.jpg",
                 filename="a.jpg",
+                size=123,
+                read=AsyncMock(return_value=b"<bytes>"),
             ),
             SimpleNamespace(
                 content_type="application/pdf",
                 url="https://cdn/b.pdf",
                 filename="b.pdf",
+                size=123,
+                read=AsyncMock(return_value=b"<bytes>"),
             ),
         ]
         msg = adapter.normalize(
@@ -102,6 +110,8 @@ class TestDiscordAttachments:
             content_type="video/mp4",
             url="https://cdn.discord.com/clip.mp4",
             filename="clip.mp4",
+            size=123,
+            read=AsyncMock(return_value=b"<bytes>"),
         )
         msg = adapter.normalize(
             self._make_msg(attachments=[att]),
@@ -137,6 +147,8 @@ class TestDiscordAttachments:
             content_type="image/png",
             url="https://cdn/img.png",
             filename="img.png",
+            size=123,
+            read=AsyncMock(return_value=b"<bytes>"),
         )
         msg = adapter.normalize(
             self._make_msg(

--- a/tests/adapters/test_discord_attachments.py
+++ b/tests/adapters/test_discord_attachments.py
@@ -59,6 +59,8 @@ class TestDiscordAttachments:
         assert a.url_or_path_or_bytes == "https://cdn.discord.com/img.png"
         assert a.mime_type == "image/png"
         assert a.filename == "img.png"
+        assert len(msg.pending_attachments) == len(msg.attachments)
+        assert msg.pending_attachments[0].size == 123
 
     def test_normalize_document_attachment(self) -> None:
         """Non-image/video/audio → type='file', correct filename."""
@@ -102,6 +104,8 @@ class TestDiscordAttachments:
             self._make_msg(attachments=atts),
         )
         assert len(msg.attachments) == 2
+        assert len(msg.pending_attachments) == len(msg.attachments)
+        assert msg.pending_attachments[0].size == 123
 
     def test_normalize_video_attachment(self) -> None:
         """Video content_type → type='video'."""

--- a/tests/inbound/test_attachment_ingest_nonaudio.py
+++ b/tests/inbound/test_attachment_ingest_nonaudio.py
@@ -312,6 +312,36 @@ class TestAttachmentIngestStageNonAudio:
         # pending_attachment cleared (singular voice path)
         assert result.pending_attachment is None
 
+    async def test_post_fetch_oversize_raises_when_size_undeclared(self) -> None:
+        """size=None + fetch > cap → AttachmentIngestError; store.put NOT called.
+
+        Covers the post-fetch hard cap (B3): when the platform does not declare a
+        size up-front (size=None), the pre-download guard is skipped.  After fetch()
+        resolves the actual byte count is checked; an oversize payload must raise
+        AttachmentIngestError and must NOT forward the bytes to store.put.
+
+        Negative: if the post-fetch cap is absent, an oversize payload is sent to
+        store.put and the store_mock.put call count assertion fails.
+        """
+        # Arrange — fetch returns one byte over the cap; size=None (undeclared)
+        oversize_data = b"x" * (MAX_ATTACHMENT_INGEST_BYTES + 1)
+        fetch_mock = AsyncMock(return_value=oversize_data)
+        store_mock = AsyncMock()
+        store_mock.put = AsyncMock()
+
+        pending = _pending_attachment(fetch=fetch_mock, size=None)
+        att = _attachment()
+        msg = _nonaudio_msg(attachments=[att], pending_attachments=[pending])
+        ctx = IngestCtx(store=store_mock)
+        stage = AttachmentIngestStage()
+
+        # Act + Assert — must raise AttachmentIngestError
+        with pytest.raises(AttachmentIngestError):
+            await stage.run(msg, ctx)
+
+        # store.put must NOT be called — bytes must not be forwarded on oversize
+        store_mock.put.assert_not_awaited()
+
     @pytest.mark.parametrize("source", ["telegram", "discord"])
     async def test_source_does_not_branch(self, source: str) -> None:
         """source="telegram" and source="discord" produce identical stamping logic.

--- a/tests/inbound/test_attachment_ingest_nonaudio.py
+++ b/tests/inbound/test_attachment_ingest_nonaudio.py
@@ -1,0 +1,346 @@
+"""RED tests for AttachmentIngestStage — non-audio attachment ingest (#1552, S5).
+
+Tests the non-audio branch of the central attachment ingest stage:
+  - multi-attachment pending list (index-aligned with .attachments)
+  - per-item size guard BEFORE fetch
+  - BlobStoreServerError → AttachmentIngestError
+  - pending_attachments cleared to [] on return (NATS safety)
+  - voice path (singular pending_attachment) unchanged
+  - source metadata never branches stage logic (axial guard)
+
+These tests will FAIL at collection until the GREEN implementation lands in
+``lyra.inbound.attachment_ingest`` (T4).  Missing symbols:
+  - MAX_ATTACHMENT_INGEST_BYTES
+  - AttachmentIngestError
+  - PendingAttachment.size field
+  - AttachmentIngestStage.run non-audio loop
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lyra.core.audio_payload import AudioPayload
+from lyra.core.auth.trust import TrustLevel
+from lyra.core.messaging.message import Attachment, InboundMessage
+from lyra.inbound.attachment_ingest import (  # noqa: E402 — module imports below do not exist yet (RED)
+    MAX_ATTACHMENT_INGEST_BYTES,
+    AttachmentIngestError,
+    AttachmentIngestStage,
+    IngestCtx,
+    PendingAttachment,
+)
+from roxabi_contracts import PENDING_STORE_KEY, BlobRef, BlobStoreServerError
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+_IMAGE_MIME = "image/jpeg"
+_DOC_MIME = "application/pdf"
+
+
+def _wire_ref(store_key: str = "blob:abc", mime: str = _IMAGE_MIME) -> BlobRef:
+    """Minimal real (non-PENDING) BlobRef."""
+    return BlobRef(
+        store_key=store_key,
+        content_hash="sha256deadbeef",
+        mime=mime,
+        size=512,
+        source="telegram",
+    )
+
+
+def _pending_attachment(
+    *,
+    fetch: AsyncMock,
+    mime: str = _IMAGE_MIME,
+    source: str = "telegram",
+    size: int | None = None,
+) -> PendingAttachment:
+    return PendingAttachment(
+        fetch=fetch,
+        mime=mime,
+        source=source,
+        platform_ref="tg:file_id:IMG001",
+        platform_message_id="99",
+        size=size,
+    )
+
+
+def _attachment(mime: str = _IMAGE_MIME) -> Attachment:
+    """Non-audio Attachment with blob_ref=None (pre-ingest)."""
+    return Attachment(
+        type="image",
+        url_or_path_or_bytes="tg:file_id:IMG001",
+        mime_type=mime,
+    )
+
+
+def _nonaudio_msg(
+    *,
+    attachments: list[Attachment],
+    pending_attachments: list[PendingAttachment],
+    source: str = "telegram",
+) -> InboundMessage:
+    """Build a minimal non-audio InboundMessage with pending_attachments."""
+    return InboundMessage(
+        id="msg-na-1",
+        platform=source,
+        bot_id="bot-1",
+        scope_id="chat:100",
+        user_id="user:10",
+        user_name="tester",
+        is_mention=False,
+        text="see attached",
+        text_raw="see attached",
+        trust_level=TrustLevel.PUBLIC,
+        attachments=attachments,
+        pending_attachments=pending_attachments,
+    )
+
+
+_PENDING_VOICE_BLOB_REF = BlobRef(
+    store_key=PENDING_STORE_KEY,
+    content_hash="",
+    mime="audio/ogg",
+    size=1024,
+    source="telegram",
+    platform_ref="tg:file_id:VOICE42",
+    platform_message_id="42",
+)
+
+
+def _voice_msg(*, pending_attachment: PendingAttachment) -> InboundMessage:
+    """Minimal voice InboundMessage (mirrors reference fixture)."""
+    return InboundMessage(
+        id="msg-v-1",
+        platform="telegram",
+        bot_id="bot-1",
+        scope_id="chat:123",
+        user_id="user:42",
+        user_name="testuser",
+        is_mention=False,
+        text="",
+        text_raw="",
+        trust_level=TrustLevel.PUBLIC,
+        modality="voice",
+        audio=AudioPayload(
+            blob_ref=_PENDING_VOICE_BLOB_REF,
+            mime_type="audio/ogg",
+            duration_ms=3000,
+            file_id="VOICE42",
+        ),
+        pending_attachment=pending_attachment,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentIngestStageNonAudio:
+    """AttachmentIngestStage.run — non-audio multi-attachment contract (#1552)."""
+
+    async def test_single_pending_stamps_blob_ref(self) -> None:
+        """Single non-audio pending → attachments[0].blob_ref stamped; pendings cleared.
+
+        Negative: if the non-audio loop is absent (P2 stub), attachments[0].blob_ref
+        stays None and the assertion on store_key fails.
+        Negative: if pending_attachments is not cleared, the [] assertion fails.
+        """
+        # Arrange
+        image_bytes = b"jpegbytes"
+        fetch_mock = AsyncMock(return_value=image_bytes)
+        real_ref = _wire_ref("blob:img-001")
+        store_mock = AsyncMock()
+        store_mock.put = AsyncMock(return_value=real_ref)
+
+        pending = _pending_attachment(fetch=fetch_mock)
+        att = _attachment()
+        msg = _nonaudio_msg(attachments=[att], pending_attachments=[pending])
+        ctx = IngestCtx(store=store_mock)
+        stage = AttachmentIngestStage()
+
+        # Act
+        result = await stage.run(msg, ctx)
+
+        # Assert — blob_ref stamped with the wire ref returned by store.put
+        assert result.attachments[0].blob_ref is not None
+        assert result.attachments[0].blob_ref.store_key == "blob:img-001"
+        # pending_attachments cleared (NATS safety)
+        assert result.pending_attachments == []
+
+    async def test_multiple_pending_all_stamped(self) -> None:
+        """N=3 pending attachments → each attachments[i].blob_ref stamped independently.
+
+        Negative: if the loop stamps only index 0, attachments[1] and [2]
+        will still have blob_ref=None and the assertions fail.
+        """
+        # Arrange
+        N = 3
+        refs = [_wire_ref(f"blob:img-{i:03d}") for i in range(N)]
+        fetches = [AsyncMock(return_value=b"bytes") for _ in range(N)]
+        store_mock = AsyncMock()
+        store_mock.put = AsyncMock(side_effect=refs)
+
+        pendings = [_pending_attachment(fetch=fetches[i]) for i in range(N)]
+        atts = [_attachment() for _ in range(N)]
+        msg = _nonaudio_msg(attachments=atts, pending_attachments=pendings)
+        ctx = IngestCtx(store=store_mock)
+        stage = AttachmentIngestStage()
+
+        # Act
+        result = await stage.run(msg, ctx)
+
+        # Assert — all three blob_refs stamped with distinct wire refs
+        for i, expected_key in enumerate(f"blob:img-{j:03d}" for j in range(N)):
+            blob_ref_i = result.attachments[i].blob_ref
+            assert blob_ref_i is not None, f"index {i} not stamped"
+            assert blob_ref_i.store_key == expected_key, f"index {i} wrong ref"
+        assert result.pending_attachments == []
+
+    async def test_oversize_raises_before_fetch(self) -> None:
+        """declared size > MAX_ATTACHMENT_INGEST_BYTES → AttachmentIngestError;
+        fetch never awaited.
+
+        This is the critical negative: if the size guard is deleted, fetch() will
+        be called (downloading a huge file) and no AttachmentIngestError is raised.
+        The test verifies BOTH the exception AND the zero-fetch invariant.
+        """
+        # Arrange
+        fetch_mock = AsyncMock(side_effect=AssertionError("fetch must not be called"))
+        oversize = MAX_ATTACHMENT_INGEST_BYTES + 1
+        pending = _pending_attachment(fetch=fetch_mock, size=oversize)
+        att = _attachment()
+        msg = _nonaudio_msg(attachments=[att], pending_attachments=[pending])
+        store_mock = AsyncMock()
+        ctx = IngestCtx(store=store_mock)
+        stage = AttachmentIngestStage()
+
+        # Act + Assert — must raise before awaiting fetch
+        with pytest.raises(AttachmentIngestError):
+            await stage.run(msg, ctx)
+
+        # Negative guard: if fetch was called, this fails
+        fetch_mock.assert_not_awaited()
+
+    async def test_store_put_server_error_raises_attachment_ingest_error(self) -> None:
+        """store.put raises BlobStoreServerError → AttachmentIngestError raised.
+
+        Negative: if the except clause is absent, BlobStoreServerError propagates
+        directly to the caller instead of being wrapped in AttachmentIngestError.
+        """
+        # Arrange
+        fetch_mock = AsyncMock(return_value=b"jpegbytes")
+        store_mock = AsyncMock()
+        store_mock.put = AsyncMock(
+            side_effect=BlobStoreServerError("upstream 503", status_code=503)
+        )
+        pending = _pending_attachment(fetch=fetch_mock)
+        att = _attachment()
+        msg = _nonaudio_msg(attachments=[att], pending_attachments=[pending])
+        ctx = IngestCtx(store=store_mock)
+        stage = AttachmentIngestStage()
+
+        # Act + Assert
+        with pytest.raises(AttachmentIngestError):
+            await stage.run(msg, ctx)
+
+    async def test_store_none_is_passthrough_nonaudio(self) -> None:
+        """store=None → no-op passthrough; attachments unchanged; no blob_ref set.
+
+        Negative: if the ``if ctx.store is None: return msg`` guard is removed,
+        the stage attempts store.put(None, ...) and raises AttributeError instead
+        of silently returning the original message.
+        """
+        # Arrange
+        fetch_mock = AsyncMock(return_value=b"jpegbytes")
+        pending = _pending_attachment(fetch=fetch_mock)
+        att = _attachment()
+        msg = _nonaudio_msg(attachments=[att], pending_attachments=[pending])
+        ctx = IngestCtx(store=None)
+        stage = AttachmentIngestStage()
+
+        # Act
+        result = await stage.run(msg, ctx)
+
+        # Assert — attachments unchanged (blob_ref still None)
+        assert result.attachments[0].blob_ref is None
+        # fetch must NOT be awaited (store is None → early return)
+        fetch_mock.assert_not_awaited()
+
+    async def test_voice_path_unchanged(self) -> None:
+        """Voice path (msg.audio set + singular pending_attachment) → blob_ref stamped.
+
+        This test mirrors the reference test_attachment_ingest_stage.py happy path.
+        Non-audio changes must not regress the existing voice contract.
+        """
+        # Arrange
+        ogg_bytes = b"oggbytes"
+        fetch_mock = AsyncMock(return_value=ogg_bytes)
+        voice_pending = PendingAttachment(
+            fetch=fetch_mock,
+            mime="audio/ogg",
+            source="telegram",
+            platform_ref="tg:file_id:VOICE42",
+            platform_message_id="42",
+            filename=None,
+        )
+        real_audio_ref = BlobRef(
+            store_key="blob:audio-xyz",
+            content_hash="sha256audio",
+            mime="audio/ogg",
+            size=len(ogg_bytes),
+            source="telegram",
+        )
+        store_mock = AsyncMock()
+        store_mock.put = AsyncMock(return_value=real_audio_ref)
+        ctx = IngestCtx(store=store_mock)
+        msg = _voice_msg(pending_attachment=voice_pending)
+        stage = AttachmentIngestStage()
+
+        # Act
+        result = await stage.run(msg, ctx)
+
+        # Assert — audio.blob_ref updated to the real wire ref
+        assert result.audio is not None
+        assert result.audio.blob_ref.store_key == "blob:audio-xyz"
+        # pending_attachment cleared (singular voice path)
+        assert result.pending_attachment is None
+
+    @pytest.mark.parametrize("source", ["telegram", "discord"])
+    async def test_source_does_not_branch(self, source: str) -> None:
+        """source="telegram" and source="discord" produce identical stamping logic.
+
+        Axial guard: the stage must NOT inspect PendingAttachment.source to
+        branch behaviour. Both sources must result in blob_ref being stamped.
+
+        Negative: if the stage had ``if p.source == "telegram": ... else: skip``,
+        the discord case would leave blob_ref=None and the assertion would fail.
+        """
+        # Arrange
+        image_bytes = b"imgbytes"
+        fetch_mock = AsyncMock(return_value=image_bytes)
+        real_ref = _wire_ref(f"blob:{source}-001")
+        store_mock = AsyncMock()
+        store_mock.put = AsyncMock(return_value=real_ref)
+
+        pending = _pending_attachment(fetch=fetch_mock, source=source)
+        att = _attachment()
+        msg = _nonaudio_msg(
+            attachments=[att], pending_attachments=[pending], source=source
+        )
+        ctx = IngestCtx(store=store_mock)
+        stage = AttachmentIngestStage()
+
+        # Act
+        result = await stage.run(msg, ctx)
+
+        # Assert — blob_ref stamped regardless of source
+        assert result.attachments[0].blob_ref is not None
+        assert result.attachments[0].blob_ref.store_key == f"blob:{source}-001"
+        assert result.pending_attachments == []

--- a/tests/inbound/test_pipeline.py
+++ b/tests/inbound/test_pipeline.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lyra.core.auth.trust import TrustLevel
-from lyra.core.messaging.message import InboundMessage, TelegramMeta
+from lyra.core.messaging.message import Attachment, InboundMessage, TelegramMeta
+from lyra.inbound.attachment_ingest import IngestCtx, PendingAttachment
 from lyra.inbound.context import DispatchCtx, InboundContext, RouterCtx, SessionCtx
 from lyra.inbound.pipeline import InboundPipeline
 from lyra.inbound.router import RouteDecision
@@ -36,7 +37,9 @@ def _make_msg(*, is_mention: bool = False) -> InboundMessage:
     )
 
 
-def _make_ctx(*, owned_threads: set[int] | None = None) -> InboundContext:
+def _make_ctx(
+    *, owned_threads: set[int] | None = None, ingest: "IngestCtx | None" = None
+) -> InboundContext:
     router_ctx = RouterCtx(
         bot_id=_BOT_ID,
         owned_threads=owned_threads if owned_threads is not None else set(),
@@ -44,7 +47,9 @@ def _make_ctx(*, owned_threads: set[int] | None = None) -> InboundContext:
     )
     session_ctx = SessionCtx(turn_store=None, thread_store=None)
     dispatch_ctx = MagicMock(spec=DispatchCtx)
-    return InboundContext(router=router_ctx, session=session_ctx, dispatch=dispatch_ctx)
+    return InboundContext(
+        router=router_ctx, session=session_ctx, dispatch=dispatch_ctx, ingest=ingest
+    )
 
 
 def _make_pipeline(
@@ -259,3 +264,64 @@ class TestInboundPipeline:
         )
         # on_drop not triggered by the pipeline itself (only Dispatcher may call it)
         on_drop.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_store_path_clears_pending_attachments(self) -> None:
+        """No-store path (ingest_stage=None or store=None): pending_attachments cleared.
+
+        B1 contract: when the ingest stage is skipped (no store configured), both
+        singular ``pending_attachment`` and plural ``pending_attachments`` must be
+        cleared before the message is forwarded to the router/dispatcher — fetch
+        closures must never cross the NATS process boundary.
+
+        Negative: if only ``pending_attachment`` is cleared (old code), a message
+        carrying ``pending_attachments`` leaks live closures downstream.
+        """
+        # Arrange — pipeline with NO ingest stage (store=None path)
+        pipeline, _mock_router, mock_session_builder, _mock_dispatcher = _make_pipeline(
+            route_decision=RouteDecision.PROCESS,
+        )
+        # Build a message carrying a non-empty pending_attachments list
+        async def _fake_fetch() -> bytes:
+            return b"data"  # pragma: no cover
+
+        pending = PendingAttachment(
+            fetch=_fake_fetch,
+            mime="image/jpeg",
+            source="telegram",
+        )
+        att = Attachment(
+            type="image", url_or_path_or_bytes="tg:x", mime_type="image/jpeg"
+        )
+        msg_with_pending = dataclasses.replace(
+            _make_msg(), attachments=[att], pending_attachments=[pending]
+        )
+
+        ctx = _make_ctx(ingest=IngestCtx(store=None))
+        parser = MagicMock()
+        parser.parse = MagicMock(return_value=msg_with_pending)
+        send_backpressure = AsyncMock()
+
+        # Capture the msg that session_builder.build receives
+        captured: list[InboundMessage] = []
+
+        async def _capture_build(m: InboundMessage, _s: object) -> InboundMessage:
+            captured.append(m)
+            return m
+
+        mock_session_builder.build = AsyncMock(side_effect=_capture_build)
+
+        # Act
+        await pipeline.run(
+            raw="raw-event",
+            ctx=ctx,
+            parser=parser,
+            send_backpressure=send_backpressure,
+        )
+
+        # Assert — the msg forwarded downstream has pending_attachments cleared
+        assert len(captured) == 1
+        forwarded = captured[0]
+        assert forwarded.pending_attachments == [], (
+            "pending_attachments must be cleared on the no-store path (B1 NATS-safety)"
+        )

--- a/tests/infrastructure/test_blobstore_adapter.py
+++ b/tests/infrastructure/test_blobstore_adapter.py
@@ -413,6 +413,67 @@ class TestHttpBlobStoreAdapterServerErrorTranslation:
         except httpx.HTTPStatusError:
             pass  # expected — raw 4xx propagates unchanged
 
+    async def test_put_translates_request_error_to_blob_store_server_error_503(
+        self,
+    ) -> None:
+        """put() wraps httpx.RequestError (e.g. ConnectError, TimeoutException) as
+        BlobStoreServerError with status_code 503.
+
+        Negative guard: removing the RequestError catch in HttpBlobStoreAdapter.put
+        makes this test fail because the raw httpx.ConnectError propagates uncaught.
+        """
+        # Arrange
+        import httpx
+
+        import roxabi_contracts
+        from lyra.infrastructure.blobstore_adapter import HttpBlobStoreAdapter
+
+        fake_store = _make_fake_http_store()
+        request = httpx.Request("PUT", "http://blobstore/blobs")
+        cast(AsyncMock, fake_store.put).side_effect = httpx.ConnectError(
+            "Connection refused", request=request
+        )
+        adapter = HttpBlobStoreAdapter(fake_store)
+
+        # Act / Assert
+        with pytest.raises(roxabi_contracts.BlobStoreServerError) as exc_info:
+            await adapter.put(b"data", mime="image/png", source="discord")
+
+        raised = exc_info.value
+        assert raised.status_code == 503
+        assert isinstance(raised, roxabi_contracts.BlobStoreServerError)
+
+    async def test_put_5xx_error_message_does_not_contain_url(self) -> None:
+        """put() 5xx BlobStoreServerError message must not leak the request URL.
+
+        W1 (secret/URL leak): str(httpx.HTTPStatusError) can include the request URL
+        and potentially token-bearing request repr. The sanitized message must contain
+        only the HTTP status code, never a raw URL or headers.
+        """
+        # Arrange
+        import httpx
+
+        import roxabi_contracts
+        from lyra.infrastructure.blobstore_adapter import HttpBlobStoreAdapter
+
+        fake_store = _make_fake_http_store()
+        request = httpx.Request("PUT", "http://blobstore.internal/blobs?token=secret")
+        response = httpx.Response(500, request=request)
+        cast(AsyncMock, fake_store.put).side_effect = httpx.HTTPStatusError(
+            "500 Internal Server Error", request=request, response=response
+        )
+        adapter = HttpBlobStoreAdapter(fake_store)
+
+        # Act
+        with pytest.raises(roxabi_contracts.BlobStoreServerError) as exc_info:
+            await adapter.put(b"data", mime="image/png", source="discord")
+
+        raised = exc_info.value
+        # The message must contain the status code but NOT a URL
+        assert "500" in raised.args[0]
+        assert "http://" not in raised.args[0]
+        assert "blobstore" not in raised.args[0]
+
 
 # ---------------------------------------------------------------------------
 # T4 — Protocol conformance: HttpBlobStoreAdapter satisfies BlobStorePort

--- a/tests/infrastructure/test_blobstore_adapter.py
+++ b/tests/infrastructure/test_blobstore_adapter.py
@@ -350,6 +350,71 @@ class TestHttpBlobStoreAdapterErrorTranslation:
 
 
 # ---------------------------------------------------------------------------
+# T6 — 5xx translation: httpx.HTTPStatusError ≥500 → BlobStoreServerError
+# ---------------------------------------------------------------------------
+
+
+class TestHttpBlobStoreAdapterServerErrorTranslation:
+    async def test_put_translates_5xx_to_blob_store_server_error(self) -> None:
+        """put() wraps httpx.HTTPStatusError with status ≥500 as BlobStoreServerError.
+
+        Negative guard: removing the 5xx catch in HttpBlobStoreAdapter.put makes
+        pytest.raises(roxabi_contracts.BlobStoreServerError) fail because the raw
+        httpx.HTTPStatusError propagates uncaught.
+        """
+        # Arrange
+        import httpx
+
+        import roxabi_contracts
+        from lyra.infrastructure.blobstore_adapter import HttpBlobStoreAdapter
+
+        fake_store = _make_fake_http_store()
+        # Build a minimal httpx.HTTPStatusError for a 503 response
+        request = httpx.Request("PUT", "http://blobstore/blobs")
+        response = httpx.Response(503, request=request)
+        cast(AsyncMock, fake_store.put).side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable", request=request, response=response
+        )
+        adapter = HttpBlobStoreAdapter(fake_store)
+
+        # Act / Assert
+        with pytest.raises(roxabi_contracts.BlobStoreServerError) as exc_info:
+            await adapter.put(b"data", mime="image/png", source="discord")
+
+        raised = exc_info.value
+        assert raised.status_code == 503
+        assert isinstance(raised, roxabi_contracts.BlobStoreServerError)
+
+    async def test_put_does_not_wrap_4xx_as_blob_store_server_error(self) -> None:
+        """put() does not wrap non-5xx HTTPStatusError as BlobStoreServerError.
+
+        A 4xx (e.g. 400 Bad Request) must propagate as the raw httpx error,
+        not be swallowed or re-typed as BlobStoreServerError.
+        """
+        # Arrange
+        import httpx
+
+        import roxabi_contracts
+        from lyra.infrastructure.blobstore_adapter import HttpBlobStoreAdapter
+
+        fake_store = _make_fake_http_store()
+        request = httpx.Request("PUT", "http://blobstore/blobs")
+        response = httpx.Response(400, request=request)
+        cast(AsyncMock, fake_store.put).side_effect = httpx.HTTPStatusError(
+            "400 Bad Request", request=request, response=response
+        )
+        adapter = HttpBlobStoreAdapter(fake_store)
+
+        # Act / Assert — 4xx passes through as raw httpx.HTTPStatusError
+        try:
+            await adapter.put(b"data", mime="image/png", source="discord")
+        except roxabi_contracts.BlobStoreServerError:
+            pytest.fail("4xx must not be wrapped as BlobStoreServerError")
+        except httpx.HTTPStatusError:
+            pass  # expected — raw 4xx propagates unchanged
+
+
+# ---------------------------------------------------------------------------
 # T4 — Protocol conformance: HttpBlobStoreAdapter satisfies BlobStorePort
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Extend the central `AttachmentIngestStage` to **non-audio** attachments (image / document / video / sticker / animation / GIF) on Telegram + Discord. Closes the dead non-audio branch where #1551 stored the blob but discarded the returned wire ref.
- **S5** — `Attachment.blob_ref` field + multi-attachment `InboundMessage.pending_attachments` (index-aligned, transient, NATS-cleared); stage iterates and stamps each `blob_ref`; `MAX_ATTACHMENT_INGEST_BYTES` (env `LYRA_MAX_ATTACHMENT_INGEST_BYTES`, 20 MiB) guard **before** download; `BlobStoreServerError` mapped at the infra seam (httpx 5xx, mirrors `404→BlobNotFoundError`) → `AttachmentIngestError`.
- **S6/S7** — Telegram + Discord `normalize()` emit `PendingAttachment` fetch closures (+ declared `size`); each adapter's `pipeline.run()` boundary catches `AttachmentIngestError` → user-facing reply (mirrors the audio-too-large path).
- **D4** (parent Open-Q1) — configurable blobstore write timeout (env `LYRA_BLOBSTORE_WRITE_TIMEOUT_S`, default 30 s) for 20 MiB CDN→PUT.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1552 | Review |
| Analysis | parent #1537 design | F-lite — n/a |
| Spec | [1552-central-ingest-non-audio-spec.mdx](artifacts/specs/1552-central-ingest-non-audio-spec.mdx) | Present |
| Plan | [1552-central-ingest-non-audio-plan.mdx](artifacts/plans/1552-central-ingest-non-audio-plan.mdx) | Present |
| Implementation | 1 commit on `feat/1552-central-ingest-non-audio` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new test files) | Passed |

## Test Plan
- [ ] Telegram: send a photo/document → blob persisted, `Attachment.blob_ref` real before hub enqueue.
- [ ] Discord: send a message with multiple files → each `blob_ref` stamped (multi-attachment).
- [ ] Oversize (> 20 MiB declared) → rejected **before** download + user reply, no hub push.
- [ ] BlobStore 5xx → user-facing error, no silent propagation.
- [ ] Voice path unchanged (regression check — `test_*_voice_ingest.py` green).
- [ ] `lint-imports` green — `lyra.inbound` imports no `httpx` / `discord` / `aiogram`.

## Axial guard
`source` never branches in `AttachmentIngestStage.run()` — the stage stays platform-agnostic; only the adapters differ.

Closes #1552
Closes #1066 (superseded — Discord eager-ingest absorbed into the central stage)

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`