### PR TITLE
feat(voice): #1553 V1 hardening follow-ups (B2 + tidy-up)

### DIFF
--- a/src/lyra/agents/simple_agent_prompts.py
+++ b/src/lyra/agents/simple_agent_prompts.py
@@ -39,6 +39,12 @@ async def build_llm_text(
         - transcription_text: Raw STT text for history, or None if not voice
 
     """
+    if any(a.type == "audio" for a in msg.attachments):
+        log.warning(
+            "build_llm_text: stray audio attachment (type='audio') detected — "
+            "protocol violation, skipping"
+        )
+
     if msg.modality == "voice":
         # Pipeline-transcribed audio - wrap for prompt injection guard (H-8)
         return f"<voice_transcript>{html.escape(msg.text)}</voice_transcript>", msg.text

--- a/src/lyra/core/messaging/message.py
+++ b/src/lyra/core/messaging/message.py
@@ -87,7 +87,7 @@ class Attachment:
     - Local path (str) for pre-download audio, or raw bytes (future).
     """
 
-    type: str  # "image" | "audio" | "video" | "file"
+    type: Literal["image", "audio", "video", "file"]
     url_or_path_or_bytes: str | bytes  # URL, local path, or raw bytes
     mime_type: str
     filename: str | None = None

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -8,7 +8,6 @@ import pytest
 
 # Backward-compatible re-exports from agent factories
 from tests.factories.agents import (  # noqa: F401
-    make_audio_message,
     make_cli_pool,
     make_config,
     make_mock_stt,
@@ -18,7 +17,6 @@ from tests.factories.agents import (  # noqa: F401
 from tests.factories.blobs import _make_mock_blob_store
 
 __all__ = [
-    "make_audio_message",
     "make_cli_pool",
     "make_config",
     "make_mock_stt",

--- a/tests/factories/agents.py
+++ b/tests/factories/agents.py
@@ -23,7 +23,6 @@ __all__ = [
     "FastAgent",
     "RecordingAgent",
     "SlowAgent",
-    "make_audio_message",
     "make_cli_pool",
     "make_config",
     "make_mock_stt",
@@ -85,28 +84,6 @@ class FastAgent:
         on_intermediate=None,
     ) -> Response:
         return Response(content=f"echo: {msg.text}")
-
-
-def make_audio_message(url: str) -> InboundMessage:
-    from lyra.core.messaging.message import Attachment, TelegramMeta
-
-    return InboundMessage(
-        id="msg-audio",
-        platform="telegram",
-        bot_id="main",
-        scope_id="chat:42",
-        user_id="alice",
-        user_name="Alice",
-        is_mention=False,
-        text="",
-        text_raw="",
-        attachments=[
-            Attachment(type="audio", url_or_path_or_bytes=url, mime_type="audio/ogg"),
-        ],
-        timestamp=datetime.now(timezone.utc),
-        platform_meta=TelegramMeta(chat_id=42),
-        trust_level=TrustLevel.TRUSTED,
-    )
 
 
 def make_text_message(text: str = "hello") -> InboundMessage:


### PR DESCRIPTION
## Summary
- Tighten `Attachment.type` from bare `str` to `Literal["image","audio","video","file"]` to prevent silent drops of future `type="audio"` attachments.
- Add warning log in `build_llm_text` for stray audio attachments (protocol violation — log + skip, not silent no-op).
- Remove unused `make_audio_message` test factory and its conftest re-export (dead code from #1553 audio-branch deletion).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1566: feat(voice): #1553 V1 hardening follow-ups (B2 + tidy-up) | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1566-feat-voice-1553-v1-hardening-follow-ups` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Verify `Attachment.type` accepts only Literal values
- [ ] Verify stray audio attachment triggers warning log in `build_llm_text`
- [ ] Verify `make_audio_message` factory is removed and no tests break

Closes #1566

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
