### PR TITLE
feat(infra): #1604 add acl-authconf-drift to pre-push (parity with acl-specs-drift)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,3 +99,10 @@ repos:
     pass_filenames: false
     stages:
     - pre-push
+  - id: acl-authconf-drift
+    name: ACL auth.conf drift (acl-matrix.json is source of truth)
+    entry: scripts/check-acl-authconf-drift.sh
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push


### PR DESCRIPTION
## Summary
- Add `scripts/check-acl-authconf-drift.sh` to `.pre-commit-config.yaml` with `stages: [pre-push]`, mirroring the existing `acl-specs-drift` gate.
- Both ACL drift gates (specs + auth.conf) now run in CI and pre-push, ensuring parity.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1604: Add check-acl-authconf-drift to pre-push (parity with acl-specs-drift gate) | OPEN |
| Implementation | 1 commit on `feat/1604-add-check-acl-authconf-drift-to-pre-push` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Push a branch and verify pre-push hook runs `check-acl-authconf-drift`
- [ ] Run `bash scripts/check-acl-authconf-drift.sh` manually (verified locally)

Closes #1604

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`