### PR TITLE
docs(process): PR template with quality-hygiene checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+PR template — quality-hygiene checklist (epic #1662, issue #1656).
+Tick each box or strike it through with a one-line reason if N/A.
+The matching CI gates will block the merge if a box is silently skipped.
+-->
+
+## Summary
+
+<!-- What changed and why. Link the issue: Closes #NNNN -->
+
+## Quality checklist
+
+- [ ] **Debt** — no `DEBT:` marker added without an open issue link (gate: `check_debt_expiry`)
+- [ ] **Test sleep** — no `sleep()` in `tests/` without an event-based / sync-window comment (gate: `check_test_sleep`)
+- [ ] **Hardcoded constants** — no new numeric literal in `src/factory/core/` without a `Config`/`Protocol` reference (gate: `check_hardcoded_constants`)
+- [ ] **Broad except** — no new `except Exception` without an inline boundary justification (axial + security review auto-labelled)
+- [ ] **Adapter copy-paste** — no Telegram/Discord logic duplicated without a shared helper
+- [ ] **Axial review** — `dev-core:axial-adr-review` passed if this PR crosses a top-level `factory.*` layer boundary
+
+## Notes
+
+<!-- Risks, follow-ups, deferred items (file siblings under the parent epic). -->


### PR DESCRIPTION
## Summary
Adds `.github/pull_request_template.md` with a quality-hygiene checklist (none existed before). Each item maps to a now-live CI gate from epic #1662, so reviewers see the guard rails inline on every PR.

Closes #1656.

## Checklist items (→ backing gate)
- Debt marker → `check_debt_expiry`
- Test sleep → `check_test_sleep`
- Hardcoded constant → `check_hardcoded_constants` (#1654)
- Broad `except Exception` → axial + security auto-label
- Adapter copy-paste → shared-helper convention
- Axial review → `dev-core:axial-adr-review` on cross-layer PRs

## Decision trace
- **Corr ∈ Patch**: pure additive process doc; no code/structural change.
- **✓**: GitHub renders `.github/pull_request_template.md` as the default PR body; markdown task-list syntax verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
