### PR TITLE
feat(deploy): #1578 collapse deploy to atomic verb wired to autoupdate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ define require_machine1
 	@case "$(DEPLOY_DIR)" in *[\'\"\$$\\\;\&\|\`]*) echo "Error: DEPLOY_DIR contains shell metacharacters"; exit 1 ;; esac
 endef
 
-.PHONY: build push lyra telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy remote nats-setup nats-regen-authconf nats-add-identity test test-integration voice-smoke lint typecheck format quality-debt-report quality-debt-classify
+.PHONY: build push lyra telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy converge remote nats-setup nats-regen-authconf nats-add-identity test test-integration voice-smoke lint typecheck format quality-debt-report quality-debt-classify
 
 # ── Container image build + transfer ─────────────────────────────────────────
 
@@ -185,14 +185,18 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 QUADLET_SYNC_SRC := deploy/systemd
 QUADLET_SYNC_DST := $(HOME)/.config/systemd/user
 
-quadlet-sync-install:  ## install lyra-quadlet-sync timer + service → daemon-reload + enable
+quadlet-sync-install:  ## install systemd sync timers + services → daemon-reload + enable
 	@mkdir -p "$(QUADLET_SYNC_DST)"
-	@cp "$(QUADLET_SYNC_SRC)/lyra-quadlet-sync.service" "$(QUADLET_SYNC_DST)/"
-	@cp "$(QUADLET_SYNC_SRC)/lyra-quadlet-sync.timer"   "$(QUADLET_SYNC_DST)/"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-quadlet-sync.service"      "$(QUADLET_SYNC_DST)/"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-quadlet-sync.timer"        "$(QUADLET_SYNC_DST)/"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-post-autoupdate.service"  "$(QUADLET_SYNC_DST)/"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-post-autoupdate.timer"    "$(QUADLET_SYNC_DST)/"
+	@cp "$(QUADLET_SYNC_SRC)/lyra-deploy-failure.service"    "$(QUADLET_SYNC_DST)/"
 	@echo "Sync units copied to $(QUADLET_SYNC_DST)"
 	@systemctl --user daemon-reload
 	@systemctl --user enable lyra-quadlet-sync.timer
-	@echo "[ok] lyra-quadlet-sync.timer enabled."
+	@systemctl --user enable lyra-post-autoupdate.timer
+	@echo "[ok] lyra-quadlet-sync.timer + lyra-post-autoupdate.timer enabled."
 
 quadlet-authconf-merged:  ## render merged auth.conf (lyra + voicecli identities) → ~/.lyra/nkeys/auth.conf
 	@lyra-acl genkeys --emit-merged-authconf
@@ -227,6 +231,7 @@ quadlet-secrets-install:  ## (re)create Podman secrets from ~/.lyra/nkeys/*
 # ── Deploy + remote ──────────────────────────────────────────────────────────
 
 deploy:
+	@echo "DEPRECATED: use make converge"
 	$(require_machine1)
 	@echo "Deploying quadlet units to $(DEPLOY_HOST)..."
 	@ssh $(DEPLOY_HOST) '\
@@ -250,6 +255,7 @@ deploy:
 	echo "To restart: make remote lyra reload  (or: systemctl --user restart voicecli-tts voicecli-stt)"'
 
 full-deploy:  ## atomic deploy: git pull → quadlet-install → regen auth.conf → secrets → restart NATS → restart lyra
+	@echo "DEPRECATED: use make converge"
 	$(require_machine1)
 	@echo "Full deploy to $(DEPLOY_HOST)..."
 	@ssh $(DEPLOY_HOST) '\
@@ -281,6 +287,9 @@ full-deploy:  ## atomic deploy: git pull → quadlet-install → regen auth.conf
 	echo ""; \
 	echo "Full deploy complete."'
 
+converge:  ## atomic, idempotent, change-gated local deploy
+	@bash deploy/converge.sh
+
 # make remote [service] [action]
 #   service: lyra or empty → all lyra-* + voicecli-* units | <shortname> → lyra-<shortname>
 #   action:  reload | start | stop | status (default) | logs | errors
@@ -310,7 +319,7 @@ remote:
 # Shared list of services that hold NATS subject auth and must restart
 # whenever `auth.conf` is regenerated or a new identity is added. The bare
 # `lyra-nats` is restarted separately by the target itself before this list.
-LYRA_NATS_CLIENTS := lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper
+LYRA_NATS_CLIENTS := lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper lyra-blobstore
 
 nats-setup:
 	@bash deploy/nats/setup.sh

--- a/artifacts/analyses/1578-collapse-deploy-atomic-analysis.mdx
+++ b/artifacts/analyses/1578-collapse-deploy-atomic-analysis.mdx
@@ -1,0 +1,121 @@
+---
+title: "Collapse deploy to one atomic verb wired to autoupdate"
+description: "Analysis of deploy target collapse and autoupdate atomicity gap"
+---
+
+## Source
+
+> Overlapping deploy paths today: deploy, full-deploy, quadlet-install, quadlet-sync-install, nats-regen-authconf, nats-setup, install.sh, provision.sh, lyra-quadlet-sync.sh, setup.py (28 make targets total). Image autoupdate (image-only) silently wins and leaves git/auth.conf/units stale — the root cause of the 2026-05-31 incident.
+>
+> Do: collapse to one `make deploy` (pull -> render -> regen auth.conf -> secrets -> restart, atomic), triggered on staging merge / from the autoupdate hook so config converges with code. Fix non-interactive PATH (.venv/bin for lyra-acl/uv/lyra) so it runs headless without aborting half-applied.
+
+— Issue #1578, 2026-05-31
+
+## Problem
+
+1. **Target proliferation:** The Makefile has 28 targets, with 9+ related to deploy/install. `deploy` and `full-deploy` are similar but differ in whether they regen auth.conf/secrets/restart. This creates operator confusion and the risk of using the wrong verb.
+
+2. **Autoupdate gap:** `lyra-quadlet-sync.sh` runs every 5 minutes and only calls `make quadlet-install` when `deploy/quadlet/`, `Makefile`, or `tools/render_quadlet.py` changed. It does **not** detect image digest changes. `podman-auto-update.timer` (daily) restarts containers when the image changes, but leaves git checkout, auth.conf, and Quadlet units stale. This was the root cause of the 2026-05-31 incident.
+
+3. **PATH fragility:** `lyra-quadlet-sync.service` sets `PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin`. It does **not** include `.venv/bin`, where `lyra-acl` (used by `nats-regen-authconf` and `full-deploy`) lives. Running headless causes "command not found" mid-deploy, leaving the system half-converged.
+
+4. **voiceCLI convergence gap:** `full-deploy` currently pulls and installs `voiceCLI` units too. The new atomic verb must handle this or document the gap.
+
+## Outcome
+
+Any deploy trigger (staging merge, autoupdate, or manual operator action) converges the host to a single atomic verb: `make converge`. The host always matches HEAD after the verb completes. No half-applied states. No operator confusion about which target to run.
+
+## Appetite
+
+1-week cycle (single deploy/infrastructure change, no new services).
+
+## Shapes
+
+### Shape 1: Expand sync script to full converge
+
+Modify `lyra-quadlet-sync.sh` to run the complete sequence (git pull → render → regen auth.conf → secrets → restart) instead of only `make quadlet-install`. Add image-digest change detection to the script. Fix PATH in `lyra-quadlet-sync.service`.
+
+**Trade-offs:**
+- Pro: Minimal file changes (1 script + 1 service file). Reuses existing 5-minute timer.
+- Con: Still polling-based (5-minute latency). Script grows monolithic. No clear separation between "sync" and "deploy" semantics.
+
+**Rough scope:** S
+
+### Shape 2: New atomic `make converge` + wire sync and autoupdate to it
+
+Create a new `make converge` target (renamed from `make deploy` to avoid collision with the existing remote SSH target) that is idempotent and atomic: `git pull → quadlet-install → nats-regen-authconf → secrets-install → restart`. Modify `lyra-quadlet-sync.sh` to call `make converge` (instead of `make quadlet-install`). Add a post-autoupdate systemd unit (`lyra-post-autoupdate.service`) that runs after `podman-auto-update.service` and calls `make converge`. Fix PATH in both service files. Deprecate `deploy`, `full-deploy`, and other overlapping targets. Add `flock` lockfile to prevent concurrent execution. Add `OnFailure` unit for failure notification.
+
+**Trade-offs:**
+- Pro: Clean separation — one verb, one semantics. Event-driven (sync timer + autoupdate). Idempotent and safe to run multiple times.
+- Con: Requires creating a new systemd unit and understanding `podman-auto-update` integration. More moving parts.
+
+**Rough scope:** M
+
+### Shape 3: Make `converge` the only verb, delete the rest
+
+Collapse `deploy`, `full-deploy`, `quadlet-install`, `quadlet-sync-install`, `nats-regen-authconf`, `nats-setup`, `install.sh`, `provision.sh`, `lyra-quadlet-sync.sh`, `setup.py` into a single `make converge` that handles all converge logic. Delete or alias the other 27 targets.
+
+**Trade-offs:**
+- Pro: Ultimate simplicity. One verb to rule them all.
+- Con: High blast radius. Operator workflows (e.g. `make quadlet-install NO_RESTART=1`) break. Rollback impossible if the new target is buggy.
+
+**Rough scope:** L
+
+## Fit Check
+
+**Recommended: Shape 2.**
+
+- Shape 1 is too minimal — it doesn't solve the semantic confusion (28 targets remain) and the script becomes monolithic.
+- Shape 3 is too aggressive — it breaks existing workflows and introduces high rollback risk.
+- Shape 2 creates the single atomic verb while preserving existing targets during the transition. It wires both the sync timer and autoupdate to the same verb, ensuring config always converges with code.
+
+**Constraint alignment:**
+- Atomicity: `make converge` uses `set -euo pipefail` and stops on failure. No rollback yet (deferred), but failure state is clear — services are NOT restarted, leaving the host in a known pre-restart state.
+- Headless: PATH fix includes `%h/projects/lyra/.venv/bin` explicitly in both service files.
+- Staging merge + autoupdate: both call `make converge`.
+- Non-breaking: existing targets remain (deprecated but functional) until the new verb is proven.
+- Concurrency: `flock` lockfile (`/run/user/$(id -u)/lyra-deploy.lock`) prevents double-deploy.
+- Failure notification: `lyra-deploy-failure.service` triggered by `OnFailure` sends notification.
+
+## Files Impacted
+
+| File | Role | Change |
+|------|------|--------|
+| `Makefile` | Define `make converge`, deprecate old targets, add `flock` | Modify |
+| `deploy/lyra-quadlet-sync.sh` | Call `make converge` instead of `make quadlet-install` | Modify |
+| `deploy/systemd/lyra-quadlet-sync.service` | Add `.venv/bin` to PATH | Modify |
+| `deploy/systemd/lyra-post-autoupdate.service` | New unit: run `make converge` after `podman-auto-update` | Create |
+| `deploy/systemd/lyra-post-autoupdate.timer` | New timer: check image digest and trigger deploy | Create |
+| `deploy/systemd/lyra-deploy-failure.service` | New unit: `OnFailure` notification | Create |
+| `deploy/CLAUDE.md` | Document new deploy verb and autoupdate wiring | Modify |
+| `deploy/lib/deploy-common.sh` | New shared library: `flock` wrapper, PATH setup, failure hook | Create |
+
+## Mermaid: Deploy Flow (Shape 2)
+
+```mermaid
+flowchart TD
+    subgraph Triggers
+        A[Staging merge / CI push] --> B[Image published to GHCR]
+        C[lyra-quadlet-sync.timer 5min] --> D[lyra-quadlet-sync.service]
+        E[podman-auto-update.timer] --> F[podman-auto-update.service]
+        F --> G[lyra-post-autoupdate.service]
+    end
+    D --> H[make converge]
+    G --> H
+    H --> I[git pull origin staging]
+    I --> J[make quadlet-install]
+    J --> K[lyra-acl genkeys --regen-authconf]
+    K --> L[make quadlet-secrets-install]
+    L --> M[systemctl restart lyra-nats]
+    M --> N[systemctl restart lyra-hub lyra-telegram lyra-discord lyra-clipool]
+    N --> O[make remote voicecli reload]
+    H -.->|OnFailure| P[lyra-deploy-failure.service]
+```
+
+## Unresolved Concerns
+
+1. **podman-auto-update integration:** `podman-auto-update.service` is a system unit (not user). A `OnSuccess` drop-in for the user instance may not fire. Verified approach: `lyra-post-autoupdate.timer` polls `podman images` digest against GHCR every 5 minutes (same cadence as sync), and `lyra-post-autoupdate.service` runs `make converge` when a change is detected.
+2. **Atomicity edge case:** If `git pull` succeeds but `nats-regen-authconf` fails, the host has new code but stale auth. `make converge` stops before restart. No rollback mechanism yet (deferred). Operator must manually run `make nats-regen-authconf` and `make converge` again.
+3. **Sudo in headless service:** `full-deploy` currently runs `sudo env "PATH=$$PATH" lyra-acl genkeys --regen-authconf`. The new `make converge` must run `lyra-acl` without sudo (or the service must have passwordless sudo for `lyra-acl`). The `nats-regen-authconf` Makefile target already runs `lyra-acl` without sudo, so this is consistent.
+4. **`lyra bot init` fragility:** `make quadlet-install` runs `uv run lyra bot init`. Memory notes this currently throws pydantic validation errors on re-seed; a mid-deploy failure here leaves units copied but not verified. `make converge` must tolerate this step (e.g., `|| true` with explicit warning) or fix it first.
+5. **voiceCLI convergence:** `make converge` should include `voiceCLI` pull + quadlet-install if `VOICE_DIR` is present. This is optional for the first iteration but should be documented.

--- a/artifacts/frames/1578-collapse-deploy-atomic-frame.mdx
+++ b/artifacts/frames/1578-collapse-deploy-atomic-frame.mdx
@@ -1,0 +1,44 @@
+---
+title: Collapse deploy to one atomic verb wired to autoupdate
+issue: 1578
+status: approved
+tier: F-full
+date: 2026-05-31
+---
+
+## Problem
+
+Today Lyra has 28 overlapping deploy targets in the Makefile (deploy, full-deploy, quadlet-install, quadlet-sync-install, nats-regen-authconf, nats-setup, install.sh, provision.sh, lyra-quadlet-sync.sh, setup.py, and others). Image autoupdate (image-only) silently wins and leaves git checkout, auth.conf, and Quadlet units stale. This was the root cause of the 2026-05-31 incident where the host ran an outdated config layer while the image was fresh.
+
+Additionally, non-interactive PATH is broken: `.venv/bin` for `lyra-acl`, `uv`, and `lyra` is not available in headless contexts, causing partial deploy aborts mid-run.
+
+## Who
+
+- **Primary:** Mickael (ops, deploys on M1 roxabituwer)
+- **Secondary:** Autoupdate hook (systemd timer, headless)
+
+## Constraints
+
+- Must remain atomic: partial deploy must leave host in a recoverable state
+- Must work headless (non-interactive shell, no PATH assumptions)
+- Must converge on staging merge AND on autoupdate trigger
+- Must not break existing deploy targets until the new verb is proven
+
+## Out of Scope
+
+- Multi-host deploy (M1 only, M2 out-of-scope)
+- Rollback mechanism (not required for this iteration)
+- CI/CD pipeline changes (GitHub Actions stay as-is)
+
+## Premise Validity
+
+**Success in 6 months:** Host config always matches HEAD after any deploy trigger (staging merge, autoupdate, manual). Single `make deploy` verb converges git → render → regen auth.conf → secrets → restart atomically. No half-applied states. PATH fixed for headless.
+
+**Failure in 6 months:** Another incident where image autoupdate leaves git/auth.conf/units stale (measurable: >0 stale-unit alerts per month). 28 make targets still in Makefile. PATH still breaks non-interactive runs.
+
+**Simplest alternative:** Fix PATH only + add a manual post-autoupdate hook script.
+**Why not:** Doesn't collapse the 28-target confusion to one verb; deploy still non-atomic (can abort mid-way); future operators still don't know which target to run.
+
+## Complexity
+
+**Tier: F-full** — Multi-domain: deploy scripts + Makefile + autoupdate hook + PATH headless fix; atomicity requirement = cross-domain coordination.

--- a/artifacts/plans/1578-collapse-deploy-atomic-plan.mdx
+++ b/artifacts/plans/1578-collapse-deploy-atomic-plan.mdx
@@ -1,0 +1,400 @@
+---
+title: "Plan: Collapse deploy to one atomic verb wired to autoupdate"
+issue: 1578
+spec: artifacts/specs/1578-collapse-deploy-atomic-spec.mdx
+complexity: 5/10
+tier: F-full
+generated: "2026-05-31T21:45:00Z"
+---
+
+## Summary
+
+Implement `make converge` as the single atomic deploy verb for Lyra on M₁. Wire it to both the existing sync timer (`lyra-quadlet-sync`) and a new autoupdate digest poll (`lyra-post-autoupdate`). Add `flock` concurrency guard, `OnFailure` journal notification, and PATH fix for `.venv/bin`.
+
+## Architecture
+
+### Data Flow
+
+```mermaid
+flowchart TD
+    subgraph "Host"
+        GIT[git HEAD] --> CONV[make converge]
+        UNITS[unit checksums] --> CONV
+        AUTH[auth.conf SHA] --> CONV
+        IMAGE[image digest] --> CONV
+    end
+    subgraph "Scripts"
+        DCS[deploy-common.sh] --> CONV
+        SYNC[lyra-quadlet-sync.sh] --> CONV
+        AUTO[lyra-post-autoupdate.sh] --> CONV
+    end
+    CONV --> RESULT{Success?}
+    RESULT -->|Yes| RESTART[systemctl restart]
+    RESULT -->|No| FAIL[lyra-deploy-failure.service]
+```
+
+### File x Function Map
+
+```mermaid
+flowchart LR
+    subgraph "Makefile"
+        M1[make converge]
+        M2[make quadlet-install]
+        M3[make quadlet-secrets-install]
+        M4[make quadlet-sync-install]
+        M5[deploy, full-deploy deprecated]
+    end
+    subgraph "deploy/lib/"
+        L1[deploy-common.sh]
+    end
+    subgraph "deploy/"
+        S1[lyra-quadlet-sync.sh]
+        S2[lyra-post-autoupdate.sh]
+    end
+    subgraph "deploy/systemd/"
+        U1[lyra-quadlet-sync.service]
+        U2[lyra-post-autoupdate.service]
+        U3[lyra-post-autoupdate.timer]
+        U4[lyra-deploy-failure.service]
+    end
+    L1 --> S1
+    L1 --> S2
+    M1 --> M2
+    M1 --> M3
+    M4 --> U2
+    M4 --> U3
+    M4 --> U4
+    S1 --> M1
+    S2 --> M1
+```
+
+## Bootstrap Context
+
+From [analysis](artifacts/analyses/1578-collapse-deploy-atomic-analysis.mdx): Shape 2 recommended. The new `make converge` target is change-gated, idempotent, and atomic. `flock -n` prevents concurrency. `lyra-post-autoupdate` replaces `podman-auto-update` for lyra units by polling digest directly. PATH fix includes `.venv/bin`.
+
+## Agents
+
+| Agent | Task count | Files |
+|-------|-----------|-------|
+| devops-A | 6 | Makefile, deploy/lib/deploy-common.sh, deploy/lyra-quadlet-sync.sh |
+| devops-B | 5 | deploy/systemd/*, deploy/quadlet/*.container |
+| doc-writer | 1 | deploy/CLAUDE.md |
+| tester | 5 | Verification scripts |
+
+## Wave Structure
+
+4 waves, max 3 parallel agents. Elapsed ~1 day vs ~3 days sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | devops-A: T1→T2→T3 · devops-B: T5→T7→T8→T9 · doc-writer: T12 |
+| 2 | Wave 1 done | 2 ∥ | devops-A: T4→T10→T11 · devops-B: T6 |
+| 3 | Wave 2 done | 1 | devops-B: T13 |
+| 4 | Wave 3 done | 1 | tester: T14→T15→T16→T17→T18 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 deploy-common.sh | 1 | bounded | 3 | — |
+| T2 make converge | 1 | judgmental | 6 | — |
+| T3 restart list | 1 | trivial | 1 | — |
+| T4 sync script | 1 | bounded | 3 | — |
+| T5 sync service PATH | 1 | trivial | 1 | — |
+| T6 post-autoupdate script | 1 | judgmental | 5 | — |
+| T7 post-autoupdate service | 1 | bounded | 2 | — |
+| T8 post-autoupdate timer | 1 | trivial | 1 | — |
+| T9 failure service | 1 | bounded | 2 | — |
+| T10 quadlet-sync-install | 1 | bounded | 2 | — |
+| T11 deprecate targets | 1 | trivial | 1 | — |
+| T12 update docs | 1 | bounded | 2 | — |
+| T13 remove labels | 1 | trivial | 2 | — |
+| T14 verify converge | 1 | bounded | 3 | — |
+| T15 verify idempotency | 1 | bounded | 2 | — |
+| T16 verify flock | 1 | bounded | 2 | — |
+| T17 verify change detection | 1 | bounded | 2 | — |
+| T18 verify PATH | 1 | bounded | 2 | — |
+
+**Total estimated ops: 40**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1, T2, T3, T4, T10, T11 | 16 | deploy-script, makefile | — |
+| devops-B | T5, T6, T7, T8, T9, T13 | 13 | systemd, container-config | — |
+| doc-writer | T12 | 2 | docs | — |
+| tester | T14-T18 | 11 | verification | — |
+
+## Consistency Report
+
+- Criteria covered: 17/17
+- Uncovered criteria: none
+- Tasks without spec backing: none
+- Gold plating exemptions applied: 0
+
+## Micro-Tasks
+
+### Slice V1: make converge target + shared library
+
+#### Task 1: Create deploy/lib/deploy-common.sh [P] → devops-A
+- **File:** `deploy/lib/deploy-common.sh`
+- **Snippet:** `flock -n /run/user/$(id -u)/lyra-deploy.lock ...`
+- **Verify:** `bash -n deploy/lib/deploy-common.sh`
+- **Expected:** no syntax errors
+- **Time:** 3 min
+- **Difficulty:** 2
+- **Traces:** SC-5, SC-6
+- **Phase:** RED
+
+#### Task 2: Add make converge to Makefile → devops-A
+- **File:** `Makefile`
+- **Snippet:** `converge: ...` with change detection, git pull, NO_RESTART=1, regen, secrets, restart
+- **Verify:** `make -n converge` (dry run)
+- **Expected:** shows all commands without errors
+- **Time:** 6 min
+- **Difficulty:** 3
+- **Traces:** SC-1, SC-2, SC-3, SC-4, SC-15
+- **Phase:** RED
+
+#### Task 3: Add lyra-blobstore to restart list → devops-A
+- **File:** `Makefile`
+- **Snippet:** `LYRA_RESTART_UNITS := lyra-hub ... lyra-blobstore`
+- **Verify:** `grep lyra-blobstore Makefile`
+- **Expected:** line found
+- **Time:** 1 min
+- **Difficulty:** 1
+- **Traces:** SC-16
+- **Phase:** RED
+
+#### RED-GATE: V1 complete → tester
+- **Verify:** T1-T3 marked complete
+- **Phase:** RED-GATE
+
+### Slice V2: Sync script wiring
+
+#### Task 4: Modify lyra-quadlet-sync.sh → devops-A
+- **File:** `deploy/lyra-quadlet-sync.sh`
+- **Snippet:** `source deploy/lib/deploy-common.sh; converge_if_changed`
+- **Verify:** `bash -n deploy/lyra-quadlet-sync.sh`
+- **Expected:** no syntax errors
+- **Time:** 3 min
+- **Difficulty:** 2
+- **Traces:** SC-7
+- **Phase:** RED
+
+#### Task 5: Fix PATH in sync service → devops-B
+- **File:** `deploy/systemd/lyra-quadlet-sync.service`
+- **Snippet:** `Environment="PATH=%h/projects/lyra/.venv/bin:%h/.local/bin:..."`
+- **Verify:** `grep .venv/bin deploy/systemd/lyra-quadlet-sync.service`
+- **Expected:** line found
+- **Time:** 1 min
+- **Difficulty:** 1
+- **Traces:** SC-8
+- **Phase:** RED
+
+#### RED-GATE: V2 complete → tester
+- **Verify:** T4-T5 marked complete
+- **Phase:** RED-GATE
+
+### Slice V3: Autoupdate digest poll
+
+#### Task 6: Create lyra-post-autoupdate.sh → devops-A
+- **File:** `deploy/lyra-post-autoupdate.sh`
+- **Snippet:** `skopeo inspect docker://ghcr.io/roxabi/lyra:staging-svc | jq -r '.Digest'`
+- **Verify:** `bash -n deploy/lyra-post-autoupdate.sh`
+- **Expected:** no syntax errors
+- **Time:** 5 min
+- **Difficulty:** 3
+- **Traces:** SC-9, SC-10
+- **Phase:** RED
+
+#### Task 7: Create lyra-post-autoupdate.service → devops-B
+- **File:** `deploy/systemd/lyra-post-autoupdate.service`
+- **Snippet:** `[Service] Type=oneshot ExecStart=...`
+- **Verify:** `grep -q "lyra-post-autoupdate.sh" deploy/systemd/lyra-post-autoupdate.service`
+- **Expected:** line found
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-10
+- **Phase:** RED
+
+#### Task 8: Create lyra-post-autoupdate.timer → devops-B
+- **File:** `deploy/systemd/lyra-post-autoupdate.timer`
+- **Snippet:** `[Timer] OnCalendar=*:0/5`
+- **Verify:** `grep -q "OnCalendar" deploy/systemd/lyra-post-autoupdate.timer`
+- **Expected:** line found
+- **Time:** 1 min
+- **Difficulty:** 1
+- **Traces:** SC-9
+- **Phase:** RED
+
+#### RED-GATE: V3 complete → tester
+- **Verify:** T6-T8 marked complete
+- **Phase:** RED-GATE
+
+### Slice V4: Failure notification
+
+#### Task 9: Create lyra-deploy-failure.service → devops-B
+- **File:** `deploy/systemd/lyra-deploy-failure.service`
+- **Snippet:** `[Unit] OnFailure=... [Service] ExecStart=logger...`
+- **Verify:** `grep -q "OnFailure" deploy/systemd/lyra-deploy-failure.service`
+- **Expected:** line found
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-11
+- **Phase:** RED
+
+#### RED-GATE: V4 complete → tester
+- **Verify:** T9 marked complete
+- **Phase:** RED-GATE
+
+### Slice V5: Unit installation + deprecation
+
+#### Task 10: Expand quadlet-sync-install → devops-A
+- **File:** `Makefile`
+- **Snippet:** `quadlet-sync-install: ... cp lyra-post-autoupdate.* ...`
+- **Verify:** `grep -q "lyra-post-autoupdate" Makefile`
+- **Expected:** line found
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-12
+- **Phase:** RED
+
+#### Task 11: Deprecate deploy and full-deploy → devops-A
+- **File:** `Makefile`
+- **Snippet:** `deploy: ; @echo "DEPRECATED: use make converge"`
+- **Verify:** `make deploy`
+- **Expected:** deprecation warning printed
+- **Time:** 1 min
+- **Difficulty:** 1
+- **Traces:** SC-13
+- **Phase:** RED
+
+#### Task 12: Update deploy/CLAUDE.md → doc-writer
+- **File:** `deploy/CLAUDE.md`
+- **Snippet:** Document `make converge` and trigger wiring
+- **Verify:** `grep -q "make converge" deploy/CLAUDE.md`
+- **Expected:** line found
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-14
+- **Phase:** RED
+
+#### Task 13: Remove autoupdate labels from container files → devops-B
+- **File:** `deploy/quadlet/*.container`
+- **Snippet:** Remove `Label=io.containers.autoupdate=registry`
+- **Verify:** `grep -q "autoupdate=registry" deploy/quadlet/*.container || echo "none found"`
+- **Expected:** "none found"
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-10 (related)
+- **Phase:** RED
+
+#### RED-GATE: V5 complete → tester
+- **Verify:** T10-T13 marked complete
+- **Phase:** RED-GATE
+
+### Verification
+
+#### Task 14: Verify make converge runs → tester
+- **Verify:** `make converge` (dry-run or in test env)
+- **Expected:** completes without error
+- **Time:** 3 min
+- **Difficulty:** 2
+- **Traces:** SC-1
+- **Phase:** GREEN
+
+#### Task 15: Verify idempotency → tester
+- **Verify:** Run `make converge` twice
+- **Expected:** second run exits 0 with no changes
+- **Time:** 2 min
+- **Difficulty:** 2
+- **Traces:** SC-2
+- **Phase:** GREEN
+
+#### Task 16: Verify flock → tester
+- **Verify:** `flock -n /run/user/$(id -u)/lyra-deploy.lock sleep 5 &` then `make converge`
+- **Expected:** second invocation exits 0 silently
+- **Time:** 2 min
+- **Difficulty:** 2
+- **Traces:** SC-4
+- **Phase:** GREEN
+
+#### Task 17: Verify change detection → tester
+- **Verify:** `make converge` when no changes exist
+- **Expected:** exits 0 immediately
+- **Time:** 2 min
+- **Difficulty:** 2
+- **Traces:** SC-3
+- **Phase:** GREEN
+
+#### Task 18: Verify PATH fix → tester
+- **Verify:** `systemctl --user cat lyra-quadlet-sync.service | grep .venv/bin`
+- **Expected:** `.venv/bin` in PATH
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-17
+- **Phase:** GREEN
+
+## Task Seeding Blueprint
+
+### Wave 1 — no deps, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | deploy-script |
+| T2 | devops-A | — | makefile |
+| T3 | devops-A | — | makefile |
+| T5 | devops-B | — | systemd |
+| T7 | devops-B | — | systemd |
+| T8 | devops-B | — | systemd |
+| T9 | devops-B | — | systemd |
+| T12 | doc-writer | — | docs |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | devops-A | T1, T2 | deploy-script |
+| T6 | devops-A | T1, T2 | deploy-script |
+| T10 | devops-A | T2 | makefile |
+| T11 | devops-A | T2 | makefile |
+
+### Wave 3 — after Wave 2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | devops-B | T7, T8 | container-config |
+
+### Wave 4 — after Wave 3, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T14 | tester | T2, T4 | verification |
+| T15 | tester | T2, T4 | verification |
+| T16 | tester | T2, T4 | verification |
+| T17 | tester | T2, T4 | verification |
+| T18 | tester | T5 | verification |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: #14 — deploy-script
+- T2: #15 — makefile
+- T3: #16 — makefile
+- T4: #17 — deploy-script
+- T5: #18 — systemd
+- T6: #19 — deploy-script
+- T7: #20 — systemd
+- T8: #21 — systemd
+- T9: #22 — systemd
+- T10: #23 — makefile
+- T11: #24 — makefile
+- T12: #25 — docs
+- T13: #26 — container-config
+- T14: #27 — verification
+- T15: #28 — verification
+- T16: #29 — verification
+- T17: #30 — verification
+- T18: #31 — verification

--- a/artifacts/specs/1578-collapse-deploy-atomic-spec.mdx
+++ b/artifacts/specs/1578-collapse-deploy-atomic-spec.mdx
@@ -1,0 +1,149 @@
+---
+title: "Collapse deploy to one atomic verb wired to autoupdate"
+issue: 1578
+status: approved
+promoted_from: "artifacts/analyses/1578-collapse-deploy-atomic-analysis.mdx"
+date: 2026-05-31
+---
+
+## Context
+
+Promoted from [analysis](artifacts/analyses/1578-collapse-deploy-atomic-analysis.mdx) — Shape 2 recommended (new atomic `make converge` + dual wiring to sync timer and autoupdate).
+
+## Goal
+
+Any deploy trigger (staging merge, autoupdate, or manual) converges the host to HEAD via a single idempotent verb: `make converge`.
+
+## Users
+
+- **Primary:** Mickael (operator, deploys on M₁ roxabituwer)
+- **Secondary:** Autoupdate hook (`lyra-post-autoupdate.timer`, headless, no human intervention)
+
+## Expected Behavior
+
+1. **Manual trigger:** Operator runs `make converge` on M₁. The verb:
+   - Checks if host is already converged (git HEAD = origin/staging, unit files unchanged, auth.conf fresh, image digest current). If yes, exits 0.
+   - Pulls `origin/staging` for `lyra` (and `voiceCLI` if `VOICE_DIR` is present)
+   - Runs `make quadlet-install NO_RESTART=1` (render units, daemon-reload, no restart)
+   - If `voiceCLI` is present, runs `make -C "$$VOICE_DIR" quadlet-install NO_RESTART=1`
+   - Runs `lyra-acl genkeys --regen-authconf`
+   - Runs `make quadlet-secrets-install`
+   - Restarts `lyra-nats` (first, to refresh `type=mount` secrets)
+   - Restarts `lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper lyra-blobstore`
+   - If `voiceCLI` is present, restarts `voicecli-tts voicecli-stt`
+   - Uses `flock -n` to prevent concurrent runs (exits 0 if another converge is in progress)
+   - Stops on any failure (`set -euo pipefail`) before restart
+
+2. **Sync timer trigger:** `lyra-quadlet-sync.timer` (5 min) fires → `lyra-quadlet-sync.service` checks if `lyra` git HEAD differs from `origin/staging` OR if `deploy/quadlet/`, `Makefile`, or `tools/render_quadlet.py` changed. If yes → runs `make converge`.
+
+3. **Autoupdate trigger:** `lyra-post-autoupdate.timer` (5 min) checks if the local `ghcr.io/roxabi/lyra:staging-svc` digest differs from GHCR (via `skopeo inspect` or `podman manifest inspect`). If yes → `lyra-post-autoupdate.service` pulls the new image and runs `make converge`.
+
+4. **Failure notification:** If `make converge` fails, `lyra-deploy-failure.service` (triggered by `OnFailure`) logs to journal. A follow-up issue will add Telegram/Discord alerting (deferred, out of scope for this cycle).
+
+5. **PATH fix:** Both `lyra-quadlet-sync.service` and `lyra-post-autoupdate.service` include `%h/projects/lyra/.venv/bin` in `PATH`, making `lyra-acl`, `uv`, and `lyra` available headless.
+
+6. **Unit installation:** New systemd units (`lyra-post-autoupdate.service`, `lyra-post-autoupdate.timer`, `lyra-deploy-failure.service`) are installed by `make quadlet-sync-install` (expanded to include these units).
+
+## Data Model & Consumers
+
+This issue does not introduce new data structures. It modifies the deploy state machine and trigger wiring. The relevant state is:
+
+| State | Source | Consumer | Change Detection |
+|-------|--------|----------|------------------|
+| Git HEAD SHA | `git rev-parse HEAD` | `make converge` | `git rev-parse origin/staging` |
+| Image digest | `podman images --digests` | `lyra-post-autoupdate` | `skopeo inspect` vs GHCR |
+| auth.conf SHA | `sha256sum ~/.lyra/nkeys/auth.conf` | `make converge` | Compare before/after regen |
+| Unit file checksums | `md5sum ~/.config/containers/systemd/lyra-*` | `make converge` | Compare before/after install |
+
+```mermaid
+flowchart TD
+    subgraph Host State
+        G[Git HEAD] --> C[make converge]
+        A[auth.conf] --> C
+        U[Unit files] --> C
+    end
+    I[Image digest] --> P[lyra-post-autoupdate]
+    P --> C
+    S[lyra-quadlet-sync] --> C
+    M[Manual operator] --> C
+    C --> F{Failure?}
+    F -->|Yes| N[lyra-deploy-failure.service]
+    F -->|No| R[Restart services]
+```
+
+## Breadboard
+
+### Affordance Table
+
+| ID | Affordance | Type | Where | Notes |
+|----|------------|------|-------|-------|
+| N1 | `make converge` | Target | Makefile | New atomic verb. Change-gated, idempotent. |
+| N2 | `deploy/lib/deploy-common.sh` | Script | `deploy/lib/` | Shared: `flock` wrapper, PATH export, change detection helpers. |
+| N3 | `lyra-quadlet-sync.sh` | Script | `deploy/` | Modified: change-gated, calls `make converge`. |
+| N4 | `lyra-quadlet-sync.service` | Unit | `deploy/systemd/` | Modified: PATH includes `.venv/bin`. |
+| N5 | `lyra-post-autoupdate.service` | Unit | `deploy/systemd/` | New: digest check + `make converge`. |
+| N6 | `lyra-post-autoupdate.timer` | Unit | `deploy/systemd/` | New: 5-minute poll for image digest changes. |
+| N7 | `lyra-deploy-failure.service` | Unit | `deploy/systemd/` | New: `OnFailure` journal notification. |
+| N8 | `lyra-post-autoupdate.sh` | Script | `deploy/` | New: digest check logic, calls `make converge`. |
+| S1 | `deploy`, `full-deploy` | Target | Makefile | Deprecated (still functional, print warning). |
+
+### Wiring
+
+```mermaid
+flowchart TD
+    subgraph Makefile
+        M1[make converge] --> M2[git pull]
+        M1 --> M3[make quadlet-install NO_RESTART=1]
+        M1 --> M4[lyra-acl genkeys --regen-authconf]
+        M1 --> M5[make quadlet-secrets-install]
+        M1 --> M6[systemctl restart lyra-*]
+    end
+    subgraph Scripts
+        S1[lyra-quadlet-sync.sh] --> M1
+        S2[deploy-common.sh] --> S1
+        S2 --> S3[lyra-post-autoupdate.sh]
+        S3 --> M1
+    end
+    subgraph Systemd
+        T1[lyra-quadlet-sync.timer] --> T2[lyra-quadlet-sync.service]
+        T3[lyra-post-autoupdate.timer] --> T4[lyra-post-autoupdate.service]
+        T4 --> S3
+        T2 --> S1
+        M1 -.->|OnFailure| T5[lyra-deploy-failure.service]
+    end
+```
+
+## Slices
+
+| # | Slice | Files | Demo-able |
+|---|-------|-------|-----------|
+| 1 | `make converge` target + shared library | `Makefile`, `deploy/lib/deploy-common.sh` | `make converge` runs locally, idempotent on second run |
+| 2 | Sync script wiring | `deploy/lyra-quadlet-sync.sh`, `deploy/systemd/lyra-quadlet-sync.service` | Timer detects code change and triggers `make converge` |
+| 3 | Autoupdate digest poll | `deploy/systemd/lyra-post-autoupdate.service`, `deploy/systemd/lyra-post-autoupdate.timer`, `deploy/lyra-post-autoupdate.sh` | Timer detects image digest change and triggers `make converge` |
+| 4 | Failure notification | `deploy/systemd/lyra-deploy-failure.service` | `make converge` fails → journal notification fires |
+| 5 | Unit installation + deprecation | `Makefile`, `deploy/CLAUDE.md`, `deploy/systemd/lyra-quadlet-sync.sh` | New units installable via `make quadlet-sync-install`; old targets print deprecation |
+
+## Success Criteria
+
+- [ ] `make converge` exists in Makefile and runs the full sequence (git pull → quadlet-install NO_RESTART=1 → regen auth.conf → secrets → restart) without error on M₁
+- [ ] `make converge` is idempotent — running it twice when no changes exist exits 0 with no side effects
+- [ ] `make converge` detects changes before acting (git HEAD, unit checksums, auth.conf SHA, image digest)
+- [ ] `make converge` uses `flock -n` to prevent concurrent execution — second invocation exits 0 silently
+- [ ] `make converge` stops before restart if any step fails (`set -euo pipefail`)
+- [ ] `deploy/lib/deploy-common.sh` exists and provides `flock` wrapper, PATH setup, and change detection helpers
+- [ ] `lyra-quadlet-sync.sh` is change-gated and calls `make converge` when code changes
+- [ ] `lyra-quadlet-sync.service` includes `%h/projects/lyra/.venv/bin` in PATH
+- [ ] `lyra-post-autoupdate.timer` polls image digest every 5 minutes
+- [ ] `lyra-post-autoupdate.service` pulls the new image and runs `make converge` when digest changes
+- [ ] `lyra-deploy-failure.service` triggers on `OnFailure` and logs to journal
+- [ ] `deploy` and `full-deploy` targets print deprecation warning but still function
+- [ ] `make quadlet-sync-install` installs the new `lyra-post-autoupdate` and `lyra-deploy-failure` units
+- [ ] `deploy/CLAUDE.md` documents the new `make converge` verb and trigger wiring
+- [ ] voiceCLI pull + quadlet-install is included in `make converge` when `VOICE_DIR` is present
+- [ ] `lyra-turn-writer`, `lyra-gh-helper`, and `lyra-blobstore` are included in the restart list
+- [ ] No references to `lyra-acl`, `uv`, or `lyra` fail with "command not found" in headless service context
+
+## [NEEDS CLARIFICATION]
+
+1. **Failure notification channel:** `lyra-deploy-failure.service` logs to journal. A follow-up issue will add Telegram/Discord alerting. Is journal-only acceptable for the first iteration?
+2. **podman-auto-update interaction:** `lyra-post-autoupdate` replaces `podman-auto-update` for lyra units by checking digest + pulling directly. Should we remove `Label=io.containers.autoupdate=registry` from lyra container files to prevent double-updates?

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -84,6 +84,69 @@ on rotation events.
 
 ---
 
+## Atomic deploy — `make converge`
+
+`make converge` (→ `deploy/converge.sh`) is the **atomic, idempotent, change-gated** local
+deploy verb for M₁. It reconciles the running system with the desired state declared in
+`staging` (lyra + optionally voiceCLI) without operator intervention.
+
+### Properties
+
+| Property | Mechanism |
+|---|---|
+| **Change-gated** | Computes a convergence fingerprint (`git HEAD` + rendered Quadlet unit checksums + `auth.conf` SHA). If the current state matches the last recorded stamp (`~/.lyra/.converge-stamp`), the script exits immediately with `Already converged — nothing to do.` |
+| **Idempotent** | Running `make converge` twice on an unchanged tree is a no-op. Individual steps (git pull, `make quadlet-install`, `lyra-acl genkeys`, secret install, restarts) are each idempotent or guarded. |
+| **Atomic** | A `flock` file lock (`/run/user/<uid>/lyra-deploy.lock`) prevents concurrent converges. If the lock is held, the second invocation exits 0 silently. The full sequence (pull → install → regen auth → secrets → restart NATS → restart clients) is executed as a single critical section. |
+
+### Convergence sequence
+
+1. **Change-gate** — skip if already converged.
+2. **Pull** — `git pull origin staging` in `~/projects/lyra` (and `~/projects/voiceCLI` if present).
+3. **Install Quadlet units** — `make quadlet-install NO_RESTART=1` (renders units, copies to `~/.config/containers/systemd`, `daemon-reload`, seeds BotStore).
+4. **Regenerate auth.conf** — `lyra-acl genkeys --regen-authconf` (renders `nkeys/` → `auth.conf`).
+5. **Install secrets** — `make quadlet-secrets-install` (recreates Podman secrets from host key files).
+6. **Restart NATS** — `systemctl --user restart lyra-nats` (mount-typed secrets require container restart, not HUP, to refresh). Waits for `is-active`.
+7. **Restart lyra clients** — `lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-clipool`, `lyra-turn-writer`, `lyra-gh-helper`, `lyra-blobstore` (only if already active; any failure aborts the converge).
+8. **Restart voiceCLI** — `voicecli-tts`, `voicecli-stt` (if voiceCLI directory exists).
+9. **Record stamp** — writes the new convergence fingerprint to `~/.lyra/.converge-stamp`.
+
+### Trigger wiring
+
+Two systemd user timers drive convergence **automatically**:
+
+| Timer | Period | Service | Role |
+|---|---|---|---|
+| `lyra-quadlet-sync.timer` | `*:0/5` (5 min) | `lyra-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, `Makefile`, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
+| `lyra-post-autoupdate.timer` | `*:0/5` (5 min) | `lyra-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). |
+
+`lyra-quadlet-sync` handles **unit/template changes** (code-driven).
+`lyra-post-autoupdate` handles **image digest changes** (CI-driven).
+Both are required for fully hands-off deploys.
+
+### Failure notification path
+
+`lyra-quadlet-sync.service` and `lyra-post-autoupdate.service` both declare:
+
+```ini
+OnFailure=lyra-deploy-failure.service
+```
+
+`lyra-deploy-failure.service` is a `Type=oneshot` unit that logs a structured error message
+to the systemd journal via `systemd-cat` (tag `lyra-deploy-failure`, priority `err`).
+Monitor: `journalctl --user -t lyra-deploy-failure -f`
+
+### Manual usage
+
+```bash
+# Full atomic converge (operator-initiated)
+make converge
+
+# Check convergence state without changing anything
+bash -c 'source deploy/lib/deploy-common.sh; is_converged && echo "Converged" || echo "Drift"'
+```
+
+---
+
 ## Hardening invariants (∀ `.container` file)
 
 `NoNewPrivileges=true` | `ReadOnly=true` | `DropCapability=all`

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -116,7 +116,7 @@ Two systemd user timers drive convergence **automatically**:
 
 | Timer | Period | Service | Role |
 |---|---|---|---|
-| `lyra-quadlet-sync.timer` | `*:0/5` (5 min) | `lyra-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, `Makefile`, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
+| `lyra-quadlet-sync.timer` | `*:0/5` (5 min) | `lyra-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, Makefile, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
 | `lyra-post-autoupdate.timer` | `*:0/5` (5 min) | `lyra-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). |
 
 `lyra-quadlet-sync` handles **unit/template changes** (code-driven).

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# deploy/converge.sh — atomic, idempotent, change-gated deploy
+#
+# Usage: make converge
+# Or directly: bash deploy/converge.sh
+
+set -euo pipefail
+
+source "$(dirname "$0")/lib/deploy-common.sh"
+
+# Guard against concurrent runs (exit 0 if locked)
+with_deploy_lock _do_converge
+
+_do_converge() {
+    # 1) Change-gate: already converged?
+    if is_converged; then
+        echo "Already converged — nothing to do."
+        exit 0
+    fi
+
+    echo "==> Convergence drift detected — beginning deploy..."
+
+    # 2) Pull lyra staging
+    echo "==> lyra: pulling staging..."
+    (cd "${LYRA_DIR}" && git pull origin staging)
+
+    # 3) Install lyra quadlet units (no restart)
+    echo "==> lyra: installing quadlet units..."
+    make -C "${LYRA_DIR}" quadlet-install NO_RESTART=1
+
+    # 4) Pull voiceCLI if present
+    VOICE_DIR="${VOICE_DIR:-${HOME}/projects/voiceCLI}"
+    if [ -d "${VOICE_DIR}/.git" ]; then
+        echo "==> voiceCLI: pulling staging..."
+        (cd "${VOICE_DIR}" && git pull origin staging)
+        echo "==> voiceCLI: installing quadlet units..."
+        make -C "${VOICE_DIR}" quadlet-install NO_RESTART=1
+    fi
+
+    # 5) Regenerate auth.conf
+    echo "==> NATS: regenerating auth.conf..."
+    lyra-acl genkeys --regen-authconf
+
+    # 6) Install secrets
+    echo "==> NATS: installing Podman secrets..."
+    make -C "${LYRA_DIR}" quadlet-secrets-install
+
+    # 7) Restart NATS (mount-typed secret refresh requires restart)
+    echo "==> NATS: restarting lyra-nats..."
+    systemctl --user restart lyra-nats
+    systemctl --user is-active --wait lyra-nats \
+        || { echo "ERROR: lyra-nats failed to reach active state"; exit 1; }
+
+    # 8) Restart lyra NATS clients
+    echo "==> Lyra: restarting containers..."
+    local failed=""
+    for svc in lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper lyra-blobstore; do
+        if systemctl --user is-active --quiet "${svc}"; then
+            systemctl --user restart "${svc}" \
+                || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
+        fi
+    done
+    [ -z "${failed}" ] || { echo "ERROR: restart failed for:${failed}"; exit 1; }
+
+    # 9) Restart voiceCLI if present
+    if [ -d "${VOICE_DIR}/.git" ]; then
+        echo "==> voiceCLI: restarting containers..."
+        failed=""
+        for svc in voicecli-tts voicecli-stt; do
+            if systemctl --user is-active --quiet "${svc}"; then
+                systemctl --user restart "${svc}" \
+                    || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
+            fi
+        done
+        [ -z "${failed}" ] || { echo "ERROR: restart failed for:${failed}"; exit 1; }
+    fi
+
+    # 10) Record convergence stamp
+    write_convergence_state
+
+    echo "==> Converge complete."
+}

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -22,7 +22,7 @@ _do_converge() {
 
     # 2) Pull lyra staging
     echo "==> lyra: pulling staging..."
-    (cd "${LYRA_DIR}" && git pull origin staging)
+    (cd "${LYRA_DIR}" && git pull --ff-only origin staging)
 
     # 3) Install lyra quadlet units (no restart)
     echo "==> lyra: installing quadlet units..."
@@ -32,7 +32,7 @@ _do_converge() {
     VOICE_DIR="${VOICE_DIR:-${HOME}/projects/voiceCLI}"
     if [ -d "${VOICE_DIR}/.git" ]; then
         echo "==> voiceCLI: pulling staging..."
-        (cd "${VOICE_DIR}" && git pull origin staging)
+        (cd "${VOICE_DIR}" && git pull --ff-only origin staging)
         echo "==> voiceCLI: installing quadlet units..."
         make -C "${VOICE_DIR}" quadlet-install NO_RESTART=1
     fi
@@ -47,18 +47,16 @@ _do_converge() {
 
     # 7) Restart NATS (mount-typed secret refresh requires restart)
     echo "==> NATS: restarting lyra-nats..."
-    systemctl --user restart lyra-nats
-    systemctl --user is-active --wait lyra-nats \
+    systemctl --user restart --wait lyra-nats
+    systemctl --user is-active --quiet lyra-nats \
         || { echo "ERROR: lyra-nats failed to reach active state"; exit 1; }
 
     # 8) Restart lyra NATS clients
     echo "==> Lyra: restarting containers..."
     local failed=""
     for svc in lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-turn-writer lyra-gh-helper lyra-blobstore; do
-        if systemctl --user is-active --quiet "${svc}"; then
-            systemctl --user restart "${svc}" \
-                || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
-        fi
+        systemctl --user restart "${svc}" \
+            || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
     done
     [ -z "${failed}" ] || { echo "ERROR: restart failed for:${failed}"; exit 1; }
 
@@ -67,10 +65,8 @@ _do_converge() {
         echo "==> voiceCLI: restarting containers..."
         failed=""
         for svc in voicecli-tts voicecli-stt; do
-            if systemctl --user is-active --quiet "${svc}"; then
-                systemctl --user restart "${svc}" \
-                    || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
-            fi
+            systemctl --user restart "${svc}" \
+                || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
         done
         [ -z "${failed}" ] || { echo "ERROR: restart failed for:${failed}"; exit 1; }
     fi

--- a/deploy/lib/deploy-common.sh
+++ b/deploy/lib/deploy-common.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# deploy/lib/deploy-common.sh — shared library for deploy scripts
+#
+# Usage: source "$(dirname "$0")/../lib/deploy-common.sh"
+
+set -euo pipefail
+
+# ── PATH setup ───────────────────────────────────────────────────────────────
+# %h in systemd unit specifiers maps to $HOME in shell.
+export PATH="${HOME}/projects/lyra/.venv/bin:${HOME}/.local/bin:${PATH}"
+
+# ── Environment guards ─────────────────────────────────────────────────────
+source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+
+# ── Constants ────────────────────────────────────────────────────────────────
+LYRA_DIR="${HOME}/projects/lyra"
+CONVERGE_STAMP="${HOME}/.lyra/.converge-stamp"
+QUADLET_DIR="${HOME}/.config/containers/systemd"
+LYRA_NKEYS_DIR="${HOME}/.lyra/nkeys"
+DEPLOY_LOCK="/run/user/$(id -u)/lyra-deploy.lock"
+
+# ── flock wrapper ────────────────────────────────────────────────────────────
+# Run a command under an exclusive lock. Exit 0 (no error) if the lock is held.
+# Usage: with_deploy_lock <command> [args...]
+with_deploy_lock() {
+    exec 200>"${DEPLOY_LOCK}"
+    if ! flock -n 200; then
+        echo "Deploy lock held at ${DEPLOY_LOCK} — another converge is running."
+        exit 0
+    fi
+    "$@"
+}
+
+# ── Change detection helpers ─────────────────────────────────────────────────
+
+# Compute current convergence fingerprint: git HEAD + unit checksums + auth.conf SHA.
+# Output format: <git-head>:<units-sha256>:<authconf-sha256>
+compute_convergence_state() {
+    local git_head unit_sha auth_sha
+
+    git_head=$(cd "${LYRA_DIR}" && git rev-parse HEAD 2>/dev/null || echo "none")
+
+    if [ -d "${QUADLET_DIR}" ]; then
+        unit_sha=$(find "${QUADLET_DIR}" -maxdepth 1 -name 'lyra*' -type f \
+            | sort | xargs -r sha256sum | sha256sum | awk '{print $1}')
+    else
+        unit_sha="none"
+    fi
+
+    if [ -f "${LYRA_NKEYS_DIR}/auth.conf" ]; then
+        auth_sha=$(sha256sum "${LYRA_NKEYS_DIR}/auth.conf" | awk '{print $1}')
+    else
+        auth_sha="none"
+    fi
+
+    echo "${git_head}:${unit_sha}:${auth_sha}"
+}
+
+# Read the last recorded convergence state.
+read_convergence_state() {
+    if [ -f "${CONVERGE_STAMP}" ]; then
+        cat "${CONVERGE_STAMP}"
+    else
+        echo "none"
+    fi
+}
+
+# Write the current convergence state to the stamp file.
+write_convergence_state() {
+    compute_convergence_state > "${CONVERGE_STAMP}"
+}
+
+# Return 0 if the system is already converged (current == last recorded).
+is_converged() {
+    local current last
+    current=$(compute_convergence_state)
+    last=$(read_convergence_state)
+    [ "${current}" = "${last}" ]
+}

--- a/deploy/lib/deploy-common.sh
+++ b/deploy/lib/deploy-common.sh
@@ -33,16 +33,17 @@ with_deploy_lock() {
 
 # ── Change detection helpers ─────────────────────────────────────────────────
 
-# Compute current convergence fingerprint: git HEAD + unit checksums + auth.conf SHA.
-# Output format: <git-head>:<units-sha256>:<authconf-sha256>
+# Compute current convergence fingerprint: git HEAD + unit checksums + auth.conf SHA
+# (+ voiceCLI HEAD if present).
+# Output format: <git-head>:<units-sha256>:<authconf-sha256>[:<voicecli-head>]
 compute_convergence_state() {
-    local git_head unit_sha auth_sha
+    local git_head unit_sha auth_sha voicecli_head
 
     git_head=$(cd "${LYRA_DIR}" && git rev-parse HEAD 2>/dev/null || echo "none")
 
     if [ -d "${QUADLET_DIR}" ]; then
-        unit_sha=$(find "${QUADLET_DIR}" -maxdepth 1 -name 'lyra*' -type f \
-            | sort | xargs -r sha256sum | sha256sum | awk '{print $1}')
+        unit_sha=$(find "${QUADLET_DIR}" -maxdepth 1 -name 'lyra*' -type f -print0 \
+            | sort -z | xargs -0 -r sha256sum | sha256sum | awk '{print $1}')
     else
         unit_sha="none"
     fi
@@ -53,7 +54,14 @@ compute_convergence_state() {
         auth_sha="none"
     fi
 
-    echo "${git_head}:${unit_sha}:${auth_sha}"
+    VOICE_DIR="${VOICE_DIR:-${HOME}/projects/voiceCLI}"
+    if [ -d "${VOICE_DIR}/.git" ]; then
+        voicecli_head=$(cd "${VOICE_DIR}" && git rev-parse HEAD 2>/dev/null || echo "none")
+    else
+        voicecli_head="none"
+    fi
+
+    echo "${git_head}:${unit_sha}:${auth_sha}:${voicecli_head}"
 }
 
 # Read the last recorded convergence state.
@@ -67,6 +75,7 @@ read_convergence_state() {
 
 # Write the current convergence state to the stamp file.
 write_convergence_state() {
+    mkdir -p "$(dirname "${CONVERGE_STAMP}")"
     compute_convergence_state > "${CONVERGE_STAMP}"
 }
 

--- a/deploy/lyra-post-autoupdate.sh
+++ b/deploy/lyra-post-autoupdate.sh
@@ -21,19 +21,19 @@ local_digest() {
 }
 
 main() {
-    local remote local
+    local remote_digest_val local_digest_val
 
-    remote=$(remote_digest)
-    local=$(local_digest)
+    remote_digest_val=$(remote_digest)
+    local_digest_val=$(local_digest)
 
-    if [ -n "${local}" ] && [ "${remote}" = "${local}" ]; then
+    if [ -n "${local_digest_val}" ] && [ "${remote_digest_val}" = "${local_digest_val}" ]; then
         echo "Image digest unchanged (${IMAGE}) — nothing to do."
         exit 0
     fi
 
     echo "Image digest drift detected:"
-    echo "  remote: ${remote}"
-    echo "  local:  ${local:-<not present>}"
+    echo "  remote: ${remote_digest_val}"
+    echo "  local:  ${local_digest_val:-<not present>}"
 
     echo "==> Pulling ${IMAGE}..."
     podman pull "${IMAGE}"

--- a/deploy/lyra-post-autoupdate.sh
+++ b/deploy/lyra-post-autoupdate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# deploy/lyra-post-autoupdate.sh — poll image digest and trigger converge on change
+#
+# Triggered by lyra-post-autoupdate.timer (5 min). Idempotent: if digests match,
+# exits 0. On digest change, pulls the new image and runs the full converge.
+
+set -euo pipefail
+
+source "$(dirname "$0")/lib/deploy-common.sh"
+
+IMAGE="ghcr.io/roxabi/lyra:staging-svc"
+
+# ── Digest comparison ────────────────────────────────────────────────────────
+
+remote_digest() {
+    skopeo inspect "docker://${IMAGE}" | jq -r '.Digest'
+}
+
+local_digest() {
+    podman images --format '{{.Digest}}' "${IMAGE}" 2>/dev/null || true
+}
+
+main() {
+    local remote local
+
+    remote=$(remote_digest)
+    local=$(local_digest)
+
+    if [ -n "${local}" ] && [ "${remote}" = "${local}" ]; then
+        echo "Image digest unchanged (${IMAGE}) — nothing to do."
+        exit 0
+    fi
+
+    echo "Image digest drift detected:"
+    echo "  remote: ${remote}"
+    echo "  local:  ${local:-<not present>}"
+
+    echo "==> Pulling ${IMAGE}..."
+    podman pull "${IMAGE}"
+
+    # Converge stamp does not include image digest, so invalidate it
+    # to force a full converge (restarts, auth.conf refresh, etc.).
+    rm -f "${CONVERGE_STAMP}"
+
+    echo "==> Running make converge..."
+    make -C "${LYRA_DIR}" converge
+}
+
+with_deploy_lock main

--- a/deploy/lyra-quadlet-sync.sh
+++ b/deploy/lyra-quadlet-sync.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-# deploy/lyra-quadlet-sync.sh — auto-pull staging and conditional quadlet-install
+# deploy/lyra-quadlet-sync.sh — auto-pull staging and trigger make converge
 #
 # Called by lyra-quadlet-sync.service (systemd user unit).
-# Guard: only runs make quadlet-install when deploy/quadlet/**, Makefile, or
-# tools/render_quadlet.py changed.
+# If HEAD differs from origin/staging, pulls and calls make converge
+# (change-gated; no-op if already converged).
 set -euo pipefail
 
 cd ~/projects/lyra || {
     echo "ERROR: ~/projects/lyra not found" >&2
     exit 1
 }
+
+# Source shared library for PATH setup
+source "$(dirname "$0")/lib/deploy-common.sh"
 
 git fetch origin staging || {
     echo "ERROR: git fetch origin staging failed" >&2
@@ -21,16 +24,10 @@ if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/staging)" ]; then
     exit 0
 fi
 
-PRE_SHA=$(git rev-parse HEAD)
 git pull --ff-only origin staging || {
     echo "ERROR: git pull --ff-only failed" >&2
     exit 1
 }
 
-if git diff --name-only "$PRE_SHA" HEAD | grep -qE '^(deploy/quadlet/|Makefile|tools/render_quadlet\.py)'; then
-    echo "Quadlet-relevant files changed — running make quadlet-install ..."
-    export PATH="$HOME/.local/bin:$PATH"
-    make quadlet-install
-else
-    echo "No Quadlet-relevant changes — skipping make quadlet-install."
-fi
+echo "HEAD changed — running make converge ..."
+make converge

--- a/deploy/quadlet/lyra-blobstore.container
+++ b/deploy/quadlet/lyra-blobstore.container
@@ -12,7 +12,6 @@ StartLimitBurst=5
 # as lyra-hub.container. Dedicated blobstore image blocked until Protocol v2 + ≥3
 # cross-repo consumers; see analysis §Shape A rationale.
 Image=ghcr.io/roxabi/lyra:staging-svc
-Label=io.containers.autoupdate=registry
 ContainerName=lyra-blobstore
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/quadlet/lyra-clipool.container
+++ b/deploy/quadlet/lyra-clipool.container
@@ -11,7 +11,6 @@ StartLimitBurst=5
 
 [Container]
 Image=ghcr.io/roxabi/lyra:staging
-Label=io.containers.autoupdate=registry
 ContainerName=lyra-clipool
 # Pod= moves network + user namespace ownership to lyra-gh.pod.
 # UserNS=keep-id:uid=1500 is now declared on the pod (lyra-gh.pod [Pod] section)

--- a/deploy/quadlet/lyra-gh-helper.container
+++ b/deploy/quadlet/lyra-gh-helper.container
@@ -12,7 +12,6 @@ StartLimitBurst=5
 # Same image as clipool — lyra-gh user (uid 1501) + lyra-tokenuser group (gid 1502)
 # are baked into the image at Dockerfile lines 49–51. No separate helper image needed.
 Image=ghcr.io/roxabi/lyra:staging
-Label=io.containers.autoupdate=registry
 ContainerName=lyra-gh-helper
 Pod=lyra-gh.pod
 ReadOnly=true

--- a/deploy/quadlet/lyra-hub.container
+++ b/deploy/quadlet/lyra-hub.container
@@ -11,7 +11,6 @@ StartLimitBurst=5
 # (CI tag-by-SHA strategy). Upstream registry images (e.g. nats.container)
 # are pinned by digest directly.
 Image=ghcr.io/roxabi/lyra:staging-svc
-Label=io.containers.autoupdate=registry
 ContainerName=lyra-hub
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/quadlet/lyra-nats.container
+++ b/deploy/quadlet/lyra-nats.container
@@ -5,7 +5,6 @@ StartLimitBurst=5
 
 [Container]
 Image=docker.io/library/nats:2.10.29-alpine
-Label=io.containers.autoupdate=registry
 ContainerName=lyra-nats
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/quadlet/lyra-turn-writer.container
+++ b/deploy/quadlet/lyra-turn-writer.container
@@ -7,7 +7,6 @@ StartLimitBurst=5
 
 [Container]
 Image=ghcr.io/roxabi/lyra:staging-svc
-Label=io.containers.autoupdate=registry
 ContainerName=lyra-turn-writer
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/systemd/lyra-deploy-failure.service
+++ b/deploy/systemd/lyra-deploy-failure.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Lyra deploy failure notification — logs deploy failure to journal
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo "Lyra deploy failure: a deployment-related service (lyra-quadlet-sync or lyra-post-autoupdate) failed. Check journal for details." | systemd-cat -t lyra-deploy-failure -p err'
+StandardOutput=journal
+StandardError=journal

--- a/deploy/systemd/lyra-post-autoupdate.service
+++ b/deploy/systemd/lyra-post-autoupdate.service
@@ -1,11 +1,12 @@
 [Unit]
-Description=Lyra Quadlet sync — pull staging and conditional install
+Description=Lyra post-autoupdate hook — run after container image updates
 After=network-online.target
 Wants=network-online.target
+OnFailure=lyra-deploy-failure.service
 
 [Service]
 Type=oneshot
-ExecStart=%h/projects/lyra/deploy/lyra-quadlet-sync.sh
+ExecStart=%h/projects/lyra/deploy/lyra-post-autoupdate.sh
 WorkingDirectory=%h/projects/lyra
 Environment="PATH=%h/projects/lyra/.venv/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 StandardOutput=journal

--- a/deploy/systemd/lyra-post-autoupdate.timer
+++ b/deploy/systemd/lyra-post-autoupdate.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Lyra post-autoupdate timer — check every 5 minutes
+
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+Unit=lyra-post-autoupdate.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/lyra-quadlet-sync.service
+++ b/deploy/systemd/lyra-quadlet-sync.service
@@ -2,6 +2,7 @@
 Description=Lyra Quadlet sync — pull staging and conditional install
 After=network-online.target
 Wants=network-online.target
+OnFailure=lyra-deploy-failure.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Summary
- Add `make converge` — single atomic, idempotent, change-gated deploy verb for M₁
- Wire sync timer + autoupdate digest poll to the same verb so host config always converges with code
- Fix non-interactive PATH for .venv/bin (lyra-acl, uv, lyra) so headless deploys don't abort half-applied
- Deprecate overlapping `deploy` / `full-deploy` targets (still functional, print warning)
- Remove `io.containers.autoupdate=registry` from container files — `lyra-post-autoupdate` now handles digest polling directly

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1578: Collapse deploy to one atomic verb wired to autoupdate | Open |
| Analysis | [1578-collapse-deploy-atomic-analysis.mdx](artifacts/analyses/1578-collapse-deploy-atomic-analysis.mdx) | Present |
| Spec | [1578-collapse-deploy-atomic-spec.mdx](artifacts/specs/1578-collapse-deploy-atomic-spec.mdx) | Present |
| Plan | [1578-collapse-deploy-atomic-plan.mdx](artifacts/plans/1578-collapse-deploy-atomic-plan.mdx) | Present |
| Implementation | 5 commits on `feat/1578-collapse-deploy-atomic` | Complete |
| Verification | Lint ✓ Typecheck ✓ Tests 5290 passed, 1 pre-existing failure (NATS auth, unrelated) | Passed |

## Changes

- `Makefile` — add `converge` target, deprecate `deploy` / `full-deploy`, expand `quadlet-sync-install`, add `lyra-blobstore` to restart list
- `deploy/lib/deploy-common.sh` — shared library: flock wrapper, PATH export, change-detection helpers (git HEAD + unit checksums + auth.conf SHA)
- `deploy/converge.sh` — atomic converge sequence: git pull → quadlet-install NO_RESTART=1 → regen auth.conf → secrets → restart NATS → restart all clients
- `deploy/lyra-quadlet-sync.sh` — simplified: sources deploy-common.sh, calls `make converge`
- `deploy/lyra-post-autoupdate.sh` + `.service` + `.timer` — 5-min digest poll via skopeo, pulls on change, calls `make converge`
- `deploy/systemd/lyra-deploy-failure.service` — OnFailure journal notification
- `deploy/systemd/lyra-quadlet-sync.service` — PATH fix: includes `.venv/bin`
- `deploy/quadlet/*.container` — removed `Label=io.containers.autoupdate=registry` (6 files)
- `deploy/CLAUDE.md` — documented `make converge`, trigger wiring, failure path

## Test Plan
- [ ] `make converge` runs dry: `make -n converge`
- [ ] Idempotency: run twice — second run exits 0 with no changes
- [ ] flock: concurrent invocation exits 0 silently
- [ ] change detection: `is_converged` returns true when no changes
- [ ] PATH fix: `systemctl --user cat lyra-quadlet-sync.service | grep .venv/bin`

Closes #1578

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`