### PR TITLE
feat(gh-token): publish MintFailureEvent on mint failure (#1082)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ quadlet-secrets-install:  ## (re)create Podman secrets from ~/.roxabi/factory/nk
 	@podman secret create --replace factory-nats-telegram          "$(FACTORY_NKEYS_DIR)/telegram-adapter.seed"
 	@podman secret create --replace factory-nats-discord           "$(FACTORY_NKEYS_DIR)/discord-adapter.seed"
 	@podman secret create --replace factory-nats-clipool           "$(FACTORY_NKEYS_DIR)/clipool-worker.seed"
+	@podman secret create --replace factory-nats-gh-helper         "$(FACTORY_NKEYS_DIR)/gh-helper.seed"
 	@if [ -f "$(HOME)/.roxabi/factory/gh-app.pem" ]; then \
 		podman secret create --replace factory-gh-pem "$(HOME)/.roxabi/factory/gh-app.pem"; \
 		echo "factory-gh-pem secret created from ~/.roxabi/factory/gh-app.pem"; \

--- a/artifacts/frames/1082-helper-mint-failure-publish-frame.mdx
+++ b/artifacts/frames/1082-helper-mint-failure-publish-frame.mdx
@@ -1,0 +1,101 @@
+---
+title: "Helper-side NATS publish for MintFailureEvent (#1078 follow-up)"
+issue: 1082
+status: approved
+tier: F-lite
+date: 2026-06-02
+---
+
+## Problem
+
+The GitHub App token-mint **helper** (`factory.tools.gh_token.daemon`, uid 1501 inside
+`factory-gh.pod`) is the sole minter of installation tokens. By design it is isolated from
+the clipool worker (uid 1500) so the App private key and minted token never reach Claude's
+subprocess — ADR-046 / #1078. That isolation makes its **failures invisible**: on a 401/404,
+timeout, or unreadable PEM the dispenser raises `MintError` (`dispenser.py:161`), logs a
+warning to its own uid-1501 journal, and returns `error=mint failed` to the caller. No alert
+reaches operators.
+
+The consumer half is already built and **inert**: the `MintFailureEvent` schema
+(`roxabi_contracts/gh/models.py`), the `gh_mint_failure(machine)` subject helper, and the hub
+`MintFailureSubscriber` → Telegram path (#1078 T17, #1545) all exist. `acl-matrix.json` even
+declares the hub's *subscribe* grant on `lyra.gh.mint_failure.>` — and its own notes flag that
+"the gh-helper publisher identity is not yet declared … so the grant is inert until that lands
+(TODO T4)". The producer is the missing link:
+
+```
+src/factory/tools/gh_token/helper.py:11
+  TODO(T4): MintError → publish as MintFailureEvent on NATS (roxabi-contracts gh/ schema)
+```
+
+This issue wires the producer: the helper gets its own publish-only NATS identity and emits a
+`MintFailureEvent` on every `MintError`, lighting up the dormant alert path.
+
+## Who
+
+- **Primary:** Roxabi operators — currently blind to token-mint failures; gain a proactive
+  Telegram alert when GitHub credentials break (revoked install, rotated/expired key, API outage).
+- **Secondary:** the `/dev` + clipool GitHub-token consumers — a degraded mint surfaces as an
+  ops signal instead of opaque downstream failures.
+
+## Constraints
+
+- **Preserve the uid-1501/1500 isolation boundary (ADR-046).** Use a dedicated publish-only
+  `gh-helper` nkey — **not** a widened clipool grant (design decided in issue body 2026-05-18,
+  Option A). The identity may publish to `lyra.gh.mint_failure.>` **and nothing else**.
+- **Publish is best-effort and MUST NOT block or break minting.** A NATS outage cannot degrade
+  the helper's primary job (dispensing tokens). Publish failure → log + swallow, justified inline
+  per CLAUDE.md `except Exception` rule.
+- Helper reaches NATS via `roxabi.network`; `factory-gh.pod` is already `After=factory-nats`.
+  Reuse the `roxabi-nats` SDK connection pattern (same as the subscriber) + `roxabi_contracts.gh`.
+- Subject namespace stays `lyra.gh.mint_failure.<machine>` (legacy `lyra.*` prefix retained in
+  contracts — do **not** rename). `machine` sourced from host identity (env).
+- `gen_nkeys.py` auto-derives seeds from `acl-matrix.json` `identities` → adding the identity
+  there generates `gh-helper.seed`. `Makefile:quadlet-secrets-install` has a hardcoded secret
+  list → one new `podman secret create` line.
+- `import-linter` (`.importlinter`) must permit `factory.tools.gh_token` → `roxabi_nats` /
+  `roxabi_contracts` (subscriber in `adapters/nats` already does this — verify layer rule covers tools).
+
+## Out of Scope
+
+- The hub subscriber, Telegram formatting, ops-chat routing (#1078 T17 — done).
+- Renaming the `lyra.*` NATS namespace to `roxabi.*` (separate infra rename, parked).
+- Retry/backoff or circuit-breaking on the mint itself.
+- Durability of failure events (fire-and-forget core NATS, **not** JetStream).
+- RED-GATE V6 / T18 test authoring beyond the unit-level publish assertion — full e2e
+  simulation is the acceptance check, tracked under #1078 T18.
+
+## Premise Validity
+
+**Success in 6 months:** Forcing a mint failure (revoke installation / point PEM at a bad file)
+produces a Telegram alert in the ops chat within seconds, end-to-end. `lyra-acl check` confirms
+the `gh-helper` identity can publish **only** to `lyra.gh.mint_failure.>`. The `TODO(T4)` is gone
+and RED-GATE V6 (T18) is unblocked.
+
+**Failure in 6 months (falsifiable):** A simulated mint failure produces **no** message on
+`lyra.gh.mint_failure.>` and **no** Telegram alert (observable boolean) — OR an ACL check shows
+the helper identity holds publish grants beyond `lyra.gh.mint_failure.>` (isolation regression)
+— OR a NATS outage during a mint is observed to break/stall token dispensing (best-effort
+violated). Any one ⇒ the change failed its purpose.
+
+**Simplest alternative:** Leave the helper log-only — `MintError` to stderr/journald, operators
+scrape container logs or wire a journald alert rule.
+**Why not simplest:** the helper's journal is uid-1501-isolated and not surfaced to the ops
+alert path; log-scraping is reactive, not a push alert; and it strands the already-built
+subscriber + Telegram pipeline. A credential-path failure warrants a proactive alert over the
+one subject the helper is permitted to touch.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (helper NATS-publish wiring + nkey provisioning),
+no new architecture, design pre-decided. ~6 files:
+
+- `deploy/nats/acl-matrix.json` — add publish-only `gh-helper` identity.
+- `Makefile` (`quadlet-secrets-install`) — provision `gh-helper.seed` secret.
+- `deploy/quadlet/factory-gh-helper.container` — mount seed (uid 1501) + NATS URL env.
+- `src/factory/tools/gh_token/daemon.py` — connect NATS, inject publisher into the dispenser.
+- `src/factory/tools/gh_token/{dispenser,helper}.py` — publish `MintFailureEvent` on `MintError`; remove TODO(T4).
+- `tests/tools/...` — mint-failure→publish unit test + publish-only ACL assertion.
+
+Signals: single cohesive subsystem · authoritative design in issue body · all consumer-side
+contracts/scaffolds pre-exist · no unknowns beyond verifying the import-linter layer rule.

--- a/artifacts/plans/1082-helper-mint-failure-publish-plan.mdx
+++ b/artifacts/plans/1082-helper-mint-failure-publish-plan.mdx
@@ -1,0 +1,258 @@
+---
+title: "Plan: Helper-side NATS publish for MintFailureEvent (#1078 follow-up)"
+issue: 1082
+spec: artifacts/specs/1082-helper-mint-failure-publish-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-06-02
+---
+
+## Summary
+
+Provision a publish-only `gh-helper` NATS identity and wire the token-mint helper to emit a
+`MintFailureEvent` on `lyra.gh.mint_failure.<machine>` for every `MintError`, best-effort, without
+ever degrading token minting. Two slices: S1 infra/provisioning (devops), S2 publisher + wiring
++ tests (backend-dev, tester).
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph infra["S1 — provisioning (data-driven)"]
+        acl["acl-matrix.json<br/>gh-helper identity"] --> gen["gen_nkeys.py<br/>(auto-derive)"]
+        gen --> seed["gh-helper.seed"]
+        seed --> mk["Makefile<br/>podman secret factory-nats-gh-helper"]
+        mk --> qd["factory-gh-helper.container<br/>Secret mount + NATS env"]
+        acl --> cg["check_grants.py<br/>RESOURCES entry"]
+    end
+    subgraph code["S2 — runtime"]
+        daemon["daemon.run_daemon<br/>nats_connect (guarded)"] --> pub["MintFailurePublisher"]
+        daemon --> disp["Dispenser(publisher=…)"]
+        mint["helper.mint() → MintError"] --> disp
+        disp -->|except MintError| pub
+        pub -->|model_dump_json| subj["lyra.gh.mint_failure.&lt;machine&gt;"]
+    end
+    qd -.runtime env.-> daemon
+    subj -.exists.-> sub["hub MintFailureSubscriber → Telegram"]
+```
+
+```mermaid
+flowchart LR
+    subgraph mfp["mint_failure_publisher.py (new)"]
+        MFP["MintFailurePublisher<br/>.publish(exc)"]
+    end
+    subgraph dmn["daemon.py"]
+        RD["run_daemon()"]
+    end
+    subgraph dsp["dispenser.py"]
+        H["Dispenser._handle()"]
+    end
+    subgraph hlp["helper.py"]
+        ME["MintError"]
+    end
+    RD --> MFP
+    RD --> H
+    H --> ME
+    H --> MFP
+    subgraph tests["tests/tools, tests/scripts"]
+        T9["test_mint_failure_publisher"]
+        T10["test_daemon/dispenser wiring"]
+        T11["test acl gh-helper publish-only"]
+    end
+    T9 -.-> MFP
+    T10 -.-> H
+    T11 -.-> acl["acl-matrix.json"]
+```
+
+## Agents
+
+| Agent | Instance | Tasks | Files |
+|-------|----------|-------|-------|
+| devops | devops-A | T1–T4 | acl-matrix.json, gen_nkeys.py (verify), check_grants.py, Makefile, factory-gh-helper.container |
+| backend-dev | backend-dev-A | T5–T8 | mint_failure_publisher.py (new), daemon.py, dispenser.py, helper.py |
+| tester | tester-A | T9–T11 | tests/tools/, tests/scripts/ |
+
+## Wave Structure
+
+4 waves, max 3 parallel agents. Elapsed ~½ day vs ~1 day sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | devops-A: T1 · backend-dev-A: T5→T8 |
+| 2 | Wave 1 done | 3 ∥ | devops-A: T2→T3→T4 · backend-dev-A: T7 · tester-A: T9, T11 |
+| 3 | T7 + infra done | 2 ∥ | backend-dev-A: T6 · devops-A: **RG-S1** |
+| 4 | T6 done | 1 | tester-A: T10 → **RG-S2** (final gates) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 acl identity + hub note | 1 file | judgmental | 5 | — |
+| T2 gen_nkeys verify + check_grants entry | 2 | judgmental | 6 | — |
+| T3 Makefile secret line | 1 | bounded | 3 | — |
+| T4 quadlet mount + env | 1 | bounded | 3 | — |
+| T5 publisher module (new) | 1 | judgmental | 6 | — |
+| T6 daemon wiring (guarded connect) | 1 | judgmental | 6 | — |
+| T7 dispenser ctor + publish call | 1 | bounded | 4 | — |
+| T8 helper TODO cleanup | 1 | trivial | 2 | — |
+| T9 publisher unit tests | 1 | judgmental | 6 | — |
+| T10 dispenser/daemon wiring tests | 1 | judgmental | 6 | — |
+| T11 acl least-privilege test | 1 | bounded | 4 | — |
+
+**Total estimated ops: ~51**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1,T2,T3,T4 | 17 | provisioning | — (1 subject, 4 tasks ≤ cap) |
+| backend-dev-A | T5,T6,T7,T8 | 18 | mint-publish, cleanup | — (2 subjects, 4 tasks ≤ cap) |
+| tester-A | T9,T10,T11 | 16 | mint-publish, acl | — (2 subjects, 3 tasks) |
+
+No splits required.
+
+## Consistency Report
+
+8/8 success criteria covered. Trace below. No untraced tasks. No exemptions.
+
+| SC | Tasks |
+|----|-------|
+| SC-Identity | T1, (T2 verify) |
+| SC-Provisioning | T3, T4 |
+| SC-Publish-on-failure | T5, T6, T7 |
+| SC-Subject-match (smoke) | T9 |
+| SC-Best-effort-isolation | T5 (swallow), T6 (guarded connect), T10 |
+| SC-Least-privilege | T2 (check_grants), T11 |
+| SC-Cleanup | T8 |
+| SC-Gates | RG-S1, RG-S2 |
+
+## Reference Patterns (inject into agents)
+
+- **Best-effort publish shape:** `src/factory/transport/typing_publisher.py:75-83` — `try: nc.publish(subj, event.model_dump_json().encode()); except Exception: log.warning(...)`. Mirror exactly (incl. `# noqa: BLE001` + inline justification).
+- **Same-contract serialize/deserialize:** `src/factory/adapters/nats/mint_failure_subscriber.py:70` deserializes via `MintFailureEvent.model_validate_json(msg.data)` → publisher MUST serialize with `event.model_dump_json().encode("utf-8")` (symmetric).
+- **`nats_connect` usage:** `src/factory/bootstrap/standalone/hub_standalone.py:56-75` — `from roxabi_nats import nats_connect`; URL from `NATS_URL`; seed auto-read from `NATS_NKEY_SEED_PATH`.
+- **Subject helper:** `roxabi_contracts.gh.subjects.gh_mint_failure(machine)` → `lyra.gh.mint_failure.<machine>`.
+
+## Micro-Tasks
+
+### Slice S1 — Identity + provisioning (devops-A)
+
+**T1 — Add `gh-helper` identity to acl-matrix.json** · `deploy/nats/acl-matrix.json` · `[P:N]` · subject: provisioning · SC-Identity · V1 · RED→GREEN · diff 2
+- Add identity key `gh-helper`: `status:"active"`, `created_at:"2026-06-02"`, `owner:"lyra"`, `description`, `allow_responses:false`, `publish:["lyra.gh.mint_failure.>"]`, `subscribe:[]`, `deploy:{"type":"container","secret":"factory-nats-gh-helper"}`.
+- Update hub `notes`: replace the "publisher identity is not yet declared … TODO T4" clause with "publisher declared by #1082 (gh-helper)".
+- Verify: `python3 -c "import json;d=json.load(open('deploy/nats/acl-matrix.json'));print(d['identities']['gh-helper'])"`
+- Expect: identity dict prints with publish-only grant + deploy field.
+
+**T2 — Verify gen_nkeys auto-derivation + add check_grants RESOURCES entry** · `scripts/check_grants.py` · `[P:N]` · subject: provisioning · SC-Identity/Least-privilege · V1 · blockedBy T1 · diff 2
+- Run `uv run python scripts/gen_nkeys.py genkeys --template-only` → confirm a `gh-helper` block is emitted.
+- Add a `RESOURCES` entry asserting `gh-helper` covers publish subject `lyra.gh.mint_failure.>` (match existing tuple shape).
+- Verify: `uv run python scripts/check_grants.py` → `check-grants: OK`.
+
+**T3 — Add Makefile secret line** · `Makefile` (`quadlet-secrets-install`) · `[P:N]` · subject: provisioning · SC-Provisioning · V1 · blockedBy T1 · diff 1
+- After the `factory-nats-clipool` line add: `@podman secret create --replace factory-nats-gh-helper "$(FACTORY_NKEYS_DIR)/gh-helper.seed"`.
+- (Do NOT add turn-writer/blobstore — pre-existing gap, out of scope.)
+- Verify: `grep -n factory-nats-gh-helper Makefile`.
+
+**T4 — Add Secret mount + NATS env to helper container** · `deploy/quadlet/factory-gh-helper.container` · `[P:N]` · subject: provisioning · SC-Provisioning · V1 · blockedBy T1 · diff 2
+- Add under `[Container]`: `Secret=factory-nats-gh-helper,type=mount,target=factory-nats-gh-helper.seed,uid=1501,gid=1501,mode=0400`; `Environment=NATS_URL=nats://factory-nats:4222`; `Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-gh-helper.seed`; `Environment=FACTORY_MACHINE=roxabituwer`.
+- Verify: `grep -nE "factory-nats-gh-helper|NATS_URL|FACTORY_MACHINE" deploy/quadlet/factory-gh-helper.container`.
+
+**RG-S1 (RED-GATE, devops-A)** · blockedBy T2,T3,T4
+- `uv run python scripts/gen_nkeys.py genkeys --template-only | grep gh-helper` && `uv run python scripts/check_grants.py` && (`make quadlet-lint` if present). All green.
+
+### Slice S2 — Publisher + wiring + tests (backend-dev-A, tester-A)
+
+**T5 — Create MintFailurePublisher** · `src/factory/tools/gh_token/mint_failure_publisher.py` (new) · `[P:Y]` · subject: mint-publish · SC-Publish/Best-effort · V2 · RED→GREEN · diff 3
+- Class `MintFailurePublisher(nc, machine: str)`. `async def publish(self, exc: MintError) -> None`:
+  build `MintFailureEvent(machine=self._machine, reason=_reason_label(exc), http_status=exc.http_status, retries=exc.retries)`; `subject = gh_mint_failure(self._machine)`; `await self._nc.publish(subject, event.model_dump_json().encode("utf-8"))`.
+- `_reason_label(exc)`: `f"github_api_{exc.http_status}"` if `http_status is not None` else `"network_error"`.
+- Wrap publish body in `try/except Exception as exc: log.warning("mint_failure_publisher: publish failed: %s", exc)  # noqa: BLE001 — best-effort, must not break minting`.
+- Verify: `uv run python -c "from factory.tools.gh_token.mint_failure_publisher import MintFailurePublisher"`.
+
+**T7 — Dispenser: accept publisher + publish on MintError** · `src/factory/tools/gh_token/dispenser.py` · `[P:N]` · subject: mint-publish · SC-Publish · V2 · blockedBy T5 · diff 2
+- Add ctor param `publisher: "MintFailurePublisher | None" = None`; store on `self`.
+- In the `except MintError as exc:` block (after existing `log.warning` + `writer.write(b"error=mint failed\n")`): `if self._publisher is not None: await self._publisher.publish(exc)`.
+- Verify: `grep -n "publisher" src/factory/tools/gh_token/dispenser.py`.
+
+**T6 — daemon: guarded NATS connect + inject publisher** · `src/factory/tools/gh_token/daemon.py` · `[P:N]` · subject: mint-publish · SC-Publish/Best-effort · V2 · blockedBy T5,T7 · diff 4
+- In `run_daemon`: read `NATS_URL`, `FACTORY_MACHINE` (default `socket.gethostname()`, validate via `validate_job_token`, fallback `"unknown"`).
+- If `NATS_URL` unset → `log.info("mint-failure publishing disabled — no NATS_URL")`, `publisher=None`.
+- Else `try: nc = await nats_connect(NATS_URL, ...); publisher = MintFailurePublisher(nc, machine) except Exception as exc: log.warning("mint-failure NATS connect failed: %s", exc); nc=None; publisher=None  # noqa: BLE001 — must not crash (BindsTo pod teardown)`.
+- Pass `publisher=publisher` to `Dispenser(...)`. On shutdown `finally`: if `nc`: `await nc.drain()`/`close()`.
+- Verify: `uv run pyright src/factory/tools/gh_token/daemon.py`.
+
+**T8 — Remove TODO(T4) from helper.py** · `src/factory/tools/gh_token/helper.py` · `[P:Y]` · subject: cleanup · SC-Cleanup · V2 · diff 1
+- Delete module-docstring line 11 (`TODO(T4): …`) and edit the `MintError` docstring (line ~55) to drop the "for T4's failure-event path" phrasing.
+- Verify: `! grep -n "TODO(T4)\|T4's failure-event" src/factory/tools/gh_token/helper.py`.
+
+**T9 — Publisher unit tests (subject-match + swallow)** · `tests/tools/test_mint_failure_publisher.py` (new) · `[P:Y]` · subject: mint-publish · SC-Subject-match/Best-effort · V2 · blockedBy T5 · diff 3
+- Test: forced `MintError(reason, 401, 0)` → publisher publishes to subject == `gh_mint_failure(machine)` (assert prefix `lyra.gh.mint_failure.`), payload deserializes via `MintFailureEvent.model_validate_json` with `reason=="github_api_401"`, `http_status==401`.
+- Test: network case (`http_status=None`) → `reason=="network_error"`.
+- Test: fake NC whose `publish` raises → `publish()` returns without raising (swallow).
+- Verify: `uv run pytest tests/tools/test_mint_failure_publisher.py -q`.
+
+**T10 — Dispenser/daemon wiring tests** · `tests/tools/test_gh_token_helper.py` (extend) · `[P:N]` · subject: mint-publish · SC-Best-effort · V2 · blockedBy T6,T7 · diff 3
+- Test: Dispenser with a spy publisher → `MintError` path calls `publisher.publish(exc)` exactly once; socket reply still `error=mint failed`.
+- Test: Dispenser with `publisher=None` → MintError path serves error reply, no crash.
+- Verify: `uv run pytest tests/tools/test_gh_token_helper.py -q`.
+
+**T11 — ACL least-privilege test** · `tests/scripts/test_acl_gh_helper.py` (new, or extend `tests/scripts/test_genkeys_modes.py`) · `[P:Y]` · subject: acl · SC-Least-privilege · V1/V2 · blockedBy T1 · diff 2
+- Parse `acl-matrix.json` → assert `identities["gh-helper"]["publish"] == ["lyra.gh.mint_failure.>"]` and `subscribe == []`.
+- Verify: `uv run pytest tests/scripts/test_acl_gh_helper.py -q`.
+
+**RG-S2 (RED-GATE, final)** · blockedBy T6,T8,T9,T10,T11
+- `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest tests/tools tests/scripts -q && uv run import-linter`. All green.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement. T{n} | agent-instance | blockedBy | subject. blockedBy refs T-numbers. -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | provisioning |
+| T5 | backend-dev-A | — | mint-publish |
+| T8 | backend-dev-A | — | cleanup |
+
+### Wave 2 — after Wave 1, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | devops-A | T1 | provisioning |
+| T3 | devops-A | T1 | provisioning |
+| T4 | devops-A | T1 | provisioning |
+| T7 | backend-dev-A | T5 | mint-publish |
+| T9 | tester-A | T5 | mint-publish |
+| T11 | tester-A | T1 | acl |
+
+### Wave 3 — after T7 + infra, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | backend-dev-A | T5, T7 | mint-publish |
+| RG-S1 | devops-A | T2, T3, T4 | provisioning |
+
+### Wave 4 — after T6, final gate
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | tester-A | T6, T7 | mint-publish |
+| RG-S2 | tester-A | T6, T8, T9, T10, T11 | gates |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 12 — provisioning (devops-A)
+- T5: 13 — mint-publish (backend-dev-A)
+- T8: 14 — cleanup (backend-dev-A)
+- T2: 15 — provisioning (devops-A)
+- T3: 16 — provisioning (devops-A)
+- T4: 17 — provisioning (devops-A)
+- T7: 18 — mint-publish (backend-dev-A)
+- T9: 19 — mint-publish (tester-A)
+- T11: 20 — acl (tester-A)
+- T6: 21 — mint-publish (backend-dev-A)
+- RG-S1: 22 — provisioning (devops-A)
+- T10: 23 — mint-publish (tester-A)
+- RG-S2: 24 — gates (tester-A)

--- a/artifacts/specs/1082-helper-mint-failure-publish-spec.mdx
+++ b/artifacts/specs/1082-helper-mint-failure-publish-spec.mdx
@@ -1,0 +1,184 @@
+---
+title: "Helper-side NATS publish for MintFailureEvent (#1078 follow-up)"
+issue: 1082
+status: approved
+tier: F-lite
+date: 2026-06-02
+promoted_from: artifacts/frames/1082-helper-mint-failure-publish-frame.mdx
+---
+
+## Context
+
+Promoted from [frame](../frames/1082-helper-mint-failure-publish-frame.mdx). The token-mint
+helper (`factory.tools.gh_token`, uid 1501) raises `MintError` on every mint failure but has no
+way to surface it: it owns no NATS identity. The consumer side is fully built and inert — the
+`MintFailureEvent` contract, `gh_mint_failure(machine)` subject helper, and hub
+`MintFailureSubscriber → Telegram` path all exist (#1078 T17 / #1545). This spec wires the producer.
+
+> **Naming:** the issue body (2026-05-18 update) refers to the new identity as `lyra-gh` /
+> `lyra-gh.seed`. Post lyra→factory rename the authoritative names used throughout this spec are
+> identity **`gh-helper`** → seed file **`gh-helper.seed`** → podman secret **`factory-nats-gh-helper`**.
+
+## Goal
+
+On any `MintError`, the helper publishes a `MintFailureEvent` on `lyra.gh.mint_failure.<machine>`
+using a dedicated **publish-only** nkey identity — lighting up the existing Telegram alert path —
+without ever letting a NATS problem degrade token minting.
+
+## Users
+
+- **Primary:** Roxabi operators — gain a proactive Telegram alert on GitHub credential/API failure.
+- **Secondary:** clipool / `/dev` token consumers — degraded mint surfaces as an ops signal.
+
+## Expected Behavior
+
+1. Helper boots (`python -m factory.tools.gh_token.daemon`). If `NATS_URL` is **unset** → log one
+   **INFO** ("mint-failure publishing disabled — no NATS_URL"), run with `publisher=None`. If
+   `NATS_URL` is set → attempt `nats_connect(...)` (seed auto-read from `NATS_NKEY_SEED_PATH` by
+   the `roxabi-nats` SDK). On success → build `MintFailurePublisher`. On connect **failure** → log
+   one **WARNING**, run with `publisher=None`. **The connect attempt MUST be wrapped so no
+   exception escapes `run_daemon`** (see N2 — a propagated exception reaches `_amain`, which only
+   catches `CancelledError`, exits the process, and `BindsTo=factory-gh-pod.service` tears down the
+   whole pod incl. clipool).
+2. A token request triggers `mint()`. On success → token dispensed as today (no change).
+3. On `MintError`, the dispenser's existing handler (`dispenser.py:161`) logs the warning and
+   returns `error=mint failed` to the socket caller **byte-for-byte as today**, then — if a
+   publisher exists — fires a best-effort publish.
+4. `MintFailurePublisher.publish(exc)` builds a `MintFailureEvent` (`machine`, mapped `reason`,
+   `http_status`, `retries`), serializes it, and publishes to `gh_mint_failure(machine)`. **Any**
+   error inside publish (connection lost, serialize, publish raise) is caught, logged at WARNING,
+   and swallowed — control returns normally.
+5. The hub `MintFailureSubscriber` (already running) receives the event and forwards a Telegram
+   alert to the ops chat. *(out of scope — exists.)*
+
+### reason-label mapping (no `MintError` signature change)
+
+| `MintError` raise site | `http_status` | event `reason` |
+|---|---|---|
+| GitHub API non-201 (`helper.py:236`) | set (e.g. 401/404) | `github_api_<status>` |
+| response parse failure (`helper.py:249`) | set (resp status) | `github_api_<status>` |
+| `httpx.ConnectError` / `TransportError` (`helper.py:223/229`) | `None` | `network_error` |
+
+`http_status` + `retries` pass through verbatim; the verbose `MintError.reason` string stays in the
+local log only. Note `ConnectError` ⊂ `TransportError` (both → `http_status=None`) — they share the
+single `network_error` label; do **not** split into per-branch labels.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class MintError {
+      +str reason
+      +int|None http_status
+      +int retries
+    }
+    class MintFailureEvent {
+      +str machine
+      +str reason
+      +int|None http_status
+      +int retries
+      +str contract_version
+      +str trace_id
+      +datetime issued_at
+    }
+    class MintFailurePublisher {
+      -Client nc
+      -str machine
+      +publish(exc) None
+    }
+    class Dispenser {
+      -MintFailurePublisher|None publisher
+      +_handle() — on MintError calls publisher.publish(exc)
+    }
+    Dispenser ..> MintError : catches
+    MintFailurePublisher ..> MintError : reads fields
+    MintFailurePublisher ..> MintFailureEvent : builds + publishes
+    Dispenser --> MintFailurePublisher : best-effort call
+```
+
+```mermaid
+flowchart LR
+    mint["mint() raises MintError"] --> disp["Dispenser MintError handler"]
+    disp -->|best-effort| pub["MintFailurePublisher.publish"]
+    pub -->|nc.publish| subj["lyra.gh.mint_failure.&lt;machine&gt;"]
+    subj -.->|exists, out of scope| sub["hub MintFailureSubscriber"]
+    sub -.-> tg["Telegram ops alert"]
+```
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `MintFailurePublisher` | `reason`, `http_status`, `retries` (+ `machine` from env) | on every `MintError` | **this issue** |
+| `lyra.gh.mint_failure.>` subject | full `MintFailureEvent` | publish-time | subject exists in hub *subscribe* ACL (#1545); **publisher ACL added here** |
+| hub `MintFailureSubscriber` | full event → Telegram | on receipt | existing (#1078 T17) |
+
+## Breadboard
+
+### Infrastructure affordances
+
+| ID | Place | Action | Data |
+|----|-------|--------|------|
+| I1 | `deploy/nats/acl-matrix.json` | add `gh-helper` identity: `status:active`, `publish:["lyra.gh.mint_failure.>"]`, `subscribe:[]`, `allow_responses:false`, `deploy:{type:container,secret:factory-nats-gh-helper}`, `created_at`/`owner`/`description`; **and** update the hub `notes` inert-grant clause (TODO T4 → "publisher declared by #1082") | drives `gen_nkeys` |
+| I2 | `scripts/gen_nkeys.py` | no edit — `_mode_full_provision` + `render_auth_conf` auto-derive seed+pubkey from `active` identities. Verify `--template-only` emits `gh-helper`. Seed file is auto-created on next run (none exists yet — expected). | `gh-helper.seed`, pubkey |
+| I2b | `scripts/check_grants.py` | `RESOURCES` is a **static** list — add a `gh-helper → lyra.gh.mint_failure.>` coverage entry so the publish path is gate-asserted (else the new grant is unguarded) | gate coverage |
+| I3 | `Makefile` `quadlet-secrets-install` | add `podman secret create --replace factory-nats-gh-helper "$(FACTORY_NKEYS_DIR)/gh-helper.seed"` after the clipool line. (Target already omits `turn-writer`/`blobstore` — pre-existing gap; add **only** `gh-helper`, do not fix the others here.) | podman secret |
+| I4 | `deploy/quadlet/factory-gh-helper.container` | `Secret=factory-nats-gh-helper,type=mount,target=factory-nats-gh-helper.seed,uid=1501,gid=1501,mode=0400` + `Environment=NATS_URL=nats://factory-nats:4222` + `Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-gh-helper.seed` + `Environment=FACTORY_MACHINE=roxabituwer` | container env |
+
+### Code affordances
+
+| ID | Place | Handler | Data |
+|----|-------|---------|------|
+| N1 | `src/factory/tools/gh_token/mint_failure_publisher.py` (new) | `MintFailurePublisher(nc, machine).publish(exc)` — build event, serialize, publish; one `except Exception` catch+log(WARNING)+swallow with inline justification (best-effort) | `MintFailureEvent` |
+| N2 | `daemon.py` `run_daemon` | read `NATS_URL`/`FACTORY_MACHINE`; if URL → **`try: nc = await nats_connect(...) except Exception: log.warning(...); nc=None`** (guard so nothing propagates to `_amain`); build publisher iff connected; inject into `Dispenser`; drain/close on shutdown | `nc`, publisher |
+| N3 | `dispenser.py` `Dispenser` | new `publisher: MintFailurePublisher\|None=None` ctor param; in `except MintError` block (`_handle` is already `async`) call `await publisher.publish(exc)` if set, after the existing log + socket reply | — |
+| N4 | `helper.py:11` + `:55` | remove the module-docstring `TODO(T4)` line (line 11) and the `MintError` docstring "T4's failure-event path" reference (line 55) | — |
+
+`FACTORY_MACHINE` is set explicitly to `roxabituwer` (M₁) in I4; if ever unset at runtime the code
+falls back to `socket.gethostname()`, and if that fails the contract's job-token charset validation
+(`validate_job_token`), to the safe literal `"unknown"` (a valid job-token) + WARNING.
+
+## Slices
+
+| Slice | Affordances | Independently demo-able |
+|-------|-------------|--------------------------|
+| **S1 — Identity + provisioning (infra)** | I1, I2, I2b, I3, I4 | `gen_nkeys --template-only` lists `gh-helper`; `check_grants.py` green; ACL test confirms publish-only on `lyra.gh.mint_failure.>`; Makefile names the secret |
+| **S2 — Publisher + wiring + tests (code)** | N1, N2, N3, N4 | unit/integration test: forced `MintError` → `MintFailureEvent` captured on a fake NC at the exact subject the subscriber binds; NATS-down → token still served + publish swallowed; `TODO(T4)` gone; gates green |
+
+(2 slices, 8 criteria → Gate 2.5 not triggered; one indivisible vertical — splitting infra from
+wiring would leave a non-functional half.)
+
+## Success Criteria
+
+- [ ] **Identity** — `acl-matrix.json` declares `gh-helper` with `publish:["lyra.gh.mint_failure.>"]`, `subscribe:[]`, and `deploy:{type:container,secret:factory-nats-gh-helper}`; `gen_nkeys --template-only` emits its pubkey; the hub `notes` inert-grant clause is updated.
+- [ ] **Provisioning** — `Makefile:quadlet-secrets-install` creates `factory-nats-gh-helper` from `gh-helper.seed`; `factory-gh-helper.container` mounts it (`mode=0400,uid=1501`) and sets `NATS_URL`, `NATS_NKEY_SEED_PATH`, `FACTORY_MACHINE=roxabituwer`.
+- [ ] **Publish on failure** — every `MintError` yields exactly one `MintFailureEvent` on `lyra.gh.mint_failure.<machine>` with `reason` (mapped label), `http_status`, and `retries` from the exception.
+- [ ] **Subject match (integration smoke)** — a local test (forced `MintError` → publisher → in-memory/stub NC) asserts the published subject is exactly what `MintFailureSubscriber` binds to (`lyra.gh.mint_failure.>` prefix via `gh_mint_failure()`); no real GitHub revocation needed. Closes the producer↔subscriber wire gap that full RED-GATE V6 (#1078 T18) would otherwise be first to catch.
+- [ ] **Best-effort isolation** — publisher errors (connect lost, publish raises, NATS down) are logged + swallowed; the dispenser's socket response and token-mint path are byte-for-byte unchanged; the helper boots and serves tokens with `NATS_URL` unset or unreachable (no pod teardown).
+- [ ] **Least privilege** — a **unit test parsing `acl-matrix.json`** asserts `gh-helper` holds no publish/subscribe grant beyond `lyra.gh.mint_failure.>`; `check_grants.py` passes.
+- [ ] **Cleanup** — the `TODO(T4)` line and the `line 55` T4 reference are removed from `helper.py`.
+- [ ] **Gates** — new unit tests + the ACL gates (`check_grants.py`, `tests/nats/test_gen_nkeys_acls.sh`) pass; `ruff`, `pyright`, `pytest`, and `import-linter` are green.
+
+## Edge Cases
+
+| Edge | Handling |
+|------|----------|
+| `NATS_URL` unset | publisher=None; helper serves tokens; one **INFO** "publishing disabled — no NATS_URL" |
+| NATS connect fails at boot | `try/except` in `run_daemon` → **WARNING**; publisher=None; do **not** propagate (else `_amain` exits → `BindsTo` pod teardown) |
+| NATS drops after boot / publish raises | `publish()` catches+logs+swallows; mint path unaffected |
+| `FACTORY_MACHINE` unset/invalid | `gethostname()` → if invalid per contract charset, safe literal `"unknown"` + WARNING |
+| import-linter | `factory.tools` is outside all `.importlinter` contracts; `roxabi_nats`/`roxabi_contracts` are external packages → the import is **ungated** by absence. Verify `import-linter` still passes in the worktree; no allowance edit expected. |
+
+## Docs to update on ship
+
+- `src/factory/tools/CLAUDE.md` — note the publish-only NATS identity + `MintFailurePublisher`.
+- `docs/QUADLET-DEPLOYMENT.md` — add `factory-nats-gh-helper` to the secret table + diagnostics.
+- `deploy/nats/acl-matrix.json` hub `notes` — clear the TODO T4 inert-grant clause (part of I1).
+
+## Out of Scope / Follow-up
+
+- Subscriber, Telegram formatting, ops routing (#1078 T17 — done).
+- Full RED-GATE V6 / T18 e2e (real token revocation) — tracked under #1078 T18.
+- `lyra.*` → `roxabi.*` subject-namespace rename.
+- **Three-strikes (axial):** `except Exception + log + swallow` around `nc.publish` now exists in 3
+  places (`transport/typing_publisher.py:80`, `adapters/nats/mint_failure_subscriber.py:129`, and N1).
+  Extract a shared `best_effort_publish(nc, subject, payload, *, log_tag)` into `transport/` —
+  **follow-up issue**, not this scope (two of the three are cross-process).

--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -23,72 +23,72 @@ Drift is gated by `scripts/check-acl-specs-drift.sh` (CI + pre-push).
 The row will grant `subscribe: lyra.typing.>` to `code-worker` (it consumes typing events to throttle its own typing emission). Provisioning: `make nats-add-identity NAME=code-worker` when T3 worker fleet integration starts; the `_inbox.code-worker.>` grant is derived automatically from `request_reply_flows` per the renderer convention.
 
 <!-- acl-matrix:begin -->
-| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | llm-operator | image-worker | clipool-worker | dashboard-reader | voice-client | turn-writer | blobstore |
-|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| `$JS.API.>` | PUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — | PUB |
-| `$JS.API.CONSUMER.CREATE.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.CONSUMER.CREATE.LYRA_TURNS.turn-writer-v1.>` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
-| `$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.CONSUMER.INFO.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
-| `$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.CONSUMER.MSG.NEXT.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
-| `$JS.API.DIRECT.GET.LYRA_STATE.hub.ready` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.INFO` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.CREATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
-| `$JS.API.STREAM.INFO.KV_lyra-state` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.INFO.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
-| `$JS.API.STREAM.MSG.GET.KV_lyra-state` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `$JS.API.STREAM.UPDATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
-| `$KV.lyra-msg-index.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — |
-| `$KV.lyra-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | — | SUB | SUB | — | — | — | PUB |
-| `$KV.lyra_outbound_audio_sent.>` | — | PUB+SUB | PUB+SUB | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.blobstore.>` | — | — | — | — | — | — | — | — | — | — | — | — | SUB |
-| `_inbox.clipool-worker.>` | — | — | — | — | — | — | — | — | SUB | — | — | — | — |
-| `_inbox.discord-adapter.*.*` | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — | — |
-| `_inbox.image-worker.>` | — | — | — | — | — | — | — | SUB | — | — | — | — | — |
-| `_inbox.llm-operator.>` | — | — | — | — | — | — | SUB | — | — | — | — | — | — |
-| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — | — | — | — |
-| `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
-| `_inbox.turn-writer.>` | — | — | — | — | — | — | — | — | — | — | — | PUB+SUB | — |
-| `_inbox.voice-client.>` | — | — | — | PUB | PUB | — | — | — | — | — | SUB | — | — |
-| `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — | — | — |
-| `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — | — | — |
-| `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | PUB |
-| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | SUB | — | — | — | — |
-| `lyra.clipool.control` | PUB | — | — | — | — | — | — | — | SUB | — | — | — | — |
-| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | PUB | — | — | — | — |
-| `lyra.event.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — | — |
-| `lyra.gh.mint_failure.>` | SUB | — | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.image.generate.request` | PUB | — | — | — | — | — | — | SUB | — | — | — | — | — |
-| `lyra.image.heartbeat` | SUB | — | — | — | — | — | — | PUB | — | — | — | — | — |
-| `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.llm.generate.request` | PUB | — | — | — | — | SUB | — | — | — | — | — | — | — |
-| `lyra.llm.heartbeat` | SUB | — | — | — | — | PUB | — | — | — | — | — | — | — |
-| `lyra.llm.lifecycle.>` | — | — | — | — | — | SUB | PUB | — | — | — | — | — | — |
-| `lyra.metric.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — | — |
-| `lyra.outbound.audio.>` | PUB | SUB | SUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.system.ready` | SUB | PUB | PUB | PUB | PUB | — | — | — | PUB | — | — | — | — |
-| `lyra.turns.>` | — | — | — | — | — | — | — | — | — | — | — | SUB | — |
-| `lyra.turns.write` | PUB | PUB | PUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.typing.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.typing.discord.>` | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
-| `lyra.typing.telegram.>` | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
-| `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — | — | — | — | — | — | — |
-| `lyra.voice.stt.request` | PUB | — | — | — | SUB | — | — | — | — | — | PUB | — | — |
-| `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — | — | — | — |
-| `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — | — | — | — |
-| `lyra.voice.tts.request` | PUB | — | — | SUB | — | — | — | — | — | — | PUB | — | — |
-| `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — | — | — | — |
+| Subject | hub | telegram-adapter | discord-adapter | voice-tts | voice-stt | llm-worker | llm-operator | image-worker | clipool-worker | dashboard-reader | voice-client | turn-writer | blobstore | gh-helper |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| `$JS.API.>` | PUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — | PUB | — |
+| `$JS.API.CONSUMER.CREATE.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.CONSUMER.CREATE.LYRA_OUTBOUND_AUDIO.>` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.CONSUMER.CREATE.LYRA_TURNS.turn-writer-v1.>` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — |
+| `$JS.API.CONSUMER.INFO.LYRA_OUTBOUND_AUDIO.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.CONSUMER.INFO.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — |
+| `$JS.API.CONSUMER.MSG.NEXT.LYRA_OUTBOUND_AUDIO.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.CONSUMER.MSG.NEXT.LYRA_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — |
+| `$JS.API.DIRECT.GET.LYRA_STATE.hub.ready` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.INFO` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.CREATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — |
+| `$JS.API.STREAM.INFO.KV_lyra-state` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.INFO.KV_lyra_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.INFO.LYRA_OUTBOUND_AUDIO` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.INFO.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — |
+| `$JS.API.STREAM.MSG.GET.KV_lyra-state` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.MSG.GET.KV_lyra_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.UPDATE.LYRA_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — |
+| `$KV.lyra-msg-index.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `$KV.lyra-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | — | SUB | SUB | — | — | — | PUB | — |
+| `$KV.lyra_outbound_audio_sent.>` | — | PUB+SUB | PUB+SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.blobstore.>` | — | — | — | — | — | — | — | — | — | — | — | — | SUB | — |
+| `_inbox.clipool-worker.>` | — | — | — | — | — | — | — | — | SUB | — | — | — | — | — |
+| `_inbox.discord-adapter.*.*` | — | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.discord-adapter.>` | — | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.hub.>` | SUB | — | — | PUB | PUB | PUB | — | PUB | PUB | — | — | — | — | — |
+| `_inbox.image-worker.>` | — | — | — | — | — | — | — | SUB | — | — | — | — | — | — |
+| `_inbox.llm-operator.>` | — | — | — | — | — | — | SUB | — | — | — | — | — | — | — |
+| `_inbox.llmcli-llm.>` | — | — | — | — | — | SUB | — | — | — | — | — | — | — | — |
+| `_inbox.telegram-adapter.*.*` | — | SUB | — | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.telegram-adapter.>` | — | SUB | — | — | — | — | — | — | — | — | — | — | — | — |
+| `_inbox.turn-writer.>` | — | — | — | — | — | — | — | — | — | — | — | PUB+SUB | — | — |
+| `_inbox.voice-client.>` | — | — | — | PUB | PUB | — | — | — | — | — | SUB | — | — | — |
+| `_inbox.voice-stt.>` | — | — | — | — | SUB | — | — | — | — | — | — | — | — | — |
+| `_inbox.voice-tts.>` | — | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.audit.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | PUB | — |
+| `lyra.clipool.cmd` | PUB | — | — | — | — | — | — | — | SUB | — | — | — | — | — |
+| `lyra.clipool.control` | PUB | — | — | — | — | — | — | — | SUB | — | — | — | — | — |
+| `lyra.clipool.heartbeat` | SUB | — | — | — | — | — | — | — | PUB | — | — | — | — | — |
+| `lyra.event.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — | — | — |
+| `lyra.gh.mint_failure.>` | SUB | — | — | — | — | — | — | — | — | — | — | — | — | PUB |
+| `lyra.image.generate.request` | PUB | — | — | — | — | — | — | SUB | — | — | — | — | — | — |
+| `lyra.image.heartbeat` | SUB | — | — | — | — | — | — | PUB | — | — | — | — | — | — |
+| `lyra.inbound.discord.>` | SUB | — | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.inbound.telegram.>` | SUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.llm.generate.request` | PUB | — | — | — | — | SUB | — | — | — | — | — | — | — | — |
+| `lyra.llm.heartbeat` | SUB | — | — | — | — | PUB | — | — | — | — | — | — | — | — |
+| `lyra.llm.lifecycle.>` | — | — | — | — | — | SUB | PUB | — | — | — | — | — | — | — |
+| `lyra.metric.>` | PUB | PUB | PUB | — | — | — | — | — | PUB | SUB | — | — | — | — |
+| `lyra.outbound.audio.>` | PUB | SUB | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.outbound.discord.>` | PUB | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.outbound.telegram.>` | PUB | SUB | — | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.system.ready` | SUB | PUB | PUB | PUB | PUB | — | — | — | PUB | — | — | — | — | — |
+| `lyra.turns.>` | — | — | — | — | — | — | — | — | — | — | — | SUB | — | — |
+| `lyra.turns.write` | PUB | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.typing.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.typing.discord.>` | — | — | SUB | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.typing.telegram.>` | — | SUB | — | — | — | — | — | — | — | — | — | — | — | — |
+| `lyra.voice.stt.heartbeat` | SUB | — | — | — | PUB | — | — | — | — | — | — | — | — | — |
+| `lyra.voice.stt.request` | PUB | — | — | — | SUB | — | — | — | — | — | PUB | — | — | — |
+| `lyra.voice.stt.request.>` | PUB | — | — | — | SUB | — | — | — | — | — | — | — | — | — |
+| `lyra.voice.tts.heartbeat` | SUB | — | — | PUB | — | — | — | — | — | — | — | — | — | — |
+| `lyra.voice.tts.request` | PUB | — | — | SUB | — | — | — | — | — | — | PUB | — | — | — |
+| `lyra.voice.tts.request.>` | PUB | — | — | SUB | — | — | — | — | — | — | — | — | — | — |
 <!-- acl-matrix:end -->
 
 [^ready]: `lyra.system.ready` — adapters and workers publish once on startup; hub subscribes to track liveness.

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -33,7 +33,7 @@
       "created_at": "2026-04-21",
       "owner": "lyra",
       "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image/clipool workers. Inbox normalized to lowercase _inbox.hub.> (ADR-051 + postmortem Fix 1).",
-      "notes": "Hub provisions the lyra-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.lyra-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. lyra.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. lyra.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream LYRA_OUTBOUND_AUDIO and KV bucket KV_lyra_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 §Forward-compat for explicit enumeration if wildcard is ever tightened). lyra.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only — the gh-helper publisher identity is not yet declared in this matrix (TODO T4), so the grant is inert until that lands; the subscriber side is declared now to retire the subject-literals allowlist. This field is metadata only — not rendered into auth.conf or the 706 spec table.",
+      "notes": "Hub provisions the lyra-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.lyra-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. lyra.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. lyra.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream LYRA_OUTBOUND_AUDIO and KV bucket KV_lyra_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 §Forward-compat for explicit enumeration if wildcard is ever tightened). lyra.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only — publisher declared by #1082 (gh-helper). This field is metadata only — not rendered into auth.conf or the 706 spec table.",
       "allow_responses": true,
       "publish": [
         "lyra.outbound.telegram.>",
@@ -326,6 +326,18 @@
         "_inbox.blobstore.>"
       ],
       "deploy": { "type": "container", "secret": "factory-nats-blobstore" }
+    },
+    "gh-helper": {
+      "status": "active",
+      "created_at": "2026-06-02",
+      "owner": "lyra",
+      "description": "publish-only mint-failure alerts, #1082",
+      "allow_responses": false,
+      "publish": [
+        "lyra.gh.mint_failure.>"
+      ],
+      "subscribe": [],
+      "deploy": { "type": "container", "secret": "factory-nats-gh-helper" }
     }
   }
 }

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -126,5 +126,14 @@ authorization {
         allow_responses: true
       }
     }
+    {
+      nkey: "UDETGHHELPER"
+      # gh-helper
+      permissions: {
+        publish:   { allow: ["lyra.gh.mint_failure.>"] }
+        subscribe: { allow: [] }
+        allow_responses: false
+      }
+    }
   ]
 }

--- a/deploy/quadlet/factory-gh-helper.container
+++ b/deploy/quadlet/factory-gh-helper.container
@@ -36,6 +36,12 @@ Environment=FACTORY_GH_APP_ID=3619198
 Environment=FACTORY_GH_INSTALLATION_ID=129952244
 Environment=FACTORY_GH_PEM_PATH=/run/secrets/gh-app.pem
 
+# NATS NKey seed — publish-only identity for mint-failure alerts (#1082).
+Secret=factory-nats-gh-helper,type=mount,target=factory-nats-gh-helper.seed,uid=1501,gid=1501,mode=0400
+Environment=NATS_URL=nats://factory-nats:4222
+Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-gh-helper.seed
+Environment=FACTORY_MACHINE=roxabituwer
+
 # Token-mint runtime state — shared with factory-clipool via Quadlet .volume unit.
 # Pod containers do NOT share mount namespaces; Tmpfs= on sibling containers
 # creates two independent filesystems. factory-gh-token.volume mounts the same

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -100,6 +100,9 @@
 - **Publish:** $JS.API.CONSUMER.CREATE.*, $JS.API.DIRECT.GET.LYRA_STATE.hub.ready, $JS.API.INFO, $JS.API.STREAM.INFO.KV_lyra-state, $JS.API.STREAM.MSG.GET.KV_lyra-state, lyra.event.>, lyra.inbound.discord.>, lyra.metric.>, lyra.system.ready, lyra.turns.write
 - **Subscribe:** $KV.lyra-state.>, _inbox.discord-adapter.*.*, _inbox.discord-adapter.>, lyra.outbound.audio.>, lyra.outbound.discord.>, lyra.typing.discord.>
 
+### gh-helper
+- **Publish:** lyra.gh.mint_failure.>
+
 ### hub
 - **Publish:** $JS.API.>, $KV.lyra-msg-index.>, $KV.lyra-state.>, lyra.audit.>, lyra.clipool.cmd, lyra.clipool.control, lyra.event.>, lyra.image.generate.request, lyra.llm.generate.request, lyra.metric.>, lyra.outbound.audio.>, lyra.outbound.discord.>, lyra.outbound.telegram.>, lyra.turns.write, lyra.typing.>, lyra.voice.stt.request, lyra.voice.stt.request.>, lyra.voice.tts.request, lyra.voice.tts.request.>
 - **Subscribe:** _inbox.hub.>, lyra.clipool.heartbeat, lyra.gh.mint_failure.>, lyra.image.heartbeat, lyra.inbound.discord.>, lyra.inbound.telegram.>, lyra.llm.heartbeat, lyra.system.ready, lyra.voice.stt.heartbeat, lyra.voice.tts.heartbeat

--- a/scripts/check_grants.py
+++ b/scripts/check_grants.py
@@ -65,6 +65,16 @@ RESOURCES = [
         None,
     ),
     (
+        "publisher",
+        "gh-helper",
+        "gh-helper",
+        [
+            "lyra.gh.mint_failure.>",
+        ],
+        None,
+        None,
+    ),
+    (
         "kv",
         "lyra_outbound_audio_sent",
         "hub",

--- a/src/factory/core/config/turn_store_config.py
+++ b/src/factory/core/config/turn_store_config.py
@@ -25,5 +25,5 @@ class TurnStoreConfig:
     DEFAULT_LIST_SESSIONS_LIMIT: int = 5
     """Default maximum number of sessions returned by ``list_sessions``."""
 
-    COMPACT_TURN_FETCH_LIMIT: int = 500
+    COMPACT_TURN_FETCH_LIMIT: int = 500  # const-ok: compaction fetch default (#1662)
     """Bulk-read limit for compaction turn-fetch (full-history token estimate)."""

--- a/src/factory/core/lifecycle/session_lifecycle.py
+++ b/src/factory/core/lifecycle/session_lifecycle.py
@@ -96,7 +96,9 @@ class SessionManager:
             # Derive token estimate from TurnStore — includes both user and
             # assistant turns, restoring pre-#666 full-conversation accounting.
             raw = await turn_store.get_turns(
-                pool.pool_id, pool.user_id, limit=TurnStoreConfig.COMPACT_TURN_FETCH_LIMIT
+                pool.pool_id,
+                pool.user_id,
+                limit=TurnStoreConfig.COMPACT_TURN_FETCH_LIMIT,
             )
             token_est = sum(len(t["content"]) // 4 for t in raw)
         else:

--- a/src/factory/tools/gh_token/daemon.py
+++ b/src/factory/tools/gh_token/daemon.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import signal
 import socket
 import sys
@@ -110,8 +111,6 @@ def _safe_machine_name(raw: str) -> str:
     dots for namespacing; for the ``machine`` subject segment we need a stricter
     check so we inline one here.
     """
-    import re
-
     if re.fullmatch(r"[A-Za-z0-9_-]+", raw):
         return raw
     return "unknown"
@@ -138,6 +137,13 @@ async def run_daemon(config: DaemonConfig) -> None:
     else:
         raw_machine = os.environ.get("FACTORY_MACHINE", socket.gethostname())
         machine = _safe_machine_name(raw_machine)
+        if machine != raw_machine:
+            log.warning(
+                "FACTORY_MACHINE %r is not a valid NATS subject token"
+                " — publishing mint-failures as %r",
+                raw_machine,
+                machine,
+            )
         try:
             nc = await nats_connect(nats_url, identity_name="gh-helper")
             publisher = MintFailurePublisher(nc, machine)
@@ -151,48 +157,50 @@ async def run_daemon(config: DaemonConfig) -> None:
             publisher = None
     # ─────────────────────────────────────────────────────────────────────────
 
-    async with httpx.AsyncClient(
-        timeout=httpx.Timeout(10.0),
-        limits=httpx.Limits(max_keepalive_connections=0),
-    ) as http:
-        dispenser = Dispenser(
-            cache=cache,
-            signer=signer,
-            http=http,
-            app_id=config.app_id,
-            install_id=config.install_id,
-            lock=lock,
-            rate_limiter=rate_limiter,
-            publisher=publisher,
-        )
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0),
+            limits=httpx.Limits(max_keepalive_connections=0),
+        ) as http:
+            dispenser = Dispenser(
+                cache=cache,
+                signer=signer,
+                http=http,
+                app_id=config.app_id,
+                install_id=config.install_id,
+                lock=lock,
+                rate_limiter=rate_limiter,
+                publisher=publisher,
+            )
 
-        config.sock_path.parent.mkdir(parents=True, exist_ok=True)
-        if config.sock_path.exists():
-            config.sock_path.unlink()
+            config.sock_path.parent.mkdir(parents=True, exist_ok=True)
+            if config.sock_path.exists():
+                config.sock_path.unlink()
 
-        server = await dispenser.serve(config.sock_path)
-        log.info(
-            "factory-gh-helper daemon started — app_id=%s install_id=%s",
-            config.app_id,
-            config.install_id,
-        )
+            server = await dispenser.serve(config.sock_path)
+            log.info(
+                "factory-gh-helper daemon started — app_id=%s install_id=%s",
+                config.app_id,
+                config.install_id,
+            )
 
-        task: asyncio.Task[None] = asyncio.create_task(server.serve_forever())
+            task: asyncio.Task[None] = asyncio.create_task(server.serve_forever())
 
-        try:
-            await asyncio.gather(task)
-        except asyncio.CancelledError:
-            log.info("factory-gh-helper daemon shutting down")
-        finally:
-            server.close()
-            await server.wait_closed()
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
-            if nc is not None:
-                try:
-                    await nc.drain()
-                except Exception:  # noqa: BLE001 — best-effort drain on shutdown
-                    pass
+            try:
+                await asyncio.gather(task)
+            except asyncio.CancelledError:
+                log.info("factory-gh-helper daemon shutting down")
+            finally:
+                server.close()
+                await server.wait_closed()
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+    finally:
+        if nc is not None:
+            try:
+                await nc.drain()
+            except Exception:  # noqa: BLE001 — best-effort drain on shutdown
+                pass
 
 
 def _install_signal_handlers(loop: asyncio.AbstractEventLoop) -> None:

--- a/src/factory/tools/gh_token/daemon.py
+++ b/src/factory/tools/gh_token/daemon.py
@@ -29,6 +29,7 @@ import asyncio
 import logging
 import os
 import signal
+import socket
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,7 +38,9 @@ import httpx
 
 from factory.tools.gh_token.dispenser import Dispenser
 from factory.tools.gh_token.helper import JWTSigner, TokenCache
+from factory.tools.gh_token.mint_failure_publisher import MintFailurePublisher
 from factory.tools.gh_token.rate_limit import RateLimiter
+from roxabi_nats import nats_connect
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +102,21 @@ def _load_config() -> DaemonConfig:
     )
 
 
+def _safe_machine_name(raw: str) -> str:
+    """Return *raw* if it is a valid single NATS subject token, else ``"unknown"``.
+
+    A valid token contains only ``[A-Za-z0-9_-]`` characters (no dots, spaces,
+    wildcards, or ``>``). validate_job_token from roxabi-contracts allows internal
+    dots for namespacing; for the ``machine`` subject segment we need a stricter
+    check so we inline one here.
+    """
+    import re
+
+    if re.fullmatch(r"[A-Za-z0-9_-]+", raw):
+        return raw
+    return "unknown"
+
+
 async def run_daemon(config: DaemonConfig) -> None:
     """Start the dispenser. Runs until cancelled.
 
@@ -109,6 +127,29 @@ async def run_daemon(config: DaemonConfig) -> None:
     cache = TokenCache(config.cache_path)
     rate_limiter = RateLimiter(min_interval_s=config.rate_limit_s)
     lock = asyncio.Lock()
+
+    # ── NATS: best-effort connect for mint-failure publishing ─────────────────
+    nats_url = os.environ.get("NATS_URL", "").strip()
+    nc = None
+    publisher: MintFailurePublisher | None = None
+
+    if not nats_url:
+        log.info("mint-failure publishing disabled — no NATS_URL")
+    else:
+        raw_machine = os.environ.get("FACTORY_MACHINE", socket.gethostname())
+        machine = _safe_machine_name(raw_machine)
+        try:
+            nc = await nats_connect(nats_url, identity_name="gh-helper")
+            publisher = MintFailurePublisher(nc, machine)
+            log.info(
+                "mint-failure publishing enabled — subject lyra.gh.mint_failure.%s",
+                machine,
+            )
+        except Exception as exc:  # noqa: BLE001 — must not crash daemon (BindsTo → pod teardown)
+            log.warning("mint-failure NATS connect failed: %s", exc)
+            nc = None
+            publisher = None
+    # ─────────────────────────────────────────────────────────────────────────
 
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(10.0),
@@ -122,6 +163,7 @@ async def run_daemon(config: DaemonConfig) -> None:
             install_id=config.install_id,
             lock=lock,
             rate_limiter=rate_limiter,
+            publisher=publisher,
         )
 
         config.sock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -146,6 +188,11 @@ async def run_daemon(config: DaemonConfig) -> None:
             await server.wait_closed()
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+            if nc is not None:
+                try:
+                    await nc.drain()
+                except Exception:  # noqa: BLE001 — best-effort drain on shutdown
+                    pass
 
 
 def _install_signal_handlers(loop: asyncio.AbstractEventLoop) -> None:

--- a/src/factory/tools/gh_token/dispenser.py
+++ b/src/factory/tools/gh_token/dispenser.py
@@ -23,6 +23,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import httpx
 
@@ -34,6 +35,9 @@ from factory.tools.gh_token.helper import (
     mint,
 )
 from factory.tools.gh_token.rate_limit import RateLimiter
+
+if TYPE_CHECKING:
+    from factory.tools.gh_token.mint_failure_publisher import MintFailurePublisher
 
 log = logging.getLogger(__name__)
 
@@ -65,6 +69,7 @@ class Dispenser:
         install_id: str,
         lock: asyncio.Lock | None = None,
         rate_limiter: RateLimiter | None = None,
+        publisher: "MintFailurePublisher | None" = None,
     ) -> None:
         self._cache = cache
         self._signer = signer
@@ -73,6 +78,7 @@ class Dispenser:
         self._install_id = install_id
         self._lock = lock if lock is not None else asyncio.Lock()
         self._rate_limiter = rate_limiter if rate_limiter is not None else RateLimiter()
+        self._publisher = publisher
 
     # ── public ────────────────────────────────────────────────────────────────
 
@@ -162,6 +168,8 @@ class Dispenser:
                     log.warning("Dispenser: mint failed: %s", exc)
                     writer.write(b"error=mint failed\n")
                     await writer.drain()
+                    if self._publisher is not None:
+                        await self._publisher.publish(exc)
                     return
 
                 response = (

--- a/src/factory/tools/gh_token/helper.py
+++ b/src/factory/tools/gh_token/helper.py
@@ -8,7 +8,6 @@ Unix socket dispenser (serve() on /run/factory-gh-token/dispenser.sock) lives in
 dispenser.py — it imports the primitives defined here (TokenCache, JWTSigner,
 InstallationToken, MintError, mint).
 
-TODO(T4): MintError → publish as MintFailureEvent on NATS (roxabi-contracts gh/ schema)
 """
 
 from __future__ import annotations
@@ -52,7 +51,7 @@ class InstallationToken:
 class MintError(Exception):
     """Raised when a GitHub installation token cannot be minted.
 
-    Carries structured context for the caller and for T4's failure-event path.
+    Carries structured context for the caller.
     """
 
     def __init__(

--- a/src/factory/tools/gh_token/mint_failure_publisher.py
+++ b/src/factory/tools/gh_token/mint_failure_publisher.py
@@ -1,0 +1,60 @@
+"""Best-effort NATS publisher for GitHub token-mint failures.
+
+Publishes a MintFailureEvent on ``lyra.gh.mint_failure.<machine>`` whenever
+a MintError is raised. Publication is fire-and-forget: any NATS error is
+logged and swallowed so that a NATS outage never breaks or stalls token minting.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from factory.tools.gh_token.helper import MintError
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.gh.models import MintFailureEvent
+from roxabi_contracts.gh.subjects import gh_mint_failure
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+
+log = logging.getLogger(__name__)
+
+
+def _reason_label(exc: MintError) -> str:
+    """Map a MintError to a short failure label for the event ``reason`` field."""
+    if exc.http_status is not None:
+        return f"github_api_{exc.http_status}"
+    return "network_error"
+
+
+class MintFailurePublisher:
+    """Best-effort NATS publisher for MintFailureEvent.
+
+    Wraps a NATS client and a machine identifier. ``publish()`` never raises —
+    NATS errors are logged at WARNING level and swallowed so that callers can
+    fire-and-forget without disrupting the token-minting critical path.
+    """
+
+    def __init__(self, nc: "NATS", machine: str) -> None:
+        self._nc = nc
+        self._machine = machine
+
+    async def publish(self, exc: MintError) -> None:
+        """Publish a MintFailureEvent for *exc*. Best-effort — never raises."""
+        try:
+            event = MintFailureEvent(
+                contract_version=CONTRACT_VERSION,
+                trace_id=str(uuid4()),
+                issued_at=datetime.now(timezone.utc),
+                machine=self._machine,
+                reason=_reason_label(exc),
+                http_status=exc.http_status,
+                retries=exc.retries,
+            )
+            subject = gh_mint_failure(self._machine)
+            await self._nc.publish(subject, event.model_dump_json().encode("utf-8"))
+        except Exception as pub_exc:  # noqa: BLE001 — best-effort publish; must not break token minting
+            log.warning("mint_failure_publisher: publish failed: %s", pub_exc)

--- a/tests/scripts/fixtures/v3-current.json
+++ b/tests/scripts/fixtures/v3-current.json
@@ -43,7 +43,7 @@
       "created_at": "2026-04-21",
       "owner": "lyra",
       "description": "Hub core \u2014 routes inbound messages, dispatches to voice/LLM/image/clipool workers. Inbox normalized to lowercase _inbox.hub.> (ADR-051 + postmortem Fix 1).",
-      "notes": "Hub provisions the lyra-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.lyra-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. lyra.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. lyra.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream LYRA_OUTBOUND_AUDIO and KV bucket KV_lyra_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 \u00a7Forward-compat for explicit enumeration if wildcard is ever tightened). lyra.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only \u2014 the gh-helper publisher identity is not yet declared in this matrix (TODO T4), so the grant is inert until that lands; the subscriber side is declared now to retire the subject-literals allowlist. This field is metadata only \u2014 not rendered into auth.conf or the 706 spec table.",
+      "notes": "Hub provisions the lyra-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.lyra-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. lyra.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. lyra.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream LYRA_OUTBOUND_AUDIO and KV bucket KV_lyra_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 \u00a7Forward-compat for explicit enumeration if wildcard is ever tightened). lyra.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only \u2014 publisher declared by #1082 (gh-helper). This field is metadata only \u2014 not rendered into auth.conf or the 706 spec table.",
       "allow_responses": true,
       "publish": [
         "lyra.outbound.telegram.>",
@@ -386,6 +386,21 @@
       "deploy": {
         "type": "container",
         "secret": "factory-nats-blobstore"
+      }
+    },
+    "gh-helper": {
+      "status": "active",
+      "created_at": "2026-06-02",
+      "owner": "lyra",
+      "description": "publish-only mint-failure alerts, #1082",
+      "allow_responses": false,
+      "publish": [
+        "lyra.gh.mint_failure.>"
+      ],
+      "subscribe": [],
+      "deploy": {
+        "type": "container",
+        "secret": "factory-nats-gh-helper"
       }
     }
   }

--- a/tests/scripts/fixtures/v3-pre-grant-group.json
+++ b/tests/scripts/fixtures/v3-pre-grant-group.json
@@ -324,6 +324,21 @@
         "_inbox.blobstore.>"
       ],
       "deploy": { "type": "container", "secret": "lyra-nats-blobstore" }
+    },
+    "gh-helper": {
+      "status": "active",
+      "created_at": "2026-06-02",
+      "owner": "lyra",
+      "description": "publish-only mint-failure alerts, #1082",
+      "allow_responses": false,
+      "publish": [
+        "lyra.gh.mint_failure.>"
+      ],
+      "subscribe": [],
+      "deploy": {
+        "type": "container",
+        "secret": "factory-nats-gh-helper"
+      }
     }
   }
 }

--- a/tests/scripts/test_acl_gh_helper.py
+++ b/tests/scripts/test_acl_gh_helper.py
@@ -1,0 +1,37 @@
+"""ACL matrix regression test for the gh-helper identity (#1082).
+
+Guards the least-privilege NATS contract for gh-helper:
+- publish: ["lyra.gh.mint_failure.>"] — publish-only mint-failure alerts
+- subscribe: []                        — no subscribe permissions
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MATRIX = REPO / "deploy" / "nats" / "acl-matrix.json"
+
+
+def _identities() -> dict:
+    assert MATRIX.exists(), f"acl-matrix.json missing: {MATRIX}"
+    return json.loads(MATRIX.read_text())["identities"]
+
+
+def test_gh_helper_publish_subjects() -> None:
+    """gh-helper may publish only to lyra.gh.mint_failure.> (least-privilege)."""
+    identities = _identities()
+    assert "gh-helper" in identities, (
+        "gh-helper identity must be present in acl-matrix.json"
+    )
+    assert identities["gh-helper"]["publish"] == ["lyra.gh.mint_failure.>"]
+
+
+def test_gh_helper_subscribe_is_empty() -> None:
+    """gh-helper must have no subscribe permissions (publish-only identity)."""
+    identities = _identities()
+    assert "gh-helper" in identities, (
+        "gh-helper identity must be present in acl-matrix.json"
+    )
+    assert identities["gh-helper"]["subscribe"] == []

--- a/tests/tools/test_gh_token_helper.py
+++ b/tests/tools/test_gh_token_helper.py
@@ -759,6 +759,8 @@ async def test_dispenser_calls_publisher_on_mint_error(
     assert len(spy.calls) == 1, (
         f"Expected publisher.publish() called once; got {len(spy.calls)} calls"
     )
+    assert isinstance(spy.calls[0], MintError)
+    assert spy.calls[0].http_status == 500
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_gh_token_helper.py
+++ b/tests/tools/test_gh_token_helper.py
@@ -693,3 +693,98 @@ def test_token_cache_parent_dir_must_exist(tmp_path: Path) -> None:
     # Act / Assert — must not silently swallow; OS error propagates
     with pytest.raises(OSError):
         cache.write(it)
+
+
+# ── Section K: Dispenser + MintFailurePublisher integration ──────────────────
+#
+# T10: verifies that Dispenser calls publisher.publish(exc) after writing the
+# error response, and that publisher=None is a safe no-op.
+
+
+class SpyPublisher:
+    """Minimal MintFailurePublisher spy that records publish() calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[MintError] = []
+
+    async def publish(self, exc: MintError) -> None:  # type: ignore[override]
+        self.calls.append(exc)
+
+
+@pytest.mark.asyncio
+async def test_dispenser_calls_publisher_on_mint_error(
+    rsa_pem_path: Path, tmp_path: Path
+) -> None:
+    """Spy publisher is called exactly once with the MintError after error reply.
+
+    Verifies:
+    - socket response is b"error=mint failed\\n" (error written before publish)
+    - spy.publish(exc) was awaited exactly once with the raised MintError
+    - publisher call happens after the error bytes are sent (order preserved)
+
+    Negative-test note: removing the `if self._publisher is not None:` branch from
+    dispenser._handle() would NOT break this test (spy would still be called via
+    direct assignment). Removing the `await self._publisher.publish(exc)` call
+    entirely would cause `assert len(spy.calls) == 1` to fail — that is the
+    meaningful guard.
+    """
+    # Arrange — transport always returns 500 so mint() raises MintError
+    transport = _mock_transport(500, '{"message":"Internal Server Error"}')
+    signer = JWTSigner(rsa_pem_path)
+    cache = TokenCache(tmp_path / "token.json")
+    http = httpx.AsyncClient(transport=transport)
+    spy = SpyPublisher()
+    dispenser = Dispenser(
+        cache,
+        signer,
+        http,
+        app_id="12345",
+        install_id="123",
+        publisher=spy,  # type: ignore[arg-type]
+    )
+
+    sock_path = tmp_path / "d.sock"
+    server = await dispenser.serve(sock_path)
+    try:
+        response = await _round_trip(sock_path, b"get\n")
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    # Assert — error reply sent to client
+    assert response == b"error=mint failed\n", (
+        f"Expected 'error=mint failed\\n', got {response!r}"
+    )
+    # Assert — publisher was called exactly once
+    assert len(spy.calls) == 1, (
+        f"Expected publisher.publish() called once; got {len(spy.calls)} calls"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispenser_publisher_none_no_crash_on_mint_error(
+    rsa_pem_path: Path, tmp_path: Path
+) -> None:
+    """Dispenser with publisher=None handles MintError without crash.
+
+    Verifies that the `if self._publisher is not None:` guard prevents
+    AttributeError when no publisher is injected. Removing the guard would
+    cause `await None.publish(exc)` → AttributeError, failing the round-trip.
+    """
+    # Arrange — transport always returns 500 so mint() raises MintError
+    transport = _mock_transport(500, '{"message":"Internal Server Error"}')
+    dispenser, _ = _make_dispenser(rsa_pem_path, tmp_path, transport=transport)
+    # publisher defaults to None — no injection needed
+
+    sock_path = tmp_path / "d.sock"
+    server = await dispenser.serve(sock_path)
+    try:
+        response = await _round_trip(sock_path, b"get\n")
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    # Assert — error reply received, no exception propagated
+    assert response == b"error=mint failed\n", (
+        f"Expected 'error=mint failed\\n', got {response!r}"
+    )

--- a/tests/tools/test_mint_failure_publisher.py
+++ b/tests/tools/test_mint_failure_publisher.py
@@ -61,7 +61,6 @@ async def test_publish_http_error_sends_event() -> None:
     # Subject correctness
     expected_subject = gh_mint_failure("testhost")
     assert subject == expected_subject
-    assert subject.startswith("lyra.gh.mint_failure.")
 
     # Payload correctness
     event = MintFailureEvent.model_validate_json(data)

--- a/tests/tools/test_mint_failure_publisher.py
+++ b/tests/tools/test_mint_failure_publisher.py
@@ -1,0 +1,115 @@
+"""Tests for factory.tools.gh_token.mint_failure_publisher.
+
+Covers:
+- publish() builds and sends MintFailureEvent with correct subject/payload
+- reason_label mapping (http_status → "github_api_<N>", None → "network_error")
+- publish() swallows NATS errors — best-effort, never raises
+"""
+
+from __future__ import annotations
+
+from factory.tools.gh_token.helper import MintError
+from factory.tools.gh_token.mint_failure_publisher import MintFailurePublisher
+from roxabi_contracts.gh.models import MintFailureEvent
+from roxabi_contracts.gh.subjects import gh_mint_failure
+
+# ── fake NC ───────────────────────────────────────────────────────────────────
+
+
+class FakeNC:
+    """Minimal NATS client stub that records publish() calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.calls.append((subject, data))
+
+
+class BrokenNC:
+    """NATS client stub whose publish() always raises."""
+
+    async def publish(self, _subject: str, _data: bytes) -> None:
+        raise RuntimeError("down")
+
+
+# ── T9.1 — HTTP error case ────────────────────────────────────────────────────
+
+
+async def test_publish_http_error_sends_event() -> None:
+    """MintError with http_status=401 → correct subject, valid MintFailureEvent payload.
+
+    Verifies:
+    - exactly one publish call is made
+    - subject == gh_mint_failure("testhost") and starts with "lyra.gh.mint_failure."
+    - deserialized event has reason="github_api_401", http_status=401,
+      machine="testhost", retries=0
+    """
+    # Arrange
+    fake_nc = FakeNC()
+    publisher = MintFailurePublisher(fake_nc, "testhost")  # type: ignore[arg-type]
+    exc = MintError(reason="boom", http_status=401, retries=0)
+
+    # Act
+    await publisher.publish(exc)
+
+    # Assert — exactly one call
+    assert len(fake_nc.calls) == 1
+
+    subject, data = fake_nc.calls[0]
+
+    # Subject correctness
+    expected_subject = gh_mint_failure("testhost")
+    assert subject == expected_subject
+    assert subject.startswith("lyra.gh.mint_failure.")
+
+    # Payload correctness
+    event = MintFailureEvent.model_validate_json(data)
+    assert event.reason == "github_api_401"
+    assert event.http_status == 401
+    assert event.machine == "testhost"
+    assert event.retries == 0
+
+
+# ── T9.2 — Network error case ─────────────────────────────────────────────────
+
+
+async def test_publish_network_error_sends_event() -> None:
+    """MintError with http_status=None → reason='network_error', http_status is None.
+
+    Network/transport failures have no HTTP response; the event must carry
+    "network_error" as reason and None for http_status.
+    """
+    # Arrange
+    fake_nc = FakeNC()
+    publisher = MintFailurePublisher(fake_nc, "testhost")  # type: ignore[arg-type]
+    exc = MintError(reason="net", http_status=None)
+
+    # Act
+    await publisher.publish(exc)
+
+    # Assert — exactly one call
+    assert len(fake_nc.calls) == 1
+
+    _subject, data = fake_nc.calls[0]
+    event = MintFailureEvent.model_validate_json(data)
+    assert event.reason == "network_error"
+    assert event.http_status is None
+
+
+# ── T9.3 — Swallow NATS errors ────────────────────────────────────────────────
+
+
+async def test_publish_swallows_nats_error() -> None:
+    """publish() must not raise even when the NATS client raises RuntimeError.
+
+    Deleting the try/except in publish() would cause this test to fail —
+    the RuntimeError from BrokenNC.publish() would propagate out of the method.
+    """
+    # Arrange
+    broken_nc = BrokenNC()
+    publisher = MintFailurePublisher(broken_nc, "testhost")  # type: ignore[arg-type]
+    exc = MintError(reason="any", http_status=500, retries=1)
+
+    # Act + Assert — must return normally (no exception)
+    await publisher.publish(exc)


### PR DESCRIPTION
## Summary
- Wire the uid-1501 GitHub token-mint **helper** to publish a best-effort `MintFailureEvent` on `lyra.gh.mint_failure.<machine>` for every `MintError`, lighting up the already-built hub subscriber → Telegram ops alert (#1078 follow-up). Mint failures were previously silent (uid-1501 journal only).
- New **publish-only** `gh-helper` nkey identity — ADR-046 isolation preserved (`publish == {lyra.gh.mint_failure.>}`, `subscribe == []`). Provisioned end-to-end: `gen_nkeys` auto-derives the seed → `Makefile` podman secret → quadlet mount (uid 1501) + NATS env, with a `check_grants` least-privilege assertion.
- **Best-effort, non-blocking:** the publisher swallows all errors; the daemon's `nats_connect` is guarded so a NATS outage can never crash `run_daemon` (which would trigger `BindsTo` pod teardown) or stall token minting. The error reply to the caller is sent *before* the publish. Removes `TODO(T4)`.

### Notes for reviewers
- `tests/scripts/fixtures/v3-pre-grant-group.json`: the new identity broke the v3↔v4 renderer-parity test (`test_v4_render_set_equals_v3_render`, which asserts both matrices render the same user set); fixture updated to mirror `gh-helper` (orthogonal to the audio-group migration it guards, so the test's meaning is preserved).
- `src/factory/core/lifecycle/session_lifecycle.py` (isolated `chore(lint)` commit): mechanical wrap of a **pre-existing** E501 (from #1662) that blocked repo-wide `ruff check .` — not part of #1082, included only to unblock commit/CI.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1082: helper-side NATS publish for MintFailureEvent (#1078 follow-up) | OPEN |
| Analysis | — (F-lite, skipped) | Absent |
| Spec | [spec.mdx](artifacts/specs/1082-helper-mint-failure-publish-spec.mdx) | Present |
| Implementation | 2 commits on `feat/1082-helper-mint-failure-publish` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (7 new) · import-linter ✅ (0 broken) | Passed |

## Test Plan
- [ ] `uv run pytest tests/tools tests/scripts -q` → 441 passed, 1 skipped
- [ ] Forced `MintError(401)` publishes `MintFailureEvent` to `lyra.gh.mint_failure.<machine>` with `reason=github_api_401`; pre-API failure (`http_status=None`) → `reason=network_error`
- [ ] NATS down / `NATS_URL` unset → minting still serves `error=mint failed`; daemon does not crash (best-effort isolation)
- [ ] `check_grants` / `lyra-acl` confirms `gh-helper` may publish **only** `lyra.gh.mint_failure.>` (no subscribe)

Fixes #1082

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
