### PR TITLE
docs(tools): domain-nature taxonomy + revalidate #493 (gh/llm plomberie)

### DIFF
--- a/artifacts/analyses/493-tool-domain-nature-consolidation.mdx
+++ b/artifacts/analyses/493-tool-domain-nature-consolidation.mdx
@@ -73,7 +73,7 @@ TOOL  (capability surfaces, LLM-invoked)         PLOMBERIE  (everything else)
 `harness` and `worker` are **not** tools and **not** plain plomberie — they are the
 **consumer plane**: they run the agentic loop / job loop and reach the `tool/` plane
 **through the registry** (uniform dispatcher, §4 of parent). They see `image.generate`
-and `bash` identically; transport is invisible. Their shared runtime is named in §2.5.
+and `bash` identically; transport is invisible. How they layer (workerEngine *calls* harness) is set in §2.5.
 
 ### 2.2 Classification table
 
@@ -140,26 +140,31 @@ resolves a pre-existing overload: **"worker" means two opposite things today.**
 `WorkerRegistry` and the `voice-worker` / `image-worker` / `llm-worker` roles in `hosts.toml`
 all use the PROVIDER sense; #1044 uses the CONSUMER sense.
 
-**Resolution (2026-06-03).** Four terms; all plomberie except `tool`:
+**Resolution (2026-06-03).** Five terms; all plomberie except `tool`:
 
 | Term | Nature | Definition | Examples |
 |---|---|---|---|
-| **workerEngine** | plomberie · runtime | the orchestration runtime — drives `{ tools · code · llm/harness }`. Calls tools; is **not** one. | the harness loop, generalized |
-| **worker** | plomberie · compute | a compute instance running **on** the workerEngine; consumes tools (the CONSUMER sense) | `code-worker`, agent/harness-worker |
-| **provider** *(ex-"worker")* | plomberie · backend | the satellite process that **backs** a remote tool. **Not** a worker. | imageCLI, voiceCLI |
-| **tool** | tool-nature | a capability surface the engine invokes (§2.2) | `voice.tts`, `image.generate` |
+| **workerEngine** | plomberie · runtime | a **coded sequence** — deterministic workflow/pipeline; orchestrates steps that call **harness** (agentic), **tools**, and **internal code** | composite `JobHandler` (#1052) |
+| **harness** | plomberie · agentic | a **pure** agentic turn (LLM + in-turn tools); **no** workflow/pipeline logic; a *callee* of workerEngine | #1490 harness loop |
+| **worker** | plomberie · compute | a deployed instance running a workerEngine; consumes tools (CONSUMER sense) | `code-worker` |
+| **provider** *(ex-"worker")* | plomberie · backend | the satellite that **backs** a remote tool. **Not** a worker. | imageCLI, voiceCLI |
+| **tool** | tool-nature | a capability surface invoked by harness / workerEngine (§2.2) | `voice.tts`, `image.generate` |
 
 ```
-workerEngine (runtime)  orchestrates → { tools · code · llm/harness }
-   │ runs
-   ▼
-worker (compute on engine) ──invokes──▶ tool ──backed by──▶ provider (satellite)
+worker  (compute instance)
+  └─ runs ─▶ workerEngine  =  coded pipeline (deterministic workflow)
+                │ calls, as steps:
+                ├─▶ harness            pure agentic turn (LLM + in-turn tools) · no pipeline logic
+                ├─▶ tools  ──backed by──▶ provider (satellite)
+                └─▶ internal code
 ```
 
-**Harness = the agentic flavor of the workerEngine** (adopted 2026-06-03). Spec #1490 shows the
-harness *is* a custom ~200-line loop — a runtime, not a job. So: one engine, two roles —
-`harness` (agentic turns) + `code-worker` (code+llm jobs). This makes **epics #1490 + #1044
-candidates to unify under one runtime** — a scope decision, flagged here, not forced.
+**Harness ≠ a flavor of workerEngine** (ruling 2026-06-03). They are **distinct, layered**:
+- **harness** = *pure* agentic — one LLM turn (LLM + in-turn tools), **no** workflow/pipeline logic (#1490).
+- **workerEngine** = the **coded pipeline** (deterministic workflow); it *calls* harness, tools, and internal code as steps.
+
+So workerEngine sits **above** harness and **invokes** it — `harness` is a callee, not a sub-type.
+Epics #1490 (harness) and #1044 (workerEngine / code-worker) stay **separate and layered**, not unified.
 
 **Placement.** `workerEngine` + `worker` are runtime, not contract domains; the wire domains
 behind them (`jobs`, harness-turn) stay plomberie (§2.2). `provider` renames the PROVIDER sense
@@ -223,7 +228,7 @@ follow-on once #1670 is green.
 | now (parallel) | B2 `roxabi-contracts/tools/` + B4 `roxabi-tools-sdk` skeleton — design-unblocked |
 | **after #1670 green** | migration issue: re-parent `voice`/`image` under `tool/` (+ infix per §2.4) |
 | **after #1670 green** | vocab rename (§2.5): tool-backing satellites `worker`→`provider` — `WorkerRegistry`, `hosts.toml` `*-worker` roles, parent §5/glossary |
-| open | scope call: unify `workerEngine` runtime across epics #1490 (harness) + #1044 (code-worker)? |
+| — | #1490 (harness) and #1044 (workerEngine) are **layered, not unified** — workerEngine *calls* harness (§2.5) |
 
 Tracks A (Postiz token, EnvFile rollout) and C (harness `@` template, POC) from the parent doc
 are unaffected by this taxonomy and remain parallel-safe.

--- a/artifacts/analyses/493-tool-domain-nature-consolidation.mdx
+++ b/artifacts/analyses/493-tool-domain-nature-consolidation.mdx
@@ -1,0 +1,190 @@
+---
+title: "Tool system — domain-nature taxonomy & #493 revalidation"
+description: "Addendum to the #493 tool-system articulation. Revalidates D1-D16 as-is, adds the missing layer #493 left implicit — a classification of roxabi-contracts wire domains by NATURE (tool vs plomberie) — and sequences the reclassification after the in-flight lyra.*→factory.* subject migration (#1670). Resolves gh + llm as plomberie via the tool-surface≠tool-nature rule."
+issue: 493
+parent: artifacts/analyses/493-tool-system-articulation-analysis.mdx
+tier: F-full
+date: 2026-06-02
+status: design-locked (revalidated)
+---
+
+## Why this doc
+
+`493-tool-system-articulation-analysis.mdx` (2026-05-27) is the SSoT for the tool layer.
+It resolved **worker ≠ tool**, the **5-layer taxonomy** (L0a/L0b/L1/L2/L3), the **uniform
+dispatcher**, the per-agent Quadlet `@` template, and 16 decisions (D1-D16). It left **one
+layer implicit**: the `roxabi-contracts` wire domains are listed flat — tool-nature and
+architecture-nature mixed — with **no classification by nature** (no ADR does this).
+
+2026-06-02 design session closes that gap:
+
+| Ref | Decision | Outcome |
+|---|---|---|
+| **a** | Status of the #493 design | **D1-D16 revalidated as-is** — no re-opening. Unblocks B-track. |
+| **b** | Domain-nature taxonomy | **Adopted** (§2 below) — the missing layer. |
+| **c** | Sequencing vs #1670 | **#1670 in-flight → let it land.** Design now, migrate as a single follow-on pass. **No parallel contracts reorg while #1670 runs.** |
+| **gh** | classification | **Plomberie** — "particular tool", stays infra (§2.3). |
+| **llm** | classification | **Plomberie** — engine substrate (§2.3). |
+
+Companion / addendum to the parent SSoT. Does not supersede it — extends it additively.
+
+---
+
+## 1. The rule (what gh + llm crystallise)
+
+A contract domain is **tool-nature** (belongs under `tool/`) **iff**:
+
+1. its sole raison d'être is to expose a capability the **LLM invokes**, **and**
+2. it is **not** the agent's own **engine / control substrate**.
+
+Everything else is **plomberie** (architecture): engine substrate, work bus, persistence,
+security, observability, delivery.
+
+> **Corollary — "particular tool" rule:** a plomberie domain MAY surface a tool without
+> becoming tool-nature. `gh` exposes a built-in L0a (`gh.list_prs`); `llm` exposes
+> `llm.generate` as an L0b. Neither promotes its **wire domain** to `tool/`.
+> **Tool-surface ≠ tool-nature.**
+
+This is why the original flat list felt "mixed": two orthogonal cuts were collapsed —
+ADR-084's **work/infra** cut (does it carry `job_id`) and this **tool/plomberie** cut (is it
+an LLM capability surface). They are independent. `cli` is work-bearing **and** plomberie;
+`voice` is work-bearing **and** tool.
+
+---
+
+## 2. Domain-nature taxonomy (the missing layer)
+
+### 2.1 Two natures, one consumer plane
+
+```
+TOOL  (capability surfaces, LLM-invoked)         PLOMBERIE  (everything else)
+  voice  · image                                   substrate : cli · llm
+  + future: postiz · xcli · vault · scrape          work bus : jobs
+            · camoufox                               infra    : gh
+                                                     persist  : turns · blob
+            ▲ exposed via registry                  security : verify · audit
+            │                                        obs      : event
+  ┌─────────┴── consume ──────────┐                 delivery : outbound
+  │  CONSUMERS (run the loop)      │
+  │   harness  ·  worker (jobs)    │ ◀── read ToolRegistry → see what's available
+  └────────────────────────────────┘
+```
+
+`harness` and `worker` are **not** tools and **not** plain plomberie — they are the
+**consumer plane**: they run the agentic loop / job loop and reach the `tool/` plane
+**through the registry** (uniform dispatcher, §4 of parent). They see `image.generate`
+and `bash` identically; transport is invisible.
+
+### 2.2 Classification table
+
+| Domain | Nature | Rationale |
+|---|---|---|
+| `voice` | **tool** | capability satellite — `voice.tts` / `voice.stt`. Only exists to be invoked. |
+| `image` | **tool** | capability satellite — `image.generate`. |
+| *(future)* `postiz` `xcli` `vault` `scrape` `camoufox` | **tool** | capability satellites (some `transport=stdio/http`, no Quadlet — 493 D11). |
+| `cli` | plomberie | clipool `claude-cli` dispatch — the **engine's own LLM transport**, not a picked tool. |
+| `llm` | plomberie | inference substrate + `llm.lifecycle.swap` control plane. **Engine, not tool** (ruling). |
+| `jobs` | plomberie | work bus (`JobEnvelope`). Composites surface as `RemoteTool`, but the bus is infra. |
+| `gh` | plomberie | `MintFailureEvent` = token-mint plumbing. "Particular tool" — stays infra (ruling). |
+| `turns` | plomberie | JetStream turn persistence (`TurnWriteEvent`). |
+| `blob` | plomberie | blob refs / content-addressed storage. |
+| `verify` | plomberie | ACL deny-probe (security). |
+| `audit` | plomberie | security event contracts. |
+| `event` | plomberie | `LyraEvent` / `LyraMetric` (observability). |
+| `outbound` | plomberie | outbound-audio delivery. |
+
+**Name-collision note (`gh`):** the wire domain `gh` (`MintFailureEvent`, plomberie) and the
+built-in tool `gh` (L0a, 493 D5, compiled in the harness) are **two different things sharing a
+name**. Accepted as-is — the tool is in-process (no wire domain), the contract domain is infra.
+No rename. Same shape applies to `llm`.
+
+### 2.3 Target package shape
+
+```
+roxabi-contracts/src/roxabi_contracts/
+├─ tool/                  ← NEW grouping (nature = capability surface)
+│   ├─ voice/   (moved)
+│   ├─ image/   (moved)
+│   └─ <future capability satellites>
+├─ tools/                 ← from 493 D1/B2 — PROTOCOLS, not wire schemas
+│   │                       (InProcessTool, RemoteTool, ToolResult, ToolManifest, ToolHints)
+│   └─ …
+├─ cli/  jobs/  llm/  gh/  turns/  blob_*  verify/  audit/  event/  outbound/   ← flat plomberie
+```
+
+Two distinct `tool*` things — keep them separate and unambiguous:
+- **`tool/`** = the *wire schemas* of capability satellites, grouped by nature.
+- **`tools/`** (493 D1) = the *protocol layer* (how any worker exposes a tool). Untouched by this doc.
+
+### 2.4 Subject grammar — DECIDED: nature infix (2026-06-02)
+
+Nature reflects in the **subject**, not just the package.
+
+| Option | Subject for voice.tts | |
+|---|---|---|
+| package-only | `factory.voice.tts.request` | rejected — reorg invisible on the wire |
+| **nature infix** ✅ | `factory.tool.voice.tts.request` | **chosen** — harness/worker subscribe/discover the **tool plane** distinctly (`factory.tool.>`), serving the registry/isolation goal directly |
+
+Applies to **tool-nature domains only** (`voice`, `image`, +future). Plomberie subjects keep
+`factory.<domain>.*`. The `factory.tool.>` prefix becomes the addressable tool plane for the
+consumer side. Lands in the post-#1670 migration (§4).
+
+---
+
+## 3. #493 revalidation (decision a)
+
+D1-D16 **accepted as-is**, no re-opening. §16 checklist item "D1-D16 user-validated" → checked
+(2026-06-02). This unblocks the parked B-track:
+
+- **B1** — breaking-change ADR on `roxabi-contracts` for `agent_id` field (D16)
+- **B2** — `roxabi-contracts/tools/` protocol submodule (D1) — *now also hosts the `tool/` nature grouping spec*
+- **B4** — `roxabi-tools-sdk` package (D9)
+
+The taxonomy **slots under D1**: D1 created `tools/` (protocols); this doc organizes the **wire
+domains those protocols govern** by nature. No conflict, pure extension.
+
+---
+
+## 4. Sequencing (decision c)
+
+```
+#1670 (lyra.*→factory.* subjects, streams, KV, ACL)   ◀ IN FLIGHT — let land, do NOT touch contracts in parallel
+   │
+   ▼
+follow-on migration (single pass, post-#1670):
+   1. re-parent  voice/ image/  →  tool/voice  tool/image
+   2. subject infix (§2.4):  factory.<cap>.*  →  factory.tool.<cap>.*   (tool-nature domains only)
+   3. update importers (hub clients, satellites) + ACL subject prefixes
+   4. additive minor bump on roxabi-contracts (re-export shims for 1 cycle)
+```
+
+Rationale for "after, not riding": #1670 is mid-migration of the *same* package. Two concurrent
+reorgs of `roxabi-contracts` = collision. Design is locked now; the diff applies as one clean
+follow-on once #1670 is green.
+
+---
+
+## 5. Vision reconnection
+
+`~/projects/docs/vision-roxabi-factory.md` was written as if the tool layer did not exist
+(workers = "réutilisation, rien de neuf"; Postiz/Camoufox = bare "outbound adapters"). Patched to:
+
+- Reference the tool model (parent #493 + this doc) as the SSoT for **how modules plug in** —
+  they are **tools** (L0b / `stdio` / `http`), not bespoke adapters.
+- Resolve open **Décision B** (X: container CLI vs skill) → **493 D11** (`RemoteTool`,
+  `transport=stdio/http`, no Quadlet). The "tool vs contract frontier" I'd flagged is now answered
+  by the domain-nature taxonomy, not a new open question.
+
+---
+
+## 6. Next executable (post-design)
+
+| When | Action |
+|---|---|
+| ~~now~~ | §2.4 subject-grammar — ✅ **DECIDED: `tool.` infix** (`factory.tool.<cap>.*`), 2026-06-02 |
+| now | B1 — open breaking-change ADR for `agent_id` (D16) — parked dependency of everything |
+| now (parallel) | B2 `roxabi-contracts/tools/` + B4 `roxabi-tools-sdk` skeleton — design-unblocked |
+| **after #1670 green** | migration issue: re-parent `voice`/`image` under `tool/` (+ infix per §2.4) |
+
+Tracks A (Postiz token, EnvFile rollout) and C (harness `@` template, POC) from the parent doc
+are unaffected by this taxonomy and remain parallel-safe.

--- a/artifacts/analyses/493-tool-domain-nature-consolidation.mdx
+++ b/artifacts/analyses/493-tool-domain-nature-consolidation.mdx
@@ -73,7 +73,7 @@ TOOL  (capability surfaces, LLM-invoked)         PLOMBERIE  (everything else)
 `harness` and `worker` are **not** tools and **not** plain plomberie — they are the
 **consumer plane**: they run the agentic loop / job loop and reach the `tool/` plane
 **through the registry** (uniform dispatcher, §4 of parent). They see `image.generate`
-and `bash` identically; transport is invisible.
+and `bash` identically; transport is invisible. Their shared runtime is named in §2.5.
 
 ### 2.2 Classification table
 
@@ -128,6 +128,43 @@ Nature reflects in the **subject**, not just the package.
 Applies to **tool-nature domains only** (`voice`, `image`, +future). Plomberie subjects keep
 `factory.<domain>.*`. The `factory.tool.>` prefix becomes the addressable tool plane for the
 consumer side. Lands in the post-#1670 migration (§4).
+
+### 2.5 Runtime vocabulary — workerEngine, worker, provider
+
+§2.1 named a consumer plane (harness + worker) without naming its **runtime**. This does — and
+resolves a pre-existing overload: **"worker" means two opposite things today.**
+
+**The overload.** Parent §5 + glossary define *worker = a service that **exposes** tools*
+(imageCLI, voiceCLI) — a PROVIDER. Epic #1044 `code-worker` is the inverse — a unit that
+*runs jobs on the engine and **consumes** tools* — a CONSUMER. Same word, opposite role.
+`WorkerRegistry` and the `voice-worker` / `image-worker` / `llm-worker` roles in `hosts.toml`
+all use the PROVIDER sense; #1044 uses the CONSUMER sense.
+
+**Resolution (2026-06-03).** Four terms; all plomberie except `tool`:
+
+| Term | Nature | Definition | Examples |
+|---|---|---|---|
+| **workerEngine** | plomberie · runtime | the orchestration runtime — drives `{ tools · code · llm/harness }`. Calls tools; is **not** one. | the harness loop, generalized |
+| **worker** | plomberie · compute | a compute instance running **on** the workerEngine; consumes tools (the CONSUMER sense) | `code-worker`, agent/harness-worker |
+| **provider** *(ex-"worker")* | plomberie · backend | the satellite process that **backs** a remote tool. **Not** a worker. | imageCLI, voiceCLI |
+| **tool** | tool-nature | a capability surface the engine invokes (§2.2) | `voice.tts`, `image.generate` |
+
+```
+workerEngine (runtime)  orchestrates → { tools · code · llm/harness }
+   │ runs
+   ▼
+worker (compute on engine) ──invokes──▶ tool ──backed by──▶ provider (satellite)
+```
+
+**Harness = the agentic flavor of the workerEngine** (adopted 2026-06-03). Spec #1490 shows the
+harness *is* a custom ~200-line loop — a runtime, not a job. So: one engine, two roles —
+`harness` (agentic turns) + `code-worker` (code+llm jobs). This makes **epics #1490 + #1044
+candidates to unify under one runtime** — a scope decision, flagged here, not forced.
+
+**Placement.** `workerEngine` + `worker` are runtime, not contract domains; the wire domains
+behind them (`jobs`, harness-turn) stay plomberie (§2.2). `provider` renames the PROVIDER sense
+of "worker" — non-trivial blast radius (`WorkerRegistry`, `hosts.toml` roles, parent §5/glossary)
+→ **rides the #1670 rename**, not a separate pass (§6).
 
 ---
 
@@ -185,6 +222,8 @@ follow-on once #1670 is green.
 | now | B1 — open breaking-change ADR for `agent_id` (D16) — parked dependency of everything |
 | now (parallel) | B2 `roxabi-contracts/tools/` + B4 `roxabi-tools-sdk` skeleton — design-unblocked |
 | **after #1670 green** | migration issue: re-parent `voice`/`image` under `tool/` (+ infix per §2.4) |
+| **after #1670 green** | vocab rename (§2.5): tool-backing satellites `worker`→`provider` — `WorkerRegistry`, `hosts.toml` `*-worker` roles, parent §5/glossary |
+| open | scope call: unify `workerEngine` runtime across epics #1490 (harness) + #1044 (code-worker)? |
 
 Tracks A (Postiz token, EnvFile rollout) and C (harness `@` template, POC) from the parent doc
 are unaffected by this taxonomy and remain parallel-safe.

--- a/artifacts/analyses/493-tool-system-articulation-analysis.mdx
+++ b/artifacts/analyses/493-tool-system-articulation-analysis.mdx
@@ -14,6 +14,11 @@ date: 2026-05-27
 
 This document captures the full design synthesis from 5 internal/external research agents + 3 domain reviewers (architect, devops, axial-adr-review). It is the **reference articulation** for the tool layer across Lyra and satellites. Companion to `harness-epic-consolidated.md`.
 
+> **Revalidated 2026-06-02** — D1-D16 accepted as-is; extended with the **domain-nature
+> taxonomy** in [`493-tool-domain-nature-consolidation.mdx`](./493-tool-domain-nature-consolidation.mdx).
+> `gh` + `llm` classified **plomberie** (tool-surface ≠ tool-nature). Reclassification rides
+> **after #1670** (lyra.*→factory.* subject migration, in flight).
+
 ---
 
 ## 1. Context — the scattered state
@@ -575,7 +580,7 @@ t3 ──── D1-D6 (satellite migration, parallel)
 
 ## 16. Resume checklist (work-in-progress tracker)
 
-- [ ] D1-D16 user-validated
+- [x] D1-D16 user-validated (2026-06-02 — see `493-tool-domain-nature-consolidation.mdx`; gh+llm = plomberie)
 - [ ] Track A1 — Postiz token migration (15 min, security)
 - [ ] Track A2-A3 — EnvironmentFile rollout (imageCLI + voiceCLI)
 - [ ] Track B1 — Breaking-change ADR on `roxabi-contracts` for `agent_id`

--- a/artifacts/analyses/493-tool-system-articulation-analysis.mdx
+++ b/artifacts/analyses/493-tool-system-articulation-analysis.mdx
@@ -193,6 +193,11 @@ User question: "Est-ce qu'on considère les workers comme des tools, un bundle d
 
 **Answer**: A worker is **not** a tool. A worker is a service that **exposes** tools.
 
+> **Refined 2026-06-03** — this "worker" is a tool **provider** (exposes tools). A second,
+> opposite sense exists — `worker` = a compute unit running *on* the engine (epic #1044,
+> *consumes* tools). Disambiguated in [`493-tool-domain-nature-consolidation.mdx`](./493-tool-domain-nature-consolidation.mdx)
+> §2.5: **workerEngine** (runtime) · **worker** (compute-on-engine) · **provider** (this row's satellite).
+
 | | Worker | Tool |
 |---|---|---|
 | Nature | Long-running NATS service | Surface of invocation visible to LLM |


### PR DESCRIPTION
## What

Consolidation addendum to the #493 tool-system articulation — closes the one layer #493 left implicit: classifying `roxabi-contracts` wire domains by **nature**.

## Decisions (2026-06-02)

- **Domain-nature taxonomy** — `tool/` (voice, image, +future capability satellites) vs plomberie (cli, llm, jobs, gh, turns, blob, verify, audit, event, outbound).
- **Rule** — tool-surface != tool-nature. `gh` + `llm` expose tools but their wire domains stay plomberie.
- **Subject grammar** — `factory.tool.<cap>.*` infix for tool-nature domains; consumer side addresses the tool plane via `factory.tool.>`.
- **D1-D16 revalidated as-is** — unblocks B-track (agent_id ADR, roxabi-contracts/tools/, roxabi-tools-sdk).
- **Sequencing** — reclassification rides *after* #1670 (in-flight lyra.*->factory.* subject migration), as one follow-on pass. No parallel contracts reorg.

## Files

- `artifacts/analyses/493-tool-domain-nature-consolidation.mdx` (new)
- `artifacts/analyses/493-tool-system-articulation-analysis.mdx` (revalidation banner + §16 checkbox)

Design only — no code. Implementation tracked by #493 / #477 / #1490 / #1044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)