### PR TITLE
feat(ci): debt expiry gate — block stale DEBT: markers older than 6 months

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -86,3 +86,8 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_architecture_snapshot.sh
+
+  debt_expiry:
+    enabled: true
+    stage: pre-push
+    script: tools/check_debt_expiry.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Check architecture snapshot freshness
         run: bash tools/check_architecture_snapshot.sh
 
+      - name: Check debt expiry (stale DEBT: markers)
+        run: bash tools/check_debt_expiry.sh
+
       - name: Enforce import layers
         run: uv run lint-imports
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Check architecture snapshot freshness
         run: bash tools/check_architecture_snapshot.sh
 
-      - name: Check debt expiry (stale DEBT: markers)
+      - name: "Check debt expiry (stale DEBT: markers)"
         run: bash tools/check_debt_expiry.sh
 
       - name: Enforce import layers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,3 +113,10 @@ repos:
     pass_filenames: false
     stages:
     - pre-push
+  - id: check-debt-expiry
+    name: debt expiry (stale DEBT: markers without issue ref)
+    entry: tools/check_debt_expiry.sh
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push

--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ docs/         — ARCHITECTURE, ADRs, guides
 | [CONFIGURATION.md](docs/CONFIGURATION.md) | All config files + env vars |
 | [ADRs](docs/architecture/adr/) | Architecture decision records |
 
+## Debt expiry policy
+
+`DEBT:` markers in source files expire after **6 months** from the file's last git commit. An expired marker without an open GitHub issue reference blocks `git push` via a pre-push hook (`tools/check_debt_expiry.sh`).
+
+To keep a `DEBT:` marker alive, do one of:
+
+1. **Resolve the debt** and remove the marker.
+2. **Open a GitHub issue** and append `#<N>` to the marker line — e.g. `# DEBT:boundary-broad-catch #1234`. The hook skips markers that carry an issue ref.
+3. **Touch the file** in a meaningful commit — resets the 6-month clock.
+
+Grace period and scan scope are configurable via environment variables `DEBT_EXPIRY_MONTHS` (default: 6) and `DEBT_SCAN_ROOT` (default: `src/`).
+
+The hook runs on macOS (BSD grep) and Linux (GNU grep) without additional dependencies. See `docs/debt-tracking.md` for the broader debt-tracking workflow.
+
 ## License
 
 MIT

--- a/tests/tools/test_check_debt_expiry.sh
+++ b/tests/tools/test_check_debt_expiry.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Smoke tests for tools/check_debt_expiry.sh.
+#
+# Verifies:
+#   A. No DEBT: markers → exit 0 (clean repo).
+#   B. Stale marker WITH issue ref (#NNN) → exempted, exit 0.
+#   C. Stale marker WITHOUT issue ref → flagged, exit 1.
+#
+# Case B is the critical negative test: it proves the issue-ref exemption guard
+# (grep -qE '#[0-9]{1,6}') correctly prevents false positives. If the guard were
+# deleted, Case B would break and CI would catch it.
+#
+# Usage: bash tests/tools/test_check_debt_expiry.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Resolve script path
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GATE="$REPO_ROOT/tools/check_debt_expiry.sh"
+
+if [ ! -f "$GATE" ]; then
+    echo "ERROR: gate not found at $GATE" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Temp git repo + cleanup
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+git init "$REPO" >/dev/null 2>&1
+git -C "$REPO" config user.name "tester"
+git -C "$REPO" config user.email "tester@example.com"
+
+# Make an initial commit so git log works inside REPO
+touch "$REPO/.gitkeep"
+git -C "$REPO" add .gitkeep
+GIT_AUTHOR_DATE="2000-01-01T00:00:00" GIT_COMMITTER_DATE="2000-01-01T00:00:00" \
+    git -C "$REPO" commit -m "init" >/dev/null 2>&1
+
+# Source directory that the gate scans (default: src/)
+mkdir -p "$REPO/src"
+
+# Helper: run gate inside REPO, capturing exit code without aborting the script
+run_gate() {
+    (cd "$REPO" && bash "$GATE" 2>&1)
+    echo $?
+}
+
+# ---------------------------------------------------------------------------
+# Case A — no DEBT: markers → exit 0
+# ---------------------------------------------------------------------------
+EXIT_A=$(cd "$REPO" && bash "$GATE" >/dev/null 2>&1; echo $?)
+if [ "$EXIT_A" -eq 0 ]; then
+    pass "A: no DEBT: markers → exit 0"
+else
+    fail "A: no DEBT: markers → exit 0" "got exit $EXIT_A"
+fi
+
+# ---------------------------------------------------------------------------
+# Case B — stale file with DEBT: + issue ref (#1234) → exempted, exit 0
+# ---------------------------------------------------------------------------
+cat > "$REPO/src/example.py" << 'PYEOF'
+# DEBT:boundary-broad-catch #1234 — tracked by open issue
+def foo():
+    pass
+PYEOF
+
+# Commit with a date far in the past (> 6 months ago)
+git -C "$REPO" add src/example.py
+GIT_AUTHOR_DATE="2020-01-01T00:00:00" GIT_COMMITTER_DATE="2020-01-01T00:00:00" \
+    git -C "$REPO" commit -m "add stale file with issue ref" >/dev/null 2>&1
+
+EXIT_B=$(cd "$REPO" && bash "$GATE" >/dev/null 2>&1; echo $?)
+if [ "$EXIT_B" -eq 0 ]; then
+    pass "B: stale DEBT: with issue ref → exempted, exit 0"
+else
+    fail "B: stale DEBT: with issue ref → exempted, exit 0" "got exit $EXIT_B (guard missing or broken)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case C — stale file with DEBT: without issue ref → flagged, exit 1
+# ---------------------------------------------------------------------------
+cat > "$REPO/src/example.py" << 'PYEOF'
+# DEBT:boundary-broad-catch — no issue ref, will expire
+def foo():
+    pass
+PYEOF
+
+git -C "$REPO" add src/example.py
+GIT_AUTHOR_DATE="2020-01-01T00:00:00" GIT_COMMITTER_DATE="2020-01-01T00:00:00" \
+    git -C "$REPO" commit -m "stale marker without issue ref" >/dev/null 2>&1
+
+EXIT_C=$(cd "$REPO" && bash "$GATE" >/dev/null 2>&1; echo $?)
+if [ "$EXIT_C" -eq 1 ]; then
+    pass "C: stale DEBT: without issue ref → flagged, exit 1"
+else
+    fail "C: stale DEBT: without issue ref → flagged, exit 1" "got exit $EXIT_C"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/check_debt_expiry.sh
+++ b/tools/check_debt_expiry.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# check_debt_expiry.sh — block stale DEBT: markers older than 6 months.
+#
+# A DEBT: marker is considered stale when ALL of the following are true:
+#   1. The file that contains it was last modified more than 6 months ago
+#      (per `git log --format=%ci -1 -- <file>`).
+#   2. The marker comment does NOT contain a GitHub issue reference (#NNN).
+#
+# Rationale: an attached issue number (#NNN) indicates an active remediation
+# path exists; file recency is the proxy for "still being worked on".
+# Markers with an issue ref are never expired here — use the audit report for
+# those.
+#
+# Exit-code contract (consistent with gate scripts in this repo — tools/CLAUDE.md):
+#   0 = no stale markers found
+#   1 = stale markers detected (merge-blocking)
+#   2 = script error (missing dep / corrupt git state)
+#
+# Environment overrides:
+#   DEBT_EXPIRY_MONTHS  — grace period in months (default: 6)
+#   DEBT_SCAN_ROOT      — directory to scan (default: src/)
+#   DEBT_INCLUDE_EXT    — file extension to scan (default: py)
+#
+# Run locally:
+#   bash tools/check_debt_expiry.sh
+# Run in CI:
+#   debt-expiry step in .github/workflows/ci.yml
+#
+# Note: git log date is file-level, not line-level. This is intentional:
+#   - git blame per-line would be O(N) subprocess calls — too slow for CI.
+#   - File-level last-modification is a conservative proxy: if the file was
+#     touched recently the debt was presumably reviewed.
+#   - False positives (file edited for unrelated reason) are low-cost: the
+#     author simply adds a #NNN reference to pin the expiry.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve repo root and move there
+# ---------------------------------------------------------------------------
+cd "$(git rev-parse --show-toplevel)" || { echo "ERROR: not a git repository" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+MONTHS="${DEBT_EXPIRY_MONTHS:-6}"
+SCAN_ROOT="${DEBT_SCAN_ROOT:-src/}"
+EXT="${DEBT_INCLUDE_EXT:-py}"
+
+# Cutoff timestamp: today minus MONTHS months (YYYY-MM-DD).
+# date -d is GNU; macOS requires date -v.
+if date --version >/dev/null 2>&1; then
+    # GNU date
+    CUTOFF=$(date -d "$MONTHS months ago" +%Y-%m-%d)
+else
+    # macOS / BSD date
+    CUTOFF=$(date -v "-${MONTHS}m" +%Y-%m-%d)
+fi
+
+# ---------------------------------------------------------------------------
+# Guard: scan root must exist
+# ---------------------------------------------------------------------------
+if [ ! -d "$SCAN_ROOT" ]; then
+    echo "WARN: $SCAN_ROOT not found, skipping check_debt_expiry" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Collect files containing DEBT: markers
+# ---------------------------------------------------------------------------
+mapfile -d '' FILES < <(
+    grep -rl "DEBT:" "$SCAN_ROOT" \
+        --include="*.$EXT" \
+        -Z \
+        2>/dev/null \
+    || true
+)
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "check_debt_expiry: no DEBT: markers found in ${SCAN_ROOT} — OK"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Gate loop
+# ---------------------------------------------------------------------------
+FAIL=0
+STALE_COUNT=0
+
+for file in "${FILES[@]}"; do
+    # File-level last-commit date (ISO 8601 YYYY-MM-DD)
+    LAST_DATE=$(git log --format="%ci" -1 -- "$file" 2>/dev/null | cut -d' ' -f1)
+    if [ -z "$LAST_DATE" ]; then
+        # Untracked / new file — not stale (no commit yet)
+        continue
+    fi
+
+    # Skip files modified after the cutoff
+    if [[ "$LAST_DATE" > "$CUTOFF" || "$LAST_DATE" == "$CUTOFF" ]]; then
+        continue
+    fi
+
+    # File is older than the grace period — inspect each DEBT: line
+    while IFS= read -r line; do
+        lineno=$(echo "$line" | cut -d: -f1)
+        content=$(echo "$line" | cut -d: -f2-)
+
+        # Presence of a GitHub issue reference (#NNN) on the same line
+        # means an active remediation path exists → skip expiry check.
+        if echo "$content" | grep -qP '#\d{1,6}\b'; then
+            continue
+        fi
+
+        # Stale marker: file old + no issue ref
+        if [ "$STALE_COUNT" -eq 0 ]; then
+            echo ""
+            echo "FAIL: stale DEBT: markers (file last modified ${LAST_DATE}, cutoff ${CUTOFF}, no issue ref):" >&2
+        fi
+        echo "  ${file}:${lineno}: ${content}" >&2
+        STALE_COUNT=$((STALE_COUNT + 1))
+        FAIL=1
+    done < <(grep -n "DEBT:" "$file" || true)
+done
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "check_debt_expiry: all DEBT: markers are within the ${MONTHS}-month grace period or have an issue ref — OK"
+else
+    echo "" >&2
+    echo "Found ${STALE_COUNT} stale DEBT: marker(s)." >&2
+    echo "Remediation options:" >&2
+    echo "  1. Resolve the debt and remove the marker." >&2
+    echo "  2. Open a GitHub issue and append '#<N>' to the DEBT: comment." >&2
+    echo "     Example:  # noqa: BLE001 — DEBT:boundary-broad-catch #1234" >&2
+    echo "  3. Touch the file with a meaningful commit (resets the 6-month clock)." >&2
+fi
+
+exit $FAIL

--- a/tools/check_debt_expiry.sh
+++ b/tools/check_debt_expiry.sh
@@ -106,7 +106,8 @@ for file in "${FILES[@]}"; do
 
         # Presence of a GitHub issue reference (#NNN) on the same line
         # means an active remediation path exists → skip expiry check.
-        if echo "$content" | grep -qP '#\d{1,6}\b'; then
+        # Use ERE (-E) instead of -P for portability across GNU grep and macOS BSD grep.
+        if echo "$content" | grep -qE '#[0-9]{1,6}([^0-9]|$)'; then
             continue
         fi
 


### PR DESCRIPTION
## Summary

- `tools/check_debt_expiry.sh`: new gate script that exits 1 when a file containing a `DEBT:` marker was last modified (via `git log`) more than 6 months ago and the inline comment does not reference a GitHub issue (`#NNN`)
- `.pre-commit-config.yaml`: wired as `check-debt-expiry` at `pre-push` stage
- `.github/workflows/ci.yml`: `Check debt expiry` step added after architecture-snapshot check

## Decision trace

**RC(P):** 172 `DEBT:` markers in the codebase have no automated expiry enforcement — they accumulate silently without remediation pressure.

**Candidate corrections:**
1. **Patch** — add a file-age gate script + CI/pre-commit wiring (local, no structural change)
2. **Archi** — introduce a DEBT registry with per-slug status files (structural, requires migration of all 172 markers)

**Chosen:** Option 1 — **Patch**. The issue specifies exactly this scope (script + pre-commit + CI). An Archi solution exists (`artifacts/debt/<slug>.md` registry already used by `audit_quality_debt.py`) but is a separate migration; the gate adds enforcement without blocking that future upgrade.

**Logic level L:** CI/tooling layer — no production code modified. The gate operates on git metadata and file content, not on runtime behaviour.

**Class:** `Patch` — local addition to tooling layer; no structural change to modules or domain.

## Gate behaviour

| Condition | Result |
|---|---|
| File modified ≤ 6 months ago | Pass (recent activity = debt being managed) |
| File old + `DEBT:` has `#NNN` | Pass (active issue = remediation tracked) |
| File old + `DEBT:` no issue ref | **Fail** (stale, no tracking) |

Grace period configurable via `DEBT_EXPIRY_MONTHS` env var (default: 6).

## Test plan

- [x] Script runs clean against current repo (all files recently modified → all pass)
- [x] Stale detection logic verified with simulated past dates
- [x] `uv run pytest` — 4564 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run lint-imports` — 11 contracts kept

Closes #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)