### PR TITLE
docs(adr): ADR-084 WorkEnvelope job_id invariant

### DIFF
--- a/artifacts/analyses/workenvelope-job-id-invariant.md
+++ b/artifacts/analyses/workenvelope-job-id-invariant.md
@@ -1,0 +1,108 @@
+# WorkEnvelope — the job_id invariant (Roxabi Factory, plan A)
+
+> Captured 2026-06-01. Design decision, pre-ADR. Source-of-truth for the job-id wire rule.
+> Context: `~/projects/docs/vision-roxabi-factory.md` (Factory = distributed-first / plan A, harness independent).
+> Status: **decided** (envelope split + ingress mint + request_id fold). Spec → issues pending.
+
+## Decision in one line
+
+Every **work** message on the bus carries `job_id` (+ `parent_job_id`), enforced **by type**
+via a `WorkEnvelope` subclass. Infra messages (heartbeat, health, lifecycle) stay on bare
+`ContractEnvelope` and carry only `trace_id`. "Every message carries a jobID" was *not*
+realistic literally — heartbeats belong to no job — but is realistic and enforceable for
+work messages.
+
+## Why (grounded in current source)
+
+| Fact | Source |
+|---|---|
+| `ContractEnvelope` = base of **every** NATS model; `trace_id` is mandatory (`min_length=1`) | `packages/roxabi-contracts/.../envelope.py` |
+| `trace_id` is therefore already on **100%** of transiting messages | all domains extend `ContractEnvelope` |
+| `job_id` exists **only** in `jobs/` (and incidentally `gh/`) | grep `job_id` |
+| Heartbeats extend `ContractEnvelope` → carry `trace_id` but belong to no job | `CliHeartbeat`, `ImageHeartbeat` |
+| Satellite RPCs carry `trace_id`, not `job_id` | `voice/`, `llm/`, `image/` models |
+| A 3rd id already floats: `request_id` ("trace_id falls back to request_id") | `voice/builders.py`, `llm/builders.py` |
+
+→ The universal "everything is correlated" invariant **already exists** as `trace_id`.
+What plan A adds is `job_id` on the **work** subset.
+
+## Id model (= OpenTelemetry)
+
+```
+trace_id       constant across the whole request tree   ("everything is linked")
+job_id         one node = one span = the "runID"
+parent_job_id  the tree edge (nesting)
+→ one trace contains N job_id. Already present together in JobEnvelope.
+```
+
+`trace_id` → Langfuse `trace_id` · `job_id` → span · `pool_id` → Langfuse `session_id`
+(aligns with obs epic #667).
+
+## Envelope hierarchy
+
+```
+ContractEnvelope            trace_id (mandatory), contract_version, issued_at
+   │                        ← INFRA: heartbeat, health, lifecycle, metrics
+   └─ WorkEnvelope          + job_id (mandatory), parent_job_id (nullable: None at root)
+                            ← WORK: llm, voice, image, turns, jobs, harness, inbound/outbound
+```
+
+- `WorkEnvelope.job_id` : `min_length=1`, required → presence guaranteed by the type.
+- `WorkEnvelope.parent_job_id` : `str | None`; `None` only at the root span.
+- `job_id` / `parent_job_id` are **not** security-bearing → additive minor bump is safe
+  (envelope `extra="ignore"` forward-compat holds; ADR-049 rules respected).
+
+## Classification rule (per-model pass required)
+
+Default: **a message that belongs to a unit of work → `WorkEnvelope`. A message about a
+component's own liveness/lifecycle → `ContractEnvelope`.**
+
+| Domain / model | Envelope | Note |
+|---|---|---|
+| `jobs/*` (JobEnvelope/Result/Progress) | WorkEnvelope | already has the fields; reparent to base |
+| `llm/` LlmRequest/Response/ChunkEvent | WorkEnvelope | harness ↔ clipool / LLM-worker |
+| `llm/` LifecycleRequest/Response | ContractEnvelope | worker lifecycle = infra |
+| `voice/` Tts/Stt Request/Response | WorkEnvelope | satellite work |
+| `image/` request/response | WorkEnvelope | satellite work |
+| `image/`/`cli/` *Heartbeat | ContractEnvelope | infra — the load-bearing exemption |
+| `cli/` CliControlCmd, CliCmdPayload | WorkEnvelope | per-turn clipool dispatch; carries `lyra_session_id` → coordinate cli bump with **#1009** |
+| `turns/` TurnWriteEvent | WorkEnvelope | belongs to the turn-job |
+| `event/` LyraEvent, LyraMetric | ContractEnvelope | observability/infra |
+| harness wire (#1490, new) | WorkEnvelope | the turn-job |
+| inbound/outbound messages | WorkEnvelope | inbound = root span; outbound = same job |
+| `audit/` | TBD | per-model — audit provenance may want job correlation |
+
+## Two correctness points
+
+1. **Root job_id minted at ingress.** The inbound adapter (Telegram/Discord receipt) mints
+   `trace_id` + root `job_id` (`parent_job_id = None`) the moment a user message enters.
+   It then flows: `inbound → hub → harness → llm/voice/image worker (child job) → outbound`,
+   the whole tree sharing one `trace_id`.
+2. **Fold `request_id` → `job_id`.** Voice/LLM builders already carry a `request_id` with a
+   "trace_id falls back to request_id" rule. Keep the system to **two** ids (trace_id, job_id);
+   `request_id` collapses into `job_id`. Avoids trace_id + request_id + job_id triplication.
+
+## Enforcement
+
+- Type-level: work subjects deserialize to `WorkEnvelope` subclasses → `job_id` cannot be absent.
+- Test-level: a subject→envelope mapping test asserts every `lyra.jobs.*` / work subject uses a
+  `WorkEnvelope` model and every infra subject (`*heartbeat*`, lifecycle) uses bare
+  `ContractEnvelope`. Same enforcement spirit as the existing importlinter contracts.
+
+## "Realistic?" — verdict
+
+| Formulation | Realistic |
+|---|---|
+| Every **work** message carries `job_id` (+parent +trace) | ✅ yes, by type (`WorkEnvelope`) |
+| **Literally every** message (heartbeat included) carries `job_id` | ❌ no — infra has no job |
+| Every message carries `trace_id` | ✅ already true today |
+
+## Next
+
+- [x] Promote to an ADR — **ADR-084**.
+- [ ] Spec the `roxabi-contracts` change: add `WorkEnvelope`, reparent work models, version bump — **#1619**.
+- [ ] Per-model classification pass (the TBD rows above) — part of #1619.
+- [ ] Ingress-mint change in inbound adapters — **#1620** · `request_id` → `job_id` fold — **#1621**.
+- [ ] Subject→envelope enforcement test — part of #1619.
+- [ ] Wire `job_id` as OTel span id — **#1623** under obs epic **#1622** (¬ #667, superseded).
+- [ ] Coordinate the `cli`-domain bump with the session-id cleanup (**#1009**) — overlapping contracts minor bump; reconcile the id taxonomy (`cli_session_id` / `lyra_session_id` / `pool_id` / `job_id` / `trace_id`).

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -1,6 +1,7 @@
 ---
 title: "ADR-084: WorkEnvelope — the job_id invariant"
 description: Split the NATS contract envelope into WorkEnvelope (mandatory job_id) vs infra ContractEnvelope (trace_id only).
+related: [049, 076, 075, 078]
 ---
 
 ## Status
@@ -120,3 +121,16 @@ parallel counter. Until #1624, typing stays on its current envelope; it is not r
 ### Neutral
 - `trace_id` semantics unchanged (already universal).
 - `JobEnvelope` already carries the three fields; it reparents to `WorkEnvelope` cleanly.
+
+## Trail
+
+- ADR-049: roxabi-contracts shared schema — extended additively by this ADR
+- ADR-076: three NATS planes — the Work/Infra split cuts across the message/persistence/typing planes
+- ADR-075: turn-writer subscriber — TurnWriteEvent is a work message that will carry `job_id`
+- ADR-078: turn-store protocol — turn persistence, related to the typing-plane discussion
+- #1619: spec for `WorkEnvelope` + reparenting work models
+- #1620: ingress-mint change in inbound adapters
+- #1621: `request_id` → `job_id` fold in voice/llm builders
+- #1622: observability pipeline (epic) — `job_id` maps to OTel span id
+- #1490: Roxabi Factory plan A (distributed-first harness) — the context that motivated this ADR
+- Reviews (2026-06-01): architect review on PR #1625 — 2 suggestions applied (pattern drift + versioning claim)

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -90,8 +90,13 @@ Supporting rules:
 - **Enforcement:** a subject→envelope mapping test asserts work subjects deserialize to
   `WorkEnvelope` subclasses and infra subjects to bare `ContractEnvelope` (same spirit as
   the importlinter contracts).
-- `job_id` / `parent_job_id` are **not security-bearing** → additive **minor** version bump
-  is safe under ADR-049 forward-compat rules.
+- Adding the `WorkEnvelope` base class itself is **additive** and safe as a **minor** bump
+  under ADR-049 forward-compat rules (`extra="ignore"`).
+- **Reparenting existing models** (other than `jobs/*`) to `WorkEnvelope` introduces a
+  **new required field** (`job_id`) where none existed before — this is **breaking** for
+  those domains (`llm`, `voice`, `image`, `turns`, `inbound/outbound`, `cli`). Each domain
+  coordinates its own major/minor bump per ADR-049. `jobs/*` is the exception: it already
+  carries the three fields, so reparenting to `WorkEnvelope` is non-breaking.
 
 ## Relationship to WorkScope and the typing plane
 

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -1,0 +1,122 @@
+---
+title: "ADR-084: WorkEnvelope — the job_id invariant"
+description: Split the NATS contract envelope into WorkEnvelope (mandatory job_id) vs infra ContractEnvelope (trace_id only).
+---
+
+## Status
+
+Accepted
+
+Extends ADR-049 (roxabi-contracts shared schema) additively. Supersedes nothing.
+Relates to ADR-076 (three NATS planes) — the Work/Infra split cuts across the
+message/persistence/typing planes (see "Relationship to WorkScope and the typing plane").
+Design source: `artifacts/analyses/workenvelope-job-id-invariant.md`.
+Implemented by: #1619 (WorkEnvelope + reparent) · #1620 (ingress mint) · #1621 (request_id fold).
+Context: Roxabi Factory plan A (distributed-first, independent harness — epic #1490).
+
+## Context
+
+Plan A makes the harness an independent NATS worker and pushes all work through the
+bus. We want any message belonging to a unit of work to carry a stable job identity so a
+turn can be followed end-to-end across hub → harness → satellites, and so jobs nest into a
+trace tree (OTel-style) feeding the observability pipeline (epic #1622).
+
+The naive form — "every message carries a `job_id`" — is **not realistic**:
+
+- `ContractEnvelope` is the base of every NATS model and already mandates `trace_id`
+  (`min_length=1`). Correlation across all hops **already exists** as `trace_id`.
+- `job_id` exists only in the `jobs/` domain today.
+- **Heartbeats** extend `ContractEnvelope` (`CliHeartbeat`, `ImageHeartbeat`) and belong to
+  **no job** — a liveness ping has no meaningful `job_id`. Forcing one fabricates fake ids.
+- A third id already floats: `request_id` (voice/llm builders: "trace_id falls back to
+  request_id"), risking trace_id + request_id + job_id triplication.
+
+The decision is the realistic, enforceable form of the invariant.
+
+## Options Considered
+
+### Option A: `job_id` mandatory on `ContractEnvelope` (every message)
+- **Pros:** one rule, trivially uniform.
+- **Cons:** semantically false for infra (heartbeat/lifecycle/metrics) — forces synthetic
+  ids on liveness pings; pollutes the trace tree with non-work nodes.
+
+### Option B: `job_id` optional on `ContractEnvelope` (nullable everywhere)
+- **Pros:** additive, no hierarchy change.
+- **Cons:** presence not guaranteed where it matters; "is this a work message?" becomes a
+  runtime guess; no type-level enforcement.
+
+### Option C: `WorkEnvelope` subclass — `job_id` mandatory on work, infra stays on base
+- **Pros:** presence guaranteed **by type** on work messages; infra honestly exempt;
+  enforceable via subject→envelope test; mirrors OTel (trace=tree, span=job).
+- **Cons:** requires a per-model classification pass and reparenting work models.
+
+## Decision
+
+**Option C.** Introduce `WorkEnvelope(ContractEnvelope)` carrying mandatory `job_id`
+(`min_length=1`) and nullable `parent_job_id` (`None` at the root span). Work-bearing
+domains (`llm`, `voice`, `image`, `turns`, `jobs`, harness wire, inbound/outbound)
+reparent to `WorkEnvelope`; infra messages (heartbeat, lifecycle, metrics) stay on bare
+`ContractEnvelope`.
+
+The **`cli` domain is split**:
+
+| `cli` model | Envelope | Why |
+|---|---|---|
+| `CliControlCmd` | WorkEnvelope | per-turn control of the clipool worker; part of a job |
+| `CliCmdPayload` | WorkEnvelope | per-turn dispatch to the clipool worker; carries `lyra_session_id` → belongs to a job |
+| `CliHeartbeat` | ContractEnvelope | worker liveness — no job |
+
+The `cli` reparent is a **breaking** `cli` minor bump (new required `job_id`). It overlaps
+with the session-id cleanup in **#1009** (rename `CliControlCmd.session_id` → `cli_session_id`,
+remove `resume_and_reset`), which is *also* a breaking `cli` bump. **Coordinate both into a
+single `cli` minor bump** to avoid two satellite-coordination events (ADR-049). The id taxonomy
+the two settle together: `cli_session_id` (claude-cli resume) · `lyra_session_id` (conversation,
+= `pool_id` ≈ Langfuse session) · `job_id` (turn) · `parent_job_id` (nesting) · `trace_id` (tree).
+
+Id model (= OpenTelemetry):
+
+```
+trace_id       constant across the whole request tree   (already universal/mandatory)
+job_id         one node = one span = the "runID"
+parent_job_id  the nesting edge
+→ one trace contains N job_id.
+```
+
+Supporting rules:
+- **Root `job_id` minted at ingress** by inbound adapters (the moment a user message
+  enters); it then flows hub → harness → satellite (child jobs), the tree sharing `trace_id`.
+- **Fold `request_id` into `job_id`** — keep the system to two ids (trace_id, job_id).
+- **Enforcement:** a subject→envelope mapping test asserts work subjects deserialize to
+  `WorkEnvelope` subclasses and infra subjects to bare `ContractEnvelope` (same spirit as
+  the importlinter contracts).
+- `job_id` / `parent_job_id` are **not security-bearing** → additive **minor** version bump
+  is safe under ADR-049 forward-compat rules.
+
+## Relationship to WorkScope and the typing plane
+
+`WorkScope` (already shipped — #1375 T1: `platform`, `bot_id`, `scope_id`, `trace_id`) is the
+**routing** identity ("where"). `WorkEnvelope` is the **work** identity ("which job"). Distinct
+roles, dangerously close names: **`WorkEnvelope` composes `WorkScope` — it does not replace it,
+and `WorkScope` is NOT promoted to a job id.**
+
+Per ADR-076 (three NATS planes), the **typing** plane (`lyra.typing.*`, display-feedback) is
+currently scope-keyed via an in-Pool ref-count (no `job_id`). It becomes job-tree-driven in
+#1624 — typing derived from root-job open/close — at which point "turn active for scope X" is
+read from the job tree (the SSoT this ADR's `job_id`/`parent_job_id` provides) instead of a
+parallel counter. Until #1624, typing stays on its current envelope; it is not reclassified here.
+
+## Consequences
+
+### Positive
+- Any work message is followable end-to-end; jobs nest into a trace tree.
+- `job_id` maps directly to the OTel span id for the obs pipeline (epic #1622).
+- Type-level guarantee removes runtime "is this work?" guessing.
+- Infra/work boundary made explicit at the envelope layer.
+
+### Negative
+- Per-model classification pass + reparenting of work models (one-time migration).
+- Ingress-mint change in inbound adapters; `request_id` → `job_id` fold in voice/llm builders.
+
+### Neutral
+- `trace_id` semantics unchanged (already universal).
+- `JobEnvelope` already carries the three fields; it reparents to `WorkEnvelope` cleanly.

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -15,6 +15,7 @@
     "076-three-nats-planes",
     "077-outbound-audio-subject",
     "079-audio-nats-contract-axial-consolidation",
+    "084-workenvelope-job-id-invariant",
     "---LLM, Streaming & Agents---",
     "028-token-level-streaming-path-shape",
     "032-llmevent-streamprocessor-renderevent-hexagonal-streaming",


### PR DESCRIPTION
## What

ADR-084 + design doc capturing the **WorkEnvelope / job_id invariant** for Roxabi Factory plan A.

- Split: `WorkEnvelope` (mandatory `job_id` + nullable `parent_job_id`, for work messages) vs bare `ContractEnvelope` (infra: heartbeat, lifecycle, metrics — `trace_id` only).
- Id model = OTel: `trace_id` (tree) / `job_id` (span) / `parent_job_id` (edge).
- Root `job_id` minted at ingress; `request_id` → `job_id` fold; split `cli` domain; WorkScope + typing-plane (ADR-076) relationship.

## Why

"Every message carries a jobID" is unrealistic (heartbeats have no job). The realistic, type-enforced form: every *work* message carries `job_id`; infra is exempt. `trace_id` is already the universal correlation.

## Scope

Docs only — no code. Implemented by #1619 (+ #1620/#1621); obs wiring under epic #1622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)