### PR TITLE
feat(ci): file exemption expiry gate — block stale file-length exemptions

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -91,3 +91,8 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_debt_expiry.sh
+
+  file_exemptions:
+    enabled: true
+    script: tools/check_file_exemptions.sh
+    description: every entry in file_exemptions.txt must have a non-expired expires=YYYY-MM-DD token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Check file length
         run: bash tools/check_file_length.sh
 
+      - name: "Check file exemption expiry (stale exemptions without valid date)"
+        run: bash tools/check_file_exemptions.sh
+
       - name: Check qg.conf drift (stack.yml is source of truth)
         run: bash scripts/check-qg-conf-drift.sh
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
     entry: tools/check_file_length.sh
     language: system
     pass_filenames: false
+  - id: check-file-exemptions
+    name: check-file-exemptions (expiry dates on file-length exemptions)
+    entry: tools/check_file_exemptions.sh
+    language: system
+    pass_filenames: false
   - id: check-file-length-roxabi-nats
     name: check-file-length (roxabi-nats)
     entry: bash -c "QG_FILE_ROOT=packages/roxabi-nats/src/ QG_FILE_EXEMPTIONS=packages/roxabi-nats/tools/file_exemptions.txt tools/check_file_length.sh"

--- a/tests/tools/test_check_file_exemptions.sh
+++ b/tests/tools/test_check_file_exemptions.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Smoke tests for tools/check_file_exemptions.sh.
+#
+# Verifies:
+#   A. Empty exemptions file (comments only) → exit 0
+#   B. Entry with a valid future expires= date → exit 0
+#   C. Entry with an expired date → exit 1
+#   D. Entry missing expires= entirely → exit 1
+#   E. Multiple entries — one expired, one valid → exit 1
+#
+# Usage: bash tests/tools/test_check_file_exemptions.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Resolve script path
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GATE="$REPO_ROOT/tools/check_file_exemptions.sh"
+
+if [ ! -f "$GATE" ]; then
+    echo "ERROR: gate not found at $GATE" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Temp dir + cleanup
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# We need a git repo so the gate can resolve repo root via git rev-parse.
+REPO="$WORK/repo"
+git init "$REPO" >/dev/null 2>&1
+git -C "$REPO" config user.name "tester"
+git -C "$REPO" config user.email "tester@example.com"
+touch "$REPO/.gitkeep"
+git -C "$REPO" add .gitkeep
+git -C "$REPO" commit -m "init" >/dev/null 2>&1
+
+EXEMPTIONS="$REPO/tools/file_exemptions.txt"
+mkdir -p "$REPO/tools"
+
+# Fixed "today" so tests are date-stable.
+FIXED_TODAY="2026-06-02"
+FUTURE="2026-12-02"
+PAST="2026-01-01"
+
+# Helper: run gate with controlled today date and a given exemptions content.
+run_gate() {
+    local content="$1"
+    printf '%s\n' "$content" > "$EXEMPTIONS"
+    (
+        cd "$REPO"
+        FILE_EXEMPTIONS_PATH="tools/file_exemptions.txt" \
+        FILE_EXEMPTIONS_TODAY="$FIXED_TODAY" \
+        bash "$GATE" >/dev/null 2>&1
+    )
+    echo $?
+}
+
+# ---------------------------------------------------------------------------
+# Case A — comments-only file → exit 0
+# ---------------------------------------------------------------------------
+CONTENT_A="$(cat <<'EOF'
+# File size exemptions
+# Format: <path>  # <N> lines — <issue> <description> expires=YYYY-MM-DD
+EOF
+)"
+EXIT_A=$(run_gate "$CONTENT_A")
+if [ "$EXIT_A" -eq 0 ]; then
+    pass "A: comments-only → exit 0"
+else
+    fail "A: comments-only → exit 0" "got exit $EXIT_A"
+fi
+
+# ---------------------------------------------------------------------------
+# Case B — valid future expires= date → exit 0
+# ---------------------------------------------------------------------------
+CONTENT_B="src/factory/foo.py  # 350 lines — DEBT:refactor — #1234 rationale expires=${FUTURE}"
+EXIT_B=$(run_gate "$CONTENT_B")
+if [ "$EXIT_B" -eq 0 ]; then
+    pass "B: valid future date → exit 0"
+else
+    fail "B: valid future date → exit 0" "got exit $EXIT_B"
+fi
+
+# ---------------------------------------------------------------------------
+# Case C — expired date → exit 1
+# ---------------------------------------------------------------------------
+CONTENT_C="src/factory/bar.py  # 320 lines — DEBT:old-debt — #999 rationale expires=${PAST}"
+EXIT_C=$(run_gate "$CONTENT_C")
+if [ "$EXIT_C" -eq 1 ]; then
+    pass "C: expired date → exit 1"
+else
+    fail "C: expired date → exit 1" "got exit $EXIT_C"
+fi
+
+# ---------------------------------------------------------------------------
+# Case D — missing expires= → exit 1
+# ---------------------------------------------------------------------------
+CONTENT_D="src/factory/baz.py  # 310 lines — DEBT:missing-date — #777 rationale"
+EXIT_D=$(run_gate "$CONTENT_D")
+if [ "$EXIT_D" -eq 1 ]; then
+    pass "D: missing expires= → exit 1"
+else
+    fail "D: missing expires= → exit 1" "got exit $EXIT_D"
+fi
+
+# ---------------------------------------------------------------------------
+# Case E — mixed: one valid + one expired → exit 1
+# ---------------------------------------------------------------------------
+CONTENT_E="$(cat <<EOF
+src/factory/ok.py  # 300 lines — DEBT:fine — #111 rationale expires=${FUTURE}
+src/factory/old.py  # 400 lines — DEBT:stale — #222 rationale expires=${PAST}
+EOF
+)"
+EXIT_E=$(run_gate "$CONTENT_E")
+if [ "$EXIT_E" -eq 1 ]; then
+    pass "E: mixed valid+expired → exit 1"
+else
+    fail "E: mixed valid+expired → exit 1" "got exit $EXIT_E"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/check_file_exemptions.sh
+++ b/tools/check_file_exemptions.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# check_file_exemptions.sh — enforce expiry dates on file-length exemptions.
+#
+# Every non-comment entry in tools/file_exemptions.txt MUST carry a well-formed
+# expires=YYYY-MM-DD token. The gate fails if:
+#   - An active entry is missing an expires= token.
+#   - An active entry carries an expires= date that is strictly before today.
+#
+# Rationale: exemptions represent acknowledged technical debt. Without an expiry
+# date they accumulate silently and become stale. The 6-month horizon forces a
+# periodic review (either resolve the debt or push the date with a new rationale).
+#
+# Exit-code contract (consistent with all gate scripts in this repo — tools/CLAUDE.md):
+#   0 = clean (all entries have a valid, non-expired date)
+#   1 = violations found (missing or expired date — merge-blocking)
+#   2 = script error (missing file, bad environment, etc.)
+#
+# Environment overrides:
+#   FILE_EXEMPTIONS_PATH   — path to the exemptions file (default: tools/file_exemptions.txt)
+#   FILE_EXEMPTIONS_TODAY  — override today's date for testing (YYYY-MM-DD)
+#
+# Run locally:
+#   bash tools/check_file_exemptions.sh
+# Run in CI:
+#   file-exemptions step in .github/workflows/ci.yml
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve repo root and move there
+# ---------------------------------------------------------------------------
+cd "$(git rev-parse --show-toplevel)" || { echo "ERROR: not a git repository" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+EXEMPT_FILE="${FILE_EXEMPTIONS_PATH:-tools/file_exemptions.txt}"
+TODAY="${FILE_EXEMPTIONS_TODAY:-$(date +%F)}"
+
+# ---------------------------------------------------------------------------
+# Guard: exemptions file must exist
+# ---------------------------------------------------------------------------
+if [ ! -f "$EXEMPT_FILE" ]; then
+    echo "WARN: $EXEMPT_FILE not found, skipping check_file_exemptions" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Validate TODAY format
+# ---------------------------------------------------------------------------
+if ! echo "$TODAY" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    echo "ERROR: TODAY='$TODAY' is not a valid YYYY-MM-DD date" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Gate loop — inspect each non-comment, non-blank line
+# ---------------------------------------------------------------------------
+FAIL=0
+MISSING_COUNT=0
+EXPIRED_COUNT=0
+
+while IFS= read -r line; do
+    # Skip blank lines and comment lines (lines whose first non-space char is #)
+    stripped="${line#"${line%%[![:space:]]*}"}"  # ltrim
+    [ -z "$stripped" ] && continue
+    [[ "$stripped" == \#* ]] && continue
+
+    # Extract the path (first whitespace-delimited field)
+    path=$(echo "$line" | awk '{ print $1 }')
+
+    # Look for expires=YYYY-MM-DD anywhere on the line
+    expires=""
+    if echo "$line" | grep -qE 'expires=[0-9]{4}-[0-9]{2}-[0-9]{2}'; then
+        expires=$(echo "$line" | grep -oE 'expires=[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 | cut -d= -f2)
+    fi
+
+    if [ -z "$expires" ]; then
+        echo "MISSING expires= : $path" >&2
+        MISSING_COUNT=$((MISSING_COUNT + 1))
+        FAIL=1
+        continue
+    fi
+
+    # Validate date format
+    if ! echo "$expires" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+        echo "MALFORMED expires=$expires : $path" >&2
+        MISSING_COUNT=$((MISSING_COUNT + 1))
+        FAIL=1
+        continue
+    fi
+
+    # Compare dates lexicographically (YYYY-MM-DD sorts correctly as strings)
+    if [[ "$expires" < "$TODAY" ]]; then
+        echo "EXPIRED expires=$expires (today=$TODAY): $path" >&2
+        EXPIRED_COUNT=$((EXPIRED_COUNT + 1))
+        FAIL=1
+    fi
+done < "$EXEMPT_FILE"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ "$FAIL" -eq 0 ]; then
+    echo "check_file_exemptions: all entries have a valid, non-expired expiry date — OK"
+else
+    echo "" >&2
+    TOTAL=$((MISSING_COUNT + EXPIRED_COUNT))
+    [ "$MISSING_COUNT" -gt 0 ] && echo "  $MISSING_COUNT entry(ies) missing expires=YYYY-MM-DD" >&2
+    [ "$EXPIRED_COUNT" -gt 0 ] && echo "  $EXPIRED_COUNT entry(ies) with an expired date (before $TODAY)" >&2
+    echo "" >&2
+    echo "Found $TOTAL violation(s) in $EXEMPT_FILE." >&2
+    echo "Remediation:" >&2
+    echo "  - Add   expires=YYYY-MM-DD  to entries that lack it." >&2
+    echo "  - Resolve the debt (remove the exemption) if it is past its expiry." >&2
+    echo "  - Push the expiry date forward with an updated rationale + issue ref." >&2
+    echo "  Example: src/factory/foo.py  # 350 lines — DEBT:refactor — #1234 rationale expires=2027-01-01" >&2
+fi
+
+exit $FAIL


### PR DESCRIPTION
## Summary

- Adds `tools/check_file_exemptions.sh`: enforces `expires=YYYY-MM-DD` on every active entry in `tools/file_exemptions.txt`; fails (exit 1) for missing or expired dates
- Wired into CI (`ci:` job, after `check-file-length`), pre-commit (commit-stage), and `.claude/stack.yml` (`file_exemptions` quality gate)
- Smoke-tested in `tests/tools/test_check_file_exemptions.sh` (5 cases: comments-only → 0, valid-future → 0, expired → 1, missing → 1, mixed → 1)

## Decision trace

- **RC**: baseline-grandfather — `file_exemptions.txt` currently has 0 active entries, so no entries needed timestamping today; the gate is forward-blocking only
- **Corr**: baseline-grandfather (6-month review horizon for future exemptions)
- **Classe**: Patch (additive gate, no logic changes)
- **Shape**: mirrors `debt_expiry` / `check_debt_expiry.sh` wiring exactly

## Gate exit codes (all green)

| Gate | Exit |
|---|---|
| `bash tools/check_file_exemptions.sh` | 0 |
| `bash tests/tools/test_check_file_exemptions.sh` | 0 (5/5 passed) |
| `bash tools/check_file_length.sh` | 0 (parser unbroken) |
| `uv run ruff check .` | 0 |
| `uv run pyright` | 0 |
| `uv run pytest tests/tools/` | 0 (215 passed, 1 skipped) |
| `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` | parses OK, `ci` job present |

Closes #1655

🤖 Generated with [Claude Code](https://claude.com/claude-code)