### PR TITLE
refactor(acl): unify subject_covered (3 copies) + single-token .* NATS semantics

### DIFF
--- a/artifacts/frames/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-frame.mdx
+++ b/artifacts/frames/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-frame.mdx
@@ -1,0 +1,56 @@
+---
+title: "refactor(acl): unify subject_covered (3 copies) + single-token .* NATS semantics"
+issue: 1567
+status: approved
+tier: F-lite
+date: 2026-05-31
+---
+
+## Problem
+
+`subject_covered` (NATS-wildcard coverage check) now exists in **3 copies** across the ACL script suite:
+- `scripts/_effective.py:subject_covered` (new, #1527)
+- `scripts/gen_nkeys.py:_subject_covered`
+- `scripts/check_request_reply_flows.py:_subject_covered`
+
+All three are logically identical today but maintained independently. A future correction applied to one silently diverges the others (`parallel-path-drift`).
+
+Two known semantic gaps shared by all three:
+1. **No single-token `.*` handling** — a grant ending `.*` is treated as a literal string, not a one-token wildcard. Currently masked because the ADR manifest expresses required subjects as exact literals or `.>`-covered. A future concrete required-subject + `.*` grant would false-negative.
+2. **Bare-prefix `.>` match** — `subject == grant[:-2]` returns covered, but NATS `foo.>` does NOT match bare `foo`. False-positive in theory; not currently triggerable (no bare-prefix subject in any manifest).
+
+Both gaps are fail-safe in the current data (false-negative / untriggerable), so the gate is correct today — this is hardening, not a live bug.
+
+## Who
+
+- **Primary:** Lyra developers maintaining ACL generation and validation scripts
+- **Secondary:** CI pipeline (`lyra-acl check grants` falsification gate) — correctness of coverage decisions
+
+## Constraints
+
+- Must keep all 3 callers green during migration (no intermediate broken state)
+- Parametric tests must cover `.*` and `.>` edge cases before semantic changes land
+- CI step `Check ACL code coverage (ADR-079)` may drop hardcoded `--matrix`/`--code-subjects` flags (optional, secondary)
+
+## Out of Scope
+
+- NATS server-side ACL changes (ADR-079 manifest format is stable)
+- Changes to `effective_grants` or other `_effective.py` exports
+- New grant types beyond `.*` and `.>` (future issue if needed)
+- CI flag cleanup is secondary and optional; can be deferred if it expands scope
+
+## Premise Validity
+
+**Success in 6 months:** One `subject_covered` in `scripts/_effective.py`, imported by all ACL scripts. `.*` matches single-token wildcards per NATS spec. `.>` no longer matches bare prefix. Parametric tests cover edge cases. Zero new `subject_covered` copies in any ACL script.
+
+**Failure in 6 months:** A 4th `subject_covered` copy appears in any ACL script, OR CI falsification gate passes a `.*` grant that should match but returns false-negative, OR the unified function still treats bare-prefix `.>` as covered (false-positive).
+
+**Simplest alternative:** Copy-paste `_effective.py` version into `gen_nkeys.py` + `check_request_reply_flows.py` without shared import.
+**Why not simplest:** Next bug fix creates a 4th copy — same drift recurs. Two semantic gaps (`.*` + `.>`) must change in all 3 copies simultaneously; shared function is the only guarantee they move together.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (ACL scripts), ~4–8 files, no new architecture.
+
+- Signals: ≤3 files changed (single script + 2 callers), 1 domain (ACL scripts), no unknowns
+- Issue label: none (default F-lite for clear refactor scope)

--- a/artifacts/plans/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-plan.mdx
+++ b/artifacts/plans/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-plan.mdx
@@ -1,0 +1,200 @@
+---
+title: "Plan: refactor(acl): unify subject_covered (3 copies) + single-token .* NATS semantics"
+issue: 1567
+status: approved
+spec: artifacts/specs/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-05-31
+---
+
+## Summary
+
+Consolidate `subject_covered` to `scripts/_effective.py`, fix `.*` and `.>` NATS semantics, add parametric tests, and migrate `gen_nkeys.py` + `check_request_reply_flows.py` to import from the canonical location.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph _effective.py
+        A["subject_covered(subject, grants)"]
+    end
+    subgraph Consumers
+        B["check_grants.py"]
+        C["gen_nkeys.py:_flow_errors"]
+        D["check_request_reply_flows.py:main()"]
+    end
+    A --> B
+    A --> C
+    A --> D
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph _effective.py
+        SC["subject_covered()"]
+    end
+    subgraph gen_nkeys.py
+        FE["_flow_errors()"]
+    end
+    subgraph check_request_reply_flows.py
+        M["main()"]
+    end
+    subgraph check_grants.py
+        CG["check grants CLI"]
+    end
+    SC --> FE
+    SC --> M
+    SC --> CG
+```
+
+## Wave Structure
+
+3 waves, max 2 parallel agents. Elapsed ~1 day sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | backend-dev-A | T1: Harden `subject_covered` + add tests |
+| 2 | Wave 1 done | backend-dev-A | T2: Migrate `gen_nkeys.py` · T3: Migrate `check_request_reply_flows.py` |
+| 3 | Wave 2 done | tester-A | T4: Verify all CI gates green |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 | 2 files | bounded | 6 | — |
+| T2 | 1 file | trivial | 2 | — |
+| T3 | 1 file | trivial | 2 | — |
+| T4 | 3 checks | exploratory | 8 | — |
+
+**Total estimated ops: 18**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3 | 10 | acl | — |
+| tester-A | T4 | 8 | test | — |
+
+## Micro-Tasks
+
+### T1 — Harden `subject_covered` in `_effective.py` + add parametric tests
+
+| Field | Value |
+|-------|-------|
+| Description | Update `subject_covered` in `_effective.py` to add `.*` handling and remove bare-prefix `.>` match. Add parametric tests `TestSubjectCovered` in `test_effective.py`. |
+| Files | `scripts/_effective.py`, `tests/scripts/test_effective.py` |
+| Code snippet | Add `if grant.endswith(".*"):` block; remove `subject == bare` from `.>` block. Add `@pytest.mark.parametrize` tests. |
+| Verify command | `uv run pytest tests/scripts/test_effective.py -k TestSubjectCovered -v` |
+| Expected output | All tests pass (8–12 cases) |
+| Time estimate | 5–8 min |
+| [P] | N |
+| Agent | backend-dev-A |
+| Subject | acl |
+| Spec trace | SC1–SC3, SC7 |
+| Slice | S1 |
+| Phase | GREEN |
+| Difficulty | 3 |
+
+### T2 — Migrate `gen_nkeys.py` to import from `_effective.py`
+
+| Field | Value |
+|-------|-------|
+| Description | Remove private `_subject_covered` from `gen_nkeys.py`. Add `from scripts._effective import subject_covered`. Update `_flow_errors` to use `subject_covered` (no underscore). |
+| Files | `scripts/gen_nkeys.py` |
+| Code snippet | Delete `def _subject_covered(...)` block. Add import. Change `_subject_covered(...)` → `subject_covered(...)` in `_flow_errors`. |
+| Verify command | `uv run pytest tests/scripts/test_check_request_reply_flows.py -v` |
+| Expected output | All tests pass |
+| Time estimate | 3 min |
+| [P] | Y |
+| Agent | backend-dev-A |
+| Subject | acl |
+| Spec trace | SC4 |
+| Slice | S2 |
+| Phase | REFACTOR |
+| Difficulty | 2 |
+
+### T3 — Migrate `check_request_reply_flows.py` to import from `_effective.py`
+
+| Field | Value |
+|-------|-------|
+| Description | Remove private `_subject_covered` from `check_request_reply_flows.py`. Add `from scripts._effective import subject_covered`. Update `main()` to use `subject_covered` (no underscore). |
+| Files | `scripts/check_request_reply_flows.py` |
+| Code snippet | Delete `def _subject_covered(...)` block. Add import. Change `_subject_covered(...)` → `subject_covered(...)` in `main()`. |
+| Verify command | `uv run pytest tests/scripts/test_check_request_reply_flows.py -v` |
+| Expected output | All tests pass |
+| Time estimate | 3 min |
+| [P] | Y |
+| Agent | backend-dev-A |
+| Subject | acl |
+| Spec trace | SC5 |
+| Slice | S3 |
+| Phase | REFACTOR |
+| Difficulty | 2 |
+
+### T4 — Verify all CI gates green
+
+| Field | Value |
+|-------|-------|
+| Description | Run the 3 CI ACL checks locally to confirm no regression: `lyra-check-flows`, `lyra-check-acl-retired`, `lyra-acl check grants`. |
+| Files | CI workflows (read-only) |
+| Verify command | `uv run lyra-check-flows && uv run lyra-check-acl-retired && uv run lyra-acl check grants --matrix deploy/nats/acl-matrix.json --code-subjects deploy/nats/code-subjects.json` |
+| Expected output | All exit 0 |
+| Time estimate | 5 min |
+| [P] | N |
+| Agent | tester-A |
+| Subject | test |
+| Spec trace | SC8–SC10 |
+| Slice | S4 |
+| Phase | RED-GATE |
+| Difficulty | 2 |
+
+## Consistency Report
+
+| Criterion | Covered | Trace |
+|-----------|---------|-------|
+| SC1: `subject_covered` handles exact/`>`/`.*`/`.` | ✓ | T1 |
+| SC2: `.>` matches sub-levels, not bare prefix | ✓ | T1 |
+| SC3: `.*` matches single token, not multi/bare | ✓ | T1 |
+| SC4: `gen_nkeys.py` imports from `_effective.py` | ✓ | T2 |
+| SC5: `check_request_reply_flows.py` imports from `_effective.py` | ✓ | T3 |
+| SC6: `check_grants.py` unchanged | ✓ | T1 (already imports) |
+| SC7: Parametric tests in `test_effective.py` | ✓ | T1 |
+| SC8: `test_check_request_reply_flows.py` passes | ✓ | T2, T3 |
+| SC9: `lyra-check-flows` CI green | ✓ | T4 |
+| SC10: `lyra-acl check grants` CI green | ✓ | T4 |
+
+**Coverage:** 10/10 ✓
+
+## Task Seeding Blueprint
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | acl |
+
+### Wave 2 — after T1, 1 agent, 2 tasks ∆
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | acl |
+| T3 | backend-dev-A | T1 | acl |
+
+### Wave 3 — after T2+T3, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | tester-A | T2, T3 | test |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — acl
+- T2: 14 — acl
+- T3: 15 — acl
+- T4: 16 — test

--- a/artifacts/specs/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-spec.mdx
+++ b/artifacts/specs/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-spec.mdx
@@ -1,0 +1,120 @@
+---
+title: "refactor(acl): unify subject_covered (3 copies) + single-token .* NATS semantics"
+issue: 1567
+status: approved
+tier: F-lite
+date: 2026-05-31
+promoted_from: "../frames/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-frame.mdx"
+---
+
+## Context
+
+Promoted from [frame #1567](../frames/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-frame.mdx).
+
+`subject_covered` (NATS-wildcard coverage check) exists in **3 copies** across the ACL script suite:
+- `scripts/_effective.py:subject_covered` (canonical, imported by `check_grants.py`)
+- `scripts/gen_nkeys.py:_subject_covered` (private, used in `_flow_errors`)
+- `scripts/check_request_reply_flows.py:_subject_covered` (private, used in `main()`)
+
+All three are logically identical today but maintained independently. A future correction applied to one silently diverges the others.
+
+## Goal
+
+Consolidate to one `subject_covered` in `_effective.py`, migrate the other two copies to import it, and fix two NATS-wildcard semantic gaps in the same change.
+
+## Users
+
+- **Primary:** Lyra developers maintaining ACL scripts
+- **Secondary:** CI pipeline (`lyra-acl check grants`, `lyra-check-flows`, `lyra-check-acl-retired` falsification gates)
+
+## Expected Behavior
+
+### Current state (all 3 copies)
+
+```python
+def subject_covered(subject: str, grants: list[str]) -> bool:
+    for grant in grants:
+        if grant == subject or grant == ">":
+            return True
+        if grant.endswith(".>"):
+            prefix = grant[:-1]      # "foo."
+            bare = grant[:-2]        # "foo"
+            if subject == bare or subject.startswith(prefix):
+                return True
+    return False
+```
+
+### Gaps
+
+1. **No `.*` handling** — `foo.*` is treated as a literal string. NATS `foo.*` matches `foo.bar` (single token), not `foo.bar.baz`.
+2. **Bare-prefix `.>` match** — `foo.>` matches `foo` (bare prefix). NATS `foo.>` does NOT match `foo`; it matches `foo.bar` and deeper.
+
+### Target state (single `_effective.py` function)
+
+```python
+def subject_covered(subject: str, grants: list[str]) -> bool:
+    for grant in grants:
+        if grant == subject or grant == ">":
+            return True
+        if grant.endswith(".>"):
+            prefix = grant[:-1]      # "foo."
+            if subject.startswith(prefix):
+                return True
+        if grant.endswith(".*"):
+            prefix = grant[:-1]      # "foo."
+            if subject.startswith(prefix) and "." not in subject[len(prefix):]:
+                return True
+    return False
+```
+
+## Data Model & Consumers
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    A["scripts/_effective.py\nsubject_covered"] --> B["scripts/check_grants.py\nlyra-acl check grants"]
+    A --> C["scripts/gen_nkeys.py\nlyra-check-flows / lyra-check-acl-retired"]
+    A --> D["scripts/check_request_reply_flows.py\nstandalone CLI"]
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|----------|-----------------|------|--------|
+| `check_grants.py` | `subject_covered(subject, grants)` | CI falsification gate | this issue |
+| `gen_nkeys.py` | `subject_covered(subject, publish)` | `_flow_errors` for flow validation | this issue |
+| `check_request_reply_flows.py` | `subject_covered(subject, publish)` | standalone CLI + subprocess tests | this issue |
+
+## Breadboard
+
+| Affordance | Handler | Data |
+|------------|---------|------|
+| `subject_covered(subject, grants)` | `_effective.py` | NATS subject + grant list |
+| `lyra-check-flows` | `gen_nkeys.py:_cmd_check_flows` → `_flow_errors` | `acl-matrix.json` |
+| `lyra-check-acl-retired` | `gen_nkeys.py:_check_retired` | `acl-matrix.json` |
+| `check_request_reply_flows.py` | `main()` | `acl-matrix.json` |
+
+## Slices
+
+| Slice | What | Files | Independent? |
+|-------|------|-------|--------------|
+| S1 | Harden `subject_covered` in `_effective.py` + add parametric tests (new test class `TestSubjectCovered` in `test_effective.py` — does not exist today) | `_effective.py`, `test_effective.py` | ✓ |
+| S2 | Migrate `gen_nkeys.py` to import from `_effective.py` | `gen_nkeys.py` | ✓ |
+| S3 | Migrate `check_request_reply_flows.py` to import from `_effective.py` | `check_request_reply_flows.py` | ✓ |
+| S4 | Verify all CI gates green | CI workflows | ✓ |
+
+S1 must land before S2/S3 (semantic correctness). S2 and S3 are file-independent and can be prepared in parallel.
+
+## Success Criteria
+
+- [ ] `subject_covered` in `scripts/_effective.py` handles exact match, `>`, `.*`, and `.>` correctly per NATS semantics
+- [ ] `.>` grants match sub-levels (e.g., `foo.>` → `foo.bar`, `foo.bar.baz`) but NOT bare prefix `foo`
+- [ ] `.*` grants match single-token suffixes (e.g., `foo.*` → `foo.bar`) but NOT multi-token `foo.bar.baz` nor bare prefix `foo`
+- [ ] `scripts/gen_nkeys.py` no longer contains a private `_subject_covered` implementation; imports from `_effective.py`
+- [ ] `scripts/check_request_reply_flows.py` no longer contains a private `_subject_covered` implementation; imports from `_effective.py`
+- [ ] `scripts/check_grants.py` continues to import `subject_covered` from `_effective.py` (unchanged)
+- [ ] Parametric tests in `tests/scripts/test_effective.py` cover: exact match, `>`, `.*` positive/negative, `.>` positive/negative, mixed grant list
+- [ ] `tests/scripts/test_check_request_reply_flows.py` still passes (subprocess CLI against prod matrix)
+- [ ] `lyra-check-flows` CI step passes (no regression in flow validation)
+- [ ] `lyra-acl check grants` CI step passes (no regression in coverage validation)

--- a/scripts/_effective.py
+++ b/scripts/_effective.py
@@ -65,22 +65,24 @@ def subject_covered(subject: str, grants: list[str]) -> bool:
     """NATS-wildcard-aware coverage check.
 
     Returns True if *subject* is covered by any grant in *grants*:
-      - Exact match:    grant == subject
-      - Bare wildcard:  grant == ">"
+      - Exact match:     grant == subject
+      - Bare wildcard:   grant == ">"
       - Suffix wildcard: grant ends with ".>" and
-          subject == grant[:-2]  (the prefix token itself)
-          OR subject starts with grant[:-1]  (any sub-level)
+          subject starts with grant[:-1] (any sub-level, bare prefix excluded)
+      - Single-token wildcard: grant ends with ".*" and
+          subject starts with grant[:-1] and has exactly one extra token
 
     Semantics are identical to _subject_covered in check_request_reply_flows.py.
     """
     for grant in grants:
-        if grant == subject:
-            return True
-        if grant == ">":
+        if grant == subject or grant == ">":
             return True
         if grant.endswith(".>"):
             prefix = grant[:-1]  # "lyra.foo."
-            bare = grant[:-2]  # "lyra.foo"
-            if subject == bare or subject.startswith(prefix):
+            if subject.startswith(prefix):
+                return True
+        if grant.endswith(".*"):
+            prefix = grant[:-1]  # "lyra.foo."
+            if subject.startswith(prefix) and "." not in subject[len(prefix):]:
                 return True
     return False

--- a/scripts/check_request_reply_flows.py
+++ b/scripts/check_request_reply_flows.py
@@ -21,30 +21,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from scripts._effective import subject_covered  # noqa: E402
 from scripts._loader import load_matrix  # noqa: E402
-
-
-def _subject_covered(subject: str, publish: list[str]) -> bool:
-    """Return True if *subject* is covered by any grant in *publish*.
-
-    Matching rules (NATS-wildcard-aware, mirrors check-request-reply-flows.sh):
-      - Exact match: grant == subject
-      - Bare wildcard: grant == ">" (covers everything)
-      - Suffix wildcard: grant ends with ".>" and:
-          subject == grant[:-2]  (the prefix level itself)
-          OR subject starts with grant[:-1]  (any sub-level)
-    """
-    for grant in publish:
-        if grant == subject:
-            return True
-        if grant == ">":
-            return True
-        if grant.endswith(".>"):
-            prefix = grant[:-1]  # "lyra.foo."
-            bare = grant[:-2]  # "lyra.foo"
-            if subject == bare or subject.startswith(prefix):
-                return True
-    return False
 
 
 def main() -> None:
@@ -80,7 +58,7 @@ def main() -> None:
 
         if subject and req_exists:
             publish = identities[requester].get("publish", [])
-            if not _subject_covered(subject, publish):
+            if not subject_covered(subject, publish):
                 errors.append(
                     f"FAIL: requester '{requester}' publish[] does not cover"
                     f" subject '{subject}'"

--- a/scripts/gen_nkeys.py
+++ b/scripts/gen_nkeys.py
@@ -34,6 +34,7 @@ from scripts._modes import (  # noqa: E402
 )
 
 __all__ = ["atomic_write", "operator_home"]  # re-exported for test imports
+from scripts._effective import subject_covered  # noqa: E402
 from scripts._renderer import render_auth_conf  # noqa: E402
 from scripts._supervisor import validate_supervisor  # noqa: E402
 
@@ -127,19 +128,6 @@ def _cmd_check_retired(args: argparse.Namespace) -> None:
     print("ok — acl-matrix lifecycle fields valid")
 
 
-def _subject_covered(subject: str, publish: list[str]) -> bool:
-    """Return True if subject is covered by any NATS wildcard grant in publish."""
-    for grant in publish:
-        if grant in (subject, ">"):
-            return True
-        if grant.endswith(".>"):
-            prefix = grant[:-1]
-            bare = grant[:-2]
-            if subject == bare or subject.startswith(prefix):
-                return True
-    return False
-
-
 def _flow_errors(flow: Flow, identities: dict[str, Identity]) -> list[str]:
     requester = flow["requester"]
     responder = flow["responder"]
@@ -152,7 +140,7 @@ def _flow_errors(flow: Flow, identities: dict[str, Identity]) -> list[str]:
         errors.append(f"FAIL: responder '{responder}' not found in identities")
     if subject and req_exists:
         publish = identities[requester].get("publish", [])
-        if not _subject_covered(subject, publish):
+        if not subject_covered(subject, publish):
             errors.append(
                 f"FAIL: requester '{requester}' publish[] does not cover"
                 f" subject '{subject}'"

--- a/tests/scripts/test_effective.py
+++ b/tests/scripts/test_effective.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 from scripts._acl_models import LoadedMatrix
-from scripts._effective import effective_grants
+from scripts._effective import effective_grants, subject_covered
 from scripts._loader import load_matrix
 
 # ── Repo root ────────────────────────────────────────────────────────────────
@@ -149,3 +149,42 @@ class TestEffectiveGrantsExcludesRetired:
         assert "old-worker" not in grants, (
             "old-worker is retired and must not appear in effective_grants keys"
         )
+
+
+# ── subject_covered ───────────────────────────────────────────────────────────
+
+
+class TestSubjectCovered:
+    @pytest.mark.parametrize(
+        ("subject", "grants", "expected"),
+        [
+            # exact match
+            ("foo", ["foo"], True),
+            # bare >
+            ("foo.bar", [">"], True),
+            # .> matches sub-level
+            ("foo.bar", ["foo.>"], True),
+            # .> matches deep sub-level
+            ("foo.bar.baz", ["foo.>"], True),
+            # .> does NOT match bare prefix
+            ("foo", ["foo.>"], False),
+            # .> does NOT match unrelated
+            ("bar.baz", ["foo.>"], False),
+            # .* matches single token
+            ("foo.bar", ["foo.*"], True),
+            # .* does NOT match multi-token
+            ("foo.bar.baz", ["foo.*"], False),
+            # .* does NOT match bare prefix
+            ("foo", ["foo.*"], False),
+            # .* does NOT match unrelated
+            ("bar.baz", ["foo.*"], False),
+            # mixed grant list
+            ("foo.bar", ["foo.>", "baz.*"], True),
+            # mixed grant list negative
+            ("foo.bar.baz", ["foo.*"], False),
+        ],
+    )
+    def test_subject_covered(
+        self, subject: str, grants: list[str], expected: bool
+    ) -> None:
+        assert subject_covered(subject, grants) is expected


### PR DESCRIPTION
## Summary
- Harden `subject_covered` in `scripts/_effective.py` to handle NATS `.*` single-token wildcard and remove bare-prefix `.>` false-positive.
- Add parametric `TestSubjectCovered` in `tests/scripts/test_effective.py` (12 cases).
- Migrate `gen_nkeys.py` and `check_request_reply_flows.py` to import canonical `subject_covered` from `scripts._effective`, eliminating 2 private copies.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1567: refactor(acl): unify subject_covered (3 copies) + single-token .* NATS semantics | OPEN |
| Analysis | — | Skipped (F-lite) |
| Spec | [1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-spec.mdx](artifacts/specs/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics-spec.mdx) | Present |
| Implementation | 2 commits on `feat/1567-refactor-acl-unify-subject-covered-3-copies-single-token-nats-semantics` | Complete |
| Verification | Lint ✓ Typecheck ✓ Tests ✓ (5286 passed, 14 skipped, 1 xfailed) | Passed |

## Test Plan
- [ ] `lyra-check-flows` exits 0
- [ ] `lyra-check-acl-retired` exits 0
- [ ] `lyra-acl check grants` exits 0
- [ ] `pytest tests/scripts/test_effective.py -k TestSubjectCovered` passes

Closes #1567

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`