### PR TITLE
refactor(pool): split process_one god-method into ≤40-line helpers

### DIFF
--- a/src/factory/core/pool/pool_processor_exec.py
+++ b/src/factory/core/pool/pool_processor_exec.py
@@ -128,170 +128,176 @@ async def guarded_process_one(  # noqa: PLR0915 — DEBT:complexity-residual
         TraceContext.reset_agent_name(token_an)
 
 
-async def process_one(  # noqa: C901, PLR0915 — DEBT:complexity-residual — session-id update adds branches
-    msg: InboundMessage, agent: AgentBase, pool: Pool
-) -> None:
+async def process_one(msg: InboundMessage, agent: AgentBase, pool: Pool) -> None:
     """Run agent.process and dispatch result (streaming or non-streaming)."""
     await pool.append(msg)
-
-    # Inject voice modality — must happen before _original_msg is
-    # captured so dispatch_streaming sees it.  Covers:
-    #   - pool.voice_mode toggle (/voice → /text)
-    #   - /voice <prompt> one-shot (agent rewrites text internally,
-    #     but _original_msg needs modality set here)
-    #   - voice messages (modality already "voice" from audio pipeline)
     if msg.modality != "voice" and (
         pool.voice_mode or (msg.text and msg.text.strip().lower().startswith("/voice "))
     ):
         import dataclasses
 
         msg = dataclasses.replace(msg, modality="voice")
-
     _ensure_fn = getattr(agent, "_ensure_system_prompt", None)
     if _ensure_fn is not None:
-        await _ensure_fn(pool)  # S3 — cache system prompt
-
-    # Processor pre-hook: enrich message before LLM (B1 — issue #363).
-    # pool.append gets the original so history shows the real command;
-    # agent.process gets the enriched version so the LLM sees scraped content.
-    _processor = None
+        await _ensure_fn(pool)
     _original_msg = msg
-    if msg.command is not None:
-        _session_tools = getattr(agent, "_session_tools", None)
-        if _session_tools is not None:
-            # Import inside the function to avoid circular imports:
-            # processors → processor_registry → message;
-            # pool_processor also imports message.
-            # Python caches modules in sys.modules after the first import,
-            # so this is effectively free (one dict lookup) on every call.
-            # registers processors via @register decorators
-            importlib.import_module("factory.core.processors")
-            from factory.core.processors.processor_registry import (
-                registry as _proc_registry,
-            )
-
-            _cmd_name = f"{msg.command.prefix}{msg.command.name}"
-            _processor = _proc_registry.build(_cmd_name, _session_tools)
-            if _processor is not None:
-                try:
-                    msg = await _processor.pre(msg)
-                except Exception:  # noqa: BLE001  — DEBT:boundary-broad-catch# top-level boundary
-                    log.warning(
-                        "Processor pre() failed for %s", _cmd_name, exc_info=True
-                    )
-                    # Surface the error rather than falling through to the LLM
-                    # with an unmodified message (confusing non-response).
-                    _error_reply = pool._msg(
-                        "generic",
-                        f"Command {_cmd_name} failed to prepare. Please try again.",
-                    )
-                    await _safe_dispatch(msg, Response(content=_error_reply), pool)
-                    return
-
+    _enriched_msg, _processor = await _run_processor_pre(msg, agent, pool)
+    if _enriched_msg is None:
+        return
+    msg = _enriched_msg
     result = agent.process(msg, pool)
     if not isinstance(result, collections.abc.AsyncIterator):  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
-        # Regular coroutine — await to get the actual result
-        try:
-            result = await result  # type: ignore[misc] — DEBT:defensive-narrow-payloads  # coroutine → Response|AsyncIterator
-        except Exception as exc:
-            pool._ctx.record_circuit_failure(exc)
-            raise
-        # Processor post-hook: side effects after LLM response (B1 — issue #363).
-        if _processor is not None and isinstance(result, Response):
-            try:
-                result = await _processor.post(_original_msg, result)
-            except Exception:  # noqa: BLE001  — DEBT:boundary-broad-catch# top-level boundary
-                log.warning("Processor post() failed", exc_info=True)
-
-    # Capture values for the deferred turn-logging callback (#316).
+        result = await _resolve_non_streaming(result, _processor, _original_msg, pool)
     _platform = pool.medium or str(msg.platform)
     _user_id = pool.user_id or msg.user_id
-
     if isinstance(result, collections.abc.AsyncIterator):
-        # Streaming path — delegate to helpers in pool_processor_streaming.py
-        _result_iter_for_sid = result
-        _content_parts: list[str] = []
-        _stream_done = asyncio.Event() if _processor is not None else None
-
-        # Wrap iterator to capture text content and signal completion
-        result = build_streaming_capture(
-            _result_iter_for_sid,
-            _content_parts,
-            pool,
-            _stream_done,
-        )
-
-        # Build outbound with turn-logging callback
-        _outbound, _log_callback = build_streaming_turn_logger(
-            StreamLogDeps(
-                pool=pool,
-                result_iter_for_sid=_result_iter_for_sid,
-                original_msg=_original_msg,
-                platform=_platform,
-                user_id=_user_id,
-                content_parts=_content_parts,
-            )
-        )
-        pool._inflight_stream_outbound = _outbound
-        _outbound.metadata["_on_dispatched"] = TrustedCallback(_log_callback)
-
-        try:
-            await pool._ctx.dispatch_streaming(_original_msg, result, _outbound)
-            pool._ctx.record_circuit_success()
-        except BaseException as exc:
-            pool._ctx.record_circuit_failure(exc)
-            raise
-
-        # Fallback session_id update for no-dispatcher path
-        _stream_sid = getattr(_result_iter_for_sid, "session_id", None)
-        if _stream_sid and pool.session_id != _stream_sid:
-            await pool._observer.end_session_async(pool.session_id)
-            pool.session_id = _stream_sid
-
-        # Processor post-hook for streaming agents (#372)
-        await run_streaming_turn_post(
-            _processor, _stream_done, _original_msg, _content_parts
+        await _process_streaming(
+            result, _processor, _original_msg, _platform, _user_id, pool
         )
     else:
-        pool._ctx.record_circuit_success()
-        # Update session_id with the real Claude CLI session UUID (#316).
-        if isinstance(result, Response):  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
-            _cli_session_id = result.metadata.get("session_id")
-            if _cli_session_id:
-                if pool.session_id != _cli_session_id:
-                    await pool._observer.end_session_async(pool.session_id)
-                pool.session_id = _cli_session_id
-        # Attach deferred turn-logging callback after adapter sends (#316).
-        if isinstance(result, Response):  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
-            _content = result.content
-
-            async def _log_turn(outbound: OutboundMessage) -> None:
-                _reply_id = outbound.metadata.get("reply_message_id")
-                await pool._observer.log_turn_async(
-                    TurnLogDeps(
-                        role="assistant",
-                        platform=_platform,
-                        user_id=_user_id,
-                        content=_content,
-                        reply_message_id=(
-                            str(_reply_id) if _reply_id is not None else None
-                        ),
-                    )
-                )
-                # Index assistant turn for reply-to session routing (#341).
-                await pool._observer.index_turn_async(
-                    str(_reply_id) if _reply_id is not None else None,
-                    session_id=pool.session_id,
-                    role="assistant",
-                )
-
-            result.metadata["_on_dispatched"] = TrustedCallback(_log_turn)
-        await pool._ctx.dispatch_response(_original_msg, result)
-        await pool._observer.session_update_async(_original_msg)
-
+        await _process_non_streaming(result, _original_msg, _platform, _user_id, pool)
     _compact_fn = getattr(agent, "compact", None)
     if _compact_fn is not None:
-        await _compact_fn(pool)  # S5 — check compaction threshold after each turn
+        await _compact_fn(pool)
+
+
+async def _run_processor_pre(
+    msg: InboundMessage, agent: AgentBase, pool: Pool
+) -> tuple[InboundMessage | None, object]:
+    """Run processor pre-hook (B1 — #363).
+
+    Returns (enriched_msg, processor) on success, (None, None) if error dispatched.
+    """
+    if msg.command is None:
+        return msg, None
+    _session_tools = getattr(agent, "_session_tools", None)
+    if _session_tools is None:
+        return msg, None
+    # Import inside fn to avoid circular imports (processors → registry → message).
+    # sys.modules cache makes this free after first import.
+    importlib.import_module("factory.core.processors")
+    from factory.core.processors.processor_registry import registry as _proc_registry
+
+    _cmd_name = f"{msg.command.prefix}{msg.command.name}"
+    _processor = _proc_registry.build(_cmd_name, _session_tools)
+    if _processor is None:
+        return msg, None
+    try:
+        msg = await _processor.pre(msg)
+    except Exception:  # noqa: BLE001  — DEBT:boundary-broad-catch# top-level boundary
+        log.warning("Processor pre() failed for %s", _cmd_name, exc_info=True)
+        _error_reply = pool._msg(
+            "generic", f"Command {_cmd_name} failed to prepare. Please try again."
+        )
+        await _safe_dispatch(msg, Response(content=_error_reply), pool)
+        return None, None
+    return msg, _processor
+
+
+async def _resolve_non_streaming(
+    result: object, _processor: object | None, _original_msg: InboundMessage, pool: Pool
+) -> object:
+    """Await coroutine result and run processor post-hook if applicable."""
+    try:
+        result = await result  # type: ignore[misc] — DEBT:defensive-narrow-payloads
+    except Exception as exc:
+        pool._ctx.record_circuit_failure(exc)
+        raise
+    if _processor is not None and isinstance(result, Response):
+        try:
+            result = await _processor.post(_original_msg, result)  # type: ignore[union-attr] — DEBT:defensive-narrow-payloads
+        except Exception:  # noqa: BLE001  — DEBT:boundary-broad-catch# top-level boundary
+            log.warning("Processor post() failed", exc_info=True)
+    return result
+
+
+async def _update_session_id(result: Response, pool: Pool) -> None:
+    """Update pool session_id from CLI session UUID in response metadata (#316)."""
+    _cli_session_id = result.metadata.get("session_id")
+    if _cli_session_id:
+        if pool.session_id != _cli_session_id:
+            await pool._observer.end_session_async(pool.session_id)
+        pool.session_id = _cli_session_id
+
+
+def _capture_turn_log(
+    result: Response, platform: str, user_id: str, pool: Pool
+) -> None:
+    """Attach deferred turn-logging callback to response metadata (#316)."""
+    _content = result.content
+
+    async def _log_turn(outbound: OutboundMessage) -> None:
+        _reply_id = outbound.metadata.get("reply_message_id")
+        await pool._observer.log_turn_async(
+            TurnLogDeps(
+                role="assistant",
+                platform=platform,
+                user_id=user_id,
+                content=_content,
+                reply_message_id=(str(_reply_id) if _reply_id is not None else None),
+            )
+        )
+        await pool._observer.index_turn_async(
+            str(_reply_id) if _reply_id is not None else None,
+            session_id=pool.session_id,
+            role="assistant",
+        )
+
+    result.metadata["_on_dispatched"] = TrustedCallback(_log_turn)
+
+
+async def _process_non_streaming(
+    result: object,
+    original_msg: InboundMessage,
+    platform: str,
+    user_id: str,
+    pool: Pool,
+) -> None:
+    """Dispatch non-streaming Response: circuit success, session_id, turn-log."""
+    pool._ctx.record_circuit_success()
+    if isinstance(result, Response):  # pyright: ignore[reportUnnecessaryIsInstance] — DEBT:defensive-narrow-payloads
+        await _update_session_id(result, pool)
+        _capture_turn_log(result, platform, user_id, pool)
+    await pool._ctx.dispatch_response(original_msg, result)  # type: ignore[arg-type] — DEBT:defensive-narrow-payloads
+    await pool._observer.session_update_async(original_msg)
+
+
+async def _process_streaming(  # noqa: PLR0913 — 6 cohesive params, no natural grouping
+    result: collections.abc.AsyncIterator,
+    processor: object | None,
+    original_msg: InboundMessage,
+    platform: str,
+    user_id: str,
+    pool: Pool,
+) -> None:
+    """Dispatch streaming result: capture, turn-log callback, circuit, post-hook."""
+    _iter = result
+    _content_parts: list[str] = []
+    _stream_done = asyncio.Event() if processor is not None else None
+    result = build_streaming_capture(_iter, _content_parts, pool, _stream_done)
+    _outbound, _log_callback = build_streaming_turn_logger(
+        StreamLogDeps(
+            pool=pool,
+            result_iter_for_sid=_iter,
+            original_msg=original_msg,
+            platform=platform,
+            user_id=user_id,
+            content_parts=_content_parts,
+        )
+    )
+    pool._inflight_stream_outbound = _outbound
+    _outbound.metadata["_on_dispatched"] = TrustedCallback(_log_callback)
+    try:
+        await pool._ctx.dispatch_streaming(original_msg, result, _outbound)
+        pool._ctx.record_circuit_success()
+    except BaseException as exc:
+        pool._ctx.record_circuit_failure(exc)
+        raise
+    _stream_sid = getattr(_iter, "session_id", None)
+    if _stream_sid and pool.session_id != _stream_sid:
+        await pool._observer.end_session_async(pool.session_id)
+        pool.session_id = _stream_sid
+    await run_streaming_turn_post(processor, _stream_done, original_msg, _content_parts)
 
 
 async def _safe_dispatch(msg: InboundMessage, response: Response, pool: Pool) -> None:


### PR DESCRIPTION
## Summary

- Extract `_run_processor_pre`, `_resolve_non_streaming`, `_update_session_id`, `_capture_turn_log`, `_process_non_streaming`, `_process_streaming` from the 165-line `process_one` god-method
- `process_one` reduced to 29-line orchestrator
- All helpers ≤40 lines; SLOC 239→258 (file stays well under 300 cap)
- Zero behavioural changes — pure structural refactor

## Decision trace

**RC(P):** `process_one` (165 lines, `noqa C901/PLR0915`) combined 6+ orthogonal concerns — streaming bifurcation, processor pre/post hooks, session-id update, error dispatch, turn-log capture, circuit recording — in one method. Root cause is accretion: each feature appended logic inline rather than extracting to a named scope.

**Candidates:**
1. Inline comment grouping only — Patch/cosmetic, ¬fixes untestability
2. Extract helpers into same file (chosen) — Patch (local, ¬structural, keeps module boundary intact)
3. Split into a new `pool_processor_hooks.py` sibling — Archi (new module boundary), justified only if ≥3 modules need the helpers; here only `process_one` calls them

**Chosen: Option 2 — Patch.** Helpers remain in `pool_processor_exec.py` (same module boundary, same import surface). Naming is `_` prefixed (module-private). No new public API, no import-layer change.

**Logic level L:** intra-function decomposition (L2 — method body). Fix applied at L2, matching the level of the root cause.

**Class: Patch** — all changes local to one file, zero API/protocol changes, all tests pass unchanged.

## Test plan

- [x] `uv run ruff format . && uv run ruff check --fix .` — clean
- [x] `uv run pytest` — 5385 passed, 14 skipped, 1 xfailed
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] Architecture snapshot unchanged (no regeneration needed)

Closes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)