### PR TITLE
feat(ci): hardcoded constant gate — baseline-grandfather for src/factory/core/

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -91,3 +91,9 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_debt_expiry.sh
+
+  hardcoded_constants:
+    enabled: true
+    script: tools/check_hardcoded_constants.sh
+    description: block new hardcoded numeric literals in src/factory/core/ (baseline-grandfather strategy — #1654)
+    baseline: tools/hardcoded_constants_baseline.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: "Check file exemption expiry (stale exemptions without valid date)"
         run: bash tools/check_file_exemptions.sh
 
+      - name: "Check hardcoded constants (new numeric literals in src/factory/core/)"
+        run: bash tools/check_hardcoded_constants.sh
+
       - name: Check qg.conf drift (stack.yml is source of truth)
         run: bash scripts/check-qg-conf-drift.sh
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
     entry: tools/check_file_exemptions.sh
     language: system
     pass_filenames: false
+  - id: check-hardcoded-constants
+    name: check-hardcoded-constants (new numeric literals in src/factory/core/)
+    entry: tools/check_hardcoded_constants.sh
+    language: system
+    pass_filenames: false
   - id: check-file-length-roxabi-nats
     name: check-file-length (roxabi-nats)
     entry: bash -c "QG_FILE_ROOT=packages/roxabi-nats/src/ QG_FILE_EXEMPTIONS=packages/roxabi-nats/tools/file_exemptions.txt tools/check_file_length.sh"

--- a/tests/tools/test_check_hardcoded_constants.sh
+++ b/tests/tools/test_check_hardcoded_constants.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Smoke tests for tools/check_hardcoded_constants.sh.
+#
+# Verifies:
+#   A. A baselined line passes (exit 0).
+#   B. A NEW hardcoded constant (not in baseline) fails (exit 1).
+#   C. A line referencing Config.SOMETHING passes (exit 0) — sanctioned indirection.
+#   D. An inline-exempt line (# const-ok: <reason>) passes (exit 0).
+#   E. The real src/factory/core/ tree passes (exit 0) — proves baseline covers current HEAD.
+#
+# Cases C and D are the critical negative tests: they prove the exemption guards
+# prevent false positives.  Delete a guard → the case breaks → CI catches it.
+#
+# Fixtures for A–D are written to a temporary git repo so the gate (which calls
+# git rev-parse to resolve repo root) works correctly.  Real source is NOT mutated.
+#
+# Usage: bash tests/tools/test_check_hardcoded_constants.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Resolve script + repo paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GATE="$REPO_ROOT/tools/check_hardcoded_constants.sh"
+REAL_BASELINE="$REPO_ROOT/tools/hardcoded_constants_baseline.txt"
+
+if [ ! -f "$GATE" ]; then
+    echo "ERROR: gate not found at $GATE" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Set up a temp git repo for fixture-based tests (A–D)
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+git init "$REPO" >/dev/null 2>&1
+git -C "$REPO" config user.name  "tester"
+git -C "$REPO" config user.email "tester@example.com"
+touch "$REPO/.gitkeep"
+git -C "$REPO" add .gitkeep
+git -C "$REPO" commit -m "init" >/dev/null 2>&1
+
+# We write fixtures under src/factory/core/ inside the temp repo so the gate
+# scans the right directory.
+CORE_DIR="$REPO/src/factory/core"
+mkdir -p "$CORE_DIR"
+
+# Baseline file inside the temp repo — we control its contents per test.
+BASELINE="$REPO/tools/baseline.txt"
+mkdir -p "$REPO/tools"
+
+# Helper: run gate against the temp repo with our controlled baseline.
+# CONST_SCAN_ROOT and CONST_BASELINE_FILE override the defaults.
+run_gate() {
+    (
+        cd "$REPO"
+        CONST_SCAN_ROOT="src/factory/core/" \
+        CONST_BASELINE_FILE="tools/baseline.txt" \
+        bash "$GATE" >/dev/null 2>&1
+    )
+    echo $?
+}
+
+# ---------------------------------------------------------------------------
+# Case A — a baselined line passes (exit 0)
+# ---------------------------------------------------------------------------
+# Write a file with a hardcoded constant
+cat > "$CORE_DIR/test_a.py" << 'PYEOF'
+TIMEOUT = 30
+PYEOF
+
+# Put that exact signature in the baseline
+printf 'src/factory/core/test_a.py:TIMEOUT = 30\n' > "$BASELINE"
+
+EXIT_A=$(run_gate)
+if [ "$EXIT_A" -eq 0 ]; then
+    pass "A: baselined line → exit 0"
+else
+    fail "A: baselined line → exit 0" "got exit $EXIT_A"
+fi
+
+# Clean up fixture
+rm -f "$CORE_DIR/test_a.py"
+
+# ---------------------------------------------------------------------------
+# Case B — NEW hardcoded constant (not in baseline) fails (exit 1)
+# ---------------------------------------------------------------------------
+cat > "$CORE_DIR/test_b.py" << 'PYEOF'
+MAX_RETRIES = 15
+PYEOF
+
+# Empty baseline — no entries grandfathered
+printf '# empty baseline\n' > "$BASELINE"
+
+EXIT_B=$(run_gate)
+if [ "$EXIT_B" -eq 1 ]; then
+    pass "B: new hardcoded constant → exit 1"
+else
+    fail "B: new hardcoded constant → exit 1" "got exit $EXIT_B"
+fi
+
+rm -f "$CORE_DIR/test_b.py"
+
+# ---------------------------------------------------------------------------
+# Case C — line referencing Config.SOMETHING passes (exit 0)
+# ---------------------------------------------------------------------------
+cat > "$CORE_DIR/test_c.py" << 'PYEOF'
+limit = BusConfig.DEFAULT_MAXSIZE
+PYEOF
+
+# Empty baseline — the Config. exemption must fire, not the baseline
+printf '# empty baseline\n' > "$BASELINE"
+
+EXIT_C=$(run_gate)
+if [ "$EXIT_C" -eq 0 ]; then
+    pass "C: Config. reference → exit 0 (sanctioned indirection)"
+else
+    fail "C: Config. reference → exit 0" "got exit $EXIT_C (Config. guard missing or broken)"
+fi
+
+rm -f "$CORE_DIR/test_c.py"
+
+# ---------------------------------------------------------------------------
+# Case D — inline-exempt line (# const-ok:) passes (exit 0)
+# ---------------------------------------------------------------------------
+cat > "$CORE_DIR/test_d.py" << 'PYEOF'
+NATS_MAX_PAYLOAD = 1024 * 1024  # const-ok: NATS protocol hard limit, cannot be config
+PYEOF
+
+# Empty baseline — the const-ok: exemption must fire
+printf '# empty baseline\n' > "$BASELINE"
+
+EXIT_D=$(run_gate)
+if [ "$EXIT_D" -eq 0 ]; then
+    pass "D: # const-ok: line → exit 0 (inline exempt)"
+else
+    fail "D: # const-ok: line → exit 0" "got exit $EXIT_D (inline-exempt guard missing or broken)"
+fi
+
+rm -f "$CORE_DIR/test_d.py"
+
+# ---------------------------------------------------------------------------
+# Case E — real src/factory/core/ tree passes (exit 0)
+# Proves the committed baseline grandfathers all constants at current HEAD.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REAL_BASELINE" ]; then
+    fail "E: real tree → exit 0" "baseline file not found at $REAL_BASELINE"
+else
+    EXIT_E=$(
+        cd "$REPO_ROOT"
+        bash "$GATE" >/dev/null 2>&1
+        echo $?
+    )
+    if [ "$EXIT_E" -eq 0 ]; then
+        pass "E: real src/factory/core/ tree → exit 0"
+    else
+        fail "E: real src/factory/core/ tree → exit 0" "got exit $EXIT_E (baseline out of sync with HEAD)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/check_hardcoded_constants.sh
+++ b/tools/check_hardcoded_constants.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# check_hardcoded_constants.sh — block NEW hardcoded numeric constants in src/factory/core/.
+#
+# DETECTION LOGIC
+# ---------------
+# A line is flagged when ALL of the following are true:
+#   1. The file is under SCAN_ROOT (default: src/factory/core/).
+#   2. The line contains a numeric literal >= 2 digits in an assignment (=N),
+#      function-call argument (,N or (N), keyword-argument (key=N), or
+#      comparison/condition context (>N, <N, >=N, <=N, ==N, !=N).
+#      grep -E pattern: [=,(<>!][[:space:]]*[0-9]{2,6}([^0-9.]|$)
+#      Rationale: 2-digit minimum avoids flagging 0, 1, and single-digit
+#      loop indices; 6-digit ceiling avoids port numbers etc.
+#   3. The line does NOT reference a Config or Protocol constant (contains
+#      "Config." or "Protocol." — the sanctioned indirections).
+#   4. The line does NOT carry an inline exemption marker "# const-ok:"
+#      anywhere on the line.
+#   5. The line is not a pure comment or blank.
+#
+# BASELINE-GRANDFATHER
+# --------------------
+# Existing constants at the time the gate was introduced are grandfathered
+# in tools/hardcoded_constants_baseline.txt.  A flagged line is a violation
+# ONLY IF its signature is NOT in the baseline.
+#
+# SIGNATURE FORMAT
+# ----------------
+# Signature = "<relpath>:<normalized-line>"
+# where:
+#   relpath          = path of the file relative to the repo root
+#                      (e.g. src/factory/core/hub/hub.py)
+#   normalized-line  = code line with leading AND trailing whitespace stripped
+#
+# Leading/trailing whitespace is stripped so that reformatting (indentation
+# changes) and minor code-moves do not produce false positives.  Line numbers
+# are NOT part of the signature for the same reason.
+#
+# ESCAPE HATCH
+# ------------
+# Add "# const-ok: <reason>" as a trailing comment on the offending line to
+# permanently exempt it.  Use sparingly and document the reason inline.
+# Example:
+#   NATS_MAX_PAYLOAD = 1024 * 1024  # const-ok: NATS protocol hard limit
+#
+# EXIT-CODE CONTRACT (consistent with all gate scripts — tools/CLAUDE.md)
+#   0 = clean (no new violations)
+#   1 = violations found (merge-blocking)
+#   2 = script error (missing dep / bad git state / missing baseline)
+#
+# ENVIRONMENT OVERRIDES
+#   CONST_SCAN_ROOT      — directory to scan (default: src/factory/core/)
+#   CONST_BASELINE_FILE  — path to baseline (default: tools/hardcoded_constants_baseline.txt)
+#
+# RUN LOCALLY
+#   bash tools/check_hardcoded_constants.sh
+# RUN IN CI
+#   check-hardcoded-constants step in .github/workflows/ci.yml
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve repo root and cd there so all relative paths are stable
+# ---------------------------------------------------------------------------
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || { echo "ERROR: not a git repository" >&2; exit 2; }
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SCAN_ROOT="${CONST_SCAN_ROOT:-src/factory/core/}"
+BASELINE_FILE="${CONST_BASELINE_FILE:-tools/hardcoded_constants_baseline.txt}"
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+if [ ! -d "$SCAN_ROOT" ]; then
+    echo "WARN: $SCAN_ROOT not found, skipping check_hardcoded_constants" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# scan_tree: emit signature lines for all flagged lines under SCAN_ROOT.
+# Signature = "<relpath>:<normalized-line>"
+# Normalization: strip leading + trailing whitespace from the source line.
+#
+# Uses grep for ERE matching (portable, handles {2,6}) then awk for
+# normalization and relpath computation.
+# ---------------------------------------------------------------------------
+scan_tree() {
+    local root="$1"
+    # Find all .py files, grep for candidate lines, then normalize.
+    # grep output format: <file>:<line-content>
+    find "$root" -type f -name "*.py" -print0 \
+        | sort -z \
+        | xargs -0 grep -E --with-filename '[=,(<>!][[:space:]]*[0-9]{2,6}([^0-9.]|$)' \
+                2>/dev/null || true
+}
+
+emit_signatures() {
+    # Filter and normalize grep output:
+    #   <filepath>:<line-content>
+    # Excludes:
+    #   - pure comment lines (first non-space char is #)
+    #   - blank lines
+    #   - lines containing Config. or Protocol. (sanctioned indirections)
+    #   - lines containing # const-ok: (inline exemption)
+    # Emits: <relpath>:<normalized-line>
+    awk '
+        {
+            # Split on first ":" to get filepath + rest
+            colon = index($0, ":")
+            if (colon == 0) next
+            filepath = substr($0, 1, colon - 1)
+            content  = substr($0, colon + 1)
+
+            # Strip leading whitespace from content to check for comment lines
+            trimmed = content
+            sub(/^[[:space:]]+/, "", trimmed)
+
+            # Skip pure comment lines and blank lines
+            if (trimmed == "" || substr(trimmed, 1, 1) == "#") next
+
+            # Skip lines with sanctioned indirections (Config. / Protocol.)
+            if (index(content, "Config.") > 0 || index(content, "Protocol.") > 0) next
+
+            # Skip lines with inline exemption marker
+            if (index(content, "# const-ok:") > 0) next
+
+            # Normalize: strip leading + trailing whitespace from content
+            normalized = content
+            sub(/^[[:space:]]+/, "", normalized)
+            sub(/[[:space:]]+$/, "", normalized)
+
+            print filepath ":" normalized
+        }
+    '
+}
+
+# ---------------------------------------------------------------------------
+# Baseline generation mode
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--generate-baseline" ]; then
+    {
+        echo "# hardcoded_constants_baseline.txt — grandfather baseline for check_hardcoded_constants.sh"
+        echo "#"
+        echo "# DO NOT EDIT MANUALLY. Regenerate with:"
+        echo "#   bash tools/check_hardcoded_constants.sh --generate-baseline > tools/hardcoded_constants_baseline.txt"
+        echo "#"
+        echo "# This file grandfathers the set of hardcoded numeric constants that existed in"
+        echo "# src/factory/core/ when the gate was introduced (issue #1654). It must be burned"
+        echo "# down incrementally — new code MUST NOT add entries here; add a named Config"
+        echo "# constant instead. Track the burn-down via the follow-up issue linked in #1654."
+        echo "#"
+        echo "# SIGNATURE FORMAT: <relpath>:<normalized-line>"
+        echo "#   relpath         = file path relative to repo root"
+        echo "#   normalized-line = line with leading + trailing whitespace stripped"
+        echo "# Line numbers are omitted so reformatting does not cause false positives."
+    }
+    scan_tree "$SCAN_ROOT" | emit_signatures | sort -u
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Normal gate mode: baseline must exist
+# ---------------------------------------------------------------------------
+if [ ! -f "$BASELINE_FILE" ]; then
+    echo "ERROR: baseline file $BASELINE_FILE not found." >&2
+    echo "  Generate it with:" >&2
+    echo "    bash tools/check_hardcoded_constants.sh --generate-baseline > $BASELINE_FILE" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Scan current tree and emit all signatures
+# ---------------------------------------------------------------------------
+ALL_SORTED="$(scan_tree "$SCAN_ROOT" | emit_signatures | sort -u)"
+
+# If nothing flagged at all, clean
+if [ -z "$ALL_SORTED" ]; then
+    echo "check_hardcoded_constants: no hardcoded numeric constants found in ${SCAN_ROOT} — OK"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Load baseline (sorted, comments stripped)
+# ---------------------------------------------------------------------------
+BASELINE_SORTED="$(grep -v '^[[:space:]]*#\|^[[:space:]]*$' "$BASELINE_FILE" | sort -u)"
+
+# ---------------------------------------------------------------------------
+# Set-difference: violations = flagged signatures NOT in baseline
+# comm -23 on two sorted inputs = lines only in the first (violations)
+# ---------------------------------------------------------------------------
+VIOLATIONS="$(comm -23 \
+    <(printf '%s\n' "$ALL_SORTED") \
+    <(printf '%s\n' "$BASELINE_SORTED") \
+    || true)"
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+if [ -z "$VIOLATIONS" ]; then
+    echo "check_hardcoded_constants: no new hardcoded numeric constants found in ${SCAN_ROOT} — OK"
+    exit 0
+fi
+
+echo "" >&2
+echo "FAIL: new hardcoded numeric constants in ${SCAN_ROOT} (not in baseline):" >&2
+while IFS= read -r v; do
+    [ -n "$v" ] || continue
+    filepath="${v%%:*}"
+    echo "  ${v}" >&2
+    echo "::error file=${filepath}::hardcoded numeric constant — use a named Config constant or add '# const-ok: <reason>' if intentional"
+done <<< "$VIOLATIONS"
+cnt="$(printf '%s\n' "$VIOLATIONS" | grep -c .)"
+echo "" >&2
+echo "Found ${cnt} new hardcoded constant(s) not in ${BASELINE_FILE}." >&2
+echo "Remediation options:" >&2
+echo "  1. Replace the literal with a named constant in a Config class." >&2
+echo "  2. Add '# const-ok: <reason>' on the line if the literal is genuinely un-configurable." >&2
+echo "  Do NOT add entries to the baseline file — it is a burn-down target." >&2
+exit 1

--- a/tools/hardcoded_constants_baseline.txt
+++ b/tools/hardcoded_constants_baseline.txt
@@ -1,0 +1,100 @@
+# hardcoded_constants_baseline.txt — grandfather baseline for check_hardcoded_constants.sh
+#
+# DO NOT EDIT MANUALLY. Regenerate with:
+#   bash tools/check_hardcoded_constants.sh --generate-baseline > tools/hardcoded_constants_baseline.txt
+#
+# This file grandfathers the set of hardcoded numeric constants that existed in
+# src/factory/core/ when the gate was introduced (issue #1654). It must be burned
+# down incrementally — new code MUST NOT add entries here; add a named Config
+# constant instead. Track the burn-down via the follow-up issue linked in #1654.
+#
+# SIGNATURE FORMAT: <relpath>:<normalized-line>
+#   relpath         = file path relative to repo root
+#   normalized-line = line with leading + trailing whitespace stripped
+# Line numbers are omitted so reformatting does not cause false positives.
+src/factory/core/agent/agent_builder.py:history_size=int(sr_data.get("history_size", 50)),
+src/factory/core/agent/agent_config.py:history_size: int = 50
+src/factory/core/agent/agent_config.py:_MAX_PROMPT_BYTES = 64 * 1024  # 64 KB
+src/factory/core/agent/agent_models.py:"""Construct an AgentRow from a raw aiosqlite SELECT tuple (24 columns)."""
+src/factory/core/agent/agent_models.py:"""One row from the agents table (24 columns after #1335 dropped dead column)."""
+src/factory/core/agent/agent.py:pool.user_id, ns, first_msg=first_msg, token_budget=700
+src/factory/core/agent/agent_refiner.py:self, io: TerminalIO, *, max_turns: int = 20
+src/factory/core/agent/bot_models.py:DEFAULT_THREAD_HOT_HOURS: int = 24
+src/factory/core/agent/bot_models.py:if len(row) != 11:
+src/factory/core/agent/schema/bot_schema.py:_N_BOT_COLS = 11
+src/factory/core/cli/cli_pool.py:pool = CliPool(idle_ttl=1200)
+src/factory/core/cli/cli_pool_send.py:default_timeout: int = 1200  # 20 min × 3 retries = 60 min max idle
+src/factory/core/cli/cli_pool_send.py:idle_ttl: int = 1200
+src/factory/core/cli/cli_pool_send.py:read_buffer_bytes: int = 1024 * 1024
+src/factory/core/cli/cli_pool_send.py:reaper_interval: int = 60
+src/factory/core/cli/cli_streaming_parser.py:_BUS_BOUND_MESSAGE_MAX_LEN = 200
+src/factory/core/cli/protocol/cli_non_streaming.py:default_timeout: float = 300,
+src/factory/core/cli/protocol/cli_protocol_types.py:proc: asyncio.subprocess.Process, limit: int = 512
+src/factory/core/cli/protocol/cli_streaming.py:default_timeout: float = 300,
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'cancel_on_new_message':<20} {rc.cancel_on_new_message}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'debounce_ms':<20} {rc.debounce_ms}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'extra_instructions':<20} {extra}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'language':<20} {rc.language}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'max_steps':<20} {rc.max_steps or '(model default)'}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'model':<20} {rc.model or '(persona default)'}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {name:<12} {state_str}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'style':<20} {rc.style}")
+src/factory/core/commands/builtin_commands.py:lines.append(f"  {'temperature':<20} {rc.temperature}")
+src/factory/core/commands/builtin_commands.py:state_str = f"{status.state.value.upper():<10} (ok)"
+src/factory/core/commands/command_loader.py:priority: int = 100
+src/factory/core/commands/command_loader.py:priority=int(data.get("priority", 100)),
+src/factory/core/commands/session_commands.py:if seconds < 3600:
+src/factory/core/commands/session_commands.py:if seconds < 60:
+src/factory/core/commands/session_commands.py:if seconds < 86400:
+src/factory/core/commands/session_commands.py:_TITLE_MAX = 60
+src/factory/core/commands/session_commands.py:title = _truncate(target.get("first_user_msg"), 40)
+src/factory/core/config/bus_config.py:DEFAULT_MAXSIZE: int = 100
+src/factory/core/config/bus_config.py:DEFAULT_QUEUE_DEPTH: int = 100
+src/factory/core/config/bus_config.py:DEFAULT_STAGING_MAXSIZE: int = 500
+src/factory/core/config/dispatch_config.py:MAX_TRANSCRIPT_LEN: int = 2000
+src/factory/core/config/__init__.py:debounce_ms: int = 300  # DEFAULT_DEBOUNCE_MS
+src/factory/core/config/__init__.py:max_merged_chars: int = 4096
+src/factory/core/config/__init__.py:max_pools: int = 500  # hard cap on pool count
+src/factory/core/config/__init__.py:rate_limit: int = 20
+src/factory/core/config/__init__.py:rate_window: int = 60
+src/factory/core/config/lifecycle_config.py:CIRCUIT_RECOVERY_TIMEOUT: int = 60
+src/factory/core/config/lifecycle_config.py:DEFAULT_DEBOUNCE_MS: int = 300
+src/factory/core/config/memory_config.py:DEFAULT_PREF_LIMIT: int = 10
+src/factory/core/config/memory_config.py:DEFAULT_PREF_TOKEN_BUDGET: int = 300
+src/factory/core/config/memory_config.py:DEFAULT_TOKEN_BUDGET: int = 1000
+src/factory/core/config/platform_config.py:COMPACT_TAIL: int = 10
+src/factory/core/config/platform_config.py:DEFAULT_CONTEXT_TOKENS: int = 200_000
+src/factory/core/config/turn_store_config.py:DEFAULT_GET_TURNS_LIMIT: int = 50
+src/factory/core/hub/event_bus.py:bus = PipelineEventBus(maxsize=1000)
+src/factory/core/hub/event_bus.py:def __init__(self, maxsize: int = 1000) -> None:
+src/factory/core/hub/hub.py:BUS_SIZE = 100
+src/factory/core/hub/middleware/middleware_stt.py:timeout_s = getattr(hub._stt, "timeout_ms", 30000) / 1000.0
+src/factory/core/hub/outbound/outbound_errors.py:_NOTIFY_TS_REAP_THRESHOLD = 512  # reap stale circuit-notify timestamps when > this size
+src/factory/core/hub/outbound/outbound_errors.py:Retryable: network errors, 5xx server errors, rate-limit (429).
+src/factory/core/hub/outbound/outbound_errors.py:return status == 429 or status >= 500
+src/factory/core/hub/outbound/outbound_errors.py:_SCOPE_REAP_THRESHOLD = 256  # reap idle scope locks when dict exceeds this size
+src/factory/core/lifecycle/circuit_breaker.py:cb = CircuitBreaker(name="openai", failure_threshold=5, recovery_timeout=60)
+src/factory/core/lifecycle/debouncer.py:_MAX_MERGED_CHARS = 4096
+src/factory/core/lifecycle/session_lifecycle.py:raw = await turn_store.get_turns(pool.pool_id, pool.user_id, limit=20)
+src/factory/core/lifecycle/session_lifecycle.py:raw = await turn_store.get_turns(pool.pool_id, pool.user_id, limit=500)
+src/factory/core/messaging/bus.py:self, platform: Platform, maxsize: int = 100, bot_id: str | None = None
+src/factory/core/messaging/inbound_bus.py:bus.register(Platform.DISCORD, maxsize=100)
+src/factory/core/messaging/inbound_bus.py:bus.register(Platform.TELEGRAM, maxsize=100)
+src/factory/core/messaging/tool_display_config.py:bash_max_len: int = 80
+src/factory/core/messaging/tool_display_config.py:throttle_ms: int = 2000
+src/factory/core/persona.py:_MAX_PROMPT_BYTES = 64 * 1024  # 64 KB
+src/factory/core/processors/_scraping.py:_SAFE_SCRAPE_MAX_CHARS = 32_000  # B5: prompt-injection + DoS guard
+src/factory/core/processors/stream_text.py:Format: ``"reasoning-<12-char-hex>"``. Mirrors ``_mint_text_block_id``
+src/factory/core/processors/stream_text.py:Format: ``"text-<12-char-hex>"``. Mirrors the ``synthetic-<uuid4>`` shape
+src/factory/core/processors/stream_tool.py:_MAX_CONTENT_BYTES = 65_536
+src/factory/core/runtime_config.py:debounce_ms: int = 300
+src/factory/core/runtime_config.py:if iv < 0 or iv > 5000:
+src/factory/core/runtime_config.py:if iv > 50:
+src/factory/core/runtime_config.py:if len(value) > 500:
+src/factory/core/stores/identity_alias_store_protocol.py:ttl_seconds: int = 300,
+src/factory/core/stores/pairing_config.py:_MAX_CODE_ATTEMPTS = 10
+src/factory/core/stores/pairing_config.py:rate_limit_window: int = 300
+src/factory/core/stores/pairing_config.py:session_max_age_days: int = 30
+src/factory/core/stores/pairing_config.py:ttl_seconds: int = 3600
+src/factory/core/trace.py:r"(?<!\w)(\d{8,12}:[A-Za-z0-9+/._=-]{30,})(?![A-Za-z0-9+/._=-])"
+src/factory/core/tts_dispatch.py:if len(text) < 10:


### PR DESCRIPTION
## Summary
CI gate blocking **new** hardcoded numeric literals (≥2 digits) in `src/factory/core/`, using a **baseline-grandfather** strategy. The ~86 pre-existing constants are committed to a signature-keyed baseline allowlist and grandfathered; only new, non-sanctioned, non-exempt additions fail the gate.

Closes #1654.

## Symbolic decision trace
- **P**: core carries ~86 hardcoded numeric constants (audit 2026-06-02); no guard prevents the set from growing.
- **RC(P)**: absence of a forward-blocking gate — not the existing constants themselves (those are a separate burn-down concern).
- **Corr ∈ Patch**: add a gate that grandfathers the existing set and blocks net-new additions. Classed **Patch** (additive tooling, no structural change to core). Not Archi — extracting the 86 to Config/Protocol is the burn-down follow-up, deliberately out of scope.
- **fix@L**: gate operates at the CI/pre-commit boundary (level = where new constants enter), not by rewriting core.
- **trust(I)**: baseline keyed on `relpath:normalized-line-content` (whitespace-stripped), **not** line numbers — reformatting/line-moves don't yield false positives. Inline `# const-ok: <reason>` escape hatch for legitimate math/format constants.
- **✓**: tested ∧ correct — 5/5 smoke cases (baselined-pass, new-fail, Config-ref-pass, inline-exempt-pass, real-tree-pass); gate exits 0 on the unmodified tree.

## Deliverables
- `tools/check_hardcoded_constants.sh` — detector + baseline filter (exit 0 clean / 1 new violation / 2 script error)
- `tools/hardcoded_constants_baseline.txt` — 86 grandfathered signatures (burn-down via follow-up sibling)
- `tests/tools/test_check_hardcoded_constants.sh` — 5 smoke cases
- Wired into `.github/workflows/ci.yml` (quoted step name), `.pre-commit-config.yaml`, `.claude/stack.yml`

## Gate exit codes (observed)
`check_hardcoded_constants` 0 · smoke-test 0 (5/5) · file_exemptions 0 · test_sleep 0 · file_length 0 · qg-conf-drift 0 · ci.yml YAML parses + `ci` job present · no architecture-snapshot drift.

## Follow-up
Baseline burn-down (extract the 86 to `Config`/`Protocol`) tracked as a sibling issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
