### PR TITLE
docs(process): debt retrospective after each /dev cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Let:
 ## TL;DR
 
 - Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle
+- Close checklist (post-merge): `docs/process/dev-cycle.md` — debt retrospective
 - Decisions → global-patterns.md
 - ¬`--force` | ¬`--hard` | ¬`--amend`
 
@@ -22,6 +23,7 @@ Let:
 | File | Role |
 |---|---|
 | `docs/ARCHITECTURE.md` | Architecture + decisions |
+| `docs/process/dev-cycle.md` | `/dev #N` close checklist — debt retrospective |
 | `docs/architecture/CURRENT.generated.md` | Generated inventory SSoT (layers/subjects/topology) — ¬edit, gated by `architecture_snapshot` |
 | `docs/CONFIGURATION.md` | Config files, load order |
 | `docs/agent-management.md` | Agent seed flow + CLI |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Let:
 ## TL;DR
 
 - Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle
-- Close checklist (post-merge): `docs/process/dev-cycle.md` — debt retrospective
+- Close checklist (pre-cleanup, from worktree): `docs/process/dev-cycle.md` — run **before** worktree removal; `/dev` skill integration pending (roxabi-plugins)
 - Decisions → global-patterns.md
 - ¬`--force` | ¬`--hard` | ¬`--amend`
 

--- a/docs/process/dev-cycle.md
+++ b/docs/process/dev-cycle.md
@@ -1,0 +1,32 @@
+# Dev Cycle — Close Checklist
+
+Run after every `/dev #N` cycle completes (PR merged, worktree cleaned up).
+
+## Debt Retrospective
+
+```bash
+# Run from worktree root before cleanup, or against the merged diff
+git diff origin/staging..HEAD -- '*.py' | grep -c 'DEBT:'
+git diff origin/staging..HEAD -- '*.py' | grep -c 'noqa:'
+git diff origin/staging..HEAD -- '*.py' | grep -c 'except Exception'
+git diff origin/staging..HEAD -- '*.py' | grep -c 'sleep('
+```
+
+| Metric | Threshold | Action |
+|--------|-----------|--------|
+| `DEBT:` added | > 3 | Split scope next cycle |
+| `noqa:` added | > 3 | Review suppressions; each needs `— DEBT:<slug>` |
+| `except Exception` added | > 2 | Narrow catch or add debt entry |
+| `sleep()` added | > 1 | Justify or replace with async wait |
+
+## Rules
+
+- Every `noqa:` / `pyright: ignore` / `type: ignore` added → must carry `— DEBT:<slug>` suffix per `docs/debt-tracking.md`.
+- DEBT: markers without a slug → `tools/audit_quality_debt.py` warns on stderr (exit 0, non-blocking).
+- > 3 DEBT: added in one cycle → flag scope for splitting in next planning session.
+
+## Reference
+
+- Debt registry: `artifacts/debt/` — one `<slug>.md` per entry.
+- Audit tool: `tools/audit_quality_debt.py` (run via `make quality-debt-report`).
+- Full debt policy: `docs/debt-tracking.md`.

--- a/docs/process/dev-cycle.md
+++ b/docs/process/dev-cycle.md
@@ -1,15 +1,15 @@
 # Dev Cycle — Close Checklist
 
-Run after every `/dev #N` cycle completes (PR merged, worktree cleaned up).
+Run from the worktree root **before** cleanup (while `HEAD` still points to the PR branch).
 
 ## Debt Retrospective
 
 ```bash
-# Run from worktree root before cleanup, or against the merged diff
-git diff origin/staging..HEAD -- '*.py' | grep -c 'DEBT:'
-git diff origin/staging..HEAD -- '*.py' | grep -c 'noqa:'
-git diff origin/staging..HEAD -- '*.py' | grep -c 'except Exception'
-git diff origin/staging..HEAD -- '*.py' | grep -c 'sleep('
+# Run from worktree root before cleanup (git diff is empty after merge + worktree removal)
+git diff origin/staging..HEAD -- '*.py' | grep '^+' | grep -c 'DEBT:'
+git diff origin/staging..HEAD -- '*.py' | grep '^+' | grep -c 'noqa:'
+git diff origin/staging..HEAD -- '*.py' | grep '^+' | grep -c 'except Exception'
+git diff origin/staging..HEAD -- '*.py' | grep '^+' | grep -c 'sleep('
 ```
 
 | Metric | Threshold | Action |
@@ -30,3 +30,7 @@ git diff origin/staging..HEAD -- '*.py' | grep -c 'sleep('
 - Debt registry: `artifacts/debt/` — one `<slug>.md` per entry.
 - Audit tool: `tools/audit_quality_debt.py` (run via `make quality-debt-report`).
 - Full debt policy: `docs/debt-tracking.md`.
+
+## Integration Status
+
+This checklist is referenced from `CLAUDE.md` TL;DR. Automated invocation from the `/dev` SKILL.md cleanup step (in `roxabi-plugins`) is **pending** — tracked as a follow-up cross-repo change. Until wired, the checklist must be run manually before worktree cleanup.


### PR DESCRIPTION
## Summary

- Create `docs/process/dev-cycle.md` with debt retrospective commands and thresholds for the post-merge close step
- Reference the new file from `CLAUDE.md` TL;DR (close checklist pointer) and Key files table
- Defines actionable thresholds: >3 DEBT: added → split scope; >3 noqa: → review; >2 `except Exception` → narrow; >1 `sleep()` → justify

## Decision trace

**RC(P):** The `/dev #N` cycle had no documented close checklist triggering debt accounting. Result: 172 untagged `DEBT:` markers accumulated silently across cycles (quality audit 2026-06-02). Root cause is at L=process (missing enforcement prompt at cycle boundary), not in code.

**Candidate corrections:**
1. Patch — Add `docs/process/dev-cycle.md` + CLAUDE.md pointer (local doc, no structural change)
2. Archi — Modify the `/dev` skill in `roxabi-plugins` to add a mandatory retrospective step

**Chosen:** Option 1 — Patch. The `/dev` skill is in a separate repo (`roxabi-plugins`). The process doc + CLAUDE.md pointer is the correct insertion point for this project: it surfaces the checklist where developers read it (CLAUDE.md TL;DR) without requiring a cross-repo change. Class: **Patch**. Logic level L=process (the root cause is a missing process prompt, not a code defect).

**Logic level:** L=process — fix applied at the level where the root cause exists.

## Test plan

- [x] `docs/process/dev-cycle.md` created with retrospective commands and thresholds
- [x] `CLAUDE.md` TL;DR references the close checklist
- [x] `CLAUDE.md` Key files table registers the new file
- [x] `uv run ruff format . && uv run ruff check --fix .` — all checks passed
- [x] `uv run pytest` — 5405 passed, 14 skipped, 1 xfailed
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] Architecture snapshot unchanged (no Python source modified)

Closes #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)