### PR TITLE
docs: #1605 fix stale gen-nkeys.sh references

### DIFF
--- a/docs/architecture/adr/064-nats-acl-request-reply-flows-derivation.mdx
+++ b/docs/architecture/adr/064-nats-acl-request-reply-flows-derivation.mdx
@@ -54,14 +54,14 @@ Replace hand-written `_inbox.{requester}.>` grants with a declarative `request_r
 
 **Adding a new responder:** declare one `request_reply_flows` entry → inbox grant is derived automatically. No manual grant authoring.
 
-**CI enforcement:** `scripts/check-request-reply-flows.sh` validates:
+**CI enforcement:** `scripts/check_request_reply_flows.py` validates:
 1. Both requester and responder identities exist in `acl-matrix.json`
 2. The requester's `publish[]` covers the flow `subject`
-3. `gen-nkeys.sh --template-only` output contains the derived `_inbox.{requester}.>` grant (postcondition)
+3. `uv run lyra-acl genkeys --template-only` output contains the derived `_inbox.{requester}.>` grant (postcondition)
 4. Regression guards: injecting an unknown responder or unknown requester must cause exit 1
 
 **ACL spec table:** the `_inbox.hub.>` row is present in the auto-generated spec table. The spec table is regenerated from `acl-matrix.json` by `scripts/render_acl_spec.py` (the hand-maintained sentinel-sync checker `check-acl-matrix-spec.sh` no longer exists; freshness is enforced by `scripts/check-acl-specs-drift.sh` in CI and pre-push).
 
 **`--emit-merged-authconf`:** `clipool-worker` added to `MERGED_LYRA_IDENTITIES` to ensure the derived grant is present in the merged auth.conf used by the lyra+voicecli combined deployment.
 
-**Inspecting effective grants:** run `gen-nkeys.sh --template-only` — the output shows the full auth.conf including derived inbox grants not visible in `acl-matrix.json` alone.
+**Inspecting effective grants:** run `uv run lyra-acl genkeys --template-only` — the output shows the full auth.conf including derived inbox grants not visible in `acl-matrix.json` alone.

--- a/docs/ops/nats-identity-lifecycle.md
+++ b/docs/ops/nats-identity-lifecycle.md
@@ -180,14 +180,14 @@ Exit 0 on success; exit 1 with per-error messages on failure. The check runs in 
 
 ## Future
 
-A `--retire <name>` subcommand for `gen-nkeys.sh` is planned. It will automate steps 1–7 of the retiring flow above (update JSON, remove flows, validate, update spec, regen auth.conf, commit). Until it ships, follow this runbook manually.
+A `--retire <name>` subcommand for `lyra-acl` is planned. It will automate steps 1–7 of the retiring flow above (update JSON, remove flows, validate, update spec, regen auth.conf, commit). Until it ships, follow this runbook manually.
 
 ---
 
 ## Cross-references
 
 - [`deploy/nats/acl-matrix.json`](../../deploy/nats/acl-matrix.json) — identity registry
-- [`deploy/nats/gen-nkeys.sh`](../../deploy/nats/gen-nkeys.sh) — seed generation and auth.conf rendering
+- [`scripts/gen_nkeys.py`](../../scripts/gen_nkeys.py) / `lyra-acl` — seed generation and auth.conf rendering
 - [`scripts/check-acl-matrix-retired.sh`](../../scripts/check-acl-matrix-retired.sh) — lifecycle field validator
 - [`scripts/render_acl_spec.py`](../../scripts/render_acl_spec.py) + [`scripts/render_acl_parity.py`](../../scripts/render_acl_parity.py) — spec table and parity fixture generators (`make nats-regen-specs`)
 - [`scripts/check-acl-specs-drift.sh`](../../scripts/check-acl-specs-drift.sh) — spec/fixture drift gate (CI + pre-push)


### PR DESCRIPTION
## Summary
- Replace stale `gen-nkeys.sh` references (deleted file, superseded by `scripts/gen_nkeys.py` / `lyra-acl`) in live docs
- `docs/ops/nats-identity-lifecycle.md`: update Future section and References list
- `docs/architecture/adr/064-...mdx`: update CI enforcement script name and inspecting-effective-grants command
- Also fix `scripts/check-request-reply-flows.sh` → `scripts/check_request_reply_flows.py` (file was renamed)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1605: Fix stale gen-nkeys.sh references (deleted) in nats-identity-lifecycle.md + adr/064 | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/1605-fix-stale-gen-nkeys-sh-references` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Verify `docs/ops/nats-identity-lifecycle.md` references `scripts/gen_nkeys.py` / `lyra-acl` instead of `deploy/nats/gen-nkeys.sh`
- [ ] Verify `docs/architecture/adr/064-...mdx` references `uv run lyra-acl genkeys --template-only` instead of `gen-nkeys.sh --template-only`
- [ ] Verify `scripts/check_request_reply_flows.py` exists

Closes #1605

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`