### PR TITLE
docs(deploy): flag lyra-* vs factory-* deployment-state drift (#1710)

### DIFF
--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -6,6 +6,8 @@ Runbook for installing, operating, and rotating secrets in the Lyra Quadlet depl
 → Component manifest: `deploy/quadlet.toml`
 → Idempotent install script: `deploy/install.sh`
 
+> **Deployment-state caveat (2026-06).** M₁ (`roxabituwer`) currently runs the **legacy `lyra-*` infra** — units `lyra-*`, secrets `lyra-nats-*` / `lyra-bot-*`, data dir `~/.lyra`, repo `~/projects/lyra`, image `ghcr.io/roxabi/lyra:staging{,-svc}`. The `factory-*` names throughout this runbook are the **post-Phase-2 infra-rename target**; that migration (data move `~/.lyra`→`~/.roxabi/factory`, secret + unit + image-repo rename) is **pending**, tracked in **#1710** (combined with the #1670 `factory.*` wire cutover). Until it lands, mentally translate `factory-*`→`lyra-*` when operating M₁.
+
 ## Architecture
 
 Eight containers on `roxabi.network` (systemd `--user`, linger enabled):


### PR DESCRIPTION
## Summary

- `docs/QUADLET-DEPLOYMENT.md` presents `factory-*` unit names, secret names, data dirs, and image refs as the live M₁ deployment — but M₁ (`roxabituwer`) **still runs the legacy `lyra-*` infra** (units `lyra-*`, secrets `lyra-nats-*` / `lyra-bot-*`, data `~/.lyra`, repo `~/projects/lyra`, image `ghcr.io/roxabi/lyra:staging{,-svc}`).
- The infra rename (`lyra-*` → `factory-*`) is a pending Phase-2 migration tracked in **#1710** (combined with the #1670 `factory.*` wire cutover). Without a caveat, any operator following this runbook on M₁ today will reference non-existent units/secrets.
- Added a single prominent blockquote caveat immediately after the runbook intro section, pointing to #1710 and explaining the `factory-*` → `lyra-*` mental translation needed until the migration lands.

## Why doc_drift gate misses this

The `doc_drift` quality gate (`tools/check_doc_drift.py`) compares **in-repo code symbols vs in-repo doc references** — it catches stale doc references to renamed Python functions, classes, or subjects. It cannot detect **repo↔deployed-host drift**: the runbook references `factory-*` consistently with the codebase, so the gate sees no mismatch. The gap is between what the repo declares as target state and what is actually running on M₁.

## What was NOT changed

- No `factory-*` → `lyra-*` rewrites in the runbook body — the `factory-*` target names are correct post-migration.
- No touches to `docs/architecture/CURRENT.generated.md` or other `doc_drift`-gated generated files.
- Kept to minimum blast radius: one file, one caveat block.

## Related

- #1710 — infra rename + data migration (pending Phase 2)
- #1670 — `factory.*` NATS wire cutover (merged, triggers Phase-2 migration)

## Test plan

- [ ] Verify caveat appears near top of `docs/QUADLET-DEPLOYMENT.md` (after intro refs, before `## Architecture`)
- [ ] Confirm no body text was rewritten (`git diff` shows only +2 lines)
- [ ] Confirm `doc_drift` gate still passes (no code symbol references changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)