### PR TITLE
refactor(outbound): #1591 emitter stage extraction — shrink emitter.py

### DIFF
--- a/src/lyra/outbound/_emitter_run.py
+++ b/src/lyra/outbound/_emitter_run.py
@@ -1,0 +1,162 @@
+"""Emitter run-loop extraction — free functions operating on an OutboundEmitter.
+
+Extracted from OutboundEmitter (issue #1591, stage-axis refactor).
+These functions accept the emitter instance as a parameter and access its
+internal state directly, keeping the class API surface minimal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import TYPE_CHECKING, Any, assert_never
+
+from lyra.core.messaging import (
+    ReasoningDeltaRenderEvent,
+    ReasoningEndRenderEvent,
+    ReasoningStartRenderEvent,
+    RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
+    TextChunkRenderEvent,
+    TextDeltaRenderEvent,
+    TextEndRenderEvent,
+    TextStartRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
+)
+from lyra.core.messaging.tool_display_config import ToolDisplayConfig
+from lyra.outbound._placeholder_lifecycle import (
+    _deliver_final,
+    _drain_fallback,
+    _handle_typing_tail,
+    _send_placeholder,
+)
+from lyra.outbound._tool_recap import ToolRecapAccumulator
+
+if TYPE_CHECKING:
+    from lyra.outbound.emitter import OutboundEmitter
+
+
+async def _prepend(
+    first: RenderEvent, rest: AsyncIterator[RenderEvent]
+) -> AsyncIterator[RenderEvent]:
+    """Yield *first*, then all items from *rest*."""
+    yield first
+    async for ev in rest:
+        yield ev
+
+
+async def _run_event_loop(  # noqa: C901
+    emitter: "OutboundEmitter",
+    events: AsyncIterator[RenderEvent],
+    placeholder_obj: Any,
+) -> None:
+    """Iterate over events, updating the placeholder with debounced edits."""
+    try:
+        async for event in events:
+            if isinstance(
+                event,
+                RunStartedRenderEvent | RunFinishedRenderEvent | RunErrorRenderEvent,
+            ):
+                # Slice 1 (#1098): Run lifecycle events are pure additive
+                # surface — adapters initially ignore (no UX). Future slices
+                # may render banners or expose run_id in observability.
+                # RunErrorRenderEvent flags the turn as error so the
+                # subsequent TextEnd (if any) sets is_error_turn=True,
+                # producing the ``❌`` prefix on the final rendered text.
+                if isinstance(event, RunErrorRenderEvent):
+                    emitter._st.is_error_pending = True
+                continue
+            if isinstance(
+                event,
+                ToolCallStartRenderEvent
+                | ToolCallArgsRenderEvent
+                | ToolCallEndRenderEvent
+                | ToolCallResultRenderEvent,
+            ):
+                # Slice 3 (#1100) / Slice 5 (#1192): ToolCall* lifecycle
+                # events. v1 ToolSummaryRenderEvent removed; platform
+                # subclasses override _on_toolcall_v2 for richer rendering.
+                await emitter._on_toolcall_v2(event)
+                continue
+            if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                event,
+                TextStartRenderEvent
+                | TextDeltaRenderEvent
+                | TextEndRenderEvent
+                | TextChunkRenderEvent,
+            ):
+                await emitter._on_text_v2(event, placeholder_obj)
+                continue
+            if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                event,
+                ReasoningStartRenderEvent
+                | ReasoningDeltaRenderEvent
+                | ReasoningEndRenderEvent,
+            ):
+                # Slice 4 (#1101): typed reasoning events. Routed through
+                # OutboundFormatter.edit_reasoning. On Start, ensure the
+                # shared trace placeholder exists so reasoning and recap
+                # share a single placeholder object.
+                if isinstance(event, ReasoningStartRenderEvent):
+                    await emitter._ensure_trace_obj()
+                await emitter._fmt.edit_reasoning(emitter._trace_obj, event)
+                continue
+            else:
+                assert_never(event)
+    except Exception as exc:  # noqa: BLE001 — terminal stream-error capture; broad-catch is intentional
+        emitter._st.stream_error = exc
+
+
+async def _run_emitter(
+    emitter: "OutboundEmitter",
+    events: AsyncIterator[RenderEvent],
+) -> None:
+    """Run the full streaming lifecycle.
+
+    Defers the placeholder until the first event arrives so that
+    backend failures never leave an orphaned "…".  Re-raises
+    stream errors after delivering the error message.
+    """
+    config = emitter.tool_display_config or ToolDisplayConfig()
+    emitter._tool_recap = ToolRecapAccumulator(config=config)
+    # Peek: empty stream → fallback, no placeholder.
+    first_event: RenderEvent | None = None
+    peek_error: Exception | None = None
+    try:
+        try:
+            first_event = await events.__anext__()
+        except StopAsyncIteration:
+            pass
+        except Exception as exc:  # noqa: BLE001 — terminal stream-error capture; broad-catch is intentional
+            peek_error = exc
+        if first_event is None and peek_error is None:
+            await _drain_fallback(emitter, events)
+            await _handle_typing_tail(emitter)
+            return
+        if peek_error is not None:
+            emitter._st.stream_error = peek_error
+            result = await _send_placeholder(emitter)
+            if result is not None:
+                await _deliver_final(emitter, result[0])
+            await _handle_typing_tail(emitter)
+            raise peek_error
+        assert first_event is not None  # narrowed above
+        result = await _send_placeholder(emitter)
+        full = _prepend(first_event, events)
+        if result is None:
+            await _drain_fallback(emitter, full)
+            await _handle_typing_tail(emitter)
+            return
+        placeholder_obj, _ = result
+        await _run_event_loop(emitter, full, placeholder_obj)
+        await _deliver_final(emitter, placeholder_obj)
+        await _handle_typing_tail(emitter)
+        if emitter._st.stream_error is not None:
+            raise emitter._st.stream_error
+    finally:
+        if isinstance(events, AsyncGenerator):
+            await events.aclose()

--- a/src/lyra/outbound/_placeholder_lifecycle.py
+++ b/src/lyra/outbound/_placeholder_lifecycle.py
@@ -63,8 +63,8 @@ async def _deliver_text_chunks(
 ) -> None:
     """Edit placeholder with first chunk, send overflow."""
     result = await emitter._handler.guard(
-        lambda p=placeholder_obj, c=final_chunks[0]: (
-            emitter._fmt.edit_placeholder_text(p, c)
+        lambda p=placeholder_obj, c=final_chunks[0]: emitter._fmt.edit_placeholder_text(
+            p, c
         ),
         context="deliver_final_edit",
     )
@@ -79,9 +79,7 @@ async def _deliver_text_chunks(
             pass  # guard already logged; non-fatal
 
 
-async def _deliver_final(
-    emitter: "OutboundEmitter", placeholder_obj: Any
-) -> None:
+async def _deliver_final(emitter: "OutboundEmitter", placeholder_obj: Any) -> None:
     """Deliver final message after the event loop.
 
     Terminal invariant: the placeholder must never be left as a bare "…".

--- a/src/lyra/outbound/emitter.py
+++ b/src/lyra/outbound/emitter.py
@@ -12,20 +12,14 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import AsyncGenerator, AsyncIterator
-from typing import TYPE_CHECKING, Any, assert_never
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from lyra.outbound.throttle import ThrottleCapability
 
 from lyra.core.messaging import (
-    ReasoningDeltaRenderEvent,
-    ReasoningEndRenderEvent,
-    ReasoningStartRenderEvent,
     RenderEvent,
-    RunErrorRenderEvent,
-    RunFinishedRenderEvent,
-    RunStartedRenderEvent,
     TextChunkRenderEvent,
     TextDeltaRenderEvent,
     TextEndRenderEvent,
@@ -35,28 +29,17 @@ from lyra.core.messaging import (
     ToolCallResultRenderEvent,
     ToolCallStartRenderEvent,
 )
-from lyra.core.messaging.message import GENERIC_ERROR_REPLY, OutboundMessage
+from lyra.core.messaging.message import OutboundMessage
 from lyra.core.messaging.tool_display_config import ToolDisplayConfig
+from lyra.outbound._emitter_run import _run_emitter
 from lyra.outbound._streaming_state import StreamState
-from lyra.outbound._tool_recap import (
-    ToolRecapAccumulator,
-    format_recap_lines,
-)
+from lyra.outbound._tool_recap import ToolRecapAccumulator, format_recap_lines
 from lyra.outbound.error_handler import OutboundErrorHandler
 from lyra.outbound.formatter import OutboundFormatter
 from lyra.outbound.throttle import STREAMING_EDIT_INTERVAL
 from lyra.transport._result import Err
 
 log = logging.getLogger(__name__)
-
-
-async def _prepend(
-    first: RenderEvent, rest: AsyncIterator[RenderEvent]
-) -> AsyncIterator[RenderEvent]:
-    """Yield *first*, then all items from *rest*."""
-    yield first
-    async for ev in rest:
-        yield ev
 
 
 class OutboundEmitter:
@@ -109,6 +92,7 @@ class OutboundEmitter:
         self._trace_obj: Any | None = None
         self._last_recap_edit: float | None = None
         self._recap_done_emitted: bool = False
+        self._tool_recap = ToolRecapAccumulator()
 
     async def _ensure_trace_obj(self) -> bool:
         """Lazily send the trace placeholder, caching it on self._trace_obj.
@@ -236,196 +220,6 @@ class OutboundEmitter:
         if self._typing is not None and self._typing_scope_id is not None:
             await self._typing.start_typing(self._typing_scope_id)
 
-    async def _send_placeholder(self) -> tuple[Any, int | None] | None:
-        """Send the placeholder and record reply_message_id on outbound.
-
-        On failure: cancels typing, drains events accumulating text, sends fallback.
-        Returns None on failure (caller should call _handle_typing_tail and return).
-        Returns (placeholder_obj, reply_message_id) on success.
-        """
-        result = await self._handler.guard(
-            self._fmt.send_placeholder,
-            context="send_placeholder",
-        )
-        if isinstance(result, Err):
-            await self._cancel_typing()
-            return None
-        placeholder_obj, reply_message_id = result.value
-        if self._outbound is not None:
-            self._outbound.metadata["reply_message_id"] = reply_message_id
-        return placeholder_obj, reply_message_id
-
-    async def _drain_fallback(self, events: AsyncIterator[RenderEvent]) -> None:
-        """Drain remaining events, accumulate text, send via fallback callback."""
-        parts: list[str] = []
-        async for event in events:
-            if isinstance(event, TextDeltaRenderEvent):
-                parts.append(event.delta)
-        fallback_text = "".join(parts) or self._fmt.placeholder_text()
-        result = await self._handler.guard(
-            lambda t=fallback_text: self._fmt.send_fallback(t),
-            context="drain_fallback",
-        )
-        if isinstance(result, Err):
-            return
-        fallback_message_id = result.value
-        if self._outbound is not None and fallback_message_id is not None:
-            self._outbound.metadata["reply_message_id"] = fallback_message_id
-
-    async def _run_event_loop(  # noqa: C901 — DEBT:wiring-bootstrap-deps — v1+v2 dispatch ladder
-        self,
-        events: AsyncIterator[RenderEvent],
-        placeholder_obj: Any,
-    ) -> None:
-        """Iterate over events, updating the placeholder with debounced edits."""
-        try:
-            async for event in events:
-                if isinstance(
-                    event,
-                    RunStartedRenderEvent
-                    | RunFinishedRenderEvent
-                    | RunErrorRenderEvent,
-                ):
-                    # Slice 1 (#1098): Run lifecycle events are pure additive
-                    # surface — adapters initially ignore (no UX). Future slices
-                    # may render banners or expose run_id in observability.
-                    # RunErrorRenderEvent flags the turn as error so the
-                    # subsequent TextEnd (if any) sets is_error_turn=True,
-                    # producing the ``❌`` prefix on the final rendered text.
-                    if isinstance(event, RunErrorRenderEvent):
-                        self._st.is_error_pending = True
-                    continue
-
-                if isinstance(
-                    event,
-                    ToolCallStartRenderEvent
-                    | ToolCallArgsRenderEvent
-                    | ToolCallEndRenderEvent
-                    | ToolCallResultRenderEvent,
-                ):
-                    # Slice 3 (#1100) / Slice 5 (#1192): ToolCall* lifecycle
-                    # events. v1 ToolSummaryRenderEvent removed; platform
-                    # subclasses override _on_toolcall_v2 for richer rendering.
-                    await self._on_toolcall_v2(event)
-                    continue
-
-                if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
-                    event,
-                    TextStartRenderEvent
-                    | TextDeltaRenderEvent
-                    | TextEndRenderEvent
-                    | TextChunkRenderEvent,
-                ):
-                    await self._on_text_v2(event, placeholder_obj)
-                    continue
-
-                if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
-                    event,
-                    ReasoningStartRenderEvent
-                    | ReasoningDeltaRenderEvent
-                    | ReasoningEndRenderEvent,
-                ):
-                    # Slice 4 (#1101): typed reasoning events. Routed through
-                    # OutboundFormatter.edit_reasoning. On Start, ensure the
-                    # shared trace placeholder exists so reasoning and recap
-                    # share a single placeholder object.
-                    if isinstance(event, ReasoningStartRenderEvent):
-                        await self._ensure_trace_obj()
-                    await self._fmt.edit_reasoning(self._trace_obj, event)
-                    continue
-                else:
-                    assert_never(event)
-
-        except Exception as exc:  # noqa: BLE001 — terminal stream-error capture; broad-catch is intentional
-            self._st.stream_error = exc
-
-    async def _deliver_text_chunks(
-        self,
-        placeholder_obj: Any,
-        final_chunks: list[str],
-    ) -> None:
-        """Edit placeholder with first chunk, send overflow."""
-        result = await self._handler.guard(
-            lambda p=placeholder_obj, c=final_chunks[0]: (
-                self._fmt.edit_placeholder_text(p, c)
-            ),
-            context="deliver_final_edit",
-        )
-        if isinstance(result, Err):
-            pass  # guard already logged; non-fatal
-        for extra_chunk in final_chunks[1:]:
-            result = await self._handler.guard(
-                lambda c=extra_chunk: self._fmt.send_message(c),
-                context="deliver_overflow_chunk",
-            )
-            if isinstance(result, Err):
-                pass  # guard already logged; non-fatal
-
-    async def _deliver_final(
-        self,
-        placeholder_obj: Any,
-    ) -> None:
-        """Deliver the final message after the event loop.
-
-        Terminal invariant: the placeholder must never be left as a bare
-        "…".  If no text was produced and no stream error was raised, edit
-        it to a generic error so the user always sees a final state.
-        """
-        # Best-effort final recap edit. Fires for graceful AND ungraceful ends
-        # (no RunFinished, no RunError) — guarantees the placeholder never
-        # sticks at "🔧 Working…".
-        if (
-            self._st.had_tool_events
-            and self._trace_obj is not None
-            and not self._recap_done_emitted
-        ):
-            self._recap_done_emitted = True
-            lines = format_recap_lines(self._tool_recap, done=True)
-            if lines:
-                trace = self._trace_obj
-                result = await self._handler.guard(
-                    lambda t=trace, ls=lines: self._fmt.edit_tool_recap(t, ls, True),
-                    context="recap_final_edit",
-                )
-                if isinstance(result, Err):
-                    pass  # guard already logged; non-fatal
-
-        display_text = self._st.build_display_text(self._fmt.get_msg)
-        chunks = self._fmt.chunk(display_text) if display_text else []
-        if chunks:
-            await self._deliver_text_chunks(placeholder_obj, chunks)
-            return
-
-        # No deliverable content — surface a descriptive error rather than "…".
-        log.warning(
-            "streaming turn ended with no display text (final_text=%r stream_error=%r)",
-            self._st.final_text,
-            self._st.stream_error,
-        )
-        error_text = (
-            self._handler.classify_stream_error(
-                self._st.stream_error,
-                had_tool_events=self._st.had_tool_events,
-                final_text=self._st.final_text,
-            )
-            or GENERIC_ERROR_REPLY
-        )
-        result = await self._handler.guard(
-            lambda p=placeholder_obj, t=error_text: self._fmt.edit_placeholder_text(
-                p, t
-            ),
-            context="error_edit",
-        )
-        if isinstance(result, Err):
-            pass  # guard already logged; non-fatal
-
-    async def _handle_typing_tail(self) -> None:
-        """Start or cancel typing based on whether the turn is intermediate."""
-        if self._outbound is not None and self._outbound.intermediate:
-            await self._start_typing()
-        else:
-            await self._cancel_typing()
-
     async def run(self, events: AsyncIterator[RenderEvent]) -> None:
         """Run the full streaming lifecycle.
 
@@ -433,42 +227,4 @@ class OutboundEmitter:
         backend failures never leave an orphaned "…".  Re-raises
         stream errors after delivering the error message.
         """
-        config = self.tool_display_config or ToolDisplayConfig()
-        self._tool_recap = ToolRecapAccumulator(config=config)
-        # Peek: empty stream → fallback, no placeholder.
-        first_event: RenderEvent | None = None
-        peek_error: Exception | None = None
-        try:
-            try:
-                first_event = await events.__anext__()
-            except StopAsyncIteration:
-                pass
-            except Exception as exc:  # noqa: BLE001 — terminal stream-error capture; broad-catch is intentional
-                peek_error = exc
-            if first_event is None and peek_error is None:
-                await self._drain_fallback(events)
-                await self._handle_typing_tail()
-                return
-            if peek_error is not None:
-                self._st.stream_error = peek_error
-                result = await self._send_placeholder()
-                if result is not None:
-                    await self._deliver_final(result[0])
-                await self._handle_typing_tail()
-                raise peek_error
-            assert first_event is not None  # narrowed above
-            result = await self._send_placeholder()
-            full = _prepend(first_event, events)
-            if result is None:
-                await self._drain_fallback(full)
-                await self._handle_typing_tail()
-                return
-            placeholder_obj, _ = result
-            await self._run_event_loop(full, placeholder_obj)
-            await self._deliver_final(placeholder_obj)
-            await self._handle_typing_tail()
-            if self._st.stream_error is not None:
-                raise self._st.stream_error
-        finally:
-            if isinstance(events, AsyncGenerator):
-                await events.aclose()
+        return await _run_emitter(self, events)

--- a/tests/adapters/test_shared.py
+++ b/tests/adapters/test_shared.py
@@ -18,6 +18,8 @@ from lyra.core.messaging.render_events import (
     TextEndRenderEvent,
     TextStartRenderEvent,
 )
+from lyra.outbound._emitter_run import _run_event_loop
+from lyra.outbound._placeholder_lifecycle import _drain_fallback
 from lyra.outbound.emitter import OutboundEmitter as StreamingSession
 
 # ---------------------------------------------------------------------------
@@ -185,7 +187,8 @@ class TestDispatchTextStartToOnTextV2:
         # called during event dispatch (only during delivery).
         fmt.edit_placeholder_text.reset_mock()
 
-        await session._run_event_loop(
+        await _run_event_loop(
+            session,
             _async_iter(TextStartRenderEvent(message_id="text-1")),
             placeholder_obj=object(),
         )
@@ -227,7 +230,8 @@ class TestDispatchAllFourV2TextTypes:
         ]
 
         # Act
-        await session._run_event_loop(
+        await _run_event_loop(
+            session,
             _async_iter(*events),
             placeholder_obj=object(),
         )
@@ -252,8 +256,9 @@ class TestDrainFallbackHarvestsV2Delta:
         session = StreamingSession(fmt, outbound=outbound)
 
         # Act — drain a v2-only stream
-        await session._drain_fallback(
-            _async_iter(TextDeltaRenderEvent(message_id="text-x", delta="Hello"))
+        await _drain_fallback(
+            session,
+            _async_iter(TextDeltaRenderEvent(message_id="text-x", delta="Hello")),
         )
 
         # Assert — send_fallback received the delta text exactly.
@@ -273,10 +278,11 @@ class TestDrainFallbackV2Accumulation:
         outbound = OutboundMessage.from_text("hi")
         session = StreamingSession(fmt, outbound=outbound)
 
-        await session._drain_fallback(
+        await _drain_fallback(
+            session,
             _async_iter(
                 TextDeltaRenderEvent(message_id="text-1", delta="Hi"),
-            )
+            ),
         )
 
         fmt.send_fallback.assert_awaited_once_with("Hi")

--- a/tests/integration/test_reasoning_e2e.py
+++ b/tests/integration/test_reasoning_e2e.py
@@ -9,7 +9,7 @@ Mocked (externals only):
 Real (not mocked):
   - CliStreamingParser  (core.cli.cli_streaming_parser)
   - StreamProcessor     (core.processors.stream_processor)
-  - StreamingSession._run_event_loop  (outbound.emitter)
+  - _run_event_loop  (outbound._emitter_run)
   - ReasoningStart/Delta/EndRenderEvent  (core.messaging.render_events)
   - ThinkingLlmEvent  (core.messaging.events)
 
@@ -44,6 +44,7 @@ from lyra.core.messaging.render_events import (
     RenderEvent,
 )
 from lyra.core.processors.stream_processor import StreamProcessor
+from lyra.outbound._emitter_run import _run_event_loop
 from lyra.outbound.emitter import OutboundEmitter as StreamingSession
 
 # DEBT:v1-stubs — for skipped tests; rewrite for v2 (#1192 S3 follow-up)
@@ -282,7 +283,7 @@ class TestCallbackInvokedThroughDispatch:
                 yield ev
 
         session = StreamingSession(fmt, outbound=None)
-        await session._run_event_loop(_render_stream(), placeholder_obj)
+        await _run_event_loop(session, _render_stream(), placeholder_obj)
 
         # Assert — edit_reasoning called once per Reasoning* event, in order
         assert edit_reasoning_spy.call_count == len(expected_reasoning_events), (

--- a/tests/outbound/test_emitter_run.py
+++ b/tests/outbound/test_emitter_run.py
@@ -1,0 +1,383 @@
+"""Unit tests for _emitter_run.py — free functions extracted from OutboundEmitter.
+
+Covers _prepend, _run_event_loop, and _run_emitter.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lyra.core.messaging import (
+    RenderEvent,
+    RunErrorRenderEvent,
+    RunFinishedRenderEvent,
+    RunStartedRenderEvent,
+    TextChunkRenderEvent,
+    TextDeltaRenderEvent,
+    TextEndRenderEvent,
+    TextStartRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallResultRenderEvent,
+    ToolCallStartRenderEvent,
+)
+from lyra.core.messaging.message import OutboundMessage
+from lyra.outbound._emitter_run import (
+    _prepend,
+    _run_emitter,
+    _run_event_loop,
+)
+from lyra.outbound.emitter import OutboundEmitter as StreamingSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_formatter(**overrides: Any) -> MagicMock:
+    """Build a mock OutboundFormatter with AsyncMock/MagicMock defaults."""
+    fmt = MagicMock()
+    fmt.placeholder_text = MagicMock(return_value="…")
+    fmt.chunk = MagicMock(side_effect=lambda t: [t] if t else [])
+    fmt.get_msg = MagicMock(side_effect=lambda key, fallback: fallback)
+    fmt.send_placeholder = AsyncMock(return_value=(object(), 42))
+    fmt.edit_placeholder_text = AsyncMock()
+    fmt.send_trace_placeholder = AsyncMock(return_value=(object(), 42))
+    fmt.send_message = AsyncMock(return_value=99)
+    fmt.send_fallback = AsyncMock(return_value=77)
+    fmt.edit_reasoning = AsyncMock()
+    fmt.edit_tool_recap = AsyncMock()
+    for k, v in overrides.items():
+        setattr(fmt, k, v)
+    return fmt
+
+
+async def _async_iter(*evts: RenderEvent) -> AsyncIterator[RenderEvent]:
+    for e in evts:
+        yield e
+
+
+# ---------------------------------------------------------------------------
+# _prepend
+# ---------------------------------------------------------------------------
+
+
+class TestPrepend:
+    async def test_prepend_yields_first_then_rest(self) -> None:
+        """_prepend yields the first item, then all items from the rest iterator."""
+        # Arrange
+        first = TextStartRenderEvent(message_id="m1")
+        rest = _async_iter(
+            TextDeltaRenderEvent(message_id="m1", delta="hello"),
+            TextEndRenderEvent(message_id="m1"),
+        )
+
+        # Act
+        items = []
+        async for item in _prepend(first, rest):
+            items.append(item)
+
+        # Assert
+        assert items == [
+            TextStartRenderEvent(message_id="m1"),
+            TextDeltaRenderEvent(message_id="m1", delta="hello"),
+            TextEndRenderEvent(message_id="m1"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# _run_event_loop
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventLoop:
+    async def test_routes_text_events_to_on_text_v2(self) -> None:
+        """Text* events are routed to _on_text_v2."""
+        # Arrange
+        seen: list[type] = []
+
+        class _SpySession(StreamingSession):
+            async def _on_text_v2(
+                self,
+                event: TextStartRenderEvent
+                | TextDeltaRenderEvent
+                | TextEndRenderEvent
+                | TextChunkRenderEvent,
+                placeholder_obj: object = None,
+            ) -> None:
+                seen.append(type(event))
+
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = _SpySession(fmt, outbound=outbound)
+        events = [
+            TextStartRenderEvent(message_id="m1"),
+            TextDeltaRenderEvent(message_id="m1", delta="x"),
+            TextEndRenderEvent(message_id="m1"),
+            TextChunkRenderEvent(message_id="m2", delta="y"),
+        ]
+
+        # Act
+        await _run_event_loop(
+            session,
+            _async_iter(*events),
+            placeholder_obj=object(),
+        )
+
+        # Assert
+        assert seen == [
+            TextStartRenderEvent,
+            TextDeltaRenderEvent,
+            TextEndRenderEvent,
+            TextChunkRenderEvent,
+        ]
+
+    async def test_routes_tool_events_to_on_toolcall_v2(self) -> None:
+        """ToolCall* events are routed to _on_toolcall_v2."""
+        seen: list[type] = []
+
+        class _SpySession(StreamingSession):
+            async def _on_toolcall_v2(
+                self,
+                event: ToolCallStartRenderEvent
+                | ToolCallArgsRenderEvent
+                | ToolCallEndRenderEvent
+                | ToolCallResultRenderEvent,
+            ) -> None:
+                seen.append(type(event))
+
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = _SpySession(fmt, outbound=outbound)
+        events = [
+            ToolCallStartRenderEvent(tool_call_id="tc1", tool_name="bash"),
+            ToolCallArgsRenderEvent(tool_call_id="tc1", delta='{"command":"ls"}'),
+            ToolCallEndRenderEvent(tool_call_id="tc1"),
+            ToolCallResultRenderEvent(tool_call_id="tc1", content="ok"),
+        ]
+
+        await _run_event_loop(
+            session,
+            _async_iter(*events),
+            placeholder_obj=object(),
+        )
+
+        assert seen == [
+            ToolCallStartRenderEvent,
+            ToolCallArgsRenderEvent,
+            ToolCallEndRenderEvent,
+            ToolCallResultRenderEvent,
+        ]
+
+    async def test_routes_run_lifecycle_events_as_no_op(self) -> None:
+        """RunStarted/RunFinished are absorbed; RunError sets is_error_pending."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        events = [
+            RunStartedRenderEvent(run_id="r1"),
+            RunErrorRenderEvent(run_id="r1", message="boom"),
+            RunFinishedRenderEvent(run_id="r1"),
+        ]
+
+        await _run_event_loop(
+            session,
+            _async_iter(*events),
+            placeholder_obj=object(),
+        )
+
+        # RunError sets the flag
+        assert session._st.is_error_pending is True
+
+    async def test_routes_reasoning_events_to_edit_reasoning(self) -> None:
+        """Reasoning* events are routed through fmt.edit_reasoning."""
+        from lyra.core.messaging import (
+            ReasoningDeltaRenderEvent,
+            ReasoningEndRenderEvent,
+            ReasoningStartRenderEvent,
+        )
+
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        events = [
+            ReasoningStartRenderEvent(message_id="r1"),
+            ReasoningDeltaRenderEvent(message_id="r1", delta="thinking"),
+            ReasoningEndRenderEvent(message_id="r1"),
+        ]
+
+        await _run_event_loop(
+            session,
+            _async_iter(*events),
+            placeholder_obj=object(),
+        )
+
+        # ReasoningStart triggers _ensure_trace_obj which calls send_trace_placeholder
+        fmt.send_trace_placeholder.assert_awaited()
+        # edit_reasoning called for each reasoning event
+        assert fmt.edit_reasoning.await_count == 3
+
+    async def test_assert_never_on_unknown_event_type(self) -> None:
+        """An unknown event type hits assert_never; the AssertionError is caught
+        by the broad terminal exception handler and stored in stream_error."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        class UnknownEvent:
+            pass
+
+        await _run_event_loop(
+            session,
+            _async_iter(UnknownEvent()),  # type: ignore[list-item]
+            placeholder_obj=object(),
+        )
+
+        # assert_never raises AssertionError, which is caught by the broad
+        # except Exception in _run_event_loop and stored in stream_error.
+        assert isinstance(session._st.stream_error, AssertionError)
+
+    async def test_captures_stream_error_in_st(self) -> None:
+        """An exception during event iteration is stored in stream_error."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        async def _broken() -> AsyncIterator[RenderEvent]:
+            yield TextStartRenderEvent(message_id="m1")
+            raise RuntimeError("stream break")
+
+        await _run_event_loop(
+            session,
+            _broken(),
+            placeholder_obj=object(),
+        )
+
+        assert isinstance(session._st.stream_error, RuntimeError)
+        assert str(session._st.stream_error) == "stream break"
+
+
+# ---------------------------------------------------------------------------
+# _run_emitter
+# ---------------------------------------------------------------------------
+
+
+class TestRunEmitter:
+    async def test_empty_stream_drains_fallback_and_typing_tail(self) -> None:
+        """Empty stream: no placeholder, drain fallback + typing tail."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        async def _empty() -> AsyncIterator[RenderEvent]:
+            if False:
+                yield  # makes this an async generator
+            return
+
+        await _run_emitter(session, _empty())
+
+        # Negative: if _drain_fallback branch were removed, send_fallback
+        # would not be called with the placeholder text.
+        fmt.send_fallback.assert_awaited_once_with("…")
+
+    async def test_peek_error_sets_stream_error_and_re_raises(self) -> None:
+        """Peek error: stream_error set, placeholder sent, then re-raised."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        async def _raises_on_peek() -> AsyncIterator[RenderEvent]:
+            if False:
+                yield  # makes this an async generator
+            raise RuntimeError("peek boom")
+
+        with pytest.raises(RuntimeError, match="peek boom"):
+            await _run_emitter(session, _raises_on_peek())
+
+        assert isinstance(session._st.stream_error, RuntimeError)
+        assert str(session._st.stream_error) == "peek boom"
+        fmt.send_placeholder.assert_awaited()
+        fmt.edit_placeholder_text.assert_awaited()
+
+    async def test_normal_stream_placeholder_event_loop_final_typing(self) -> None:
+        """Normal stream: placeholder → event loop → final → typing tail."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        events = [
+            TextStartRenderEvent(message_id="m1"),
+            TextDeltaRenderEvent(message_id="m1", delta="hello"),
+            TextEndRenderEvent(message_id="m1"),
+        ]
+
+        await _run_emitter(session, _async_iter(*events))
+
+        fmt.send_placeholder.assert_awaited()
+        fmt.edit_placeholder_text.assert_awaited()
+        fmt.send_message.assert_not_awaited()
+
+    async def test_placeholder_failure_calls_drain_fallback(self) -> None:
+        """Placeholder send fails: fall back to drain + typing tail."""
+        fmt = _make_formatter(send_placeholder=AsyncMock(return_value=(object(), 42)))
+
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        # Force _send_placeholder to return None by making guard return Err
+        async def _failing_guard(call, *, context):
+            from lyra.transport._result import Err, SanitizedError
+
+            if context == "send_placeholder":
+                return Err(SanitizedError(code="test", message="Boom", retryable=False))
+            # Let other calls through
+            from lyra.transport._result import Ok
+
+            return Ok(await call())
+
+        session._handler.guard = _failing_guard  # type: ignore[method-assign]
+
+        events = [
+            TextStartRenderEvent(message_id="m1"),
+            TextDeltaRenderEvent(message_id="m1", delta="hello"),
+            TextEndRenderEvent(message_id="m1"),
+        ]
+
+        await _run_emitter(session, _async_iter(*events))
+
+        fmt.send_fallback.assert_awaited_once_with("hello")
+
+    async def test_async_generator_closed_in_finally(self) -> None:
+        """AsyncGenerator is aclosed in the finally block even after an exception."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        aclose_tracker: list[bool] = []
+
+        async def _gen() -> AsyncIterator[RenderEvent]:
+            try:
+                yield TextStartRenderEvent(message_id="m1")
+            except GeneratorExit:
+                aclose_tracker.append(True)
+                raise
+
+        # Patch _send_placeholder to raise after the peek so the generator is
+        # still alive when the finally block runs.
+        async def _failing_send_placeholder(*args, **kwargs):
+            raise RuntimeError("placeholder boom")
+
+        with patch(
+            "lyra.outbound._emitter_run._send_placeholder",
+            side_effect=_failing_send_placeholder,
+        ):
+            with pytest.raises(RuntimeError, match="placeholder boom"):
+                await _run_emitter(session, _gen())
+
+        assert aclose_tracker == [True]

--- a/tests/outbound/test_placeholder_lifecycle.py
+++ b/tests/outbound/test_placeholder_lifecycle.py
@@ -1,0 +1,303 @@
+"""Unit tests for _placeholder_lifecycle.py.
+
+Covers _send_placeholder, _drain_fallback, _deliver_text_chunks, _deliver_final,
+and _handle_typing_tail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from lyra.core.messaging import (
+    RenderEvent,
+    TextDeltaRenderEvent,
+    ToolCallArgsRenderEvent,
+    ToolCallEndRenderEvent,
+    ToolCallStartRenderEvent,
+)
+from lyra.core.messaging.message import OutboundMessage
+from lyra.outbound._placeholder_lifecycle import (
+    _deliver_final,
+    _deliver_text_chunks,
+    _drain_fallback,
+    _handle_typing_tail,
+    _send_placeholder,
+)
+from lyra.outbound.emitter import OutboundEmitter as StreamingSession
+from lyra.transport._result import Err, Ok, SanitizedError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_formatter(**overrides: Any) -> MagicMock:
+    """Build a mock OutboundFormatter with AsyncMock/MagicMock defaults."""
+    fmt = MagicMock()
+    fmt.placeholder_text = MagicMock(return_value="…")
+    fmt.chunk = MagicMock(side_effect=lambda t: [t] if t else [])
+    fmt.get_msg = MagicMock(side_effect=lambda key, fallback: fallback)
+    fmt.send_placeholder = AsyncMock(return_value=(object(), 42))
+    fmt.edit_placeholder_text = AsyncMock()
+    fmt.send_trace_placeholder = AsyncMock(return_value=(object(), 42))
+    fmt.send_message = AsyncMock(return_value=99)
+    fmt.send_fallback = AsyncMock(return_value=77)
+    fmt.edit_reasoning = AsyncMock()
+    fmt.edit_tool_recap = AsyncMock()
+    for k, v in overrides.items():
+        setattr(fmt, k, v)
+    return fmt
+
+
+async def _async_iter(*evts: RenderEvent) -> AsyncIterator[RenderEvent]:
+    for e in evts:
+        yield e
+
+
+# ---------------------------------------------------------------------------
+# _send_placeholder
+# ---------------------------------------------------------------------------
+
+
+class TestSendPlaceholder:
+    async def test_success_returns_tuple_and_sets_reply_message_id(self) -> None:
+        """Success: returns tuple and writes reply_message_id to metadata."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        ph_obj = object()
+        fmt.send_placeholder = AsyncMock(return_value=(ph_obj, 123))
+
+        result = await _send_placeholder(session)
+
+        assert result is not None
+        assert result[0] is ph_obj
+        assert result[1] == 123
+        assert outbound.metadata["reply_message_id"] == 123
+
+    async def test_failure_returns_none_and_cancels_typing(self) -> None:
+        """Failure path: returns None and cancels typing indicator."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        async def _failing_guard(call, *, context):
+            return Err(SanitizedError(code="test", message="Boom", retryable=False))
+
+        session._handler.guard = _failing_guard  # type: ignore[method-assign]
+        session._cancel_typing = AsyncMock()  # type: ignore[method-assign]
+
+        result = await _send_placeholder(session)
+
+        assert result is None
+        session._cancel_typing.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _drain_fallback
+# ---------------------------------------------------------------------------
+
+
+class TestDrainFallback:
+    async def test_accumulates_text_delta_and_sends_fallback(self) -> None:
+        """TextDeltaRenderEvent deltas are accumulated and sent via send_fallback."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        await _drain_fallback(
+            session,
+            _async_iter(
+                TextDeltaRenderEvent(message_id="m1", delta="Hello"),
+                TextDeltaRenderEvent(message_id="m1", delta=" world"),
+            ),
+        )
+
+        fmt.send_fallback.assert_awaited_once_with("Hello world")
+
+    async def test_empty_stream_sends_placeholder_text(self) -> None:
+        """Empty stream: send_fallback receives placeholder_text()."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        async def _empty() -> AsyncIterator[RenderEvent]:
+            if False:
+                yield
+            return
+
+        await _drain_fallback(session, _empty())
+
+        fmt.send_fallback.assert_awaited_once_with("…")
+
+
+# ---------------------------------------------------------------------------
+# _deliver_text_chunks
+# ---------------------------------------------------------------------------
+
+
+class TestDeliverTextChunks:
+    async def test_single_chunk_edits_placeholder(self) -> None:
+        """Single chunk: edit_placeholder_text called once, send_message not called."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        placeholder_obj = object()
+
+        await _deliver_text_chunks(session, placeholder_obj, ["hello"])
+
+        fmt.edit_placeholder_text.assert_awaited_once_with(placeholder_obj, "hello")
+        fmt.send_message.assert_not_awaited()
+
+    async def test_multiple_chunks_edit_then_send_overflow(self) -> None:
+        """Multiple chunks: first chunk edits, remainder sent as new messages."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        placeholder_obj = object()
+
+        await _deliver_text_chunks(
+            session, placeholder_obj, ["chunk1", "chunk2", "chunk3"]
+        )
+
+        fmt.edit_placeholder_text.assert_awaited_once_with(placeholder_obj, "chunk1")
+        assert fmt.send_message.await_count == 2
+        fmt.send_message.assert_any_await("chunk2")
+        fmt.send_message.assert_any_await("chunk3")
+
+    async def test_error_on_edit_is_non_fatal(self) -> None:
+        """Err on edit is swallowed; overflow chunks still attempted."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+
+        async def _guard_that_fails_first(call, *, context):
+            if context == "deliver_final_edit":
+                return Err(
+                    SanitizedError(code="test", message="EditFail", retryable=False)
+                )
+            return Ok(await call())
+
+        session._handler.guard = _guard_that_fails_first  # type: ignore[method-assign]
+        placeholder_obj = object()
+
+        await _deliver_text_chunks(session, placeholder_obj, ["chunk1", "chunk2"])
+
+        fmt.send_message.assert_awaited_once_with("chunk2")
+
+
+# ---------------------------------------------------------------------------
+# _deliver_final
+# ---------------------------------------------------------------------------
+
+
+class TestDeliverFinal:
+    async def test_with_display_text_calls_deliver_text_chunks(self) -> None:
+        """When display text exists, _deliver_text_chunks is invoked."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        session._st.set_final_text("final hello")
+        placeholder_obj = object()
+
+        await _deliver_final(session, placeholder_obj)
+
+        fmt.edit_placeholder_text.assert_awaited_once_with(
+            placeholder_obj, "final hello"
+        )
+        fmt.send_message.assert_not_awaited()
+
+    async def test_no_display_text_calls_edit_with_error_text(self) -> None:
+        """No display text: edit_placeholder_text receives a generic error fallback."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        placeholder_obj = object()
+
+        await _deliver_final(session, placeholder_obj)
+
+        fmt.edit_placeholder_text.assert_awaited()
+        call_text = fmt.edit_placeholder_text.call_args[0][1]
+        assert call_text == "Something went wrong. Please try again."
+
+    async def test_tool_events_with_trace_calls_edit_tool_recap_done(self) -> None:
+        """Tool events + trace_obj present: edit_tool_recap with done=True."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        session._st.had_tool_events = True
+        session._trace_obj = object()
+        session._recap_done_emitted = False
+        # Feed a tool so recap lines are non-empty
+        session._tool_recap.observe_start(
+            ToolCallStartRenderEvent(tool_call_id="tc1", tool_name="bash")
+        )
+        session._tool_recap.observe_args(
+            ToolCallArgsRenderEvent(tool_call_id="tc1", delta='{"command":"ls"}')
+        )
+        session._tool_recap.observe_end(ToolCallEndRenderEvent(tool_call_id="tc1"))
+        placeholder_obj = object()
+
+        await _deliver_final(session, placeholder_obj)
+
+        fmt.edit_tool_recap.assert_awaited()
+        assert session._recap_done_emitted is True
+
+    async def test_tool_events_without_trace_skips_recap(self) -> None:
+        """Tool events but no trace_obj: recap skipped."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        session = StreamingSession(fmt, outbound=outbound)
+        session._st.had_tool_events = True
+        session._trace_obj = None
+        placeholder_obj = object()
+
+        await _deliver_final(session, placeholder_obj)
+
+        fmt.edit_tool_recap.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _handle_typing_tail
+# ---------------------------------------------------------------------------
+
+
+class TestHandleTypingTail:
+    async def test_intermediate_calls_start_typing(self) -> None:
+        """intermediate=True → _start_typing."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        outbound.intermediate = True
+        session = StreamingSession(fmt, outbound=outbound)
+        session._start_typing = AsyncMock()  # type: ignore[method-assign]
+        session._cancel_typing = AsyncMock()  # type: ignore[method-assign]
+
+        await _handle_typing_tail(session)
+
+        session._start_typing.assert_awaited_once()
+        session._cancel_typing.assert_not_awaited()
+
+    async def test_final_calls_cancel_typing(self) -> None:
+        """intermediate=False → _cancel_typing."""
+        fmt = _make_formatter()
+        outbound = OutboundMessage.from_text("hi")
+        outbound.intermediate = False
+        session = StreamingSession(fmt, outbound=outbound)
+        session._start_typing = AsyncMock()  # type: ignore[method-assign]
+        session._cancel_typing = AsyncMock()  # type: ignore[method-assign]
+
+        await _handle_typing_tail(session)
+
+        session._cancel_typing.assert_awaited_once()
+        session._start_typing.assert_not_awaited()
+
+    async def test_outbound_none_is_no_op(self) -> None:
+        """outbound=None: no typing calls are made (typing is None by default)."""
+        fmt = _make_formatter()
+        session = StreamingSession(fmt, outbound=None)
+
+        # No typing mock attached; real _cancel_typing is a no-op because
+        # self._typing is None. The call must not raise.
+        await _handle_typing_tail(session)


### PR DESCRIPTION
## Summary
- Extract placeholder lifecycle (5 methods) and run-loop orchestration (run + _run_event_loop) from emitter.py into focused sibling modules.
- OutboundEmitter.run() becomes a thin delegate; public API unchanged.
- Tests updated to call free functions directly.
- Result: emitter.py 474 → 230 lines (file-length gate passes without exemption).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1591: refactor: emitter stage extraction — shrink emitter.py | OPEN |
| Analysis | — | Skipped (F-lite) |
| Spec | [1591-refactor-emitter-stage-extraction-spec.mdx](artifacts/specs/1591-refactor-emitter-stage-extraction-spec.mdx) | Present |
| Implementation | 4 commits on `feat/1591-refactor-emitter-stage-extraction` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] pytest outbound + adapter shared tests pass
- [ ] import-linter passes (11/11)
- [ ] check_file_length.sh passes for emitter.py

Closes #1591

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)