### PR TITLE
feat(process): mandatory axial review for cross-layer PRs

### DIFF
--- a/.github/workflows/axial-review.yml
+++ b/.github/workflows/axial-review.yml
@@ -1,0 +1,100 @@
+name: Axial Review
+
+# Auto-label PRs that cross architectural layer boundaries.
+# Triggers (issue #1657):
+#   - inbound/ + adapters/ touched     → dev-core:axial-adr-review
+#   - core/ + infrastructure/ touched  → dev-core:axial-adr-review
+#   - ports/ + hub/ touched            → dev-core:axial-adr-review
+#   - except Exception: added          → dev-core:security-auditor + dev-core:axial-adr-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, staging]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  axial-label:
+    name: Detect cross-layer boundaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files and apply labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const paths = files.map(f => f.filename);
+
+            // Layer membership helpers
+            const touches = (segment) => paths.some(p => p.includes(`/${segment}/`) || p.startsWith(`${segment}/`));
+
+            const inInbound      = touches('inbound');
+            const inAdapters     = touches('adapters');
+            const inCore         = touches('core');
+            const inInfra        = touches('infrastructure');
+            const inPorts        = touches('ports');
+            const inHub          = touches('hub');
+
+            // except Exception: detection — scan patch hunks for added lines
+            const exceptException = files.some(f =>
+              f.patch && f.patch.split('\n').some(line =>
+                line.startsWith('+') && !line.startsWith('+++') && /except\s+Exception\s*[:\(]/.test(line)
+              )
+            );
+
+            const crossLayer =
+              (inInbound && inAdapters) ||
+              (inCore && inInfra)       ||
+              (inPorts && inHub);
+
+            const labelsToAdd = new Set();
+
+            if (crossLayer)      labelsToAdd.add('dev-core:axial-adr-review');
+            if (exceptException) {
+              labelsToAdd.add('dev-core:axial-adr-review');
+              labelsToAdd.add('dev-core:security-auditor');
+            }
+
+            if (labelsToAdd.size === 0) {
+              core.info('No cross-layer boundary detected — no labels added');
+              return;
+            }
+
+            core.info(`Labels to add: ${[...labelsToAdd].join(', ')}`);
+
+            // Fetch existing labels to avoid duplicates
+            const { data: existing } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existingNames = new Set(existing.map(l => l.name));
+
+            const toApply = [...labelsToAdd].filter(l => !existingNames.has(l));
+            if (toApply.length === 0) {
+              core.info('Labels already present — nothing to do');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: toApply,
+            });
+            core.info(`Added labels: ${toApply.join(', ')}`);

--- a/.github/workflows/axial-review.yml
+++ b/.github/workflows/axial-review.yml
@@ -2,10 +2,10 @@ name: Axial Review
 
 # Auto-label PRs that cross architectural layer boundaries.
 # Triggers (issue #1657):
-#   - inbound/ + adapters/ touched     → dev-core:axial-adr-review
-#   - core/ + infrastructure/ touched  → dev-core:axial-adr-review
-#   - ports/ + hub/ touched            → dev-core:axial-adr-review
-#   - except Exception: added          → dev-core:security-auditor + dev-core:axial-adr-review
+#   - inbound/ + adapters/ touched (top-level factory modules)  → dev-core:axial-adr-review
+#   - core/ + infrastructure/ touched (top-level factory modules) → dev-core:axial-adr-review
+#   - except Exception added (any binding form)                 → dev-core:security-auditor + dev-core:axial-adr-review
+# Note: core/ports/ and core/hub/ are intra-core sub-packages — no separate trigger.
 
 on:
   pull_request:
@@ -31,36 +31,55 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 100,
-            });
+            // Paginate through all changed files (GitHub REST caps each page at 100)
+            let files = [];
+            let page = 1;
+            while (true) {
+              const { data: batch } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+                page,
+              });
+              files = files.concat(batch);
+              if (batch.length < 100) break;
+              page++;
+            }
 
             const paths = files.map(f => f.filename);
 
             // Layer membership helpers
-            const touches = (segment) => paths.some(p => p.includes(`/${segment}/`) || p.startsWith(`${segment}/`));
+            // touches() checks if any path contains the segment as a path component.
+            // For cross-layer detection we need top-level module membership, so we
+            // only match paths whose first src/factory/<segment> segment is the
+            // target — this avoids false positives from same-layer subdirectories
+            // (e.g. core/ports/ and core/hub/ are both inside core/, not separate layers).
+            const touchesTopLevel = (segment) =>
+              paths.some(p => p.includes(`/factory/${segment}/`) || p.startsWith(`factory/${segment}/`));
 
-            const inInbound      = touches('inbound');
-            const inAdapters     = touches('adapters');
-            const inCore         = touches('core');
-            const inInfra        = touches('infrastructure');
-            const inPorts        = touches('ports');
-            const inHub          = touches('hub');
+            const inInbound  = touchesTopLevel('inbound');
+            const inAdapters = touchesTopLevel('adapters');
+            const inCore     = touchesTopLevel('core');
+            const inInfra    = touchesTopLevel('infrastructure');
 
-            // except Exception: detection — scan patch hunks for added lines
+            // except Exception detection — match all Python bare-except-all forms:
+            //   except Exception:          (no binding)
+            //   except Exception as e:     (canonical binding)
+            //   except Exception as exc:   (any identifier)
+            //   except(Exception):         (parenthesised — uncommon but valid)
+            // Regex: after 'Exception', allow optional whitespace then either
+            //   ':' | '(' | 'as <identifier>'
             const exceptException = files.some(f =>
               f.patch && f.patch.split('\n').some(line =>
-                line.startsWith('+') && !line.startsWith('+++') && /except\s+Exception\s*[:\(]/.test(line)
+                line.startsWith('+') && !line.startsWith('+++') &&
+                /except\s+Exception\s*(?::|[(]|\bas\s+\w)/.test(line)
               )
             );
 
             const crossLayer =
               (inInbound && inAdapters) ||
-              (inCore && inInfra)       ||
-              (inPorts && inHub);
+              (inCore && inInfra);
 
             const labelsToAdd = new Set();
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,23 @@ Let:
 - Decisions → global-patterns.md
 - ¬`--force` | ¬`--hard` | ¬`--amend`
 
+## Axial Review (mandatory)
+
+PRs that cross architectural layer boundaries MUST carry `dev-core:axial-adr-review` before merge.
+`.github/workflows/axial-review.yml` applies labels automatically; do NOT strip them manually.
+
+| Trigger | Labels applied |
+|---------|---------------|
+| PR touches `inbound/` **and** `adapters/` | `dev-core:axial-adr-review` |
+| PR touches `core/` **and** `infrastructure/` | `dev-core:axial-adr-review` |
+| PR touches `ports/` **and** `hub/` | `dev-core:axial-adr-review` |
+| PR adds `except Exception:` | `dev-core:axial-adr-review` + `dev-core:security-auditor` |
+
+Review checklist (applies when `dev-core:axial-adr-review` is present):
+- Confirm no inbound-layer logic leaks into adapters (ADR boundary)
+- Confirm core domain objects are not polluted with infrastructure concerns
+- `except Exception:` must be justified inline with a comment; open a follow-up issue if swallowing
+
 ## Key files
 
 | File | Role |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,11 @@ PRs that cross architectural layer boundaries MUST carry `dev-core:axial-adr-rev
 
 | Trigger | Labels applied |
 |---------|---------------|
-| PR touches `inbound/` **and** `adapters/` | `dev-core:axial-adr-review` |
-| PR touches `core/` **and** `infrastructure/` | `dev-core:axial-adr-review` |
-| PR touches `ports/` **and** `hub/` | `dev-core:axial-adr-review` |
-| PR adds `except Exception:` | `dev-core:axial-adr-review` + `dev-core:security-auditor` |
+| PR touches top-level `inbound/` **and** top-level `adapters/` | `dev-core:axial-adr-review` |
+| PR touches top-level `core/` **and** top-level `infrastructure/` | `dev-core:axial-adr-review` |
+| PR adds `except Exception` (any binding form: `as e`, `as exc`, bare) | `dev-core:axial-adr-review` + `dev-core:security-auditor` |
+
+Note: `core/ports/` and `core/hub/` are both sub-packages of `core/` — intra-core changes touching both do NOT trigger the label. Only changes that cross the top-level `factory.*` module boundary trigger `dev-core:axial-adr-review`.
 
 Review checklist (applies when `dev-core:axial-adr-review` is present):
 - Confirm no inbound-layer logic leaks into adapters (ADR boundary)


### PR DESCRIPTION
## Summary

- Add `.github/workflows/axial-review.yml` — auto-labels PRs that cross architectural layer boundaries with `dev-core:axial-adr-review`
- Add `dev-core:security-auditor` label when PR introduces `except Exception:` catches
- Update `CLAUDE.md` with axial review rules and checklist

## Decision trace

**RC(P):** Quality audit 2026-06-02 found 2 blocking axial drift issues. Root cause: no automated enforcement of cross-layer review at PR time — reviewers had no signal that a PR crossed layer boundaries defined in ADRs.

**Candidate Corr:**
1. Manual checklist in CLAUDE.md only (Patch — documentation, no enforcement)
2. GitHub Action auto-labeling + CLAUDE.md documentation (Patch — tooling enforcement at PR boundary)
3. Import linter extension to block cross-layer imports at CI (Archi — structural, invasive)

**Chosen Corr:** Option 2 — Patch. The issue asks for a GitHub Action + CLAUDE.md update. Option 3 would be Archi (modifying `.importlinter` to add new rule sets) and is out of scope for this issue. The Action applies labels automatically so reviewers always see the signal without relying on human categorization.

**Class:** Patch — adds CI automation and documentation; no structural change to source code, no new modules, no import-layer changes.

**Logic level L:** L=CI/process (the symptom appeared at review time → fix applied at review-gate level, not at source level).

## Test plan

- [ ] Open a test PR touching `src/factory/inbound/` and `src/factory/adapters/` → verify `dev-core:axial-adr-review` label is applied
- [ ] Open a test PR adding `except Exception:` in a patch → verify both labels applied
- [ ] Open a PR touching only one layer → verify no label added

Closes #1657