### PR TITLE
docs(rename): finish lyra→factory residual cleanup (living docs, env, config)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,21 +6,13 @@
 # └──────────────────────────────────────────────────────────────────────────┘
 
 # --- Voice & Audio ---
-# FACTORY_STT_ENABLED=1                    # enable NATS STT adapter (set to 1 to activate)
 # FACTORY_STT_MODEL=large-v3-turbo         # faster-whisper model: tiny | small | medium | large-v3-turbo
-# FACTORY_TTS_ENABLED=1                    # enable NATS TTS adapter (set to 1 to activate)
-# FACTORY_TTS_ENGINE=qwen-fast             # TTS engine: qwen-fast | qwen | chatterbox | chatterbox-turbo
-# FACTORY_TTS_VOICE=                       # override default voice (engine-specific)
-# FACTORY_TTS_LANGUAGE=                    # override default language
-# TTS_ENGINE=                           # DEPRECATED — use FACTORY_TTS_ENGINE
 # STT_MODEL_SIZE=                       # DEPRECATED — use FACTORY_STT_MODEL
 # FACTORY_AUDIO_TMP=                       # custom tmp dir for audio files (must be writable)
 # FACTORY_MAX_AUDIO_BYTES=5242880          # max audio upload size (default: 5 MB)
-# FACTORY_STT_TIMEOUT=15.0                 # STT NATS request timeout in seconds (default: 15.0)
 
 # --- Health endpoint (used by external probes; replaces the deprecated host-timer monitor — see #1035) ---
 # FACTORY_HEALTH_SECRET=                   # bearer token for /health endpoint (leave empty to disable auth)
-# FACTORY_CONFIG_SECRET=                   # bearer token for /config endpoint
 
 # --- Deployment target — used by `make deploy` and `make remote` ---
 DEPLOY_HOST=                            # SSH user@host for production hub (e.g. user@192.168.1.16)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 # CLAUDE.md — Instructions for Claude Code
 
 Let:
-  A := ~/.lyra/auth.db (grants, identity only) | C := ~/.lyra/config.db (agents, bots, prefs) | T := TOML seed | P := CLAUDE.md path
+  A := ~/.roxabi/factory/auth.db (grants, identity only) | C := ~/.roxabi/factory/config.db (agents, bots, prefs) | T := TOML seed | P := CLAUDE.md path
 
 ## Project
 
@@ -27,15 +27,15 @@ Let:
 | `docs/agent-management.md` | Agent seed flow + CLI |
 | `docs/bot-management.md` | Bot seed flow + CLI |
 | `docs/ops/container-publishing.md` | CI → GHCR → Quadlet pattern |
-| `deploy/quadlet/lyra-nats.container` | NATS Quadlet unit — `type=mount` secret anchor (restart-not-HUP for ACL changes) |
+| `deploy/quadlet/factory-nats.container` | NATS Quadlet unit — `type=mount` secret anchor (restart-not-HUP for ACL changes) |
 | `packages/roxabi-nats/` | NATS transport SDK (ADR-045) |
 | `packages/roxabi-contracts/` | NATS contract schemas (ADR-049) |
 | `src/factory/transport/` | NATS transport + WorkerPoolClient (3-layer composition, #1278) |
 
 ## Agent management
 
-Agents ∈ C (SQLite) | T files = seed only → `lyra agent init` before use
-Search: `~/.lyra/agents/` (override) → `src/factory/agents/` (default)
+Agents ∈ C (SQLite) | T files = seed only → `factory agent init` before use
+Search: `~/.roxabi/factory/agents/` (override) → `src/factory/agents/` (default)
 `cwd` → `config.toml [defaults]` (¬T)
 
 → `docs/agent-management.md` — CLI verbs: `init | list | show | edit | patch | validate | create | delete | assign | unassign | refine`
@@ -58,7 +58,7 @@ File/rename → update P immediately
 | `src/factory/integrations/CLAUDE.md` | external boundary layer (supervisor, systemctl, vault-cli, web-intel) |
 | `src/factory/agent_cmd/CLAUDE.md` | agent + bot CLI commands — applicative layer above core |
 | `src/factory/llm/CLAUDE.md` | LLM drivers |
-| `src/factory/monitoring/CLAUDE.md` | standalone health-check subsystem (`python -m lyra.monitoring`) |
+| `src/factory/monitoring/CLAUDE.md` | standalone health-check subsystem (`python -m factory.monitoring`) |
 | `src/factory/obs/CLAUDE.md` | observability scaffolding (OTel/Langfuse) — ¬wired, see #1235 |
 | `src/factory/outbound/CLAUDE.md` | outbound stage composition (formatter/throttle/error_handler/emitter, #1279) |
 | `src/factory/streaming/CLAUDE.md` | stage-axis streaming primitives (parser Protocol, state_machine, event_emitter) — composed by CliStreamingParser + StreamProcessor (#1282) |
@@ -82,19 +82,19 @@ Rules: add/delete/move → update P | new subdir with non-obvious invariants →
 
 | Subcommand | CLI | Bootstrap |
 |---|---|---|
-| `hub` | `lyra hub` | `_bootstrap_hub_standalone()` |
-| `adapter telegram` | `lyra adapter telegram` | `_bootstrap_adapter_standalone()` |
-| `adapter discord` | `lyra adapter discord` | `_bootstrap_adapter_standalone()` |
-| `adapter clipool` | `lyra adapter clipool` | `_bootstrap_clipool_standalone()` |
-| `turn-writer` | `lyra turn-writer` | `_bootstrap_turn_writer_standalone()` |
+| `hub` | `factory hub` | `_bootstrap_hub_standalone()` |
+| `adapter telegram` | `factory adapter telegram` | `_bootstrap_adapter_standalone()` |
+| `adapter discord` | `factory adapter discord` | `_bootstrap_adapter_standalone()` |
+| `adapter clipool` | `factory adapter clipool` | `_bootstrap_clipool_standalone()` |
+| `turn-writer` | `factory turn-writer` | `_bootstrap_turn_writer_standalone()` |
 
 Topics: `lyra.inbound.<platform>.<bot_id>` | `lyra.outbound.<platform>.<bot_id>`
 
-Unified: `lyra start` → hub + adapters in 1 process + embedded NATS
+Unified: `factory start` → hub + adapters in 1 process + embedded NATS
 
 ## Container deployment
 
-Prod: Podman Quadlet (systemd `--user`) on M₁ (`lyra-hub` role). Eight containers: `lyra-nats`, `lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-clipool`, `factory-gh-helper`, `lyra-turn-writer`, `lyra-blobstore`. Install: `deploy/install.sh` (idempotent). Manifest: `deploy/quadlet.toml`.
+Prod: Podman Quadlet (systemd `--user`) on M₁ (`factory-hub` role). Eight containers: `factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`. Install: `deploy/install.sh` (idempotent). Manifest: `deploy/quadlet.toml`.
 
 → `docs/QUADLET-DEPLOYMENT.md` — install runbook, secret rotation, diagnostic
 → `~/projects/docs/container-deployment-standard.md` — 18 standards (S7 secret target, S8 naming, S12 RestartSec=10)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ```bash
 # 1. Clone and install dependencies
-git clone https://github.com/Roxabi/lyra.git
+git clone https://github.com/Roxabi/roxabi-factory.git
 cd lyra
 uv sync
 
@@ -90,8 +90,8 @@ class Platform(str, Enum):
 **2. Create `src/factory/adapters/signal.py`** inheriting `OutboundAdapterBase`:
 
 ```python
-from lyra.adapters._base_outbound import OutboundAdapterBase
-from lyra.adapters._shared_streaming import PlatformCallbacks
+from factory.adapters._base_outbound import OutboundAdapterBase
+from factory.adapters._shared_streaming import PlatformCallbacks
 
 class SignalAdapter(OutboundAdapterBase):
     async def send(self, original_msg: InboundMessage, outbound: OutboundMessage) -> None:
@@ -128,7 +128,7 @@ adapter via `hub.register_adapter(Platform.SIGNAL, bot_id, proxy)` where `proxy`
 
 ```python
 # In hub_standalone.py — register NATS proxy for the new adapter
-from lyra.nats.nats_channel_proxy import NatsChannelProxy
+from factory.nats.nats_channel_proxy import NatsChannelProxy
 proxy = NatsChannelProxy(nc, f"lyra.outbound.signal.{bot_id}")
 hub.register_adapter(Platform.SIGNAL, bot_id, proxy)
 hub.register_binding(Platform.SIGNAL, bot_id, "*", "lyra", ...)
@@ -138,7 +138,7 @@ hub.register_binding(Platform.SIGNAL, bot_id, "*", "lyra", ...)
 
 ## Adding an agent
 
-An agent is a stateless singleton defined by a TOML seed file and stored in the AgentStore (SQLite at `~/.lyra/auth.db`).
+An agent is a stateless singleton defined by a TOML seed file and stored in the AgentStore (SQLite at `~/.roxabi/factory/auth.db`).
 
 **1. Create a TOML seed** in `src/factory/agents/my_agent.toml`:
 
@@ -161,8 +161,8 @@ system = """You are ..."""
 **2. Import into the AgentStore**:
 
 ```bash
-lyra agent init          # imports all TOML seeds into the DB
-lyra agent list          # verify it appears
+factory agent init          # imports all TOML seeds into the DB
+factory agent list          # verify it appears
 ```
 
 **3. Wire a bot to the agent** in `config.toml`:
@@ -177,7 +177,7 @@ agent = "my_agent"
 **4. Assign the bot** (if not auto-assigned at startup):
 
 ```bash
-lyra agent assign my_agent --platform telegram --bot my_bot
+factory agent assign my_agent --platform telegram --bot my_bot
 ```
 
 For a custom agent class (beyond `SimpleAgent`), subclass `AgentBase` from `src/factory/core/agent.py` and implement `process()`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Personal AI agent engine** — hub-and-spoke, asyncio, multi-channel.
 
-[![CI](https://github.com/Roxabi/lyra/actions/workflows/ci.yml/badge.svg)](https://github.com/Roxabi/lyra/actions/workflows/ci.yml)
+[![CI](https://github.com/Roxabi/roxabi-factory/actions/workflows/ci.yml/badge.svg)](https://github.com/Roxabi/roxabi-factory/actions/workflows/ci.yml)
 ![Python](https://img.shields.io/badge/python-3.12-3776AB?logo=python&logoColor=white)
 ![uv](https://img.shields.io/badge/uv-package%20manager-DE5FE9)
 ![asyncio](https://img.shields.io/badge/concurrency-asyncio-0ea5e9)
@@ -21,13 +21,13 @@ It's for developers who want a persistent personal AI without giving up ownershi
 ## How it works
 
 1. **Channel adapters** (Telegram, Discord) run as separate processes. They normalize incoming messages and publish them over NATS (`lyra.inbound.<platform>.<bot_id>`).
-2. **The Hub** (`lyra-hub` process) subscribes to NATS, routes each message to the right agent via typed `(platform, bot_id, scope_id)` bindings — one pool per conversation scope (chat, thread, channel).
+2. **The Hub** (`factory-hub` process) subscribes to NATS, routes each message to the right agent via typed `(platform, bot_id, scope_id)` bindings — one pool per conversation scope (chat, thread, channel).
 3. **The Agent** processes the message, calls the LLM, and publishes the response over NATS (`lyra.outbound.<platform>.<bot_id>`). The adapter's `NatsOutboundListener` delivers it to the platform.
 
 ## Architecture
 
 ```
-lyra-telegram          lyra-hub                lyra-discord
+factory-telegram          factory-hub                factory-discord
     │                     │                        │
     │  inbound.telegram   │      clipool.cmd       │  inbound.discord
     ├────────────────────►├───────────────────────►│
@@ -42,9 +42,9 @@ lyra-telegram          lyra-hub                lyra-discord
               NATS message bus
 ```
 
-**Production**: Four independent processes (`lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-clipool`) communicate via NATS. Each runs in its own container.
+**Production**: Four independent processes (`factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`) communicate via NATS. Each runs in its own container.
 
-**Development**: `lyra start` runs everything in one process with an embedded NATS server.
+**Development**: `factory start` runs everything in one process with an embedded NATS server.
 
 ## Features
 
@@ -86,14 +86,14 @@ cp config.toml.example config.toml
 # Edit config.toml: set bot_id, agent, owner_users
 
 # 3. Store credentials (encrypted)
-lyra bot secret install telegram <bot_id>
+factory bot secret install telegram <bot_id>
 
 # 4. Seed DB from TOML
-lyra agent init              # agents
-lyra bot init                # bots (required since #1416)
+factory agent init              # agents
+factory bot init                # bots (required since #1416)
 
 # 5. Run
-lyra start
+factory start
 ```
 
 See [QUICKSTART.md](docs/QUICKSTART.md) for full setup — bot creation, environment variables, first message.
@@ -104,36 +104,36 @@ See [QUICKSTART.md](docs/QUICKSTART.md) for full setup — bot creation, environ
 
 ```bash
 lyra                        # start unified (hub + adapters, embedded NATS)
-lyra start                  # same as above
-lyra hub                    # standalone hub (requires external NATS)
-lyra adapter telegram       # standalone Telegram adapter
-lyra adapter discord        # standalone Discord adapter
-lyra adapter clipool        # standalone CliPool worker
+factory start                  # same as above
+factory hub                    # standalone hub (requires external NATS)
+factory adapter telegram       # standalone Telegram adapter
+factory adapter discord        # standalone Discord adapter
+factory adapter clipool        # standalone CliPool worker
 ```
 
 ### Agent management
 
 ```bash
-lyra agent init             # seed DB from TOML files
-lyra agent init --force     # overwrite existing
-lyra agent list             # list all agents
-lyra agent show <name>      # full config for one agent
-lyra agent edit <name>      # interactive edit
-lyra agent patch <name>     # patch fields via JSON
-lyra agent validate <name>  # validate schema
-lyra agent create           # create new agent (writes TOML)
-lyra agent assign <agent>   # assign agent to a bot
-lyra agent unassign         # unassign agent from a bot
-lyra agent refine <name>    # LLM-guided profile refinement
+factory agent init             # seed DB from TOML files
+factory agent init --force     # overwrite existing
+factory agent list             # list all agents
+factory agent show <name>      # full config for one agent
+factory agent edit <name>      # interactive edit
+factory agent patch <name>     # patch fields via JSON
+factory agent validate <name>  # validate schema
+factory agent create           # create new agent (writes TOML)
+factory agent assign <agent>   # assign agent to a bot
+factory agent unassign         # unassign agent from a bot
+factory agent refine <name>    # LLM-guided profile refinement
 ```
 
 ### Bot management
 
 ```bash
-lyra bot init                                      # seed BotStore from config.toml
-lyra bot init --force                              # overwrite existing rows
-lyra bot secret install telegram <bot_id>          # store encrypted token
-lyra bot secret install discord <bot_id>
+factory bot init                                      # seed BotStore from config.toml
+factory bot init --force                              # overwrite existing rows
+factory bot secret install telegram <bot_id>          # store encrypted token
+factory bot secret install discord <bot_id>
 ```
 
 ### Configuration
@@ -176,7 +176,7 @@ Two files:
 - `config.toml` — bot instances, auth rules, adapter settings
 - `.env` — secrets: `NATS_URL`, `ANTHROPIC_API_KEY` (optional for CLI driver)
 
-Agent and bot configs stored in `~/.lyra/config.db` (SQLite). TOML files are seed sources — import with `lyra agent init` (agents) and `lyra bot init` (bots).
+Agent and bot configs stored in `~/.roxabi/factory/config.db` (SQLite). TOML files are seed sources — import with `factory agent init` (agents) and `factory bot init` (bots).
 
 ## Project structure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 Please **do not** open a public GitHub issue for security vulnerabilities.
 
 **Option 1 — GitHub Security Advisories (preferred):**
-[Report a vulnerability](https://github.com/Roxabi/lyra/security/advisories/new)
+[Report a vulnerability](https://github.com/Roxabi/roxabi-factory/security/advisories/new)
 
 **Option 2 — Email:**
 mickael@bouly.io

--- a/artifacts/frames/1668-finish-lyra-factory-cleanup-frame.mdx
+++ b/artifacts/frames/1668-finish-lyra-factory-cleanup-frame.mdx
@@ -1,0 +1,78 @@
+---
+title: "Finish lyra→factory rename — residual non-functional refs"
+issue: 1668
+status: approved
+tier: F-lite
+date: 2026-06-02
+---
+
+## Problem
+
+The `lyra`→`factory` rename (PR #1669) is functionally complete and merged to `staging`:
+package, CLI surface, `LYRA_*`→`FACTORY_*` env vars, container identity, and the
+image-breaking Dockerfile gh-shim ENV are all done. Deliberately deferred — to keep the
+rename PR tightly scoped — were three classes of **residual, non-functional** references
+that still misrepresent the project as `lyra`:
+
+1. **Doc/artifact sweep** — stale `LYRA_*`, `lyra-*` unit/image refs, `~/.lyra`,
+   `ghcr.io/roxabi/lyra`, `Roxabi/lyra` confined to `.md`/`.mdx`/`docs/`/`artifacts/`,
+   including *living* docs (`deploy/CLAUDE.md`, `src/factory/tools/CLAUDE.md`, the root
+   `CLAUDE.md` container table, etc.) that Claude + contributors read as SSoT.
+2. **Dead env vars** — 7 `FACTORY_*` toggle vars in `.env.example` with **zero readers**
+   in the repo (STT/TTS init is unconditional per `tests/bootstrap/test_voice_overlay.py`).
+   Prefix-renamed in the rename PR for file consistency but still *lie* about a feature gate.
+   (+ bonus: `TTS_ENGINE=` line marked DEPRECATED, also dead.)
+3. **Config-filename drift** (pre-existing) — `FACTORY_CONFIG` default disagrees:
+   `monitoring/config.py:134` → `"lyra.toml"`; `config_loader.py` → canonical `config.toml`;
+   `authenticator.py:266` log msg → `lyra.toml`. Align all to `config.toml`. Test-touching.
+
+## Who
+
+- **Primary:** contributors + Claude reading living docs (`CLAUDE.md`, `deploy/`) as the
+  source of truth — stale `lyra-*` refs mislead about unit/image/path names.
+- **Secondary:** anyone setting `FACTORY_STT_ENABLED`/`FACTORY_TTS_*` in `.env` expecting a
+  toggle that does not exist (silent no-op → confusion).
+
+## Constraints
+
+- Pure cleanup — **no runtime behavior change** beyond the config-filename alignment.
+- **Keep (do NOT touch):** NATS subject examples (`lyra.*`) — separate WIRE workstream #1670;
+  "Lyra" persona / `lyra_default` / `bot_id "lyra"` / `/svc` label / `lyra-bot@` git author;
+  frozen historical fixture `tests/scripts/fixtures/v3-pre-grant-group.json`.
+- Config-filename change touches `tests/test_monitoring_config.py` — keep tests green.
+- Single low-risk PR → `staging`, merge-commit convention.
+
+## Out of Scope
+
+- NATS subjects `lyra.*`→`factory.*`, JetStream streams (`LYRA_OUTBOUND_AUDIO`, `LYRA_AUDIT`,
+  `LYRA_TURNS`), KV `LYRA_STATE`, ACL `owner: "lyra"` — cross-repo wire contract → #1670.
+- Frozen pre-migration test fixture (intentional `lyra-nats-*` / `~/.lyra`).
+- Kept app identity (persona, default agent/bot ids, service label, git author).
+- Prod cutover (data move, host secrets, hosts.toml role, auto-update timer) → Part 2.
+
+## Premise Validity
+
+**Success in 6 months:** `git grep -niE 'lyra' -- '*.md' '*.mdx' docs/ artifacts/` returns
+**only** intentional matches (NATS `lyra.*` subjects, "Lyra" persona, frozen fixture);
+`FACTORY_CONFIG` resolves to `config.toml` in all 3 resolvers; `.env.example` has zero
+dead toggle vars. No contributor/Claude is misled by a stale `lyra-*` ref or phantom flag.
+
+**Failure in 6 months:** A `git grep` over docs still surfaces ≥1 non-subject `lyra`/`LYRA_`
+ref in a living doc (e.g. `deploy/CLAUDE.md` still names `lyra-hub`), OR a contributor files a
+bug/question about `FACTORY_STT_ENABLED` having no effect — i.e. the dead vars still ship.
+(Falsifiable: grep count > 0 on the defined exclusion set; or ≥1 such issue/question.)
+
+**Simplest alternative:** Do nothing — it's pure docs + dead config, zero runtime impact.
+**Why not simplest:** Living docs (`CLAUDE.md`, `deploy/`) are the SSoT that Claude and
+contributors act on; stale refs cause wrong commands/paths, and the dead env vars *actively
+assert* a feature toggle that silently does nothing — misleading, not merely cosmetic.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (cleanup), no new architecture, one real
+decision (item 2: remove vs wire the dead vars → **remove**, working stance).
+
+Signals observed:
+- >3 files (doc sweep spans many `.md`) but mechanical string-replace bulk.
+- One code+test change (item 3) — bounded, 3 source files + 1 test.
+- No unknowns; issue body is already a de-facto spec with exact paths + grep commands.

--- a/artifacts/plans/1668-finish-lyra-factory-cleanup-plan.mdx
+++ b/artifacts/plans/1668-finish-lyra-factory-cleanup-plan.mdx
@@ -1,0 +1,166 @@
+---
+title: "Plan: Finish lyra→factory residual cleanup"
+issue: 1668
+spec: artifacts/specs/1668-finish-lyra-factory-cleanup-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-06-02
+---
+
+## Summary
+
+Apply the scoped rename map to 59 living-doc files (782 hits) + remove 8 dead `.env.example`
+vars + align `FACTORY_CONFIG` default to `config.toml` in 2 code spots and 1 test. Doc sweep
+via a **protected sed script** (stream-name placeholders + import/verb anchoring) so the KEEP
+set — subjects `lyra.*`, streams `LYRA_*`, persona, plugin dirs — is never touched.
+
+## Architecture
+
+### Replacement data flow
+
+```mermaid
+flowchart TD
+  subgraph KEEP[protected — never replaced]
+    SUBJ["lyra.inbound/outbound/typing.*"]
+    STREAM["LYRA_OUTBOUND_AUDIO / LYRA_AUDIT / LYRA_TURNS / LYRA_STATE"]
+    ID["Lyra persona / lyra_default / bot_id"]
+    PLUG["plugins/lyra-ops, lyra-send"]
+  end
+  subgraph MAP[anchored rename map]
+    P1["LYRA_<x> → FACTORY_<x> (stream-protected)"]
+    P2["lyra <verb> → factory <verb>"]
+    P3["from/import/-m/src/ lyra → factory"]
+    P4["~/.lyra → ~/.roxabi/factory"]
+    P5["Roxabi/lyra, ghcr.io/roxabi/lyra, projects/lyra"]
+    P6["lyra-<unit> → factory-<unit> (whitelist)"]
+  end
+  FILES["59 living-doc files"] --> SCRIPT["tools/_sweep_1668.sh (protected sed)"]
+  STREAM -. placeholder .-> SCRIPT
+  SUBJ -. anchor-miss .-> SCRIPT
+  PLUG -. whitelist-miss .-> SCRIPT
+  MAP --> SCRIPT
+  SCRIPT --> VERIFY["grep: replaceable→0 ∧ KEEP counts stable"]
+```
+
+### File × change map
+
+```mermaid
+flowchart LR
+  subgraph code[W1 — code]
+    MC["monitoring/config.py L21,129,134"]
+    AU["core/auth/authenticator.py L266"]
+    TC["tests/test_monitoring_config.py"]
+  end
+  subgraph cfg[W2 — config]
+    ENV[".env.example (−8 dead vars)"]
+  end
+  subgraph docs[W3 — docs]
+    SW["59 living-doc files"]
+  end
+  MC --> TC
+  AU --> LOG["(log string only)"]
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1 | `monitoring/config.py`, `core/auth/authenticator.py`, `tests/test_monitoring_config.py` |
+| devops-A | T2 | `.env.example` |
+| doc-writer-A | T3 | `tools/_sweep_1668.sh` (throwaway) + 59 living-doc files |
+| tester-A | T4 | (verification — full suite + gates) |
+
+## Wave Structure
+
+2 waves, max 3 parallel agents. Elapsed ~1 pass vs ~4 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 3 ∥ | backend-dev-A: T1 · devops-A: T2 · doc-writer-A: T3 |
+| 2 | Wave 1 done | 1 | tester-A: T4 (RED-GATE: all gates green) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 config align + test | 3 files | bounded | 8 | — |
+| T2 dead env vars | 1 file | trivial | 3 | — |
+| T3 doc sweep (script+apply+verify) | 59 files | judgmental | 28 | — (<50) |
+| T4 verification suite | gates | bounded | 8 | — |
+
+**Total estimated ops: ~47**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|---|---|---|---|---|
+| backend-dev-A | T1 | 8 | config | — |
+| devops-A | T2 | 3 | env | — |
+| doc-writer-A | T3 | 28 | docs | — |
+| tester-A | T4 | 8 | verify | — |
+
+## Consistency Report
+
+- Covered: SC-1 (T3), SC-2 (T2), SC-3 (T1), SC-4 (T3 verify), SC-5 (T4), SC-6 (T4) — 6/6.
+- Uncovered: none. Untraced tasks: none. Exemptions: none.
+
+## Micro-Tasks
+
+### Slice S1 — Config-filename alignment  [backend-dev-A · subject: config]
+
+- **T1** — Replace `lyra.toml`→`config.toml` in `src/factory/monitoring/config.py` (L21 docstring, L129 docstring, L134 `os.environ.get("FACTORY_CONFIG", ...)` default) and the log string in `src/factory/core/auth/authenticator.py:266`; update the matching expectation in `tests/test_monitoring_config.py`.
+  - Verify: `grep -rn 'lyra.toml' src/factory && echo FAIL || echo OK` → OK; `uv run pytest tests/test_monitoring_config.py -q`
+  - Spec trace: SC-3 · Phase: GREEN · Difficulty: 2
+
+### Slice S2 — Dead env vars  [devops-A · subject: env]
+
+- **T2** — Delete from `.env.example`: `FACTORY_STT_ENABLED`, `FACTORY_TTS_ENABLED`, `FACTORY_TTS_ENGINE`, `FACTORY_TTS_VOICE`, `FACTORY_TTS_LANGUAGE`, `FACTORY_STT_TIMEOUT`, `FACTORY_CONFIG_SECRET`, and the deprecated `TTS_ENGINE` line (+ any now-orphaned section header/comment). Do NOT wire flag-gates.
+  - Verify: `grep -nE 'FACTORY_(STT_ENABLED|TTS_ENABLED|TTS_ENGINE|TTS_VOICE|TTS_LANGUAGE|STT_TIMEOUT|CONFIG_SECRET)' .env.example && echo FAIL || echo OK`; confirm zero readers unchanged: `git grep -nE 'FACTORY_STT_ENABLED|FACTORY_TTS_ENABLED' -- 'src/**' && echo HAS_READER || echo NO_READER`
+  - Spec trace: SC-2 · Phase: GREEN · Difficulty: 1
+
+### Slice S3 — Living-doc sweep  [doc-writer-A · subject: docs]
+
+- **T3** — Write `tools/_sweep_1668.sh`: a protected sed over the living-doc fileset
+  (`CLAUDE.md` anywhere, `README/CONTRIBUTING/SECURITY`, `docs/**` ∖ `history`+`adr`,
+  `deploy/**.md`, `packages/**` ∖ CHANGELOG). Order: (1) placeholder-protect stream names
+  `LYRA_(OUTBOUND_AUDIO|AUDIT|TURNS|STATE)`; (2) apply rename map with anchoring —
+  `LYRA_`→`FACTORY_`, `~/.lyra`→`~/.roxabi/factory`, `Roxabi/lyra`→`Roxabi/roxabi-factory`,
+  `ghcr.io/roxabi/lyra`→`ghcr.io/roxabi/factory`, `projects/lyra`→`projects/roxabi-factory`,
+  `(from |import |-m |src/)lyra`→`\1factory`, `lyra-(nats|hub|telegram|discord|clipool|turn-writer|blobstore)`→`factory-\1`,
+  `\blyra (hub|start|agent|bot|adapter|turn-writer)`→`factory \1`; (3) restore placeholders.
+  Dry-run preview (`git diff --stat`), apply, then **delete the script**.
+  - Verify (SC-1): `git grep -nE '<replaceable patterns>' -- <living fileset> | grep -ivE '<keep>'` → 0
+  - Verify (SC-4 / KEEP stable): subjects `lyra.` count, stream names, `"Lyra"`/`lyra_default`, `plugins/lyra-(ops|send)`, `lyra_session_id` — before/after diff on those patterns = empty. Eyeball `git diff` for any subject/persona hit → revert if found.
+  - Spec trace: SC-1, SC-4 · Phase: GREEN · Difficulty: 3
+
+### Slice S-GATE — Verification  [tester-A · subject: verify]
+
+- **T4** [RED-GATE] — After T1–T3: `uv run pytest -q` (full suite green), `uv run python tools/check_doc_drift.py` (or via pre-push), `uv run ruff format . && uv run ruff check .`, `uv run pyright`. All green → gate passes.
+  - Verify: each command exit 0.
+  - Spec trace: SC-5, SC-6 · Phase: RED-GATE · Difficulty: 2 · blockedBy: T1, T2, T3
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T-numbers ref this list. -->
+
+### Wave 1 — no deps, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | backend-dev-A | — | config |
+| T2 | devops-A | — | env |
+| T3 | doc-writer-A | — | docs |
+
+### Wave 2 — after Wave 1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T4 | tester-A | T1, T2, T3 | verify |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — config (backend-dev-A)
+- T2: 13 — env (devops-A)
+- T3: 14 — docs (doc-writer-A)
+- T4: 15 — verify (tester-A) — blockedBy T1,T2,T3

--- a/artifacts/specs/1668-finish-lyra-factory-cleanup-spec.mdx
+++ b/artifacts/specs/1668-finish-lyra-factory-cleanup-spec.mdx
@@ -1,0 +1,108 @@
+---
+title: "Finish lyra→factory rename — residual non-functional refs"
+issue: 1668
+status: approved
+tier: F-lite
+date: 2026-06-02
+promoted_from: artifacts/frames/1668-finish-lyra-factory-cleanup-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1668-finish-lyra-factory-cleanup-frame.mdx`.
+The `lyra`→`factory` rename (PR #1669) is merged to `staging` — package, CLI, env vars,
+container identity, deploy artifacts (`deploy/quadlet/factory-*.container`, image
+`ghcr.io/roxabi/factory`), and `paths.py` data-dir default (`~/.roxabi/factory`) are all
+done. This spec covers the 3 deferred residual classes that still misrepresent the project.
+
+**Grounded facts (verified in tree):** CLI verb is `factory` (pyproject `[project.scripts]`);
+data-dir default is `~/.roxabi/factory` (`src/factory/paths.py:16`); modules are `factory.*`;
+repo is `Roxabi/roxabi-factory`; Quadlet units are `factory-*`. Living docs still carrying
+`lyra` forms therefore **disagree with the code** and are stale (not merely cosmetic).
+
+## Goal
+
+Eliminate every *misleading* `lyra` reference from **living** docs + dead config, without
+touching the NATS wire contract (#1670), app identity, or historical records.
+
+## Users
+
+- **Primary:** contributors + Claude reading living docs (`CLAUDE.md`, `docs/`, `deploy/`)
+  as SSoT — stale refs yield wrong commands/paths.
+- **Secondary:** anyone setting a phantom `FACTORY_STT_ENABLED`/`FACTORY_TTS_*` toggle.
+
+## Expected Behavior
+
+After this change, `git grep` over the living-doc fileset finds **zero** replaceable
+`lyra` tokens (per the rename map below); `.env.example` has no dead toggle vars;
+`FACTORY_CONFIG` resolves to `config.toml` in all three resolvers; and every exclusion
+(subjects, streams, persona, plugins, history) is **untouched** (counts stable).
+
+## Data Model & Consumers
+
+### Rename map (living docs only)
+
+| Stale token | → Replacement | Note |
+|---|---|---|
+| `LYRA_<X>` env | `FACTORY_<X>` | **except** stream/KV names below |
+| `lyra <verb>` (hub/start/agent/bot/adapter/turn-writer) | `factory <verb>` | CLI |
+| `from lyra` / `import lyra` / `python -m lyra` / `src/lyra` | `factory` / `src/factory` | module/import |
+| `~/.lyra` , `/.lyra` | `~/.roxabi/factory` | data dir |
+| `Roxabi/lyra` | `Roxabi/roxabi-factory` | repo slug |
+| `ghcr.io/roxabi/lyra` | `ghcr.io/roxabi/factory` | image |
+| `projects/lyra` | `projects/roxabi-factory` | path |
+| `lyra-{nats,hub,telegram,discord,clipool,turn-writer,blobstore}` | `factory-*` | unit/container |
+
+### KEEP — explicit exclusion set (must NOT change)
+
+| Class | Examples | Why |
+|---|---|---|
+| NATS subjects | `lyra.inbound.*`, `lyra.outbound.*`, `lyra.typing.*` | wire contract → #1670 |
+| JetStream streams / KV | `LYRA_OUTBOUND_AUDIO`, `LYRA_AUDIT`, `LYRA_TURNS`, `LYRA_STATE` | wire contract → #1670 |
+| App identity | `"Lyra"` persona, `lyra_default`, `bot_id "lyra"`, `/svc`, `lyra-bot@` | intentional |
+| Plugin dirs/names | `plugins/lyra-ops`, `plugins/lyra-send` | match disk; rename = separate functional change |
+| Code field | `lyra_session_id` | functional identifier (possible contract field) |
+| Historical records | `artifacts/**`, `CHANGELOG.md`, `packages/**/CHANGELOG.md`, `docs/history/**`, `docs/architecture/adr/**`, fixture `v3-pre-grant-group.json` | point-in-time truth |
+
+### Item-3 config resolver (the one with real consumers)
+
+```mermaid
+flowchart LR
+  ENV["$FACTORY_CONFIG (unset)"] --> R1["monitoring/config.py:134\n default 'lyra.toml' ❌→ 'config.toml'"]
+  ENV --> R2["bootstrap/.../config_loader.py\n canonical 'config.toml' ✅"]
+  ENV --> R3["core/auth/authenticator.py:266\n log msg 'lyra.toml' ❌→ 'config.toml'"]
+  R1 --> OUT["resolved config path"]
+  R2 --> OUT
+  R3 -.->|log only| LOG["operator log"]
+```
+
+Consumer summary: 3 resolvers read `$FACTORY_CONFIG`; only `config_loader.py` is already
+canonical. `monitoring/config.py` (default + 2 docstrings) and `authenticator.py` (log
+string) must align to `config.toml`. `tests/test_monitoring_config.py` asserts the default.
+
+## Breadboard
+
+| ID | Work item | Files | Action |
+|---|---|---|---|
+| W1 | Config-filename alignment | `src/factory/monitoring/config.py` (L21,129,134), `src/factory/core/auth/authenticator.py` (L266), `tests/test_monitoring_config.py` | replace `lyra.toml`→`config.toml`; update test expectation |
+| W2 | Dead env-var removal | `.env.example` | delete `FACTORY_STT_ENABLED`, `FACTORY_TTS_ENABLED`, `FACTORY_TTS_ENGINE`, `FACTORY_TTS_VOICE`, `FACTORY_TTS_LANGUAGE`, `FACTORY_STT_TIMEOUT`, `FACTORY_CONFIG_SECRET`, deprecated `TTS_ENGINE` |
+| W3 | Living-doc sweep | 59 files (per audit), apply rename map, honor KEEP set | targeted replace + verify |
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|---|---|---|
+| S1 | Config alignment + test | W1 | `pytest tests/test_monitoring_config.py` green; grep `lyra.toml` in src → 0 |
+| S2 | Dead env vars | W2 | `.env.example` clean; the 7+1 vars gone; still zero readers |
+| S3 | Living-doc sweep | W3 | living-doc grep (rename map) → 0; KEEP-set counts unchanged; doc-drift gate green |
+
+Slices independent; S1+S2 tiny/code-adjacent, S3 is the bulk (mechanical, agent-parallelizable by directory cluster).
+
+## Success Criteria
+
+- [ ] `git grep -nE '<rename-map patterns>'` over the living-doc fileset (CLAUDE.md anywhere, root community docs, `docs/**` ∖ `history`+`adr`, `deploy/**.md`, `packages/**` ∖ CHANGELOG) returns **0**, after excluding the KEEP set.
+- [ ] `.env.example`: all 7 dead `FACTORY_*` vars + deprecated `TTS_ENGINE` removed; `git grep -nE 'FACTORY_(STT_ENABLED|TTS_ENABLED|TTS_ENGINE|TTS_VOICE|TTS_LANGUAGE|STT_TIMEOUT|CONFIG_SECRET)'` across repo confirms still **zero readers** (no wiring added).
+- [ ] `FACTORY_CONFIG` default is `config.toml` in `monitoring/config.py:134`; docstrings L21/L129 and `authenticator.py:266` log say `config.toml`.
+- [ ] KEEP set unchanged: subject `lyra.*` count, stream names (`LYRA_OUTBOUND_AUDIO`/`LYRA_AUDIT`/`LYRA_TURNS`/`LYRA_STATE`), `"Lyra"`/`lyra_default`/`bot_id`, `plugins/lyra-{ops,send}`, `lyra_session_id`, and all historical files — verified by before/after diff scoped to those patterns = empty.
+- [ ] `uv run pytest` green (esp. `tests/test_monitoring_config.py`).
+- [ ] `tools/check_doc_drift.py` passes; `ruff check`/`ruff format`/`pyright` clean.

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -24,13 +24,13 @@ Network: all units attach to `roxabi.network` (defined in `quadlet/roxabi.networ
 
 ## NATS server
 
-`lyra-nats.container` is part of the deploy bundle — it is the sole NATS server on M₁.
+`factory-nats.container` is part of the deploy bundle — it is the sole NATS server on M₁.
 The host `nats.service` is retired (big-bang consolidation). Hub and adapters declare
-`After=lyra-nats.service` / `Requires=lyra-nats.service` so systemd boots NATS first.
+`After=factory-nats.service` / `Requires=factory-nats.service` so systemd boots NATS first.
 
 NATS config: `nats/nats-container.conf` (bind-mounted read-only).
-Auth credentials: Podman secret `lyra-nats-auth` (type=mount, tmpfs-backed).
-NATS version: pinned by digest in `lyra-nats.container` — ¬autoupdate, bump manually.
+Auth credentials: Podman secret `factory-nats-auth` (type=mount, tmpfs-backed).
+NATS version: pinned by digest in `factory-nats.container` — ¬autoupdate, bump manually.
 
 ---
 
@@ -40,15 +40,15 @@ Full pattern → `docs/ops/container-publishing.md`
 
 | Phase | Image tag | `AutoUpdate=` |
 |---|---|---|
-| Staging validation | `ghcr.io/roxabi/lyra:staging` | `registry` |
-| Post-release prod pin | `ghcr.io/roxabi/lyra:X.Y.Z` | none (edit manually) |
+| Staging validation | `ghcr.io/roxabi/factory:staging` | `registry` |
+| Post-release prod pin | `ghcr.io/roxabi/factory:X.Y.Z` | none (edit manually) |
 
-CI: push to `staging` → `publish.yml` → `ghcr.io/roxabi/lyra:staging`.
+CI: push to `staging` → `publish.yml` → `ghcr.io/roxabi/factory:staging`.
 Prod pull: `podman-auto-update.timer` fires every 5 min, checks digest, restarts on change.
 Rollback: edit `Image=` to previous semver tag → `systemctl --user daemon-reload` → restart.
 
 **Schema-floor bumps** (wire-protocol change): stop auto-update timer, restart hub + telegram
-+ discord atomically, re-enable timer. `lyra-clipool` excluded (not a RenderEvent receiver).
++ discord atomically, re-enable timer. `factory-clipool` excluded (not a RenderEvent receiver).
 
 ---
 
@@ -57,7 +57,7 @@ Rollback: edit `Image=` to previous semver tag → `systemctl --user daemon-relo
 `provision.sh` — M₁ post-install script. Run once per machine, or after a full wipe.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra/staging/deploy/provision.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Roxabi/roxabi-factory/staging/deploy/provision.sh | bash
 ```
 
 Who runs it: operator (Mickael) — ¬automated, ¬CI. Idempotent for most steps.
@@ -65,8 +65,8 @@ Who runs it: operator (Mickael) — ¬automated, ¬CI. Idempotent for most steps
 `systemctl --user daemon-reload`.
 
 Secrets bootstrap: `make quadlet-secrets-install` (installs Podman secrets from host key files).
-BotStore bootstrap: `make quadlet-install` runs `lyra bot init` as its first step (seeds
-`~/.lyra/config.db` from `config.toml` — idempotent, skip-existing). Required since #1416.
+BotStore bootstrap: `make quadlet-install` runs `factory bot init` as its first step (seeds
+`~/.roxabi/factory/config.db` from `config.toml` — idempotent, skip-existing). Required since #1416.
 Operator scripts: `scripts/rotate-claude-oauth.sh`, `scripts/rotate-gh-key.sh` — run manually
 on rotation events.
 
@@ -82,21 +82,21 @@ deploy verb for M₁. It reconciles the running system with the desired state de
 
 | Property | Mechanism |
 |---|---|
-| **Change-gated** | Computes a convergence fingerprint (`git HEAD` + rendered Quadlet unit checksums + `auth.conf` SHA). If the current state matches the last recorded stamp (`~/.lyra/.converge-stamp`), the script exits immediately with `Already converged — nothing to do.` |
+| **Change-gated** | Computes a convergence fingerprint (`git HEAD` + rendered Quadlet unit checksums + `auth.conf` SHA). If the current state matches the last recorded stamp (`~/.roxabi/factory/.converge-stamp`), the script exits immediately with `Already converged — nothing to do.` |
 | **Idempotent** | Running `make converge` twice on an unchanged tree is a no-op. Individual steps (git pull, `make quadlet-install`, `factory-acl genkeys`, secret install, restarts) are each idempotent or guarded. |
 | **Atomic** | A `flock` file lock (`/run/user/<uid>/lyra-deploy.lock`) prevents concurrent converges. If the lock is held, the second invocation exits 0 silently. The full sequence (pull → install → regen auth → secrets → restart NATS → restart clients) is executed as a single critical section. |
 
 ### Convergence sequence
 
 1. **Change-gate** — skip if already converged.
-2. **Pull** — `git pull origin staging` in `~/projects/lyra` (and `~/projects/voiceCLI` if present).
+2. **Pull** — `git pull origin staging` in `~/projects/roxabi-factory` (and `~/projects/voiceCLI` if present).
 3. **Install Quadlet units** — `make quadlet-install NO_RESTART=1` (renders units, copies to `~/.config/containers/systemd`, `daemon-reload`, seeds BotStore).
 4. **Regenerate auth.conf** — `factory-acl genkeys --regen-authconf` (renders `nkeys/` → `auth.conf`).
 5. **Install secrets** — `make quadlet-secrets-install` (recreates Podman secrets from host key files).
-6. **Restart NATS** — `systemctl --user restart lyra-nats` (mount-typed secrets require container restart, not HUP, to refresh). Waits for `is-active`.
-7. **Restart lyra clients** — `lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-clipool`, `lyra-turn-writer`, `factory-gh-helper`, `lyra-blobstore` (only if already active; any failure aborts the converge).
+6. **Restart NATS** — `systemctl --user restart factory-nats` (mount-typed secrets require container restart, not HUP, to refresh). Waits for `is-active`.
+7. **Restart lyra clients** — `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-turn-writer`, `factory-gh-helper`, `factory-blobstore` (only if already active; any failure aborts the converge).
 8. **Restart voiceCLI** — `voicecli-tts`, `voicecli-stt` (if voiceCLI directory exists).
-9. **Record stamp** — writes the new convergence fingerprint to `~/.lyra/.converge-stamp`.
+9. **Record stamp** — writes the new convergence fingerprint to `~/.roxabi/factory/.converge-stamp`.
 
 ### Trigger wiring
 
@@ -104,24 +104,24 @@ Two systemd user timers drive convergence **automatically**:
 
 | Timer | Period | Service | Role |
 |---|---|---|---|
-| `lyra-quadlet-sync.timer` | `*:0/5` (5 min) | `lyra-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, Makefile, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
-| `lyra-post-autoupdate.timer` | `*:0/5` (5 min) | `lyra-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). |
+| `factory-quadlet-sync.timer` | `*:0/5` (5 min) | `factory-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, Makefile, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
+| `factory-post-autoupdate.timer` | `*:0/5` (5 min) | `factory-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). |
 
-`lyra-quadlet-sync` handles **unit/template changes** (code-driven).
-`lyra-post-autoupdate` handles **image digest changes** (CI-driven).
+`factory-quadlet-sync` handles **unit/template changes** (code-driven).
+`factory-post-autoupdate` handles **image digest changes** (CI-driven).
 Both are required for fully hands-off deploys.
 
 ### Failure notification path
 
-`lyra-quadlet-sync.service` and `lyra-post-autoupdate.service` both declare:
+`factory-quadlet-sync.service` and `factory-post-autoupdate.service` both declare:
 
 ```ini
-OnFailure=lyra-deploy-failure.service
+OnFailure=factory-deploy-failure.service
 ```
 
-`lyra-deploy-failure.service` is a `Type=oneshot` unit that logs a structured error message
-to the systemd journal via `systemd-cat` (tag `lyra-deploy-failure`, priority `err`).
-Monitor: `journalctl --user -t lyra-deploy-failure -f`
+`factory-deploy-failure.service` is a `Type=oneshot` unit that logs a structured error message
+to the systemd journal via `systemd-cat` (tag `factory-deploy-failure`, priority `err`).
+Monitor: `journalctl --user -t factory-deploy-failure -f`
 
 ### Manual usage
 
@@ -145,9 +145,9 @@ Operational consequence: `type=mount` secrets are bound at container init — `-
 
 ### Secret naming convention
 
-NATS-related secrets use hyphens (`lyra-nats-<role>`) — this predates the underscore
+NATS-related secrets use hyphens (`factory-nats-<role>`) — this predates the underscore
 convention and is preserved for NATS NKey compatibility. Non-NATS secrets (bearer tokens,
-API keys) use underscores (`lyra_<service>_<purpose>`, e.g. `lyra_blobstore_token`).
+API keys) use underscores (`lyra_<service>_<purpose>`, e.g. `factory_blobstore_token`).
 Mixing styles is intentional and tracked; do not "normalize" without coordinating
 with the operator (Mickael).
 
@@ -155,15 +155,15 @@ Bot per-platform secrets follow the hyphen convention:
 
 | Secret name | In-container target | Mode | Notes |
 |---|---|---|---|
-| `lyra-bot-<platform>-<bot_id>` | `bot_token-<bot_id>` | 0400 | Bot token; always emitted per bot |
-| `lyra-bot-<platform>-<bot_id>-webhook` | `bot_webhook-<bot_id>` | 0400 | Telegram webhook secret; only emitted when `[[auth.<platform>_bots]].webhook_enabled = true` |
+| `factory-bot-<platform>-<bot_id>` | `bot_token-<bot_id>` | 0400 | Bot token; always emitted per bot |
+| `factory-bot-<platform>-<bot_id>-webhook` | `bot_webhook-<bot_id>` | 0400 | Telegram webhook secret; only emitted when `[[auth.<platform>_bots]].webhook_enabled = true` |
 
 ### Known residual risk — blobstore PublishPort Tailscale fallback (#1330)
 
-`lyra-blobstore.container` binds PublishPort to `${TAILSCALE_IPV4}:8449:8449` (resolved at
+`factory-blobstore.container` binds PublishPort to `${TAILSCALE_IPV4}:8449:8449` (resolved at
 provision time via `tailscale ip -4 | head -1`). If `TAILSCALE_IPV4` is unset or `tailscale0`
 is absent at container start, Podman falls back to `0.0.0.0:8449` (LAN-exposed). The bearer
-token (`lyra_blobstore_token`) is then the **sole** auth boundary. Accepted for V8; Phase 2
+token (`factory_blobstore_token`) is then the **sole** auth boundary. Accepted for V8; Phase 2
 (network policy / per-identity tokens) will address this systematically.
 
 The `ExecStartPre=` guard strips all whitespace before the `-n` test (POSIX `tr -d`) so

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -16,7 +16,7 @@ Cross-repo adoption checklist → `docs/ops/container-publishing.md § Cross-rep
 ## Unit naming convention
 
 Authoritative unit manifest: `deploy/quadlet.toml`.
-Pattern: `lyra-<component>.container` → `ContainerName=lyra-<component>` → `lyra-<component>.service`.
+Pattern: `factory-<component>.container` → `ContainerName=factory-<component>` → `factory-<component>.service`.
 Telegram and discord units are rendered from `.container.tmpl` at deploy time (bot-token injection).
 Network: all units attach to `roxabi.network` (defined in `quadlet/roxabi.network`).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@
 Hub-and-spoke AI agent engine. One hub routes inbound messages from multiple platforms (Telegram, Discord, CLI) to per-conversation pools backed by a Claude CLI subprocess. Responses stream back through NATS to the originating adapter. All state is per-pool; agents are immutable singletons. Multiple bots per platform are supported via independent bindings.
 
 ```
-lyra_telegram                     lyra_hub                      lyra_discord
+factory_telegram                     factory_hub                      factory_discord
 ─────────────                   ─────────────                  ─────────────
 aiogram long-poll                NatsBus                       discord.py gateway
       │                              │                              │
@@ -53,14 +53,14 @@ aiogram long-poll                NatsBus                       discord.py gatewa
       ◄──────────────────────────────┴──────────────────────────────▶
 ```
 
-All four processes run on Machine 1 (hub). NATS topics: `lyra.inbound.<platform>.<bot_id>` (adapter→hub), `lyra.outbound.<platform>.<bot_id>` (hub→adapter). `lyra start` runs hub + adapters in one process with embedded NATS.
+All four processes run on Machine 1 (hub). NATS topics: `lyra.inbound.<platform>.<bot_id>` (adapter→hub), `lyra.outbound.<platform>.<bot_id>` (hub→adapter). `factory start` runs hub + adapters in one process with embedded NATS.
 
 ---
 
 ## Key Invariants
 
 1. **Library first** — `lyra` is a Python library; CLI is a thin shell. `uv add --editable path/to/lyra` works.
-2. **No side effects on import** — engines load lazily; `import lyra` is instant.
+2. **No side effects on import** — engines load lazily; `import factory` is instant.
 3. **Agent = stateless singleton** — immutable config (prompt, permissions, namespace). All mutable state lives in the Pool.
 4. **Adapters send `trust=PUBLIC`** — trust resolution is Hub-side only (C3 pattern). Adapters never decide who may speak.
 5. **User-scoped memory** — every memory query must include `user_id`. Even stats, aggregate per user.
@@ -73,9 +73,9 @@ All four processes run on Machine 1 (hub). NATS topics: `lyra.inbound.<platform>
 
 | Concept | What it is | Where it lives | Managed by |
 |---|---|---|---|
-| **Bot** | Platform identity (`@RoxabiLyraBot`). Owns token, `bot_id`, `platform`. | `config.toml` → `BotStore` (`config.db` `bots`) | `lyra bot init` |
-| **Agent** | AI brain. `model`, `backend`, `persona`, `tools`, `plugins`. | `src/lyra/agents/*.toml` → `AgentStore` (`config.db` `agents`) | `lyra agent init` |
-| **Binding** | `bot_id` → `agent_name` for a conversation scope. | `config.db` `bot_agent_map` | `lyra agent assign` / `unassign` |
+| **Bot** | Platform identity (`@RoxabiLyraBot`). Owns token, `bot_id`, `platform`. | `config.toml` → `BotStore` (`config.db` `bots`) | `factory bot init` |
+| **Agent** | AI brain. `model`, `backend`, `persona`, `tools`, `plugins`. | `src/factory/agents/*.toml` → `AgentStore` (`config.db` `agents`) | `factory agent init` |
+| **Binding** | `bot_id` → `agent_name` for a conversation scope. | `config.db` `bot_agent_map` | `factory agent assign` / `unassign` |
 
 Routing: `(platform, bot_id, scope_id)` → `(agent, pool_id)`. One pool per scope. Scope = `chat:{id}` | `thread:{id}` | `channel:{id}`.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -15,7 +15,7 @@ After `uv sync`, activate the virtual environment to put `lyra` on your PATH:
 ```bash
 source .venv/bin/activate
 # Or add .venv/bin to your PATH permanently in ~/.bashrc:
-# export PATH="$HOME/projects/lyra/.venv/bin:$PATH"
+# export PATH="$HOME/projects/roxabi-factory/.venv/bin:$PATH"
 ```
 
 ### Subcommands
@@ -24,7 +24,7 @@ source .venv/bin/activate
 
 | Command | Description |
 |---------|-------------|
-| `lyra` / `lyra start` | Start hub + adapters in one process (auto-starts embedded NATS if `NATS_URL` is not set) |
+| `lyra` / `factory start` | Start hub + adapters in one process (auto-starts embedded NATS if `NATS_URL` is not set) |
 | `lyra --version` / `lyra -V` | Print the installed version |
 | `lyra --help` | List all available subcommands |
 
@@ -32,36 +32,36 @@ source .venv/bin/activate
 
 | Command | Description |
 |---------|-------------|
-| `lyra agent init` | Seed DB from TOML files (first-time setup) |
-| `lyra agent init --force` | Overwrite existing DB rows with TOML |
-| `lyra agent list` | List all discovered agents |
-| `lyra agent show <name>` | Full config for one agent |
-| `lyra agent create` | Interactively create a new agent TOML |
-| `lyra agent edit <name>` | Edit an agent interactively in DB |
-| `lyra agent validate <name>` | Validate agent config in DB |
-| `lyra agent assign <name> --platform <p> --bot <id>` | Assign agent to a bot |
-| `lyra agent unassign --platform <p> --bot <id>` | Remove a bot-agent mapping |
-| `lyra agent delete <name>` | Delete agent (refuses if bot still assigned) |
-| `lyra agent patch <name> --json <json_object>` | Apply a partial JSON patch to an agent |
-| `lyra agent refine <name>` | Interactively refine agent persona/voice |
+| `factory agent init` | Seed DB from TOML files (first-time setup) |
+| `factory agent init --force` | Overwrite existing DB rows with TOML |
+| `factory agent list` | List all discovered agents |
+| `factory agent show <name>` | Full config for one agent |
+| `factory agent create` | Interactively create a new agent TOML |
+| `factory agent edit <name>` | Edit an agent interactively in DB |
+| `factory agent validate <name>` | Validate agent config in DB |
+| `factory agent assign <name> --platform <p> --bot <id>` | Assign agent to a bot |
+| `factory agent unassign --platform <p> --bot <id>` | Remove a bot-agent mapping |
+| `factory agent delete <name>` | Delete agent (refuses if bot still assigned) |
+| `factory agent patch <name> --json <json_object>` | Apply a partial JSON patch to an agent |
+| `factory agent refine <name>` | Interactively refine agent persona/voice |
 
 **Bot management**
 
 | Command | Description |
 |---------|-------------|
-| `lyra bot init` | Seed BotStore from `config.toml` (idempotent) |
-| `lyra bot init --force` | Overwrite existing BotStore rows |
-| `lyra bot secret install <platform> <bot_id>` | Store bot token as Podman secret |
-| `lyra bot secret install <platform> <bot_id>-webhook` | Store webhook secret as Podman secret |
+| `factory bot init` | Seed BotStore from `config.toml` (idempotent) |
+| `factory bot init --force` | Overwrite existing BotStore rows |
+| `factory bot secret install <platform> <bot_id>` | Store bot token as Podman secret |
+| `factory bot secret install <platform> <bot_id>-webhook` | Store webhook secret as Podman secret |
 
 **Hub and adapter (production four-process mode)**
 
 | Command | Description |
 |---------|-------------|
-| `lyra hub` | Start the standalone Hub process (requires NATS) |
-| `lyra adapter telegram` | Start the standalone Telegram adapter (requires NATS) |
-| `lyra adapter discord` | Start the standalone Discord adapter (requires NATS) |
-| `lyra adapter clipool` | Start the standalone CliPool NATS worker (requires NATS) |
+| `factory hub` | Start the standalone Hub process (requires NATS) |
+| `factory adapter telegram` | Start the standalone Telegram adapter (requires NATS) |
+| `factory adapter discord` | Start the standalone Discord adapter (requires NATS) |
+| `factory adapter clipool` | Start the standalone CliPool NATS worker (requires NATS) |
 
 **Config management**
 
@@ -70,14 +70,14 @@ source .venv/bin/activate
 | `lyra config show` | Print the resolved `config.toml` |
 | `lyra config validate` | Validate `config.toml` against the schema |
 
-> `lyra-agent` still works but prints a deprecation warning. Migrate to `lyra agent <subcommand>`.
+> `factory-agent` still works but prints a deprecation warning. Migrate to `factory agent <subcommand>`.
 
 ### Agent config directories
 
 Lyra searches for agent TOML files in two locations, in order of precedence:
 
-1. `~/.lyra/agents/` — user-level configs (take precedence)
-2. `src/lyra/agents/` — project-level configs (bundled defaults)
+1. `~/.roxabi/factory/agents/` — user-level configs (take precedence)
+2. `src/factory/agents/` — project-level configs (bundled defaults)
 
 If the same agent name exists in both directories, the user-level file wins.
 
@@ -87,10 +87,10 @@ The `[defaults]` section in `config.toml` lets you set machine-wide fallbacks fo
 
 ```toml
 [defaults]
-cwd = "~/projects/lyra"
+cwd = "~/projects/roxabi-factory"
 
 [defaults.workspaces]
-lyra     = "~/projects/lyra"
+lyra     = "~/projects/roxabi-factory"
 projects = "~/projects"
 ```
 
@@ -194,7 +194,7 @@ Incoming message
 | `/explain <url>` | Scrape URL → plain-language explanation | `web-intel:scrape` |
 | `/summarize <url>` | Scrape URL → bullet-point summary | `web-intel:scrape` |
 | `/search <query>` | Full-text search over vault | `vault` (plugin) |
-| `<url>` (bare) | Auto-rewritten to `/vault-add <url>` (configured in `src/lyra/data/patterns.toml`) | — |
+| `<url>` (bare) | Auto-rewritten to `/vault-add <url>` (configured in `src/factory/data/patterns.toml`) | — |
 | `/workspace <name> [question]` | Switch working directory to named workspace | — (builtin) |
 | `/workspace ls` | List configured workspaces | — (builtin) |
 
@@ -238,7 +238,7 @@ Sending a bare URL (no slash command prefix) is automatically rewritten to `/vau
 https://example.com/article   →   /vault-add https://example.com/article
 ```
 
-The detection uses `CommandRouter._BARE_URL_RE` (`^https?://\S+$`). The target command is read from `src/lyra/data/patterns.toml` `[bare_url].command` — change it there to reroute bare URLs to a different command without touching Python.
+The detection uses `CommandRouter._BARE_URL_RE` (`^https?://\S+$`). The target command is read from `src/factory/data/patterns.toml` `[bare_url].command` — change it there to reroute bare URLs to a different command without touching Python.
 
 ### `/search <query>` — Vault full-text search
 
@@ -262,7 +262,7 @@ Runs `vault search <query>` and returns matching results. Stateless — no LLM c
 Processor commands use `BaseProcessor` from `processor_registry.py` and are registered with the `@register` decorator. Each processor implements `pre()` (enriches the message before pool submission) and optionally `post()` (side effects after the LLM response). Because they run inside the normal pool flow, responses appear in conversation history and are available for follow-up questions.
 
 ```python
-from lyra.core.processor_registry import BaseProcessor, register
+from factory.core.processor_registry import BaseProcessor, register
 
 @register("/my-cmd", description="Do something: /my-cmd <url>")
 class MyCmdProcessor(BaseProcessor):
@@ -279,13 +279,13 @@ Workspaces are named directory shortcuts defined in the agent TOML under `[works
 ### Configuration
 
 ```toml
-# src/lyra/agents/lyra_default.toml
+# src/factory/agents/lyra_default.toml
 
 [model]
-cwd = "~/projects/lyra"   # optional: fixed default cwd for this agent
+cwd = "~/projects/roxabi-factory"   # optional: fixed default cwd for this agent
 
 [workspaces]
-lyra        = "~/projects/lyra"
+lyra        = "~/projects/roxabi-factory"
 projects    = "~/projects"
 roxabi-vault = "~/.roxabi-vault"
 ```
@@ -300,8 +300,8 @@ Syntax: /workspace <name>
         /workspace
 ```
 
-- `/workspace lyra` — sets the workspace to `~/projects/lyra`, responds with a context confirmation
-- `/workspace lyra what's the last commit?` — sets the workspace, then forwards the question to Claude with `cwd=~/projects/lyra`
+- `/workspace lyra` — sets the workspace to `~/projects/roxabi-factory`, responds with a context confirmation
+- `/workspace lyra what's the last commit?` — sets the workspace, then forwards the question to Claude with `cwd=~/projects/roxabi-factory`
 - `/workspace ls` — lists all configured workspaces with their paths
 - `/workspace` — same as `/workspace ls`
 
@@ -409,10 +409,10 @@ Lyra: ⚠ Command timed out.
 
 ## Configuration
 
-Built-in commands are implemented in `src/lyra/core/builtin_commands.py` and workspace commands in `src/lyra/core/workspace_commands.py`. Plugin commands are declared in each plugin's `plugin.toml`:
+Built-in commands are implemented in `src/factory/core/builtin_commands.py` and workspace commands in `src/factory/core/workspace_commands.py`. Plugin commands are declared in each plugin's `plugin.toml`:
 
 ```toml
-# src/lyra/commands/echo/plugin.toml
+# src/factory/commands/echo/plugin.toml
 
 [[commands]]
 name = "echo"
@@ -423,7 +423,7 @@ handler = "cmd_echo"
 Plugins are enabled per-agent in the agent TOML config:
 
 ```toml
-# src/lyra/agents/lyra_default.toml
+# src/factory/agents/lyra_default.toml
 
 [plugins]
 enabled = ["echo"]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,7 +312,7 @@ Services: `claude-cli`, `telegram`, `discord`, `hub`.
 
 ## Bot credentials
 
-Bot tokens and webhook secrets are stored as **Podman secrets**, not in `~/.roxabi/factory/config.db`. Adapter containers mount these via `Secret=` directives in `deploy/quadlet/lyra-<platform>.container`; the adapter process reads each token at bootstrap from `/run/secrets/bot_token-<bot_id>` (and optionally `/run/secrets/bot_webhook-<bot_id>`).
+Bot tokens and webhook secrets are stored as **Podman secrets**, not in `~/.roxabi/factory/config.db`. Adapter containers mount these via `Secret=` directives in `deploy/quadlet/factory-<platform>.container`; the adapter process reads each token at bootstrap from `/run/secrets/bot_token-<bot_id>` (and optionally `/run/secrets/bot_webhook-<bot_id>`).
 
 ### CLI
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,21 +12,21 @@ Lyra uses two types of configuration files with distinct responsibilities:
 | File | Type | Versioned | Purpose |
 |------|------|-----------|---------|
 | `config.toml` | Instance config | No | Deployment wiring: bots, tokens, auth, defaults |
-| lyra.toml | Instance config | No | Monitoring thresholds (read by `factory.monitoring` only) |
-| `~/.lyra/config.db` | Runtime DB | No | Agents, credentials, grants, user prefs (SQLite) |
-| `~/.lyra/turns.db` | Runtime DB | No | Conversation turns, pool sessions |
-| `~/.lyra/discord.db` | Runtime DB | No | Discord thread data (owned by Discord adapter) |
-| `~/.lyra/auth.db` | Runtime DB | No | Auth grants, identity aliases (legacy name, still used) |
-| `~/.lyra/message_index.db` | Runtime DB | No | Message index for search/retrieval |
-| `~/.lyra/agents/<name>.toml` | Seed source | No | Agent seed: imported into DB by `lyra agent init` |
-| `src/lyra/agents/<name>.toml` | Seed source | Yes | Agent seed: system defaults, imported into DB |
-| `src/lyra/commands/<name>/plugin.toml` | System data | Yes | Plugin manifest: commands, handlers |
+| `config.toml` | Instance config | No | Monitoring thresholds — `[monitoring]` section of the same `config.toml`, read by `factory.monitoring` |
+| `~/.roxabi/factory/config.db` | Runtime DB | No | Agents, credentials, grants, user prefs (SQLite) |
+| `~/.roxabi/factory/turns.db` | Runtime DB | No | Conversation turns, pool sessions |
+| `~/.roxabi/factory/discord.db` | Runtime DB | No | Discord thread data (owned by Discord adapter) |
+| `~/.roxabi/factory/auth.db` | Runtime DB | No | Auth grants, identity aliases (legacy name, still used) |
+| `~/.roxabi/factory/message_index.db` | Runtime DB | No | Message index for search/retrieval |
+| `~/.roxabi/factory/agents/<name>.toml` | Seed source | No | Agent seed: imported into DB by `factory agent init` |
+| `src/factory/agents/<name>.toml` | Seed source | Yes | Agent seed: system defaults, imported into DB |
+| `src/factory/commands/<name>/plugin.toml` | System data | Yes | Plugin manifest: commands, handlers |
 | `src/factory/data/messages.toml` | System data | Yes | i18n strings |
 | `pyproject.toml` | System data | Yes | Package metadata, dependencies, tool config |
 
 **Rule:** if a value is machine-specific, personal, or secret → `config.toml`. Everything else → versioned.
 
-**Agent rule:** TOML files define what agents *should be*. The DB holds what they *are* at runtime. Startup reads from the DB only — TOML changes require `lyra agent init` (or `--force`) to take effect.
+**Agent rule:** TOML files define what agents *should be*. The DB holds what they *are* at runtime. Startup reads from the DB only — TOML changes require `factory agent init` (or `--force`) to take effect.
 
 ---
 
@@ -37,43 +37,43 @@ Lyra uses two types of configuration files with distinct responsibilities:
 Resolution order (first match wins):
 
 ```
-1. $LYRA_CONFIG           (if set, must be under $HOME)
-2. $LYRA_VAULT_DIR/config.toml
+1. $FACTORY_CONFIG           (if set, must be under $HOME)
+2. $FACTORY_VAULT_DIR/config.toml
 3. ./config.toml          (cwd)
 4. Empty dict (defaults)
 ```
 
-The path is validated to be under `$HOME` when set via `LYRA_CONFIG`.
+The path is validated to be under `$HOME` when set via `FACTORY_CONFIG`.
 
-### lyra.toml — Monitoring only
+### config.toml — Monitoring (`[monitoring]` section)
 
 Resolution order:
 
 ```
-1. $LYRA_CONFIG           (if set, must be under $HOME)
-2. ./lyra.toml           (cwd)
+1. $FACTORY_CONFIG           (if set, must be under $HOME)
+2. ./config.toml           (cwd)
 3. Empty dict (defaults)
 ```
 
-**Note:** Hub uses `config.toml`, monitoring uses lyra.toml. If you set `$LYRA_CONFIG`, it must contain both `[monitoring]` and any other sections you need.
+**Note:** Hub and monitoring both read `config.toml` (monitoring reads the `[monitoring]` section). If you set `$FACTORY_CONFIG`, it must contain `[monitoring]` plus any other sections you need.
 
 ### `messages.toml` — i18n strings
 
 Resolution order:
 
 ```
-1. $LYRA_MESSAGES_CONFIG  (if set, must end in .toml and be under $HOME)
+1. $FACTORY_MESSAGES_CONFIG  (if set, must end in .toml and be under $HOME)
 2. ./messages.toml        (cwd)
-3. src/lyra/data/messages.toml  (bundled)
+3. src/factory/data/messages.toml  (bundled)
 ```
 
-### Store directory (`~/.lyra/`)
+### Store directory (`~/.roxabi/factory/`)
 
-Controlled by `LYRA_VAULT_DIR`:
+Controlled by `FACTORY_VAULT_DIR`:
 
 ```
-$LYRA_VAULT_DIR  (if set)
-~/.lyra          (default)
+$FACTORY_VAULT_DIR  (if set)
+~/.roxabi/factory          (default)
 ```
 
 Databases created under this directory:
@@ -96,7 +96,7 @@ Databases created under this directory:
 [defaults]
 cwd = "~/projects"              # default working directory for agent subprocesses
 persona = "lyra_default"        # fallback persona if agent doesn't specify one
-workspaces.lyra = "~/projects/lyra"    # adds /lyra slash command
+workspaces.lyra = "~/projects/roxabi-factory"    # adds /lyra slash command
 workspaces.projects = "~/projects"     # adds /projects slash command
 ```
 
@@ -114,9 +114,9 @@ hardcoded default              (cwd = "~", persona = none)
 
 ```toml
 [agents.lyra_default]
-cwd = "~/projects/lyra"
+cwd = "~/projects/roxabi-factory"
 persona = "dev-assistant"
-workspaces.lyra = "~/projects/lyra"
+workspaces.lyra = "~/projects/roxabi-factory"
 ```
 
 Merged with `[defaults]` — agent-specific values win. Workspaces are deep-merged.
@@ -312,15 +312,15 @@ Services: `claude-cli`, `telegram`, `discord`, `hub`.
 
 ## Bot credentials
 
-Bot tokens and webhook secrets are stored as **Podman secrets**, not in `~/.lyra/config.db`. Adapter containers mount these via `Secret=` directives in `deploy/quadlet/lyra-<platform>.container`; the adapter process reads each token at bootstrap from `/run/secrets/bot_token-<bot_id>` (and optionally `/run/secrets/bot_webhook-<bot_id>`).
+Bot tokens and webhook secrets are stored as **Podman secrets**, not in `~/.roxabi/factory/config.db`. Adapter containers mount these via `Secret=` directives in `deploy/quadlet/lyra-<platform>.container`; the adapter process reads each token at bootstrap from `/run/secrets/bot_token-<bot_id>` (and optionally `/run/secrets/bot_webhook-<bot_id>`).
 
 ### CLI
 
 | Command | Purpose |
 |---|---|
-| `lyra bot secret install <platform> <bot_id> [--from-env TOK] [--webhook-from-env WHK]` | Create or replace a bot's token (and optional webhook secret) |
-| `lyra bot secret rm <platform> <bot_id>` | Remove the bot's token + webhook secret |
-| `lyra bot secret list` | List provisioned bot secrets (filtered by `lyra-bot-` prefix) |
+| `factory bot secret install <platform> <bot_id> [--from-env TOK] [--webhook-from-env WHK]` | Create or replace a bot's token (and optional webhook secret) |
+| `factory bot secret rm <platform> <bot_id>` | Remove the bot's token + webhook secret |
+| `factory bot secret list` | List provisioned bot secrets (filtered by `factory-bot-` prefix) |
 | *(not a subcommand)* `python3 tools/migrate_bot_secrets_to_podman.py` | One-shot operator script — migrates pre-#1057 `bot_secrets` rows from `config.db` to Podman secrets; run once on M₁ then discard. See [§ Migrating from pre-#1057 `bot_secrets` rows](#migrating-from-pre-1057-bot_secrets-rows) |
 
 `<bot_id>` must match `^[A-Za-z0-9_-]+$` (alphanumeric, hyphen, underscore — slash-free for safe Podman secret names and tmpfs mount targets).
@@ -330,8 +330,8 @@ Bot tokens and webhook secrets are stored as **Podman secrets**, not in `~/.lyra
 Each bot expects one `Secret=` line per credential in the appropriate `.container` file:
 
 ```
-Secret=lyra-bot-telegram-<bot_id>,type=mount,target=bot_token-<bot_id>,mode=0400,uid=1500,gid=1500
-Secret=lyra-bot-telegram-<bot_id>-webhook,type=mount,target=bot_webhook-<bot_id>,mode=0400,uid=1500,gid=1500
+Secret=factory-bot-telegram-<bot_id>,type=mount,target=bot_token-<bot_id>,mode=0400,uid=1500,gid=1500
+Secret=factory-bot-telegram-<bot_id>-webhook,type=mount,target=bot_webhook-<bot_id>,mode=0400,uid=1500,gid=1500
 ```
 
 (Omit the webhook line if the bot does not use webhooks.)
@@ -340,22 +340,22 @@ Re-render the Quadlet after any secret provisioning change:
 
 ```bash
 make quadlet-install
-# Renders per-bot Secret= directives from ~/.lyra/config.toml into
-# lyra-telegram.container and lyra-discord.container, then reloads units.
+# Renders per-bot Secret= directives from ~/.roxabi/factory/config.toml into
+# factory-telegram.container and factory-discord.container, then reloads units.
 ```
 
 After running `make quadlet-install`, restart the adapter to remount: `make telegram-adapter restart` (or `discord-adapter`). `type=mount` secrets are tmpfs binds; `podman secret create --replace` updates the store but the in-container file is stale until container restart.
 
 ### Migrating from pre-#1057 `bot_secrets` rows
 
-Operators on M₁ with a pre-existing `~/.lyra/config.db` `bot_secrets` table run the one-shot migration script — it reads each row, decrypts via the existing Fernet keyring, and provisions a Podman secret per `(platform, bot_id)`. The script is self-contained (it does NOT depend on the deleted `CredentialStore` class) and idempotent:
+Operators on M₁ with a pre-existing `~/.roxabi/factory/config.db` `bot_secrets` table run the one-shot migration script — it reads each row, decrypts via the existing Fernet keyring, and provisions a Podman secret per `(platform, bot_id)`. The script is self-contained (it does NOT depend on the deleted `CredentialStore` class) and idempotent:
 
 ```bash
 python3 tools/migrate_bot_secrets_to_podman.py            # apply
 python3 tools/migrate_bot_secrets_to_podman.py --dry-run  # preview
 ```
 
-After migration: run `make quadlet-install` to re-render the Quadlet with the newly-provisioned secrets, restart the adapters, and optionally drop the now-orphan `bot_secrets` table (`sqlite3 ~/.lyra/config.db 'DROP TABLE bot_secrets'`). The script prints the same post-migration checklist on success.
+After migration: run `make quadlet-install` to re-render the Quadlet with the newly-provisioned secrets, restart the adapters, and optionally drop the now-orphan `bot_secrets` table (`sqlite3 ~/.roxabi/factory/config.db 'DROP TABLE bot_secrets'`). The script prints the same post-migration checklist on success.
 
 ### Rationale
 
@@ -363,16 +363,16 @@ webhook_secret packing: separate secret (not packed into JSON). This matches the
 
 ### Production guard
 
-`LYRA_RUN_SECRETS_DIR` lets tests and local development point at a temporary directory instead of `/run/secrets`. In production this override is **ignored** as a defense-in-depth measure: an attacker with env-write access on a prod host cannot redirect token reads to a path they control.
+`FACTORY_RUN_SECRETS_DIR` lets tests and local development point at a temporary directory instead of `/run/secrets`. In production this override is **ignored** as a defense-in-depth measure: an attacker with env-write access on a prod host cannot redirect token reads to a path they control.
 
 The guard activates when **either** condition is true:
 
 | Condition | Detection |
 |---|---|
 | Inside a container | `/run/.containerenv` exists (Podman runtime marker) |
-| Explicit prod mode | `LYRA_ENV=prod` |
+| Explicit prod mode | `FACTORY_ENV=prod` |
 
-When active, `load_bot_token` logs a warning and falls back to `/run/secrets` regardless of the env variable. Operators should **never** set `LYRA_RUN_SECRETS_DIR=` in Quadlet `.container` files — the override is intended for local dev and CI only.
+When active, `load_bot_token` logs a warning and falls back to `/run/secrets` regardless of the env variable. Operators should **never** set `FACTORY_RUN_SECRETS_DIR=` in Quadlet `.container` files — the override is intended for local dev and CI only.
 
 ### Backup
 
@@ -381,30 +381,30 @@ Podman secrets are the authoritative copy of bot tokens. There is no automatic b
 **Snapshot all bot secrets:**
 
 ```bash
-podman secret ls --filter name=lyra-bot- --format '{{.Name}}' | \
+podman secret ls --filter name=factory-bot- --format '{{.Name}}' | \
   xargs -n1 --no-run-if-empty podman secret inspect --showsecret | \
   jq -s '[.[] | {name: .[0].Spec.Name, data: .[0].SecretData}]' \
-  > lyra-bot-secrets-$(date +%Y%m%d).json
+  > factory-bot-secrets-$(date +%Y%m%d).json
 ```
 
-**Recommended cadence:** snapshot after every token rotation or bot provisioning change. Store the JSON file in your usual infrastructure backup location (e.g. alongside `~/.lyra/config.db` backups, or in your password-manager/secret-manager's export path).
+**Recommended cadence:** snapshot after every token rotation or bot provisioning change. Store the JSON file in your usual infrastructure backup location (e.g. alongside `~/.roxabi/factory/config.db` backups, or in your password-manager/secret-manager's export path).
 
 **Restore a secret from snapshot:**
 
 ```bash
 # Re-create a single secret from the snapshot file
-cat lyra-bot-secrets-YYYYMMDD.json | \
-  jq -r '.[] | select(.name == "lyra-bot-telegram-mybot") | .data' | \
-  podman secret create lyra-bot-telegram-mybot -
+cat factory-bot-secrets-YYYYMMDD.json | \
+  jq -r '.[] | select(.name == "factory-bot-telegram-mybot") | .data' | \
+  podman secret create factory-bot-telegram-mybot -
 ```
 
-After restoring, run `make quadlet-install` to re-render the Quadlet and restart the affected adapter. Per-bot Secret= directives are rendered at install time; no fragment files need separate backup. Source of truth is `~/.lyra/config.toml`.
+After restoring, run `make quadlet-install` to re-render the Quadlet and restart the affected adapter. Per-bot Secret= directives are rendered at install time; no fragment files need separate backup. Source of truth is `~/.roxabi/factory/config.toml`.
 
 **Note:** The snapshot contains raw secret data. Encryption-at-rest for the snapshot file is out of scope for this document; handle it according to your organization's secret-management policy.
 
 ---
 
-## lyra.toml — Monitoring Only
+## config.toml — Monitoring Only
 
 Read exclusively by `factory.monitoring`. Hub does NOT read this file.
 
@@ -423,7 +423,7 @@ min_disk_free_gb = 1                          # disk alert threshold (default: 1
 health_endpoint_url = "http://localhost:8443/health/detail"
 diagnostic_model = "claude-haiku-4-5-20251001"
 disk_check_path = "/"                         # filesystem to check (default: "/")
-service_names = ["lyra-hub", "lyra-telegram", "lyra-discord"]
+service_names = ["factory-hub", "factory-telegram", "factory-discord"]
 health_secret = ""                            # optional health endpoint auth
 ```
 
@@ -435,10 +435,10 @@ health_secret = ""                            # optional health endpoint auth
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LYRA_CONFIG` | — | Path to `config.toml` (hub) or lyra.toml (monitoring) |
-| `LYRA_VAULT_DIR` | `~/.lyra` | Store directory for all databases |
-| `LYRA_MESSAGES_CONFIG` | bundled | Path to custom `messages.toml` |
-| `LYRA_DB` | — | Override database path (test only) |
+| `FACTORY_CONFIG` | — | Path to `config.toml` (hub) or config.toml (monitoring) |
+| `FACTORY_VAULT_DIR` | `~/.roxabi/factory` | Store directory for all databases |
+| `FACTORY_MESSAGES_CONFIG` | bundled | Path to custom `messages.toml` |
+| `FACTORY_DB` | — | Override database path (test only) |
 
 ### Telegram
 
@@ -466,23 +466,23 @@ health_secret = ""                            # optional health endpoint auth
 
 Read by `init_blobstore()` in each adapter process (Telegram, Discord) + unified at startup.
 Token is read **once** at startup (restart-not-HUP — the value is never re-read without a
-process restart). If `LYRA_BLOBSTORE_TOKEN_PATH` points to an absent file, `blob_store`
+process restart). If `FACTORY_BLOBSTORE_TOKEN_PATH` points to an absent file, `blob_store`
 degrades to `None`: audio attachments are disabled and a warning is logged; no crash occurs.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LYRA_BLOBSTORE_URL` | `http://localhost:8449` | BlobStore service base URL |
-| `LYRA_BLOBSTORE_TOKEN_PATH` | `~/.lyra/blobstore.tok` | Path to bearer-token file; read once at startup |
+| `FACTORY_BLOBSTORE_URL` | `http://localhost:8449` | BlobStore service base URL |
+| `FACTORY_BLOBSTORE_TOKEN_PATH` | `~/.roxabi/factory/blobstore.tok` | Path to bearer-token file; read once at startup |
 
 #### BlobStore env file
 
-`~/.lyra/env/blobstore.env` is a Quadlet env file consumed by `lyra-blobstore.container` at
-container start via `EnvironmentFile=%h/.lyra/env/blobstore.env`. It is NOT loaded by the
-lyra application itself.
+`~/.roxabi/factory/env/blobstore.env` is a Quadlet env file consumed by `factory-blobstore.container` at
+container start via `EnvironmentFile=%h/.roxabi/factory/env/blobstore.env`. It is NOT loaded by the
+factory application itself.
 
 | File | Versioned | Purpose |
 |------|-----------|---------|
-| `~/.lyra/env/blobstore.env` (on M₁) | No (operator copy) | Live env file read by the container at startup |
+| `~/.roxabi/factory/env/blobstore.env` (on M₁) | No (operator copy) | Live env file read by the container at startup |
 
 **Bootstrap:** `deploy/install.sh` §1c generates this file idempotently — it skips creation
 if the file already exists, and regenerates it with `--force`.
@@ -492,20 +492,20 @@ Variables written by install.sh:
 | Variable | Source | Notes |
 |----------|--------|-------|
 | `TAILSCALE_IPV4` | `tailscale ip -4 \| head -1` at bootstrap | Empty string if Tailscale is absent at install time — the unit's ExecStartPre guard rejects start when unset (fail-closed; see `deploy/CLAUDE.md §Known residual risk`) |
-| `NATS_URL` | Omitted from the file | Supplied exclusively by the unit's inline `Environment=NATS_URL=nats://lyra-nats:4222`; omitting it from the env file prevents an empty value in systemd scope from shadowing the inline directive |
+| `NATS_URL` | Omitted from the file | Supplied exclusively by the unit's inline `Environment=NATS_URL=nats://factory-nats:4222`; omitting it from the env file prevents an empty value in systemd scope from shadowing the inline directive |
 
 File permissions: `0600` (set atomically via `umask 0077` subshell in install.sh).
 
 **Recovery:** delete the file and re-run install.sh to regenerate.
 
 ```bash
-rm ~/.lyra/env/blobstore.env
+rm ~/.roxabi/factory/env/blobstore.env
 ./deploy/install.sh --force
 ```
 
 Load order: N/A — this is a Quadlet env file, not an application config file. The bearer
 token and blob data path are delivered via `Secret=` and `Volume=` directives in
-`deploy/quadlet/lyra-blobstore.container` (not via env vars).
+`deploy/quadlet/factory-blobstore.container` (not via env vars).
 
 #### JetStream persistent storage
 
@@ -513,20 +513,20 @@ JetStream is enabled via the config file stanza in `deploy/nats/nats-container.c
 
 | Unit | Host path | Container path |
 |------|-----------|----------------|
-| `lyra-jetstream.volume` | `~/.lyra/nats/jetstream` | `/var/lib/nats/jetstream` |
+| `factory-jetstream.volume` | `~/.roxabi/factory/nats/jetstream` | `/var/lib/nats/jetstream` |
 
 **First-time setup (production, uid 1500):**
 
 ```bash
-make quadlet-install                          # creates ~/.lyra/nats/jetstream at mode 0700
-podman unshare chown 1500:1500 ~/.lyra/nats/jetstream
+make quadlet-install                          # creates ~/.roxabi/factory/nats/jetstream at mode 0700
+podman unshare chown 1500:1500 ~/.roxabi/factory/nats/jetstream
 make quadlet-secrets-install                  # skip if secrets already installed
-systemctl --user restart lyra-nats
+systemctl --user restart factory-nats
 ```
 
 **Dev (no fixed uid mapping):** `make quadlet-install` is sufficient — omit the `podman unshare chown` step.
 
-**Upgrade:** after `make quadlet-install`, run `systemctl --user daemon-reload && systemctl --user restart lyra-nats` to pick up unit file changes.
+**Upgrade:** after `make quadlet-install`, run `systemctl --user daemon-reload && systemctl --user restart factory-nats` to pick up unit file changes.
 
 **Lint:** before deploying, validate all Quadlet unit files locally:
 
@@ -540,34 +540,34 @@ Runs `podman quadlet --dryrun` (parse errors) and a comment-guard that rejects i
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LYRA_STT_MODEL` | `large-v3-turbo` | Whisper model size |
-| `LYRA_STT_TIMEOUT` | `15` | STT timeout in seconds |
-| `LYRA_TTS_ENGINE` | — | TTS engine (per-adapter in voiceCLI container) |
-| `LYRA_TTS_VOICE` | — | TTS voice ID |
-| `LYRA_TTS_LANGUAGE` | — | TTS language code |
-| `LYRA_TTS_TIMEOUT` | — | TTS timeout in seconds |
-| `LYRA_AUDIO_TMP` | — | Audio temp directory |
-| `LYRA_MAX_AUDIO_BYTES` | — | Max audio file size |
+| `FACTORY_STT_MODEL` | `large-v3-turbo` | Whisper model size |
+| `FACTORY_STT_TIMEOUT` | `15` | STT timeout in seconds |
+| `FACTORY_TTS_ENGINE` | — | TTS engine (per-adapter in voiceCLI container) |
+| `FACTORY_TTS_VOICE` | — | TTS voice ID |
+| `FACTORY_TTS_LANGUAGE` | — | TTS language code |
+| `FACTORY_TTS_TIMEOUT` | — | TTS timeout in seconds |
+| `FACTORY_AUDIO_TMP` | — | Audio temp directory |
+| `FACTORY_MAX_AUDIO_BYTES` | — | Max audio file size |
 
 ### Health endpoint
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LYRA_HEALTH_HOST` | — | Health endpoint host |
-| `LYRA_HEALTH_PORT` | — | Health endpoint port |
-| `LYRA_HEALTH_SECRET` | — | Health endpoint auth secret |
+| `FACTORY_HEALTH_HOST` | — | Health endpoint host |
+| `FACTORY_HEALTH_PORT` | — | Health endpoint port |
+| `FACTORY_HEALTH_SECRET` | — | Health endpoint auth secret |
 
 ### Misc
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LYRA_AGENT_STORE_PATH` | — | Override agent store path |
-| `LYRA_CLAUDE_CWD` | — | Claude CLI working directory |
-| `LYRA_WEB_INTEL_PATH` | — | Web intel output path |
+| `FACTORY_AGENT_STORE_PATH` | — | Override agent store path |
+| `FACTORY_CLAUDE_CWD` | — | Claude CLI working directory |
+| `FACTORY_WEB_INTEL_PATH` | — | Web intel output path |
 
 ---
 
-## Runtime databases — `~/.lyra/`
+## Runtime databases — `~/.roxabi/factory/`
 
 | Database | Contents |
 |----------|----------|
@@ -583,22 +583,22 @@ Runs `podman quadlet --dryrun` (parse errors) and a comment-guard that rejects i
 
 ## Agent definitions — SQLite DB + TOML seeds
 
-Agents are stored in **`~/.lyra/config.db`** (SQLite). This is the runtime source of truth.
+Agents are stored in **`~/.roxabi/factory/config.db`** (SQLite). This is the runtime source of truth.
 
-TOML files are **seed sources** — imported via `lyra agent init`. After import, TOML edits have no effect until re-imported.
+TOML files are **seed sources** — imported via `factory agent init`. After import, TOML edits have no effect until re-imported.
 
 ### CLI workflow
 
 ```bash
-lyra agent init              # seed DB from TOML files
-lyra agent init --force      # force re-import (overwrites DB rows)
-lyra agent list              # list all agents in DB
-lyra agent show <name>       # show full config for one agent
-lyra agent edit <name>       # edit an agent in DB interactively
-lyra agent validate <name>   # schema + constraint checks
-lyra agent delete <name>     # delete an agent (refuses if bot assigned)
-lyra agent assign <name> --platform telegram --bot <bot_id>
-lyra agent unassign --platform telegram --bot <bot_id>
+factory agent init              # seed DB from TOML files
+factory agent init --force      # force re-import (overwrites DB rows)
+factory agent list              # list all agents in DB
+factory agent show <name>       # show full config for one agent
+factory agent edit <name>       # edit an agent in DB interactively
+factory agent validate <name>   # schema + constraint checks
+factory agent delete <name>     # delete an agent (refuses if bot assigned)
+factory agent assign <name> --platform telegram --bot <bot_id>
+factory agent unassign --platform telegram --bot <bot_id>
 ```
 
 ### TOML format (seed files)
@@ -632,8 +632,8 @@ enabled = ["echo"]
 ```
 startup
   ├── _load_raw_config() → config.toml
-  │     ├── $LYRA_CONFIG (validated under $HOME)
-  │     ├── $LYRA_VAULT_DIR/config.toml
+  │     ├── $FACTORY_CONFIG (validated under $HOME)
+  │     ├── $FACTORY_VAULT_DIR/config.toml
   │     ├── cwd/config.toml
   │     └── {} (empty → all defaults)
   │
@@ -648,7 +648,7 @@ startup
   │     ├── [logging], [message_index], [pairing]
   │     └── [tool_display]
   │
-  └── AgentStore.connect() → ~/.lyra/config.db
+  └── AgentStore.connect() → ~/.roxabi/factory/config.db
         └── for each bot → resolve agent from DB
               ├── bot_agent_map row (highest priority)
               └── if missing → config.toml bot.agent → auto-seed
@@ -662,8 +662,8 @@ it runs `deploy/quadlet-install-verify.sh`, which:
 
 1. Runs `systemctl --user daemon-reload` — triggers the Quadlet generator to
    produce fresh `.service` units from the copied files.
-2. Restarts (or starts) each container unit: `lyra-nats`, `lyra-hub`,
-   `lyra-telegram`, `lyra-discord`, `lyra-clipool`.
+2. Restarts (or starts) each container unit: `factory-nats`, `factory-hub`,
+   `factory-telegram`, `factory-discord`, `factory-clipool`.
 3. Waits up to 10 s per unit and checks `systemctl --user is-active`.
 4. If any unit is not `active`, dumps the last 20 lines of
    `journalctl --user -u <unit>` and exits non-zero — the deploy fails loudly.
@@ -684,7 +684,7 @@ copy runs.  Use this when:
 - Performing a manual recovery where one or more units are intentionally not
   running (e.g. after an nkey rotation before new seeds are in place).
 - Deploying on a host that does not yet have the full secrets set up (initial
-  bootstrap before `~/.lyra/env/` files exist).
+  bootstrap before `~/.roxabi/factory/env/` files exist).
 
 After fixing the underlying issue, run a normal `make quadlet-install` (without
 `NO_RESTART=1`) to verify all units come up.
@@ -694,12 +694,12 @@ After fixing the underlying issue, run a normal `make quadlet-install` (without
 
 ## Monitoring — removed; superseded by Monitoring v2 (#1035)
 
-The host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. The Python module `src/lyra/monitoring/` is retained for [Monitoring v2 (#1035)](https://github.com/Roxabi/lyra/issues/1035) spec mining. It pokes `systemctl --user`, `podman logs`, and host loopback ports — none of which translate cleanly to a containerised world — and offers no UI beyond a Telegram message.
+The host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. The Python module `src/factory/monitoring/` is retained for [Monitoring v2 (#1035)](https://github.com/Roxabi/roxabi-factory/issues/1035) spec mining. It pokes `systemctl --user`, `podman logs`, and host loopback ports — none of which translate cleanly to a containerised world — and offers no UI beyond a Telegram message.
 
 For ad-hoc hub-health probes, hit `/health/detail` directly:
 
 ```bash
-curl -fsS -H "Authorization: Bearer $LYRA_HEALTH_SECRET" \
+curl -fsS -H "Authorization: Bearer $FACTORY_HEALTH_SECRET" \
   http://127.0.0.1:8443/health/detail | jq .
 ```
 
@@ -710,7 +710,7 @@ curl -fsS -H "Authorization: Bearer $LYRA_HEALTH_SECRET" \
 Enable when running `voicecli_tts` / `voicecli_stt` via voiceCLI:
 
 ```bash
-LYRA_STT_MODEL=large-v3-turbo   # faster-whisper model
+FACTORY_STT_MODEL=large-v3-turbo   # faster-whisper model
 ```
 
 Hub probes STT/TTS adapters at startup via NATS heartbeats. Workers are discovered dynamically — no explicit enable flag needed.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,27 +11,27 @@ Lyra runs as **six containers** on a shared `roxabi.network` bridge, managed by 
 ```
 Machine 1 (roxabituwer, 192.168.1.16)
 ├── systemd --user (linger enabled)
-│   ├── lyra-nats.service         ← Quadlet NATS container (port 4222, roxabi.network)
-│   ├── lyra-hub.service          ← hub container (NatsBus, pool, routing, memory)
-│   ├── lyra-telegram.service     ← Telegram adapter container
-│   ├── lyra-discord.service      ← Discord adapter container
-│   ├── lyra-clipool.service      ← CliPool NATS worker (Claude subprocesses)
-│   └── lyra-gh-helper.service    ← GitHub App token-mint helper (lyra-gh.pod)
+│   ├── factory-nats.service         ← Quadlet NATS container (port 4222, roxabi.network)
+│   ├── factory-hub.service          ← hub container (NatsBus, pool, routing, memory)
+│   ├── factory-telegram.service     ← Telegram adapter container
+│   ├── factory-discord.service      ← Discord adapter container
+│   ├── factory-clipool.service      ← CliPool NATS worker (Claude subprocesses)
+│   └── factory-gh-helper.service    ← GitHub App token-mint helper (factory-gh.pod)
 ├── Quadlet unit files: ~/.config/containers/systemd/
 │   ├── roxabi.network
-│   ├── lyra-hub.container
-│   ├── lyra-telegram.container
-│   ├── lyra-discord.container
-│   ├── lyra-clipool.container
-│   ├── lyra-nats.container
-│   ├── lyra-gh-helper.container
-│   ├── lyra-gh.pod
+│   ├── factory-hub.container
+│   ├── factory-telegram.container
+│   ├── factory-discord.container
+│   ├── factory-clipool.container
+│   ├── factory-nats.container
+│   ├── factory-gh-helper.container
+│   ├── factory-gh.pod
 │   └── lyra-*.volume
-├── config: ~/projects/lyra/config.toml
-├── credentials: ~/.lyra/config.db (bot config) + Podman secrets (bot tokens)
-├── nkey seeds: ~/.lyra/nkeys/*.seed
-├── Podman secrets: lyra-nats-auth, lyra-nats-hub, lyra-nats-telegram, lyra-nats-discord, lyra-nats-clipool
-└── logs: journalctl --user -u lyra-hub
+├── config: ~/projects/roxabi-factory/config.toml
+├── credentials: ~/.roxabi/factory/config.db (bot config) + Podman secrets (bot tokens)
+├── nkey seeds: ~/.roxabi/factory/nkeys/*.seed
+├── Podman secrets: factory-nats-auth, factory-nats-hub, factory-nats-telegram, factory-nats-discord, factory-nats-clipool
+└── logs: journalctl --user -u factory-hub
 ```
 
 ## Prerequisites
@@ -48,7 +48,7 @@ Machine 1 requires:
 
 ### Auto-update from GHCR (canonical, since #929)
 
-Production pulls images from GitHub Container Registry. CI publishes `ghcr.io/roxabi/lyra:staging` on every staging merge. Quadlet's `Label=io.containers.autoupdate=registry` paired with `podman-auto-update.timer` (daily by default; configure a drop-in for shorter intervals) restarts the container as soon as a new digest is published — no manual intervention needed after a merge.
+Production pulls images from GitHub Container Registry. CI publishes `ghcr.io/roxabi/factory:staging` on every staging merge. Quadlet's `Label=io.containers.autoupdate=registry` paired with `podman-auto-update.timer` (daily by default; configure a drop-in for shorter intervals) restarts the container as soon as a new digest is published — no manual intervention needed after a merge.
 
 ```bash
 # Verify the timer is active (one-time, on Machine 1)
@@ -65,14 +65,14 @@ See [ops/container-publishing.md](ops/container-publishing.md#auto-update-flow) 
 When CI is unavailable and you must rebuild from a local checkout (Machine 2):
 
 ```bash
-make build              # podman build → localhost/lyra:dev
+make build              # podman build → localhost/factory:dev
 make push               # podman save | ssh M1 podman load
 ```
 
 On Machine 1:
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make quadlet-install    # copy unit files to ~/.config/containers/systemd/
 make lyra reload        # restart containers
 ```
@@ -85,23 +85,23 @@ make lyra reload        # restart containers
 
 ## 2. Configure environment
 
-**Credentials (tokens):** Bot tokens are stored as Podman secrets (`lyra-bot-<platform>-<bot_id>`). Adapters mount them at container start.
+**Credentials (tokens):** Bot tokens are stored as Podman secrets (`factory-bot-<platform>-<bot_id>`). Adapters mount them at container start.
 
 ```bash
 # Store bot tokens (run once per bot)
-lyra bot secret install telegram lyra
-lyra bot secret install discord lyra
+factory bot secret install telegram lyra
+factory bot secret install discord lyra
 ```
 
 **Environment inline in `.container` files:** NATS connection vars are set directly in each Quadlet unit:
 
 ```ini
-# In lyra-hub.container, lyra-telegram.container, etc.
-Environment=NATS_URL=nats://lyra-nats:4222
-Environment=NATS_NKEY_SEED_PATH=/run/secrets/lyra-nats-hub.seed
+# In factory-hub.container, factory-telegram.container, etc.
+Environment=NATS_URL=nats://factory-nats:4222
+Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-hub.seed
 ```
 
-**Nkey secrets:** Seed files are mounted as Podman secrets from `~/.lyra/nkeys/`:
+**Nkey secrets:** Seed files are mounted as Podman secrets from `~/.roxabi/factory/nkeys/`:
 
 ```bash
 # Generate nkeys + auth.conf
@@ -111,12 +111,12 @@ make nats-setup
 make quadlet-secrets-install
 ```
 
-Volume + secret layout is documented inline in `deploy/quadlet/lyra-hub.container` and the other unit files.
+Volume + secret layout is documented inline in `deploy/quadlet/factory-hub.container` and the other unit files.
 
 ## Multi-Bot Deployment
 
 Multiple bots are configured in `config.toml` — no container changes needed. The five-container
-topology (`lyra-nats`, `lyra-hub`, `lyra-telegram`, `lyra-discord`, `lyra-clipool`) is fixed regardless of how many bots
+topology (`factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`) is fixed regardless of how many bots
 are configured.
 
 ### Adding a second bot
@@ -134,7 +134,7 @@ owner_users = []
 
 2. Store the bot token:
 ```bash
-lyra bot secret install telegram aryl
+factory bot secret install telegram aryl
 ```
 
 3. Restart containers:
@@ -144,14 +144,14 @@ make lyra reload
 
 ### Resource considerations
 
-All bots share the `lyra-hub` container for routing and the `lyra-clipool` container for Claude subprocess execution.
-Adapter containers (`lyra-telegram`, `lyra-discord`) are lightweight thin NATS clients.
+All bots share the `factory-hub` container for routing and the `factory-clipool` container for Claude subprocess execution.
+Adapter containers (`factory-telegram`, `factory-discord`) are lightweight thin NATS clients.
 
 - **CPU / RAM**: each additional bot adds a small constant overhead. At personal-use scale this
   is negligible — expect under 50 MB additional RAM per bot across hub and clipool.
 - **CliPool contention**: simultaneous long-running LLM requests from multiple bots compete for
-  subprocess slots in the shared `lyra-clipool` container.
-- **Crash scope**: an unhandled exception in `lyra-hub` takes down all bot routing at once. The
+  subprocess slots in the shared `factory-clipool` container.
+- **Crash scope**: an unhandled exception in `factory-hub` takes down all bot routing at once. The
   adapter containers survive independently. systemd `Restart=on-failure` brings everything back.
 
 ---
@@ -160,7 +160,7 @@ Adapter containers (`lyra-telegram`, `lyra-discord`) are lightweight thin NATS c
 
 ```bash
 # One-time setup on Machine 1 — installs units and reloads systemd
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make quadlet-install
 
 # Enable the auto-update timer (only needed if provision.sh was not run)
@@ -185,12 +185,12 @@ All commands can be run from Machine 1 or from Machine 2 via SSH (`make remote <
 
 ```bash
 # From Machine 1
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make lyra          # status
 make lyra reload   # restart
 make lyra stop     # stop
-make lyra logs     # tail lyra-hub stdout
-make lyra errors   # tail lyra-hub stderr
+make lyra logs     # tail factory-hub stdout
+make lyra errors   # tail factory-hub stderr
 
 # From Machine 2 (via SSH)
 make remote status
@@ -202,11 +202,11 @@ make remote errors
 ## 5. Enable debug logging
 
 Lyra logs go to journald. The log level defaults to `INFO`. To enable debug output, set
-`LOG_LEVEL=DEBUG` in `~/.lyra/env/hub.env` and restart:
+`LOG_LEVEL=DEBUG` in `~/.roxabi/factory/env/hub.env` and restart:
 
 ```bash
 make lyra reload
-journalctl --user -u lyra-hub -f
+journalctl --user -u factory-hub -f
 ```
 
 ## 6. Monitor VRAM (Machine 1)
@@ -246,7 +246,7 @@ Machine connection is read from `.env`:
 ```bash
 # .env (on your dev machine)
 DEPLOY_HOST=user@your-hub-ip          # SSH user@host for production hub
-DEPLOY_DIR=~/projects/lyra            # project path on the production host
+DEPLOY_DIR=~/projects/roxabi-factory            # project path on the production host
 ```
 
 ### Deploy (pull + test + restart)
@@ -280,11 +280,11 @@ loginctl enable-linger $USER
 systemctl --user enable --now podman-auto-update.timer
 
 # Check all Lyra unit statuses
-systemctl --user status 'lyra-*.service' lyra-nats.service
+systemctl --user status 'lyra-*.service' factory-nats.service
 
 # View journald logs
-journalctl --user -u lyra-hub --no-pager -n 50
-journalctl --user -u lyra-telegram --no-pager -n 50
+journalctl --user -u factory-hub --no-pager -n 50
+journalctl --user -u factory-telegram --no-pager -n 50
 ```
 
 ---
@@ -296,18 +296,18 @@ When the subject→identity ACL matrix changes (spec #706), regenerate nkeys and
 ### Regenerate
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 factory-acl genkeys --regen-authconf
 ```
 
-This rotates all nkeys — old seeds are backed up to `~/.lyra/nkeys.bak.{epoch}/` and the old
+This rotates all nkeys — old seeds are backed up to `~/.roxabi/factory/nkeys.bak.{epoch}/` and the old
 `auth.conf` is backed up before any files are overwritten.
 
 ### Update Podman secret and reload
 
 ```bash
 make quadlet-secrets-install   # recreate Podman secrets from new seeds
-systemctl --user restart lyra-nats.service
+systemctl --user restart factory-nats.service
 ```
 
 ### Reconnect clients
@@ -317,7 +317,7 @@ Restart adapters and clipool so they reconnect with new credentials:
 ```bash
 make telegram reload && make discord reload
 make clipool reload
-systemctl --user restart lyra-hub.service  # hub last
+systemctl --user restart factory-hub.service  # hub last
 ```
 
 > Voice workers (TTS/STT) live in the voiceCLI project and are reloaded via its own Makefile
@@ -336,14 +336,14 @@ tools/check-nats-acls.sh --since "$(date -Iseconds)" --window 90
 **Container fails to start — "Missing required env var"**
 The env file is either missing, has wrong permissions, or references an unset variable. Check:
 ```bash
-journalctl --user -u lyra-hub --no-pager -n 50
+journalctl --user -u factory-hub --no-pager -n 50
 make lyra errors
 ```
 
 **Container restarts in a loop**
 systemd `Restart=on-failure` retries on crash. Check the journal for the root cause:
 ```bash
-journalctl --user -u lyra-hub -f
+journalctl --user -u factory-hub -f
 ```
 
 **`uv` not found (inside container)**

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,7 +26,7 @@ Machine 1 (roxabituwer, 192.168.1.16)
 │   ├── factory-nats.container
 │   ├── factory-gh-helper.container
 │   ├── factory-gh.pod
-│   └── lyra-*.volume
+│   └── factory-*.volume
 ├── config: ~/projects/roxabi-factory/config.toml
 ├── credentials: ~/.roxabi/factory/config.db (bot config) + Podman secrets (bot tokens)
 ├── nkey seeds: ~/.roxabi/factory/nkeys/*.seed
@@ -280,7 +280,7 @@ loginctl enable-linger $USER
 systemctl --user enable --now podman-auto-update.timer
 
 # Check all Lyra unit statuses
-systemctl --user status 'lyra-*.service' factory-nats.service
+systemctl --user status 'factory-*.service' factory-nats.service
 
 # View journald logs
 journalctl --user -u factory-hub --no-pager -n 50

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -365,7 +365,7 @@ curl -fsS -H "Authorization: Bearer $(cat ~/.roxabi/factory/env/health_secret)" 
 
 ```bash
 cd ~/projects/roxabi-factory
-systemctl --user status 'lyra-*.service'
+systemctl --user status 'factory-*.service'
 ```
 
 You should see all eight units active:
@@ -438,7 +438,7 @@ ssh -i ~/.ssh/lyra_agent lyra@<MACHINE_1_IP> "id && git --version"
 | Agent access | `ssh -i ~/.ssh/lyra_agent lyra@<IP>` (optional) |
 | Lyra project | `~/projects/roxabi-factory/` |
 | VoiceCLI project | `~/projects/voiceCLI/` (if installed) |
-| Quadlet units | `~/.config/containers/systemd/lyra-*.container` |
+| Quadlet units | `~/.config/containers/systemd/factory-*.container` |
 | VoiceCLI Quadlet units | `~/.config/containers/systemd/voicecli-*.container` (if voiceCLI installed) |
 | Config | `~/projects/roxabi-factory/config.toml` |
 | Credentials | `~/.roxabi/factory/config.db` (bot config) + Podman secrets (bot tokens) |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -19,7 +19,7 @@ Three ways to run lyra — pick the one that matches your goal.
 
 | Tier | Goal | Setup |
 |------|------|-------|
-| **1. Library** | Import `lyra` in your own code | `uv add "lyra @ git+https://github.com/Roxabi/lyra.git@staging"` — nothing else |
+| **1. Library** | Import `lyra` in your own code | `uv add "lyra @ git+https://github.com/Roxabi/roxabi-factory.git@staging"` — nothing else |
 | **2. Standalone** | Run lyra on one machine (dev or personal use) | See **Tier 2** below — 5 commands, no containers, no separate NATS server |
 | **3. Full production** | 24/7 hub with adapters, auto-deploy, monitoring | Continue to **Step 1** below — this guide covers Machine 1 hub setup |
 
@@ -27,15 +27,15 @@ Three ways to run lyra — pick the one that matches your goal.
 
 ## Tier 2 — Standalone (unified mode)
 
-For single-machine dev or personal use. `lyra start` runs hub + adapters in one process and auto-starts an embedded nats-server when `NATS_URL` is unset.
+For single-machine dev or personal use. `factory start` runs hub + adapters in one process and auto-starts an embedded nats-server when `NATS_URL` is unset.
 
 ```bash
-git clone git@github.com:Roxabi/lyra.git ~/projects/lyra
-cd ~/projects/lyra && uv sync
+git clone git@github.com:Roxabi/roxabi-factory.git ~/projects/roxabi-factory
+cd ~/projects/roxabi-factory && uv sync
 cp config.toml.example config.toml   # edit owner_users with your IDs
-lyra agent init                      # seed agents DB from bundled TOML
-lyra bot secret install telegram lyra   # store token encrypted
-lyra start                           # hub + telegram + discord in one process
+factory agent init                      # seed agents DB from bundled TOML
+factory bot secret install telegram lyra   # store token encrypted
+factory start                           # hub + telegram + discord in one process
 ```
 
 No containers. No systemd. No `make deploy`. Stop with `Ctrl+C`.
@@ -148,7 +148,7 @@ ssh-copy-id yourname@<MACHINE_1_IP>
 
 ```bash
 ssh yourname@<MACHINE_1_IP>
-curl -fsSL https://raw.githubusercontent.com/Roxabi/lyra/staging/deploy/provision.sh | ADMIN_USER=yourname bash
+curl -fsSL https://raw.githubusercontent.com/Roxabi/roxabi-factory/staging/deploy/provision.sh | ADMIN_USER=yourname bash
 ```
 
 The script handles:
@@ -199,8 +199,8 @@ ssh yourname@<MACHINE_1_IP>
 # Add your GitHub SSH key if not already done
 # https://github.com/settings/keys → paste output of: cat ~/.ssh/id_ed25519.pub
 
-git clone git@github.com:Roxabi/lyra.git ~/projects/lyra
-cd ~/projects/lyra && python3 deploy/setup.py
+git clone git@github.com:Roxabi/roxabi-factory.git ~/projects/roxabi-factory
+cd ~/projects/roxabi-factory && python3 deploy/setup.py
 ```
 
 `deploy/setup.py` will:
@@ -214,8 +214,8 @@ cd ~/projects/lyra && python3 deploy/setup.py
 4. `make quadlet-install` — install Quadlet units to `~/.config/containers/systemd/`
 5. Create log directories (`~/.local/state/*/logs/`)
 6. Scaffold `config.toml` from example
-7. Seed agents into the DB (`lyra agent init`)
-8. Seed bots into BotStore (`lyra bot init`)
+7. Seed agents into the DB (`factory agent init`)
+8. Seed bots into BotStore (`factory bot init`)
 9. Install Claude Code plugins:
    - **Mandatory:** `web-intel`, `agent-browser`, `lyra-send`, `refine-agent`
    - **Conditional:** `voice-cli` (auto-installed if voiceCLI was installed)
@@ -236,7 +236,7 @@ The setup scaffolded `config.toml` from the example. Fill in:
 ### 1. Auth config (`config.toml`)
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 nano config.toml
 ```
 
@@ -244,7 +244,7 @@ Fill in your user IDs in the `owner_users` arrays:
 - Telegram ID: message [@userinfobot](https://t.me/userinfobot) on Telegram
 - Discord ID: Settings → Advanced → Developer Mode → right-click your username → Copy User ID
 
-> **Agents vs Bots:** Your setup already created a default agent (`lyra`) in the DB (`lyra agent init`). An **agent** is the AI brain (model, persona, tools). A **bot** is the platform identity (Telegram bot token, Discord bot token). One agent can answer many bots. Step 2 and 3 below are about creating the *platform identity* (bot), not the AI brain (agent).
+> **Agents vs Bots:** Your setup already created a default agent (`lyra`) in the DB (`factory agent init`). An **agent** is the AI brain (model, persona, tools). A **bot** is the platform identity (Telegram bot token, Discord bot token). One agent can answer many bots. Step 2 and 3 below are about creating the *platform identity* (bot), not the AI brain (agent).
 
 ### 2. Create your bots
 
@@ -264,16 +264,16 @@ Fill in your user IDs in the `owner_users` arrays:
 Bot tokens are **not** stored in `.env`. They are delivered as Podman `type=mount` secrets:
 
 ```bash
-lyra bot secret install telegram lyra
-lyra bot secret install discord lyra
+factory bot secret install telegram lyra
+factory bot secret install discord lyra
 ```
 
-These create `lyra-bot-telegram-lyra` and `lyra-bot-discord-lyra` in the Podman secret store.
+These create `factory-bot-telegram-lyra` and `factory-bot-discord-lyra` in the Podman secret store.
 
-> **Note:** Bot tokens are encrypted in `~/.lyra/config.db` — not in `.env`. The `.env` file is for:
+> **Note:** Bot tokens are encrypted in `~/.roxabi/factory/config.db` — not in `.env`. The `.env` file is for:
 > - `DEPLOY_HOST`, `DEPLOY_DIR` — remote deployment target
-> - `LYRA_HEALTH_SECRET` — bearer token for health endpoint
-> - Voice settings (`LYRA_STT_ENABLED`, `LYRA_TTS_ENGINE`, etc.)
+> - `FACTORY_HEALTH_SECRET` — bearer token for health endpoint
+> - Voice settings (`FACTORY_STT_ENABLED`, `FACTORY_TTS_ENGINE`, etc.)
 >
 > See `.env.example` for all available options.
 
@@ -291,12 +291,12 @@ Follow the prompts to authenticate. Lyra uses Claude Code as its LLM backend —
 
 ## Step 10 — NATS setup (production only)
 
-For **single-machine development**, no NATS setup is required. `lyra start` auto-starts an embedded nats-server when `NATS_URL` is not set.
+For **single-machine development**, no NATS setup is required. `factory start` auto-starts an embedded nats-server when `NATS_URL` is not set.
 
 For **production** (Quadlet containers on `roxabi.network`):
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 
 # Generate nkeys and auth.conf for all identities
 make nats-setup
@@ -308,10 +308,10 @@ make quadlet-secrets-install
 > If `nk` is not installed: `apt install nats-tools` (or download from https://github.com/nats-io/nkeys/releases and place at `/usr/local/bin/nk`).
 
 `make nats-setup` generates:
-- `~/.lyra/nkeys/*.seed` — nkey seed files for each identity (hub, telegram-adapter, discord-adapter, clipool-worker)
-- `~/.lyra/nkeys/auth.conf` — merged auth config for NATS
+- `~/.roxabi/factory/nkeys/*.seed` — nkey seed files for each identity (hub, telegram-adapter, discord-adapter, clipool-worker)
+- `~/.roxabi/factory/nkeys/auth.conf` — merged auth config for NATS
 
-The Quadlet NATS container (`lyra-nats.container`) runs rootless on `roxabi.network` with no TLS (container-to-container traffic is internal). Clients connect via `NATS_URL=nats://lyra-nats:4222`.
+The Quadlet NATS container (`factory-nats.container`) runs rootless on `roxabi.network` with no TLS (container-to-container traffic is internal). Clients connect via `NATS_URL=nats://factory-nats:4222`.
 
 ---
 
@@ -330,54 +330,54 @@ make quadlet-install
 make quadlet-secrets-install
 
 # Start all Lyra containers now
-systemctl --user start lyra-nats.service
+systemctl --user start factory-nats.service
 sleep 3  # wait for NATS to be ready
-systemctl --user start lyra-hub.service lyra-telegram.service lyra-discord.service lyra-clipool.service
+systemctl --user start factory-hub.service factory-telegram.service factory-discord.service factory-clipool.service
 ```
 
 Or use the Makefile dispatcher:
 ```bash
-make lyra start
+make factory start
 ```
 
 ## Step 12 — Health monitoring
 
-> **Removed.** The legacy host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. Only the Python module `src/lyra/monitoring/` is retained for [Monitoring v2 (#1035)](https://github.com/Roxabi/lyra/issues/1035) spec mining. Skip this step on new installs.
+> **Removed.** The legacy host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. Only the Python module `src/factory/monitoring/` is retained for [Monitoring v2 (#1035)](https://github.com/Roxabi/roxabi-factory/issues/1035) spec mining. Skip this step on new installs.
 
 If you still want a quick way to check hub health from the command line, hit the health endpoint directly:
 
 ```bash
 # Generate the health secret used by /health/detail
-mkdir -p ~/.lyra/env
-openssl rand -hex 32 > ~/.lyra/env/health_secret
-chmod 600 ~/.lyra/env/health_secret
-echo "LYRA_HEALTH_SECRET=$(cat ~/.lyra/env/health_secret)" >> ~/.lyra/env/hub.env
+mkdir -p ~/.roxabi/factory/env
+openssl rand -hex 32 > ~/.roxabi/factory/env/health_secret
+chmod 600 ~/.roxabi/factory/env/health_secret
+echo "FACTORY_HEALTH_SECRET=$(cat ~/.roxabi/factory/env/health_secret)" >> ~/.roxabi/factory/env/hub.env
 
 # Reload the hub so the new EnvironmentFile value is picked up
-systemctl --user restart lyra-hub.service
+systemctl --user restart factory-hub.service
 
-# Probe (after lyra-hub.service is running)
-curl -fsS -H "Authorization: Bearer $(cat ~/.lyra/env/health_secret)" \
+# Probe (after factory-hub.service is running)
+curl -fsS -H "Authorization: Bearer $(cat ~/.roxabi/factory/env/health_secret)" \
   http://127.0.0.1:8443/health/detail | jq .
 ```
 
 ## Step 13 — Verify services
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 systemctl --user status 'lyra-*.service'
 ```
 
 You should see all eight units active:
 ```
-lyra-nats.service         active (running)
-lyra-hub.service          active (running)
-lyra-telegram.service     active (running)
-lyra-discord.service      active (running)
-lyra-clipool.service      active (running)
-lyra-gh-helper.service    active (running)
-lyra-turn-writer.service  active (running)
-lyra-blobstore.service    active (running)
+factory-nats.service         active (running)
+factory-hub.service          active (running)
+factory-telegram.service     active (running)
+factory-discord.service      active (running)
+factory-clipool.service      active (running)
+factory-gh-helper.service    active (running)
+factory-turn-writer.service  active (running)
+factory-blobstore.service    active (running)
 ```
 
 Or check the full container list:
@@ -387,8 +387,8 @@ podman ps --format "table {{.Names}}\t{{.Status}}"
 
 Check the logs:
 ```bash
-make lyra logs        # journalctl for lyra-hub
-make lyra errors      # journalctl for lyra-hub (errors only)
+make lyra logs        # journalctl for factory-hub
+make lyra errors      # journalctl for factory-hub (errors only)
 ```
 
 ---
@@ -403,13 +403,13 @@ What happens under the hood:
 1. The adapter (standalone process) normalizes your message into an `InboundMessage`
 2. It publishes to NATS (`lyra.inbound.<platform>.<bot_id>`)
 3. The Hub picks it up via its `NatsBus` subscription and resolves the routing
-4. The Hub publishes the turn to NATS (`lyra.clipool.cmd`); the `lyra-clipool` worker receives it and spawns the `claude` subprocess, streaming replies back via NATS (`lyra.clipool.heartbeat`)
+4. The Hub publishes the turn to NATS (`lyra.clipool.cmd`); the `factory-clipool` worker receives it and spawns the `claude` subprocess, streaming replies back via NATS (`lyra.clipool.heartbeat`)
 5. The Hub publishes the response to NATS (`lyra.outbound.<platform>.<bot_id>`)
 6. The `NatsOutboundListener` in the adapter process receives it and dispatches to the platform
 
 ---
 
-## Step 15 — Set up lyra agent account (optional)
+## Step 15 — Set up factory agent account (optional)
 
 Generate a dedicated SSH key for the agent on Machine 2:
 
@@ -436,23 +436,23 @@ ssh -i ~/.ssh/lyra_agent lyra@<MACHINE_1_IP> "id && git --version"
 |------|-------|
 | Admin access | `ssh yourname@<IP>` |
 | Agent access | `ssh -i ~/.ssh/lyra_agent lyra@<IP>` (optional) |
-| Lyra project | `~/projects/lyra/` |
+| Lyra project | `~/projects/roxabi-factory/` |
 | VoiceCLI project | `~/projects/voiceCLI/` (if installed) |
 | Quadlet units | `~/.config/containers/systemd/lyra-*.container` |
 | VoiceCLI Quadlet units | `~/.config/containers/systemd/voicecli-*.container` (if voiceCLI installed) |
-| Config | `~/projects/lyra/config.toml` |
-| Credentials | `~/.lyra/config.db` (bot config) + Podman secrets (bot tokens) |
-| Nkey seeds | `~/.lyra/nkeys/*.seed` |
-| Podman secrets | `podman secret ls` (lyra-nats-auth, lyra-nats-hub, lyra-nats-telegram, lyra-nats-discord, lyra-nats-clipool) |
-| Logs | `journalctl --user -u lyra-hub` |
+| Config | `~/projects/roxabi-factory/config.toml` |
+| Credentials | `~/.roxabi/factory/config.db` (bot config) + Podman secrets (bot tokens) |
+| Nkey seeds | `~/.roxabi/factory/nkeys/*.seed` |
+| Podman secrets | `podman secret ls` (factory-nats-auth, factory-nats-hub, factory-nats-telegram, factory-nats-discord, factory-nats-clipool) |
+| Logs | `journalctl --user -u factory-hub` |
 | Diagrams | `~/.roxabi/forge/` (if installed) |
 | Firewall | UFW, SSH only |
 
-**Daily commands** (from `~/projects/lyra`):
+**Daily commands** (from `~/projects/roxabi-factory`):
 ```bash
 make lyra status     # status of all lyra containers
 make lyra reload     # restart hub + adapters + clipool
-make lyra logs       # journalctl for lyra-hub
+make lyra logs       # journalctl for factory-hub
 make deploy          # pull latest staging, install quadlet units (from Machine 2)
 ```
 
@@ -463,7 +463,7 @@ make deploy          # pull latest staging, install quadlet units (from Machine 
 You can test the hub routing without any platform tokens:
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 uv run python demo.py
 ```
 

--- a/docs/HAPPY-PATHS.md
+++ b/docs/HAPPY-PATHS.md
@@ -666,7 +666,7 @@ After response generated:
   → TurnStore.log_turn(pool_id, session_id, "user", user_text, inbound.id)
   → TurnStore.log_turn(pool_id, session_id, "assistant", response_text, outbound_id)
   → fire-and-forget: asyncio.create_task() — never blocks message processing
-  → writes to ~/.lyra/turns.db (SQLite):
+  → writes to ~/.roxabi/factory/turns.db (SQLite):
     → table: conversation_turns
     → columns: pool_id, session_id, role, content, user_id,
                inbound_message_id, reply_message_id, timestamp

--- a/docs/MULTI-BOT.md
+++ b/docs/MULTI-BOT.md
@@ -1,6 +1,6 @@
 # Multi-Bot Support
 
-Run multiple bots — each with its own persona, model, and auth policy — without duplicating infrastructure. All bots share the hub container (`lyra-hub`) and are served by the same adapter containers (`lyra-telegram`, `lyra-discord`).
+Run multiple bots — each with its own persona, model, and auth policy — without duplicating infrastructure. All bots share the hub container (`factory-hub`) and are served by the same adapter containers (`factory-telegram`, `factory-discord`).
 
 ## What multi-bot support enables
 
@@ -46,7 +46,7 @@ The flat `[telegram]` and `[discord]` sections use `bot_id = "main"` internally.
 
 Replace the flat sections with `[[telegram.bots]]` and `[[discord.bots]]` arrays. Each entry takes a `bot_id` that must match a corresponding `[[auth.telegram_bots]]` or `[[auth.discord_bots]]` entry.
 
-> **Note:** In production multi-bot deployments, tokens are delivered via per-bot Podman secrets mounted at `/run/secrets/bot_token-<bot_id>` — provision them with `lyra bot secret install <platform> <bot_id>` (see the `## Bot credentials` section in `docs/CONFIGURATION.md`). The `token` fields below illustrate the legacy single-bot `env:` path only.
+> **Note:** In production multi-bot deployments, tokens are delivered via per-bot Podman secrets mounted at `/run/secrets/bot_token-<bot_id>` — provision them with `factory bot secret install <platform> <bot_id>` (see the `## Bot credentials` section in `docs/CONFIGURATION.md`). The `token` fields below illustrate the legacy single-bot `env:` path only.
 
 ```toml
 [admin]
@@ -105,7 +105,7 @@ Every `bot_id` string is arbitrary but must be unique per platform and consisten
 
 ## Agent TOML: defining a persona
 
-Each bot references an agent by name (`agent = "aryl_default"`). Agent configs live at `src/lyra/agents/<name>.toml`.
+Each bot references an agent by name (`agent = "aryl_default"`). Agent configs live at `src/factory/agents/<name>.toml`.
 
 ```toml
 [agent]
@@ -117,13 +117,13 @@ show_intermediate = false
 backend = "claude-cli"
 model = "claude-haiku-4-5-20251001"
 max_turns = 20
-cwd = "~/projects/lyra"
+cwd = "~/projects/roxabi-factory"
 
 # [prompt]
 # system = "..."  # Optional: raw string overrides persona composition
 
 [workspaces]
-lyra     = "~/projects/lyra"
+lyra     = "~/projects/roxabi-factory"
 projects = "~/projects"
 ```
 
@@ -250,7 +250,7 @@ The `CliPool` is the Claude CLI subprocess pool. It is shared across all agents 
    - Discord: Discord Developer Portal → New Application → Bot → Reset Token → enable Message Content Intent
 
 2. **Create the agent TOML** (if using a new persona)
-   - Copy `src/lyra/agents/lyra_default.toml` to `src/lyra/agents/<name>.toml`
+   - Copy `src/factory/agents/lyra_default.toml` to `src/factory/agents/<name>.toml`
    - Edit `name`, `memory_namespace`, `model`, and `[prompt]`
    - Do not enable `smart_routing` (`enabled = false` or omit the section)
 
@@ -310,7 +310,7 @@ The `CliPool` is the Claude CLI subprocess pool. It is shared across all agents 
 | `bot_id` must be unique per platform | Two Telegram bots cannot share the same `bot_id` |
 | `auth_bots` entry required per bot | A bot without a matching auth entry is silently skipped at startup — add `[[auth.telegram_bots]]` / `[[auth.discord_bots]]` entry or the bot will not start. The process exits only if ALL bots lack auth. |
 | `CliPool` is shared | All bots share the subprocess pool — heavy concurrent use increases subprocess contention |
-| Shared hub container | All bots route through `lyra-hub` — a hub crash affects all bots (systemd `Restart=on-failure` recovers automatically) |
+| Shared hub container | All bots route through `factory-hub` — a hub crash affects all bots (systemd `Restart=on-failure` recovers automatically) |
 
 ---
 
@@ -320,8 +320,8 @@ The `CliPool` is the Claude CLI subprocess pool. It is shared across all agents 
 Check the logs for registration and ready messages:
 ```bash
 make lyra logs
-# Telegram: INFO lyra.__main__: Registered Telegram bot bot_id='<name>' agent='<agent>'
-# Discord:  INFO lyra.adapters.discord: Discord bot ready: <BotUsername> (id=<id>)
+# Telegram: INFO factory.__main__: Registered Telegram bot bot_id='<name>' agent='<agent>'
+# Discord:  INFO factory.adapters.discord: Discord bot ready: <BotUsername> (id=<id>)
 ```
 If the line is missing, the bot was skipped at startup — see below.
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -16,7 +16,7 @@ Each inbound turn receives a unique `trace_id` (UUID4) that propagates through t
 
 **Level:** `INFO` by default; override via `[logging] level` in `config.toml`.
 
-Configured in `src/lyra/__main__.py` — `_setup_logging()`.
+Configured in `src/factory/__main__.py` — `_setup_logging()`.
 
 ---
 
@@ -29,12 +29,12 @@ A `TraceIdFilter` (attached to all logging handlers at startup) reads `trace_id`
 To isolate a single turn's log lines:
 
 ```bash
-journalctl --user -u lyra-hub | grep 'abc-123-...'
+journalctl --user -u factory-hub | grep 'abc-123-...'
 ```
 
 **Scope boundary:** Log lines emitted in `Hub.run()` outside of pipeline processing (e.g., the main loop itself) do not carry a `trace_id`. Only per-turn processing is traced.
 
-Implemented in `src/lyra/core/trace.py`. See #270.
+Implemented in `src/factory/core/trace.py`. See #270.
 
 ---
 
@@ -50,7 +50,7 @@ The `pool_id` is a stable string that identifies a conversation scope and appear
 To reconstruct a full conversation scope:
 
 ```bash
-journalctl --user -u lyra-hub | grep "telegram:main:chat:123456"
+journalctl --user -u factory-hub | grep "telegram:main:chat:123456"
 ```
 
 ---
@@ -61,13 +61,13 @@ The following events are emitted (at INFO unless noted) for each inbound message
 
 | Stage | Logger | Example line |
 |-------|--------|-------------|
-| Hub routing | `lyra.core.hub` | Pool resolved, workspace/cwd overrides |
-| Agent dispatch | `lyra.agents.anthropic_agent` | `[agent:lyra][pool:telegram:main:chat:123] response: 156 chars` |
-| LLM call (SDK) | `lyra.llm.drivers.sdk` | `SDK stream [pool:...]: in=45 out=87 tokens` |
-| Retry/backoff | `lyra.llm.decorators` | Retry attempt N, backoff delay |
-| Timeout / cancel | `lyra.core.cli_pool` (WARNING/ERROR) | `pool ...: no output for Ns — alive, waiting (1/3)` or `Timeout: no output for Ns` |
-| Cancel-in-flight | `lyra.core.pool` (DEBUG) | New message while LLM processing |
-| Circuit breaker | `lyra.core.circuit_breaker` (WARNING) | State transition old→new |
+| Hub routing | `factory.core.hub` | Pool resolved, workspace/cwd overrides |
+| Agent dispatch | `factory.agents.anthropic_agent` | `[agent:lyra][pool:telegram:main:chat:123] response: 156 chars` |
+| LLM call (SDK) | `factory.llm.drivers.sdk` | `SDK stream [pool:...]: in=45 out=87 tokens` |
+| Retry/backoff | `factory.llm.decorators` | Retry attempt N, backoff delay |
+| Timeout / cancel | `factory.core.cli_pool` (WARNING/ERROR) | `pool ...: no output for Ns — alive, waiting (1/3)` or `Timeout: no output for Ns` |
+| Cancel-in-flight | `factory.core.pool` (DEBUG) | New message while LLM processing |
+| Circuit breaker | `factory.core.circuit_breaker` (WARNING) | State transition old→new |
 
 **What is NOT logged:** message content, full prompts/responses (only char/token counts). For full content capture, see the Turn Store below.
 
@@ -77,7 +77,7 @@ The following events are emitted (at INFO unless noted) for each inbound message
 
 > Shipped in #67 (L1 memory layer).
 
-The `TurnStore` (`src/lyra/core/turn_store.py`) persists every user and assistant turn to a dedicated **`~/.lyra/turns.db`** SQLite database (separate from roxabi-vault to avoid write contention). This provides a complete audit trail with message content, platform IDs, and session context.
+The `TurnStore` (`src/factory/core/turn_store.py`) persists every user and assistant turn to a dedicated **`~/.roxabi/factory/turns.db`** SQLite database (separate from roxabi-vault to avoid write contention). This provides a complete audit trail with message content, platform IDs, and session context.
 
 | Column | Purpose |
 |--------|---------|
@@ -103,7 +103,7 @@ The `TurnStore` (`src/lyra/core/turn_store.py`) persists every user and assistan
 
 ## Pipeline Telemetry Events
 
-Typed telemetry events are emitted at middleware seam boundaries for observability (#432). These are defined in `src/lyra/core/hub/pipeline_events.py` and fanned out via `PipelineEventBus` (`src/lyra/core/hub/event_bus.py`).
+Typed telemetry events are emitted at middleware seam boundaries for observability (#432). These are defined in `src/factory/core/hub/pipeline_events.py` and fanned out via `PipelineEventBus` (`src/factory/core/hub/event_bus.py`).
 
 > **Note:** The original `events.py` (AgentStarted, AgentCompleted, etc.) was deleted in `6cd433c` — these types were never wired into the codebase. The current pipeline event system replaced them for middleware telemetry.
 
@@ -121,10 +121,10 @@ The `PipelineEventBus` is injected via constructor (DI, not singleton) per ADR-0
 
 ## Health Monitoring
 
-> **Removed — see [#1035](https://github.com/Roxabi/lyra/issues/1035).** The host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. The Python module `src/lyra/monitoring/` is preserved for Monitoring v2 spec reference.
+> **Removed — see [#1035](https://github.com/Roxabi/roxabi-factory/issues/1035).** The host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. The Python module `src/factory/monitoring/` is preserved for Monitoring v2 spec reference.
 
 > For ad-hoc hub health probes, see `docs/CONFIGURATION.md` § Monitoring — removed.
-> For the planned successor, see [#1035](https://github.com/Roxabi/lyra/issues/1035) (Monitoring v2 — NATS event stream + Tauri dashboard).
+> For the planned successor, see [#1035](https://github.com/Roxabi/roxabi-factory/issues/1035) (Monitoring v2 — NATS event stream + Tauri dashboard).
 
 ---
 

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -12,14 +12,14 @@ Eight containers on `roxabi.network` (systemd `--user`, linger enabled):
 
 | Service | Container | Role |
 |---|---|---|
-| `lyra-nats` | NATS 2.x | Message bus (port 4222) |
-| `lyra-hub` | lyra | Hub — routing, pool, memory |
-| `lyra-telegram` | lyra | Telegram adapter |
-| `lyra-discord` | lyra | Discord adapter |
-| `lyra-clipool` | lyra | CliPool NATS worker (Claude subprocesses) |
-| `lyra-gh-helper` | lyra | GitHub App token-mint helper (`lyra-gh.pod`) |
-| `lyra-turn-writer` | lyra | JetStream subscriber-writer for turns.db (#1331) |
-| `lyra-blobstore` | lyra | HTTP-fronted BlobStore service (port 8449, #1330) |
+| `factory-nats` | NATS 2.x | Message bus (port 4222) |
+| `factory-hub` | lyra | Hub — routing, pool, memory |
+| `factory-telegram` | lyra | Telegram adapter |
+| `factory-discord` | lyra | Discord adapter |
+| `factory-clipool` | lyra | CliPool NATS worker (Claude subprocesses) |
+| `factory-gh-helper` | lyra | GitHub App token-mint helper (`factory-gh.pod`) |
+| `factory-turn-writer` | lyra | JetStream subscriber-writer for turns.db (#1331) |
+| `factory-blobstore` | lyra | HTTP-fronted BlobStore service (port 8449, #1330) |
 
 ## Install
 
@@ -27,20 +27,20 @@ Eight containers on `roxabi.network` (systemd `--user`, linger enabled):
 
 ```bash
 # 1. Generate nkeys + auth.conf (if not done yet)
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make nats-setup
 
 # 2. Install secrets + static units
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 ./deploy/install.sh
 
 # 3. Seed BotStore + render adapter templates + daemon-reload
-#    Required since #1416: hub bootstraps auth from BotStore (~/.lyra/config.db),
+#    Required since #1416: hub bootstraps auth from BotStore (~/.roxabi/factory/config.db),
 #    not from config.toml directly. Skipping this step causes a hub crash-loop.
 make quadlet-install
 
 # 4. Start services
-systemctl --user start lyra-nats lyra-hub lyra-telegram lyra-discord lyra-clipool lyra-gh-helper
+systemctl --user start factory-nats factory-hub factory-telegram factory-discord factory-clipool factory-gh-helper
 
 # 5. Provision JetStream monitoring streams (idempotent)
 uv run python deploy/nats/bootstrap_streams.py
@@ -55,27 +55,27 @@ podman ps
 Auto-update handles this for GHCR images. Manual:
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make quadlet-install    # copy units + daemon-reload
 # then restart affected services
-systemctl --user restart lyra-hub lyra-telegram lyra-discord lyra-clipool
+systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool
 ```
 
 ## Auto-sync for Quadlet file changes
 
 Tracked Quadlet files (`deploy/quadlet/**`, Makefile, `tools/render_quadlet.py`) are
-auto-converged on M₁ by `lyra-quadlet-sync.timer`:
+auto-converged on M₁ by `factory-quadlet-sync.timer`:
 
 | Path | Cadence | What it does |
 |---|---|---|
-| **Auto** (`lyra-quadlet-sync.timer`) | Every 5 min | `git fetch` → `ff-only pull` → diff-guard → conditional `make quadlet-install` |
+| **Auto** (`factory-quadlet-sync.timer`) | Every 5 min | `git fetch` → `ff-only pull` → diff-guard → conditional `make quadlet-install` |
 | **Manual** (`make quadlet-install`) | Operator-driven | Immediate — use when you need a change NOW or the timer is disabled |
 
 ### First-time enable
 
 Run once (idempotent):
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make quadlet-sync-install
 ```
 
@@ -83,10 +83,10 @@ make quadlet-sync-install
 
 ```bash
 # Last run output
-journalctl --user -u lyra-quadlet-sync -n 20
+journalctl --user -u factory-quadlet-sync -n 20
 
 # Timer next trigger
-systemctl --user list-timers lyra-quadlet-sync.timer
+systemctl --user list-timers factory-quadlet-sync.timer
 ```
 
 ### When to use manual `make quadlet-install`
@@ -100,17 +100,17 @@ systemctl --user list-timers lyra-quadlet-sync.timer
 
 | Podman secret | Source file | Mounted at |
 |---|---|---|
-| `lyra-nats-auth` | `~/.lyra/nkeys/auth.conf` | `/etc/nats/nkeys/auth.conf` (in lyra-nats) |
-| `lyra-nats-hub` | `~/.lyra/nkeys/hub.seed` | `/run/secrets/lyra-nats-hub.seed` |
-| `lyra-nats-telegram` | `~/.lyra/nkeys/telegram-adapter.seed` | `/run/secrets/lyra-nats-telegram.seed` |
-| `lyra-nats-discord` | `~/.lyra/nkeys/discord-adapter.seed` | `/run/secrets/lyra-nats-discord.seed` |
-| `lyra-nats-clipool` | `~/.lyra/nkeys/clipool-worker.seed` | `/run/secrets/lyra-nats-clipool.seed` |
-| `lyra-gh-pem` | `~/.lyra/gh-app.pem` | `/run/secrets/gh-app.pem` (helper only) |
-| `lyra-claude-oauth` | `~/.lyra/claude-oauth.tok` | `CLAUDE_CODE_OAUTH_TOKEN` env (clipool) |
-| `lyra_blobstore_token` | `~/.lyra/blobstore.tok` | `/run/secrets/lyra_blobstore_token` (uid=1500, gid=1500, mode=0400) |
+| `factory-nats-auth` | `~/.roxabi/factory/nkeys/auth.conf` | `/etc/nats/nkeys/auth.conf` (in factory-nats) |
+| `factory-nats-hub` | `~/.roxabi/factory/nkeys/hub.seed` | `/run/secrets/factory-nats-hub.seed` |
+| `factory-nats-telegram` | `~/.roxabi/factory/nkeys/telegram-adapter.seed` | `/run/secrets/factory-nats-telegram.seed` |
+| `factory-nats-discord` | `~/.roxabi/factory/nkeys/discord-adapter.seed` | `/run/secrets/factory-nats-discord.seed` |
+| `factory-nats-clipool` | `~/.roxabi/factory/nkeys/clipool-worker.seed` | `/run/secrets/factory-nats-clipool.seed` |
+| `factory-gh-pem` | `~/.roxabi/factory/gh-app.pem` | `/run/secrets/gh-app.pem` (helper only) |
+| `factory-claude-oauth` | `~/.roxabi/factory/claude-oauth.tok` | `CLAUDE_CODE_OAUTH_TOKEN` env (clipool) |
+| `factory_blobstore_token` | `~/.roxabi/factory/blobstore.tok` | `/run/secrets/factory_blobstore_token` (uid=1500, gid=1500, mode=0400) |
 
-All seed secrets use `type=mount` (tmpfs-backed). `lyra-claude-oauth` uses `type=env`. (S7, S18)
-`lyra_blobstore_token` uses `type=mount`; the bearer token is read once at container startup by
+All seed secrets use `type=mount` (tmpfs-backed). `factory-claude-oauth` uses `type=env`. (S7, S18)
+`factory_blobstore_token` uses `type=mount`; the bearer token is read once at container startup by
 the auth middleware and never re-read until the container restarts (ADR-054).
 
 ## JetStream streams
@@ -120,7 +120,7 @@ the auth middleware and never re-read until the container restarts (ADR-054).
 | `lyra-events` | `lyra.event.>` | Limits | 24 h (hot) | 512 MiB |
 | `lyra-metrics` | `lyra.metric.>` | Limits | 7 d (warm) | 256 MiB |
 
-Both streams use `StorageType.FILE` backed by `lyra-jetstream.volume` (`~/.lyra/nats/jetstream`).
+Both streams use `StorageType.FILE` backed by `factory-jetstream.volume` (`~/.roxabi/factory/nats/jetstream`).
 Provisioning is idempotent via `uv run python deploy/nats/bootstrap_streams.py` (called in first-time setup above).
 
 Ops decision (#1183): events = 24 h hot (high churn, dashboard real-time), metrics = 7 d warm
@@ -131,7 +131,7 @@ message; durable consumers for the future dashboard are tracked in #1035.
 
 ### (a) No manual splicing
 
-The tracked files `deploy/quadlet/lyra-{telegram,discord}.container.tmpl` are **pure templates** — they contain a `{{bot_secrets}}` marker and zero `Secret=lyra-bot-*` lines. Per-bot `Secret=lyra-bot-<platform>-<bot_id>,…` directives are generated at install time by `tools/render_quadlet.py`, which reads bot rows from `BotStore` (`~/.lyra/config.db`) and substitutes the rendered block into each template before writing the live Quadlet to `~/.config/containers/systemd/`.
+The tracked files `deploy/quadlet/lyra-{telegram,discord}.container.tmpl` are **pure templates** — they contain a `{{bot_secrets}}` marker and zero `Secret=factory-bot-*` lines. Per-bot `Secret=factory-bot-<platform>-<bot_id>,…` directives are generated at install time by `tools/render_quadlet.py`, which reads bot rows from `BotStore` (`~/.roxabi/factory/config.db`) and substitutes the rendered block into each template before writing the live Quadlet to `~/.config/containers/systemd/`.
 
 **Never edit `~/.config/containers/systemd/lyra-{telegram,discord}.container` directly.** Any manual change is silently overwritten on the next `make quadlet-install`. This replaces the prior fragment-paste workflow that caused the 2026-05-26 crash-loop cascade (#1369): a `git pull --ff-only` during the #1331 deploy discarded an operator-spliced `BEGIN/END` block, stranding 4 bot-token mounts and forcing 6.5 h of adapter crash-loop before re-splice. Use the onboarding flow in (b) instead.
 
@@ -141,24 +141,24 @@ End-to-end flow for adding a new bot:
 
 1. Add the bot to the DB (DB-first since #1415):
    ```bash
-   lyra agent <platform> add <bot_id> --agent <agent>
+   factory agent <platform> add <bot_id> --agent <agent>
    ```
    (Replace `<platform>` with `telegram` or `discord`.)
 
 2. Install the Podman secret for the bot token (host-local):
    ```bash
-   lyra bot secret install <platform> <bot_id>
+   factory bot secret install <platform> <bot_id>
    ```
-   This creates `lyra-bot-<platform>-<bot_id>` in the Podman secret store. For webhook variants, also run:
+   This creates `factory-bot-<platform>-<bot_id>` in the Podman secret store. For webhook variants, also run:
    ```bash
-   lyra bot secret install <platform> <bot_id>-webhook
+   factory bot secret install <platform> <bot_id>-webhook
    ```
 
 3. Render and restart:
    ```bash
    make quadlet-install
    ```
-   The target runs `lyra bot init` (idempotent re-sync of `config.toml` → `BotStore`), then `render_quadlet.py` reads from `BotStore`, generates the `Secret=` directives, writes the new Quadlet atomically, runs `systemctl --user daemon-reload`, then restarts the adapter container.
+   The target runs `factory bot init` (idempotent re-sync of `config.toml` → `BotStore`), then `render_quadlet.py` reads from `BotStore`, generates the `Secret=` directives, writes the new Quadlet atomically, runs `systemctl --user daemon-reload`, then restarts the adapter container.
 
 4. Verify the adapter is healthy:
    ```bash
@@ -172,27 +172,27 @@ End-to-end flow for adding a new bot:
 
 Three artefacts prevent re-introduction of the manual-splice pattern:
 
-- `tools/check_quadlet_template_purity.sh` — enforces three invariants on all tracked `deploy/quadlet/*.container.tmpl` files: (i) no `Secret=lyra-bot-*` lines present; (ii) no `# --- BEGIN … ---` splice-block markers present; (iii) `tools/render_quadlet.py` exists (guards against accidental deletion of the render script).
+- `tools/check_quadlet_template_purity.sh` — enforces three invariants on all tracked `deploy/quadlet/*.container.tmpl` files: (i) no `Secret=factory-bot-*` lines present; (ii) no `# --- BEGIN … ---` splice-block markers present; (iii) `tools/render_quadlet.py` exists (guards against accidental deletion of the render script).
 - `make quadlet-lint` — local entry point; run before pushing to catch purity failures early.
-- `.github/workflows/quadlet-lint.yml` — CI job that runs the purity check on every PR touching `deploy/quadlet/**`. A PR that reintroduces a `Secret=lyra-bot-` line or a `BEGIN/END` splice block into any `.container.tmpl` will fail here.
+- `.github/workflows/quadlet-lint.yml` — CI job that runs the purity check on every PR touching `deploy/quadlet/**`. A PR that reintroduces a `Secret=factory-bot-` line or a `BEGIN/END` splice block into any `.container.tmpl` will fail here.
 
 ### (d) Multi-host caveat
 
-`~/.lyra/config.toml` is Syncthing-synced across M₁, M₂, and laptop. That means `[[auth.telegram_bots]]` and `[[auth.discord_bots]]` enumerate **all bots across all hosts** in one shared file. `make quadlet-install` runs `lyra bot init` first (seeds `BotStore` from `config.toml`), then `render_quadlet.py` reads from `BotStore` — so the rendered Quadlet on every host includes `Secret=` lines for every configured bot.
+`~/.roxabi/factory/config.toml` is Syncthing-synced across M₁, M₂, and laptop. That means `[[auth.telegram_bots]]` and `[[auth.discord_bots]]` enumerate **all bots across all hosts** in one shared file. `make quadlet-install` runs `factory bot init` first (seeds `BotStore` from `config.toml`), then `render_quadlet.py` reads from `BotStore` — so the rendered Quadlet on every host includes `Secret=` lines for every configured bot.
 
-However, Podman secrets (`lyra-bot-<platform>-<bot_id>`) are **host-local** and must be installed per host. A mismatch — `config.toml` lists a bot but its Podman secret is absent — causes `systemctl --user start lyra-<platform>` to fail immediately:
+However, Podman secrets (`factory-bot-<platform>-<bot_id>`) are **host-local** and must be installed per host. A mismatch — `config.toml` lists a bot but its Podman secret is absent — causes `systemctl --user start lyra-<platform>` to fail immediately:
 
 ```
-Error: looking up secret name "lyra-bot-telegram-<bot_id>": no such secret
+Error: looking up secret name "factory-bot-telegram-<bot_id>": no such secret
 ```
 
-**Mitigation:** When adding a bot, run `lyra bot secret install <platform> <bot_id>` on **every host that runs the adapter for that platform** before executing `make quadlet-install`.
+**Mitigation:** When adding a bot, run `factory bot secret install <platform> <bot_id>` on **every host that runs the adapter for that platform** before executing `make quadlet-install`.
 
 Current host-role mapping (from `~/projects/hosts.toml`):
 
 | Host | Role | Adapter units |
 |---|---|---|
-| M₁ `roxabituwer` | `lyra-hub` | `lyra-telegram`, `lyra-discord` (all 4 bots) |
+| M₁ `roxabituwer` | `factory-hub` | `factory-telegram`, `factory-discord` (all 4 bots) |
 | M₂ `roxabitower` | `image-worker` | none today |
 
 ## Secret rotation
@@ -201,73 +201,73 @@ Current host-role mapping (from `~/projects/hosts.toml`):
 
 ```bash
 # 1. Generate new seed
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 make nats-regen-authconf    # re-renders auth.conf; auto-creates missing seeds
 
 # 2. Re-install the affected secret
-podman secret create --replace lyra-nats-hub ~/.lyra/nkeys/hub.seed
+podman secret create --replace factory-nats-hub ~/.roxabi/factory/nkeys/hub.seed
 
 # 3. Reload NATS (auth.conf change), then restart the affected container
-systemctl --user restart lyra-nats
-systemctl --user restart lyra-hub
+systemctl --user restart factory-nats
+systemctl --user restart factory-hub
 ```
 
 ### Rotate all nkey secrets at once
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 ./deploy/install.sh --force --secrets-only
-systemctl --user restart lyra-nats lyra-hub lyra-telegram lyra-discord lyra-clipool
+systemctl --user restart factory-nats factory-hub factory-telegram factory-discord factory-clipool
 ```
 
 ### Rotate GitHub App PEM
 
 ```bash
-# Copy new PEM to ~/.lyra/gh-app.pem, then:
-podman secret create --replace lyra-gh-pem ~/.lyra/gh-app.pem
-systemctl --user restart lyra-gh-helper
+# Copy new PEM to ~/.roxabi/factory/gh-app.pem, then:
+podman secret create --replace factory-gh-pem ~/.roxabi/factory/gh-app.pem
+systemctl --user restart factory-gh-helper
 ```
 
 ### Rotating the BlobStore bearer token
 
-`lyra_blobstore_token` is a `type=mount` secret — the tmpfs file is bound at container init.
+`factory_blobstore_token` is a `type=mount` secret — the tmpfs file is bound at container init.
 `podman secret create --replace` alone does NOT refresh the in-container file; a restart is
 mandatory (ADR-054). Keep the prior source file as `.prev` until rotation is confirmed.
 
 1. Write the new token to the host source file:
    ```bash
-   printf '%s' "$NEW_TOK" > ~/.lyra/blobstore.tok && chmod 0600 ~/.lyra/blobstore.tok
+   printf '%s' "$NEW_TOK" > ~/.roxabi/factory/blobstore.tok && chmod 0600 ~/.roxabi/factory/blobstore.tok
    ```
-   Keeping the source file at `~/.lyra/blobstore.tok` ensures reinstall scripts remain idempotent.
+   Keeping the source file at `~/.roxabi/factory/blobstore.tok` ensures reinstall scripts remain idempotent.
 
 2. Update the Podman secret store:
    ```bash
-   podman secret create --replace lyra_blobstore_token ~/.lyra/blobstore.tok
+   podman secret create --replace factory_blobstore_token ~/.roxabi/factory/blobstore.tok
    ```
 
 3. Restart the service so the new tmpfs file is bound at container init:
    ```bash
-   systemctl --user restart lyra-blobstore.service
+   systemctl --user restart factory-blobstore.service
    ```
 
 4. Verify the new token is in place (first 8 chars should match `$NEW_TOK`):
    ```bash
-   podman exec lyra-blobstore sh -c 'head -c 8 /run/secrets/lyra_blobstore_token'
+   podman exec factory-blobstore sh -c 'head -c 8 /run/secrets/factory_blobstore_token'
    ```
 
 5. Rollback (if step 4 fails — keep `.prev` until this step is confirmed unnecessary):
    ```bash
-   podman secret create --replace lyra_blobstore_token ~/.lyra/blobstore.tok.prev
-   systemctl --user restart lyra-blobstore.service
+   podman secret create --replace factory_blobstore_token ~/.roxabi/factory/blobstore.tok.prev
+   systemctl --user restart factory-blobstore.service
    ```
 
 ## Backing up the BlobStore
 
-> **Host vs container path:** `/data/lyra/blobs` is the canonical host path. `~/.lyra/blobstore` is the container view (bind-mounted into `lyra-blobstore` via `Volume=/data/lyra/blobs:/home/lyra/.lyra/blobstore:z`). All backup and restore commands below reference the canonical host path.
+> **Host vs container path:** `/data/factory/blobs` is the canonical host path. `~/.roxabi/factory/blobstore` is the container view (bind-mounted into `factory-blobstore` via `Volume=/data/factory/blobs:/home/factory/.roxabi/factory/blobstore:z`). All backup and restore commands below reference the canonical host path.
 
 The BlobStore consists of two parts that must be snapshotted in order: the SQLite index
-(`/data/lyra/blobs/index.sqlite`) first, then the content-addressed shard tree
-(`/data/lyra/blobs/`). Reversing the order risks capturing a `blob_refs` row
+(`/data/factory/blobs/index.sqlite`) first, then the content-addressed shard tree
+(`/data/factory/blobs/`). Reversing the order risks capturing a `blob_refs` row
 whose shard file was not yet in the snapshot — a phantom row at restore time.
 
 `FsBlobStore` uses a per-instance `asyncio.Lock`, not a global write-quiesce. A concurrent
@@ -278,12 +278,12 @@ row was NOT captured in the DB snapshot. The restore invariant handles this safe
 1. Snapshot the SQLite index (atomic per the SQLite `.backup` API):
    ```bash
    mkdir -p /tmp/blobstore-snapshot
-   sqlite3 /data/lyra/blobs/index.sqlite ".backup '/tmp/blobstore-snapshot/index.sqlite'"
+   sqlite3 /data/factory/blobs/index.sqlite ".backup '/tmp/blobstore-snapshot/index.sqlite'"
    ```
 
 2. Snapshot the shard tree together with the DB snapshot (use hardlinks to minimise disk usage):
    ```bash
-   cp -al /data/lyra/blobs /tmp/blobstore-snapshot/blobs
+   cp -al /data/factory/blobs /tmp/blobstore-snapshot/blobs
    ```
    For off-host backup, pipe through Restic or similar:
    ```bash
@@ -295,7 +295,7 @@ row was NOT captured in the DB snapshot. The restore invariant handles this safe
    sha256sum -c <(find /tmp/blobstore-snapshot/blobs -type f -exec sha256sum {} +)
    ```
 
-Recommended cadence: daily, scheduled when traffic is low. Store alongside `~/.lyra/config.db`
+Recommended cadence: daily, scheduled when traffic is low. Store alongside `~/.roxabi/factory/config.db`
 backups.
 
 ## Restore invariant
@@ -328,25 +328,25 @@ that underpins this restore procedure.
 
 ## Host-level mount requirements
 
-The `/data/lyra/blobs` filesystem must be mounted with `noatime` and `nodiratime` on the host. This prevents every blob read (GET, HEAD, or consistency check) from updating the inode `atime`, which would otherwise generate unnecessary write I/O and accelerate SSD wear on the content-addressed shard tree.
+The `/data/factory/blobs` filesystem must be mounted with `noatime` and `nodiratime` on the host. This prevents every blob read (GET, HEAD, or consistency check) from updating the inode `atime`, which would otherwise generate unnecessary write I/O and accelerate SSD wear on the content-addressed shard tree.
 
 Verify current mount options:
 
 ```bash
-findmnt -n -o OPTIONS /data/lyra/blobs
+findmnt -n -o OPTIONS /data/factory/blobs
 ```
 
 If `noatime` is missing, update `/etc/fstab` and remount:
 
 ```bash
 # Example fstab entry
-/dev/mapper/data-lyra-blobs  /data/lyra/blobs  ext4  defaults,noatime,nodiratime  0  2
+/dev/mapper/data-lyra-blobs  /data/factory/blobs  ext4  defaults,noatime,nodiratime  0  2
 ```
 
 Apply without reboot:
 
 ```bash
-sudo mount -o remount,noatime,nodiratime /data/lyra/blobs
+sudo mount -o remount,noatime,nodiratime /data/factory/blobs
 ```
 
 ## Diagnostic
@@ -359,10 +359,10 @@ systemctl --user status 'lyra-*'
 podman ps --filter 'name=lyra'
 
 # Logs
-journalctl --user -u lyra-hub -f
-journalctl --user -u lyra-telegram -f
-journalctl --user -u lyra-clipool -f
-journalctl --user -u lyra-gh-helper -f
+journalctl --user -u factory-hub -f
+journalctl --user -u factory-telegram -f
+journalctl --user -u factory-clipool -f
+journalctl --user -u factory-gh-helper -f
 
 # NATS health
 curl -s http://127.0.0.1:8222/varz | python3 -m json.tool | grep -E '"connections"|"version"'
@@ -371,7 +371,7 @@ curl -s http://127.0.0.1:8222/varz | python3 -m json.tool | grep -E '"connection
 podman secret ls
 
 # Verify secret is readable in a container
-podman exec lyra-hub cat /run/secrets/lyra-nats-hub.seed | head -c 4
+podman exec factory-hub cat /run/secrets/factory-nats-hub.seed | head -c 4
 
 # Auto-update status
 podman auto-update --dry-run
@@ -382,19 +382,19 @@ systemctl --user status podman-auto-update.timer
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `lyra-hub` fails to start | Missing `lyra-nats-hub` secret | `./deploy/install.sh --secrets-only` |
+| `factory-hub` fails to start | Missing `factory-nats-hub` secret | `./deploy/install.sh --secrets-only` |
 | NATS auth failure in logs | Stale auth.conf | `make nats-regen-authconf` + restart NATS |
-| `lyra-gh-helper` fails | Missing `lyra-gh-pem` | Install PEM secret (see above) |
+| `factory-gh-helper` fails | Missing `factory-gh-pem` | Install PEM secret (see above) |
 | Container restart loop | `RestartSec=10` applies — check logs | `journalctl --user -u <svc> -n 50` |
 | Auto-update not pulling | Timer inactive | `systemctl --user start podman-auto-update.timer` |
 
 ## Pitfall: double-quotes in HealthCmd= are dropped by the Quadlet generator
 
 The Quadlet generator silently drops the closing double-quote from `HealthCmd=` values,
-turning `HealthCmd=pgrep -f "lyra adapter X"` into the JSON array
-`["CMD-SHELL","pgrep -f \"lyra adapter X"]` — note the missing closing `"`.
+turning `HealthCmd=pgrep -f "factory adapter X"` into the JSON array
+`["CMD-SHELL","pgrep -f \"factory adapter X"]` — note the missing closing `"`.
 `/bin/sh` then fails with `Syntax error: Unterminated quoted string`, and the container
-reports `unhealthy` indefinitely (all 6 `lyra-*` units were affected until issue #1370).
+reports `unhealthy` indefinitely (all 6 `factory-*` units were affected until issue #1370).
 
 Workaround: use `/proc/1/cmdline` — no quotes required, and `grep`/`cat` are present in
 both the slim (`:staging-svc`) and fat (`:staging`) images (unlike `pgrep` which requires
@@ -433,20 +433,20 @@ and KV dedup bucket `lyra_outbound_audio_sent`. See ADR-077 for the full decisio
 
 ### Deploy order (strict — each step is a prerequisite for the next)
 
-**Step 1 — ACL: update `acl-matrix.json` → regen `auth.conf` → RESTART `lyra-nats`**
+**Step 1 — ACL: update `acl-matrix.json` → regen `auth.conf` → RESTART `factory-nats`**
 
 ```bash
-# On M₁ (roxabituwer) — regen auth.conf from real nkey seeds in ~/.lyra/nkeys/
+# On M₁ (roxabituwer) — regen auth.conf from real nkey seeds in ~/.roxabi/factory/nkeys/
 sudo env "PATH=$PATH" factory-acl genkeys --regen-authconf
 
 # Re-install the NATS auth secret from the regenerated file
-podman secret create --replace lyra-nats-auth ~/.lyra/nkeys/auth.conf
+podman secret create --replace factory-nats-auth ~/.roxabi/factory/nkeys/auth.conf
 
-# RESTART lyra-nats — a HUP is NOT sufficient
+# RESTART factory-nats — a HUP is NOT sufficient
 # auth.conf is a type=mount secret (tmpfs-backed); the in-container file is bound
 # at container init only. --replace updates the Podman store but the running
 # container still reads the old file. A full restart is mandatory.
-systemctl --user restart lyra-nats
+systemctl --user restart factory-nats
 ```
 
 **Why ACL must precede adapters:** the adapters call `ensure_stream`, `ensure_consumer`,
@@ -458,7 +458,7 @@ error and the adapter crashes before completing bootstrap.
 **Step 2 — Deploy hub** (now publishes audio via JetStream + PubAck instead of Core fire-and-forget)
 
 ```bash
-systemctl --user restart lyra-hub
+systemctl --user restart factory-hub
 ```
 
 The hub publishes to `lyra.outbound.audio.<platform>.<bot_id>` and returns immediately
@@ -468,7 +468,7 @@ entirely by the adapters.
 **Step 3 — Deploy adapters** (auto-provision stream/consumer/KV on boot, then start the pull consumer)
 
 ```bash
-systemctl --user restart lyra-telegram lyra-discord
+systemctl --user restart factory-telegram factory-discord
 ```
 
 On boot each adapter calls (in order):
@@ -494,11 +494,11 @@ nats consumer info LYRA_OUTBOUND_AUDIO outbound-audio-telegram
 nats consumer info LYRA_OUTBOUND_AUDIO outbound-audio-discord
 
 # Confirm adapters are healthy (NRestarts=0 expected)
-systemctl --user status lyra-telegram lyra-discord
+systemctl --user status factory-telegram factory-discord
 
-# Adapter logs — audio delivery failures surface here, NOT in lyra-nats.service
-journalctl --user -u lyra-telegram -n 50 | grep -E "audio|LYRA_OUTBOUND"
-journalctl --user -u lyra-discord  -n 50 | grep -E "audio|LYRA_OUTBOUND"
+# Adapter logs — audio delivery failures surface here, NOT in factory-nats.service
+journalctl --user -u factory-telegram -n 50 | grep -E "audio|FACTORY_OUTBOUND"
+journalctl --user -u factory-discord  -n 50 | grep -E "audio|FACTORY_OUTBOUND"
 
 # Check NATS HTTP monitoring for consumer lag and stream usage
 # (thresholds: num_pending > 50 → lag warning; used > 80% of 32 MiB → fullness warning)
@@ -506,7 +506,7 @@ curl -s "http://127.0.0.1:8222/jsz?consumers=1&name=LYRA_OUTBOUND_AUDIO" \
   | python3 -m json.tool | grep -E '"num_pending"|"name"|"bytes"'
 ```
 
-The monitoring subsystem (`python -m lyra.monitoring`) runs two audio-specific probes after
+The monitoring subsystem (`python -m factory.monitoring`) runs two audio-specific probes after
 this deploy:
 
 | Check name | What it monitors | Fail condition |
@@ -524,8 +524,8 @@ and harmless.
 
 ```bash
 # Point hub back to the previous image tag and restart
-# (edit Image= in lyra-hub.container, or make quadlet-install with prior tag)
-systemctl --user restart lyra-hub
+# (edit Image= in factory-hub.container, or make quadlet-install with prior tag)
+systemctl --user restart factory-hub
 ```
 
 The reverted hub stops publishing to `lyra.outbound.audio.>`. Any messages already in
@@ -535,7 +535,7 @@ delivered because the adapters' pull consumers are stopped in the next step.
 **Step R2 — Stop audio consumers (revert adapter images or restart without audio bootstrap)**
 
 ```bash
-systemctl --user restart lyra-telegram lyra-discord
+systemctl --user restart factory-telegram factory-discord
 ```
 
 If the adapter image is also rolled back to a version without `JetStreamAudioConsumer`,
@@ -561,7 +561,7 @@ nats stream rm KV_lyra_outbound_audio_sent --force
 
 The `lyra.outbound.audio.>` publish grant (hub) and the adapter JetStream API grants are
 additive. Leaving them in `auth.conf` has no functional impact when the audio code path is
-inactive. Remove them only if a full ACL audit is underway (requires regen + `lyra-nats` RESTART).
+inactive. Remove them only if a full ACL audit is underway (requires regen + `factory-nats` RESTART).
 
 > **Note:** in-flight messages in `LYRA_OUTBOUND_AUDIO` at the time of hub rollback will
 > not be delivered — the hub no longer publishes, and the adapters have stopped consuming.

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -46,7 +46,7 @@ systemctl --user start factory-nats factory-hub factory-telegram factory-discord
 uv run python deploy/nats/bootstrap_streams.py
 
 # 6. Verify
-systemctl --user status 'lyra-*'
+systemctl --user status 'factory-*'
 podman ps
 ```
 
@@ -162,7 +162,7 @@ End-to-end flow for adding a new bot:
 
 4. Verify the adapter is healthy:
    ```bash
-   systemctl --user status lyra-<platform>
+   systemctl --user status factory-<platform>
    ```
    Expected: `Active: active (running)` with `NRestarts=0`.
 
@@ -180,7 +180,7 @@ Three artefacts prevent re-introduction of the manual-splice pattern:
 
 `~/.roxabi/factory/config.toml` is Syncthing-synced across M₁, M₂, and laptop. That means `[[auth.telegram_bots]]` and `[[auth.discord_bots]]` enumerate **all bots across all hosts** in one shared file. `make quadlet-install` runs `factory bot init` first (seeds `BotStore` from `config.toml`), then `render_quadlet.py` reads from `BotStore` — so the rendered Quadlet on every host includes `Secret=` lines for every configured bot.
 
-However, Podman secrets (`factory-bot-<platform>-<bot_id>`) are **host-local** and must be installed per host. A mismatch — `config.toml` lists a bot but its Podman secret is absent — causes `systemctl --user start lyra-<platform>` to fail immediately:
+However, Podman secrets (`factory-bot-<platform>-<bot_id>`) are **host-local** and must be installed per host. A mismatch — `config.toml` lists a bot but its Podman secret is absent — causes `systemctl --user start factory-<platform>` to fail immediately:
 
 ```
 Error: looking up secret name "factory-bot-telegram-<bot_id>": no such secret
@@ -353,7 +353,7 @@ sudo mount -o remount,noatime,nodiratime /data/factory/blobs
 
 ```bash
 # Service status
-systemctl --user status 'lyra-*'
+systemctl --user status 'factory-*'
 
 # Running containers
 podman ps --filter 'name=lyra'

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -17,7 +17,7 @@ Get Lyra running and send your first message in about 5 minutes.
 ## 1. Install
 
 ```bash
-git clone https://github.com/Roxabi/lyra
+git clone https://github.com/Roxabi/roxabi-factory
 cd lyra
 uv sync
 
@@ -56,20 +56,20 @@ DISCORD_TOKEN=MTIz...                      # from Discord Developer Portal → B
 
 ## 3. Configure the agent (optional)
 
-Agents are managed via **AgentStore** (SQLite at `~/.lyra/config.db`). TOML files in `src/lyra/agents/` (system defaults) and `~/.lyra/agents/` (user overrides) are seed sources — import them into the DB on first setup:
+Agents are managed via **AgentStore** (SQLite at `~/.roxabi/factory/config.db`). TOML files in `src/factory/agents/` (system defaults) and `~/.roxabi/factory/agents/` (user overrides) are seed sources — import them into the DB on first setup:
 
 ```bash
 # First-time: seed DB from TOML files
-lyra agent init
+factory agent init
 
 # List all agents in DB
-lyra agent list
+factory agent list
 
 # Edit an agent interactively (changes take effect on restart)
-lyra agent edit lyra_default
+factory agent edit lyra_default
 
 # Validate an agent
-lyra agent validate lyra_default
+factory agent validate lyra_default
 ```
 
 Agent seeds are TOML files — no Python needed:
@@ -90,20 +90,20 @@ tools = ["Read", "Grep", "Glob", "WebFetch", "WebSearch"]
 system = """You are Lyra, a personal AI assistant..."""
 ```
 
-**User-level overrides**: put your customised TOML at `~/.lyra/agents/<name>.toml` — it takes precedence over the system default at `init` time.
+**User-level overrides**: put your customised TOML at `~/.roxabi/factory/agents/<name>.toml` — it takes precedence over the system default at `init` time.
 
-**Second agent**: duplicate any `.toml` under a new name, run `lyra agent init`, then add a `[[telegram.bots]]` or `[[discord.bots]]` entry in `config.toml` pointing `agent = "<name>"`. No Python changes needed.
+**Second agent**: duplicate any `.toml` under a new name, run `factory agent init`, then add a `[[telegram.bots]]` or `[[discord.bots]]` entry in `config.toml` pointing `agent = "<name>"`. No Python changes needed.
 
 ## 4. Run
 
 ```bash
-lyra start
+factory start
 ```
 
 Expected output:
 
 ```
-2026-01-01 12:00:00 INFO lyra.__main__: Lyra started — Telegram + Discord adapters running.
+2026-01-01 12:00:00 INFO factory.__main__: Lyra started — Telegram + Discord adapters running.
 ```
 
 Lyra is now:
@@ -167,7 +167,7 @@ If the hub logs `Processing your request…`, the bounded queue (100) is full. T
 
 Lyra supports running multiple bots (each with its own persona and model) — all sharing the hub and adapter processes. The short version:
 
-1. Create an agent TOML in `src/lyra/agents/<name>.toml` for the new persona. Copy `lyra_default.toml` and edit `[agent].name`, `[model].model`, and `[prompt]`. Then run `lyra agent init` to import it into the DB.
+1. Create an agent TOML in `src/factory/agents/<name>.toml` for the new persona. Copy `lyra_default.toml` and edit `[agent].name`, `[model].model`, and `[prompt]`. Then run `factory agent init` to import it into the DB.
 2. Add `[[telegram.bots]]` and/or `[[discord.bots]]` entries to `config.toml`, each with a unique `bot_id` and `agent = "<name>"`.
 3. Add matching `[[auth.telegram_bots]]` / `[[auth.discord_bots]]` entries and the new bot tokens to `.env`.
 

--- a/docs/agent-management.md
+++ b/docs/agent-management.md
@@ -1,6 +1,6 @@
 # Agent Management
 
-Agents and bots are stored in **`~/.lyra/config.db`** (SQLite). TOML files are seed sources only — run `lyra agent init` (agents) and `lyra bot init` (bots) to import them into the DB before use.
+Agents and bots are stored in **`~/.roxabi/factory/config.db`** (SQLite). TOML files are seed sources only — run `factory agent init` (agents) and `factory bot init` (bots) to import them into the DB before use.
 
 ## Database Tables
 
@@ -12,45 +12,45 @@ Agents and bots are stored in **`~/.lyra/config.db`** (SQLite). TOML files are s
 
 ## Bot Configuration
 
-Bots are configured in `~/.lyra/config.toml` (`[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`). The hub reads bot metadata from `BotStore` (table `bots`), not from `config.toml` directly.
+Bots are configured in `~/.roxabi/factory/config.toml` (`[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`). The hub reads bot metadata from `BotStore` (table `bots`), not from `config.toml` directly.
 
 ```bash
 # Seeding (required before first hub boot since #1416)
-lyra bot init                     # import config.toml → BotStore (skip existing)
-lyra bot init --force             # overwrite existing rows
+factory bot init                     # import config.toml → BotStore (skip existing)
+factory bot init --force             # overwrite existing rows
 
 # Secret management
-lyra bot secret install <platform> <bot_id>   # create Podman secret for bot token
-lyra bot secret install <platform> <bot_id>-webhook
+factory bot secret install <platform> <bot_id>   # create Podman secret for bot token
+factory bot secret install <platform> <bot_id>-webhook
 ```
 
-**Rule:** `lyra bot init` is idempotent. Run it after every `config.toml` edit that changes bot definitions.
+**Rule:** `factory bot init` is idempotent. Run it after every `config.toml` edit that changes bot definitions.
 
 ### Bot CLI management (per platform)
 
-Bot management commands are grouped under `lyra agent <platform>` (telegram or discord). Each platform exposes the same 9 verbs.
+Bot management commands are grouped under `factory agent <platform>` (telegram or discord). Each platform exposes the same 9 verbs.
 
 ```bash
 # Listing & inspection
-lyra agent telegram list                     # all Telegram bots in DB
-lyra agent discord list                      # all Discord bots in DB
-lyra agent telegram show <bot_id>          # full bot record
+factory agent telegram list                     # all Telegram bots in DB
+factory agent discord list                      # all Discord bots in DB
+factory agent telegram show <bot_id>          # full bot record
 
 # Creation & editing
-lyra agent telegram add <bot_id> --agent foo --webhook-enabled
-lyra agent telegram edit <bot_id>            # interactive field editor
-lyra agent telegram patch <bot_id> --webhook-enabled true
-lyra agent telegram patch <bot_id> --agent foo
-lyra agent telegram patch <bot_id> --owner-users "123,456"
-lyra agent telegram remove <bot_id>          # delete + cascade bot_agent_map cleanup
-lyra agent telegram remove <bot_id> --yes    # skip confirmation
+factory agent telegram add <bot_id> --agent foo --webhook-enabled
+factory agent telegram edit <bot_id>            # interactive field editor
+factory agent telegram patch <bot_id> --webhook-enabled true
+factory agent telegram patch <bot_id> --agent foo
+factory agent telegram patch <bot_id> --owner-users "123,456"
+factory agent telegram remove <bot_id>          # delete + cascade bot_agent_map cleanup
+factory agent telegram remove <bot_id> --yes    # skip confirmation
 
 # Agent assignment
-lyra agent telegram assign <bot_id> --agent foo
-lyra agent telegram unassign <bot_id>        # revert to empty agent
+factory agent telegram assign <bot_id> --agent foo
+factory agent telegram unassign <bot_id>        # revert to empty agent
 
 # Validation
-lyra agent telegram validate <bot_id>        # check agent exists, owners non-empty, secret present
+factory agent telegram validate <bot_id>        # check agent exists, owners non-empty, secret present
 ```
 
 **Valid trust levels:** `owner`, `trusted`, `public`, `blocked` (default: `blocked`).
@@ -62,42 +62,42 @@ lyra agent telegram validate <bot_id>        # check agent exists, owners non-em
 Precedence (later overrides earlier):
 
 1. `src/factory/agents/` — bundled system defaults
-2. `~/.lyra/agents/` — user-level overrides (machine-specific, gitignored)
+2. `~/.roxabi/factory/agents/` — user-level overrides (machine-specific, gitignored)
 
-Override via `LYRA_VAULT_DIR` env var: `$LYRA_VAULT_DIR/agents/`.
+Override via `FACTORY_VAULT_DIR` env var: `$FACTORY_VAULT_DIR/agents/`.
 
 ## CLI Commands
 
 ```bash
 # Seeding & sync
-lyra agent init                     # import TOMLs → DB (skip existing)
-lyra agent init --force             # overwrite existing rows
+factory agent init                     # import TOMLs → DB (skip existing)
+factory agent init --force             # overwrite existing rows
 
 # Listing & inspection
-lyra agent list                     # DB agents with status + bot assignments
-lyra agent list --agents-dir PATH   # list TOML files instead
-lyra agent show <name>              # full config dump from DB
+factory agent list                     # DB agents with status + bot assignments
+factory agent list --agents-dir PATH   # list TOML files instead
+factory agent show <name>              # full config dump from DB
 
 # Editing (DB-only, no TOML sync)
-lyra agent edit <name>              # interactive field editor
-lyra agent patch <name> --json '{"model": "claude-opus-4-6"}'
-lyra agent patch <name> --effort high   # set extended-thinking effort
-lyra agent patch <name> --effort none   # disable extended thinking (store NULL)
+factory agent edit <name>              # interactive field editor
+factory agent patch <name> --json '{"model": "claude-opus-4-6"}'
+factory agent patch <name> --effort high   # set extended-thinking effort
+factory agent patch <name> --effort none   # disable extended thinking (store NULL)
 
 # Creation & deletion
-lyra agent create                   # interactive wizard → TOML file
-lyra agent create <name> --backend claude-cli --model <model> [--effort medium]
+factory agent create                   # interactive wizard → TOML file
+factory agent create <name> --backend claude-cli --model <model> [--effort medium]
                                     # non-interactive: creates directly in DB
-lyra agent delete <name>            # remove from DB (refuses if bots assigned)
-lyra agent delete <name> --yes      # skip confirmation
+factory agent delete <name>            # remove from DB (refuses if bots assigned)
+factory agent delete <name> --yes      # skip confirmation
 
 # Bot assignment
-lyra agent assign <agent> --platform telegram --bot <bot_id>
-lyra agent unassign --platform telegram --bot <bot_id>
+factory agent assign <agent> --platform telegram --bot <bot_id>
+factory agent unassign --platform telegram --bot <bot_id>
 
 # Validation & refinement
-lyra agent validate <name>          # check backend, model, JSON fields
-lyra agent refine <name>            # LLM-guided profile refinement
+factory agent validate <name>          # check backend, model, JSON fields
+factory agent refine <name>            # LLM-guided profile refinement
 ```
 
 ## Validation Rules
@@ -107,44 +107,44 @@ lyra agent refine <name>            # LLM-guided profile refinement
 - **Model**: non-empty string
 - **JSON fields**: `tools_json`, `plugins_json`, `permissions_json` must be valid JSON arrays; `workspaces_json`, `commands_json` must be valid objects
 - **Smart routing**: `enabled=true` is deprecated (no backend supports it)
-- **Effort**: `low` | `medium` | `high` | `xhigh` | `max` | `none` (NULL). Controls Anthropic extended-thinking token budget. `none` (or absent) = thinking disabled. New agents default to `medium` via `lyra agent create`; existing agents keep `NULL` after migration. Changing `effort` on a live agent requires pool restart to take effect.
+- **Effort**: `low` | `medium` | `high` | `xhigh` | `max` | `none` (NULL). Controls Anthropic extended-thinking token budget. `none` (or absent) = thinking disabled. New agents default to `medium` via `factory agent create`; existing agents keep `NULL` after migration. Changing `effort` on a live agent requires pool restart to take effect.
 
 ## Workflows
 
 ### Create a new agent
 
 ```bash
-lyra agent create           # wizard prompts → ~/.lyra/agents/<name>.toml
-lyra agent init             # import to DB
-lyra agent validate <name>  # verify config
+factory agent create           # wizard prompts → ~/.roxabi/factory/agents/<name>.toml
+factory agent init             # import to DB
+factory agent validate <name>  # verify config
 ```
 
 ### Edit existing agent
 
 ```bash
-lyra agent edit <name>      # interactive DB edit
+factory agent edit <name>      # interactive DB edit
 # OR
-lyra agent patch <name> --json '{"model": "claude-sonnet-4-5"}'
+factory agent patch <name> --json '{"model": "claude-sonnet-4-5"}'
 ```
 
-TOML edits require `lyra agent init --force` + restart to take effect.
+TOML edits require `factory agent init --force` + restart to take effect.
 
 ### Assign bot to agent
 
 ```bash
-lyra agent assign researcher --platform telegram --bot 123456
-lyra agent list              # shows assignment
+factory agent assign researcher --platform telegram --bot 123456
+factory agent list              # shows assignment
 ```
 
 ## Deprecated alias
 
-`lyra-agent` is a deprecated entry point. Invoking it prints:
+`factory-agent` is a deprecated entry point. Invoking it prints:
 
 ```
-Warning: lyra-agent is deprecated, use 'lyra agent ...' instead.
+Warning: factory-agent is deprecated, use 'factory agent ...' instead.
 ```
 
-Use `lyra agent <subcommand>` instead.
+Use `factory agent <subcommand>` instead.
 
 ## Workspaces & cwd
 
@@ -205,7 +205,7 @@ originating agent and session via two independent channels:
   image-baked template identity on the commit object itself (full mode only).
 - **Message trailers** — `Lyra-Session-Id` and `Lyra-Agent` are appended by the
   `prepare-commit-msg` hook (`deploy/lyra-gh/hooks/prepare-commit-msg`) whenever
-  `LYRA_SESSION_ID` and `LYRA_AGENT` are present in the subprocess environment.
+  `FACTORY_SESSION_ID` and `FACTORY_AGENT` are present in the subprocess environment.
 
 ### Querying attribution
 
@@ -233,7 +233,7 @@ The spawn-time gate in `CliPoolWorkerMixin._spawn()` is layered:
 | Condition | Behaviour |
 |---|---|
 | `agent_name` absent | No identity vars injected; subprocess uses the template identity entirely. |
-| `agent_name` present, `agent_email` absent | **Trailers-only mode**: `LYRA_AGENT` + `LYRA_SESSION_ID` injected; hook appends trailers; committer stays template. |
+| `agent_name` present, `agent_email` absent | **Trailers-only mode**: `FACTORY_AGENT` + `FACTORY_SESSION_ID` injected; hook appends trailers; committer stays template. |
 | `agent_name` + `agent_email` both present | **Full mode**: all four vars injected; committer identity AND trailers carry attribution. |
 
 Trailers-only mode is the **production steady state today** — `AgentRow` does not yet

--- a/docs/architecture/adapters.md
+++ b/docs/architecture/adapters.md
@@ -38,12 +38,12 @@ Agent management commands (`create`, `list`, `validate`, etc.) are exposed via a
 dedicated `[project.scripts]` entry in `pyproject.toml`:
 
 ```
-lyra-agent = "lyra.cli:agent_main"
+factory-agent = "factory.cli:agent_main"
 ```
 
 `__main__.py` is single-purpose (daemon bootstrap) and untouched by CLI dispatch.
 `cli.py` is the sole home of CLI logic and is independently testable without `sys.argv`
-patching. Invocation is `uv run lyra-agent <sub-command>`, consistent with the
+patching. Invocation is `uv run factory-agent <sub-command>`, consistent with the
 `voicecli` / `imagecli` conventions. supervisord, `make lyra`, and the production deploy
 path are unaffected. → ADR-020
 
@@ -57,7 +57,7 @@ path, read back via `tmp_path.read_bytes()`, and deleted via `tmp_path.unlink(mi
 the inbound pipeline carries forward without touching the filesystem again.
 No transcription/STT-service call site is involved; the old `try/finally`-at-transcribe
 ownership model has been superseded by this immediate-read-and-unlink pattern.
-A startup-time stale-file sweep of `LYRA_AUDIO_TMP` remains recommended as a safety net
+A startup-time stale-file sweep of `FACTORY_AUDIO_TMP` remains recommended as a safety net
 for crash-orphaned files (deferred). → ADR-013
 
 ### Inbound audio routing
@@ -102,7 +102,7 @@ routing or trust. → ADR-023
 ### STT/TTS NATS decoupling
 
 `lyra_stt` and `lyra_tts` run as independent NATS adapter services alongside
-`lyra_hub`, `lyra_telegram`, and `lyra_discord`. The hub never imports `voicecli`.
+`factory_hub`, `factory_telegram`, and `factory_discord`. The hub never imports `voicecli`.
 `AudioPipeline` calls `NatsSttClient.transcribe()` and `NatsTtsClient.synthesize()`
 over NATS request-reply (`lyra.voice.stt.request` / `lyra.voice.tts.request`). Both
 clients satisfy `STTProtocol` / `TtsProtocol` structural interfaces. On NATS timeout, `STTUnavailableError` is raised;
@@ -198,7 +198,7 @@ runs post-NATS inside the hub process. See `ARCHITECTURE.md §Inbound Message Pi
   before a third platform adapter is added.
 - `OutboundDispatcher._queue` is unbounded; `queue_maxsize` constructor parameter and a
   sensible default are recommended but not yet added.
-- Startup-time stale temp-file sweep of `LYRA_AUDIO_TMP` on hub restart is deferred.
+- Startup-time stale temp-file sweep of `FACTORY_AUDIO_TMP` on hub restart is deferred.
 - Multi-agent `AgentTTSConfig` — until Option B is verified at `AudioPipeline` /
   TTSService call sites, multi-agent deployments should log a warning when two agents
   differ in `AgentTTSConfig`.

--- a/docs/architecture/architecture-patterns.md
+++ b/docs/architecture/architecture-patterns.md
@@ -218,7 +218,7 @@ When adding new code, ask:
 ## File Placement Rules
 
 ```
-src/lyra/
+src/factory/
 ├── core/                    # KERNEL
 │   ├── events.py            # frozen event types
 │   ├── protocols.py         # Port definitions
@@ -277,7 +277,7 @@ src/lyra/
 
 ### Hexagonal canonical model
 
-Four layers, innermost to outermost: **Domain** (entities, port protocols, business rules — zero I/O imports) → **Application** (use cases, command handlers — depends on Domain ports only) → **Infrastructure** (SQLite stores, NATS transport, model loaders — implements Domain ports; lives in `lyra.infrastructure.*` per ADR-048) → **Adapters** (Telegram, Discord, CLI, NATS adapters — outermost ring, never imported by inner layers).
+Four layers, innermost to outermost: **Domain** (entities, port protocols, business rules — zero I/O imports) → **Application** (use cases, command handlers — depends on Domain ports only) → **Infrastructure** (SQLite stores, NATS transport, model loaders — implements Domain ports; lives in `factory.infrastructure.*` per ADR-048) → **Adapters** (Telegram, Discord, CLI, NATS adapters — outermost ring, never imported by inner layers).
 
 The **CLI protocol circular import** (ADR-060, absorbed here) established the canonical fix shape: when a CLI protocol port was co-located with its Infrastructure importer, the solution was to define the port in `factory.core` (Domain) and have Infrastructure import it from there. The **Composition Root** (`src/factory/bootstrap/`) is the only site that wires concrete Infrastructure implementations to Domain ports. → ADR-059 (absorbs ADR-048, ADR-060)
 
@@ -297,7 +297,7 @@ NullMessageManager replaces `if hub._msg_manager is None: return _DROP` guards, 
 
 - Domain layer imports nothing outside its own module (no I/O libs, no adapters, no infrastructure)
 - Application orchestrates Domain via ports defined in Domain; it never imports Infrastructure concretions
-- Infrastructure implements ports; lives in `lyra.infrastructure.*`; is the only layer that may hold migration runners and connection pools
+- Infrastructure implements ports; lives in `factory.infrastructure.*`; is the only layer that may hold migration runners and connection pools
 - Adapters are the outer ring; never imported by inner layers; lateral adapter-to-adapter imports are forbidden
 - All user-visible errors are LyraUserError subclasses raised at the point of failure
 - All unhandled pipeline errors are caught at ErrorBoundaryMiddleware and translated into a user reply, never silently dropped

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -51,7 +51,7 @@ registry, adopted on `TtsResponse`, `SttResponse`, `ImageResponse`, `LlmResponse
 
 The `[testing]` extra is the only install path that pulls transport code; production installs have
 zero `nats-py` dependency. Three production-contamination guards on test doubles: extras gate,
-`LYRA_ENV` assertion, loopback-only NATS URL check. This package absorbed the voice contract
+`FACTORY_ENV` assertion, loopback-only NATS URL check. This package absorbed the voice contract
 (ADR-044), the image contract (ADR-050), and the unified error envelope (ADR-066).
 
 → ADR-049

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -12,7 +12,7 @@
 │  TG / DC     │←────────────────│             │←────────────│  (Claude)    │
 └──────────────┘  NATS outbound  └──────┬──────┘  NATS reply  └──────┬───────┘
                                         │                             │
-                                   ~/.lyra/                     ~/.claude/
+                                   ~/.roxabi/factory/                     ~/.claude/
                                    (volume)                     (volume)
 ```
 
@@ -82,7 +82,7 @@ Resume (restart / reply-to):
   Claude reads ~/.claude/projects/<cwd>/<cli_sid>.jsonl → continues
 ```
 
-CliPool does **not** need `~/.lyra/` — it only receives the resume UUID as a
+CliPool does **not** need `~/.roxabi/factory/` — it only receives the resume UUID as a
 command argument from the Hub over NATS.
 
 ---
@@ -96,7 +96,7 @@ All trust resolution is Hub-side. Adapters are untrusted normalizers.
 |---|---|---|
 | Transport auth | Telegram HMAC webhook secret; Discord gateway token | Adapter container |
 | Trust resolution | C3 — adapters always send PUBLIC, hub resolves via Authenticator | Hub middleware stage 2–3 |
-| `auth.db` | Identity grants, trust assignments, cross-platform aliases | Hub container (`~/.lyra/auth.db`) |
+| `auth.db` | Identity grants, trust assignments, cross-platform aliases | Hub container (`~/.roxabi/factory/auth.db`) |
 | Secrets | Bot tokens delivered as Podman secrets (`type=mount`) — see ADR-074 | `/run/secrets/bot_token-<bot_id>` inside adapter containers |
 | NATS channel | TLS + auth tokens required in production | Infrastructure |
 
@@ -135,15 +135,15 @@ resumes it rather than starting fresh.
 
 | File | Container(s) | Access | Contents |
 |---|---|---|---|
-| `~/.lyra/auth.db` | Hub | rw | Auth grants, identity aliases |
-| `~/.lyra/config.db` | Hub | rw | Agent registry, user prefs (bot secrets removed — see ADR-074) |
-| `~/.lyra/turns.db` | Hub, Telegram, Discord | rw | Conversation turns, pool sessions, lyra→cli session map |
-| `~/.lyra/message_index.db` | Hub | rw | reply-to session routing index |
-| `~/.lyra/keyring.key` | Hub | rw | Encryption key for `config.db` sibling stores (bot-secrets path removed — safe to delete once no remaining consumers; see ADR-074) |
-| `~/.lyra/discord.db` | Discord | rw | Thread ownership + session cache |
+| `~/.roxabi/factory/auth.db` | Hub | rw | Auth grants, identity aliases |
+| `~/.roxabi/factory/config.db` | Hub | rw | Agent registry, user prefs (bot secrets removed — see ADR-074) |
+| `~/.roxabi/factory/turns.db` | Hub, Telegram, Discord | rw | Conversation turns, pool sessions, lyra→cli session map |
+| `~/.roxabi/factory/message_index.db` | Hub | rw | reply-to session routing index |
+| `~/.roxabi/factory/keyring.key` | Hub | rw | Encryption key for `config.db` sibling stores (bot-secrets path removed — safe to delete once no remaining consumers; see ADR-074) |
+| `~/.roxabi/factory/discord.db` | Discord | rw | Thread ownership + session cache |
 | `~/.claude/` | CliPool | rw | Claude session `.jsonl` files (required for `--resume`) |
 
-Adapter mounts are per-file inline binds (not the full `lyra-data.volume`) — adapters never touch `auth.db` or `message_index.db`.
+Adapter mounts are per-file inline binds (not the full `factory-data.volume`) — adapters never touch `auth.db` or `message_index.db`.
 
 ---
 
@@ -167,7 +167,7 @@ Adapter mounts are per-file inline binds (not the full `lyra-data.volume`) — a
 |---|---|---|
 | Hub ↔ Adapter | Already NATS (3-process mode) | Same, containerized |
 | Hub ↔ CliPool | In-process (stdio, method calls) | ✅ Done (#941) — NATS protocol (`lyra.clipool.cmd` / `lyra.clipool.heartbeat`) |
-| DBs | All in `~/.lyra/` on one host | Split across volumes per container |
+| DBs | All in `~/.roxabi/factory/` on one host | Split across volumes per container |
 | Session resume | In-process `_resume_session_ids` dict | Hub sends UUID over NATS |
 
 ---
@@ -183,22 +183,22 @@ Seven design questions deferred from ADR-053 are closed here. Each applies to al
 - **D1 — Image registry namespace:** Project-named, no `roxabi-` prefix. CI/prod images go to `ghcr.io/roxabi/<project>`; local dev builds use `localhost/<project>-<service>:dev`. The `roxabi-` prefix is reserved for genuinely shared SDKs (e.g. `roxabi-nats`), not per-project container images.
 - **D2 — NATS topology:** Per-project NATS during migration; shared NATS at Phase 4. Each project runs its own `<project>-nats.container` on an incrementing port (Lyra: 4223, voiceCLI: 4224, …) until Phase 4 consolidates onto a single `nats.container` at port 4222 on `roxabi.network`.
 - **D3 — Podman network:** NATS-bus participants share `roxabi.network` at Phase 4; HTTP-only projects (forge, intel, idna, live) use isolated per-project networks. Topology follows communication intent.
-- **D4 — Env file path:** `~/.<project>/env/<service>.env` per project. Lyra uses `~/.lyra/env/hub.env`; voiceCLI uses `~/.voicecli/env/tts.env`. Centralizing under `~/.roxabi/env/` is deferred — the per-project runtime root is already established.
+- **D4 — Env file path:** `~/.<project>/env/<service>.env` per project. Lyra uses `~/.roxabi/factory/env/hub.env`; voiceCLI uses `~/.voicecli/env/tts.env`. Centralizing under `~/.roxabi/env/` is deferred — the per-project runtime root is already established.
 - **D5 — Deploy script:** Shared shell library at `lyra/scripts/deploy-lib.sh`, installed to `~/.local/lib/roxabi/deploy-lib.sh` at bootstrap. Superseded in practice by `podman auto-update.timer` (GHCR registry auto-pull) + `make full-deploy` as manual fallback (#1035).
 - **D6 — Upgrade coordination:** Independent releases by default; batch coordination only for shared-infra breaking changes (NATS auth.conf change, Phase 4 NATS consolidation, `roxabi.network` rename, breaking NATS contract version bump per ADR-049).
 - **D7 — Shared infra home:** Lyra repo. NATS config, auth.conf, nkey issuance, Quadlet patterns, and deploy scripts live in `lyra/` because Lyra created the patterns. No `roxabi-infra` repo will be created.
 
 ### Container publishing workflow
 
-CI builds container images and pushes them to GHCR via a reusable GHA workflow (`Roxabi/.github/.github/workflows/publish-container.yml@v1`). Live reference: `.github/workflows/publish.yml`. Key invariants resolved in ADR-056: actions are SHA-pinned (no floating action tags), semver parsing strips the `lyra/` tag prefix, `LYRA_IMAGE` (local build) is separated from `GHCR_IMAGE` (registry name), and `secrets: inherit` was dropped in favor of the built-in `GITHUB_TOKEN`. Production hosts pull from GHCR via `podman auto-update` — images are never built on the production host. → ADR-056
+CI builds container images and pushes them to GHCR via a reusable GHA workflow (`Roxabi/.github/.github/workflows/publish-container.yml@v1`). Live reference: `.github/workflows/publish.yml`. Key invariants resolved in ADR-056: actions are SHA-pinned (no floating action tags), semver parsing strips the `lyra/` tag prefix, `FACTORY_IMAGE` (local build) is separated from `GHCR_IMAGE` (registry name), and `secrets: inherit` was dropped in favor of the built-in `GITHUB_TOKEN`. Production hosts pull from GHCR via `podman auto-update` — images are never built on the production host. → ADR-056
 
 ### Credential store
 
-File-based credentials (nkey seeds, NATS auth tokens) are delivered as Podman secrets using `type=mount`, placing the secret at a predictable path inside the container without exposing it as an environment variable. Naming convention: `<project>-nats-<identity>` (e.g. `lyra-nats-hub`). All containers use `UserNS=keep-id:uid=1500,gid=1500` so container processes run as host UID 1000 (`mickael`) — files in `~/.lyra/` are readable without `chown`. The `lyra-data.volume` is a bind-mount of `%h/.lyra` (`Type=none; Device=%h/.lyra; Options=bind`). Adapter data mounts use `:z` (read-write), not `:ro`. → ADR-054
+File-based credentials (nkey seeds, NATS auth tokens) are delivered as Podman secrets using `type=mount`, placing the secret at a predictable path inside the container without exposing it as an environment variable. Naming convention: `<project>-nats-<identity>` (e.g. `factory-nats-hub`). All containers use `UserNS=keep-id:uid=1500,gid=1500` so container processes run as host UID 1000 (`mickael`) — files in `~/.roxabi/factory/` are readable without `chown`. The `factory-data.volume` is a bind-mount of `%h/.roxabi/factory` (`Type=none; Device=%h/.roxabi/factory; Options=bind`). Adapter data mounts use `:z` (read-write), not `:ro`. → ADR-054
 
 ### SELinux Z-label policy
 
-All Quadlet bind-mount volumes carry `:z` for portability. On the current production host (Ubuntu 26.04 LTS, AppArmor-only), `:z` is a no-op at runtime. On SELinux hosts, `:z` relabels the bind-mounted directory so the container process can read it — it is load-bearing. Do not drop `:z` from bind-mounts. The JetStream volume (`lyra-jetstream.volume`) uses `Device=%h/.lyra/nats/jetstream` and retains `Volume=lyra-jetstream.volume:/var/lib/nats/jetstream:z` in `lyra-nats.container`. → ADR-068
+All Quadlet bind-mount volumes carry `:z` for portability. On the current production host (Ubuntu 26.04 LTS, AppArmor-only), `:z` is a no-op at runtime. On SELinux hosts, `:z` relabels the bind-mounted directory so the container process can read it — it is load-bearing. Do not drop `:z` from bind-mounts. The JetStream volume (`factory-jetstream.volume`) uses `Device=%h/.roxabi/factory/nats/jetstream` and retains `Volume=factory-jetstream.volume:/var/lib/nats/jetstream:z` in `factory-nats.container`. → ADR-068
 
 ### Historical: supervisord era (ADR-041)
 

--- a/docs/architecture/llm-streaming.md
+++ b/docs/architecture/llm-streaming.md
@@ -43,11 +43,11 @@ is superseded — see RenderEvent v2 below.
 The pipeline is a strict hexagonal layering enforced by import-linter:
 
 ```
-LlmEvent          (lyra.core.messaging.events)          — port, provider-agnostic
+LlmEvent          (factory.core.messaging.events)          — port, provider-agnostic
     ↓
-StreamProcessor   (lyra.core.stream_processor) — domain, config-driven, no network deps
+StreamProcessor   (factory.core.stream_processor) — domain, config-driven, no network deps
     ↓
-RenderEvent       (lyra.core.messaging.render_events) — adapter-facing, no platform types
+RenderEvent       (factory.core.messaging.render_events) — adapter-facing, no platform types
 ```
 
 `LlmEvent` owns per-token/per-chunk semantics from the LLM source. `StreamProcessor` handles
@@ -104,10 +104,10 @@ Every new event carries a `SCHEMA_VERSION_*` constant (ADR-049 discipline). `run
   `streaming`) triggers an automatic process respawn via the existing mismatch check.
 - Every `RenderEvent` subtype carries its own `SCHEMA_VERSION_*` constant. → See `messaging.md` (Schema versioning) and `ARCHITECTURE.md` (Schema versioning section) for the bump procedure and receiver policy.
 - **Error envelope on `ResultLlmEvent`** — `error_text` and `worker_error` are populated together by drivers/parsers on terminal failure events: `worker_error` carries the structured taxonomy (`domain`, `code`, `message`, `retryable`); `error_text` is an in-process presentation cache of `worker_error.message` consumed directly by adapter renderers. `error_text` is **not a wire-contract field** — only `worker_error` exists on NATS contracts. Neither field is a shim for the other (ADR-066 archive Status, issue #1029).
-- `lyra-clipool` is excluded from the RenderEvent co-deploy gate (it is an `LlmEvent`
+- `factory-clipool` is excluded from the RenderEvent co-deploy gate (it is an `LlmEvent`
   producer only, no `render_events` import). Slices that change `LlmEvent` shape include it.
-- Slices that introduce new `RenderEvent` types require co-deploying `lyra-hub` +
-  `lyra-telegram` + `lyra-discord`. Receivers drop unknown schema versions with a rate-limited
+- Slices that introduce new `RenderEvent` types require co-deploying `factory-hub` +
+  `factory-telegram` + `factory-discord`. Receivers drop unknown schema versions with a rate-limited
   ERROR log (one per envelope name per 60s); they do not raise.
 
 ## Open questions / known gaps

--- a/docs/architecture/messaging.md
+++ b/docs/architecture/messaging.md
@@ -233,8 +233,8 @@ Every hub↔adapter envelope (`InboundMessage`, `AudioPayload`, `OutboundMessage
 
 1. Bump the `SCHEMA_VERSION_<ENVELOPE>` constant in `src/factory/core/messaging/message.py` or `src/factory/core/messaging/render_events.py` by 1.
 2. Update the `schema_version` field default on the corresponding envelope to match.
-3. Coordinate a simultaneous deploy of `lyra_hub` + `lyra_telegram` + `lyra_discord`. Rolling deploys across a version bump produce loud ERROR logs on still-old receivers.
-4. Verify: `grep SCHEMA_VERSION_ src/lyra/core/*.py`.
+3. Coordinate a simultaneous deploy of `factory_hub` + `factory_telegram` + `factory_discord`. Rolling deploys across a version bump produce loud ERROR logs on still-old receivers.
+4. Verify: `grep SCHEMA_VERSION_ src/factory/core/*.py`.
 
 → See `ARCHITECTURE.md` (Schema versioning section) for full detail on the receiver drop-and-log policy and the unversioned outer envelope note.
 
@@ -265,7 +265,7 @@ NatsTransport           — call() / publish() / open_inbox()
       │
 WorkerPoolClient        — routing + circuit-breaker + heartbeat subscription
       │
-DomainClient            — thin wrapper in lyra.nats / lyra.llm
+DomainClient            — thin wrapper in factory.nats / factory.llm
                           (e.g. LlmClient, NatsSttClient, NatsTtsClient)
 ```
 
@@ -284,7 +284,7 @@ DomainClient            — thin wrapper in lyra.nats / lyra.llm
 - `stream_request(subject, payload)` — opens inbox CM, publishes, iterates chunks.
 - `start(nc)` / `stop()` — heartbeat subscription lifecycle.
 
-**Domain clients** (`lyra.nats.*_client`, `factory.llm.llm_client`) are thin wrappers that
+**Domain clients** (`factory.nats.*_client`, `factory.llm.llm_client`) are thin wrappers that
 compose a `WorkerPoolClient` with a codec. They must NOT add a second circuit-breaker.
 
 ### Typed boundary
@@ -325,9 +325,9 @@ providers. Domain clients compose via
 
 ## See also
 
-- Security & ACLs → `/home/mickael/projects/lyra/docs/architecture/security-routing.md` (covers ADR-051, 064, 046, 057, 069)
-- Cross-project contracts → `/home/mickael/projects/lyra/docs/architecture/contracts.md` (covers ADR-045, 049, 052)
-- LLM streaming pipeline → `/home/mickael/projects/lyra/docs/architecture/llm-streaming.md` (covers ADR-032, 070)
+- Security & ACLs → `/home/mickael/projects/roxabi-factory/docs/architecture/security-routing.md` (covers ADR-051, 064, 046, 057, 069)
+- Cross-project contracts → `/home/mickael/projects/roxabi-factory/docs/architecture/contracts.md` (covers ADR-045, 049, 052)
+- LLM streaming pipeline → `/home/mickael/projects/roxabi-factory/docs/architecture/llm-streaming.md` (covers ADR-032, 070)
 
 ## ADR archive
 

--- a/docs/architecture/security-routing.md
+++ b/docs/architecture/security-routing.md
@@ -80,7 +80,7 @@ At least one section must be present. A missing section logs a warning and disab
 - [x] `Authenticator` (identity resolver) in `src/factory/core/auth/authenticator.py`
 - [x] `GuardChain` (composable guard pipeline) in `src/factory/core/auth/guard.py`
 - [x] `TrustLevel` enum in `src/factory/core/auth/trust.py`
-- [x] Config-driven trust_map (TOML), parsed in src/lyra/core/auth.py
+- [x] Config-driven trust_map (TOML), parsed in src/factory/core/auth.py
 - [x] Integrated in TelegramAdapter + DiscordAdapter
 - [x] CLIAdapter (trust = OWNER by default)
 - [x] Rejection logging
@@ -91,7 +91,7 @@ At least one section must be present. A missing section logs a warning and disab
 
 `owner_users` in `[auth.telegram]` / `[auth.discord]` are automatically added to the admin set at startup — no need to duplicate IDs in `[admin].user_ids`. Extra non-owner admins can be added there explicitly.
 
-Module-level registry: lyra.core.admin — `is_admin(user_id)` / `set_admin_user_ids()` / `get_admin_user_ids()`. Plugins use `is_admin()` to gate admin-only commands without needing access to the config layer.
+Module-level registry: factory.core.admin — `is_admin(user_id)` / `set_admin_user_ids()` / `get_admin_user_ids()`. Plugins use `is_admin()` to gate admin-only commands without needing access to the config layer.
 
 ---
 
@@ -187,7 +187,7 @@ Every NATS identity must connect with `inbox_prefix="_INBOX.<identity-name>"`. T
 
 ### Security event audit
 
-`CliPool` subprocess spawns (carrying `skip_permissions`, tools allowlist, model, PID, pool_id, agent_name) are audited via a port/adapter split that respects import layer boundaries. `AuditSink` is a `Protocol` defined in `factory.core.cli` — the port. `JetStreamAuditSink` in `factory.infrastructure.audit` is the concrete adapter; it publishes `SecurityEvent` (a `roxabi-contracts` Pydantic model) to the `LYRA_AUDIT` JetStream stream (`lyra.audit.>`, FILE storage, 90-day retention, 1 GiB cap). When JetStream is unavailable, the sink falls back to the lyra.security logger without crashing the runtime. Both `hub_standalone.py` and the unified `lyra start` bootstrap (`wiring_helpers.py:309`) wire the sink. → ADR-057
+`CliPool` subprocess spawns (carrying `skip_permissions`, tools allowlist, model, PID, pool_id, agent_name) are audited via a port/adapter split that respects import layer boundaries. `AuditSink` is a `Protocol` defined in `factory.core.cli` — the port. `JetStreamAuditSink` in `factory.infrastructure.audit` is the concrete adapter; it publishes `SecurityEvent` (a `roxabi-contracts` Pydantic model) to the `LYRA_AUDIT` JetStream stream (`lyra.audit.>`, FILE storage, 90-day retention, 1 GiB cap). When JetStream is unavailable, the sink falls back to the lyra.security logger without crashing the runtime. Both `hub_standalone.py` and the unified `factory start` bootstrap (`wiring_helpers.py:309`) wire the sink. → ADR-057
 
 ### ACL request/reply derivation
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -37,7 +37,7 @@ five-level taxonomy in `ARCHITECTURE.md` is the long-term target. → ADR-008
 |-------|------|-----------|
 | L0 Working | `dict` in memory, scoped by `pool_id` | Pool-scoped |
 | L1 Session | Store keyed by `(user_id, session_id)` | User + session scoped |
-| L2 Episodic | `~/.lyra/memory/episodic/{user_id}/YYYY-MM-DD/` — user_id in path | User-scoped path |
+| L2 Episodic | `~/.roxabi/factory/memory/episodic/{user_id}/YYYY-MM-DD/` — user_id in path | User-scoped path |
 | L3 Semantic | SQLite, `WHERE user_id = ?` mandatory on all queries | User-scoped query |
 | L4 Procedural | Global (skills = agent capabilities, not user data) | Global |
 
@@ -129,11 +129,11 @@ cache; a closed store must not be reused. → ADR-024
 ### DB-first agent config + hot-reload
 
 The SQLite `agents` table is the single runtime source of truth. TOMLs under `src/factory/agents/`
-are seed-only files, consumed exclusively by `lyra agent init` and `lyra agent validate`. At
+are seed-only files, consumed exclusively by `factory agent init` and `factory agent validate`. At
 runtime, `AgentBase._maybe_reload()` compares `AgentRow.updated_at` (ISO-8601 string, O(1)
 dict lookup from the `AgentStore` cache) against a locally cached timestamp; on change it calls
 `agent_row_to_config()`. No TOML is read post-startup. No background polling timer — reload is
-lazy, per-message. `lyra agent edit` changes are visible on the next inbound message with no
+lazy, per-message. `factory agent edit` changes are visible on the next inbound message with no
 daemon restart. Persona files (`.persona.toml`) remain file-based; persona hot-reload requires
 a DB `upsert()` to trigger. → ADR-029
 
@@ -151,29 +151,29 @@ The `wire_discord_adapters` function returns `(adapters, dispatchers, thread_sto
 
 Binary payloads (Telegram/Discord attachments, STT/TTS audio) are stored behind a `BlobStore`
 Protocol with three methods: `put`, `get`, `exists`. The v1 backend is `FsBlobStore`: a
-SHA-256-addressed flat-FS tree (`/data/lyra/blobs/<sha[:2]>/<sha>`) plus a SQLite index at
-`/data/lyra/blobs/index.sqlite` (two tables: `blobs` keyed by `content_hash`; `blob_refs` for
-per-ingestion provenance). The backend runs on `lyra-hub` role (M₁) and is exposed via a
-dedicated Quadlet container `lyra-blobstore.container` (FastAPI on TCP `:8449`, image
-`ghcr.io/roxabi/lyra` + `lyra blobstore serve` subcommand) — V8 issue #1330. Host paths:
-`~/.lyra/blobs/` (data, bind-mount into container) and `~/.roxabi/lyra/env/blobstore.env`
+SHA-256-addressed flat-FS tree (`/data/factory/blobs/<sha[:2]>/<sha>`) plus a SQLite index at
+`/data/factory/blobs/index.sqlite` (two tables: `blobs` keyed by `content_hash`; `blob_refs` for
+per-ingestion provenance). The backend runs on `factory-hub` role (M₁) and is exposed via a
+dedicated Quadlet container `factory-blobstore.container` (FastAPI on TCP `:8449`, image
+`ghcr.io/roxabi/factory` + `lyra blobstore serve` subcommand) — V8 issue #1330. Host paths:
+`~/.roxabi/factory/blobs/` (data, bind-mount into container) and `~/.roxabi/factory/env/blobstore.env`
 (Quadlet env). Direct-FS access is reserved for co-located writers only (telegram_normalize,
 hub middleware); all other consumers (e.g., M₂ image-worker) use `HttpBlobStore` — the store
-host is invisible to them. Auth: shared bearer token via Podman secret `lyra_blobstore_token`
+host is invisible to them. Auth: shared bearer token via Podman secret `factory_blobstore_token`
 (`type=mount`) in Phase 1 → per-identity JWT or `auth.db` lookup + `blob_grants` table in
 Phase 2 (see ADR-067 §Auth plane). Dedup: `put()` hashes first; if `blobs.content_hash`
 exists, only a new `blob_refs` row is appended. Write durability order: write file → `fsync`
 → INSERT. Backup (Phase 1): Restic → Cloudflare R2 daily, `index.sqlite` snapshotted via
 SQLite `.backup` API before FS tarball (atomicity invariant). `audio_b64` / `audio_bytes` in
 `roxabi-contracts` are deprecated; removal is a coordinated atomic migration across contracts
-→ voiceCLI workers → lyra adapters. Adapters download eagerly at ingress (Telegram URL valid
+→ voiceCLI workers → factory adapters. Adapters download eagerly at ingress (Telegram URL valid
 ≥1h; Discord CDN URLs expire ~24h). Raw bytes never traverse NATS. MinIO swap triggers: disk
 >70% on blobstore volume, HA requirement, or ML S3 demand. → ADR-067 (amended), ADR-068
 
 #### HTTP service (V8 — #1330)
 
-`lyra-blobstore` is a dedicated Quadlet container (`lyra-blobstore.service`) that exposes
-`FsBlobStore` over HTTP on port `8449`. It runs on the `lyra-hub` role (M₁, `roxabituwer`)
+`factory-blobstore` is a dedicated Quadlet container (`factory-blobstore.service`) that exposes
+`FsBlobStore` over HTTP on port `8449`. It runs on the `factory-hub` role (M₁, `roxabituwer`)
 only — same host as the data volume.
 
 Six endpoints (N1–N6 per spec):
@@ -190,12 +190,12 @@ Six endpoints (N1–N6 per spec):
 async. Zero `lyra.*` imports; importable from voiceCLI, imageCLI, and any other cross-repo
 consumer without pulling in the Lyra runtime.
 
-**Auth (Phase 1):** shared bearer token via Podman secret `lyra_blobstore_token`
-(`type=mount`, `/run/secrets/lyra_blobstore_token`, uid=1500, gid=1500, mode=0400).
+**Auth (Phase 1):** shared bearer token via Podman secret `factory_blobstore_token`
+(`type=mount`, `/run/secrets/factory_blobstore_token`, uid=1500, gid=1500, mode=0400).
 Unauthorized requests return `401` with an audit row (`result: "unauthorized"`).
 
 **Wiring:** same-host clients (Telegram, Discord, clipool adapters) use Quadlet DNS
-`http://lyra-blobstore:8449`. Cross-host clients use Tailnet MagicDNS (see `## Cross-host
+`http://factory-blobstore:8449`. Cross-host clients use Tailnet MagicDNS (see `## Cross-host
 access pattern` below). The Protocol call-site is identical in both cases.
 
 #### Cross-host access pattern
@@ -211,7 +211,7 @@ Transport encryption is provided by Tailnet (WireGuard) — V8 is HTTP at the ap
 layer. A future phase may add mTLS at the app layer if the Tailnet boundary is broadened
 (tracked as TBD in ADR-067 §Auth plane Phase 2).
 
-**Topology rule:** only the `lyra-blobstore` process uses `FsBlobStore` directly. Every
+**Topology rule:** only the `factory-blobstore` process uses `FsBlobStore` directly. Every
 other process — hub, adapters, M₂ workers — constructs `HttpBlobStore`. Direct-FS access
 is a violation of this boundary from V8 onwards.
 
@@ -254,7 +254,7 @@ guard pattern is gone; the bus is either injected or absent. → ADR-022 (amende
 - **DB-first writes:** all `AgentStore` writes commit to SQLite before updating the in-memory
   cache. Cache is never ahead of DB on the success path.
 - **DB is runtime authority:** `agents` table is the single runtime source of truth for agent
-  config. TOMLs are read only during `lyra agent init` / `lyra agent validate`.
+  config. TOMLs are read only during `factory agent init` / `factory agent validate`.
 - **Blob content-addressed:** every binary payload is stored by SHA-256 hash; identical content
   written N times occupies one file.
 - **Blob write order:** file → `fsync` → INSERT into `blob_refs` / `blobs`. Reversed order
@@ -277,9 +277,9 @@ guard pattern is gone; the bus is either injected or absent. → ADR-022 (amende
   AnthropicAgent does). The gap pre-dates ADR-029 and surfaces on every
   `_rebuild_command_router()` call. Fix: `SimpleAgent._register_session_commands()` override.
 - Persona hot-reload (changing `.persona.toml` without a DB `upsert()`) no longer fires
-  automatically post ADR-029. Operators must run `lyra agent edit` or `lyra agent init --force`.
+  automatically post ADR-029. Operators must run `factory agent edit` or `factory agent init --force`.
 - The TOML fallback path in `multibot.py` (degraded mode for users who have not run
-  `lyra agent init`) emits a startup warning but remains in the codebase. It is a known
+  `factory agent init`) emits a startup warning but remains in the codebase. It is a known
   transitional artifact.
 - `_wire_adapters` return tuple is now 5 elements; revisit if it reaches 6+.
 - BlobStore backup atomicity: naive `tar` of FS + DB while live produces an inconsistent

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -328,7 +328,7 @@ Every hub↔adapter envelope carries `schema_version: int`.
 1. Bump `SCHEMA_VERSION_<ENVELOPE>` constant
 2. Update `schema_version` field default on envelope
 3. Coordinate simultaneous deploy of hub + adapters
-4. Verify: `grep SCHEMA_VERSION_ src/lyra/core/messaging/*.py`
+4. Verify: `grep SCHEMA_VERSION_ src/factory/core/messaging/*.py`
 
 ---
 

--- a/docs/architecture/voice-to-voice-analysis.md
+++ b/docs/architecture/voice-to-voice-analysis.md
@@ -472,8 +472,8 @@ The key constraint: **Omni (~8 GB) and TTS+STT (~3 GB) cannot coexist on the RTX
 │  roxabituwer (prod, RTX 3080 12 GB, 24/7)           │
 │                                                     │
 │  lyra_omni     (~8 GB)  ← Qwen2.5-Omni-7B INT4     │
-│  lyra_telegram           ← adapter (no VRAM)        │
-│  lyra_discord            ← adapter (no VRAM)        │
+│  factory_telegram           ← adapter (no VRAM)        │
+│  factory_discord            ← adapter (no VRAM)        │
 │                                                     │
 │  Voice mode:  Omni handles voice-to-voice natively   │
 │  HQ TTS/STT:  calls ROXABITOWER API                  │
@@ -498,8 +498,8 @@ The key constraint: **Omni (~8 GB) and TTS+STT (~3 GB) cannot coexist on the RTX
 │  lyra_omni:    STOPPED (VRAM freed)                  │
 │  voicecli_tts  (~2.6 GB)  ← loaded locally           │
 │  voicecli_stt  (~0.5 GB)  ← loaded locally           │
-│  lyra_telegram              ← adapter (no VRAM)      │
-│  lyra_discord               ← adapter (no VRAM)      │
+│  factory_telegram              ← adapter (no VRAM)      │
+│  factory_discord               ← adapter (no VRAM)      │
 │                                                     │
 │  Pipeline mode:                                      │
 │    Audio → Whisper (STT) → Claude API → Qwen3-TTS    │
@@ -691,8 +691,8 @@ New: HTTP API wrapper process (or extend existing daemons to also listen on TCP)
 **roxabituwer** (new — all programs present, mode manager controls which are running):
 ```ini
 [program:lyra_omni]
-command=%(ENV_HOME)s/projects/lyra/scripts/run_omni.sh
-directory=%(ENV_HOME)s/projects/lyra
+command=%(ENV_HOME)s/projects/roxabi-factory/scripts/run_omni.sh
+directory=%(ENV_HOME)s/projects/roxabi-factory
 autostart=false           # mode manager decides
 autorestart=unexpected
 # Serves Qwen2.5-Omni-7B INT4 via vLLM-Omni on port 8901

--- a/docs/architecture/workers-tooling.md
+++ b/docs/architecture/workers-tooling.md
@@ -19,11 +19,11 @@ Runtime workers (CliPool subprocess pool, satellite adapters), tool integration 
 
 #### CliPool cwd resolution
 
-`_LYRA_ROOT` is resolved via a `pyproject.toml` anchor walk (`_find_project_root()`), not a fixed `.parent.parent...` chain. The anchor pattern is robust to file moves and editable installs; it fails loudly at import time if no `pyproject.toml` is found. The fixed parent-chain pattern is prohibited in any path-resolution code that must survive layout changes. `SimpleAgent.__init__` annotates `config` as `Agent` (not `AgentBase.__class__`). → ADR-004
+`_FACTORY_ROOT` is resolved via a `pyproject.toml` anchor walk (`_find_project_root()`), not a fixed `.parent.parent...` chain. The anchor pattern is robust to file moves and editable installs; it fails loudly at import time if no `pyproject.toml` is found. The fixed parent-chain pattern is prohibited in any path-resolution code that must survive layout changes. `SimpleAgent.__init__` annotates `config` as `Agent` (not `AgentBase.__class__`). → ADR-004
 
 #### CliPool Claude OAuth token
 
-`lyra-clipool.container` injects `CLAUDE_CODE_OAUTH_TOKEN` via `Secret=lyra-claude-oauth,type=env,target=CLAUDE_CODE_OAUTH_TOKEN`. The `claude` CLI has no `--token-file` flag; env is the only delivery path. `ANTHROPIC_API_KEY` is explicitly excluded from `_SAFE_ENV_KEYS` (enforced by unit test) to prevent silent rerouting to Console pay-per-token billing. Token rotation is manual, annual. Re-run the Podman #28075 verification recipe after any Podman version bump on M₁. → ADR-071
+`factory-clipool.container` injects `CLAUDE_CODE_OAUTH_TOKEN` via `Secret=factory-claude-oauth,type=env,target=CLAUDE_CODE_OAUTH_TOKEN`. The `claude` CLI has no `--token-file` flag; env is the only delivery path. `ANTHROPIC_API_KEY` is explicitly excluded from `_SAFE_ENV_KEYS` (enforced by unit test) to prevent silent rerouting to Console pay-per-token billing. Token rotation is manual, annual. Re-run the Podman #28075 verification recipe after any Podman version bump on M₁. → ADR-071
 
 #### Wildcard binding & per-scope pools
 
@@ -31,7 +31,7 @@ Phase 1 used a shared `telegram:main:*` pool; all users shared one lock and one 
 
 #### Multi-bot startup
 
-Each active agent gets its own `ProviderRegistry` (with a SmartRoutingDecorator configured from that agent's `smart_routing` config) and its own `MessageManager` (keyed to that agent's `i18n_language`). `CliPool` is a single shared instance — it is a process-management resource, not a per-agent config resource. Construction lives in `src/lyra/bootstrap/factory/agent_factory.py::_build_per_agent_registry()`. A startup warning fires when `len(agent_names) > 1` and agents have differing routing configs or languages. → ADR-019
+Each active agent gets its own `ProviderRegistry` (with a SmartRoutingDecorator configured from that agent's `smart_routing` config) and its own `MessageManager` (keyed to that agent's `i18n_language`). `CliPool` is a single shared instance — it is a process-management resource, not a per-agent config resource. Construction lives in `src/factory/bootstrap/factory/agent_factory.py::_build_per_agent_registry()`. A startup warning fires when `len(agent_names) > 1` and agents have differing routing configs or languages. → ADR-019
 
 #### Pool callback wiring
 
@@ -51,7 +51,7 @@ External CLIs (voicecli, imagecli, gws, scraper) follow a 3-layer Install–Wrap
 
 #### Tool-provider protocol
 
-`ScrapeProvider` and `VaultProvider` are async Protocols defined in `factory.integrations.base`. Concrete implementations (`WebIntelScraper`, `VaultCli`) live in `factory.integrations.web_intel` and `factory.integrations.vault_cli`. Both are bundled into a `SessionTools` dataclass injected into every `SessionCommandEntry` as a required (non-optional) parameter. `session_helpers.py` (which previously hardcoded subprocess invocations inside `lyra.core`) is deleted. The `commands/search` plugin receives `VaultProvider` via a module-level injectable set at agent startup, a separate injection path from `SessionCommandEntry`. → ADR-030
+`ScrapeProvider` and `VaultProvider` are async Protocols defined in `factory.integrations.base`. Concrete implementations (`WebIntelScraper`, `VaultCli`) live in `factory.integrations.web_intel` and `factory.integrations.vault_cli`. Both are bundled into a `SessionTools` dataclass injected into every `SessionCommandEntry` as a required (non-optional) parameter. `session_helpers.py` (which previously hardcoded subprocess invocations inside `factory.core`) is deleted. The `commands/search` plugin receives `VaultProvider` via a module-level injectable set at agent startup, a separate injection path from `SessionCommandEntry`. → ADR-030
 
 #### Model selection (ComplexityEstimator)
 
@@ -99,7 +99,7 @@ Slash commands that need conversation history are implemented as `BaseProcessor`
 
 #### Importlinter port-import fix
 
-The `shared-modules-independence` contract enforces peer isolation between 8 floating modules (`factory.obs`, lyra.stt, lyra.tts, `factory.errors`, `factory.config`, `factory.integrations`, `factory.monitoring`, `factory.agent_cmd`). As of 2026-05-08, 4 `ignore_imports` suppressions remain. The target is 2: fix `factory.core.agent.agent` to import `STTProtocol`/`TtsProtocol` from `lyra.core.ports.*` (not from lyra.stt/lyra.tts), and introduce SessionToolsProtocol in lyra.core.ports.integrations so `processor_registry.py` no longer imports the concrete `SessionTools` from `factory.integrations.base`. The two remaining suppressions (`core/ports/stt.py → lyra.stt:TranscriptionResult` and `core/ports/tts.py → lyra.tts:SynthesisResult`) are TYPE_CHECKING-only and track a separate result-type migration. → ADR-061
+The `shared-modules-independence` contract enforces peer isolation between 8 floating modules (`factory.obs`, factory.stt, factory.tts, `factory.errors`, `factory.config`, `factory.integrations`, `factory.monitoring`, `factory.agent_cmd`). As of 2026-05-08, 4 `ignore_imports` suppressions remain. The target is 2: fix `factory.core.agent.agent` to import `STTProtocol`/`TtsProtocol` from `factory.core.ports.*` (not from factory.stt/factory.tts), and introduce SessionToolsProtocol in factory.core.ports.integrations so `processor_registry.py` no longer imports the concrete `SessionTools` from `factory.integrations.base`. The two remaining suppressions (`core/ports/stt.py → factory.stt:TranscriptionResult` and `core/ports/tts.py → factory.tts:SynthesisResult`) are TYPE_CHECKING-only and track a separate result-type migration. → ADR-061
 
 #### Health monitoring layer boundaries
 
@@ -113,7 +113,7 @@ When `CliPool.send()` receives a `ModelConfig` that differs from the one used to
 
 ## Key invariants
 
-- `_find_project_root()` anchor walk is the only permitted pattern for locating `_LYRA_ROOT`; fixed `.parent` chains are prohibited.
+- `_find_project_root()` anchor walk is the only permitted pattern for locating `_FACTORY_ROOT`; fixed `.parent` chains are prohibited.
 - `ANTHROPIC_API_KEY` must never appear in `_SAFE_ENV_KEYS`; the unit test `test_anthropic_api_key_not_forwarded` is load-bearing.
 - `configure_pool(pool)` must be called before `_resolve_context` on every message; lazy callback wiring inside `process()` is insufficient.
 - Each agent gets its own `ProviderRegistry` and `MessageManager`; `CliPool` is the only shared process resource.
@@ -128,7 +128,7 @@ When `CliPool.send()` receives a `ModelConfig` that differs from the one used to
 
 ## Open questions / known gaps
 
-- ADR-061: 4 `ignore_imports` remain — target is 2; lyra.core.ports.integrations (SessionToolsProtocol) not yet created; import sites in `agent.py` and `processor_registry.py` not yet updated.
+- ADR-061: 4 `ignore_imports` remain — target is 2; factory.core.ports.integrations (SessionToolsProtocol) not yet created; import sites in `agent.py` and `processor_registry.py` not yet updated.
 - ADR-007: non-streaming path (`cli_pool.py`) still silently ignores model-config mismatch; migration gated on model-selector SLM.
 - ADR-005 / #112: CliPool subprocess isolation (one subprocess per scope) and memory-namespace isolation per scope are not yet implemented; only Hub-layer pool isolation is complete.
 - ADR-038: audit of `cli_protocol.py` for silent-failure paths not confirmed complete; some empty-stdout failures may not yet reach `cb.record_failure()`.

--- a/docs/bot-management.md
+++ b/docs/bot-management.md
@@ -1,6 +1,6 @@
 # Bot Management
 
-Bots are stored in **`~/.lyra/config.db`** (SQLite, table `bots`). TOML files are seed sources only — run `lyra bot init` to import them into the DB before use.
+Bots are stored in **`~/.roxabi/factory/config.db`** (SQLite, table `bots`). TOML files are seed sources only — run `factory bot init` to import them into the DB before use.
 
 ## Database Tables
 
@@ -11,67 +11,67 @@ Bots are stored in **`~/.lyra/config.db`** (SQLite, table `bots`). TOML files ar
 
 ## Bot Configuration
 
-Bots are configured in `~/.lyra/config.toml` (`[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`). The hub reads bot metadata from `BotStore` (table `bots`), not from `config.toml` directly.
+Bots are configured in `~/.roxabi/factory/config.toml` (`[[telegram.bots]]`, `[[discord.bots]]`, `[[auth.telegram_bots]]`, `[[auth.discord_bots]]`). The hub reads bot metadata from `BotStore` (table `bots`), not from `config.toml` directly.
 
 ```bash
 # Seeding (required before first hub boot since #1416)
-lyra bot init                     # import config.toml → BotStore (skip existing)
-lyra bot init --force             # overwrite existing rows
+factory bot init                     # import config.toml → BotStore (skip existing)
+factory bot init --force             # overwrite existing rows
 
 # Secret management
-lyra bot secret install <platform> <bot_id>   # create Podman secret for bot token
-lyra bot secret install <platform> <bot_id>-webhook
+factory bot secret install <platform> <bot_id>   # create Podman secret for bot token
+factory bot secret install <platform> <bot_id>-webhook
 ```
 
-**Rule:** `lyra bot init` is idempotent. Run it after every `config.toml` edit that changes bot definitions.
+**Rule:** `factory bot init` is idempotent. Run it after every `config.toml` edit that changes bot definitions.
 
 ## Deprecation Timeline
 
-As of this release, the four TOML bot sections are **deprecated and seed-only**. The runtime bot roster is read from BotStore (`~/.lyra/config.db`), not from `config.toml`.
+As of this release, the four TOML bot sections are **deprecated and seed-only**. The runtime bot roster is read from BotStore (`~/.roxabi/factory/config.db`), not from `config.toml`.
 
 | Deprecated section | Replacement |
 |---|---|
-| `[[telegram.bots]]` | BotStore via `lyra bot init` |
-| `[[discord.bots]]` | BotStore via `lyra bot init` |
-| `[[auth.telegram_bots]]` | BotStore via `lyra bot init` |
-| `[[auth.discord_bots]]` | BotStore via `lyra bot init` |
+| `[[telegram.bots]]` | BotStore via `factory bot init` |
+| `[[discord.bots]]` | BotStore via `factory bot init` |
+| `[[auth.telegram_bots]]` | BotStore via `factory bot init` |
+| `[[auth.discord_bots]]` | BotStore via `factory bot init` |
 
 At runtime, presence of any of these sections logs a one-time `DeprecationWarning`.
 
 **Migration path:**
 
-1. Run `lyra bot init` to seed BotStore from your existing TOML sections.
-2. Verify with `lyra agent telegram list` / `lyra agent discord list`.
+1. Run `factory bot init` to seed BotStore from your existing TOML sections.
+2. Verify with `factory agent telegram list` / `factory agent discord list`.
 3. Remove the four deprecated sections from `config.toml`.
 
-**Removal schedule:** The four sections will be removed in the `next major` release (`v1.0.0`; current is `0.2.1`). Until then they remain parsable and are consumed only by `lyra bot init`.
+**Removal schedule:** The four sections will be removed in the `next major` release (`v1.0.0`; current is `0.2.1`). Until then they remain parsable and are consumed only by `factory bot init`.
 
 ## CLI Commands (per platform)
 
-Bot management commands are grouped under `lyra agent <platform>` (`telegram` or `discord`). Each platform exposes the same 9 verbs.
+Bot management commands are grouped under `factory agent <platform>` (`telegram` or `discord`). Each platform exposes the same 9 verbs.
 
 ```bash
 # Listing & inspection
-lyra agent telegram list                     # all Telegram bots in DB
-lyra agent discord list                      # all Discord bots in DB
-lyra agent telegram show <bot_id>            # full bot record
-lyra agent discord show <bot_id>             # full bot record
+factory agent telegram list                     # all Telegram bots in DB
+factory agent discord list                      # all Discord bots in DB
+factory agent telegram show <bot_id>            # full bot record
+factory agent discord show <bot_id>             # full bot record
 
 # Creation & editing
-lyra agent telegram add <bot_id> --agent foo --webhook-enabled
-lyra agent telegram edit <bot_id>            # interactive field editor
-lyra agent telegram patch <bot_id> --webhook-enabled true
-lyra agent telegram patch <bot_id> --agent foo
-lyra agent telegram patch <bot_id> --owner-users "123,456"
-lyra agent telegram remove <bot_id>          # delete + cascade bot_agent_map cleanup
-lyra agent telegram remove <bot_id> --yes    # skip confirmation
+factory agent telegram add <bot_id> --agent foo --webhook-enabled
+factory agent telegram edit <bot_id>            # interactive field editor
+factory agent telegram patch <bot_id> --webhook-enabled true
+factory agent telegram patch <bot_id> --agent foo
+factory agent telegram patch <bot_id> --owner-users "123,456"
+factory agent telegram remove <bot_id>          # delete + cascade bot_agent_map cleanup
+factory agent telegram remove <bot_id> --yes    # skip confirmation
 
 # Agent assignment
-lyra agent telegram assign <bot_id> --agent foo
-lyra agent telegram unassign <bot_id>        # revert to empty agent
+factory agent telegram assign <bot_id> --agent foo
+factory agent telegram unassign <bot_id>        # revert to empty agent
 
 # Validation
-lyra agent telegram validate <bot_id>        # check agent exists, owners non-empty, secret present
+factory agent telegram validate <bot_id>        # check agent exists, owners non-empty, secret present
 ```
 
 **Valid trust levels:** `owner`, `trusted`, `public`, `blocked` (default: `blocked`).
@@ -102,7 +102,7 @@ lyra agent telegram validate <bot_id>        # check agent exists, owners non-em
 
 ```bash
 # 1. Seed BotStore from config.toml (idempotent — skips existing rows)
-lyra bot init
+factory bot init
 
 # 2. Render adapter templates + daemon-reload
 make quadlet-install
@@ -111,22 +111,22 @@ make quadlet-install
 ### Add a new bot
 
 ```bash
-lyra agent discord add newbot --agent foo
-lyra bot secret install discord newbot
+factory agent discord add newbot --agent foo
+factory bot secret install discord newbot
 make quadlet-install
 ```
 
 ### Update a bot
 
 ```bash
-lyra agent telegram patch main --webhook-enabled true
+factory agent telegram patch main --webhook-enabled true
 make quadlet-install   # restart adapter so Quadlet picks up Secret= changes
 ```
 
 ### Remove a bot
 
 ```bash
-lyra agent discord remove oldbot
+factory agent discord remove oldbot
 make quadlet-install   # re-renders Quadlet without the removed bot's Secret= line
 ```
 
@@ -135,7 +135,7 @@ make quadlet-install   # re-renders Quadlet without the removed bot's Secret= li
 Existing deployments that already have bots in `config.toml`:
 
 ```bash
-lyra bot init
+factory bot init
 ```
 
 This is a **no-op** if rows already exist (idempotent skip). No data loss. Run once per host after upgrading to the BotStore-based flow (#1416).
@@ -144,8 +144,8 @@ This is a **no-op** if rows already exist (idempotent skip). No data loss. Run o
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `lyra agent <platform> show <bot_id>` returns "not found" | Bot not seeded | `lyra bot init` |
-| `lyra agent <platform> validate <bot_id>` fails on secret | Podman secret missing | `lyra bot secret install <platform> <bot_id>` |
-| `lyra agent <platform> patch` fails with "no fields provided" | All flag values are `None` | Provide at least one `--field value` |
+| `factory agent <platform> show <bot_id>` returns "not found" | Bot not seeded | `factory bot init` |
+| `factory agent <platform> validate <bot_id>` fails on secret | Podman secret missing | `factory bot secret install <platform> <bot_id>` |
+| `factory agent <platform> patch` fails with "no fields provided" | All flag values are `None` | Provide at least one `--field value` |
 | Adapter fails to start after adding bot | Quadlet not re-rendered | `make quadlet-install` (re-renders templates + restarts adapter) |
-| `lyra bot init` reports 0 seeded, N skipped | Rows already exist | Use `--force` to overwrite, or this is expected |
+| `factory bot init` reports 0 seeded, N skipped | Rows already exist | Use `--force` to overwrite, or this is expected |

--- a/docs/code-quality-exceptions.md
+++ b/docs/code-quality-exceptions.md
@@ -10,8 +10,8 @@ Summary of all inline and configured exceptions to quality rules.
 
 | Path | Lines | Issue | Reason |
 |------|-------|-------|--------|
-| `src/lyra/core/pool/pool.py` | 326 | #858 | Backward-compat param overrides |
-| `src/lyra/bootstrap/factory/wiring_helpers.py` | 400 | ADR-059/V10 | Bootstrap helper aggregator |
+| `src/factory/core/pool/pool.py` | 326 | #858 | Backward-compat param overrides |
+| `src/factory/bootstrap/factory/wiring_helpers.py` | 400 | ADR-059/V10 | Bootstrap helper aggregator |
 
 ### Folder Size (>12 files)
 
@@ -19,8 +19,8 @@ Summary of all inline and configured exceptions to quality rules.
 
 | Path | Files | Issue | Reason |
 |------|-------|-------|--------|
-| `src/lyra/core` | 13 | #858 | Config dataclass extraction |
-| `src/lyra/infrastructure/stores` | 14 | #935 | ADR-048 store migration |
+| `src/factory/core` | 13 | #858 | Config dataclass extraction |
+| `src/factory/infrastructure/stores` | 14 | #935 | ADR-048 store migration |
 
 ---
 

--- a/docs/data-dirs.md
+++ b/docs/data-dirs.md
@@ -4,12 +4,12 @@ Lyra stores runtime data in two root locations:
 
 | Host path | Purpose | Container path |
 |---|---|---|
-| `~/.lyra/` | Application vault (databases, secrets, config, env) | `/home/lyra/.lyra` (via `lyra-data.volume`) |
-| `/data/lyra/blobs/` | BlobStore shard tree + SQLite index | `/home/lyra/.lyra/blobstore` (via bind-mount in `lyra-blobstore.container`) |
+| `~/.roxabi/factory/` | Application vault (databases, secrets, config, env) | `/home/factory/.roxabi/factory` (via `factory-data.volume`) |
+| `/data/factory/blobs/` | BlobStore shard tree + SQLite index | `/home/factory/.roxabi/factory/blobstore` (via bind-mount in `factory-blobstore.container`) |
 
 ---
 
-## `~/.lyra/` — Application vault
+## `~/.roxabi/factory/` — Application vault
 
 | Subdirectory / File | Purpose | Syncthing |
 |---|---|---|
@@ -23,13 +23,13 @@ Lyra stores runtime data in two root locations:
 | `nkeys/` | NATS nkey seeds and `auth.conf` | **Synced** |
 | `env/` | Quadlet env files (`hub.env`, `blobstore.env`) | **Synced** |
 | `nats/jetstream/` | JetStream persistent storage | **Excluded** (host-local, large WAL files) |
-| `blobstore/` | **Symlink / container view** — points to `/data/lyra/blobs/` | **Excluded** (canonical path is `/data/lyra/blobs/`) |
+| `blobstore/` | **Symlink / container view** — points to `/data/factory/blobs/` | **Excluded** (canonical path is `/data/factory/blobs/`) |
 
-**Note:** `~/.lyra/blobstore/` is a bind-mount view from the container perspective. The canonical host directory is `/data/lyra/blobs/`. Backups and Syncthing exclusions must reference the canonical path.
+**Note:** `~/.roxabi/factory/blobstore/` is a bind-mount view from the container perspective. The canonical host directory is `/data/factory/blobs/`. Backups and Syncthing exclusions must reference the canonical path.
 
 ---
 
-## `/data/lyra/blobs/` — BlobStore canonical host path
+## `/data/factory/blobs/` — BlobStore canonical host path
 
 | Subdirectory / File | Purpose |
 |---|---|
@@ -44,21 +44,21 @@ This directory is **excluded from Syncthing** across all hosts. It is large, app
 
 ## `~/.roxabi-vault/` — Vault CLI database
 
-Mounted into `lyra-hub` so the `vault put` subprocess can write to it. Not part of Syncthing.
+Mounted into `factory-hub` so the `vault put` subprocess can write to it. Not part of Syncthing.
 
 ---
 
 ## Syncthing exclusions
 
-Syncthing syncs `~/.lyra/` across M₁, M₂, and laptop. The following paths are excluded:
+Syncthing syncs `~/.roxabi/factory/` across M₁, M₂, and laptop. The following paths are excluded:
 
 | Path | Reason |
 |---|---|
-| `~/.lyra/nats/jetstream/` | Host-local JetStream WAL; large, not portable |
-| `~/.lyra/blobstore/` | Redirects to `/data/lyra/blobs/`; large binary data |
-| `/data/lyra/blobs/` | Canonical BlobStore host path; excluded from Syncthing |
+| `~/.roxabi/factory/nats/jetstream/` | Host-local JetStream WAL; large, not portable |
+| `~/.roxabi/factory/blobstore/` | Redirects to `/data/factory/blobs/`; large binary data |
+| `/data/factory/blobs/` | Canonical BlobStore host path; excluded from Syncthing |
 
-Exclusion rule (add to `.stignore` in `~/.lyra/`):
+Exclusion rule (add to `.stignore` in `~/.roxabi/factory/`):
 
 ```
 # Syncthing exclusions for Lyra
@@ -66,4 +66,4 @@ nats/jetstream
 blobstore
 ```
 
-The `/data/lyra/blobs/` path is outside `~/.lyra/` so it does not need an `.stignore` rule — it is excluded by simply not adding it to Syncthing at all.
+The `/data/factory/blobs/` path is outside `~/.roxabi/factory/` so it does not need an `.stignore` rule — it is excluded by simply not adding it to Syncthing at all.

--- a/docs/ops/bigbang-nats-consolidation.md
+++ b/docs/ops/bigbang-nats-consolidation.md
@@ -134,7 +134,7 @@ T+0:08  Start voicecli workers
           systemctl --user start voicecli-tts.service voicecli-stt.service
 
 T+0:09  Verify
-          systemctl --user status 'lyra-*.service' 'voicecli-*.service' --no-pager | grep -E 'Active|Main PID'
+          systemctl --user status 'factory-*.service' 'voicecli-*.service' --no-pager | grep -E 'Active|Main PID'
           journalctl --user --since "2 min ago" | grep -iE 'nats|connect|auth|error' | grep -v debug
 
 T+0:10  Smoke test
@@ -156,7 +156,7 @@ sudo cp /etc/nats/nkeys/auth.conf /root/auth.conf.bak-$(date +%Y%m%d)
 # Verify final state
 podman network ls       # roxabi.network only (no lyra.network, no voicecli.network)
 podman secret ls        # factory-nats-auth, lyra-nkey-*, voicecli-nats-{tts,stt}
-systemctl --user list-units 'lyra-*' 'voicecli-*'
+systemctl --user list-units 'factory-*' 'voicecli-*'
 sudo systemctl status nats.service    # inactive (disabled)
 ```
 
@@ -166,7 +166,7 @@ Bots are already stopped at this point — rollback is purely recovery; no user-
 
 ```bash
 # 1. Stop any partially-started Quadlet units
-systemctl --user stop 'lyra-*' 'voicecli-*'
+systemctl --user stop 'factory-*' 'voicecli-*'
 
 # 2. Restore old nats.container from git
 git show HEAD~1:deploy/quadlet/nats.container > /tmp/nats.container

--- a/docs/ops/bigbang-nats-consolidation.md
+++ b/docs/ops/bigbang-nats-consolidation.md
@@ -8,7 +8,7 @@
                      M₁ (roxabituwer)
                      ─────────────────
                    ┌─────────────────────┐
-                   │  lyra-nats Quadlet  │
+                   │  factory-nats Quadlet  │
                    │  :4222 (no TLS)     │
                    │  roxabi.network     │
                    │  auth.conf: lyra +  │
@@ -17,7 +17,7 @@
                              │
    ┌─────────────┬───────────┼───────────┬─────────────┐
    │             │           │           │             │
- lyra-hub   lyra-telegram  lyra-discord  voicecli-tts  voicecli-stt
+ factory-hub   factory-telegram  factory-discord  voicecli-tts  voicecli-stt
 
                      DEAD:
                      ─ host nats.service (was :4222 TLS)
@@ -26,8 +26,8 @@
                      ─ supervisord voicecli_tts / voicecli_stt
 ```
 
-- One merged `auth.conf` at `~/.lyra/nkeys/auth.conf` → Podman secret `lyra-nats-auth`
-- Every client: `Network=roxabi.network`, `NATS_URL=nats://lyra-nats:4222` (no `tls://`)
+- One merged `auth.conf` at `~/.roxabi/factory/nkeys/auth.conf` → Podman secret `factory-nats-auth`
+- Every client: `Network=roxabi.network`, `NATS_URL=nats://factory-nats:4222` (no `tls://`)
 - voicecli workers = Quadlet, same cutover window
 
 ## Staging prep (PRs that must land on `staging` before cutover)
@@ -36,16 +36,16 @@
 
 1. `deploy/nats/gen-nkeys.sh` — add `--emit-merged-authconf` mode; read identities from `acl-matrix.json` (hub, telegram, discord, voice-tts, voice-stt)
 2. Makefile:
-   - `quadlet-authconf-merged` → writes `~/.lyra/nkeys/auth.conf`
-   - `quadlet-secrets-install` → upload as `lyra-nats-auth` (replaces existing)
-3. `deploy/quadlet/lyra-nats.container`:
+   - `quadlet-authconf-merged` → writes `~/.roxabi/factory/nkeys/auth.conf`
+   - `quadlet-secrets-install` → upload as `factory-nats-auth` (replaces existing)
+3. `deploy/quadlet/factory-nats.container`:
    - `PublishPort=127.0.0.1:4222:4222`
    - `Network=roxabi.network`
    - Drop TLS certs volume + TLS args from `Exec=`
-   - `Secret=lyra-nats-auth,type=mount,target=/etc/nats/nkeys/auth.conf,mode=0444`
+   - `Secret=factory-nats-auth,type=mount,target=/etc/nats/nkeys/auth.conf,mode=0444`
 4. `deploy/quadlet/lyra-{hub,telegram,discord}.container`:
    - `Network=lyra.network` → `Network=roxabi.network`
-   - `NATS_URL=nats://lyra-nats:4222` (drop `tls://`)
+   - `NATS_URL=nats://factory-nats:4222` (drop `tls://`)
 5. `deploy/quadlet/lyra.network` — rename file to `roxabi.network`, update label
 6. Remove client-side TLS env (`NATS_TLS_CA`, etc.) from hub/adapter env examples
 
@@ -55,7 +55,7 @@
 2. `rm deploy/quadlet/voicecli.network`
 3. `deploy/quadlet/voicecli-{tts,stt}.container`:
    - `Network=voicecli.network` → `Network=roxabi.network`
-   - `NATS_URL=nats://voicecli-nats:4222` → `NATS_URL=nats://lyra-nats:4222`
+   - `NATS_URL=nats://voicecli-nats:4222` → `NATS_URL=nats://factory-nats:4222`
    - Drop `voicecli-nats-auth` secret mount (not needed on clients)
    - Keep `voicecli-nats-{tts,stt}` seed secret mounts
 4. Makefile — drop voicecli-nats install + drop `voicecli-nats-auth` secret creation
@@ -66,7 +66,7 @@ Merge order doesn't matter — cutover reconciles.
 
 ```bash
 # 1. Pull latest staging on both repos
-cd ~/projects/lyra      && git pull --ff-only origin staging
+cd ~/projects/roxabi-factory      && git pull --ff-only origin staging
 cd ~/projects/voiceCLI  && git pull --ff-only origin staging
 
 # 2. Pre-pull NATS image (avoid blocking download mid-cutover)
@@ -77,13 +77,13 @@ cd ~/projects/voiceCLI && podman build -t localhost/voicecli:latest .
 
 # 4. Relocate voicecli seeds to owner path (ADR-055 D4) — cp, not mv
 mkdir -p ~/.voicecli/nkeys
-cp ~/.lyra/nkeys/voice-tts.seed ~/.voicecli/nkeys/
-cp ~/.lyra/nkeys/voice-stt.seed ~/.voicecli/nkeys/
+cp ~/.roxabi/factory/nkeys/voice-tts.seed ~/.voicecli/nkeys/
+cp ~/.roxabi/factory/nkeys/voice-stt.seed ~/.voicecli/nkeys/
 chmod 600 ~/.voicecli/nkeys/*.seed
 
 # 5. Render merged auth.conf (reads voice-* pubkeys from new seeds)
-cd ~/projects/lyra && make quadlet-authconf-merged
-# Verify: ~/.lyra/nkeys/auth.conf contains hub, telegram, discord, voice-tts, voice-stt blocks
+cd ~/projects/roxabi-factory && make quadlet-authconf-merged
+# Verify: ~/.roxabi/factory/nkeys/auth.conf contains hub, telegram, discord, voice-tts, voice-stt blocks
 
 # 6. Delete stale Podman secrets from prior attempts
 podman secret rm voicecli-tts.seed voicecli-stt.seed 2>/dev/null || true
@@ -94,7 +94,7 @@ podman secret rm voicecli-nats-auth 2>/dev/null || true
 
 ```
 T+0:00  Stop all clients
-          systemctl --user stop lyra-hub lyra-telegram lyra-discord
+          systemctl --user stop factory-hub factory-telegram factory-discord
           systemctl --user stop voicecli-tts voicecli-stt  # was: supervisorctl (retired #886/#1036)
 
 T+0:01  Kill host NATS
@@ -102,12 +102,12 @@ T+0:01  Kill host NATS
           sudo systemctl disable nats.service
           ss -tlnp | grep ':4222 '   # must be empty
 
-T+0:02  Stop old lyra-nats Quadlet (was on :4223)
-          systemctl --user stop lyra-nats.service
+T+0:02  Stop old factory-nats Quadlet (was on :4223)
+          systemctl --user stop factory-nats.service
 
 T+0:03  Install new Quadlet units — lyra
-          cd ~/projects/lyra
-          make quadlet-secrets-install   # uploads lyra-nats-auth + lyra seed secrets
+          cd ~/projects/roxabi-factory
+          make quadlet-secrets-install   # uploads factory-nats-auth + lyra seed secrets
           make quadlet-install           # drops new .container files + roxabi.network
 
 T+0:04  Install new Quadlet units — voicecli
@@ -120,15 +120,15 @@ T+0:05  Reload systemd, drop old network
           podman network rm lyra.network voicecli.network 2>/dev/null || true
 
 T+0:06  Start NATS
-          systemctl --user start lyra-nats.service
+          systemctl --user start factory-nats.service
           sleep 3
           ss -tlnp | grep ':4222 '   # must show podman/rootlessport
-          systemctl --user status lyra-nats.service --no-pager
+          systemctl --user status factory-nats.service --no-pager
 
 T+0:07  Start lyra clients (dependency order)
-          systemctl --user start lyra-hub.service
+          systemctl --user start factory-hub.service
           sleep 2
-          systemctl --user start lyra-telegram.service lyra-discord.service
+          systemctl --user start factory-telegram.service factory-discord.service
 
 T+0:08  Start voicecli workers
           systemctl --user start voicecli-tts.service voicecli-stt.service
@@ -155,7 +155,7 @@ sudo cp /etc/nats/nkeys/auth.conf /root/auth.conf.bak-$(date +%Y%m%d)
 
 # Verify final state
 podman network ls       # roxabi.network only (no lyra.network, no voicecli.network)
-podman secret ls        # lyra-nats-auth, lyra-nkey-*, voicecli-nats-{tts,stt}
+podman secret ls        # factory-nats-auth, lyra-nkey-*, voicecli-nats-{tts,stt}
 systemctl --user list-units 'lyra-*' 'voicecli-*'
 sudo systemctl status nats.service    # inactive (disabled)
 ```
@@ -182,7 +182,7 @@ git revert HEAD   # lyra
 make quadlet-install
 
 # 5. Restart bots via old Quadlet units
-systemctl --user start lyra-hub.service lyra-telegram.service lyra-discord.service
+systemctl --user start factory-hub.service factory-telegram.service factory-discord.service
 ```
 
 ## References

--- a/docs/ops/clipool-git.md
+++ b/docs/ops/clipool-git.md
@@ -1,10 +1,10 @@
 # Clipool — Git Behavior Reference
 
-Operator notes on how `git` behaves inside the `lyra-clipool` container. Not a runbook — see `gh-key-rotation.md` for procedures.
+Operator notes on how `git` behaves inside the `factory-clipool` container. Not a runbook — see `gh-key-rotation.md` for procedures.
 
 ## SSH → HTTPS URL rewrite
 
-`deploy/lyra-gh/git.config.tmpl` is loaded as `GIT_CONFIG_GLOBAL` inside `lyra-clipool`. It contains:
+`deploy/lyra-gh/git.config.tmpl` is loaded as `GIT_CONFIG_GLOBAL` inside `factory-clipool`. It contains:
 
 ```ini
 [url "https://github.com/"]
@@ -18,7 +18,7 @@ These rules silently rewrite SSH-form GitHub remote URLs to HTTPS at command tim
 
 ## Authentication
 
-Git uses HTTPS + a credential helper (`/opt/lyra-gh/git-credential-lyra-gh`) which fetches a fresh GitHub App installation token from the `lyra-gh-helper` sidecar over a Unix socket. Tokens have a 1 h TTL and are refreshed proactively.
+Git uses HTTPS + a credential helper (`/opt/lyra-gh/git-credential-lyra-gh`) which fetches a fresh GitHub App installation token from the `factory-gh-helper` sidecar over a Unix socket. Tokens have a 1 h TTL and are refreshed proactively.
 
 → `docs/ops/gh-key-rotation.md` — rotating the App PEM.
 
@@ -34,10 +34,10 @@ Set image-baked in `git.config.tmpl`. Per-agent attribution is tracked as a foll
 
 ## Safe directory
 
-The image-baked config trusts repos under `/home/lyra/projects/*` via `safe.directory`. This works around uid drift between host (1000) and container (1500) on bind-mounted Syncthing trees. Tracked for replacement with proper `idmap` in issue #1149.
+The image-baked config trusts repos under `/home/factory/projects/*` via `safe.directory`. This works around uid drift between host (1000) and container (1500) on bind-mounted Syncthing trees. Tracked for replacement with proper `idmap` in issue #1149.
 
 ## Cross-References
 
 - [`deploy/lyra-gh/git.config.tmpl`](../../deploy/lyra-gh/git.config.tmpl) — the config loaded as `GIT_CONFIG_GLOBAL`
-- [`deploy/quadlet/lyra-clipool.container`](../../deploy/quadlet/lyra-clipool.container) — env wiring (`GIT_CONFIG_GLOBAL`, mounts)
+- [`deploy/quadlet/factory-clipool.container`](../../deploy/quadlet/factory-clipool.container) — env wiring (`GIT_CONFIG_GLOBAL`, mounts)
 - [`docs/ops/gh-key-rotation.md`](gh-key-rotation.md) — PEM rotation runbook

--- a/docs/ops/clipool-uid-model.md
+++ b/docs/ops/clipool-uid-model.md
@@ -1,15 +1,15 @@
 # Clipool UID Trust Model
 
-Read this when you hit a git ownership error inside `lyra-clipool`, or when auditing
+Read this when you hit a git ownership error inside `factory-clipool`, or when auditing
 why `safe.directory` wildcards no longer appear in `git.config.tmpl`.
 
 ---
 
 ## Trust grant
 
-`deploy/quadlet/lyra-gh.pod` carries `UserNS=keep-id:uid=1500,gid=1500`. This remaps
+`deploy/quadlet/factory-gh.pod` carries `UserNS=keep-id:uid=1500,gid=1500`. This remaps
 the host operator (uid 1000, `mickael`) to container uid 1500 (`lyra`). Bind-mounted
-repos under `~/.lyra/` and `/home/lyra/projects/` are owned by uid 1000 on the host;
+repos under `~/.roxabi/factory/` and `/home/factory/projects/` are owned by uid 1000 on the host;
 inside the container they appear owned by uid 1500, which is exactly the uid git runs
 as. The native ownership check passes without any config override. This userns mapping
 is the trust boundary — everything else follows from it.
@@ -18,7 +18,7 @@ is the trust boundary — everything else follows from it.
 
 ## Why no `safe.directory` wildcards
 
-A wildcard such as `directory = /home/lyra/projects/*` expresses "trust any repo under
+A wildcard such as `directory = /home/factory/projects/*` expresses "trust any repo under
 this path regardless of owner". That is trust-by-path, a pattern in the CWE-426/427
 lineage (untrusted search path). The userns remap already guarantees that only the
 intended uid can place files on the bind-mount host side; the path wildcard adds no
@@ -31,17 +31,17 @@ absent from `deploy/lyra-gh/git.config.tmpl`.
 
 `src/factory/bootstrap/infra/git_ownership_probe.py` runs at clipool startup. It invokes
 `git rev-parse HEAD` on a known bind-mounted repo (default:
-`/home/lyra/projects/lyra`; overridable via `LYRA_OWNERSHIP_PROBE_PATH`). If the userns
-mapping ever breaks — for example because someone removes `keep-id` from `lyra-gh.pod`
+`/home/factory/projects/roxabi-factory`; overridable via `FACTORY_OWNERSHIP_PROBE_PATH`). If the userns
+mapping ever breaks — for example because someone removes `keep-id` from `factory-gh.pod`
 — git sees a uid mismatch and returns a non-zero exit code. The probe propagates that
 exit, `_bootstrap_clipool_standalone` fails, and systemd retries per `Restart=on-failure`
-up to `StartLimitBurst=5` within 60 s, then marks `lyra-clipool.service` failed. The
-failure is visible in `journalctl --user -u lyra-clipool.service`; it does not cascade to
+up to `StartLimitBurst=5` within 60 s, then marks `factory-clipool.service` failed. The
+failure is visible in `journalctl --user -u factory-clipool.service`; it does not cascade to
 the pod, which keeps running. "Loud" here means logged loudly — operator monitoring or a
-`systemctl --user status lyra-clipool.service` check is what surfaces it.
+`systemctl --user status factory-clipool.service` check is what surfaces it.
 
-**Precondition:** the host must have `~/projects/lyra` checked out (or Syncthing-synced)
-before `lyra-clipool.service` is started. The bind-mount path `/home/lyra/projects/lyra`
+**Precondition:** the host must have `~/projects/roxabi-factory` checked out (or Syncthing-synced)
+before `factory-clipool.service` is started. The bind-mount path `/home/factory/projects/roxabi-factory`
 inside the container is the probe target; if it does not exist on the host, the probe
 fails fast with "target directory does not exist" — correct behavior, but confusing on
 first provision. Add this to the operator's provision checklist.
@@ -61,7 +61,7 @@ Upstream tracking: https://github.com/containers/podman/issues/24918
 
 ## References
 
-- `deploy/quadlet/lyra-gh.pod` — line `UserNS=keep-id:uid=1500,gid=1500`
+- `deploy/quadlet/factory-gh.pod` — line `UserNS=keep-id:uid=1500,gid=1500`
 - `deploy/lyra-gh/git.config.tmpl` — post-T2 state: no `[safe]` block
 - `src/factory/bootstrap/infra/git_ownership_probe.py` — startup ownership probe
 - `artifacts/specs/1149-safe-directory-idmap-spec.mdx` — full rationale, Podman #24918

--- a/docs/ops/container-publishing.md
+++ b/docs/ops/container-publishing.md
@@ -48,7 +48,7 @@ The reusable workflow accepts four inputs:
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `image_name` | yes | — | Full registry path, e.g. `ghcr.io/roxabi/lyra` |
+| `image_name` | yes | — | Full registry path, e.g. `ghcr.io/roxabi/factory` |
 | `release_please_component` | yes | — | Component name as used in the release-please tag, e.g. `lyra` |
 | `dockerfile_path` | no | `./Dockerfile` | Path to the Dockerfile relative to the build context |
 | `build_context` | no | `.` | Docker build context path |
@@ -69,7 +69,7 @@ jobs:
     uses: Roxabi/.github/.github/workflows/publish-container.yml@v1
     secrets: inherit
     with:
-      image_name: ghcr.io/roxabi/lyra
+      image_name: ghcr.io/roxabi/factory
       release_please_component: lyra
       # Manifest format (oci-mediatypes=false) is handled by the reusable workflow.
       # No extra inputs are needed to preserve HEALTHCHECK.
@@ -90,10 +90,10 @@ release-please. This ensures a daemon-reload never silently pulls a different la
 
 ```ini
 # Before (floating staging tag):
-Image=ghcr.io/roxabi/lyra:staging
+Image=ghcr.io/roxabi/factory:staging
 
 # After first release cut (semver pin):
-Image=ghcr.io/roxabi/lyra:1.0.0
+Image=ghcr.io/roxabi/factory:1.0.0
 ```
 
 **Rule B — pre-release / staging validation:** use `:staging` so that each push to the
@@ -129,14 +129,14 @@ containers. No manual intervention is needed after a staging merge.
 
 | Container | Image | AutoUpdate |
 |---|---|---|
-| lyra-hub | `ghcr.io/roxabi/lyra:staging-svc` | registry |
-| lyra-telegram | `ghcr.io/roxabi/lyra:staging-svc` | registry |
-| lyra-discord | `ghcr.io/roxabi/lyra:staging-svc` | registry |
-| lyra-clipool | `ghcr.io/roxabi/lyra:staging` | registry |
-| lyra-gh-helper | `ghcr.io/roxabi/lyra:staging` | registry |
+| factory-hub | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| factory-telegram | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| factory-discord | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| factory-clipool | `ghcr.io/roxabi/factory:staging` | registry |
+| factory-gh-helper | `ghcr.io/roxabi/factory:staging` | registry |
 | voicecli-tts | `ghcr.io/roxabi/voicecli-tts:staging` | registry |
 | voicecli-stt | `ghcr.io/roxabi/voicecli-stt:staging` | registry |
-| lyra-nats | pinned by digest | none (pinned) |
+| factory-nats | pinned by digest | none (pinned) |
 
 ### Verify
 
@@ -172,20 +172,20 @@ podman auto-update
 If auto-update is disabled or you need an immediate deploy without waiting for the timer:
 
 ```bash
-podman pull ghcr.io/roxabi/lyra:staging
+podman pull ghcr.io/roxabi/factory:staging
 systemctl --user daemon-reload
-systemctl --user restart lyra-hub lyra-telegram lyra-discord lyra-clipool
+systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool
 ```
 
 Verify all four units are healthy:
 
 ```bash
-systemctl --user is-active lyra-hub lyra-telegram lyra-discord lyra-clipool
+systemctl --user is-active factory-hub factory-telegram factory-discord factory-clipool
 curl -fsS localhost:8443/health
 ```
 
 `is-active` prints `active` for each unit on success. The health endpoint is served by
-`lyra-hub` on `127.0.0.1:8443` (published via PublishPort in the Quadlet unit).
+`factory-hub` on `127.0.0.1:8443` (published via PublishPort in the Quadlet unit).
 
 ---
 
@@ -210,16 +210,16 @@ Edit the `Image=` line in the affected `.container` file back to the previous se
 reload and restart:
 
 ```bash
-# Edit deploy/quadlet/lyra-hub.container (and telegram/discord as needed):
-#   Image=ghcr.io/roxabi/lyra:1.0.0   ← revert to previous known-good tag
+# Edit deploy/quadlet/factory-hub.container (and telegram/discord as needed):
+#   Image=ghcr.io/roxabi/factory:1.0.0   ← revert to previous known-good tag
 
 systemctl --user daemon-reload
-systemctl --user restart lyra-hub lyra-telegram lyra-discord lyra-clipool
+systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool
 ```
 
 The previous image layer is still present in the local podman store as long as it has not been
 pruned, so the restart is immediate with no pull required. Confirm with
-`systemctl --user is-active lyra-hub lyra-telegram lyra-discord lyra-clipool`.
+`systemctl --user is-active factory-hub factory-telegram factory-discord factory-clipool`.
 
 ---
 
@@ -234,11 +234,11 @@ logs on still-old receivers and may drop events silently.
 
 | Unit | Image |
 |---|---|
-| `lyra-hub` | `ghcr.io/roxabi/lyra:<tag>` |
-| `lyra-telegram` | `ghcr.io/roxabi/lyra:<tag>` |
-| `lyra-discord` | `ghcr.io/roxabi/lyra:<tag>` |
+| `factory-hub` | `ghcr.io/roxabi/factory:<tag>` |
+| `factory-telegram` | `ghcr.io/roxabi/factory:<tag>` |
+| `factory-discord` | `ghcr.io/roxabi/factory:<tag>` |
 
-`lyra-clipool` is intentionally **excluded** from the schema-floor restart sequence — it is on
+`factory-clipool` is intentionally **excluded** from the schema-floor restart sequence — it is on
 the LLM-driver path (`lyra.clipool.cmd`), not a `RenderEvent` receiver, and does not participate
 in the schema handshake. This omission is deliberate; do not add it back when reading the generic
 "M₁ manual pull + restart" pattern above.
@@ -253,21 +253,21 @@ The auto-update timer must NOT fire mid-restart — a 5-minute window between hu
 restarts produces partial-version skew. The procedure is therefore manual: stop the timer,
 restart the three units atomically, then re-enable the timer.
 
-1. Merge the schema-bump PR to `staging` — CI publishes `ghcr.io/roxabi/lyra:staging`.
+1. Merge the schema-bump PR to `staging` — CI publishes `ghcr.io/roxabi/factory:staging`.
 2. On M₁, stop the auto-update timer to prevent mid-restart skew:
    ```bash
    systemctl --user stop podman-auto-update.timer
    ```
 3. Pull the new image and restart hub + telegram + discord atomically:
    ```bash
-   podman pull ghcr.io/roxabi/lyra:staging
-   systemctl --user restart lyra-hub lyra-telegram lyra-discord
+   podman pull ghcr.io/roxabi/factory:staging
+   systemctl --user restart factory-hub factory-telegram factory-discord
    ```
 4. Re-enable the auto-update timer:
    ```bash
    systemctl --user start podman-auto-update.timer
    ```
-5. Confirm with `systemctl --user is-active lyra-hub lyra-telegram lyra-discord` and
+5. Confirm with `systemctl --user is-active factory-hub factory-telegram factory-discord` and
    `curl -fsS localhost:8443/health`.
 
 For production semver releases, pin all three units to the same `X.Y.Z` tag simultaneously.
@@ -301,8 +301,8 @@ Steps for a new Roxabi project (voiceCLI, 2ndBrain, imageCLI, llmCLI) to adopt t
 
 - `.github/workflows/publish.yml` — lyra caller workflow
 - `Roxabi/.github/.github/workflows/publish-container.yml@v1` — reusable workflow (upstream)
-- `deploy/quadlet/lyra-hub.container` — `Image=` reference example
-- `deploy/quadlet/lyra-telegram.container` — `Image=` reference example
-- `deploy/quadlet/lyra-discord.container` — `Image=` reference example
-- `deploy/quadlet/lyra-clipool.container` — `Image=` reference example
-- [#920](https://github.com/Roxabi/lyra/issues/920) — container publishing pattern epic
+- `deploy/quadlet/factory-hub.container` — `Image=` reference example
+- `deploy/quadlet/factory-telegram.container` — `Image=` reference example
+- `deploy/quadlet/factory-discord.container` — `Image=` reference example
+- `deploy/quadlet/factory-clipool.container` — `Image=` reference example
+- [#920](https://github.com/Roxabi/roxabi-factory/issues/920) — container publishing pattern epic

--- a/docs/ops/deploy-smoke-canary.md
+++ b/docs/ops/deploy-smoke-canary.md
@@ -11,16 +11,16 @@ The 2026-04-27 incident showed that a bad image deploy caused 3h15m of silent fa
 
 ## Canary rollout procedure
 
-Use `lyra-telegram` (aryl bot) as the canary unit — lowest user impact, fastest to verify.
+Use `factory-telegram` (aryl bot) as the canary unit — lowest user impact, fastest to verify.
 
 **Step 1 — Deploy canary**
 
 ```bash
 # Pull new image
-podman pull ghcr.io/roxabi/lyra:staging
+podman pull ghcr.io/roxabi/factory:staging
 
 # Restart canary unit only
-systemctl --user restart lyra-telegram.service
+systemctl --user restart factory-telegram.service
 ```
 
 **Step 2 — Smoke test the canary** (see below — run immediately after restart)
@@ -30,7 +30,7 @@ systemctl --user restart lyra-telegram.service
 Watch logs for errors:
 
 ```bash
-journalctl --user -u lyra-telegram -f
+journalctl --user -u factory-telegram -f
 ```
 
 If the smoke test passed and no errors appear after 5 minutes, proceed.
@@ -38,9 +38,9 @@ If the smoke test passed and no errors appear after 5 minutes, proceed.
 **Step 4 — Promote to remaining units**
 
 ```bash
-systemctl --user restart lyra-discord.service
-systemctl --user restart lyra-clipool.service
-systemctl --user restart lyra-hub.service
+systemctl --user restart factory-discord.service
+systemctl --user restart factory-clipool.service
+systemctl --user restart factory-hub.service
 ```
 
 Restart hub last — it is the sole consumer of inbound queues.
@@ -65,10 +65,10 @@ Tests the critical path: hub receives a message, dispatches to clipool, clipool 
 
 ```bash
 # After sending the test message, check hub dispatched and received a reply:
-journalctl --user -u lyra-hub --since "1 min ago" | grep -E "clipool|stream_gen|timeout|dispatch"
+journalctl --user -u factory-hub --since "1 min ago" | grep -E "clipool|stream_gen|timeout|dispatch"
 
 # Check NATS for permission violations:
-journalctl --user -u lyra-nats --since "1 min ago" | grep -i "violation"
+journalctl --user -u factory-nats --since "1 min ago" | grep -i "violation"
 ```
 
 Pass criteria:
@@ -122,11 +122,11 @@ If the smoke test fails after canary deploy:
 
 ```bash
 # Roll back to previous image tag
-podman pull ghcr.io/roxabi/lyra:<previous-tag>
-systemctl --user restart lyra-telegram.service
+podman pull ghcr.io/roxabi/factory:<previous-tag>
+systemctl --user restart factory-telegram.service
 ```
 
-Previous image tag is in the release notes or `podman image ls ghcr.io/roxabi/lyra`.
+Previous image tag is in the release notes or `podman image ls ghcr.io/roxabi/factory`.
 
 If the failure is an ACL/NATS issue (permission violations in logs), see [nats-authconf-update.md](nats-authconf-update.md) rollback section instead.
 

--- a/docs/ops/gh-key-rotation.md
+++ b/docs/ops/gh-key-rotation.md
@@ -2,9 +2,9 @@
 
 ## Scope
 
-This runbook covers rotating the private key (PEM) for the Lyra GitHub App. Rotate when the key is suspected compromised, as part of a scheduled key refresh, or when a new operator takes ownership. The operation replaces the `lyra-gh-pem` Podman secret on the target host and restarts `lyra-gh-helper` (the only container that mounts the PEM in the sidecar Pod design) to load the new key; expected downtime is ≤10 s end-to-end. Measured 0.58 s on M₁ (Podman 5.7.0) on 2026-05-06.
+This runbook covers rotating the private key (PEM) for the Lyra GitHub App. Rotate when the key is suspected compromised, as part of a scheduled key refresh, or when a new operator takes ownership. The operation replaces the `factory-gh-pem` Podman secret on the target host and restarts `factory-gh-helper` (the only container that mounts the PEM in the sidecar Pod design) to load the new key; expected downtime is ≤10 s end-to-end. Measured 0.58 s on M₁ (Podman 5.7.0) on 2026-05-06.
 
-This runbook does **not** cover changing the GitHub App ID or installation ID — those are properties of the registered App and changing them requires re-registering the App and updating the `Environment=` values in `deploy/quadlet/lyra-gh-helper.container`. It also does not cover first-time bootstrap; for that, see `deploy/provision.sh` section "Lyra GitHub App PEM (Podman secret)".
+This runbook does **not** cover changing the GitHub App ID or installation ID — those are properties of the registered App and changing them requires re-registering the App and updating the `Environment=` values in `deploy/quadlet/factory-gh-helper.container`. It also does not cover first-time bootstrap; for that, see `deploy/provision.sh` section "Lyra GitHub App PEM (Podman secret)".
 
 ---
 
@@ -22,10 +22,10 @@ A single GitHub App `lyra-harness` (id `3619198`, install_id `129952244`) is use
 
 | App | Host | Quadlet unit (PEM consumer) | Secret name |
 |---|---|---|---|
-| `lyra-harness` | M₁ — roxabituwer (192.168.1.16) | `lyra-gh-helper.service` | `lyra-gh-pem` |
-| `lyra-harness` | M₂ — ROXABITOWER | `lyra-gh-helper.service` | `lyra-gh-pem` |
+| `lyra-harness` | M₁ — roxabituwer (192.168.1.16) | `factory-gh-helper.service` | `factory-gh-pem` |
+| `lyra-harness` | M₂ — ROXABITOWER | `factory-gh-helper.service` | `factory-gh-pem` |
 
-App ID + install_id are git-versioned in `deploy/quadlet/lyra-gh-helper.container` and identical on both hosts. The secret name `lyra-gh-pem` is identical on both hosts. Each host has an isolated Podman secret store — there is no cross-host conflict, and a single PEM file may be re-used (or a per-host PEM, at the operator's discretion).
+App ID + install_id are git-versioned in `deploy/quadlet/factory-gh-helper.container` and identical on both hosts. The secret name `factory-gh-pem` is identical on both hosts. Each host has an isolated Podman secret store — there is no cross-host conflict, and a single PEM file may be re-used (or a per-host PEM, at the operator's discretion).
 
 ---
 
@@ -39,7 +39,7 @@ On github.com, navigate to Settings → Developer settings → GitHub Apps → L
 For M₁:
 
 ```bash
-scp ~/Downloads/lyra-harness.private-key.YYYY-MM-DD.pem mickael@192.168.1.16:/home/lyra/secrets/new-lyra-harness.pem
+scp ~/Downloads/lyra-harness.private-key.YYYY-MM-DD.pem mickael@192.168.1.16:/home/factory/secrets/new-lyra-harness.pem
 ```
 
 For M₂, use the equivalent path on ROXABITOWER — the script runs locally, so no SCP is needed if you are already on M₂.
@@ -48,7 +48,7 @@ For M₂, use the equivalent path on ROXABITOWER — the script runs locally, so
 
 ```bash
 ssh mickael@192.168.1.16 \
-  'systemctl --user is-active lyra-gh-pod.service lyra-gh-helper.service lyra-clipool.service'
+  'systemctl --user is-active factory-gh-pod.service factory-gh-helper.service factory-clipool.service'
 ```
 
 Expected: `active` for all three. If any is down for an unrelated reason, resolve that first — a degraded baseline makes post-rotation verification ambiguous.
@@ -67,20 +67,20 @@ echo "Rotation start: $RT"
 On the target host:
 
 ```bash
-cd ~/projects/lyra
-time bash deploy/scripts/rotate-gh-key.sh /home/lyra/secrets/new-lyra-harness.pem
+cd ~/projects/roxabi-factory
+time bash deploy/scripts/rotate-gh-key.sh /home/factory/secrets/new-lyra-harness.pem
 ```
 
 The script:
-1. Removes the existing `lyra-gh-pem` Podman secret (tolerates first-time absence).
-2. Creates a new `lyra-gh-pem` secret from the supplied PEM path.
-3. Runs `systemctl --user restart lyra-gh-helper.service`.
-4. Polls every 0.5 s for up to 10 s, waiting for two conditions: helper container Up AND the dispenser socket reachable from inside `lyra-clipool` (`test -S /run/lyra-gh-token/dispenser.sock`).
+1. Removes the existing `factory-gh-pem` Podman secret (tolerates first-time absence).
+2. Creates a new `factory-gh-pem` secret from the supplied PEM path.
+3. Runs `systemctl --user restart factory-gh-helper.service`.
+4. Polls every 0.5 s for up to 10 s, waiting for two conditions: helper container Up AND the dispenser socket reachable from inside `factory-clipool` (`test -S /run/factory-gh-token/dispenser.sock`).
 
-**Expected output:** `lyra-gh-helper restarted, dispenser reachable, secret rotated.`
+**Expected output:** `factory-gh-helper restarted, dispenser reachable, secret rotated.`
 **Expected wall-clock:** ≤10 s total. Reference measurement: 0.58 s on M₁ (Podman 5.7.0) 2026-05-06.
 
-> **Warning:** the helper restart is a hard stop — in-flight `git push` or `gh` operations that already hold a minted token continue uninterrupted, but new token requests from `lyra-clipool` during the helper restart window will fail with `ECONNREFUSED` on the dispenser socket. The script does not drain in-flight operations. If you need to avoid disrupting an active operation, wait for it to complete before running the script.
+> **Warning:** the helper restart is a hard stop — in-flight `git push` or `gh` operations that already hold a minted token continue uninterrupted, but new token requests from `factory-clipool` during the helper restart window will fail with `ECONNREFUSED` on the dispenser socket. The script does not drain in-flight operations. If you need to avoid disrupting an active operation, wait for it to complete before running the script.
 
 If the script exits non-zero, jump to **[4. Rollback](#4-rollback)**.
 
@@ -91,8 +91,8 @@ If the script exits non-zero, jump to **[4. Rollback](#4-rollback)**.
 **3.1 Confirm helper + clipool are healthy.**
 
 ```bash
-systemctl --user is-active lyra-gh-helper.service lyra-clipool.service
-podman ps --filter name=lyra-gh-helper --filter name=lyra-clipool --format '{{.Names}} {{.Status}}'
+systemctl --user is-active factory-gh-helper.service factory-clipool.service
+podman ps --filter name=factory-gh-helper --filter name=factory-clipool --format '{{.Names}} {{.Status}}'
 ```
 
 Expected: `active active` and two status lines beginning with Up.
@@ -100,7 +100,7 @@ Expected: `active active` and two status lines beginning with Up.
 **3.2 Check helper logs for mint activity.**
 
 ```bash
-journalctl --user -u lyra-gh-helper --since "$RT" | grep -iE 'mint|github|token|error'
+journalctl --user -u factory-gh-helper --since "$RT" | grep -iE 'mint|github|token|error'
 ```
 
 Look for absence of MintFailure lines. A successful token mint by the helper confirms the new PEM was read and accepted by GitHub's API.
@@ -110,7 +110,7 @@ Look for absence of MintFailure lines. A successful token mint by the helper con
 From inside the clipool container, exercise the dispenser path with the new PEM:
 
 ```bash
-podman exec lyra-clipool lyra-gh issue list --repo Roxabi/lyra --limit 1
+podman exec factory-clipool lyra-gh issue list --repo Roxabi/roxabi-factory --limit 1
 ```
 
 Expected: a real issue line is printed. The `lyra-gh` shim resolves a fresh installation token from the new PEM via the dispenser socket and runs `gh` with `GH_TOKEN` scoped to the single subprocess invocation.
@@ -118,7 +118,7 @@ Expected: a real issue line is printed. The `lyra-gh` shim resolves a fresh inst
 **3.4 Wipe the staging copy of the PEM from the host.**
 
 ```bash
-shred -u /home/lyra/secrets/new-lyra-harness.pem
+shred -u /home/factory/secrets/new-lyra-harness.pem
 ```
 
 ---
@@ -127,7 +127,7 @@ shred -u /home/lyra/secrets/new-lyra-harness.pem
 
 Trigger rollback when:
 - The rotation script exits non-zero.
-- `lyra-clipool` fails to return to Up state within 10 s.
+- `factory-clipool` fails to return to Up state within 10 s.
 - `git fetch`/`git push` returns auth errors post-rotation.
 
 **4.1 If you have the previous PEM archived** (recommended: keep the prior rotation's PEM in a sealed location for ≥7 days):

--- a/docs/ops/nats-acl-inbox-case-postmortem.md
+++ b/docs/ops/nats-acl-inbox-case-postmortem.md
@@ -158,7 +158,7 @@ lyra only while voicecli still uses uppercase is an identical silent breakage.
 **Safe deploy order:**
 1. `acl-matrix.json` update (add lowercase, keep uppercase during transition)
 2. `gen-nkeys.sh --regen-authconf` → `make quadlet-secrets-install`
-3. `make lyra-nats reload`
+3. `make factory-nats reload`
 4. Redeploy containers one at a time, verify each reconnects
 5. Once all services confirmed on lowercase: drop uppercase entries, repeat 2–4
 
@@ -330,8 +330,8 @@ No documented procedure for the full sequence. Until written:
 
 1. `gen-nkeys.sh --regenerate` (has auto-restore on failure)
 2. `make quadlet-secrets-install`
-3. `make lyra-nats reload`
-4. Verify each service reconnects: `make lyra-hub logs`, `make lyra-clipool logs`, etc.
+3. `make factory-nats reload`
+4. Verify each service reconnects: `make factory-hub logs`, `make factory-clipool logs`, etc.
 
 ---
 
@@ -380,8 +380,8 @@ Four independent analyses were run after the initial postmortem: architect, prod
 
 #### Why-chain 4: `acl-matrix.json` is not the operational SSoT
 
-1. The sequence to apply an ACL change to production is: edit JSON → `gen-nkeys.sh --regen-authconf` → `make quadlet-secrets-install` → `make lyra-nats reload` — four distinct manual actions.
-2. Podman secrets are immutable once created; updating requires delete + recreate, a separate command from reloading NATS. A `make lyra-nats reload` executed before `make quadlet-secrets-install` silently reloads NATS against the old `auth.conf`.
+1. The sequence to apply an ACL change to production is: edit JSON → `gen-nkeys.sh --regen-authconf` → `make quadlet-secrets-install` → `make factory-nats reload` — four distinct manual actions.
+2. Podman secrets are immutable once created; updating requires delete + recreate, a separate command from reloading NATS. A `make factory-nats reload` executed before `make quadlet-secrets-install` silently reloads NATS against the old `auth.conf`.
 3. The four steps are separate Makefile targets with independent dependencies. No atomic wrapper exists; no dependency chain prevents partial execution.
 4. No post-apply verification step exists at any stage. There is no automatic check that NATS is now enforcing the new ACL, that each service reconnected, or that no permission violations appear in the first 30 seconds after reload.
 5. **Root:** `acl-matrix.json` was designed as the SSoT for one-time provisioning (ADR-046). As ACL changes became frequent operational work (#949, ADR-051 rollout, etc.), the multi-step manual pipeline became a routine hazard rather than a rare provisioning activity. Every ACL change is an opportunity to leave the system silently inconsistent.

--- a/docs/ops/nats-acl-postmortem-remaining.md
+++ b/docs/ops/nats-acl-postmortem-remaining.md
@@ -24,7 +24,7 @@ Source: [nats-acl-inbox-case-postmortem.md](nats-acl-inbox-case-postmortem.md)
 | Drop `allow_responses: true` from all identities | `5b3b6c4a` — hub/adapters explicit `false`; others omit field (NATS default = false) |
 | Kill hardcoded identity list in gen-nkeys.sh — IDENTITIES[] driven from JSON SSoT | `load_matrix()` populates from acl-matrix.json |
 | Alert on `permissions violation` in NATS logs | `src/factory/monitoring/checks_log.py` — `check_nats_log_errors` |
-| Alert on sustained `_dict_stream_gen timeout` in hub logs | `src/lyra/monitoring/checks_log.py:57` — `check_hub_dict_stream_gen_timeout` |
+| Alert on sustained `_dict_stream_gen timeout` in hub logs | `src/factory/monitoring/checks_log.py:57` — `check_hub_dict_stream_gen_timeout` |
 | NATS HTTP monitoring on 127.0.0.1 | `bcab1197` |
 | Retire `tts-adapter`/`sst-adapter` from acl-matrix.json | `5b3b6c4a` |
 | Fix gen-nkeys.sh missing `clipool-worker` in key-gen block | `5b3b6c4a` |
@@ -121,7 +121,7 @@ Add a fixture that removes a flow declaration from `request_reply_flows` and ass
 2. `gen-nkeys.sh` `render_auth_conf`: skip any identity where `status == "retired"` — do not emit a `users[]` block for it.
 3. `gen-nkeys.sh` `generate_nkeys` (full mode): skip `generate_nkey` call for retired identities — do not create or regenerate seeds.
 4. Add a CI check that rejects any identity with `status == "retired"` and no `retired_at` date field. This forces retirement to be a documented, dated action rather than a passive omission.
-5. Document the retirement process: set `status: retired`, add `retired_at: YYYY-MM-DD`, run `gen-nkeys.sh --regen-authconf`, run `make quadlet-secrets-install`, run `make lyra-nats reload`, verify logs show no reconnect from the retired identity.
+5. Document the retirement process: set `status: retired`, add `retired_at: YYYY-MM-DD`, run `gen-nkeys.sh --regen-authconf`, run `make quadlet-secrets-install`, run `make factory-nats reload`, verify logs show no reconnect from the retired identity.
 
 **Reason this matters:** A future identity added to the JSON but later abandoned will accumulate live credentials and ACL grants on every `--regenerate` run unless retirement is an explicit, tooling-enforced step.
 
@@ -163,7 +163,7 @@ HealthRetries=3
 
 ### 5. `make nats-rotate-secrets` atomic wrapper ❌
 
-**Priority:** P1 — the current 4-step manual process is a routine hazard. Every ACL change is an opportunity to leave the system silently inconsistent (e.g., `make lyra-nats reload` executed before `make quadlet-secrets-install` silently reloads NATS against the old `auth.conf`).
+**Priority:** P1 — the current 4-step manual process is a routine hazard. Every ACL change is an opportunity to leave the system silently inconsistent (e.g., `make factory-nats reload` executed before `make quadlet-secrets-install` silently reloads NATS against the old `auth.conf`).
 
 **Current state:** Makefile has `nats-regen-authconf` (pull + regen) and `quadlet-secrets-install` (create Podman secrets) as separate targets with no dependency chain.
 
@@ -172,12 +172,12 @@ HealthRetries=3
 ```makefile
 nats-rotate-secrets: ## atomic: regen + scoped install + restart (via nats-regen-authconf) → wait-ready → verify → smoke
 	@$(MAKE) nats-regen-authconf
-	@# nats-regen-authconf scopes the install to lyra-nats-auth and restarts lyra-nats.
+	@# nats-regen-authconf scopes the install to factory-nats-auth and restarts factory-nats.
 	@# This wrapper adds remote wait-ready + log verification + voice smoke.
-	@ssh $(DEPLOY_HOST) "systemctl --user is-active --wait lyra-nats" \
-		|| { echo "ERROR: lyra-nats failed to reach active state on $(DEPLOY_HOST)"; exit 1; }
-	@if ssh $(DEPLOY_HOST) "journalctl --user -u lyra-nats --since '10 seconds ago' | grep -qi 'permission\|error\|fatal'"; then \
-		echo "ERROR: violations detected in lyra-nats log — inspect: journalctl --user -u lyra-nats"; \
+	@ssh $(DEPLOY_HOST) "systemctl --user is-active --wait factory-nats" \
+		|| { echo "ERROR: factory-nats failed to reach active state on $(DEPLOY_HOST)"; exit 1; }
+	@if ssh $(DEPLOY_HOST) "journalctl --user -u factory-nats --since '10 seconds ago' | grep -qi 'permission\|error\|fatal'"; then \
+		echo "ERROR: violations detected in factory-nats log — inspect: journalctl --user -u factory-nats"; \
 		exit 1; \
 	fi
 	@echo "No errors detected — rotation complete"
@@ -218,7 +218,7 @@ The post-restart verification step is load-bearing — it turns a silent partial
    - Event-triggered rotation: suspected compromise, personnel change with prod access, seed file visible in logs
    - Scheduled rotation: quarterly (mark in calendar or set a cron reminder)
 
-2. **Rotation log:** create `~/.lyra/nkeys/rotation-log.md` (or append to a fixed path) with an entry on every rotation:
+2. **Rotation log:** create `~/.roxabi/factory/nkeys/rotation-log.md` (or append to a fixed path) with an entry on every rotation:
    ```
    2026-04-28 | identities: hub, clipool-worker | reason: quarterly | operator: mickael
    ```
@@ -232,7 +232,7 @@ The post-restart verification step is load-bearing — it turns a silent partial
 
 **Verified 2026-04-28 — already handled.**
 
-`StreamProcessor` (`src/lyra/core/processors/stream_processor.py:134`) detects when the stream ends without a `ResultLlmEvent` and emits `TextRenderEvent("Something went wrong. Please try again.", is_error=True)`. The user receives a message; there is no silent failure.
+`StreamProcessor` (`src/factory/core/processors/stream_processor.py:134`) detects when the stream ends without a `ResultLlmEvent` and emits `TextRenderEvent("Something went wrong. Please try again.", is_error=True)`. The user receives a message; there is no silent failure.
 
 The only remaining gap is cosmetic: the error text is generic and does not distinguish "clipool unreachable" from other truncation causes. Not worth a dedicated issue.
 
@@ -246,7 +246,7 @@ The only remaining gap is cosmetic: the error text is generic and does not disti
 
 ```bash
 ssh mickael@192.168.1.16 \
-  "journalctl --user -u lyra-nats --since '24 hours ago' | grep -i 'permissions violation' | wc -l"
+  "journalctl --user -u factory-nats --since '24 hours ago' | grep -i 'permissions violation' | wc -l"
 ```
 
 Expected output: `0`. If non-zero, investigate before closing this item.

--- a/docs/ops/nats-authconf-update.md
+++ b/docs/ops/nats-authconf-update.md
@@ -19,7 +19,7 @@ Routine updates to `acl-matrix.json`: adding/removing identities, changing publi
 **1. Pull latest staging**
 
 ```bash
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 git pull
 ```
 
@@ -29,16 +29,16 @@ git pull
 make nats-regen-authconf
 ```
 
-This runs `scripts/gen_nkeys.py` (entry point `factory-acl genkeys --regen-authconf`) to re-derive `auth.conf` from all existing seeds, back up the previous `auth.conf`, recreate the Podman secret, then runs `systemctl --user restart lyra-nats` to recreate the container with the refreshed mount.
+This runs `scripts/gen_nkeys.py` (entry point `factory-acl genkeys --regen-authconf`) to re-derive `auth.conf` from all existing seeds, back up the previous `auth.conf`, recreate the Podman secret, then runs `systemctl --user restart factory-nats` to recreate the container with the refreshed mount.
 
-> **Why restart and not SIGHUP?** Podman secrets declared `type=mount` in `deploy/quadlet/lyra-nats.container` are tmpfs bind-mounts bound at container init. `podman secret create --replace` updates the secret store, but the file inside the running container still resolves to the old tmpfs content. `nats-server` re-reads its config path on SIGHUP, but the path itself is stale — so ACL changes silently fail to apply. Container recreation is the only way to refresh a mount-typed secret. Confirmed during PR #1292 deploy (2026-05-20); see #1293 for the broader ACL-hardening epic.
+> **Why restart and not SIGHUP?** Podman secrets declared `type=mount` in `deploy/quadlet/factory-nats.container` are tmpfs bind-mounts bound at container init. `podman secret create --replace` updates the secret store, but the file inside the running container still resolves to the old tmpfs content. `nats-server` re-reads its config path on SIGHUP, but the path itself is stale — so ACL changes silently fail to apply. Container recreation is the only way to refresh a mount-typed secret. Confirmed during PR #1292 deploy (2026-05-20); see #1293 for the broader ACL-hardening epic.
 >
 > **What about `type=env`?** It does not avoid the restart requirement. Podman injects `type=env` secrets into the container's environment at start; SIGHUP does not re-exec the entrypoint and does not update `environ`, so the value is also baked in. `type=env` would trade `type=mount`'s init-bound tmpfs for an `environ`-baked value with the additional cost of secret content being visible to `podman inspect`. Both forms require container recreation for ACL changes; `type=mount` is preferred by the hardening invariants in [`deploy/CLAUDE.md`](../../deploy/CLAUDE.md#hardening-invariants).
 
 **3. Verify — no permission violations**
 
 ```bash
-journalctl --user -u lyra-nats --since "2 min ago" | grep -i "violation\|error\|warn"
+journalctl --user -u factory-nats --since "2 min ago" | grep -i "violation\|error\|warn"
 ```
 
 Expected: no output. Any `Permissions Violation` line means the new ACL does not match what a service is connecting with — see Rollback.
@@ -46,13 +46,13 @@ Expected: no output. Any `Permissions Violation` line means the new ACL does not
 **4. Verify each service reconnected**
 
 ```bash
-journalctl --user -u lyra-hub      --since "2 min ago" | grep -i "nats\|connected\|error"
-journalctl --user -u lyra-telegram --since "2 min ago" | grep -i "nats\|connected\|error"
-journalctl --user -u lyra-discord  --since "2 min ago" | grep -i "nats\|connected\|error"
-journalctl --user -u lyra-clipool  --since "2 min ago" | grep -i "nats\|connected\|error"
+journalctl --user -u factory-hub      --since "2 min ago" | grep -i "nats\|connected\|error"
+journalctl --user -u factory-telegram --since "2 min ago" | grep -i "nats\|connected\|error"
+journalctl --user -u factory-discord  --since "2 min ago" | grep -i "nats\|connected\|error"
+journalctl --user -u factory-clipool  --since "2 min ago" | grep -i "nats\|connected\|error"
 ```
 
-Services reconnect automatically after the NATS restart — no service restart required unless the ACL change added a new identity whose seed is newly generated (in which case restart that service only). Reconnect typically completes in under 2 seconds on the Podman bridge network once `lyra-nats` is back up; if a service has not reconnected within 10 s, treat it as a failure and proceed to Rollback.
+Services reconnect automatically after the NATS restart — no service restart required unless the ACL change added a new identity whose seed is newly generated (in which case restart that service only). Reconnect typically completes in under 2 seconds on the Podman bridge network once `factory-nats` is back up; if a service has not reconnected within 10 s, treat it as a failure and proceed to Rollback.
 
 **5. Smoke test**
 
@@ -90,7 +90,7 @@ scp <local-seed-path> $USER@<host>:<target_path>
 current `getpass.getuser()`. Example for the current matrix:
 
 ```bash
-scp ~/.lyra/nkeys/voice-client.seed $USER@roxabitower:~/.voicecli/nkeys/voice-client.seed
+scp ~/.roxabi/factory/nkeys/voice-client.seed $USER@roxabitower:~/.voicecli/nkeys/voice-client.seed
 ```
 
 Copy and run these lines after every `genkeys --regenerate` that touches external identities.
@@ -115,16 +115,16 @@ insufficient as a safeguard. Issue #1379 introduced the fail-loud guard — exit
 
 ## Rollback
 
-`factory-acl genkeys --regen-authconf` (`scripts/gen_nkeys.py`) backs up `auth.conf` to `~/.lyra/nkeys/auth.conf.bak.<timestamp>` before overwriting. To revert:
+`factory-acl genkeys --regen-authconf` (`scripts/gen_nkeys.py`) backs up `auth.conf` to `~/.roxabi/factory/nkeys/auth.conf.bak.<timestamp>` before overwriting. To revert:
 
 ```bash
 # Replace TIMESTAMP with the backup suffix printed by `make nats-regen-authconf` in step 2
-cp ~/.lyra/nkeys/auth.conf.bak.TIMESTAMP ~/.lyra/nkeys/auth.conf
+cp ~/.roxabi/factory/nkeys/auth.conf.bak.TIMESTAMP ~/.roxabi/factory/nkeys/auth.conf
 # Rollback uses the full `quadlet-secrets-install` (all 5 secrets) — broader
-# than the scoped forward path (`nats-regen-authconf` only touches lyra-nats-auth).
+# than the scoped forward path (`nats-regen-authconf` only touches factory-nats-auth).
 # Intentional: emergency rollback restores a known-good snapshot atomically.
 make quadlet-secrets-install
-systemctl --user restart lyra-nats
+systemctl --user restart factory-nats
 ```
 
 Then revert the `acl-matrix.json` change in git and investigate before re-applying.
@@ -139,10 +139,10 @@ After a hub-sole-provisioner ACL tightening (where stream/KV CREATE grants are
 removed from adapter identities and owned exclusively by the hub), the restart
 sequence is **order-sensitive**:
 
-1. Regenerate `auth.conf` + restart `lyra-nats` (step 2 above, `make nats-regen-authconf`).
-2. **Restart `lyra-hub` first** — so it re-provisions stream `LYRA_OUTBOUND_AUDIO`
+1. Regenerate `auth.conf` + restart `factory-nats` (step 2 above, `make nats-regen-authconf`).
+2. **Restart `factory-hub` first** — so it re-provisions stream `LYRA_OUTBOUND_AUDIO`
    and KV bucket `KV_lyra_outbound_audio_sent` before signalling `announce_hub_ready`.
-3. **Only then** restart `lyra-telegram` and `lyra-discord` — they call `wait_for_hub`
+3. **Only then** restart `factory-telegram` and `factory-discord` — they call `wait_for_hub`
    which blocks until the hub has finished provisioning, then bind (not create) stream+KV.
 
 Reversing steps 2–3 (adapters before hub) will cause adapters to hit `wait_for_hub`
@@ -152,7 +152,7 @@ With the new ACL (CREATE grants removed from adapters), any adapter that bypasse
 violation.
 
 **Caveat — auto-reconnect is NOT gated:** `wait_for_hub` only blocks at adapter
-**startup**, not on automatic NATS reconnect after a NATS server restart. If `lyra-nats`
+**startup**, not on automatic NATS reconnect after a NATS server restart. If `factory-nats`
 is restarted while the hub and adapters are already running, all three processes
 reconnect simultaneously. The hub will re-provision stream+KV on reconnect (ensure_stream
 and ensure_kv are idempotent), but adapters may attempt their reconnect sequence before

--- a/docs/ops/nats-identity-lifecycle.md
+++ b/docs/ops/nats-identity-lifecycle.md
@@ -28,7 +28,7 @@ If the identity participates in request-reply, add the corresponding entry to `r
 
 **2. Run `make nats-add-identity NAME=<name>`.**
 
-This single rootless verb chains: generate the new seed, re-render `auth.conf` preserving existing pubkeys, create the local Podman secret, and restart consuming services (`lyra-nats` and any active adapters). No `sudo` required.
+This single rootless verb chains: generate the new seed, re-render `auth.conf` preserving existing pubkeys, create the local Podman secret, and restart consuming services (`factory-nats` and any active adapters). No `sudo` required.
 
 ```bash
 make nats-add-identity NAME=new-worker
@@ -55,20 +55,20 @@ git commit -m "feat(nats): add <name> identity"
 
 ### Multi-host: running on M₁, M₂, Mₙ
 
-Seeds and `auth.conf` propagate across hosts via Syncthing on `~/.lyra/nkeys/`. The Podman secret store does **not** auto-propagate. Run `make nats-add-identity NAME=<name>` on every host that consumes that identity — the same verb, no host-specific procedure.
+Seeds and `auth.conf` propagate across hosts via Syncthing on `~/.roxabi/factory/nkeys/`. The Podman secret store does **not** auto-propagate. Run `make nats-add-identity NAME=<name>` on every host that consumes that identity — the same verb, no host-specific procedure.
 
 How the gate works:
 
-- factory-acl emits `STATE=noop|repaired|added` based on filesystem state (seed present in `~/.lyra/nkeys/` and identity block present in `auth.conf`).
-- The Makefile additionally checks `podman secret inspect lyra-nats-<NAME>`. Phase 2 (secret create + restart) runs when **either** factory-acl mutated the filesystem **or** the local Podman secret is missing.
+- factory-acl emits `STATE=noop|repaired|added` based on filesystem state (seed present in `~/.roxabi/factory/nkeys/` and identity block present in `auth.conf`).
+- The Makefile additionally checks `podman secret inspect factory-nats-<NAME>`. Phase 2 (secret create + restart) runs when **either** factory-acl mutated the filesystem **or** the local Podman secret is missing.
 
 Per-host behavior:
 
-- **Authoring host (e.g. M₁):** factory-acl emits `STATE=added`; Phase 2 runs locally — creates the seed secret and refreshes `lyra-nats-auth`, then restarts `lyra-nats` and adapters.
-- **Receiving host (e.g. M₂, after Syncthing delivered seed + auth.conf):** factory-acl emits `STATE=noop` (filesystem already consistent), but `podman secret inspect lyra-nats-<NAME>` returns non-zero (secret not yet in the local Podman store) → Phase 2 still runs to create the local secret and restart any local Lyra units.
+- **Authoring host (e.g. M₁):** factory-acl emits `STATE=added`; Phase 2 runs locally — creates the seed secret and refreshes `factory-nats-auth`, then restarts `factory-nats` and adapters.
+- **Receiving host (e.g. M₂, after Syncthing delivered seed + auth.conf):** factory-acl emits `STATE=noop` (filesystem already consistent), but `podman secret inspect factory-nats-<NAME>` returns non-zero (secret not yet in the local Podman store) → Phase 2 still runs to create the local secret and restart any local Lyra units.
 - **Non-consuming host:** factory-acl emits `STATE=noop` AND `podman secret inspect` succeeds → true no-op; Phase 2 is skipped entirely.
 
-The restart loop is `systemctl --user is-active`-gated over `{lyra-nats, lyra-hub, lyra-telegram, lyra-discord, lyra-clipool}` — nats first, then adapters in declared `After=` order. On a host with no Lyra units running, the loop is a complete no-op. The verb is safe to run on any host without knowledge of its topology.
+The restart loop is `systemctl --user is-active`-gated over `{factory-nats, factory-hub, factory-telegram, factory-discord, factory-clipool}` — nats first, then adapters in declared `After=` order. On a host with no Lyra units running, the loop is a complete no-op. The verb is safe to run on any host without knowledge of its topology.
 
 ---
 
@@ -76,7 +76,7 @@ The restart loop is `systemctl --user is-active`-gated over `{lyra-nats, lyra-hu
 
 **Scenario:** factory-acl already mutated the filesystem (new seed + new `auth.conf` written and `STATE=added` emitted), but a subsequent `podman secret create --replace` or `systemctl --user restart` call failed (e.g. transient daemon error, stale socket, permissions hiccup).
 
-**Recovery:** re-run `make nats-add-identity NAME=<name>`. On the second invocation, factory-acl finds the seed and auth.conf block already consistent and emits `STATE=noop`. The Makefile gate then checks `podman secret inspect lyra-nats-<NAME>` — if the secret is missing or stale, Phase 2 runs again. `--replace` makes the Podman call safe regardless of prior state.
+**Recovery:** re-run `make nats-add-identity NAME=<name>`. On the second invocation, factory-acl finds the seed and auth.conf block already consistent and emits `STATE=noop`. The Makefile gate then checks `podman secret inspect factory-nats-<NAME>` — if the secret is missing or stale, Phase 2 runs again. `--replace` makes the Podman call safe regardless of prior state.
 
 There is no double-rotation risk: factory-acl's `added` path only generates a seed when the seed file is absent. The existing seed file on disk is preserved on every subsequent invocation.
 
@@ -147,16 +147,16 @@ nats-server --signal reload
 Attempt to connect with the retired seed and confirm NATS returns an auth error. Any active services should be unaffected; check their logs for unexpected reconnect errors:
 
 ```bash
-journalctl --user -u lyra-hub --since "2 min ago" | grep -i "auth\|error\|nats"
-journalctl --user -u lyra-telegram --since "2 min ago" | grep -i "auth\|error\|nats"
+journalctl --user -u factory-hub --since "2 min ago" | grep -i "auth\|error\|nats"
+journalctl --user -u factory-telegram --since "2 min ago" | grep -i "auth\|error\|nats"
 ```
 
 **9. Seed file decision.**
 
-The seed file at `~/.lyra/nkeys/<name>.seed` remains on disk. NATS rejects the credential regardless once `auth.conf` is reloaded. Once you have confirmed the identity is fully offline and no rollback is needed, you may shred the file:
+The seed file at `~/.roxabi/factory/nkeys/<name>.seed` remains on disk. NATS rejects the credential regardless once `auth.conf` is reloaded. Once you have confirmed the identity is fully offline and no rollback is needed, you may shred the file:
 
 ```bash
-shred -u ~/.lyra/nkeys/<name>.seed
+shred -u ~/.roxabi/factory/nkeys/<name>.seed
 ```
 
 This is optional — the file is inert after step 7.

--- a/docs/ops/nkey-rotation.md
+++ b/docs/ops/nkey-rotation.md
@@ -13,18 +13,18 @@ Rotation replaces the seed file (private key material) for one or more identitie
 ## Identity → Systemd Unit Map
 
 > Production runs Podman Quadlet units (as of #611). The restart commands in Step 5 use
-> `systemctl --user` accordingly. NATS runs as `lyra-nats.service` (Quadlet container).
+> `systemctl --user` accordingly. NATS runs as `factory-nats.service` (Quadlet container).
 
 | Identity (seed file) | Systemd unit | Log command |
 |---|---|---|
-| `hub.seed` | `lyra-hub.service` | `journalctl --user -u lyra-hub` |
-| `telegram-adapter.seed` | `lyra-telegram.service` | `journalctl --user -u lyra-telegram` |
-| `discord-adapter.seed` | `lyra-discord.service` | `journalctl --user -u lyra-discord` |
-| `clipool-worker.seed` | `lyra-clipool.service` | `journalctl --user -u lyra-clipool` |
+| `hub.seed` | `factory-hub.service` | `journalctl --user -u factory-hub` |
+| `telegram-adapter.seed` | `factory-telegram.service` | `journalctl --user -u factory-telegram` |
+| `discord-adapter.seed` | `factory-discord.service` | `journalctl --user -u factory-discord` |
+| `clipool-worker.seed` | `factory-clipool.service` | `journalctl --user -u factory-clipool` |
 | `voice-tts.seed` | `voicecli-tts.service` (voiceCLI project) | `journalctl --user -u voicecli-tts` |
 | `voice-stt.seed` | `voicecli-stt.service` (voiceCLI project) | `journalctl --user -u voicecli-stt` |
 
-All seeds live in `~/.lyra/nkeys/` on Machine 1. The merged `auth.conf` is stored as Podman secret `lyra-nats-auth`.
+All seeds live in `~/.roxabi/factory/nkeys/` on Machine 1. The merged `auth.conf` is stored as Podman secret `factory-nats-auth`.
 
 ---
 
@@ -86,8 +86,8 @@ For each identity being rotated, back up its seed before deletion. Use a timesta
 
 IDENTITY=telegram-adapter
 TS=$(date +%Y%m%d-%H%M%S)
-cp ~/.lyra/nkeys/${IDENTITY}.seed ~/.lyra/nkeys/${IDENTITY}.seed.bak-${TS}
-chmod 0600 ~/.lyra/nkeys/${IDENTITY}.seed.bak-${TS}
+cp ~/.roxabi/factory/nkeys/${IDENTITY}.seed ~/.roxabi/factory/nkeys/${IDENTITY}.seed.bak-${TS}
+chmod 0600 ~/.roxabi/factory/nkeys/${IDENTITY}.seed.bak-${TS}
 ```
 
 The backup preserves the compromised material for forensic reference. It is never re-used to authenticate.
@@ -102,11 +102,11 @@ Delete the seed file for each compromised identity, then run `--regen-authconf`.
 # On Machine 1 — requires sudo.
 
 # 3.1 Delete the compromised seed(s).
-rm ~/.lyra/nkeys/${IDENTITY}.seed
+rm ~/.roxabi/factory/nkeys/${IDENTITY}.seed
 # Repeat rm for each additional compromised identity.
 
 # 3.2 Re-render auth.conf with the new public key(s).
-cd ~/projects/lyra
+cd ~/projects/roxabi-factory
 factory-acl genkeys --regen-authconf
 ```
 
@@ -115,7 +115,7 @@ Expected output includes:
 - `[+] Derived pubkey from existing seed: <identity>` for unchanged identities
 - `[+] Backed up auth.conf → /etc/nats/nkeys/auth.conf.bak.<timestamp>`
 - `[+] auth.conf re-rendered from 10 existing seeds.`
-- `[+] Next: sudo systemctl reload lyra-nats.service`
+- `[+] Next: sudo systemctl reload factory-nats.service`
 
 If `nats-server` is on PATH and `/etc/nats/nats.conf` exists, the script validates the new config via `nats-server -t` before writing. A validation failure restores the backup automatically.
 
@@ -128,7 +128,7 @@ If `nats-server` is on PATH and `/etc/nats/nats.conf` exists, the script validat
 make quadlet-secrets-install
 
 # Restart NATS container to pick up new secret
-systemctl --user restart lyra-nats.service
+systemctl --user restart factory-nats.service
 ```
 
 Record the restart timestamp — you will need it for the verification step:
@@ -146,7 +146,7 @@ The container restart evicts all existing connections. All clients will reconnec
 
 Restart affected units in this order: workers first, adapters second, hub last. Workers and adapters first — they are reconnect-tolerant (circuit breaker in roxabi-nats) and can queue at NATS while the hub is briefly down. Hub last — it is the sole consumer of inbound queues; restarting it last minimises the window where inbound messages could fill NATS queues with no consumer.
 
-Only restart units that use a rotated identity. If only `telegram-adapter` was rotated, restart only `lyra-telegram`. If `hub` was rotated, restart all units.
+Only restart units that use a rotated identity. If only `telegram-adapter` was rotated, restart only `factory-telegram`. If `hub` was rotated, restart all units.
 
 **5.1 voicecli workers** (if `voice-tts.seed` or `voice-stt.seed` was rotated — voiceCLI project):
 
@@ -165,14 +165,14 @@ systemctl --user restart imagecli-gen.service
 **5.3 Lyra adapters** (if any adapter seed was rotated):
 
 ```bash
-systemctl --user restart lyra-telegram.service
-systemctl --user restart lyra-discord.service
+systemctl --user restart factory-telegram.service
+systemctl --user restart factory-discord.service
 ```
 
 **5.4 Lyra hub** (if `hub.seed` was rotated):
 
 ```bash
-systemctl --user restart lyra-hub.service
+systemctl --user restart factory-hub.service
 ```
 
 After each restart, wait for the unit to reach `active (running)` state before restarting the next one:
@@ -194,7 +194,7 @@ Run `lyra ops verify` for a quick ACL matrix check (ADR-046 invariant 5) before 
 tools/check-nats-acls.sh --since "${RELOAD_TS}" --window 90 | tee ~/nkey-rotation-evidence.txt
 ```
 
-Expected output on success: `OK: no Permissions Violation in lyra-nats.service over 90s window`
+Expected output on success: `OK: no Permissions Violation in factory-nats.service over 90s window`
 
 If violations are detected, the script prints the offending lines and exits 1. Jump to **Rollback** immediately.
 
@@ -204,13 +204,13 @@ All container stdout/stderr goes to journald. Check with `journalctl --user`:
 
 ```bash
 # Hub
-journalctl --user -u lyra-hub --since "5 min ago" | grep -i "nats\|connected\|ready\|auth\|error"
+journalctl --user -u factory-hub --since "5 min ago" | grep -i "nats\|connected\|ready\|auth\|error"
 
 # Telegram adapter
-journalctl --user -u lyra-telegram --since "5 min ago" | grep -i "nats\|connected\|ready\|auth\|error"
+journalctl --user -u factory-telegram --since "5 min ago" | grep -i "nats\|connected\|ready\|auth\|error"
 
 # Discord adapter
-journalctl --user -u lyra-discord --since "5 min ago" | grep -i "nats\|connected\|ready\|auth\|error"
+journalctl --user -u factory-discord --since "5 min ago" | grep -i "nats\|connected\|ready\|auth\|error"
 
 # voicecli workers (if rotated)
 # Note: voicecli connects via tls://127.0.0.1:4222 — connection errors here may
@@ -233,7 +233,7 @@ Send a message through Telegram or Discord to the bot and confirm a response arr
 **6.5 Verify the new seed is in place and perms are correct:**
 
 ```bash
-ls -la ~/.lyra/nkeys/ | grep "${IDENTITY}"
+ls -la ~/.roxabi/factory/nkeys/ | grep "${IDENTITY}"
 # Should show 0600 permissions, owner mickael, no backup file as active seed.
 ```
 
@@ -248,7 +248,7 @@ Rollback restores the pre-rotation seed and auth.conf so the old credentials wor
 **7.1 Identify the backup files:**
 
 ```bash
-ls ~/.lyra/nkeys/*.bak-*
+ls ~/.roxabi/factory/nkeys/*.bak-*
 # Note the timestamp suffix from Step 2.
 
 ls /etc/nats/nkeys/auth.conf.bak.*
@@ -263,19 +263,19 @@ ls /etc/nats/nkeys/auth.conf.bak.*
 # Replace BAK_TS with the actual timestamp from your Step 2 output (format: YYYYMMDD-HHMMSS).
 BAK_TS=YYYYMMDD-HHMMSS  # ← replace with timestamp from Step 2 output
 
-cp ~/.lyra/nkeys/${IDENTITY}.seed.bak-${BAK_TS} ~/.lyra/nkeys/${IDENTITY}.seed
-chmod 0600 ~/.lyra/nkeys/${IDENTITY}.seed
+cp ~/.roxabi/factory/nkeys/${IDENTITY}.seed.bak-${BAK_TS} ~/.roxabi/factory/nkeys/${IDENTITY}.seed
+chmod 0600 ~/.roxabi/factory/nkeys/${IDENTITY}.seed
 ```
 
 **7.3 Restore auth.conf and restart NATS:**
 
 ```bash
 # Replace CONF_BAK with the actual backup filename from Step 3 output (format: YYYYMMDD-HHMMSS).
-CONF_BAK=~/.lyra/nkeys/auth.conf.bak.YYYYMMDD-HHMMSS  # ← replace with timestamp from Step 3 output
+CONF_BAK=~/.roxabi/factory/nkeys/auth.conf.bak.YYYYMMDD-HHMMSS  # ← replace with timestamp from Step 3 output
 
-cp "${CONF_BAK}" ~/.lyra/nkeys/auth.conf
+cp "${CONF_BAK}" ~/.roxabi/factory/nkeys/auth.conf
 make quadlet-secrets-install   # recreate Podman secret
-systemctl --user restart lyra-nats.service
+systemctl --user restart factory-nats.service
 ```
 
 **7.4 Reverse-order restart** (workers first, hub last — same order as Step 5).
@@ -287,12 +287,12 @@ systemctl --user restart voicecli-tts.service
 systemctl --user restart voicecli-stt.service
 systemctl --user status voicecli-tts.service voicecli-stt.service
 
-systemctl --user restart lyra-telegram.service
-systemctl --user restart lyra-discord.service
-systemctl --user status lyra-telegram.service lyra-discord.service
+systemctl --user restart factory-telegram.service
+systemctl --user restart factory-discord.service
+systemctl --user status factory-telegram.service factory-discord.service
 
-systemctl --user restart lyra-hub.service
-systemctl --user status lyra-hub.service
+systemctl --user restart factory-hub.service
+systemctl --user status factory-hub.service
 ```
 
 **7.5 Re-run verification** (Step 6) to confirm the rollback restored service. Then escalate: the rotation failed, the compromised seed is live again, and the compromise signal must be reassessed before the next attempt.
@@ -306,20 +306,20 @@ After verification passes (Step 6), dispose of the seed backup. Compromised key 
 **Option A — delete:**
 
 ```bash
-rm ~/.lyra/nkeys/${IDENTITY}.seed.bak-${TS}
+rm ~/.roxabi/factory/nkeys/${IDENTITY}.seed.bak-${TS}
 ```
 
 **Option B — move to forensics archive:**
 
 ```bash
-mkdir -p ~/.lyra/forensics
-mv ~/.lyra/nkeys/${IDENTITY}.seed.bak-${TS} ~/.lyra/forensics/
+mkdir -p ~/.roxabi/factory/forensics
+mv ~/.roxabi/factory/nkeys/${IDENTITY}.seed.bak-${TS} ~/.roxabi/factory/forensics/
 ```
 
-Use Option B if you need to preserve the seed for incident investigation. In either case, confirm no `.bak-*` file remains in `~/.lyra/nkeys/`:
+Use Option B if you need to preserve the seed for incident investigation. In either case, confirm no `.bak-*` file remains in `~/.roxabi/factory/nkeys/`:
 
 ```bash
-ls ~/.lyra/nkeys/*.bak-* 2>/dev/null && echo "WARNING: backup files still present"
+ls ~/.roxabi/factory/nkeys/*.bak-* 2>/dev/null && echo "WARNING: backup files still present"
 ```
 
 > **TODO:** consider automating backup cleanup via a retention hook in gen-nkeys.sh.
@@ -329,7 +329,7 @@ ls ~/.lyra/nkeys/*.bak-* 2>/dev/null && echo "WARNING: backup files still presen
 ## 9. Cross-References
 
 - [ADR-046](../architecture/adr/046-nkey-provisioning-declarative-authconf.mdx) — declarative provisioning invariants, `--regen-authconf` semantics, `lyra ops verify` (Invariant 5)
-- [#561](https://github.com/Roxabi/lyra/issues/561) — parent epic (NATS nkey provisioning)
-- [#714](https://github.com/Roxabi/lyra/issues/714) — per-role ACL rework
+- [#561](https://github.com/Roxabi/roxabi-factory/issues/561) — parent epic (NATS nkey provisioning)
+- [#714](https://github.com/Roxabi/roxabi-factory/issues/714) — per-role ACL rework
 - [`deploy/nats/gen-nkeys.sh`](../../deploy/nats/gen-nkeys.sh) — seed generation and auth.conf rendering
 - [`tools/check-nats-acls.sh`](../../tools/check-nats-acls.sh) — ACL violation detector used in Step 6.1

--- a/docs/ops/nkey-rotation.md
+++ b/docs/ops/nkey-rotation.md
@@ -68,7 +68,7 @@ If you prefer to inspect raw identity counts, the legacy manual equivalent is st
 sudo ./deploy/nats/gen-nkeys.sh --show
 # Verify seed count matches expected 10 identities.
 
-systemctl --user status 'lyra-*.service'
+systemctl --user status 'factory-*.service'
 # All units should be active (running) before you begin.
 ```
 
@@ -178,7 +178,7 @@ systemctl --user restart factory-hub.service
 After each restart, wait for the unit to reach `active (running)` state before restarting the next one:
 
 ```bash
-systemctl --user status 'lyra-*.service'
+systemctl --user status 'factory-*.service'
 # Confirm the restarted unit shows active (running) before continuing.
 ```
 
@@ -222,7 +222,7 @@ journalctl --user -u voicecli-stt --since "5 min ago" | grep -i "nats\|connected
 **6.3 Confirm unit states:**
 
 ```bash
-systemctl --user status 'lyra-*.service'
+systemctl --user status 'factory-*.service'
 ```
 
 All units should show `active (running)`. Any unit in `failed` state immediately after restart indicates an auth failure — see Rollback.

--- a/docs/standards/agents-plugins.md
+++ b/docs/standards/agents-plugins.md
@@ -21,16 +21,16 @@ An agent is a class that implements `AgentBase` (defined in `core/agent.py`) and
 
 ### Agent store
 
-Agent config is stored in SQLite (`~/.lyra/config.db`). TOML files are **seed sources only** — the runtime reads from the DB, not TOML.
+Agent config is stored in SQLite (`~/.roxabi/factory/config.db`). TOML files are **seed sources only** — the runtime reads from the DB, not TOML.
 
 ```
-~/.lyra/agents/<name>.toml   ← user overrides (gitignored, machine-specific)
-         ↓  lyra agent init [--force]
-~/.lyra/config.db            ← runtime source of truth
+~/.roxabi/factory/agents/<name>.toml   ← user overrides (gitignored, machine-specific)
+         ↓  factory agent init [--force]
+~/.roxabi/factory/config.db            ← runtime source of truth
 ```
 
 After editing any TOML file:
-1. `lyra agent init --force` — re-seed the DB.
+1. `factory agent init --force` — re-seed the DB.
 2. Restart the daemon.
 
 The DB is NOT updated automatically on file change. There is no file watcher.
@@ -62,7 +62,7 @@ enabled = ["echo", "search"]   # plugin names to enable for this agent
 voice = "Sohee"
 
 [workspaces]
-lyra = "~/projects/lyra"       # /workspace lyra → switches cwd
+lyra = "~/projects/roxabi-factory"       # /workspace lyra → switches cwd
 ```
 
 **`cwd` does NOT go in agent TOML** — it is machine-specific and belongs in `config.toml [defaults]`.
@@ -74,7 +74,7 @@ lyra = "~/projects/lyra"       # /workspace lyra → switches cwd
 ### Agent lifecycle
 
 ```
-1. Startup:  AgentStore.connect() → lyra agent init → DB seeded
+1. Startup:  AgentStore.connect() → factory agent init → DB seeded
 2. Register: hub.register_agent(agent)
 3. Message:  PoolManager.get_or_create_pool() → pool.submit(msg)
              → agent.handle(msg, pool)
@@ -85,14 +85,14 @@ lyra = "~/projects/lyra"       # /workspace lyra → switches cwd
 ### CLI commands
 
 ```bash
-lyra agent list                     # list all agents in DB
-lyra agent show <name>              # show agent config
-lyra agent init                     # seed DB from TOML files (idempotent)
-lyra agent init --force             # overwrite existing DB entries
-lyra agent edit <name>              # open TOML in $EDITOR
-lyra agent create                   # interactive wizard
-lyra agent delete <name>            # remove from DB
-lyra agent assign <name> --bot telegram:main  # assign to bot
+factory agent list                     # list all agents in DB
+factory agent show <name>              # show agent config
+factory agent init                     # seed DB from TOML files (idempotent)
+factory agent init --force             # overwrite existing DB entries
+factory agent edit <name>              # open TOML in $EDITOR
+factory agent create                   # interactive wizard
+factory agent delete <name>            # remove from DB
+factory agent assign <name> --bot telegram:main  # assign to bot
 ```
 
 ---
@@ -214,7 +214,7 @@ A plugin not listed in `enabled` is discovered but not registered for that agent
 
 ALWAYS return `Response(content=...)` from command handlers — never `None`, never raise.
 
-ALWAYS run `lyra agent init --force` after editing a TOML file, then restart the daemon.
+ALWAYS run `factory agent init --force` after editing a TOML file, then restart the daemon.
 
 ALWAYS set `[agent.smart_routing] enabled = false` — the validator rejects `true`.
 

--- a/docs/standards/backend-patterns.md
+++ b/docs/standards/backend-patterns.md
@@ -231,12 +231,12 @@ Do NOT create plugin names that conflict with built-ins: `help`, `stop`, `circui
 
 ```
 Exception
-├── LyraUserError               # base for all user-visible errors (lyra.core.errors)
+├── LyraUserError               # base for all user-visible errors (factory.core.errors)
 │   ├── AudioDownloadError
 │   ├── AudioTooLargeError
 │   ├── AudioInvalidFormatError
 │   └── SttError
-├── ProviderError               # LLM driver errors (src/lyra/errors.py)
+├── ProviderError               # LLM driver errors (src/factory/errors.py)
 │   ├── ProviderAuthError       # retryable=False
 │   ├── ProviderRateLimitError  # retryable=True
 │   └── ProviderApiError        # retryable=False by default

--- a/docs/standards/renderer-roundtrip.md
+++ b/docs/standards/renderer-roundtrip.md
@@ -102,7 +102,7 @@ Error messages must name the violation, the location, and the observed value. Ex
 ```
 nkey expected length 56, got 62 at user 'hub'
 cert chain: leaf.crt does not verify against ca.crt (openssl exit 2)
-volume line contains '#': 'Volume=/data/lyra#backup:/backup' in lyra-hub.container
+volume line contains '#': 'Volume=/data/lyra#backup:/backup' in factory-hub.container
 ```
 
 Bad: `Error: validation failed` — this is not actionable. The developer must be able to fix the issue without re-running locally.

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -19,7 +19,7 @@ This document is the developer-facing companion to `docs/architecture/testing-co
 uv run pytest                          # full suite
 uv run pytest tests/test_config.py     # single file
 uv run pytest -k "TestResolveValue"    # by class/function name
-uv run pytest --cov=src/lyra tests/   # with coverage
+uv run pytest --cov=src/factory tests/   # with coverage
 ```
 
 ---
@@ -73,7 +73,7 @@ When a tool or static file in `deploy/` is consumed by an external binary (nats-
 ## Coverage Rules
 
 ```bash
-uv run pytest --cov=src/lyra tests/    # must show > 0% on the module under test
+uv run pytest --cov=src/factory tests/    # must show > 0% on the module under test
 ```
 
 If coverage shows 0% on a module you intended to test, you are patching the wrong import site. Patch at the import site of the **dependency**, never the module under test.
@@ -83,7 +83,7 @@ If coverage shows 0% on a module you intended to test, you are patching the wron
 monkeypatch.setattr(stores_mod, "AuthStore", lambda **kw: fake_auth_store)
 
 # Wrong: patch the source module
-monkeypatch.setattr("lyra.infrastructure.stores.auth_store.AuthStore", ...)  # may silently miss
+monkeypatch.setattr("factory.infrastructure.stores.auth_store.AuthStore", ...)  # may silently miss
 ```
 
 ---
@@ -97,7 +97,7 @@ monkeypatch.setattr("lyra.infrastructure.stores.auth_store.AuthStore", ...)  # m
 ```
 tests/
   conftest.py                          # shared fixtures (fixtures only, no tests)
-  test_config.py                       # tests for src/lyra/config.py
+  test_config.py                       # tests for src/factory/config.py
   test_monitoring_checks_primitives.py # tests for monitoring/checks.py primitives
 ```
 
@@ -152,10 +152,10 @@ fake_keyring, fake_cred_store = make_fake_stores(monkeypatch)
 
 Use `_patch_nats_stubs(monkeypatch)` (from `conftest.py`) to prevent tests from touching a real NATS server. It patches `ensure_nats`, `acquire_lockfile`, `release_lockfile`, `NatsBus`, and `JetStreamAuditSink`.
 
-Always set `LYRA_VAULT_DIR` to a temp dir in tests that touch the credential store:
+Always set `FACTORY_VAULT_DIR` to a temp dir in tests that touch the credential store:
 
 ```python
-monkeypatch.setenv("LYRA_VAULT_DIR", tempfile.mkdtemp())
+monkeypatch.setenv("FACTORY_VAULT_DIR", tempfile.mkdtemp())
 ```
 
 ---
@@ -193,7 +193,7 @@ ALWAYS patch at the dependency's import site, not the source module.
 
 ALWAYS use `yield_once()` or `_drain()` instead of `asyncio.sleep(0)` in async tests.
 
-ALWAYS set `LYRA_VAULT_DIR` to a temp dir in tests that instantiate credential stores.
+ALWAYS set `FACTORY_VAULT_DIR` to a temp dir in tests that instantiate credential stores.
 
 NEVER mock the module under test — only mock its dependencies.
 
@@ -205,4 +205,4 @@ PREFER integration tests (real modules wired) over unit tests with heavy mocks.
 
 PREFER `pytest.raises(ExceptionType, match="expected message")` over bare `pytest.raises(ExceptionType)`.
 
-Run: `uv run pytest --cov=src/lyra tests/` — 0% coverage on the target module means wrong patch site.
+Run: `uv run pytest --cov=src/factory tests/` — 0% coverage on the target module means wrong patch site.

--- a/packages/roxabi-blobs/CLAUDE.md
+++ b/packages/roxabi-blobs/CLAUDE.md
@@ -14,7 +14,7 @@
 ```toml
 [tool.uv.sources]
 roxabi-blobs = {
-  git = "https://github.com/Roxabi/lyra.git",
+  git = "https://github.com/Roxabi/roxabi-factory.git",
   subdirectory = "packages/roxabi-blobs",
   tag = "roxabi-blobs/vX.Y.Z"
 }

--- a/packages/roxabi-blobs/README.md
+++ b/packages/roxabi-blobs/README.md
@@ -11,7 +11,7 @@ Implements [ADR-067](../../docs/architecture/adr/067-blobstore-abstraction-flat-
 ```python
 from roxabi_blobs import BlobStore, BlobRef, BlobNotFoundError, BlobWriteError
 
-async with FsBlobStore(root=Path("/data/lyra/blobs")) as store:
+async with FsBlobStore(root=Path("/data/factory/blobs")) as store:
     ref = await store.put(data, mime="audio/ogg", source="telegram")
     bytes_back = await store.get(ref.store_key)
     found = await store.exists(ref.content_hash)

--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -7,7 +7,7 @@ Shared Pydantic schemas for Lyra cross-project NATS contracts. Per-domain submod
 ```toml
 [tool.uv.sources]
 roxabi-contracts = {
-  git = "https://github.com/Roxabi/lyra.git",
+  git = "https://github.com/Roxabi/roxabi-factory.git",
   subdirectory = "packages/roxabi-contracts",
   tag = "roxabi-contracts/v0.1.0"
 }
@@ -22,7 +22,7 @@ Satellites pin `roxabi-contracts` (and `roxabi-nats`) by git tag. Without an aut
 {
   "packageRules": [{
     "matchDatasources": ["git-refs"],
-    "matchSourceUrls": ["https://github.com/Roxabi/lyra"],
+    "matchSourceUrls": ["https://github.com/Roxabi/roxabi-factory"],
     "matchPackageNames": ["roxabi-nats", "roxabi-contracts"],
     "groupName": "roxabi sdk",
     "schedule": ["before 6am on monday"]
@@ -161,7 +161,7 @@ Three non-bypassable guards prevent production contamination
    bare `roxabi-contracts` install (no `[testing]` extra) fails with
    `ModuleNotFoundError: No module named 'nats'` before any runtime code runs.
 2. **Environment assertion.** `__init__` raises `RuntimeError` when
-   `LYRA_ENV=production`. No override flag.
+   `FACTORY_ENV=production`. No override flag.
 3. **Loopback-only URL.** `start()` raises `ValueError` on any non-loopback
    NATS URL (`127.0.0.1`, `localhost`, `::1`, `0:0:0:0:0:0:0:1` are the only
    accepted hosts). No override.

--- a/packages/roxabi-nats/CLAUDE.md
+++ b/packages/roxabi-nats/CLAUDE.md
@@ -16,7 +16,7 @@ with the wire contract (ADR-044 (absorbed into ADR-049)/049) but is versioned in
 ```toml
 [tool.uv.sources]
 roxabi-nats = {
-  git = "https://github.com/Roxabi/lyra.git",
+  git = "https://github.com/Roxabi/roxabi-factory.git",
   subdirectory = "packages/roxabi-nats",
   tag = "roxabi-nats/vX.Y.Z"
 }

--- a/packages/roxabi-nats/README.md
+++ b/packages/roxabi-nats/README.md
@@ -7,7 +7,7 @@
 ```toml
 [tool.uv.sources]
 roxabi-nats = {
-  git = "https://github.com/Roxabi/lyra.git",
+  git = "https://github.com/Roxabi/roxabi-factory.git",
   subdirectory = "packages/roxabi-nats",
   tag = "roxabi-nats/v0.1.0"
 }

--- a/plugins/lyra-ops/CLAUDE.md
+++ b/plugins/lyra-ops/CLAUDE.md
@@ -13,12 +13,12 @@ Claude Code plugin via `roxabi-plugins` (or loaded locally from this path).
 
 - All production access goes through `make remote <unit> <action>` or explicit
   `ssh $H "..."` calls — never direct Python imports or lyra source references.
-- `$H` := `DEPLOY_HOST` read from `~/projects/lyra/.env` on the local machine.
+- `$H` := `DEPLOY_HOST` read from `~/projects/roxabi-factory/.env` on the local machine.
 - Production runtime: Podman Quadlet (rootless systemd --user units).
 - Health endpoint: `http://localhost:8443/health/detail` (loopback on `$H`,
-  bearer token from `~/.lyra/secrets/health_secret`).
+  bearer token from `~/.roxabi/factory/secrets/health_secret`).
 - Logs: `journalctl --user -u <unit>` on `$H`. In-container files via
-  `podman exec lyra-hub`.
+  `podman exec factory-hub`.
 
 ## Isolation rules
 

--- a/plugins/lyra-ops/skills/lyra-debug/SKILL.md
+++ b/plugins/lyra-ops/skills/lyra-debug/SKILL.md
@@ -8,13 +8,13 @@ allowed-tools: Bash, Read, Glob, Grep
 # Lyra Debug
 
 Diagnose Lyra issues on production (roxabituwer). Runs from the **local** machine
-(`~/projects/lyra`) — all production access is via `make remote` and SSH.
+(`~/projects/roxabi-factory`) — all production access is via `make remote` and SSH.
 
 Production runs **Podman Quadlet** (rootless, systemd --user units).
 
 Let:
-  H      := DEPLOY_HOST (from `~/projects/lyra/.env`)
-  units  := {lyra-hub, lyra-telegram, lyra-discord, lyra-nats}
+  H      := DEPLOY_HOST (from `~/projects/roxabi-factory/.env`)
+  units  := {factory-hub, factory-telegram, factory-discord, factory-nats}
   Σ      := severity (🔴 down | 🟡 degraded | 🟢 healthy)
   pat    := known error patterns (see §Known Patterns)
 
@@ -23,27 +23,27 @@ Let:
 | Pattern | Root Cause | Fix |
 |---------|-----------|-----|
 | `OperationalError: database is locked` | Hub + adapter race on same SQLite DB at startup | Stagger restarts or add busy_timeout |
-| `suspiciously fast.*dead backend` | Claude CLI pool not responding | Restart lyra-hub |
-| `backend is dead — skipping guard` | Stale session with dead CLI process | Restart lyra-hub |
-| `dead_backend_hits > 0` in /health/detail | Backend silently failing (fast empty returns) | Restart lyra-hub (counter resets on restart) |
+| `suspiciously fast.*dead backend` | Claude CLI pool not responding | Restart factory-hub |
+| `backend is dead — skipping guard` | Stale session with dead CLI process | Restart factory-hub |
+| `dead_backend_hits > 0` in /health/detail | Backend silently failing (fast empty returns) | Restart factory-hub (counter resets on restart) |
 | `start-limit-hit` / unit in `failed` | systemd gave up after 5 restarts in 60s | Inspect journal, fix root cause, `systemctl --user reset-failed` |
 | `CancelledError` in starlette | Normal shutdown noise — not a root cause | Ignore unless paired with other errors |
 | `Rate limit` / `429` | Anthropic API rate limit | Wait or check API key quota |
-| `NATS.*connection` / `no servers available` | Hub ↔ adapter NATS transport broken or lyra-nats.service down | Restart `lyra-nats` first, then `lyra-hub`, then adapters |
-| `IsADirectoryError.*config.toml` | Quadlet bind-mount downgrade (see commit c9187fb) | Ensure inline `Volume=%h/.lyra/config.toml:/app/config.toml:ro,z` |
+| `NATS.*connection` / `no servers available` | Hub ↔ adapter NATS transport broken or factory-nats.service down | Restart `factory-nats` first, then `factory-hub`, then adapters |
+| `IsADirectoryError.*config.toml` | Quadlet bind-mount downgrade (see commit c9187fb) | Ensure inline `Volume=%h/.roxabi/factory/config.toml:/app/config.toml:ro,z` |
 | `permission denied.*\.lyra` | UserNS mapping mismatch (ADR-054) | Verify `UserNS=keep-id:uid=1500,gid=1500` in container unit |
 
 ## Phase 1 — Status
 
 ```bash
-cd ~/projects/lyra && make remote status
+cd ~/projects/roxabi-factory && make remote status
 ```
 
 Also inspect containers + nats directly:
 
 ```bash
 ssh $H "podman ps -a --format '{{.Names}}\t{{.Status}}\t{{.Image}}' | grep -E 'lyra-|nats'"
-ssh $H "systemctl --user status lyra-hub lyra-telegram lyra-discord lyra-nats --no-pager"
+ssh $H "systemctl --user status factory-hub factory-telegram factory-discord factory-nats --no-pager"
 ```
 
 ∀ unit ∈ units: record state (active/running + uptime | failed | inactive).
@@ -51,10 +51,10 @@ All active → Σ := 🟢; ∃ failed → Σ := 🔴; else 🟡.
 
 ## Phase 2 — Health Endpoint
 
-Health is published on host loopback at `127.0.0.1:8443` (see `deploy/quadlet/lyra-hub.container` `PublishPort`):
+Health is published on host loopback at `127.0.0.1:8443` (see `deploy/quadlet/factory-hub.container` `PublishPort`):
 
 ```bash
-ssh $H "curl -s -H 'Authorization: Bearer $(cat ~/.lyra/secrets/health_secret)' http://localhost:8443/health/detail"
+ssh $H "curl -s -H 'Authorization: Bearer $(cat ~/.roxabi/factory/secrets/health_secret)' http://localhost:8443/health/detail"
 ```
 
 Parse JSON. Key fields:
@@ -65,7 +65,7 @@ Parse JSON. Key fields:
 - `reaper_last_sweep_age` > 120 → 🟡 reaper stalled
 
 If curl fails: hub container is either not running, crash-looping before bind,
-or `LYRA_HEALTH_HOST` wasn't set to `0.0.0.0` inside the container (see commits c3e3d03/b2fc3bc).
+or `FACTORY_HEALTH_HOST` wasn't set to `0.0.0.0` inside the container (see commits c3e3d03/b2fc3bc).
 
 ## Phase 3 — Logs
 
@@ -73,11 +73,11 @@ Quadlet logs go to the user journal (stdout/stderr captured by systemd).
 Pull last 200 lines per unit — run in parallel:
 
 ```bash
-ssh $H "journalctl --user -u lyra-hub -n 200 --no-pager"
-ssh $H "journalctl --user -u lyra-hub -n 200 -p err --no-pager"
-ssh $H "journalctl --user -u lyra-telegram -n 200 --no-pager"
-ssh $H "journalctl --user -u lyra-discord -n 200 --no-pager"
-ssh $H "journalctl --user -u lyra-nats -n 100 --no-pager"
+ssh $H "journalctl --user -u factory-hub -n 200 --no-pager"
+ssh $H "journalctl --user -u factory-hub -n 200 -p err --no-pager"
+ssh $H "journalctl --user -u factory-telegram -n 200 --no-pager"
+ssh $H "journalctl --user -u factory-discord -n 200 --no-pager"
+ssh $H "journalctl --user -u factory-nats -n 100 --no-pager"
 ```
 
 Equivalent via Makefile (foreground tail): `make remote hub logs` / `telegram logs` / `discord logs` / `hub errors`.
@@ -85,8 +85,8 @@ Equivalent via Makefile (foreground tail): `make remote hub logs` / `telegram lo
 In-container structured logs (if the hub writes files to the logs volume):
 
 ```bash
-ssh $H "podman exec lyra-hub ls -t /home/factory/.local/state/lyra/logs/ | head -10"
-ssh $H "podman exec lyra-hub tail -200 /home/factory/.local/state/lyra/logs/<file>"
+ssh $H "podman exec factory-hub ls -t /home/factory/.local/state/lyra/logs/ | head -10"
+ssh $H "podman exec factory-hub tail -200 /home/factory/.local/state/lyra/logs/<file>"
 ```
 
 ## Phase 4 — Diagnosis
@@ -130,9 +130,9 @@ Present fix options via DP(A) (load `${CLAUDE_PLUGIN_ROOT}/../shared/references/
 | Restart hub only | `make remote hub reload` | Dead backend, stale CLI pool |
 | Restart all Lyra | `make remote lyra reload` | DB locked, NATS broken |
 | Restart specific adapter | `make remote discord reload` / `make remote telegram reload` | Single adapter failed |
-| Restart NATS | `ssh $H "systemctl --user restart lyra-nats"` | NATS connection errors |
-| Clear failed state | `ssh $H "systemctl --user reset-failed lyra-hub"` | Unit stuck in `failed` after start-limit-hit |
-| Check DB locks | `ssh $H "podman exec lyra-hub fuser /home/factory/.lyra/*.db"` | Persistent DB locked errors |
+| Restart NATS | `ssh $H "systemctl --user restart factory-nats"` | NATS connection errors |
+| Clear failed state | `ssh $H "systemctl --user reset-failed factory-hub"` | Unit stuck in `failed` after start-limit-hit |
+| Check DB locks | `ssh $H "podman exec factory-hub fuser /home/factory/.roxabi/factory/*.db"` | Persistent DB locked errors |
 | Reinstall Quadlet units | `make quadlet-install` then `ssh $H "systemctl --user daemon-reload"` | Unit file drift |
 | Full deploy | `make deploy` | Code fix needed on production |
 | Rebuild + push image | `make build && make push && make remote lyra reload` | Image-level fix needed |
@@ -147,7 +147,7 @@ flag it as recurring and suggest a code-level fix:
 
 - DB locking → add `busy_timeout` pragma or serialize startup
 - Dead backend → CLI pool health-check + auto-restart
-- Crash loops → check recent deploys (`ssh $H "cd $DEPLOY_DIR && git log --oneline -5"`) and last image (`ssh $H "podman images localhost/lyra --format '{{.Created}}\t{{.ID}}'"`)
+- Crash loops → check recent deploys (`ssh $H "cd $DEPLOY_DIR && git log --oneline -5"`) and last image (`ssh $H "podman images localhost/factory --format '{{.Created}}\t{{.ID}}'"`)
 - start-limit-hit → tune `StartLimitIntervalSec` / `StartLimitBurst` in the .container unit, or fix the underlying crash
 
 $ARGUMENTS

--- a/plugins/lyra-send/CLAUDE.md
+++ b/plugins/lyra-send/CLAUDE.md
@@ -19,12 +19,12 @@ locally and makes HTTP calls inline.
 
 ## Auth / identity model
 
-Tokens are stored encrypted in `~/.lyra/config.db` (`bot_secrets` table), encrypted
-with a Fernet key at `~/.lyra/keyring.key`. The skill decrypts at call time, holds the
+Tokens are stored encrypted in `~/.roxabi/factory/config.db` (`bot_secrets` table), encrypted
+with a Fernet key at `~/.roxabi/factory/keyring.key`. The skill decrypts at call time, holds the
 token in a local variable only, and never prints or persists it. Populated by
-`lyra bot secret install` (creates Podman secret) and read by the skill from `config.db`.
+`factory bot secret install` (creates Podman secret) and read by the skill from `config.db`.
 
-Target identity (who to send to) is resolved from `~/.lyra/turns.db` — the plugin
+Target identity (who to send to) is resolved from `~/.roxabi/factory/turns.db` — the plugin
 queries recent turns to surface known `chat_id` (Telegram) or `channel_id`/`thread_id`
 (Discord), then asks the user to confirm if ambiguous.
 
@@ -39,7 +39,7 @@ queries recent turns to surface known `chat_id` (Telegram) or `channel_id`/`thre
 
 - Telegram: bot cannot initiate with a user who has never messaged it first.
 - Discord: bot must have `Send Messages` permission in the target channel.
-- Both: `lyra bot secret install` must have run to populate `bot_secrets`.
+- Both: `factory bot secret install` must have run to populate `bot_secrets`.
 
 ## Skill entry point
 
@@ -48,8 +48,8 @@ resolve args → find target ID → send → confirm.
 
 ## Lyra cross-references
 
-- `~/.lyra/turns.db` — turn history (target ID discovery)
-- `~/.lyra/config.db` — bot secrets
-- `~/.lyra/keyring.key` — encryption key
+- `~/.roxabi/factory/turns.db` — turn history (target ID discovery)
+- `~/.roxabi/factory/config.db` — bot secrets
+- `~/.roxabi/factory/keyring.key` — encryption key
 - Lyra adapters (`src/factory/adapters/`) own the inbound side; this plugin owns
   the proactive outbound side independently.

--- a/plugins/lyra-send/skills/send/SKILL.md
+++ b/plugins/lyra-send/skills/send/SKILL.md
@@ -52,8 +52,8 @@ python3 - <<'EOF'
 from pathlib import Path
 import sqlite3, json
 
-lyra_dir = Path.home() / '.lyra'
-conn = sqlite3.connect(lyra_dir / 'turns.db')
+factory_dir = Path.home() / '.lyra'
+conn = sqlite3.connect(factory_dir / 'turns.db')
 # Show recent unique telegram chat IDs with last message preview
 rows = conn.execute("""
     SELECT platform_meta, content, created_at
@@ -81,8 +81,8 @@ python3 - <<'EOF'
 from pathlib import Path
 import sqlite3, json
 
-lyra_dir = Path.home() / '.lyra'
-conn = sqlite3.connect(lyra_dir / 'turns.db')
+factory_dir = Path.home() / '.lyra'
+conn = sqlite3.connect(factory_dir / 'turns.db')
 rows = conn.execute("""
     SELECT platform_meta, content, created_at
     FROM turns
@@ -121,10 +121,10 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-lyra_dir = Path.home() / '.lyra'
-key = (lyra_dir / 'keyring.key').read_bytes()
+factory_dir = Path.home() / '.lyra'
+key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
-conn = sqlite3.connect(lyra_dir / 'config.db')
+conn = sqlite3.connect(factory_dir / 'config.db')
 row = conn.execute(
     'SELECT token FROM bot_secrets WHERE bot_id=? AND platform=?',
     ('lyra', 'telegram')
@@ -150,10 +150,10 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-lyra_dir = Path.home() / '.lyra'
-key = (lyra_dir / 'keyring.key').read_bytes()
+factory_dir = Path.home() / '.lyra'
+key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
-conn = sqlite3.connect(lyra_dir / 'config.db')
+conn = sqlite3.connect(factory_dir / 'config.db')
 row = conn.execute(
     'SELECT token FROM bot_secrets WHERE bot_id=? AND platform=?',
     ('lyra', 'telegram')
@@ -181,10 +181,10 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-lyra_dir = Path.home() / '.lyra'
-key = (lyra_dir / 'keyring.key').read_bytes()
+factory_dir = Path.home() / '.lyra'
+key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
-conn = sqlite3.connect(lyra_dir / 'config.db')
+conn = sqlite3.connect(factory_dir / 'config.db')
 row = conn.execute(
     'SELECT token FROM bot_secrets WHERE bot_id=? AND platform=?',
     ('lyra', 'telegram')
@@ -210,10 +210,10 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-lyra_dir = Path.home() / '.lyra'
-key = (lyra_dir / 'keyring.key').read_bytes()
+factory_dir = Path.home() / '.lyra'
+key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
-conn = sqlite3.connect(lyra_dir / 'config.db')
+conn = sqlite3.connect(factory_dir / 'config.db')
 row = conn.execute(
     'SELECT token FROM bot_secrets WHERE bot_id=? AND platform=?',
     ('lyra', 'telegram')
@@ -241,10 +241,10 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-lyra_dir = Path.home() / '.lyra'
-key = (lyra_dir / 'keyring.key').read_bytes()
+factory_dir = Path.home() / '.lyra'
+key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
-conn = sqlite3.connect(lyra_dir / 'config.db')
+conn = sqlite3.connect(factory_dir / 'config.db')
 row = conn.execute(
     'SELECT token FROM bot_secrets WHERE bot_id=? AND platform=?',
     ('lyra', 'discord')
@@ -271,10 +271,10 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-lyra_dir = Path.home() / '.lyra'
-key = (lyra_dir / 'keyring.key').read_bytes()
+factory_dir = Path.home() / '.lyra'
+key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
-conn = sqlite3.connect(lyra_dir / 'config.db')
+conn = sqlite3.connect(factory_dir / 'config.db')
 row = conn.execute(
     'SELECT token FROM bot_secrets WHERE bot_id=? AND platform=?',
     ('lyra', 'discord')
@@ -296,13 +296,13 @@ EOF
 ```
 
 If output starts with `ERROR` → stop and tell the user: "No Lyra bot token found for
-`{platform}`. Make sure `lyra agent init` has been run."
+`{platform}`. Make sure `factory agent init` has been run."
 
 ## Step 4 — Confirm
 
 If `ok: True` (Telegram) or status 200 (Discord) → "✅ Sent successfully."
 Otherwise → show the error message and suggest checking:
-- Token validity (`lyra agent init --force`)
+- Token validity (`factory agent init --force`)
 - That the bot has previously spoken with this user/channel (Telegram bots can't
   initiate conversations with users who have never messaged them first)
 - Discord: that the bot has permission to post in the target channel

--- a/plugins/refine-agent/CLAUDE.md
+++ b/plugins/refine-agent/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 Conversational CLI plugin for refining a Lyra agent profile (persona, voice,
-passthroughs, model). Wraps `lyra agent refine` — do NOT touch lyra source code,
-`~/.lyra/auth.db` directly, or any file outside this plugin directory.
+passthroughs, model). Wraps `factory agent refine` — do NOT touch lyra source code,
+`~/.roxabi/factory/auth.db` directly, or any file outside this plugin directory.
 
 ## Skill
 
@@ -14,14 +14,14 @@ Trigger: `/refine-agent [agent-name]`
 
 ## Storage contract
 
-Agents live in `~/.lyra/config.db` (SQLite). TOML files are seed-only:
+Agents live in `~/.roxabi/factory/config.db` (SQLite). TOML files are seed-only:
 
 | Source | Role |
 |--------|------|
 | `src/factory/agents/<name>.toml` | bundled system defaults |
-| `~/.lyra/agents/<name>.toml` | user-level override (machine-specific, gitignored) |
+| `~/.roxabi/factory/agents/<name>.toml` | user-level override (machine-specific, gitignored) |
 
-Reads use `lyra agent show`. Writes use `lyra agent patch` → DB only.
+Reads use `factory agent show`. Writes use `factory agent patch` → DB only.
 No TOML file is written by this plugin.
 
 → `docs/agent-management.md` — full CLI reference + DB schema
@@ -30,9 +30,9 @@ No TOML file is written by this plugin.
 
 | Command | Mode | Use when |
 |---------|------|----------|
-| `lyra agent refine` | conversational (this plugin) | exploring or uncertain about target value |
-| `lyra agent edit` | interactive field editor | direct field mutation, value known |
-| `lyra agent patch --json` | non-interactive JSON merge | scripted or single-field update |
+| `factory agent refine` | conversational (this plugin) | exploring or uncertain about target value |
+| `factory agent edit` | interactive field editor | direct field mutation, value known |
+| `factory agent patch --json` | non-interactive JSON merge | scripted or single-field update |
 
 ## Refinable fields
 
@@ -56,8 +56,8 @@ No TOML file is written by this plugin.
   → lyra adapter restart          # operator step; ¬done by plugin
 ```
 
-Override TOML (`~/.lyra/agents/<name>.toml`) takes precedence on next
-`lyra agent init --force` — patch DB directly to avoid init reverting changes.
+Override TOML (`~/.roxabi/factory/agents/<name>.toml`) takes precedence on next
+`factory agent init --force` — patch DB directly to avoid init reverting changes.
 
 ## Boundaries
 

--- a/plugins/refine-agent/skills/refine-agent/SKILL.md
+++ b/plugins/refine-agent/skills/refine-agent/SKILL.md
@@ -11,12 +11,12 @@ allowed-tools: Bash, Read, Glob
 
 Let:
 - α = agent name (from $ARGUMENTS or user input)
-- σ = current agent state (from `lyra agent show`)
+- σ = current agent state (from `factory agent show`)
 - Σ = confirmed changes dict { field → new_value }
 - N = iteration count in refinement loop
 
 Interactively refine a Lyra agent's profile. Reads current config, proposes targeted
-changes, and applies them via `lyra agent patch`.
+changes, and applies them via `factory agent patch`.
 
 ## Entry
 
@@ -31,7 +31,7 @@ changes, and applies them via `lyra agent patch`.
 ¬∃ $ARGUMENTS ⇒ run:
 
 ```bash
-lyra agent list
+factory agent list
 ```
 
 Ask user via DP(A): "Which agent would you like to refine?" with agent names as
@@ -40,10 +40,10 @@ Ask user via DP(A): "Which agent would you like to refine?" with agent names as
 Verify α exists:
 
 ```bash
-lyra agent show {α}
+factory agent show {α}
 ```
 
-¬∃ α in output ⇒ "Agent '{α}' not found. Run `lyra agent list` to see available agents."
+¬∃ α in output ⇒ "Agent '{α}' not found. Run `factory agent list` to see available agents."
 Stop.
 
 ## Step 2 — Read Profile
@@ -51,13 +51,13 @@ Stop.
 Capture full agent config as σ:
 
 ```bash
-lyra agent show {α}
+factory agent show {α}
 ```
 
 Also read system TOML if present (for context, not authoritative):
 
 ```bash
-cat ~/projects/lyra/src/factory/agents/{α}.toml 2>/dev/null || echo "(no TOML — DB-only agent)"
+cat ~/projects/roxabi-factory/src/factory/agents/{α}.toml 2>/dev/null || echo "(no TOML — DB-only agent)"
 ```
 
 ∃ persona_name in σ ⇒ attempt to read persona file:
@@ -115,13 +115,13 @@ N = 0. Repeat while operator has not said done/exit/quit:
 ∀ (field, value) in Σ, apply via:
 
 ```bash
-lyra agent patch {α} --json '{"{field}": {value}}'
+factory agent patch {α} --json '{"{field}": {value}}'
 ```
 
 For nested JSON fields (e.g. `voice_json`), build full replacement object:
 
 ```bash
-lyra agent patch {α} --json '{"voice_json": {"tts": {"engine": "kokoro", "voice": "nova"}, "stt": {"engine": "whisper"}}}'
+factory agent patch {α} --json '{"voice_json": {"tts": {"engine": "kokoro", "voice": "nova"}, "stt": {"engine": "whisper"}}}'
 ```
 
 Show applied diff after all patches:
@@ -132,7 +132,7 @@ Applied to {α}:
   model      → claude-haiku-4-5-20251001
 ```
 
-Remind operator: "Run `lyra agent init --force` or restart lyra adapters for voice/model
+Remind operator: "Run `factory agent init --force` or restart lyra adapters for voice/model
 changes to take effect."
 
 ## Completion
@@ -149,6 +149,6 @@ Output:
 - Σ = ∅ after loop ⇒ "No changes applied." (¬run patch).
 - Persona file not found ⇒ use `persona_json` from DB only (¬block on missing file).
 - Operator asks about a field not in AgentRow ⇒ clarify which fields are patchable, show
-  field list from `lyra agent show` output.
+  field list from `factory agent show` output.
 
 $ARGUMENTS

--- a/src/factory/agent_cmd/CLAUDE.md
+++ b/src/factory/agent_cmd/CLAUDE.md
@@ -1,8 +1,8 @@
-# CLAUDE.md — lyra.agent_cmd
+# CLAUDE.md — factory.agent_cmd
 
 ## Role
 
-CLI command implementations for `lyra agent ...` and `lyra bot ...`.
+CLI command implementations for `factory agent ...` and `factory bot ...`.
 Verb list: `docs/agent-management.md`.
 Wired via `src/factory/agent_cmd/agents/`, `src/factory/agent_cmd/bots/`, and
 `src/factory/agent_cmd/platforms/` subdirs; dispatched by the Typer CLI entrypoint.
@@ -17,17 +17,17 @@ wire everything applies here.
 ```
 lyra CLI entrypoint
       ↓
-  lyra.agent_cmd     ← you are here
+  factory.agent_cmd     ← you are here
       ↓
-  lyra.core (stores, config.db [agents/bots/prefs], auth.db [grants only])
+  factory.core (stores, config.db [agents/bots/prefs], auth.db [grants only])
 ```
 
 ## Invariants
 
-- `lyra agent init` **must** be called before the hub can use an agent.
-  `~/.lyra/config.db` is the SSoT for agents; TOML files are seed inputs only (¬override at runtime).
-  `~/.lyra/auth.db` holds grants and identity only (AuthStore — separate DB).
-- `lyra bot init` seeds bot configurations from `config.toml` into `BotStore` (`~/.lyra/config.db`);
+- `factory agent init` **must** be called before the hub can use an agent.
+  `~/.roxabi/factory/config.db` is the SSoT for agents; TOML files are seed inputs only (¬override at runtime).
+  `~/.roxabi/factory/auth.db` holds grants and identity only (AuthStore — separate DB).
+- `factory bot init` seeds bot configurations from `config.toml` into `BotStore` (`~/.roxabi/factory/config.db`);
   idempotent by default; `--force` overwrites existing rows.
 - Commands in `agent_cmd/agents/` and `agent_cmd/bots/` must not bypass their respective
   stores — always go through `AgentStore` / `BotStore` (read/write), never directly to the TOML file.

--- a/src/factory/agents/CLAUDE.md
+++ b/src/factory/agents/CLAUDE.md
@@ -24,20 +24,20 @@ non-`None` at construction time is active.
 
 TOML and persona file changes are picked up on the **next** `process()` call — no daemon restart
 needed for content edits. Schema changes (new fields, backend swap) still require
-`lyra agent init --force` + restart.
+`factory agent init --force` + restart.
 
 ## TOML → DB seeding rule
 
-TOML files are **seed-only**. The runtime reads from SQLite (`~/.lyra/config.db`), never from TOML
+TOML files are **seed-only**. The runtime reads from SQLite (`~/.roxabi/factory/config.db`), never from TOML
 directly.
 
 ```
-~/.lyra/agents/<name>.toml   ← edit here
+~/.roxabi/factory/agents/<name>.toml   ← edit here
          ↓  lyra agent init [--force]
-~/.lyra/config.db            ← runtime SSoT
+~/.roxabi/factory/config.db            ← runtime SSoT
 ```
 
-After any TOML edit: `lyra agent init --force` + daemon restart (no file watcher).
+After any TOML edit: `factory agent init --force` + daemon restart (no file watcher).
 
 `cwd` is machine-specific — set in `config.toml [defaults]`, NOT in agent TOML.
 

--- a/src/factory/blobstore/CLAUDE.md
+++ b/src/factory/blobstore/CLAUDE.md
@@ -4,7 +4,7 @@
 
 HTTP-fronted BlobStore service: FastAPI process that exposes `FsBlobStore` over HTTP on
 port 8449. Peer-of-adapters per Framing B (spec §Context). Receives blob writes and reads,
-backs them with `FsBlobStore` on `~/.lyra/blobs/`, and is the only process that touches
+backs them with `FsBlobStore` on `~/.roxabi/factory/blobs/`, and is the only process that touches
 `FsBlobStore` directly. All other consumers (same-host or cross-host) use `HttpBlobStore`
 from `packages/roxabi-blobs`.
 
@@ -13,7 +13,7 @@ Entry point: `lyra blobstore serve`.
 
 ## Host topology
 
-Runs on M₁ (`lyra-hub` role) only. M₂ workers connect via:
+Runs on M₁ (`factory-hub` role) only. M₂ workers connect via:
 
 ```
 http://roxabituwer.goose-logarithm.ts.net:8449
@@ -21,7 +21,7 @@ http://roxabituwer.goose-logarithm.ts.net:8449
 
 ## Image
 
-`ghcr.io/roxabi/lyra:staging-svc`. Three-strikes rule defers a dedicated
+`ghcr.io/roxabi/factory:staging-svc`. Three-strikes rule defers a dedicated
 `ghcr.io/roxabi/blobstore` image to ≥3 cross-repo consumers (#1334 + ADR-073).
 
 ## Boot order invariant
@@ -36,7 +36,7 @@ intentionally loud; re-provision deferred to next container restart.
 
 ## Token semantics
 
-- Bearer token read **once at startup** from `/run/secrets/lyra_blobstore_token`
+- Bearer token read **once at startup** from `/run/secrets/factory_blobstore_token`
   (Podman `type=mount` secret, ADR-054 (absorbed into ADR-055)).
 - Stored in memory for the process lifetime. Re-read requires container restart — NOT a
   `HUP`. Sending `SIGHUP` does NOT rotate the in-memory token.

--- a/src/factory/bootstrap/CLAUDE.md
+++ b/src/factory/bootstrap/CLAUDE.md
@@ -9,7 +9,7 @@ Bootstrap = orchestration only. No business logic — all domain behaviour lives
 - `_bootstrap_hub_standalone` — hub process
 - `_bootstrap_adapter_standalone` — Telegram / Discord adapter process
 - `_bootstrap_clipool_standalone` — CLI pool process
-- `_bootstrap_turn_writer_standalone` — turn-writer JetStream subscriber process (`lyra turn-writer`, `standalone/worker_standalone.py`)
+- `_bootstrap_turn_writer_standalone` — turn-writer JetStream subscriber process (`factory turn-writer`, `standalone/worker_standalone.py`)
 - `_bootstrap_unified` — all-in-one single process
 
 ## Flat files at root
@@ -32,4 +32,4 @@ treat the returned object as opaque — they only call domain methods (`complete
 
 ## Rules
 
-- All intra-bootstrap imports: full absolute paths (`lyra.bootstrap.<subdir>.<module>`).
+- All intra-bootstrap imports: full absolute paths (`factory.bootstrap.<subdir>.<module>`).

--- a/src/factory/core/CLAUDE.md
+++ b/src/factory/core/CLAUDE.md
@@ -31,7 +31,7 @@ Two flavours of `Protocol` live in `core/`:
 
 Rule of thumb: if the Protocol abstracts something *outside* lyra (LLM, TTS, audit log, future Langfuse, …) → **driven port** → `core/ports/`. If it abstracts an *internal* collaboration (a role another file inside `factory.core` fills) → **role interface**, co-located with its sub-domain. Driven ports are pure Protocol with no infrastructure import (TYPE_CHECKING-only allowed). Role interfaces follow the same constraint.
 
-`ports/llm.py`, `ports/stt.py`, `ports/tts.py` follow the same shape: protocol + value objects + errors only. `ports/` is the single owner of domain types. Adapter-adjacent helpers (`is_whisper_noise`, `mime_from_suffix`) live in `lyra/nats/stt/stt_helpers.py`, not in `ports/`.
+`ports/llm.py`, `ports/stt.py`, `ports/tts.py` follow the same shape: protocol + value objects + errors only. `ports/` is the single owner of domain types. Adapter-adjacent helpers (`is_whisper_noise`, `mime_from_suffix`) live in `factory/nats/stt/stt_helpers.py`, not in `ports/`.
 
 ## Store pattern (ADR-048 (absorbed into ADR-059))
 

--- a/src/factory/core/auth/authenticator.py
+++ b/src/factory/core/auth/authenticator.py
@@ -263,7 +263,7 @@ class Authenticator:
                     alias_store=alias_store,
                 )
             log.warning(
-                "Missing [auth.%s] in lyra.toml -- %s adapter will be disabled",
+                "Missing [auth.%s] in config.toml -- %s adapter will be disabled",
                 section,
                 section,
             )

--- a/src/factory/inbound/CLAUDE.md
+++ b/src/factory/inbound/CLAUDE.md
@@ -24,7 +24,7 @@ parse → AttachmentIngestStage (store-conditional; no-store path clears pending
 ## Layer invariants
 
 - `router.py`, `session_builder.py`, `dispatcher.py`, `pipeline.py` must NOT import `discord` or `aiogram`. Platform isolation lives in `wire_parser_telegram.py` / `wire_parser_discord.py` and adapter-side hooks.
-- Stages depend on `factory.core` only — never `factory.adapters`. Enforced by `.importlinter` (`inbound-no-adapters` contract, #1287). Known violations are tagged `DEBT:inbound-adapters-transition` / `DEBT:inbound-adapters-wireparser` and listed as `ignore_imports` in that contract pending relocation to `factory.core`/lyra.shared (deferred to #1283 Phase 6).
+- Stages depend on `factory.core` only — never `factory.adapters`. Enforced by `.importlinter` (`inbound-no-adapters` contract, #1287). Known violations are tagged `DEBT:inbound-adapters-transition` / `DEBT:inbound-adapters-wireparser` and listed as `ignore_imports` in that contract pending relocation to `factory.core`/factory.shared (deferred to #1283 Phase 6).
 - `InboundContext`, `RouterCtx`, `SessionCtx`, `DispatchCtx` are `@dataclass(frozen=True)`. The container references are frozen; the mutable collections they carry (`RouterCtx.owned_threads: set`, `SessionCtx.thread_sessions_cache: dict`) are mutated in place by hooks and `SessionBuilder`. Document this contract on `context.py` module docstring.
 - Hook signatures (verified post-Phase-3):
   - `pre_route_hook(InboundMessage, InboundContext) -> Awaitable[None]` — may mutate

--- a/src/factory/infrastructure/CLAUDE.md
+++ b/src/factory/infrastructure/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## ADR-048 (absorbed into ADR-059) invariant
 
-Protocols → `lyra.core.stores/` | Implementations → `lyra.infrastructure.stores/`
+Protocols → `factory.core.stores/` | Implementations → `factory.infrastructure.stores/`
 
 Never place a SQLite or I/O implementation in `core/`; never place a Protocol in `infrastructure/`.
 Stores impl ⊂ infrastructure, protocols ⊂ core/stores. Past migration history in git log.
@@ -10,7 +10,7 @@ Stores impl ⊂ infrastructure, protocols ⊂ core/stores. Past migration histor
 ## Layer ordering
 
 ```
-lyra.core (protocols) ← lyra.llm | lyra.nats ← lyra.infrastructure (implementations) ← lyra.adapters ← lyra.bootstrap
+factory.core (protocols) ← factory.llm | factory.nats ← factory.infrastructure (implementations) ← factory.adapters ← factory.bootstrap
 ```
 
 ## BlobStore adapter invariants

--- a/src/factory/infrastructure/turn_writer/CLAUDE.md
+++ b/src/factory/infrastructure/turn_writer/CLAUDE.md
@@ -14,7 +14,7 @@ ADR-075 authorises this sublayer (axial: `stage-of-pipeline` →
 ## Invariants
 
 - **Sole writer**: only this subsystem mutates `turns.db`. Hub + adapters
-  mount the file read-only (per `deploy/quadlet/lyra-hub.container` T26).
+  mount the file read-only (per `deploy/quadlet/factory-hub.container` T26).
 - **Durable consumer**: `LYRA_TURNS` stream + `turn-writer-v1` consumer
   with AckExplicit, AckWait=60s, MaxDeliver=5, MaxAge=24h, WorkQueue
   retention. Horizontal scaling via shared durable name (queue group
@@ -33,8 +33,8 @@ ADR-075 authorises this sublayer (axial: `stage-of-pipeline` →
 
 ## Process boundary
 
-Runs as its own systemd unit: `lyra-turn-writer.container`. Entry point:
-`lyra turn-writer` CLI subcommand → `_bootstrap_turn_writer_standalone`.
+Runs as its own systemd unit: `factory-turn-writer.container`. Entry point:
+`factory turn-writer` CLI subcommand → `_bootstrap_turn_writer_standalone`.
 
 NATS user: `turn-writer` (subscribes `lyra.turns.>`, publishes _INBOX.>
 for ACK path, JetStream API scoped to `LYRA_TURNS` + `turn-writer-v1`
@@ -52,7 +52,7 @@ process start).
 `health.py` exposes `GET /health` (writer task + NATS + DB liveness) and
 `GET /metrics` (Prometheus text exposition with
 `turn_writer_lag_seconds`). Default port 8083; override via
-`LYRA_TURN_WRITER_HEALTH_PORT`.
+`FACTORY_TURN_WRITER_HEALTH_PORT`.
 
 ## What NOT to do
 

--- a/src/factory/integrations/CLAUDE.md
+++ b/src/factory/integrations/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — lyra.integrations
+# CLAUDE.md — factory.integrations
 
 ## Role
 
@@ -58,7 +58,7 @@ processors      (src/factory/core/processors/)
 simple_agent    (src/factory/agents/simple_agent.py)
 bootstrap factory
         ↓
-  lyra.integrations   ← you are here
+  factory.integrations   ← you are here
         ↓
   external world (systemd, vault CLI, web-intel, ffmpeg)
 ```

--- a/src/factory/llm/CLAUDE.md
+++ b/src/factory/llm/CLAUDE.md
@@ -33,10 +33,10 @@ not add it to the Protocol until all drivers implement it.
 The NATS LLM driver is a 3-layer composition (since #1278):
 
 ```
-LlmClient (lyra.llm.llm_client)
-   ├─ pool: WorkerPoolClient (lyra.transport.worker_pool_client)
-   │     └─ transport: NatsTransport (lyra.transport.nats_request_response)
-   └─ codec: LlmCodec (lyra.llm.codec)
+LlmClient (factory.llm.llm_client)
+   ├─ pool: WorkerPoolClient (factory.transport.worker_pool_client)
+   │     └─ transport: NatsTransport (factory.transport.nats_request_response)
+   └─ codec: LlmCodec (factory.llm.codec)
 ```
 
 - `LlmClient`: implements `LlmProvider`; orchestrates encode → pool → decode.

--- a/src/factory/monitoring/CLAUDE.md
+++ b/src/factory/monitoring/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Invariants
 
-**STANDALONE** — invoked as `python -m lyra.monitoring` (valid triggers: manual / cron / CI smoke — ¬systemd timer).
+**STANDALONE** — invoked as `python -m factory.monitoring` (valid triggers: manual / cron / CI smoke — ¬systemd timer).
 ¬imported by any other `src/factory/*` module. Only tests import this package.
 
 **Exit-code contract** — `main()` returns and `SystemExit` propagates:
@@ -32,13 +32,13 @@ primary observability path.
 
 ## Config
 
-Thresholds: `[monitoring]` section in lyra.toml (or `$LYRA_CONFIG`).
+Thresholds: `[monitoring]` section in config.toml (or `$FACTORY_CONFIG`).
 Secrets (required at runtime, ¬in TOML): `TELEGRAM_TOKEN`, `TELEGRAM_ADMIN_CHAT_ID`.
-Optional: `LYRA_HEALTH_SECRET` (Bearer token for `/health/detail`).
+Optional: `FACTORY_HEALTH_SECRET` (Bearer token for `/health/detail`).
 Missing secrets → `ValueError` at startup (fail-fast, ¬silent misconfiguration).
 
 ## Operational notes
 
-- `checks_varz.py` writes state to `~/.lyra/nats-monitor-state.json` to detect deltas across
+- `checks_varz.py` writes state to `~/.roxabi/factory/nats-monitor-state.json` to detect deltas across
   runs. ¬delete this file without expecting a spurious alert on the next run.
 - LLM backend: `claude` CLI (OAuth, ¬API key). If absent, falls back to raw Telegram alert.

--- a/src/factory/monitoring/config.py
+++ b/src/factory/monitoring/config.py
@@ -18,7 +18,7 @@ _SERVICE_NAME_RE = re.compile(r"^[a-zA-Z0-9_@.\-]+$")
 class MonitoringConfig(BaseModel):
     """Configuration for the monitoring system.
 
-    Thresholds come from [monitoring] section in lyra.toml.
+    Thresholds come from [monitoring] section in config.toml.
     Secrets come from environment variables.
     """
 
@@ -126,12 +126,12 @@ class MonitoringConfig(BaseModel):
 def load_monitoring_config(config_path: str | None = None) -> MonitoringConfig:
     """Load monitoring config from TOML thresholds + env var secrets.
 
-    Config path resolution: config_path arg → $FACTORY_CONFIG → lyra.toml in cwd.
+    Config path resolution: config_path arg → $FACTORY_CONFIG → config.toml in cwd.
     Missing config file → all defaults for thresholds.
     Missing required env vars → ValueError.
     """
     # Load TOML thresholds
-    path = config_path or os.environ.get("FACTORY_CONFIG", "lyra.toml")
+    path = config_path or os.environ.get("FACTORY_CONFIG", "config.toml")
     raw: dict[str, object] = {}
     try:
         with open(path, "rb") as f:

--- a/src/factory/obs/CLAUDE.md
+++ b/src/factory/obs/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — lyra.obs
+# CLAUDE.md — factory.obs
 
 ## Role
 

--- a/src/factory/outbound/CLAUDE.md
+++ b/src/factory/outbound/CLAUDE.md
@@ -32,7 +32,7 @@ formatter/throttle/error_handler methods directly.
   `DiscordAdapter.__init__` flows to `discord.Client(intents=intents)` via
   `super().__init__(intents=intents)`. Do NOT add `__init__` to any class in the
   `OutboundAdapterBase` inheritance chain.
-- **Single broad-catch site in the emitter.** `OutboundErrorHandler.guard` is the single semantic broad-catch site in `lyra.outbound/`. Two additional terminal sites in `OutboundEmitter.run` and `_run_event_loop` capture stream errors with broad-catch — these are intentional (terminal stream-error path).
+- **Single broad-catch site in the emitter.** `OutboundErrorHandler.guard` is the single semantic broad-catch site in `factory.outbound/`. Two additional terminal sites in `OutboundEmitter.run` and `_run_event_loop` capture stream errors with broad-catch — these are intentional (terminal stream-error path).
 
 ## State + recap helpers
 

--- a/src/factory/tools/CLAUDE.md
+++ b/src/factory/tools/CLAUDE.md
@@ -1,6 +1,6 @@
 # src/factory/tools/ — In-container helper utilities
 
-Helper processes that run inside `lyra-clipool` but with **isolated identity** from Claude (uid 1500).
+Helper processes that run inside `factory-clipool` but with **isolated identity** from Claude (uid 1500).
 Each helper module is self-contained — pure stdlib + project deps, no hub/core imports at module level.
 
 ## gh_token/ — dispenser

--- a/src/factory/transport/CLAUDE.md
+++ b/src/factory/transport/CLAUDE.md
@@ -3,14 +3,14 @@
 ## Purpose
 
 Domain-agnostic NATS transport primitives consumed by all domain worker clients
-(`lyra.nats.*_client`, `factory.llm.llm_client`). Lives here, NOT in `packages/roxabi-nats/`.
+(`factory.nats.*_client`, `factory.llm.llm_client`). Lives here, NOT in `packages/roxabi-nats/`.
 
 ## Layer contract
 
 ```
 NatsTransport          — call() + open_inbox() CM; owns NATS inbox lifecycle
 WorkerPoolClient       — routing + CB + heartbeat subscription; registry via DI
-DomainClient           — thin wrapper in lyra.nats / lyra.llm (compose pool + codec)
+DomainClient           — thin wrapper in factory.nats / factory.llm (compose pool + codec)
 ```
 
 ## Key invariants

--- a/tests/test_circuit_config.py
+++ b/tests/test_circuit_config.py
@@ -24,7 +24,7 @@ class TestLoadCircuitConfigDefaults:
     def test_load_circuit_config_uses_defaults_when_no_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """SC-16: Missing lyra.toml → 4 CBs with failure_threshold=5, recovery_timeout=60."""  # noqa: E501
+        """SC-16: Missing config.toml → 4 CBs with failure_threshold=5, recovery_timeout=60."""  # noqa: E501
         # Arrange — point FACTORY_CONFIG at a nonexistent file
         monkeypatch.setenv("FACTORY_CONFIG", str(tmp_path / "nonexistent.toml"))
         monkeypatch.setattr(
@@ -52,8 +52,8 @@ class TestLoadCircuitConfigDefaults:
     def test_load_circuit_config_uses_defaults_when_env_not_set(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """SC-16: FACTORY_CONFIG unset and no lyra.toml in cwd → defaults returned."""
-        # Arrange — unset env var and ensure cwd has no lyra.toml
+        """SC-16: FACTORY_CONFIG unset and no config.toml in cwd → defaults returned."""
+        # Arrange — unset env var and ensure cwd has no config.toml
         monkeypatch.delenv("FACTORY_CONFIG", raising=False)
         monkeypatch.chdir(tmp_path)
 
@@ -78,7 +78,7 @@ class TestLoadCircuitConfigTomlOverrides:
     ) -> None:
         """SC-16: TOML config overrides claude-cli thresholds; other services keep defaults."""  # noqa: E501
         # Arrange
-        config = tmp_path / "lyra.toml"
+        config = tmp_path / "config.toml"
         config.write_text(
             "[circuit_breaker.claude-cli]\n"
             "failure_threshold = 2\n"
@@ -115,7 +115,7 @@ class TestLoadCircuitConfigTomlOverrides:
     ) -> None:
         """SC-16: Multiple admin user_ids parsed into a set."""
         # Arrange
-        config = tmp_path / "lyra.toml"
+        config = tmp_path / "config.toml"
         config.write_text(
             "[admin]\nuser_ids = ['telegram:tg:user:1', 'discord:dc:user:2']\n"
         )
@@ -140,7 +140,7 @@ class TestLoadCircuitConfigTomlOverrides:
     ) -> None:
         """SC-16: Only recovery_timeout overridden → failure_threshold stays default."""
         # Arrange
-        config = tmp_path / "lyra.toml"
+        config = tmp_path / "config.toml"
         config.write_text("[circuit_breaker.hub]\nrecovery_timeout = 120\n")
         monkeypatch.setenv("FACTORY_CONFIG", str(config))
         monkeypatch.setattr(

--- a/tests/test_monitoring_config.py
+++ b/tests/test_monitoring_config.py
@@ -55,7 +55,7 @@ class TestMonitoringConfigToml:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SC-5: TOML values override defaults."""
-        config_file = tmp_path / "lyra.toml"
+        config_file = tmp_path / "config.toml"
         config_file.write_text(
             "[monitoring]\n"
             "check_interval_minutes = 10\n"
@@ -84,7 +84,7 @@ class TestMonitoringConfigToml:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SC-6: Idle check is opt-in with quiet hours."""
-        config_file = tmp_path / "lyra.toml"
+        config_file = tmp_path / "config.toml"
         config_file.write_text(
             "[monitoring]\n"
             "idle_check_enabled = true\n"

--- a/tests/test_monitoring_config.py
+++ b/tests/test_monitoring_config.py
@@ -80,6 +80,29 @@ class TestMonitoringConfigToml:
         assert config.health_endpoint_timeout_s == 5
         assert config.idle_threshold_hours == 6
 
+    def test_load_from_cwd_default_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SC-3: bare default is config.toml in cwd when $FACTORY_CONFIG unset.
+
+        Guards the resolver default (config.py: env.get("FACTORY_CONFIG",
+        "config.toml")). If the default regressed to "lyra.toml", the cwd
+        config.toml would not be read and this assertion would fail.
+        """
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("[monitoring]\ncheck_interval_minutes = 11\n")
+        monkeypatch.delenv("FACTORY_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "fake")
+        monkeypatch.setenv("TELEGRAM_ADMIN_CHAT_ID", "12345")
+
+        from factory.monitoring.config import load_monitoring_config
+
+        config = load_monitoring_config()
+
+        assert config.check_interval_minutes == 11
+
     def test_idle_check_opt_in(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- Finishes the residual `lyra`→`factory` rename deferred from merge PR #1669 — **living docs now match the merged code + deploy artifacts**, with the NATS wire contract and app identity held invariant.
- Living-doc structural sweep (deploy units/secrets/paths, container user `factory`, `lyra.<module>`→`factory.<module>` disambiguated from `lyra.*` subjects), config-filename alignment (`FACTORY_CONFIG` default → `config.toml`), removal of 7 dead `FACTORY_*` toggle vars + deprecated `TTS_ENGINE` (zero readers).
- **Scope grew beyond the approved spec's token list** (gh-helper family, host/container paths, volumes, secrets, ~80 module refs) — every token ground-truthed against `src/` and `deploy/quadlet/`. Two defects fixed mid-flight: **33 leaked sed placeholders** restored to `LYRA_*` stream names; **3 mangled `.lyra` paths** repaired.

## KEEP — verified net-0 (before/after diff)
`lyra.*` NATS subjects + `LYRA_*` JetStream streams (→ #1670), `"Lyra"` persona, `lyra_default`, `lyra_session_id`, `plugins/lyra-{ops,send}`, and the still-real deploy units `lyra-{monitor,harness,tts,stt,metrics,events}` + bot ids `lyra`/`aryl`.

## Deferred → #1674
Prose audit (~337 bare `Lyra`/`lyra`), `LyraUserError` (base class removed from code), `~/.local/state/lyra` XDG dir, `workspaces.lyra` alias, ADR-043 historical script paths, `STT_MODEL_SIZE`. Host identity (`ssh lyra@<IP>`, host `/home/lyra`) → Part 2 prod cutover.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1668: residual lyra→factory cleanup | Open |
| Frame | [frame.mdx](artifacts/frames/1668-finish-lyra-factory-cleanup-frame.mdx) | Present |
| Spec | [spec.mdx](artifacts/specs/1668-finish-lyra-factory-cleanup-spec.mdx) | Present |
| Plan | [plan.mdx](artifacts/plans/1668-finish-lyra-factory-cleanup-plan.mdx) | Present |
| Implementation | 4 commits on `feat/1668-finish-lyra-factory-cleanup` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5381 passed) · doc-drift ✅ · arch-snapshot ✅ | Passed |

## Test Plan
- [ ] `git grep` living docs for replaceable `lyra` tokens → only KEEP set remains
- [ ] `factory.monitoring` resolves `config.toml` by default (T1)
- [ ] `.env.example` has no dead `FACTORY_*` toggle vars (T2)
- [ ] KEEP set (subjects/streams/persona) unchanged

Closes #1668
Refs #1671

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`