### PR TITLE
feat(nats): acl-matrix v4 grant-groups + audio-consumer migration

### DIFF
--- a/artifacts/frames/1526-s4-acl-grant-group-frame.mdx
+++ b/artifacts/frames/1526-s4-acl-grant-group-frame.mdx
@@ -1,0 +1,81 @@
+---
+title: S4 — ACL grant-group (acl-matrix.json v4 + generator)
+issue: 1526
+status: approved
+tier: F-lite
+date: 2026-05-31
+---
+
+## Problem
+
+The audio publish/subscribe grant set is copy-pasted verbatim across the
+`telegram-adapter` and `discord-adapter` identity blocks in
+`deploy/nats/acl-matrix.json` (flat ACL, no group/role/extends). This is the N×M
+drift root cause of the 2026-05-29 crash-loop (ADR-079 §incident): a new audio
+concern must be edited into all N adapter targets, and grants silently diverge.
+
+Slice S4 of #1521 (ADR-079 §b) introduces an `acl-matrix.json` schema **v4** with
+a top-level `groups` key. The post-S3 audio grant set is defined **once** as the
+`audio-consumer` group; each platform-adapter identity references it via
+`"groups": ["audio-consumer"]`. The generator (`scripts/_acl_models.py`,
+`_loader.py`, `_renderer.py`) expands group subjects into the effective grant list
+**before** flow injection — groups are a source-side abstraction only, so the
+rendered `auth.conf` is byte-equivalent (or strictly tighter) versus v3.
+
+## Who
+
+- **Primary:** ACL maintainers / ops — edit `acl-matrix.json` + run
+  `make nats-regen-authconf`; a future 3rd adapter adds one line, not 11 grants.
+- **Secondary:** `lyra-telegram` / `lyra-discord` runtimes — must observe an
+  identical effective grant set post-migration (no auth regression).
+
+## Constraints
+
+- **Render-equality contract:** `render(v4) == render(v3)` proven via
+  `parse_auth_conf` equality — identical-or-tighter `auth.conf`. Touches the
+  renderer feeding **prod** auth.conf.
+- **Backward compat:** existing v3 matrices stay valid (`groups` optional, loader
+  defaults to empty).
+- **Derive, don't invent:** the `audio-consumer` group set is the *current
+  post-S3* adapter audio grant (CONSUMER.CREATE uses `.>`), extracted from the
+  live matrix — not hand-authored.
+- **Deploy ordering (prior retro):** regen + restart-not-HUP, no root; permissive
+  dev NATS hides gaps — equality must be asserted in code/CI, not at deploy time.
+- Single domain (ACL generation infra under `scripts/` + `deploy/nats/`).
+
+## Out of Scope
+
+- S5 / CI falsification gate (#1527) — stream-keyed assertion lives in its own slice.
+- Hub identity grants / sole-provisioner (done in S3 / #1525).
+- Any runtime/adapter Python code — this is generator + matrix data only.
+- Adding a 3rd adapter (the group merely makes it a one-liner later).
+
+## Premise Validity
+
+**Success in 6 months:** `acl-matrix.json` is v4; the audio grant set appears in
+exactly **one** place (`groups.audio-consumer`); both adapters reference it by
+name; `render(v4) == render(v3)` holds as a passing test. Adding a future adapter
+is a one-line `"groups": ["audio-consumer"]` change with zero grant copy-paste.
+
+**Failure in 6 months (falsifiable):** the audio publish grant set is still
+duplicated inline across ≥2 identity blocks (per-identity copy-pasted audio grant
+count > 0) **OR** a pre-existing v3 matrix fails to load/render after the change —
+observable by grep + the render-equality test, decidable within this epic.
+
+**Simplest alternative:** keep the flat per-identity grant lists (status quo).
+**Why not simplest:** that *is* the N×M drift that caused the 2026-05-29
+production crash-loop — every new audio concern edits all N adapters and grants
+diverge silently; the group abstraction is the ADR-073-compliant fix (define once,
+apply N times by reference).
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (ACL generator), design fully
+specified in ADR-079 §b; 4–5 files, no new architecture, no unknowns.
+
+Signals observed:
+- 3 generator modules + 1 data file + tests (~4–5 files) → F-lite range.
+- Single domain (`scripts/` ACL generation) → not F-full.
+- Schema-version bump + render-equality contract feeding prod auth.conf → above S
+  (warrants spec/plan gates).
+- Design already in an accepted ADR → no deep unknowns (not F-full).

--- a/artifacts/plans/1526-s4-acl-grant-group-plan.mdx
+++ b/artifacts/plans/1526-s4-acl-grant-group-plan.mdx
@@ -1,0 +1,308 @@
+---
+title: "Plan: S4 — ACL grant-group (acl-matrix.json v4 + generator)"
+issue: 1526
+spec: artifacts/specs/1526-s4-acl-grant-group-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-05-31
+---
+
+## Summary
+
+Add `audio-consumer` ACL grant-group support to the generator (`_acl_models.py`,
+`_loader.py`, `_renderer.py`), migrate `deploy/nats/acl-matrix.json` to schema v4
+(audio grants defined once, referenced by both adapters), regenerate the committed
+`auth.conf`, and prove `frozenset(parse(render_v4).users) == frozenset(parse(render_v3).users)`.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph matrix[deploy/nats/acl-matrix.json v4]
+      G[groups.audio-consumer<br/>8 pub + 1 sub]
+      ID["identities[adapter].groups=[audio-consumer]"]
+    end
+    subgraph loader[scripts/_loader.py]
+      LM["load_matrix → LoadedMatrix{groups, identities}"]
+      XR[cross-ref validate: identity.groups ⊆ groups]
+    end
+    subgraph renderer[scripts/_renderer.py]
+      RE["render_auth_conf: expand groups → pub/sub_allow<br/>(first loop, before flow injection)"]
+      PA[parse_auth_conf → ParsedAuthConf]
+    end
+    matrix --> LM --> XR --> RE
+    RE --> AC[deploy/nats/auth.conf]
+    AC --> DRIFT[check-acl-authconf-drift.sh CI gate]
+    RE -.test.-> PA
+    PA -.T8 set-eq.-> V3[(v3 fixture render)]
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph models[_acl_models.py]
+      GD[GroupDefinition NEW]
+      LMt["LoadedMatrix +groups"]
+      IDt["Identity +groups"]
+    end
+    subgraph load[_loader.py]
+      VV[_VALID_VERSIONS +4]
+      LMx[load_matrix]
+      VI[_validate_identity flow+deploy gates +v4]
+    end
+    subgraph rend[_renderer.py]
+      RAC[render_auth_conf +expand]
+      PAC[parse_auth_conf]
+    end
+    GD --> LMt --> LMx
+    IDt --> VI
+    VV --> LMx
+    LMx --> RAC
+    RAC --> PAC
+    subgraph tests[tests/scripts]
+      TR[test_renderer.py]
+      TL[test_loader.py]
+      FX[fixtures/v3-pre-grant-group.json]
+    end
+    RAC --> TR
+    LMx --> TL
+    FX --> TR
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1–T3 | `scripts/_acl_models.py`, `scripts/_loader.py`, `scripts/_renderer.py` |
+| devops-A | T4–T6 | `deploy/nats/acl-matrix.json`, `deploy/nats/auth.conf`, acl CI gates |
+| tester-A | T7–T10 | `tests/scripts/fixtures/`, `tests/scripts/test_renderer.py`, `test_loader.py` |
+
+## Bootstrap Context
+
+- Render-equality is enforced two ways: (a) CI drift gate `scripts/check-acl-authconf-drift.sh`
+  regenerates auth.conf via `lyra-acl genkeys --template-only` and textually diffs the
+  committed file → committed `auth.conf` MUST be regenerated + committed (T5); (b) the
+  T8 regression test proves v4≡v3 set-equality.
+- `parse_auth_conf` returns `ParsedAuthConf.users: tuple[...]` (order-sensitive). T8 wraps
+  in `frozenset(...)` for order-independent set-equality (ParsedUser is `frozen=True`,
+  `nkey` excluded via `compare=False`).
+- `audio-consumer` = the 8 `$JS.*`/`$KV.*` publish + 1 `$KV.*` subscribe subjects
+  duplicated across telegram+discord today (enumerated in spec §"Group Definition").
+  `lyra.outbound.audio.>` and non-audio shared grants STAY inline.
+- Other matrix consumers (`check-acl-matrix-spec.sh`, `check_subject_literals.py`,
+  `check_request_reply_flows.py`, `check_acl_matrix_retired.py`,
+  `tools/check_renderer_roundtrip.sh`) compute effective grants WITHOUT group expansion.
+  Since the group holds only `$JS`/`$KV` subjects and the spec-table gate filters to
+  `lyra.*`/`_inbox.*`, they are expected unaffected — T6 VERIFIES this, fixing any
+  consumer that needs group-expansion rather than assuming.
+- Ref pattern: `tests/scripts/test_renderer.py` (uses `prod_matrix` fixture, `_fake_pubkeys`,
+  `render_auth_conf`/`parse_auth_conf`); `tests/scripts/conftest.py` fixture style;
+  fixtures `tests/scripts/fixtures/v1-legacy.json`, `v2-with-retired.json`.
+
+## Wave Structure
+
+6 waves, max 2 parallel agents. Elapsed ~1.5 sessions vs ~3 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | backend-dev-A: T1 · tester-A: T7 |
+| 2 | W1 done | 1 | backend-dev-A: T2 |
+| 3 | W2 done | 2 ∥ | backend-dev-A: T3 · tester-A: T10 |
+| 4 | W3 done | 2 ∥ | devops-A: T4 · tester-A: T9 |
+| 5 | W4 done | 1 | devops-A: T5 |
+| 6 | W5 done | 2 ∥ | devops-A: T6 · tester-A: T8 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 models | 3 types | bounded | 4 | — |
+| T2 loader | 4 edits | judgmental | 8 | — |
+| T3 renderer | 1 loop | judgmental | 6 | — |
+| T4 matrix migrate | 2 adapters + group | bounded | 6 | — |
+| T5 auth.conf regen | 1 cmd | trivial | 2 | — |
+| T6 consumer-compat verify | 6 gates | judgmental | 12 | — |
+| T7 v3 fixture snapshot | 1 file | trivial | 2 | — |
+| T8 equality test | 1 test | judgmental | 6 | — |
+| T9 v3-valid test | 1 test | bounded | 4 | — |
+| T10 loader tests | 3 cases | judgmental | 6 | — |
+
+**Total estimated ops: ~56**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1,T2,T3 | 18 | acl-codegen | — |
+| devops-A | T4,T5,T6 | 20 | acl-deploy | — |
+| tester-A | T7,T8,T9,T10 | 18 | acl-tests | — (\|tasks\|=4, ≤cap) |
+
+## Consistency Report
+
+Covered: 11/11 success criteria. Untraced tasks: 0. Exemptions: none.
+
+| SC | Task |
+|---|---|
+| GroupDefinition + LoadedMatrix.groups + Identity.groups | T1 |
+| version "4" + 1/2/3 still valid | T2, T10 |
+| v4 flow-parse inherited | T2, T10 |
+| v4 deploy-guard inherited | T2, T10 |
+| parse top-level groups (default {}) | T2, T10 |
+| dangling group-ref → exit non-zero | T2, T10 |
+| render_auth_conf expands before flow injection | T3, T8 |
+| v3 byte-identical (no regression) | T3, T9 |
+| matrix v4, group-only audio grants, adapters reference | T4 |
+| committed auth.conf regenerated + parse-equal | T5, T6 |
+| frozenset(parse(v4).users)==frozenset(parse(v3).users) | T8 |
+| ruff/pyright/pytest pass | T6 (gates), all |
+
+## Micro-Tasks
+
+### Slice 1 — Generator supports groups (backend-dev-A · subject: acl-codegen)
+
+**T1 [GREEN] · diff 2 · SC: models** — `scripts/_acl_models.py`
+Add `class GroupDefinition(TypedDict)` with `description: NotRequired[str]`,
+`publish: list[str]`, `subscribe: list[str]`. Add `groups: NotRequired[dict[str, GroupDefinition]]`
+to `LoadedMatrix`; add `groups: NotRequired[list[str]]` to `Identity`.
+Verify: `uv run pyright scripts/_acl_models.py` → 0 errors.
+
+**T2 [GREEN] · diff 3 · dep T1 · SC: loader** — `scripts/_loader.py`
+- `_VALID_VERSIONS` → add `"4"`.
+- line ~71 deploy guard: `elif version in {"3", "4"} and data.get("status") == "active":`.
+- line ~93 flow parse: `if version in {"2", "3", "4"}:`.
+- After identities loop: parse `raw.get("groups", {})` → `dict[str, GroupDefinition]`;
+  validate each is a dict with `publish`/`subscribe` lists.
+- Cross-ref: for each identity with `groups`, every name ∈ parsed groups else `_die(...)`.
+- Add `groups` to returned `LoadedMatrix` (default `{}`).
+Verify: `uv run pytest tests/scripts/test_loader.py -q`.
+
+**T3 [GREEN] · diff 3 · dep T1,T2 · SC: renderer** — `scripts/_renderer.py`
+In `render_auth_conf`, read `groups = matrix.get("groups", {})`. In the FIRST identity
+loop (where `pub_allow`/`sub_allow` are seeded, before the flow-injection loop), after
+seeding from inline `publish`/`subscribe`:
+```python
+for gname in identity.get("groups", []):
+    g = groups[gname]
+    pub_allow[name].extend(g.get("publish", []))
+    sub_allow[name].extend(g.get("subscribe", []))
+```
+Verify: `uv run pytest tests/scripts/test_renderer.py -q`.
+
+### Slice 2 — Matrix migration + regen + consumer-compat (devops-A · subject: acl-deploy)
+
+**T4 [GREEN] · diff 3 · dep T3 · SC: matrix** — `deploy/nats/acl-matrix.json`
+- `"version": "4"`.
+- Add top-level `"groups": { "audio-consumer": { "description": ..., "publish": [<8>], "subscribe": ["$KV.lyra_outbound_audio_sent.>"] } }` — exact 8 publish per spec §"Group Definition".
+- `telegram-adapter` + `discord-adapter`: add `"groups": ["audio-consumer"]`; REMOVE the
+  8 publish + 1 subscribe (`$KV.lyra_outbound_audio_sent.>`) audio subjects from inline
+  arrays. KEEP `lyra.outbound.audio.>` and all non-audio grants inline.
+Verify: `uv run python -c "from pathlib import Path; from scripts._loader import load_matrix; m=load_matrix(Path('deploy/nats/acl-matrix.json')); print(m['version'], list(m['groups']))"` → `4 ['audio-consumer']`.
+
+**T5 [GREEN] · diff 1 · dep T4 · SC: auth.conf** — `deploy/nats/auth.conf`
+Run `uv run lyra-acl genkeys --template-only > deploy/nats/auth.conf`.
+Verify: `bash scripts/check-acl-authconf-drift.sh` → exit 0.
+
+**T6 [VERIFY] · diff 3 · dep T4,T5 · SC: gates** — acl CI gates
+Run each and confirm green; fix any consumer that computes effective grants without
+group-expansion (expected: none, since group is `$JS`/`$KV`-only and spec-table filters
+to `lyra.*`/`_inbox.*`):
+- `bash scripts/check-acl-authconf-drift.sh`
+- `bash scripts/check-acl-matrix-spec.sh`
+- `uv run pytest tests/scripts/ -q`
+- `bash tools/check_renderer_roundtrip.sh acl` (if nats-server available; else note skip)
+Verify: all gates exit 0 (or roundtrip skipped with note).
+
+### Slice 3 — Tests (tester-A · subject: acl-tests)
+
+**T7 [setup] · diff 1 · no dep · Wave 1** — `tests/scripts/fixtures/v3-pre-grant-group.json`
+Snapshot the pre-migration v3 matrix (ordering-robust):
+`git show origin/staging:deploy/nats/acl-matrix.json > tests/scripts/fixtures/v3-pre-grant-group.json`.
+This is the v3 baseline (audio grants inline) for the equality proof.
+Verify: `jq .version tests/scripts/fixtures/v3-pre-grant-group.json` → `"3"`.
+
+**T8 [GREEN] · diff 3 · dep T3,T7,T4 · SC: equality** — `tests/scripts/test_renderer.py`
+Add `TestGrantGroupEquality`:
+- Load v4 = `load_matrix(deploy/nats/acl-matrix.json)`; v3 = `load_matrix(fixtures/v3-pre-grant-group.json)`.
+- Shared `_fake_pubkeys` keyed off identity names (same for both).
+- `assert frozenset(parse_auth_conf(render_auth_conf(v4, pk)).users) == frozenset(parse_auth_conf(render_auth_conf(v3, pk)).users)`.
+- Assert the 8 audio publish subjects are ABSENT from v4 `identities['telegram-adapter']['publish']` (inline) yet PRESENT in the rendered telegram block.
+Verify: `uv run pytest tests/scripts/test_renderer.py::TestGrantGroupEquality -q`.
+
+**T9 [GREEN] · diff 2 · dep T3 · SC: v3-valid** — `tests/scripts/test_renderer.py`
+Assert an unmodified v3 matrix (`v1-legacy.json` / `v2-with-retired.json` / v3 fixture)
+loads and renders without error and contains expected inline grants (no `groups`
+regression for group-less matrices).
+Verify: `uv run pytest tests/scripts/test_renderer.py -q -k v3 or legacy`.
+
+**T10 [GREEN] · diff 3 · dep T2 · SC: loader** — `tests/scripts/test_loader.py`
+Add: (a) `version:"4"` loads OK; (b) top-level `groups` parsed into `LoadedMatrix.groups`;
+(c) identity referencing undefined group → `pytest.raises(SystemExit)`; (d) v4 active
+identity missing `deploy` → `SystemExit` (deploy-guard inherited).
+Verify: `uv run pytest tests/scripts/test_loader.py -q`.
+
+## RED-GATE
+
+- After Slice 1 (T3): `uv run pyright scripts/ && uv run pytest tests/scripts/test_loader.py tests/scripts/test_renderer.py -q` green.
+- After Slice 2 (T6): all acl gates green.
+- After Slice 3 (T8,T9,T10): `uv run pytest tests/scripts/ -q` green; T8 equality passes.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement. T-numbers ref this list; instances map to spawned agents. -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | acl-codegen |
+| T7 | tester-A | — | acl-tests |
+
+### Wave 2 — after T1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | acl-codegen |
+
+### Wave 3 — after T2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T2 | acl-codegen |
+| T10 | tester-A | T2 | acl-tests |
+
+### Wave 4 — after T3, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | devops-A | T3 | acl-deploy |
+| T9 | tester-A | T3 | acl-tests |
+
+### Wave 5 — after T4, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | devops-A | T4 | acl-deploy |
+
+### Wave 6 — after T5, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | devops-A | T5 | acl-deploy |
+| T8 | tester-A | T3, T7, T4 | acl-tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — acl-codegen (backend-dev-A)
+- T2: 13 — acl-codegen (backend-dev-A)
+- T3: 14 — acl-codegen (backend-dev-A)
+- T4: 15 — acl-deploy (devops-A)
+- T5: 16 — acl-deploy (devops-A)
+- T6: 17 — acl-deploy (devops-A)
+- T7: 18 — acl-tests (tester-A)
+- T8: 19 — acl-tests (tester-A)
+- T9: 20 — acl-tests (tester-A)
+- T10: 21 — acl-tests (tester-A)

--- a/artifacts/specs/1526-s4-acl-grant-group-spec.mdx
+++ b/artifacts/specs/1526-s4-acl-grant-group-spec.mdx
@@ -1,0 +1,193 @@
+---
+title: S4 — ACL grant-group (acl-matrix.json v4 + generator)
+issue: 1526
+status: approved
+tier: F-lite
+date: 2026-05-31
+promoted_from: artifacts/frames/1526-s4-acl-grant-group-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1526-s4-acl-grant-group-frame.mdx` (ADR-079 §b, slice S4 of #1521).
+
+The audio publish/subscribe grant set is copy-pasted verbatim across the
+`telegram-adapter` and `discord-adapter` blocks of `deploy/nats/acl-matrix.json`
+(currently schema v3). This flat duplication is the N×M-drift root cause of the
+2026-05-29 crash-loop. ADR-079 §b prescribes schema **v4**: define the grant set
+once as the `audio-consumer` group; each adapter references it by name. The
+generator (`scripts/_acl_models.py`, `_loader.py`, `_renderer.py`) expands the
+group into the effective grant list before rendering — a source-side abstraction
+only, so the rendered `auth.conf` is byte-for-set identical to v3.
+
+## Goal
+
+Replace per-adapter audio-grant duplication with a single referenced
+`audio-consumer` group, while proving the rendered `auth.conf` is
+identical-or-tighter versus v3.
+
+## Users
+
+- **Primary:** ACL maintainers / ops editing `acl-matrix.json` then running
+  `make nats-regen-authconf`. A future 3rd adapter adds one `"groups"` line.
+- **Secondary:** `lyra-telegram` / `lyra-discord` runtimes — must see an
+  identical effective grant set (no auth regression at deploy).
+
+## Expected Behavior
+
+1. `load_matrix` accepts `version: "4"` (and still `"1"/"2"/"3"`). v4 inherits all
+   v3 invariants: `request_reply_flows` are parsed (flow-parse version set becomes
+   `{"2","3","4"}`), and active identities still require a `deploy` field
+   (deploy-guard version set becomes `{"3","4"}`).
+2. A v4 matrix MAY carry a top-level `groups` object; each group has `publish`
+   and `subscribe` string lists (+ optional `description`).
+3. An identity MAY carry `"groups": ["audio-consumer", ...]`. The loader rejects a
+   reference to a group not defined in `groups` by exiting non-zero (`_die` →
+   `sys.exit(1)`).
+4. `render_auth_conf` expands each identity's referenced groups into its effective
+   publish/subscribe lists **inside the first identity loop, before** request_reply
+   flow injection. Expansion appends group subjects to the inline list.
+5. Existing v3 matrices (no `groups` key, no identity `groups`) render exactly as
+   today — `groups` defaults to `{}`, identity `groups` defaults to `[]`.
+6. After migrating `acl-matrix.json` to v4, the audio grants live **only** in
+   `groups.audio-consumer`; both adapters reference it; the rendered `auth.conf`
+   parses **set-equal** to the rendered v3 output (the expansion re-adds exactly the
+   subjects removed from inline, so the effective grant set is identical, never
+   looser). Textual ordering of subjects within a user block MAY differ (audio
+   subjects move to the end of each list); the proof is parse-based, not textual.
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class LoadedMatrix {
+        +str version
+        +dict~str,Identity~ identities
+        +list~Flow~ request_reply_flows  NotRequired
+        +dict~str,GroupDefinition~ groups  NEW, NotRequired
+    }
+    class Identity {
+        +Owner owner
+        +Status status
+        +list~str~ publish
+        +list~str~ subscribe
+        +bool allow_responses
+        +list~str~ groups  NEW, NotRequired
+        +... existing fields omitted (description, created_at, deploy?, ...)
+    }
+    class GroupDefinition {
+        +str description  optional
+        +list~str~ publish
+        +list~str~ subscribe
+    }
+    LoadedMatrix "1" o-- "*" Identity
+    LoadedMatrix "1" o-- "*" GroupDefinition
+    Identity ..> GroupDefinition : references by name
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    matrix[acl-matrix.json v4] --> loader[_loader.load_matrix]
+    loader -->|LoadedMatrix incl. groups| renderer[_renderer.render_auth_conf]
+    renderer -->|expand groups → effective lists| authconf[auth.conf]
+    authconf --> nats[(NATS server)]
+    renderer -.->|render-equality test| parse[parse_auth_conf set-eq]
+    parse -.->|S5 stream-keyed CI gate| future[#1527 future]
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `load_matrix` | `version`, `groups`, `identities[].groups` | parse | this issue |
+| `render_auth_conf` | `groups`, `identities[].groups`, `publish`, `subscribe` | render | this issue |
+| render-equality test | rendered v4 vs v3 (via `parse_auth_conf`) | test | this issue |
+| #1527 CI falsification gate | `groups.audio-consumer`, identities referencing it | CI | future (out of scope) |
+
+## `audio-consumer` Group Definition (derived from current v3 matrix)
+
+The group set is **exactly** the audio JetStream/dedup-KV grants currently
+duplicated verbatim across `telegram-adapter` and `discord-adapter`. Enumerated
+explicitly so the implementer does not guess (matches ADR-079 §b):
+
+**publish (8):**
+```
+$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO
+$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>
+$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*
+$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*
+$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent
+$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent
+$JS.ACK.LYRA_OUTBOUND_AUDIO.>
+$KV.lyra_outbound_audio_sent.>
+```
+
+**subscribe (1):**
+```
+$KV.lyra_outbound_audio_sent.>
+```
+
+**Stays INLINE on each adapter (NOT in the group):**
+- Platform-axis (per-platform, cannot be shared): `lyra.inbound.<platform>.>`,
+  `lyra.outbound.<platform>.>`, `lyra.typing.<platform>.>`, `_inbox.<adapter>.>`,
+  `_inbox.<adapter>.*.*`.
+- `lyra.outbound.audio.>` (subscribe) — kept inline per ADR-079 §b (group scoped to
+  JS-consumer + dedup-KV only).
+- Non-audio shared grants (`lyra.system.ready`, `lyra.turns.write`, `lyra.event.>`,
+  `lyra.metric.>`, `$JS.API.DIRECT.GET.LYRA_STATE.hub.ready`, `$JS.API.INFO`,
+  `$JS.API.CONSUMER.CREATE.*`, `$KV.lyra-state.>`) — **out of scope** for S4; a
+  future `adapter-base` group could consolidate these (backlog, not this issue).
+
+Net per adapter: remove the 8 publish + 1 subscribe above from inline lists, add
+`"groups": ["audio-consumer"]`. Effective grant set unchanged.
+
+## Breadboard
+
+| ID | Affordance | Location | Handler / wiring | Data |
+|---|---|---|---|---|
+| N1 | `GroupDefinition(TypedDict)` | `_acl_models.py` | `description?`, `publish: list[str]`, `subscribe: list[str]` | new type |
+| N2 | `LoadedMatrix.groups` | `_acl_models.py` | `NotRequired[dict[str, GroupDefinition]]` | extends N1 |
+| N3 | `Identity.groups` | `_acl_models.py` | `NotRequired[list[str]]` | — |
+| N4 | version `"4"` + v3 invariants inherited | `_loader.py` | add `"4"` to `_VALID_VERSIONS`; flow-parse gate `{"2","3"}`→`{"2","3","4"}` (line 93); deploy-required-for-active gate `version == "3"`→`version in {"3","4"}` (line 71) | — |
+| N5 | parse + validate `groups` | `_loader.py` | parse top-level `groups` → `dict[str, GroupDefinition]`; default `{}` | reads N1 |
+| N6 | validate group cross-refs | `_loader.py` | each `identity.groups[i]` ∈ `groups` else `_die` (`sys.exit(1)`) | reads N5 |
+| N7 | group expansion | `_renderer.py:render_auth_conf` | in **first** identity loop, before flow injection: `pub_allow[name].extend(group.publish)`, `sub_allow[name].extend(group.subscribe)`; carry `groups` into renderer via `LoadedMatrix` | reads N2,N3 |
+| N8 | `groups.audio-consumer` | `acl-matrix.json` | 8 publish + 1 subscribe — exact subjects per "Group Definition" section above | data |
+| N9 | adapters reference group | `acl-matrix.json` | remove the 8 pub + 1 sub inline audio grants from both adapters; add `"groups": ["audio-consumer"]` | data |
+| N10 | regenerate committed auth.conf | `deploy/nats/auth.conf` | refresh via renderer/`make nats-regen-authconf`; parse-equal to prior | reads N7,N9 |
+| T1 | render-equality test | `tests/scripts/test_*.py` | `frozenset(parse_auth_conf(render(v4)).users) == frozenset(parse_auth_conf(render(v3_fixture)).users)` — order-independent, covers pub+sub | reads N7,N8,N9 |
+| T2 | v3-still-valid test | `tests/scripts/` | load+render an unmodified v3 matrix → byte-identical to pre-change output | reads N4 |
+| T3 | dangling-ref test | `tests/scripts/` | identity references undefined group → `SystemExit` (non-zero) | reads N6 |
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|---|---|---|
+| 1 | Generator supports groups | N1–N7 | a v4 matrix with a group renders expanded grants; v3 matrix renders byte-identically |
+| 2 | Migrate matrix to v4 + regen auth.conf | N8, N9, N10 | `acl-matrix.json` is v4; audio grants only in group; both adapters reference it; committed `auth.conf` refreshed + parse-equal |
+| 3 | Render-equality + regression tests | T1, T2, T3 | `frozenset(parse(v4).users) == frozenset(parse(v3).users)`; v3 loads; dangling ref dies |
+
+## Success Criteria
+
+- [ ] `_acl_models.py` defines `GroupDefinition` and `LoadedMatrix` carries optional `groups`; `Identity` carries optional `groups`.
+- [ ] `_loader.py` accepts `version: "4"` and still accepts `"1"/"2"/"3"`.
+- [ ] `_loader.py` parses `request_reply_flows` for v4 (flow-parse gate includes `"4"`) — no inbox-injection regression.
+- [ ] `_loader.py` enforces `deploy`-required-for-active on v4 (deploy-guard gate includes `"4"`).
+- [ ] `_loader.py` parses a top-level `groups` object into `LoadedMatrix.groups` (defaults to `{}` when absent).
+- [ ] `_loader.py` exits non-zero (`sys.exit(1)`) when an identity references a group name not present in `groups`.
+- [ ] `render_auth_conf` expands referenced groups into each identity's effective publish/subscribe lists in the first identity loop, before flow injection.
+- [ ] An unmodified v3 matrix renders byte-identically to pre-change output (no `groups` regression).
+- [ ] `deploy/nats/acl-matrix.json` is `version: "4"`, the audio grant set (8 pub + 1 sub, enumerated above) appears only under `groups.audio-consumer`, and `telegram-adapter` + `discord-adapter` each declare `"groups": ["audio-consumer"]` with those subjects removed from inline lists.
+- [ ] The committed `deploy/nats/auth.conf` is regenerated from the v4 matrix and parses set-equal to the pre-change version.
+- [ ] A regression test asserts `frozenset(parse_auth_conf(render_v4).users) == frozenset(parse_auth_conf(render_v3).users)` for the migrated matrix (effective grant set identical — never looser).
+- [ ] `uv run ruff check`, `uv run pyright`, and `uv run pytest tests/scripts/` pass.
+
+## Out of Scope
+
+- S5 / #1527 stream-keyed CI falsification gate (consumes the group but is its own slice).
+- Hub identity grants / sole-provisioner (S3 / #1525, done).
+- Any `src/lyra` runtime code; adding an actual 3rd adapter.

--- a/scripts/_acl_models.py
+++ b/scripts/_acl_models.py
@@ -26,6 +26,12 @@ class ExternalDeploy(TypedDict):
 Deploy = ContainerDeploy | HostDeploy | ExternalDeploy
 
 
+class GroupDefinition(TypedDict):
+    description: NotRequired[str]
+    publish: list[str]
+    subscribe: list[str]
+
+
 class Identity(TypedDict):
     owner: Owner
     status: Status
@@ -37,6 +43,7 @@ class Identity(TypedDict):
     retired_at: NotRequired[str]
     notes: NotRequired[str]
     deploy: NotRequired[Deploy]
+    groups: NotRequired[list[str]]
 
 
 class Flow(TypedDict):
@@ -49,6 +56,7 @@ class LoadedMatrix(TypedDict):
     version: str
     identities: dict[str, Identity]
     request_reply_flows: NotRequired[list[Flow]]
+    groups: NotRequired[dict[str, GroupDefinition]]
 
 
 @dataclass(eq=True, frozen=True)

--- a/scripts/_loader.py
+++ b/scripts/_loader.py
@@ -5,10 +5,10 @@ import re
 import sys
 from pathlib import Path
 
-from scripts._acl_models import Flow, Identity, LoadedMatrix
+from scripts._acl_models import Flow, GroupDefinition, Identity, LoadedMatrix
 
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-_VALID_VERSIONS = {"1", "2", "3"}
+_VALID_VERSIONS = {"1", "2", "3", "4"}
 _VALID_STATUSES = {"active", "retired"}
 _VALID_OWNERS = {"lyra", "voicecli", "imagecli", "reserved"}
 _REQUIRED_FIELDS = (
@@ -68,10 +68,32 @@ def _validate_identity(name: str, data: dict, version: str) -> Identity:
 
     if "deploy" in data:
         _validate_deploy(name, data["deploy"])  # type: ignore[arg-type]
-    elif version == "3" and data.get("status") == "active":
+    elif version in {"3", "4"} and data.get("status") == "active":
         _die(f"identity '{name}': v3 requires 'deploy' for active identities")
 
     return data  # type: ignore[return-value]
+
+
+def _parse_groups(raw_groups: dict) -> dict[str, GroupDefinition]:
+    groups: dict[str, GroupDefinition] = {}
+    for gname, gdata in raw_groups.items():
+        if not isinstance(gdata, dict):
+            _die(f"group '{gname}': must be an object")
+        if "publish" not in gdata or not isinstance(gdata["publish"], list):
+            _die(f"group '{gname}': missing or invalid 'publish' list")
+        if "subscribe" not in gdata or not isinstance(gdata["subscribe"], list):
+            _die(f"group '{gname}': missing or invalid 'subscribe' list")
+        groups[gname] = gdata  # type: ignore[assignment]
+    return groups
+
+
+def _validate_group_refs(
+    identities: dict[str, Identity], groups: dict[str, GroupDefinition]
+) -> None:
+    for name, identity in identities.items():
+        for ref in identity.get("groups", []):  # type: ignore[union-attr]
+            if ref not in groups:
+                _die(f"identity '{name}': references unknown group '{ref}'")
 
 
 def load_matrix(path: Path) -> LoadedMatrix:
@@ -90,7 +112,7 @@ def load_matrix(path: Path) -> LoadedMatrix:
         identities[name] = _validate_identity(name, data, version)
 
     flows: list[Flow] = []
-    if version in {"2", "3"}:
+    if version in {"2", "3", "4"}:
         raw_flows = raw.get("request_reply_flows", [])
         seen: set[tuple[str, str]] = set()
         for flow in raw_flows:
@@ -101,6 +123,12 @@ def load_matrix(path: Path) -> LoadedMatrix:
             seen.add(pair)
             flows.append(flow)
 
+    groups = _parse_groups(raw.get("groups", {}))
+    _validate_group_refs(identities, groups)
+
     return LoadedMatrix(
-        version=version, identities=identities, request_reply_flows=flows
+        version=version,
+        identities=identities,
+        request_reply_flows=flows,
+        groups=groups,
     )

--- a/scripts/_loader.py
+++ b/scripts/_loader.py
@@ -69,7 +69,7 @@ def _validate_identity(name: str, data: dict, version: str) -> Identity:
     if "deploy" in data:
         _validate_deploy(name, data["deploy"])  # type: ignore[arg-type]
     elif version in {"3", "4"} and data.get("status") == "active":
-        _die(f"identity '{name}': v3 requires 'deploy' for active identities")
+        _die(f"identity '{name}': v{version} requires 'deploy' for active identities")
 
     return data  # type: ignore[return-value]
 
@@ -81,8 +81,12 @@ def _parse_groups(raw_groups: dict) -> dict[str, GroupDefinition]:
             _die(f"group '{gname}': must be an object")
         if "publish" not in gdata or not isinstance(gdata["publish"], list):
             _die(f"group '{gname}': missing or invalid 'publish' list")
+        if not all(isinstance(s, str) for s in gdata["publish"]):
+            _die(f"group '{gname}': 'publish' entries must be strings")
         if "subscribe" not in gdata or not isinstance(gdata["subscribe"], list):
             _die(f"group '{gname}': missing or invalid 'subscribe' list")
+        if not all(isinstance(s, str) for s in gdata["subscribe"]):
+            _die(f"group '{gname}': 'subscribe' entries must be strings")
         groups[gname] = gdata  # type: ignore[assignment]
     return groups
 

--- a/scripts/_renderer.py
+++ b/scripts/_renderer.py
@@ -56,6 +56,7 @@ def render_auth_conf(matrix: LoadedMatrix, pubkeys: dict[str, str]) -> str:
     identities = matrix["identities"]
     flows = matrix.get("request_reply_flows", [])
 
+    groups = matrix.get("groups", {})
     pub_allow: dict[str, list[str]] = {}
     sub_allow: dict[str, list[str]] = {}
 
@@ -64,6 +65,10 @@ def render_auth_conf(matrix: LoadedMatrix, pubkeys: dict[str, str]) -> str:
             continue
         pub_allow[name] = list(identity.get("publish", []))
         sub_allow[name] = list(identity.get("subscribe", []))
+        for gname in identity.get("groups", []):
+            g = groups[gname]
+            pub_allow[name].extend(g.get("publish", []))
+            sub_allow[name].extend(g.get("subscribe", []))
 
     for flow in flows:
         requester, responder = flow["requester"], flow["responder"]

--- a/scripts/_renderer.py
+++ b/scripts/_renderer.py
@@ -69,6 +69,8 @@ def render_auth_conf(matrix: LoadedMatrix, pubkeys: dict[str, str]) -> str:
             g = groups[gname]
             pub_allow[name].extend(g.get("publish", []))
             sub_allow[name].extend(g.get("subscribe", []))
+        pub_allow[name] = list(dict.fromkeys(pub_allow[name]))
+        sub_allow[name] = list(dict.fromkeys(sub_allow[name]))
 
     for flow in flows:
         requester, responder = flow["requester"], flow["responder"]

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -28,11 +28,40 @@ SPEC="${REPO_ROOT}/artifacts/specs/706-per-role-nkeys-acls-spec.mdx"
 [[ -f "$JSON" ]] || { echo "::error::acl-matrix.json not found: $JSON"; exit 1; }
 [[ -f "$SPEC" ]] || { echo "::error::spec file not found: $SPEC"; exit 1; }
 
-# Pre-compute effective ACL (static grants + derived from request_reply_flows).
+# Pre-compute effective ACL in two passes:
+#   Pass 1 — expand group grants into each identity's publish/subscribe arrays.
+#            Groups are defined in .groups (v4+); absent in v1-v3 (safe no-op).
+#   Pass 2 — derive inbox grants from request_reply_flows.
 # Guard: skip flows that reference unknown identities (prevents auto-vivification).
 # Use |= unique after each += to prevent duplicate entries when the same identity
 # appears as requester/responder in multiple flows.
 EFFECTIVE_JSON=$(jq '
+  # Pass 1: expand group grants into each identity'\''s publish/subscribe arrays.
+  # Capture .groups before the reduce so jq path resolution is stable after
+  # in-place mutations to .identities (referencing .groups inside the reduce
+  # body would re-evaluate against the mutated accumulator and fail).
+  (.groups // {}) as $all_groups |
+  reduce (.identities | to_entries[]) as $entry (
+    .;
+    ($entry.value.groups // []) as $grps |
+    if ($grps | length) > 0 then
+      reduce $grps[] as $gname (
+        .;
+        if $all_groups[$gname] != null then
+          .identities[$entry.key].publish   |= (. + ($all_groups[$gname].publish   // []) | unique) |
+          .identities[$entry.key].subscribe |= (. + ($all_groups[$gname].subscribe // []) | unique)
+        else
+          .
+        end
+      )
+    else
+      .
+    end
+  ) |
+  # Pass 2: derive inbox grants from request_reply_flows.
+  # Guard: skip flows that reference unknown identities (prevents auto-vivification).
+  # Use |= unique after each += to prevent duplicate entries when the same identity
+  # appears as requester/responder in multiple flows.
   reduce (.request_reply_flows[]?) as $flow (
     .;
     if (.identities[$flow.requester] != null and .identities[$flow.responder] != null) then

--- a/scripts/check-acl-matrix-spec.sh
+++ b/scripts/check-acl-matrix-spec.sh
@@ -51,7 +51,7 @@ EFFECTIVE_JSON=$(jq '
           .identities[$entry.key].publish   |= (. + ($all_groups[$gname].publish   // []) | unique) |
           .identities[$entry.key].subscribe |= (. + ($all_groups[$gname].subscribe // []) | unique)
         else
-          .
+          error("unknown group: \($gname)")
         end
       )
     else

--- a/tests/scripts/fixtures/v3-pre-grant-group.json
+++ b/tests/scripts/fixtures/v3-pre-grant-group.json
@@ -1,23 +1,5 @@
 {
-  "version": "4",
-  "groups": {
-    "audio-consumer": {
-      "description": "Durable outbound-audio JetStream consumer + dedup-KV grants (ADR-079 §b). Referenced by platform adapters; defined once to prevent N×M drift.",
-      "publish": [
-        "$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO",
-        "$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>",
-        "$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*",
-        "$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*",
-        "$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent",
-        "$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent",
-        "$JS.ACK.LYRA_OUTBOUND_AUDIO.>",
-        "$KV.lyra_outbound_audio_sent.>"
-      ],
-      "subscribe": [
-        "$KV.lyra_outbound_audio_sent.>"
-      ]
-    }
-  },
+  "version": "3",
   "request_reply_flows": [
     { "requester": "hub", "responder": "clipool-worker", "subject": "lyra.clipool.cmd" },
     { "requester": "hub", "responder": "voice-tts",      "subject": "lyra.voice.tts.request.>" },
@@ -76,7 +58,6 @@
       "description": "Telegram bot adapter — inbox normalized to _inbox.telegram-adapter.> (ADR-051 + postmortem Fix 1).",
       "notes": "$JS.API.> narrowed to minimal KV read-only subjects (#1014): DIRECT.GET for KV key reads, INFO for JetStream availability, CONSUMER.CREATE for kv.watch() ephemeral consumer. lyra.turns.write added by T27 (#1331): telegram adapter publishes TurnWriteEvents. Outbound-audio JetStream consumer grants added by T7 (#1482): stream/consumer create+info, pull-next, KV dedup bucket. $KV.lyra_outbound_audio_sent.> added to publish (#1482 B1): kv.put() in KvSentSet.mark_sent publishes directly to $KV.<bucket>.<key> subjects and requires an explicit publish grant. Hotfix (2026-05-29, prod crash-loop): added $JS.API.STREAM.CREATE.KV_lyra_outbound_audio_sent (create_key_value triggers add_stream on the KV backing stream), $JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent (key_value() bind path calls stream_info when bucket already exists), $JS.ACK.LYRA_OUTBOUND_AUDIO.> (msg.ack()/term() publish to msg.reply which is scoped to $JS.ACK.<stream>.>), $JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent (kv.get() non-direct path calls STREAM.MSG.GET). All confirmed by tracing nats-py source (aio/msg.py, js/manager.py, js/client.py). Hotfix superseded by the sole-provisioner axis migration #1521 (S3, #1525): the 3 CREATE/UPDATE grants ($JS.API.STREAM.CREATE.LYRA_OUTBOUND_AUDIO, $JS.API.STREAM.UPDATE.LYRA_OUTBOUND_AUDIO, $JS.API.STREAM.CREATE.KV_lyra_outbound_audio_sent) moved to hub sole-ownership under ADR-079 — removed from this adapter identity. Bug fix (2026-05-29, pre-existing #1482 scoping bug): $JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO changed from .* to .> — add_consumer wire subject is $JS.API.CONSUMER.CREATE.<stream>.<durable>.<filter_subject> where filter_subject is multi-token (e.g. lyra.outbound.audio.telegram.lyra = 5 tokens); .* matches exactly one token and denied at runtime. CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.* and CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.* retain .* because consumer_info and MSG.NEXT take only <stream>.<durable> (1-token tail). Unscoped CONSUMER.CREATE.* (kv.watch ephemeral) also retains .* — wire subject is $JS.API.CONSUMER.CREATE.<stream> (1-token tail, no durable suffix).",
       "allow_responses": false,
-      "groups": ["audio-consumer"],
       "publish": [
         "lyra.inbound.telegram.>",
         "lyra.system.ready",
@@ -85,7 +66,15 @@
         "lyra.metric.>",
         "$JS.API.DIRECT.GET.LYRA_STATE.hub.ready",
         "$JS.API.INFO",
-        "$JS.API.CONSUMER.CREATE.*"
+        "$JS.API.CONSUMER.CREATE.*",
+        "$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO",
+        "$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>",
+        "$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*",
+        "$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*",
+        "$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent",
+        "$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent",
+        "$JS.ACK.LYRA_OUTBOUND_AUDIO.>",
+        "$KV.lyra_outbound_audio_sent.>"
       ],
       "subscribe": [
         "lyra.outbound.telegram.>",
@@ -93,7 +82,8 @@
         "lyra.typing.telegram.>",
         "_inbox.telegram-adapter.>",
         "_inbox.telegram-adapter.*.*",
-        "$KV.lyra-state.>"
+        "$KV.lyra-state.>",
+        "$KV.lyra_outbound_audio_sent.>"
       ],
       "deploy": { "type": "container", "secret": "lyra-nats-telegram" }
     },
@@ -104,7 +94,6 @@
       "description": "Discord bot adapter — inbox normalized to _inbox.discord-adapter.> (ADR-051 + postmortem Fix 1).",
       "notes": "$JS.API.> narrowed to minimal KV read-only subjects (#1014): DIRECT.GET for KV key reads, INFO for JetStream availability, CONSUMER.CREATE for kv.watch() ephemeral consumer. lyra.turns.write added by T27 (#1331): discord adapter publishes TurnWriteEvents. Outbound-audio JetStream consumer grants added by T7 (#1482): stream/consumer create+info, pull-next, KV dedup bucket. $KV.lyra_outbound_audio_sent.> added to publish (#1482 B1): kv.put() in KvSentSet.mark_sent publishes directly to $KV.<bucket>.<key> subjects and requires an explicit publish grant. Hotfix (2026-05-29, prod crash-loop): added $JS.API.STREAM.CREATE.KV_lyra_outbound_audio_sent (create_key_value triggers add_stream on the KV backing stream), $JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent (key_value() bind path calls stream_info when bucket already exists), $JS.ACK.LYRA_OUTBOUND_AUDIO.> (msg.ack()/term() publish to msg.reply which is scoped to $JS.ACK.<stream>.>), $JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent (kv.get() non-direct path calls STREAM.MSG.GET). All confirmed by tracing nats-py source (aio/msg.py, js/manager.py, js/client.py). Hotfix superseded by the sole-provisioner axis migration #1521 (S3, #1525): the 3 CREATE/UPDATE grants ($JS.API.STREAM.CREATE.LYRA_OUTBOUND_AUDIO, $JS.API.STREAM.UPDATE.LYRA_OUTBOUND_AUDIO, $JS.API.STREAM.CREATE.KV_lyra_outbound_audio_sent) moved to hub sole-ownership under ADR-079 — removed from this adapter identity. Bug fix (2026-05-29, pre-existing #1482 scoping bug): $JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO changed from .* to .> — add_consumer wire subject is $JS.API.CONSUMER.CREATE.<stream>.<durable>.<filter_subject> where filter_subject is multi-token (e.g. lyra.outbound.audio.discord.lyra = 5 tokens); .* matches exactly one token and denied at runtime. CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.* and CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.* retain .* because consumer_info and MSG.NEXT take only <stream>.<durable> (1-token tail). Unscoped CONSUMER.CREATE.* (kv.watch ephemeral) also retains .* — wire subject is $JS.API.CONSUMER.CREATE.<stream> (1-token tail, no durable suffix).",
       "allow_responses": false,
-      "groups": ["audio-consumer"],
       "publish": [
         "lyra.inbound.discord.>",
         "lyra.system.ready",
@@ -113,7 +102,15 @@
         "lyra.metric.>",
         "$JS.API.DIRECT.GET.LYRA_STATE.hub.ready",
         "$JS.API.INFO",
-        "$JS.API.CONSUMER.CREATE.*"
+        "$JS.API.CONSUMER.CREATE.*",
+        "$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO",
+        "$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>",
+        "$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*",
+        "$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*",
+        "$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent",
+        "$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent",
+        "$JS.ACK.LYRA_OUTBOUND_AUDIO.>",
+        "$KV.lyra_outbound_audio_sent.>"
       ],
       "subscribe": [
         "lyra.outbound.discord.>",
@@ -121,7 +118,8 @@
         "lyra.typing.discord.>",
         "_inbox.discord-adapter.>",
         "_inbox.discord-adapter.*.*",
-        "$KV.lyra-state.>"
+        "$KV.lyra-state.>",
+        "$KV.lyra_outbound_audio_sent.>"
       ],
       "deploy": { "type": "container", "secret": "lyra-nats-discord" }
     },

--- a/tests/scripts/test_loader.py
+++ b/tests/scripts/test_loader.py
@@ -65,7 +65,7 @@ class TestLoadMatrixPositive:
 
         result = load_matrix(prod_matrix_path)
 
-        assert result["version"] in ("1", "2", "3")
+        assert result["version"] in ("1", "2", "3", "4")
         assert isinstance(result["identities"], dict)
         assert len(result["identities"]) >= 1
         flows = result.get("request_reply_flows")
@@ -508,3 +508,189 @@ class TestDeployField:
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "host missing 'path'" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# v4 groups — T10 (S4 ACL grant-group, #1526)
+# ---------------------------------------------------------------------------
+
+
+def _valid_identity_with_deploy(
+    *,
+    status: str = "active",
+    owner: str = "lyra",
+    groups: list[str] | None = None,
+) -> dict:
+    """Return a minimal valid active identity with deploy field (required in v3/v4)."""
+    entry: dict = {
+        "status": status,
+        "owner": owner,
+        "created_at": "2026-05-01",
+        "description": "Test identity",
+        "allow_responses": False,
+        "publish": ["lyra.test.>"],
+        "subscribe": ["lyra.test.cmd"],
+        "deploy": {"type": "container", "secret": "lyra-nats-test"},
+    }
+    if groups is not None:
+        entry["groups"] = groups
+    return entry
+
+
+class TestLoadMatrixV4Groups:
+    """T10 (a, b) — v4 matrix with valid groups loads correctly."""
+
+    def test_v4_with_groups_loads_ok(self, tmp_path: Path) -> None:
+        """v4 matrix with a valid top-level 'groups' and identity referencing it loads
+        without error and load_matrix(...)['groups'] contains the defined group.
+
+        verified: removing _parse_groups call from load_matrix would either drop
+        the 'groups' key from the result or raise KeyError, failing this assertion.
+        """
+        # Arrange
+        data = {
+            "version": "4",
+            "request_reply_flows": [],
+            "groups": {
+                "audio-consumers": {
+                    "publish": ["$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO"],
+                    "subscribe": ["lyra.outbound.audio.>"],
+                }
+            },
+            "identities": {
+                "telegram-adapter": _valid_identity_with_deploy(
+                    groups=["audio-consumers"]
+                ),
+            },
+        }
+        path = _write_matrix(tmp_path, data)
+
+        # Act
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        result = load_matrix(path)
+
+        # Assert — group key present and identity loads
+        assert result["version"] == "4"
+        assert "telegram-adapter" in result["identities"]
+        assert "audio-consumers" in result["groups"]  # type: ignore[typeddict-item]
+
+    def test_v4_groups_parsed_into_loaded_matrix(self, tmp_path: Path) -> None:
+        """load_matrix['groups'] exposes each group with 'publish'/'subscribe' lists.
+
+        verified: stripping publish/subscribe from GroupDefinition or omitting groups
+        from LoadedMatrix would fail the shape assertion.
+        """
+        # Arrange
+        data = {
+            "version": "4",
+            "request_reply_flows": [],
+            "groups": {
+                "audio-consumers": {
+                    "description": "Adapter audio grant bundle",
+                    "publish": ["$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO"],
+                    "subscribe": ["lyra.outbound.audio.>"],
+                },
+                "kv-readers": {
+                    "publish": [],
+                    "subscribe": ["$KV.lyra-state.>"],
+                },
+            },
+            "identities": {
+                "hub": _valid_identity_with_deploy(
+                    groups=["audio-consumers", "kv-readers"]
+                ),
+            },
+        }
+        path = _write_matrix(tmp_path, data)
+
+        # Act
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        result = load_matrix(path)
+        groups = result["groups"]  # type: ignore[typeddict-item]
+
+        # Assert — shape of each group
+        assert isinstance(groups, dict)
+        assert set(groups.keys()) == {"audio-consumers", "kv-readers"}
+
+        ag = groups["audio-consumers"]
+        assert isinstance(ag["publish"], list)
+        assert isinstance(ag["subscribe"], list)
+        assert "$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO" in ag["publish"]
+        assert "lyra.outbound.audio.>" in ag["subscribe"]
+
+        kv = groups["kv-readers"]
+        assert isinstance(kv["publish"], list)
+        assert kv["publish"] == []
+        assert "$KV.lyra-state.>" in kv["subscribe"]
+
+
+class TestLoadMatrixV4GroupsNegatives:
+    """T10 (c, d) — v4 guard: undefined group ref and missing deploy."""
+
+    def test_v4_identity_referencing_undefined_group_dies(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Identity referencing a group name not present in top-level 'groups' must die.
+
+        verified: removing _validate_group_refs from load_matrix causes this test to
+        pass silently — the undefined ref goes undetected.
+        """
+        # Arrange
+        data = {
+            "version": "4",
+            "request_reply_flows": [],
+            "groups": {
+                "audio-consumers": {
+                    "publish": ["$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO"],
+                    "subscribe": [],
+                }
+            },
+            "identities": {
+                "telegram-adapter": _valid_identity_with_deploy(
+                    groups=["audio-consumers", "does-not-exist"]
+                ),
+            },
+        }
+        path = _write_matrix(tmp_path, data)
+
+        # Act / Assert
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        with pytest.raises(SystemExit) as exc_info:
+            load_matrix(path)
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "does-not-exist" in captured.err
+
+    def test_v4_active_identity_missing_deploy_dies(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """v4 matrix with an active identity missing deploy must die.
+
+        The deploy guard inherited from v3 must apply equally to v4.
+
+        verified: removing version '4' from the guard condition in _validate_identity
+        (i.e. keeping only v3) causes this test to pass silently — the v4 missing-
+        deploy identity would load without error.
+        """
+        # Arrange — active identity without deploy (plain _valid_identity omits it)
+        identity = _valid_identity(status="active")
+        assert "deploy" not in identity
+        data = {
+            "version": "4",
+            "request_reply_flows": [],
+            "groups": {},
+            "identities": {"hub": identity},
+        }
+        path = _write_matrix(tmp_path, data)
+
+        # Act / Assert
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        with pytest.raises(SystemExit) as exc_info:
+            load_matrix(path)
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "v3 requires 'deploy'" in captured.err

--- a/tests/scripts/test_loader.py
+++ b/tests/scripts/test_loader.py
@@ -163,7 +163,7 @@ class TestLoadMatrixNegatives:
         assert exc_info.value.code != 0
 
     def test_invalid_version(self, tmp_path: Path) -> None:
-        """Guard: version must be '1' or '2'."""
+        """Guard: unsupported version (e.g. '99') is rejected."""
         # verified: removing version allowlist guard → test fails
         identity = _valid_identity()
         data = {
@@ -693,4 +693,4 @@ class TestLoadMatrixV4GroupsNegatives:
             load_matrix(path)
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
-        assert "v3 requires 'deploy'" in captured.err
+        assert "v4 requires 'deploy'" in captured.err

--- a/tests/scripts/test_renderer.py
+++ b/tests/scripts/test_renderer.py
@@ -8,6 +8,7 @@ S3 regression tests assert the rendered conf for adapters no longer contains the
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 # This import will fail at collection time — that is the intended RED state.
 from scripts._acl_models import LoadedMatrix
@@ -445,6 +446,87 @@ class TestGrantGroupEquality:
         assert not missing, (
             f"telegram-adapter rendered publish_allow is missing audio subjects: "
             f"{missing!r}"
+        )
+
+
+    def test_group_subscribe_subject_present_in_v4_rendered_telegram(self) -> None:
+        """The audio-consumer group's subscribe subject is PRESENT in the
+        rendered/parsed telegram-adapter subscribe_allow set after group expansion.
+
+        # verified: deleting sub_allow[name].extend(g.get("subscribe", [])) from
+        # _renderer.py causes this test to fail — $KV.lyra_outbound_audio_sent.>
+        # is absent from telegram-adapter subscribe_allow.
+        """
+        # Arrange
+        v4, _ = self._load_both()
+        pk = self._shared_pubkeys(v4, v4)
+        rendered = render_auth_conf(v4, pk)
+        parsed = parse_auth_conf(rendered)
+        users = {u.comment_name: u for u in parsed.users}
+
+        # Act
+        tg_sub = users["telegram-adapter"].subscribe_allow
+
+        # Assert — $KV.lyra_outbound_audio_sent.> is the group's subscribe subject
+        assert "$KV.lyra_outbound_audio_sent.>" in tg_sub, (
+            "telegram-adapter subscribe_allow is missing "
+            "$KV.lyra_outbound_audio_sent.> "
+            "— group subscribe expansion did not fire"
+        )
+
+    def test_empty_group_renders_without_error_and_adds_no_subjects(
+        self, tmp_path: Path
+    ) -> None:
+        """Identity referencing a group with empty publish/subscribe lists renders
+        without error and the identity's allow sets are unchanged relative to its
+        inline grants.
+
+        # verified: if group expansion raises on an empty list, this test errors;
+        # if it incorrectly adds spurious subjects, the equality assertion fails.
+        """
+        import json  # noqa: PLC0415
+
+        # Arrange — v4 matrix with an empty group
+        data = {
+            "version": "4",
+            "request_reply_flows": [],
+            "groups": {
+                "empty-group": {"publish": [], "subscribe": []},
+            },
+            "identities": {
+                "hub": {
+                    "status": "active",
+                    "owner": "lyra",
+                    "created_at": "2026-05-01",
+                    "description": "hub test identity",
+                    "allow_responses": False,
+                    "publish": ["lyra.outbound.telegram.>"],
+                    "subscribe": ["lyra.inbound.telegram.>"],
+                    "deploy": {"type": "container", "secret": "lyra-nats-hub"},
+                    "groups": ["empty-group"],
+                },
+            },
+        }
+        matrix_path = tmp_path / "matrix.json"
+        matrix_path.write_text(json.dumps(data))
+
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        matrix = load_matrix(matrix_path)
+        pk = {"hub": "UDETHUB"}
+
+        # Act — must not raise
+        rendered = render_auth_conf(matrix, pk)
+        parsed = parse_auth_conf(rendered)
+        users = {u.comment_name: u for u in parsed.users}
+
+        # Assert — allow sets equal the inline grants exactly (no subjects added)
+        hub = users["hub"]
+        assert hub.publish_allow == frozenset({"lyra.outbound.telegram.>"}), (
+            f"unexpected publish_allow: {hub.publish_allow!r}"
+        )
+        assert hub.subscribe_allow == frozenset({"lyra.inbound.telegram.>"}), (
+            f"unexpected subscribe_allow: {hub.subscribe_allow!r}"
         )
 
 

--- a/tests/scripts/test_renderer.py
+++ b/tests/scripts/test_renderer.py
@@ -241,6 +241,213 @@ class TestAclRegressionS3AdapterNoStreamCreate:
         )
 
 
+class TestGrouplessMatrixBackwardCompat:
+    """T9 (S4 ACL grant-group, #1526) — matrices without a top-level 'groups' key
+    must load and render without error.
+
+    Covers v1-legacy.json, v2-with-retired.json, and v3-pre-grant-group.json.
+    Each fixture has no 'groups' key.  The test asserts:
+      - render_auth_conf returns a non-empty string
+      - parse_auth_conf succeeds without exception
+      - every expected active identity is present by comment_name in the result
+
+    Structural-only assertions (¬byte-equality) because nkeys are deterministic
+    only given the same pubkeys dict, and the point is absence-of-regression.
+
+    verified: if render_auth_conf raises on a missing 'groups' key (e.g. a
+    KeyError or AttributeError introduced by group expansion logic), every case
+    here fails immediately.
+    """
+
+    def test_v1_legacy_renders_without_error(self, legacy_matrix: LoadedMatrix) -> None:
+        """v1-legacy.json loads and renders; hub is present in parsed output."""
+        pubkeys = _fake_pubkeys(legacy_matrix)
+        rendered = render_auth_conf(legacy_matrix, pubkeys)
+
+        assert rendered  # non-empty
+        parsed = parse_auth_conf(rendered)
+        names = {u.comment_name for u in parsed.users}
+        assert "hub" in names
+
+    def test_v2_with_retired_renders_without_error(
+        self, with_retired_matrix: LoadedMatrix
+    ) -> None:
+        """v2-with-retired.json loads and renders; active identities present,
+        retired old-worker absent."""
+        pubkeys = _fake_pubkeys(with_retired_matrix)
+        rendered = render_auth_conf(with_retired_matrix, pubkeys)
+
+        assert rendered
+        parsed = parse_auth_conf(rendered)
+        names = {u.comment_name for u in parsed.users}
+        # active identities must be present
+        assert "hub" in names
+        assert "voice-tts" in names
+        assert "clipool-worker" in names
+        # retired identity must be excluded
+        assert "old-worker" not in names
+
+    def test_v3_pre_grant_group_renders_without_error(self) -> None:
+        """v3-pre-grant-group.json (no groups key) loads and renders; key active
+        identities are present in the parsed output."""
+        from pathlib import Path  # noqa: PLC0415
+
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        fixture = (
+            Path(__file__).resolve().parent / "fixtures" / "v3-pre-grant-group.json"
+        )
+        matrix = load_matrix(fixture)
+        pubkeys = _fake_pubkeys(matrix)
+        rendered = render_auth_conf(matrix, pubkeys)
+
+        assert rendered
+        parsed = parse_auth_conf(rendered)
+        names = {u.comment_name for u in parsed.users}
+        # spot-check a selection of expected active identities
+        expected_active = (
+            "hub", "telegram-adapter", "discord-adapter", "clipool-worker"
+        )
+        for expected in expected_active:
+            assert expected in names, f"expected {expected!r} in rendered output"
+        # retired monitor must be excluded
+        assert "monitor" not in names
+
+    def test_v2_with_retired_inline_grants_present(
+        self, with_retired_matrix: LoadedMatrix
+    ) -> None:
+        """Inline publish/subscribe grants from v2-with-retired are faithfully rendered.
+
+        Verifies that the backward-compat path does not silently drop subjects.
+
+        verified: stripping publish/subscribe subjects from _emit_user would remove
+        them from the rendered output, failing this assertion.
+        """
+        pubkeys = _fake_pubkeys(with_retired_matrix)
+        rendered = render_auth_conf(with_retired_matrix, pubkeys)
+        parsed = parse_auth_conf(rendered)
+        users_by_name = {u.comment_name: u for u in parsed.users}
+
+        hub = users_by_name["hub"]
+        assert "lyra.outbound.telegram.>" in hub.publish_allow
+        assert "lyra.inbound.telegram.>" in hub.subscribe_allow
+
+
+class TestGrantGroupEquality:
+    """T8 (S4 ACL grant-group, #1526) — v4 group-expansion renders set-identically
+    to the v3 inline baseline.
+
+    v4 = deploy/nats/acl-matrix.json (version 4: telegram/discord reference the
+         audio-consumer group; 8 audio subjects moved out of the inline publish list).
+    v3 = tests/scripts/fixtures/v3-pre-grant-group.json (pre-migration snapshot:
+         the same 8 subjects listed inline in telegram/discord publish).
+
+    Both matrices have the same identity names, so _fake_pubkeys produces the same
+    pubkey dict for both.  We build a union dict as belt-and-suspenders.
+
+    ParsedUser.nkey has compare=False, so frozenset equality compares
+    publish_allow + subscribe_allow + allow_responses + comment_name only —
+    i.e. the rendered permission sets, independent of nkey values.
+
+    verified: if the renderer does NOT expand groups, v4 telegram-adapter
+    publish_allow is missing the 8 audio subjects → ParsedUser differs from v3 →
+    frozenset assertion fails.
+    """
+
+    _AUDIO_GROUP_PUBLISH = frozenset(
+        {
+            "$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO",
+            "$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>",
+            "$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*",
+            "$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*",
+            "$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent",
+            "$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent",
+            "$JS.ACK.LYRA_OUTBOUND_AUDIO.>",
+            "$KV.lyra_outbound_audio_sent.>",
+        }
+    )
+
+    def _load_both(self) -> tuple[LoadedMatrix, LoadedMatrix]:
+        from pathlib import Path  # noqa: PLC0415
+
+        from scripts._loader import load_matrix  # noqa: PLC0415
+
+        root = Path(__file__).resolve().parents[2]
+        v4 = load_matrix(root / "deploy" / "nats" / "acl-matrix.json")
+        v3 = load_matrix(
+            root / "tests" / "scripts" / "fixtures" / "v3-pre-grant-group.json"
+        )
+        return v4, v3
+
+    def _shared_pubkeys(
+        self, v4: LoadedMatrix, v3: LoadedMatrix
+    ) -> dict[str, str]:
+        """Union of identity names from both matrices → deterministic fake pubkeys."""
+        all_names = set(v4["identities"]) | set(v3["identities"])
+        return {
+            name: f"UDET{name.upper().replace('-', '')}" for name in all_names
+        }
+
+    def test_v4_render_set_equals_v3_render(self) -> None:
+        """Rendered ParsedUser set for v4 == v3: group expansion is set-identical to
+        inline grants.
+
+        verified: if the renderer skips group expansion (removes the for-gname loop),
+        v4 telegram/discord ParsedUsers are missing 8 subjects → frozensets differ.
+        """
+        # Arrange
+        v4, v3 = self._load_both()
+        pk = self._shared_pubkeys(v4, v3)
+
+        # Act
+        parsed_v4 = parse_auth_conf(render_auth_conf(v4, pk))
+        parsed_v3 = parse_auth_conf(render_auth_conf(v3, pk))
+
+        # Assert — order-independent set equality (nkey excluded from comparison)
+        assert frozenset(parsed_v4.users) == frozenset(parsed_v3.users)
+
+    def test_audio_subjects_absent_from_v4_inline_list(self) -> None:
+        """The 8 audio publish subjects are NOT in telegram-adapter's inline publish
+        list in v4 (they were moved to the audio-consumer group).
+
+        verified: if the migration is reversed (subjects put back inline), v4
+        telegram-adapter identity["publish"] would contain them → assertion fails.
+        """
+        # Arrange
+        v4, _ = self._load_both()
+
+        # Assert — inline list must NOT contain any audio-group subject
+        tg_inline = frozenset(v4["identities"]["telegram-adapter"]["publish"])
+        assert self._AUDIO_GROUP_PUBLISH.isdisjoint(tg_inline), (
+            f"audio subjects still inline in v4 telegram-adapter publish: "
+            f"{self._AUDIO_GROUP_PUBLISH & tg_inline!r}"
+        )
+
+    def test_audio_subjects_present_in_v4_rendered_telegram(self) -> None:
+        """The 8 audio publish subjects ARE present in the rendered/parsed
+        telegram-adapter publish_allow set (group expansion re-added them).
+
+        verified: if the renderer does not expand groups, publish_allow is missing
+        these subjects → assertion fails.
+        """
+        # Arrange
+        v4, _ = self._load_both()
+        pk = self._shared_pubkeys(v4, v4)
+        rendered = render_auth_conf(v4, pk)
+        parsed = parse_auth_conf(rendered)
+        users = {u.comment_name: u for u in parsed.users}
+
+        # Act
+        tg_pub = users["telegram-adapter"].publish_allow
+
+        # Assert
+        missing = self._AUDIO_GROUP_PUBLISH - tg_pub
+        assert not missing, (
+            f"telegram-adapter rendered publish_allow is missing audio subjects: "
+            f"{missing!r}"
+        )
+
+
 class TestNatsSubjectCharset:
     def test_nats_subject_charset(self, prod_matrix: LoadedMatrix) -> None:
         """All rendered subjects only contain valid NATS subject characters.


### PR DESCRIPTION
## Summary
- Introduce `acl-matrix.json` schema **v4** with a top-level `groups` key: an ACL grant set is defined once and referenced by name, fixing the N×M drift that caused the 2026-05-29 outbound-audio crash-loop (ADR-079 §b, slice S4 of #1521).
- Migrate the audio JS-consumer + dedup-KV grants (8 publish + 1 subscribe) into `groups.audio-consumer`; `telegram-adapter` & `discord-adapter` reference it instead of duplicating inline. Rendered `auth.conf` is **byte-identical** to v3 (stronger than the set-equality contract required).

## What changed
**Generator** (`scripts/`)
- `_acl_models.py`: `GroupDefinition` TypedDict; `LoadedMatrix.groups`, `Identity.groups` (both `NotRequired`).
- `_loader.py`: accept `version: "4"` (inherits v3 deploy-guard + flow-parse gates); parse top-level `groups`; reject dangling identity→group refs via `_die` (`sys.exit(1)`). Extracted `_parse_groups` / `_validate_group_refs` to stay within the complexity gate.
- `_renderer.py`: expand each identity's referenced groups into effective publish/subscribe in the first identity loop, **before** request_reply-flow injection — source-side abstraction only.

**Matrix** (`deploy/nats/acl-matrix.json`)
- `version → "4"`; audio grants live only in `groups.audio-consumer`; both adapters declare `"groups": ["audio-consumer"]` with inline copies removed. `lyra.outbound.audio.>` and non-audio shared grants stay inline. #1545 verify-deny / mint-failure grants untouched.

**Consumer compat** (`scripts/check-acl-matrix-spec.sh`)
- The spec-table jq pipeline now expands `groups` (capture `$all_groups` before the `reduce`) before the flows pass, so the effective-grant table is correct. Other matrix consumers index only `lyra.*`/`_inbox.*` and are unaffected (group holds `$JS.*`/`$KV.*` only) — verified, not assumed.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1526: S4 — ACL grant-group (acl-matrix.json v4 + generator) | OPEN |
| Frame | [1526-…-frame.mdx](artifacts/frames/1526-s4-acl-grant-group-frame.mdx) | Present |
| Spec | [1526-…-spec.mdx](artifacts/specs/1526-s4-acl-grant-group-spec.mdx) | Present |
| Plan | [1526-…-plan.mdx](artifacts/plans/1526-s4-acl-grant-group-plan.mdx) | Present |
| Implementation | 1 commit on `feat/1526-s4-acl-grant-group` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 new test classes) | Passed |

## Test Plan
- [x] `frozenset(parse_auth_conf(render_v4).users) == frozenset(parse_auth_conf(render_v3).users)` — effective grant set identical, never looser (`TestGrantGroupEquality`).
- [x] Audio subjects absent from v4 inline `telegram-adapter.publish` yet present in the rendered block (group expansion proven).
- [x] Group-less v1/v2/v3 matrices still load+render (no regression).
- [x] v4 loads; `groups` parsed; dangling ref + active-identity-missing-`deploy` → `SystemExit`.
- [x] All ACL CI gates green: drift, spec-table, subject-literals, request-reply-flows, retired, renderer-roundtrip (nats-server v2.10.22).
- [x] Committed `auth.conf` in sync with v4 matrix (drift gate exit 0).

Closes #1526

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`