### PR TITLE
perf(tests): fix three slow test families (#1629)

### DIFF
--- a/src/lyra/infrastructure/stores/base/bot_agent_map.py
+++ b/src/lyra/infrastructure/stores/base/bot_agent_map.py
@@ -145,6 +145,8 @@ class BotAgentMapStore(SqliteStore):
             (settings_raw, now, platform, bot_id),
         )
         if cursor.rowcount == 0:
+            await cursor.close()
+            await db.rollback()
             raise ValueError(
                 f"No bot_agent_map row for platform={platform!r}, bot_id={bot_id!r}. "
                 "Call set_bot_agent() first."

--- a/tests/blobstore/conftest.py
+++ b/tests/blobstore/conftest.py
@@ -4,8 +4,26 @@ from __future__ import annotations
 
 import os
 import socket
+from unittest.mock import AsyncMock
+
+import pytest
 
 
 def on_m1() -> bool:
     """True iff we appear to be running on M1 (roxabituwer)."""
     return socket.gethostname() == "roxabituwer" or os.environ.get("LYRA_HOST") == "m1"
+
+
+@pytest.fixture(autouse=True)
+def _patch_nats_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent build_app from attempting real NATS connect in blobstore tests.
+
+    Without this, _connect_nats() follows NATS_URL in the environment and
+    _provision_nats() times out on missing JetStream permissions (~5 s).
+    Tests that explicitly inject a mock NATS client pass ``nats=`` directly
+    to build_app and are unaffected by this patch.
+    """
+    monkeypatch.setattr(
+        "lyra.blobstore.serve._connect_nats",
+        AsyncMock(return_value=None),
+    )

--- a/tests/scripts/test_parity_e2e.py
+++ b/tests/scripts/test_parity_e2e.py
@@ -488,13 +488,14 @@ def test_retired_identity_connect_rejected(
                 f"nats://127.0.0.1:{client_port}",
                 nkeys_seed_str=seed_str,
                 connect_timeout=2,
+                allow_reconnect=False,
             )
 
         with pytest.raises(
             Exception,
             match=(
-                r"authorization violation|auth error|connection refused"
-                r"|no servers available"
+                r"authorization violation|Authorization Violation|auth error"
+                r"|connection refused|no servers available"
             ),
         ):
             asyncio.run(_connect_retired())


### PR DESCRIPTION
**Done:**
- `test_parity_e2e.py` — add `allow_reconnect=False` to prevent 120s nats-py retry loop on auth violation
- `tests/blobstore/conftest.py` — autouse monkeypatch `_connect_nats` to bypass ~5s JetStream timeout per blobstore test
- `src/lyra/infrastructure/stores/bot_agent_map.py` — close cursor + rollback before raising in `set_bot_settings` to prevent 30s WAL checkpoint busy timeout on teardown

**Gains:**
| Suite | Before | After |
|-------|--------|-------|
| Full test run (5 333 tests) | ~128 s | ~22 s |

**Verification:**
- All 3 slow families eliminated from top-20 durations
- 5 333 passed, 14 skipped, 1 xfailed

🤖 Generated with [Claude Code](https://claude.com/code/claude-code)