### PR TITLE
refactor(scripts): isolate test fakes from production imports

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -157,8 +157,5 @@ source_modules =
     lyra
     scripts
 forbidden_modules =
-    tests.fakes
+    tests
 allow_indirect_imports = true
-ignore_imports =
-    # Guarded by LYRA_TEST_MODE runtime check; test-only fake nkey provider (#1283)
-    scripts._modes -> tests.fakes.nkey_provider

--- a/artifacts/frames/1093-isolate-test-fakes-frame.mdx
+++ b/artifacts/frames/1093-isolate-test-fakes-frame.mdx
@@ -1,0 +1,107 @@
+---
+title: "refactor: isolate test fakes from production imports — remove the rejected band-aid"
+issue: 1093
+status: approved
+tier: F-lite
+date: 2026-05-31
+---
+
+## Problem
+
+Issue #1093 was filed after incident #1089: `FakeNkeyProvider` (a test fake) was
+reachable from a production code path and rendered a 62-char malformed nkey into
+M₁'s `auth.conf`, taking down the NATS broker. The issue's thesis: make it
+**structurally impossible** to import test code from production code — runtime
+guards are band-aids.
+
+**Drift since filing (verified at recheck, 2026-05-31):** PR #1283 (Phase 6
+bootstrap) already did the structural *move* and added the contract:
+
+- ✅ All fakes live under `tests/fakes/` (`nkey_provider`, `nats_client`, `store`, `drivers`, `agents`).
+- ✅ `.importlinter` contract `tests-fakes-isolation` exists (`source_modules = lyra, scripts` → `forbidden = tests.fakes`).
+
+But #1283 implemented exactly the band-aid #1093 **rejected**, and it survives in the tree today:
+
+1. `scripts/_modes.py::_get_provider` branches on a fake env var —
+   `if env_provider == "fake": … return FakeNkeyProvider()` (lazy import), gated
+   only by a `LYRA_TEST_MODE=1` *runtime* check. This is AC #5's forbidden pattern verbatim.
+2. `.importlinter` carries an `ignore_imports` exemption
+   `scripts._modes -> tests.fakes.nkey_provider` — a documented **hole** in the
+   very contract meant to prevent recurrence.
+
+**Why the band-aid exists (the real constraint):** the env-branch doubles as the
+**subprocess test-injection seam**. ~5 test files run the real CLI
+(`subprocess.run([python, "scripts/gen_nkeys.py", "genkeys", …], env={NKEY_PROVIDER: "fake"})`)
+to get true end-to-end coverage of file modes, atomic writes, and full
+provisioning. A subprocess cannot have `_provider_factory` monkeypatched from the
+parent process, so today `NKEY_PROVIDER=fake` is the *only* way these tests
+inject the fake. Removing the branch naively breaks those tests.
+
+So the residual work is not "delete a line" — it is **relocate the subprocess
+injection seam out of production code into `tests/`**, then drop the env-branch
+and the importlinter exemption, and prove reintroduction fails CI.
+
+## Who
+
+- **Primary:** Ops / the production NATS provisioning path on M₁ — a reachable
+  fake in `scripts/_modes.py` is the standing liability #1089 proved can take down the broker.
+- **Secondary:** Devs — the `.importlinter` `ignore_imports` exemption is a hole
+  in the CI gate; any future `scripts.*`/`lyra.*` → `tests.fakes` leak that
+  routes through `_modes` is silently allowed.
+
+## Constraints
+
+- **Subprocess test fidelity must be preserved** — `test_file_modes`,
+  `test_genkeys_modes`, `test_genkeys_modes_add_identity` exercise the real CLI
+  via subprocess; the new injection seam must keep that coverage (no downgrade to
+  in-process-only) unless explicitly traded in the spec.
+- **Security-sensitive path** — this is the exact code that renders `auth.conf`;
+  changes must not weaken the `LYRA_TEST_MODE` safety property (fake never
+  reachable in a real prod invocation).
+- The `_provider_factory: Callable[[], NkeyProvider]` DI seam already exists in
+  `scripts/_modes.py` — in-process tests can override it; the design must extend
+  an equivalent seam to the subprocess path **without** a prod env-branch.
+- Single domain (scripts provisioning + build-config); no new architecture.
+
+## Out of Scope
+
+- The fakes *move* itself (done in #1283) — not re-litigated.
+- Migrating other env-driven feature flags (file separately if found — issue says so).
+- Adding *more* runtime guards (band-aid; the structural fix supersedes).
+- Broadening fakes isolation to non-nkey fakes beyond the required audit pass.
+
+## Premise Validity
+
+**Success in 6 months:** `grep -c 'fake' scripts/_modes.py` → 0 (no env-branch,
+no fake import in prod); `.importlinter` `tests-fakes-isolation` has **zero**
+`ignore_imports` entries; a verify-test asserts a reintroduced
+`from tests.fakes import …` in `scripts/`/`src/` fails `lint-imports`; all
+subprocess tests still pass via a `tests/`-resident injection seam.
+
+**Failure in 6 months (falsifiable):** `scripts/_modes.py` still contains
+`if env_provider == "fake"` **OR** `.importlinter` still lists the
+`scripts._modes -> tests.fakes.nkey_provider` exemption — i.e. the band-aid
+survived because relocating the subprocess seam was judged too costly. Measurable:
+`grep -c 'env_provider == "fake"' scripts/_modes.py > 0` or exemption count > 0.
+
+**Simplest alternative:** Leave it as-is. #1283 already added (a) a `LYRA_TEST_MODE=1`
+runtime refusal, (b) lazy import, (c) a fake that now produces valid nkeys — so
+the #1089 *failure* is already mitigated three ways.
+**Why not simplest:** The issue's whole thesis is that a runtime guard is a
+band-aid and a reachable fake in prod is a standing liability — #1089 proved the
+class of bug. The `ignore_imports` exemption is a self-documented hole in the
+recurrence-prevention contract. The structural fix removes the liability instead
+of guarding it. *(Tension acknowledged: if the spec finds no clean seam
+relocation, the simplest alternative may legitimately win — the spec resolves this.)*
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain, no new architecture, but one real
+design decision (where/how to relocate the subprocess injection seam) that
+warrants a spec gate before implementation.
+
+Signals observed:
+- ~3 prod files touched (`scripts/_modes.py`, `.importlinter`, + a verify-test) → S-ish volume
+- BUT a non-trivial design fork (subprocess injection seam: test-only entry shim
+  vs. in-process conversion vs. CLI flag) → spec needed → F-lite
+- Issue label `size:F-lite` concurs

--- a/artifacts/plans/1093-audit-log.md
+++ b/artifacts/plans/1093-audit-log.md
@@ -1,0 +1,35 @@
+# #1093 — Fake/Mock/Stub Audit Log
+
+Scope: `grep -rn "fake|mock|stub" src/ scripts/ --include="*.py"` (7 hits across 7 files).
+Date: 2026-05-31
+
+## Audit table
+
+| symbol/term | file:line | kind | in prod-importable path? (Y/N) | note |
+|---|---|---|---|---|
+| `fake Co-Authored-By` | `src/lyra/core/cli/cli_pool_worker.py:118` | domain term | N | In a docstring — describes a security concern about crafted git trailer strings. No import, no test-double. |
+| `fake_clock.now` | `src/lyra/tools/gh_token/rate_limit.py:36` | domain term | N | In a docstring — documents injection point for `clock` constructor parameter. No import, no test-double present in this file. |
+| `tests can stub all I/O` | `src/lyra/tools/gh_token/dispenser.py:51` | domain term | N | In a docstring — describes constructor injection pattern. No import, no test-double present. |
+| `Attribute stubs below` | `src/lyra/core/session_lifecycle.py:28` | domain term | N | In a docstring — "stubs" used in the sense of Protocol/mixin attribute declarations satisfied by `AgentBase.__init__`. Not a test-double. |
+| `inject a mock or an in-process ASGI-backed store` | `src/lyra/infrastructure/blobstore_adapter.py:33` | domain term | N | In a docstring — describes testability of the adapter via constructor injection. No mock import. |
+| `audit sink is a logger-only stub` | `src/lyra/blobstore/serve.py:122` | domain term | N | In an inline comment — "stub" refers to the degraded `BlobAuditSink()` instance (no NATS). This is a legitimate domain fallback, not a test-double. The class is in prod code and is the real degraded-mode implementation. |
+| `fake nkeys` | `scripts/gen_nkeys.py:200` | domain term | N | In a CLI `--help` string for `--template-only` flag. Describes that the flag renders auth.conf without real nkey generation (uses placeholder values, no test import). |
+
+## Summary
+
+**Prod-path test-doubles found: 0.**
+
+All 7 hits are documentation (docstrings, comments, help strings) describing design intent
+or injection patterns using the words "fake", "mock", or "stub" as natural-language terms.
+None of them import or instantiate a test-double class from `tests/`.
+
+## Retired quality-debt entry
+
+The `scripts._modes -> tests.fakes.nkey_provider` exemption in `.importlinter`
+(`ignore_imports` under `[importlinter:contract:tests-fakes-isolation]`) was the only
+production→test-double import path tracked in this project. It is **RETIRED** in this PR
+(#1093, N6).
+
+The runtime guard it protected (`NKEY_PROVIDER=fake` env-branch in `scripts/_modes.py::_get_provider`)
+is also deleted (N2). The structural replacement — `import-linter` forbidding all `tests.*`
+imports from `lyra` and `scripts` with no exemption — is verified by `tests/scripts/test_fake_isolation.py`.

--- a/artifacts/plans/1093-isolate-test-fakes-plan.mdx
+++ b/artifacts/plans/1093-isolate-test-fakes-plan.mdx
@@ -1,0 +1,251 @@
+---
+title: "Plan: Isolate test fakes from production imports"
+issue: 1093
+spec: artifacts/specs/1093-isolate-test-fakes-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-05-31
+---
+
+## Summary
+
+Relocate the nkey fake-injection seam out of `scripts/_modes.py` into a `tests/`-resident
+shim, then delete the `NKEY_PROVIDER=="fake"` env-branch and the `.importlinter`
+`ignore_imports` exemption — making a prod→`tests.fakes` import structurally impossible (CI-enforced).
+
+## Architecture
+
+### Data flow (config → loader → runtime injection)
+
+```mermaid
+flowchart TD
+    subgraph cfg["build config"]
+        IL[".importlinter<br/>tests-fakes-isolation<br/>forbidden: tests (was tests.fakes)<br/>ignore_imports: REMOVED"]
+    end
+    subgraph prod["scripts/ (production)"]
+        MAIN["gen_nkeys.py::main(argv)<br/>sys.path += repo-root"]
+        GETP["_modes._get_provider()<br/>p = _provider_factory()<br/>p.ensure_available()"]
+        FACT["_provider_factory<br/>= SubprocessNkeyProvider"]
+        SUB["SubprocessNkeyProvider<br/>ensure_available()→ensure_nk_or_exit()"]
+        MAIN --> GETP --> FACT --> SUB
+    end
+    subgraph test["tests/ (test-only DI seam)"]
+        SHIM["_fake_genkeys.py<br/>sys.path += repo-root<br/>_modes._provider_factory = FakeNkeyProvider<br/>→ main()"]
+        MP["in-process: monkeypatch.setattr<br/>(_modes,_provider_factory,Fake)"]
+        FAKE["FakeNkeyProvider<br/>inherits no-op ensure_available()"]
+    end
+    SHIM -.overrides.-> FACT
+    MP -.overrides.-> FACT
+    SHIM -.selects.-> FAKE
+    IL -.lint-imports gate.-> prod
+    style prod fill:#1b2a1b
+    style test fill:#2a1b2a
+    style cfg fill:#2a2a1b
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph nk["scripts/_nk.py"]
+        ABC["NkeyProvider (ABC)<br/>+ensure_available() no-op  ◀NEW"]
+        SP["SubprocessNkeyProvider<br/>+ensure_available() override  ◀NEW"]
+        ENK["ensure_nk_or_exit()"]
+        SP --> ENK
+    end
+    subgraph modes["scripts/_modes.py"]
+        GP["_get_provider()  ◀REWRITE (drop env-branch)"]
+        PF["_provider_factory"]
+    end
+    subgraph shim["tests/scripts/_fake_genkeys.py  ◀NEW"]
+        SH["module body"]
+    end
+    subgraph vt["tests/scripts/test_fake_isolation.py  ◀NEW"]
+        T_GUARD["regression guards ×2"]
+        T_PLANT["planted-violation"]
+    end
+    subgraph helpers["3 test run-helpers  ◀EDIT"]
+        RH["_run_genkeys() → shim"]
+    end
+    GP --> PF
+    SH --> GP
+    SH --> ABC
+    RH --> SH
+    T_GUARD -.reads.-> modes
+    T_GUARD -.reads.-> nk
+    T_PLANT -.subprocess.-> ENK_lint["lint-imports (tmp stub)"]
+```
+
+## Agents
+
+| Agent instance | Tasks | Files | Subject |
+|----------------|-------|-------|---------|
+| backend-dev-A | T1, T2 | `scripts/_nk.py`, `scripts/_modes.py` | provider |
+| tester-A | T3, T4, T5, T6 | `tests/scripts/_fake_genkeys.py` (new), 3 run-helpers, `test_genkeys_modes.py` in-process | test-injection |
+| devops-A | T7 | `.importlinter` | import-contract |
+| tester-B | T8, T9 | `tests/scripts/test_fake_isolation.py` (new), audit grep | verify, audit |
+
+## Wave Structure
+
+3 waves, max 2 parallel agents. Elapsed ~1 session vs ~1.5 sequential. Wave 1 is the
+atomic Slice-1 change (prod + tests land together to stay green).
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | backend-dev-A: T1→T2 · tester-A: T3→T4→T5 ; then tester-A: T6 (RED-GATE, after T1–T5) |
+| 2 | Wave 1 green | 1 | devops-A: T7 |
+| 3 | Wave 2 green | 1 | tester-B: T8 · T9 |
+
+> Slice-1 coupling: backend-dev-A (scripts/) and tester-A (tests/) edit disjoint files →
+> parallel-safe. The worktree only goes green once BOTH finish (T6 barrier). The Slice-1
+> commit covers all of T1–T5. T7 (Slice 2) must commit **after** Slice 1 — removing the
+> exemption while `_modes.py` still imports `tests.fakes` fails the pre-commit `import-layers` hook.
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 add ensure_available | 1 ABC + 1 override | bounded | 3 | — |
+| T2 rewrite _get_provider | 1 fn + import cleanup | judgmental | 5 | — |
+| T3 write shim | 1 new file | judgmental | 5 | — |
+| T4 migrate 3 run-helpers | 3 files | judgmental | 6 | — |
+| T5 migrate 2 in-process tests | 2 edits | judgmental | 4 | — |
+| T6 RED-GATE pytest tests/scripts | 1 run | bounded | 2 | — |
+| T7 .importlinter edit + lint-imports | 1 file | bounded | 3 | — |
+| T8 verify-tests (3) | 1 new file | judgmental | 8 | — |
+| T9 audit grep + PR log | scan | judgmental | 5 | — |
+
+**Total estimated ops: ~41**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2 | 8 | provider | — |
+| tester-A | T3, T4, T5, T6 | 17 | test-injection | — (|tasks|=4 ≤ 4, 1 subject) |
+| devops-A | T7 | 3 | import-contract | — |
+| tester-B | T8, T9 | 13 | verify, audit | — (2 subjects ≤ 2) |
+
+No splits required. (tester split A/B deliberately keeps each instance ≤ 2 subjects.)
+
+## Consistency Report
+
+13 / 13 spec criteria covered. 0 untraced tasks. 0 exemptions.
+
+| Spec criterion (SC) | Task(s) |
+|---|---|
+| SC1 `_modes.py` no NKEY_PROVIDER/env/tests.fakes | T2 |
+| SC2 `_get_provider` pure dispatch | T2 |
+| SC3 `ensure_available()` concrete no-op + Subprocess override + nk-absent exit | T1 |
+| SC4 shim exists (sys.path + factory + delegate) | T3 |
+| SC5 3 run-helpers use shim, no env | T4 |
+| SC6 2 in-process tests use `setattr` | T5 |
+| SC7 no NKEY_PROVIDER/LYRA_TEST_MODE under `tests/scripts/` | T4, T5, T6 |
+| SC8 `.importlinter` no ignore_imports, forbidden=tests | T7 |
+| SC9 planted-violation fails lint-imports | T8 |
+| SC10 regression guards unconditional + in default run | T8 |
+| SC11 no new fakes in prod paths | T9 |
+| SC12 lint-imports 0 + pytest green | T6, T7, T8 (+ /validate) |
+| SC13 PR audit log + retired-debt note | T9 |
+
+## Micro-Tasks
+
+### Slice V1 — Relocate injection seam (Wave 1, atomic)
+
+**T1** — Add `ensure_available()` to provider hierarchy · `scripts/_nk.py` · backend-dev-A · subject: provider · SC3 · GREEN · diff 2
+- Add concrete no-op to ABC: `def ensure_available(self) -> None: return None` (NOT `@abstractmethod`).
+- Override in `SubprocessNkeyProvider`: `def ensure_available(self) -> None: ensure_nk_or_exit()`.
+- Verify: `grep -A1 "def ensure_available" scripts/_nk.py` shows both; `uv run pyright scripts/_nk.py` clean.
+
+**T2** — Rewrite `_get_provider()`, delete env-branch · `scripts/_modes.py` · backend-dev-A · subject: provider · SC1,SC2 · GREEN · diff 3
+- New body: `provider = _provider_factory(); provider.ensure_available(); return provider`.
+- Delete the `if env_provider == "fake": …` block, the lazy `from tests.fakes…` import, the `LYRA_TEST_MODE` check.
+- Drop now-unused imports from `_modes.py` (`ensure_nk_or_exit` — moved into `SubprocessNkeyProvider`; keep `os`/`sys` only if still used elsewhere — check).
+- Verify: `grep -c "NKEY_PROVIDER\|env_provider\|tests.fakes" scripts/_modes.py` → `0`; `uv run pyright scripts/_modes.py` clean.
+
+**T3** — Create subprocess DI shim · `tests/scripts/_fake_genkeys.py` (new) · tester-A · subject: test-injection · SC4 · GREEN · diff 3
+- `sys.path.insert(0, str(Path(__file__).resolve().parents[2]))` BEFORE any `scripts`/`tests` import (mirror `gen_nkeys.py:14-17`).
+- `import scripts._modes as _modes` ; `from scripts.gen_nkeys import main` ; `from tests.fakes.nkey_provider import FakeNkeyProvider`.
+- `_modes._provider_factory = FakeNkeyProvider` ; `if __name__ == "__main__": main()`.
+- Verify: `cd <repo> && python tests/scripts/_fake_genkeys.py genkeys --help` exits 0 (resolves imports, no nk needed).
+
+**T4** — Migrate 3 subprocess run-helpers → shim · `tests/scripts/test_file_modes.py`, `test_genkeys_modes.py`, `test_genkeys_modes_add_identity.py` · tester-A · subject: test-injection · SC5 · REFACTOR · diff 2
+- In each `_run_genkeys`: swap `"scripts/gen_nkeys.py"` → `"tests/scripts/_fake_genkeys.py"`; delete the `run_env["NKEY_PROVIDER"]` + `run_env["LYRA_TEST_MODE"]` lines.
+- Verify: `grep -c "NKEY_PROVIDER" tests/scripts/test_file_modes.py tests/scripts/test_genkeys_modes_add_identity.py` → `0` each.
+
+**T5** — Migrate 2 in-process tests → `setattr` DI · `tests/scripts/test_genkeys_modes.py` · tester-A · subject: test-injection · SC6 · REFACTOR · diff 2
+- In the `_mode_full_provision` (~:541) and `_mode_regenerate` (~:778) cases: replace `monkeypatch.setenv("NKEY_PROVIDER","fake")` + `monkeypatch.setenv("LYRA_TEST_MODE","1")` with `monkeypatch.setattr(_modes, "_provider_factory", FakeNkeyProvider)` (import `_modes` + `FakeNkeyProvider`).
+- Verify: `grep -c "NKEY_PROVIDER\|LYRA_TEST_MODE" tests/scripts/test_genkeys_modes.py` → `0`.
+
+**T6** — RED-GATE: Slice 1 green · tester-A · subject: test-injection · SC7,SC12 · RED-GATE · diff 1 · blockedBy T1,T2,T3,T4,T5
+- Verify: `uv run pytest tests/scripts/ -q` exit 0; `grep -rc "NKEY_PROVIDER\|LYRA_TEST_MODE" tests/scripts/ | grep -v ':0'` empty.
+
+### Slice V2 — Seal the contract (Wave 2)
+
+**T7** — Remove exemption + broaden forbidden · `.importlinter` · devops-A · subject: import-contract · SC8 · REFACTOR · diff 2 · blockedBy T6
+- In `[importlinter:contract:tests-fakes-isolation]`: delete the entire `ignore_imports = …` block; change `forbidden_modules` from `tests.fakes` to `tests`.
+- Verify: `uv run lint-imports` exit 0; `awk '/tests-fakes-isolation/,/^\[/' .importlinter | grep -c ignore_imports` → `0`.
+
+### Slice V3 — Prove + audit (Wave 3)
+
+**T8** — Verify-tests · `tests/scripts/test_fake_isolation.py` (new) · tester-B · subject: verify · SC9,SC10 · GREEN · diff 4 · blockedBy T7
+- Test (a) prod-path guard: read `scripts/_modes.py`; assert no `NKEY_PROVIDER`, `env_provider`, `tests.fakes`.
+- Test (b) contract guard: parse `.importlinter`; assert `tests-fakes-isolation` has no `ignore_imports` and `forbidden_modules` includes `tests`.
+- Test (c) planted-violation: build `tmp_path` stub (`scripts/{__init__,_violation}.py` with `from tests.fakes import nkey_provider`; `tests/{__init__}.py`, `tests/fakes/__init__.py`); write `tmp_path/.importlinter` with `root_packages = scripts, tests` ONLY, `source_modules = scripts`, `forbidden_modules = tests`; `subprocess.run(["lint-imports","--config",str(p/".importlinter")], cwd=tmp_path, env={**os.environ, "PYTHONPATH": ""})`; assert returncode ≠ 0 and `_violation` in output.
+- All three unconditional (no `@skip`/`xfail`).
+- Verify: `uv run pytest tests/scripts/test_fake_isolation.py -q` exit 0 (3 passed).
+
+**T9** — Fakes/stubs audit + PR log · audit grep · tester-B · subject: audit · SC11,SC13 · GREEN · diff 3 · blockedBy T7
+- `grep -rilE 'fake|mock|stub' src/ scripts/ --include='*.py'`; classify each hit (test-double vs legitimate domain term).
+- Produce the PR-body audit table: every fake/mock/stub + location + verdict (in prod-importable path? Y/N); note the retired `scripts._modes -> tests.fakes.nkey_provider` quality-debt entry. Save to `artifacts/plans/1093-audit-log.md` for the /pr step to inline.
+- Verify: audit table exists; 0 hits classified as "test-double in prod path".
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T-numbers ref this list, not session IDs.
+     Seed in wave order; within a wave all rows are parallel (∥) unless chained (T1→T2). -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | provider |
+| T2 | backend-dev-A | T1 | provider |
+| T3 | tester-A | — | test-injection |
+| T4 | tester-A | T3 | test-injection |
+| T5 | tester-A | T3 | test-injection |
+| T6 | tester-A | T1,T2,T3,T4,T5 | test-injection |
+
+### Wave 2 — after Wave 1 green, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | devops-A | T6 | import-contract |
+
+### Wave 3 — after Wave 2 green, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T8 | tester-B | T7 | verify |
+| T9 | tester-B | T7 | audit |
+
+## Reference Patterns
+
+- `scripts/gen_nkeys.py:14-17` — the `sys.path` repo-root bootstrap the shim (T3) mirrors.
+- `scripts/gen_nkeys.py:298` — `main(argv)` the shim delegates to.
+- `tests/scripts/conftest.py:11` — existing `FakeNkeyProvider` re-export (import convention).
+- `tests/scripts/test_genkeys_modes.py:33-46` — existing `_run_genkeys` shape (T4 edits in place).
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart.
+     These are kind:"plan-task" session tasks, distinct from the kind:"dev-pipeline" tasks. -->
+- T1: 13 — provider (ensure_available hook) · Wave 1 · backend-dev-A
+- T2: 14 — provider (_get_provider rewrite) · Wave 1 · backend-dev-A · blockedBy T1
+- T3: 15 — test-injection (shim) · Wave 1 · tester-A
+- T4: 16 — test-injection (3 run-helpers) · Wave 1 · tester-A · blockedBy T3
+- T5: 17 — test-injection (2 in-process) · Wave 1 · tester-A · blockedBy T3
+- T6: 18 — RED-GATE (Slice 1 green) · Wave 1 · tester-A · blockedBy T1,T2,T3,T4,T5
+- T7: 19 — import-contract (.importlinter) · Wave 2 · devops-A · blockedBy T6
+- T8: 20 — verify (verify-tests) · Wave 3 · tester-B · blockedBy T7
+- T9: 21 — audit (fakes/stubs + PR log) · Wave 3 · tester-B · blockedBy T7

--- a/artifacts/specs/1093-isolate-test-fakes-spec.mdx
+++ b/artifacts/specs/1093-isolate-test-fakes-spec.mdx
@@ -1,0 +1,178 @@
+---
+title: "Isolate test fakes from production imports — remove the rejected band-aid"
+issue: 1093
+status: approved
+tier: F-lite
+date: 2026-05-31
+promoted_from: artifacts/frames/1093-isolate-test-fakes-frame.mdx
+reviewers: [architect, doc-writer, product-lead, devops]
+---
+
+## Context
+
+Source: [frame](../frames/1093-isolate-test-fakes-frame.mdx) (analyze skipped — F-lite).
+
+PR #1283 already moved all fakes to `tests/fakes/` and added the `.importlinter`
+`tests-fakes-isolation` contract. But it shipped the exact band-aid #1093 rejected:
+`scripts/_modes.py::_get_provider` branches on `NKEY_PROVIDER == "fake"` (runtime-guarded
+by `LYRA_TEST_MODE`) and the contract carries an `ignore_imports` exemption
+`scripts._modes -> tests.fakes.nkey_provider`. That env-branch is load-bearing: it is the
+**subprocess test-injection seam** (3 test run-helpers exec the real CLI via `subprocess.run`
++ `NKEY_PROVIDER=fake`). This spec relocates that seam into `tests/` so the env-branch and
+the exemption can be removed without losing subprocess E2E coverage.
+
+## Goal
+
+Make it **structurally impossible** to reach a test fake from production code:
+zero fake/env-branch in `scripts/_modes.py`, zero `ignore_imports` holes in the isolation
+contract, with subprocess test fidelity preserved via a `tests/`-resident dependency-injection
+entry point (AC #5: "gate via DI at test entry points only").
+
+## Users
+
+- **Primary:** Production NATS provisioning path on M₁ — `scripts/gen_nkeys.py` renders
+  `auth.conf`; a reachable fake here is the #1089 liability class.
+- **Secondary:** Devs — the `ignore_imports` exemption is a hole in the CI recurrence gate.
+
+## Expected Behavior
+
+| Invocation | Today | After |
+|---|---|---|
+| `python scripts/gen_nkeys.py genkeys …` (prod) | `_get_provider` reads env; `NKEY_PROVIDER=fake`+`LYRA_TEST_MODE=1` selects fake | env ignored; always real `SubprocessNkeyProvider`; `nk` precondition enforced via `provider.ensure_available()` |
+| Subprocess test | `subprocess.run([py,"scripts/gen_nkeys.py","genkeys",…], env=NKEY_PROVIDER=fake)` | `subprocess.run([py,"tests/scripts/_fake_genkeys.py","genkeys",…])` — shim bootstraps `sys.path`, sets `_provider_factory=FakeNkeyProvider`, delegates to `gen_nkeys.main` |
+| In-process test | `monkeypatch.setenv("NKEY_PROVIDER","fake")` then call `_mode_*` | `monkeypatch.setattr(_modes,"_provider_factory",FakeNkeyProvider)` then call `_mode_*` |
+| `lint-imports` | passes *because* of the exemption | passes with **no** exemption; forbids all `tests.*` from `lyra`+`scripts` |
+| Reintroduce `from tests.fakes import …` in `scripts/` | passes (exemption) | **fails CI** (proven by planted-violation verify-test) |
+
+Safety property: prod can never select a fake (no env path exists at all) — strictly
+stronger than the `LYRA_TEST_MODE` runtime refusal it replaces.
+
+## Data Model & Consumers
+
+### Provider seam (class diagram)
+
+```mermaid
+classDiagram
+    class NkeyProvider {
+        <<abstract>>
+        +gen_seed(name) bytes
+        +pubkey_from_seed(seed) str
+        +ensure_available() None
+    }
+    class SubprocessNkeyProvider
+    class FakeNkeyProvider
+    NkeyProvider <|-- SubprocessNkeyProvider
+    NkeyProvider <|-- FakeNkeyProvider
+    note for NkeyProvider "ensure_available(): NEW, CONCRETE default (returns None — not @abstractmethod).\nOnly SubprocessNkeyProvider overrides it → calls ensure_nk_or_exit().\nFakeNkeyProvider inherits the no-op, so it needs no nk binary.\nLets _get_provider() drop all env/isinstance sniffing."
+```
+
+### Injection map (who selects the provider)
+
+```mermaid
+flowchart LR
+    subgraph prod["scripts/ (production)"]
+        GP["_get_provider():<br/>p = _provider_factory()<br/>p.ensure_available()<br/>return p"]
+        PF["_provider_factory<br/>= SubprocessNkeyProvider (default)"]
+        GP --> PF
+    end
+    subgraph tests["tests/ (test-only seam)"]
+        SHIM["tests/scripts/_fake_genkeys.py<br/>sys.path += repo-root<br/>_modes._provider_factory = FakeNkeyProvider<br/>gen_nkeys.main()"]
+        IP["in-process tests<br/>monkeypatch.setattr(_modes,_provider_factory,Fake)"]
+    end
+    SHIM -.overrides.-> PF
+    IP -.overrides.-> PF
+    style prod fill:#1b2a1b
+    style tests fill:#2a1b2a
+```
+
+### Consumer summary
+
+| Consumer | Selects fake via | When | Status |
+|---|---|---|---|
+| prod CLI (`gen_nkeys.py`) | nothing — always real | always | this issue (env path deleted) |
+| 3 subprocess run-helpers (`test_file_modes`, `test_genkeys_modes`, `test_genkeys_modes_add_identity`) | `_fake_genkeys.py` shim (out-of-process DI) | test | this issue |
+| 2 in-process tests (`test_genkeys_modes`: `_mode_full_provision`, `_mode_regenerate` cases) | `monkeypatch.setattr` on `_provider_factory` | test | this issue |
+| direct-instantiation tests (`test_nk`, `test_parity_e2e`) | `FakeNkeyProvider()` directly (no factory involved) | test | unchanged — no edit needed |
+| `tests/nats/test_gen_nkeys_acls.sh` | `--template-only`, never calls `_get_provider` | test | unchanged — verified not provider-dependent |
+
+## Breadboard
+
+| ID | Seam (affordance) | Handler / change | Effect |
+|---|---|---|---|
+| N1 | `NkeyProvider.ensure_available()` (`scripts/_nk.py`) | add **concrete** no-op (`def ensure_available(self) -> None: return None`) to the ABC; `SubprocessNkeyProvider` overrides → `ensure_nk_or_exit()` | per-provider precondition; `_get_provider` becomes provider-agnostic; `FakeNkeyProvider` inherits no-op (needs no `nk`) |
+| N2 | `_modes._get_provider()` | delete env-branch + lazy fake import + `LYRA_TEST_MODE` check; body = `p=_provider_factory(); p.ensure_available(); return p` | zero fake/env ref in prod; nk-absent still exits 1 with hint, enforced **at `_get_provider`**, the sole prod entry |
+| N3 | `tests/scripts/_fake_genkeys.py` (new) | `sys.path.insert(0, parents[2])` **first** (mirror `gen_nkeys.py:14-17`); then `import scripts._modes as _modes`; `from scripts.gen_nkeys import main`; `from tests.fakes.nkey_provider import FakeNkeyProvider`; `_modes._provider_factory = FakeNkeyProvider`; `if __name__=="__main__": main()` | out-of-process DI seam; resolves `scripts`/`tests` imports regardless of cwd; module-global set before any `_get_provider` call → all 4 call sites see override |
+| N4 | 3 subprocess run-helpers (`_run_genkeys` in the 3 files) | swap script path `scripts/gen_nkeys.py` → `tests/scripts/_fake_genkeys.py`; drop `NKEY_PROVIDER`/`LYRA_TEST_MODE` env lines | subprocess tests inject via DI shim, not env |
+| N5 | 2 in-process tests (`test_genkeys_modes`, the `_mode_full_provision` + `_mode_regenerate` cases that call `monkeypatch.setenv("NKEY_PROVIDER",…)`) | replace the 2 `setenv` lines with `monkeypatch.setattr(_modes,"_provider_factory",FakeNkeyProvider)` | in-process tests use DI |
+| N6 | `.importlinter` `tests-fakes-isolation` | remove `ignore_imports` block; change `forbidden_modules` from `tests.fakes` to `tests` (forbids all `tests.*`) | no holes; forbids every `tests.*` import from `lyra`+`scripts` |
+| N7 | `tests/scripts/test_fake_isolation.py` (new) | verify-tests: (a) regression guard, (b) planted-violation — see §Verify-test design | CI proves reintroduction fails + band-aid cannot return |
+
+## Verify-test design (N7)
+
+Three unconditional tests (no `@skip`/`xfail`; run in the default `pytest tests/scripts/`):
+
+1. **Regression guard — prod path** (cheap, deterministic): read `scripts/_modes.py` source;
+   assert it contains no `NKEY_PROVIDER`, no `env_provider`, no `tests.fakes` import.
+2. **Regression guard — contract** (cheap, deterministic): parse `.importlinter`; assert the
+   `tests-fakes-isolation` contract has **zero** `ignore_imports` entries and
+   `forbidden_modules` includes `tests`.
+3. **Planted-violation — AC #4 literal** (proves the mechanism bites). Constraints (from devops review):
+   - Build a **minimal stub tree** in `tmp_path`: `scripts/__init__.py`, `scripts/_violation.py`
+     (`from tests.fakes import nkey_provider`), `tests/__init__.py`, `tests/fakes/__init__.py`,
+     `tests/fakes/nkey_provider.py`.
+   - Write a `tmp_path/.importlinter` with `root_packages = scripts, tests` **only** (NOT `lyra`
+     — keeps grimp's graph tiny and avoids evaluating the real tree), `source_modules = scripts`,
+     `forbidden_modules = tests`.
+   - Run `lint-imports --config <tmp>/.importlinter` with `cwd=tmp_path` so cwd is prepended to
+     `sys.path` and `find_spec("scripts")` resolves to the stub (do **not** rely on `source_roots`,
+     which import-linter does not add to `sys.path`). Scrub `PYTHONPATH` from the subprocess env so
+     the real `scripts` package cannot shadow the stub.
+   - Assert exit code ≠ 0 and the planted module is named in the report.
+
+## Slices
+
+| # | Slice | Affordances | Demo-able green state |
+|---|-------|-------------|-----------------------|
+| 1 | **Relocate injection seam** (prod + tests land in ONE commit — atomic to stay green) | N1, N2, N3, N4, N5 | `grep NKEY_PROVIDER scripts/_modes.py` = 0; full `tests/scripts/` suite green |
+| 2 | **Seal the contract** (commit **after** Slice 1 — pre-commit `import-layers` runs every commit; removing the exemption before N2 lands fails the hook) | N6 | `lint-imports` green, zero `ignore_imports`, forbids `tests` |
+| 3 | **Prove + audit** | N7 + audit pass | verify-tests pass; PR body carries fakes/stubs audit log |
+
+> Slice 1's prod + test edits are coupled by construction: deleting the env-branch (N2)
+> breaks the subprocess + in-process tests until N3–N5 migrate them, so they ship together.
+> Slice 2 **must not** be cherry-picked/rebased ahead of Slice 1. Slices 2 and 3 are
+> independently revertible after Slice 1.
+
+## Success Criteria
+
+- [ ] `scripts/_modes.py` contains no `NKEY_PROVIDER`, no `env_provider`, no `tests.fakes` import (`grep -c` each → 0)
+- [ ] `_get_provider()` body is pure factory dispatch + `ensure_available()` (no `if env…`, no lazy fake import)
+- [ ] `NkeyProvider.ensure_available()` exists as a **concrete no-op** default; `SubprocessNkeyProvider` overrides it to call `ensure_nk_or_exit()`; a real prod run still exits 1 with the nk install hint when `nk` is absent (enforced via `_get_provider`, the sole prod entry — direct `SubprocessNkeyProvider()` construction in `test_nk` is `@skipif`-guarded, no regression)
+- [ ] `tests/scripts/_fake_genkeys.py` exists, bootstraps repo-root onto `sys.path` before importing `scripts`/`tests`, sets `_modes._provider_factory = FakeNkeyProvider`, delegates to `gen_nkeys.main`
+- [ ] The 3 subprocess run-helpers invoke the shim and set neither `NKEY_PROVIDER` nor `LYRA_TEST_MODE`
+- [ ] The 2 in-process tests inject via `monkeypatch.setattr(_modes, "_provider_factory", …)`
+- [ ] No `NKEY_PROVIDER` or `LYRA_TEST_MODE` remains under `tests/scripts/` (`grep -rc` → 0) — scoped to this domain, not the whole `tests/` tree
+- [ ] `.importlinter` `tests-fakes-isolation` has **zero** `ignore_imports` and `forbidden_modules = tests`, `source_modules = lyra, scripts` (`src.*` = `lyra` exhaustively — `src/` holds only the `lyra` package; verified)
+- [ ] Verify-test (planted): a `tmp_path` stub `scripts`→`tests.fakes` import makes `lint-imports` exit ≠ 0, per §Verify-test design constraints
+- [ ] Verify-tests (regression guards) assert `_modes.py` has no env-branch AND the real contract has no `ignore_imports`; both are unconditional (no `@skip`/`xfail`) and run in `uv run pytest tests/scripts/`
+- [ ] No new fake/mock/stub escaped into prod paths: `grep -rilE 'fake|mock|stub' src/ scripts/ --include='*.py' -l` reviewed → only legitimate (non-test-double) matches remain
+- [ ] `uv run lint-imports` exits 0 on the tree; `uv run pytest tests/scripts/` fully green
+- [ ] PR body contains an audit log: every fake/mock/stub + its location, confirming none sit in a prod-importable path; notes the retired `ignore_imports` quality-debt entry (**manual gate** — reviewer-verified, not CI-enforced)
+
+## Out of Scope
+
+- The fakes *move* (done #1283); other env-driven flags; additional runtime guards.
+
+## Gate 2.5 — Splitting
+
+|criteria| > 8 trips the dev-core splitting trigger (`|acceptance criteria| > 8 ∨ |slices| > 3`,
+per spec Gate 2.5), but **splitting is declined**: this is one cohesive atomic refactor
+(≤7 files, single domain). The real reason is atomicity — any split creates a broken
+intermediate (env-branch gone but tests still env-driven, or contract sealed before the seam
+moves). Ship as a single PR with 3 internal slices.
+
+## Review notes (resolved)
+
+- **architect:** shim `sys.path` bootstrap added (N3); `ensure_available()` concrete-default clarified (N1); module-global timing + nk-absent guarantee documented; all subprocess callers audited (3 need migration; `.sh` `--template-only` + conftest cleared).
+- **devops:** planted-violation mechanism fully specified (root_packages=scripts+tests only, cwd=tmp_path, scrub PYTHONPATH, no source_roots reliance); Slice 2-after-Slice-1 ordering made explicit; PR audit log notes retired debt entry.
+- **product-lead:** `src.*`=`lyra` rationale added; no-new-fakes regression-grep criterion added; verify-tests required unconditional + in default run; audit-log flagged manual gate.
+- **doc-writer:** N5 keyed to test functions not line numbers; criterion split; N6 notation disambiguated; consumer table annotated.

--- a/scripts/_modes.py
+++ b/scripts/_modes.py
@@ -19,7 +19,6 @@ from scripts._loader import load_matrix
 from scripts._nk import (
     NkeyProvider,
     SubprocessNkeyProvider,
-    ensure_nk_or_exit,
 )
 from scripts._renderer import parse_auth_conf, render_auth_conf
 
@@ -28,28 +27,9 @@ _provider_factory: Callable[[], NkeyProvider] = SubprocessNkeyProvider
 
 def _get_provider() -> NkeyProvider:
     """Return the active NkeyProvider; exit 1 with install hint when nk is absent."""
-    env_provider = os.environ.get("NKEY_PROVIDER", "").lower()
-    if env_provider == "fake":
-        if os.environ.get("LYRA_TEST_MODE") != "1":
-            print(
-                "error: NKEY_PROVIDER=fake requires LYRA_TEST_MODE=1"
-                " — refusing to generate fake seeds outside test context",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        # Lazy import — test-only fake provider,
-        # guarded by LYRA_TEST_MODE runtime check.
-        try:
-            from tests.fakes.nkey_provider import FakeNkeyProvider  # noqa: I001  # type: ignore[reportMissingImports]
-        except ImportError:
-            print(
-                "error: FakeNkeyProvider not available — tests package not importable",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        return FakeNkeyProvider()
-    ensure_nk_or_exit()
-    return _provider_factory()
+    provider = _provider_factory()
+    provider.ensure_available()
+    return provider
 
 
 def operator_home() -> Path:

--- a/scripts/_nk.py
+++ b/scripts/_nk.py
@@ -22,8 +22,18 @@ class NkeyProvider(ABC):
     @abstractmethod
     def pubkey_from_seed(self, seed: bytes) -> str: ...
 
+    def ensure_available(self) -> None:
+        """Hook: verify provider prerequisites.
+
+        Default no-op; the subprocess provider overrides to check for `nk`.
+        """
+        return None
+
 
 class SubprocessNkeyProvider(NkeyProvider):
+    def ensure_available(self) -> None:
+        ensure_nk_or_exit()
+
     def gen_seed(self, name: str) -> bytes:
         result = subprocess.run(["nk", "-gen", "user"], capture_output=True, check=True)
         return result.stdout.strip()

--- a/tests/scripts/_fake_genkeys.py
+++ b/tests/scripts/_fake_genkeys.py
@@ -1,0 +1,30 @@
+"""Test-only entry point: runs gen_nkeys with the fake nkey provider pre-seeded.
+Lives under tests/ so production scripts never import a fake. (#1093)"""
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import importlib.util as _ilu  # noqa: E402
+
+import scripts._modes as _modes  # noqa: E402
+from scripts.gen_nkeys import main  # noqa: E402
+
+# Import FakeNkeyProvider directly from its module file to avoid executing
+# tests/fakes/__init__.py, which transitively imports lyra (not installed in
+# this subprocess environment).
+_spec = _ilu.spec_from_file_location(
+    "tests.fakes.nkey_provider",
+    _REPO_ROOT / "tests" / "fakes" / "nkey_provider.py",
+)
+_mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+FakeNkeyProvider = _mod.FakeNkeyProvider
+
+_modes._provider_factory = FakeNkeyProvider
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_fake_isolation.py
+++ b/tests/scripts/test_fake_isolation.py
@@ -1,0 +1,149 @@
+"""Verify-tests for fake isolation refactor (#1093, N7).
+
+Three unconditional guards — no @skip, no xfail — run in the default
+`uv run pytest tests/scripts/` suite.
+
+(a) prod-path guard   — scripts/_modes.py must contain no env-branch remnants
+(b) contract guard    — .importlinter tests-fakes-isolation must have no ignore_imports
+(c) planted-violation — proves lint-imports *actually* catches a scripts→tests import
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ── (a) prod-path guard ───────────────────────────────────────────────────────
+
+
+def test_modes_has_no_env_branch_or_fake_import() -> None:
+    """Regression guard: scripts/_modes.py must not contain the retired env-branch.
+
+    Deleted in this PR (N2): the NKEY_PROVIDER env read, the env_provider variable,
+    and the `from tests.fakes` lazy import.  Any reintroduction trips this guard.
+    """
+    source = (REPO_ROOT / "scripts" / "_modes.py").read_text()
+
+    forbidden = ["NKEY_PROVIDER", "env_provider", "tests.fakes"]
+    for term in forbidden:
+        assert term not in source, (
+            f"scripts/_modes.py contains retired term {term!r}. "
+            "The env-branch or fake import was reintroduced — remove it."
+        )
+
+
+# ── (b) contract guard ────────────────────────────────────────────────────────
+
+
+def test_importlinter_contract_has_no_ignore_imports() -> None:
+    """Regression guard: tests-fakes-isolation contract must have no ignore_imports.
+
+    The exemption `scripts._modes -> tests.fakes.nkey_provider` was removed in
+    this PR (N6).  Any re-addition would silently bypass the isolation guarantee.
+    Checks only the target contract block — not other contracts that legitimately
+    carry ignore_imports.
+    """
+    config_path = REPO_ROOT / ".importlinter"
+    config_text = config_path.read_text()
+
+    # Parse with configparser, scoped to the target section.
+    parser = configparser.ConfigParser()
+    parser.read_string(config_text)
+
+    section = "importlinter:contract:tests-fakes-isolation"
+    assert parser.has_section(section), (
+        f".importlinter is missing [{section}] — was it renamed or deleted?"
+    )
+
+    # No ignore_imports key in this block.
+    assert not parser.has_option(section, "ignore_imports"), (
+        "tests-fakes-isolation contract has an ignore_imports entry. "
+        "This re-opens the isolation hole — remove it."
+    )
+
+    # forbidden_modules must include 'tests' (the broad ban, not just tests.fakes).
+    forbidden_modules_raw = parser.get(section, "forbidden_modules", fallback="")
+    forbidden_entries = {
+        e.strip() for e in forbidden_modules_raw.splitlines() if e.strip()
+    }
+    assert "tests" in forbidden_entries, (
+        f"tests-fakes-isolation.forbidden_modules does not include 'tests'. "
+        f"Got: {forbidden_entries!r}. The contract must ban all tests.* imports."
+    )
+
+
+# ── (c) planted-violation ────────────────────────────────────────────────────
+
+
+def test_lint_imports_catches_scripts_importing_tests(tmp_path: Path) -> None:
+    """Planted-violation: proves lint-imports actually rejects a scripts→tests import.
+
+    Builds a minimal stub tree in tmp_path so grimp only needs to resolve two tiny
+    packages (scripts + tests).  Runs lint-imports with cwd=tmp_path (so the stub
+    packages resolve via sys.path cwd prepend) and PYTHONPATH="" (so the real
+    repo packages cannot shadow the stubs).
+
+    The contract MUST fail — if it exits 0, the mechanism is broken.
+    """
+    # ── stub tree ──────────────────────────────────────────────────────────────
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "__init__.py").write_text("")
+    (tmp_path / "scripts" / "_violation.py").write_text(
+        "from tests.fakes import nkey_provider\n"
+    )
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("")
+    (tmp_path / "tests" / "fakes").mkdir()
+    (tmp_path / "tests" / "fakes" / "__init__.py").write_text("")
+    (tmp_path / "tests" / "fakes" / "nkey_provider.py").write_text("")
+
+    # ── minimal importlinter config ───────────────────────────────────────────
+    # root_packages = scripts + tests ONLY (not lyra — keeps grimp graph tiny
+    # and avoids resolving the real tree).
+    # source_roots intentionally omitted — import-linter does not add it to
+    # sys.path; cwd=tmp_path is the correct resolution mechanism.
+    config = textwrap.dedent("""\
+        [importlinter]
+        root_packages =
+            scripts
+            tests
+
+        [importlinter:contract:no-fakes]
+        name = planted violation
+        type = forbidden
+        source_modules =
+            scripts
+        forbidden_modules =
+            tests
+    """)
+    (tmp_path / ".importlinter").write_text(config)
+
+    # ── run lint-imports in the stub cwd ──────────────────────────────────────
+    # PYTHONPATH="" prevents the real repo's scripts/tests packages from
+    # shadowing the stubs.  cwd=tmp_path prepends tmp_path to sys.path so
+    # find_spec("scripts") resolves to the stub.
+    env = {**os.environ, "PYTHONPATH": ""}
+    result = subprocess.run(
+        ["lint-imports", "--config", str(tmp_path / ".importlinter")],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, (
+        f"lint-imports exited 0 — planted violation was NOT detected.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "_violation" in combined, (
+        f"lint-imports exited {result.returncode}; '_violation' not in output.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/scripts/test_file_modes.py
+++ b/tests/scripts/test_file_modes.py
@@ -40,12 +40,10 @@ def _run_genkeys(
 ) -> subprocess.CompletedProcess[str]:
     """Run gen_nkeys.py genkeys with given args via subprocess."""
     run_env = os.environ.copy()
-    run_env["NKEY_PROVIDER"] = "fake"  # tests write name.encode() seed bytes
-    run_env["LYRA_TEST_MODE"] = "1"
     if env:
         run_env.update(env)
     return subprocess.run(
-        [sys.executable, "scripts/gen_nkeys.py", "genkeys"] + args,
+        [sys.executable, "tests/scripts/_fake_genkeys.py", "genkeys"] + args,
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),

--- a/tests/scripts/test_genkeys_modes.py
+++ b/tests/scripts/test_genkeys_modes.py
@@ -17,6 +17,9 @@ import sys
 from pathlib import Path
 
 import pytest
+import scripts._modes as _modes
+
+from tests.fakes.nkey_provider import FakeNkeyProvider
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _MATRIX_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "v2-prod.json"
@@ -32,12 +35,10 @@ def _run_genkeys(
 ) -> subprocess.CompletedProcess[str]:
     """Run gen_nkeys.py genkeys with given args via subprocess."""
     run_env = os.environ.copy()
-    run_env["NKEY_PROVIDER"] = "fake"  # tests write name.encode() seed bytes
-    run_env["LYRA_TEST_MODE"] = "1"  # required sentinel for fake provider
     if env:
         run_env.update(env)
     return subprocess.run(
-        [sys.executable, "scripts/gen_nkeys.py", "genkeys"] + args,
+        [sys.executable, "tests/scripts/_fake_genkeys.py", "genkeys"] + args,
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
@@ -538,8 +539,7 @@ class TestExternalFailLoud:
         auth_dir.mkdir(parents=True)
         monkeypatch.setenv("SEEDS_DIR", str(seeds_dir))
         monkeypatch.setenv("AUTH_DIR", str(auth_dir))
-        monkeypatch.setenv("NKEY_PROVIDER", "fake")
-        monkeypatch.setenv("LYRA_TEST_MODE", "1")
+        monkeypatch.setattr(_modes, "_provider_factory", FakeNkeyProvider)
 
         # No externals → []
         matrix_no_ext = _make_matrix(tmp_path, with_external=False)
@@ -775,8 +775,7 @@ class TestExternalFailLoud:
 
         monkeypatch.setenv("SEEDS_DIR", str(seeds_dir))
         monkeypatch.setenv("AUTH_DIR", str(auth_dir))
-        monkeypatch.setenv("NKEY_PROVIDER", "fake")
-        monkeypatch.setenv("LYRA_TEST_MODE", "1")
+        monkeypatch.setattr(_modes, "_provider_factory", FakeNkeyProvider)
 
         args = argparse.Namespace(
             matrix=matrix_path,

--- a/tests/scripts/test_genkeys_modes_add_identity.py
+++ b/tests/scripts/test_genkeys_modes_add_identity.py
@@ -5,7 +5,8 @@ All tests are expected to FAIL until T5/T6 implementation lands:
   - _mode_add_identity does not exist in _modes.py
 
 Tests use:
-  - NKEY_PROVIDER=fake + LYRA_TEST_MODE=1 (deterministic, no nk binary needed)
+  - tests/scripts/_fake_genkeys.py shim (FakeNkeyProvider pre-seeded —
+    deterministic, no nk binary needed)
   - SEEDS_DIR=tmp_path fixture to avoid touching ~/.lyra/nkeys/
   - AUTH_DIR=tmp_path fixture to avoid /etc/nats/nkeys/ (bypasses _require_root)
   - A tiny 3-identity matrix created in tmp_path (hub, telegram-adapter, turn-writer)
@@ -83,12 +84,10 @@ def _run_genkeys(
 ) -> subprocess.CompletedProcess[str]:
     """Run gen_nkeys.py genkeys with given args via subprocess."""
     run_env = os.environ.copy()
-    run_env["NKEY_PROVIDER"] = "fake"
-    run_env["LYRA_TEST_MODE"] = "1"
     if env:
         run_env.update(env)
     return subprocess.run(
-        [sys.executable, "scripts/gen_nkeys.py", "genkeys"] + args,
+        [sys.executable, "tests/scripts/_fake_genkeys.py", "genkeys"] + args,
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),


### PR DESCRIPTION
## Summary

Make it **structurally impossible** to import a test fake from production code — closing the class of bug behind incident #1089 (a `FakeNkeyProvider` reachable from a prod path rendered a malformed nkey into `auth.conf` and took down NATS).

#1283 already moved the fakes to `tests/fakes/` and added the import-linter contract, but shipped the runtime guard this issue explicitly rejected — a `NKEY_PROVIDER=="fake"` env-branch in `scripts/_modes.py` (gated only by a `LYRA_TEST_MODE` runtime check) plus an `ignore_imports` exemption, a self-documented hole in the recurrence-prevention contract. This PR removes the band-aid by **relocating the subprocess test-injection seam into `tests/`**, then deleting the env-branch and the exemption.

- **Prod can no longer reach a fake.** `_get_provider()` is now pure factory dispatch (`provider = _provider_factory(); provider.ensure_available()`) — no env var selects a fake. The subprocess injection seam moved to `tests/scripts/_fake_genkeys.py`, a test-only entry point that pre-seeds `_provider_factory = FakeNkeyProvider` then delegates to `gen_nkeys.main()`. A new `ensure_available()` hook (no-op on the ABC, `ensure_nk_or_exit()` on `SubprocessNkeyProvider`) keeps `_get_provider()` provider-agnostic.
- **Contract sealed + CI-enforced.** `.importlinter` `tests-fakes-isolation` drops the `scripts._modes -> tests.fakes.nkey_provider` exemption and broadens `forbidden_modules` from `tests.fakes` to `tests`. A planted-violation test proves `lint-imports` actually rejects a `scripts → tests` import (not just asserts config text).

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Fakes under `tests/fakes/` | ✅ pre-existing (#1283) |
| 2 | `.importlinter` forbids `lyra.*`/`scripts.*` → `tests.*` | ✅ broadened to `tests`, exemption removed |
| 3 | CI fails on `from tests.fakes import` in prod | ✅ contract + planted-violation test |
| 4 | Reintroduction trips a verify-test | ✅ `tests/scripts/test_fake_isolation.py` (3 guards) |
| 5 | No prod path branches on a fake env var | ✅ env-branch deleted (`grep` → 0) |
| 6 | Audit log in PR body | ✅ below |

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1093: refactor: isolate test fakes from production imports | Open |
| Analysis | — | Absent (F-lite) |
| Spec | [1093-isolate-test-fakes-spec.mdx](artifacts/specs/1093-isolate-test-fakes-spec.mdx) | Present |
| Implementation | 2 commits on `feat/1093-isolate-test-fakes` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (4 new files: 3 guards + shim) | Passed |

## Fakes / mocks / stubs audit (AC#6)

`grep -rinE 'fake\|mock\|stub' src/ scripts/ --include='*.py'` → 7 hits, **0 test-doubles reachable from a prod-importable path**:

| term | location | kind | prod path? |
|---|---|---|:---:|
| `fake Co-Authored-By` | `src/lyra/core/cli/cli_pool_worker.py:118` | docstring (git-trailer security note) | N |
| `fake_clock.now` | `src/lyra/tools/gh_token/rate_limit.py:36` | docstring (injection point) | N |
| `tests can stub all I/O` | `src/lyra/tools/gh_token/dispenser.py:51` | docstring (DI pattern) | N |
| `Attribute stubs below` | `src/lyra/core/session_lifecycle.py:28` | docstring (Protocol attrs) | N |
| `inject a mock …` | `src/lyra/infrastructure/blobstore_adapter.py:33` | docstring (testability) | N |
| `logger-only stub` | `src/lyra/blobstore/serve.py:122` | comment (real degraded-mode impl) | N |
| `fake nkeys` | `scripts/gen_nkeys.py:200` | `--help` string (`--template-only`) | N |

All 7 are natural-language uses in docstrings/comments/help — none import or instantiate a test-double from `tests/`. **Retired quality-debt:** the `scripts._modes -> tests.fakes.nkey_provider` exemption (the only prod→test-double path this project tracked) is removed; structural import-linter isolation replaces the runtime guard. Full log: [artifacts/plans/1093-audit-log.md](artifacts/plans/1093-audit-log.md).

## Test plan

- [ ] `uv run lint-imports` → 11/11 contracts kept
- [ ] `uv run pytest tests/scripts/test_fake_isolation.py` → 3 passed (incl. planted-violation: `lint-imports` exit ≠ 0 on a `scripts → tests` import)
- [ ] `uv run pytest tests/scripts/` → green (subprocess tests inject the fake via `_fake_genkeys.py`, no `NKEY_PROVIDER`/`LYRA_TEST_MODE`)
- [ ] `grep -c 'NKEY_PROVIDER\|env_provider\|tests.fakes' scripts/_modes.py` → 0

> **CI note:** `tests/scripts/test_parity_e2e.py::test_retired_identity_connect_rejected` can flake under `pytest-xdist` (NATS `ConnectionResetError` from worker contention); passes in isolation. Pre-existing infra flake, unrelated to this change.

Closes #1093

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
