### PR TITLE
feat(deploy): repair M₁ auto-deploy (labels + timers + docs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,10 +192,12 @@ quadlet-sync-install:  ## install systemd sync timers + services → daemon-relo
 	@cp "$(QUADLET_SYNC_SRC)/factory-post-autoupdate.service"  "$(QUADLET_SYNC_DST)/"
 	@cp "$(QUADLET_SYNC_SRC)/factory-post-autoupdate.timer"    "$(QUADLET_SYNC_DST)/"
 	@cp "$(QUADLET_SYNC_SRC)/factory-deploy-failure.service"    "$(QUADLET_SYNC_DST)/"
+	@mkdir -p "$(QUADLET_SYNC_DST)/podman-auto-update.timer.d"
+	@cp "$(QUADLET_SYNC_SRC)/podman-auto-update.timer.d/override.conf" "$(QUADLET_SYNC_DST)/podman-auto-update.timer.d/"
 	@echo "Sync units copied to $(QUADLET_SYNC_DST)"
 	@systemctl --user daemon-reload
-	@systemctl --user enable factory-quadlet-sync.timer
-	@systemctl --user enable factory-post-autoupdate.timer
+	@systemctl --user enable --now factory-quadlet-sync.timer
+	@systemctl --user enable --now factory-post-autoupdate.timer
 	@echo "[ok] factory-quadlet-sync.timer + factory-post-autoupdate.timer enabled."
 
 quadlet-authconf-merged:  ## render merged auth.conf (factory + voicecli identities) → ~/.roxabi/factory/nkeys/auth.conf

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ quadlet-sync-install:  ## install systemd sync timers + services → daemon-relo
 	@cp "$(QUADLET_SYNC_SRC)/podman-auto-update.timer.d/override.conf" "$(QUADLET_SYNC_DST)/podman-auto-update.timer.d/"
 	@echo "Sync units copied to $(QUADLET_SYNC_DST)"
 	@systemctl --user daemon-reload
+	@systemctl --user restart podman-auto-update.timer
 	@systemctl --user enable --now factory-quadlet-sync.timer
 	@systemctl --user enable --now factory-post-autoupdate.timer
 	@echo "[ok] factory-quadlet-sync.timer + factory-post-autoupdate.timer enabled."

--- a/artifacts/frames/1729-m1-auto-deploy-dead-frame.mdx
+++ b/artifacts/frames/1729-m1-auto-deploy-dead-frame.mdx
@@ -1,0 +1,89 @@
+---
+title: "M₁ auto-deploy is dead: timer install + AutoUpdate-label defects"
+issue: 1729
+status: approved
+tier: F-lite
+date: 2026-06-04
+---
+
+## Problem
+
+`docs/ops/container-publishing.md` promises M₁ (`roxabituwer`) auto-deploys every staging
+merge with *"no manual intervention"* — images via `podman-auto-update.timer`, git checkout +
+quadlet re-render via `factory-quadlet-sync.timer`. On M₁ right now both are dead:
+`podman-auto-update.timer` is **disabled** and `factory-quadlet-sync.timer` is **not-found**.
+Every staging merge silently drifts prod from the repo (image **and** the git checkout that
+renders `auth.conf`/quadlets); ACL/auth.conf changes never reach NATS without a manual
+`factory-acl genkeys --regen-authconf` + secret refresh + `factory-nats` restart.
+
+Investigation shows the units are **present in the repo** — the failure is a cluster of
+install/label defects, not missing source:
+
+1. **AutoUpdate label coverage gap.** Only `factory-telegram` + `factory-discord`
+   (`*.container.tmpl`) carry `Label=io.containers.autoupdate=registry`. The 6 static
+   `.container` files (hub, clipool, gh-helper, nats, turn-writer, blobstore) lack it →
+   `podman auto-update` skips them even when its timer runs. The doc
+   (`container-publishing.md:123`) asserts *every* `.container` must have the label.
+2. **`enable` without `--now`.** `make quadlet-sync-install` (Makefile:197–198) enables
+   `factory-quadlet-sync.timer` + `factory-post-autoupdate.timer` but never starts them →
+   installed-but-dormant until reboot.
+3. **5-minute cadence never provisioned.** Doc claims `OnCalendar=*:0/5`; `podman-auto-update`
+   ships daily by default. `provision.sh` enables the timer but installs no `OnCalendar`
+   override drop-in.
+4. **Operational gap on M₁.** Neither `install.sh` step 9 (`make quadlet-sync-install`) nor a
+   re-`provision.sh` was run on M₁ after these paths landed → timer absent, host timer disabled.
+5. **Doc↔reality drift.** "No manual intervention" + "every 5 minutes" describe a path that
+   was never fully wired.
+
+## Who
+
+- **Primary:** Mickael / ops — every staging merge currently requires a manual M₁ pull +
+  image restart + (for ACL changes) authconf regen + secret refresh + NATS restart.
+- **Secondary:** every contributor whose merged change silently fails to reach prod, and any
+  downstream consumer relying on prod tracking staging.
+
+## Constraints
+
+- Single host in scope: M₁ (`factory-hub` role). M₂ unaffected.
+- Rootless Podman + systemd `--user`; `podman-auto-update.timer` is an apt-provided static unit.
+- Idempotent installers only — no `--force`; re-runnable `make`/`install.sh` targets.
+- `factory-nats` ACL/auth.conf changes need restart-not-HUP (per repo convention) — the sync
+  path's `make converge` must respect that.
+- Fix must be testable in repo (label presence, `--now`, drop-in) **and** carry a host runbook
+  for the one-time M₁ remediation (which is operational, not code).
+
+## Out of Scope
+
+- Rewriting the deploy mechanism (collapse/atomic deploy = #1578/#1380 territory).
+- Monitoring v2 / host-timer alerting (superseded, #1035).
+- M₂ deploy path; secret-rotation redesign.
+- Auto-update cadence policy debate beyond reconciling doc with the chosen value.
+
+## Premise Validity
+
+**Success in 6 months:** A staging merge that changes an image **and** a quadlet/auth.conf
+reaches M₁ with zero manual steps; `systemctl --user is-enabled podman-auto-update.timer` →
+`enabled` and `is-active factory-quadlet-sync.timer` → `active` on M₁; all 8 container units
+carry the AutoUpdate label; doc matches observed behaviour.
+
+**Failure in 6 months:** After the fix, ≥1 staging merge in a 3-merge window still requires a
+manual M₁ pull/restart to reach prod, OR `podman auto-update --dry-run` on M₁ reports <8
+containers as registry-tracked. (Falsifiable: observable counts + a 3-merge horizon.)
+
+**Simplest alternative:** Manually run `make quadlet-sync-install` + `systemctl --user enable
+--now podman-auto-update.timer` on M₁ once and close the issue.
+**Why not simplest:** It re-greens M₁ today but leaves the three latent code defects (label gap,
+missing `--now`, no 5-min drop-in) — the next re-provision or fresh host reproduces the exact
+outage, and 6 of 8 containers still never image-update. The repo must encode the fix, not just
+the host.
+
+## Complexity
+
+**Tier: F-lite** — single domain (devops/deploy), clear bounded scope: 6 `.container` label
+adds + 1 Makefile target (`--now` + optional drop-in) + `provision.sh`/`install.sh`
+reconciliation + 1 doc + a host runbook. No new architecture, no cross-layer boundary.
+
+Signals observed:
+- Single domain (deploy/systemd/quadlet) + 1 doc.
+- ~8–10 files, no new patterns, root cause fully diagnosed (no remaining unknowns).
+- Operational remediation is a runbook step, not code — keeps code change small.

--- a/artifacts/plans/1729-m1-auto-deploy-dead-plan.mdx
+++ b/artifacts/plans/1729-m1-auto-deploy-dead-plan.mdx
@@ -1,0 +1,220 @@
+---
+title: "Plan: M₁ auto-deploy repair — AutoUpdate labels + timer start + doc reconcile"
+issue: 1729
+spec: artifacts/specs/1729-m1-auto-deploy-dead-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-06-04
+---
+
+## Summary
+
+Repair M₁ auto-deploy by encoding three latent fixes in the repo (AutoUpdate label coverage,
+`enable --now` + drop-in for the 5-min cadence, `install.sh` host-timer enable) and reconciling
+three docs + an M₁ remediation runbook. Pure devops + docs; no application code.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph quadlet["deploy/quadlet/*.container(.tmpl)"]
+        HUB[factory-hub] -->|+ Label| L[autoupdate=registry]
+        CLI[factory-clipool] --> L
+        GH[factory-gh-helper] --> L
+        TW[factory-turn-writer] --> L
+        BS[factory-blobstore] --> L
+        TG[factory-telegram.tmpl] -.->|already| L
+        DC[factory-discord.tmpl] -.->|already| L
+        NATS[factory-nats] -.->|NO label, pinned| X[excluded]
+    end
+    subgraph systemd["deploy/systemd + Makefile + install.sh"]
+        DROP[podman-auto-update.timer.d/override.conf] -->|OnCalendar=*:0/5| PAU
+        MK[Makefile quadlet-sync-install] -->|enable --now + mkdir .d/| SYNC[factory-quadlet-sync.timer]
+        MK --> POST[factory-post-autoupdate.timer]
+        MK --> DROP
+        INS[install.sh] -->|enable --now| PAU[podman-auto-update.timer]
+    end
+    L --> PAU
+    PAU --> PULL[pull+restart 7 containers]
+    PULL --> POST --> CONV[make converge]
+    subgraph docs["docs reconcile"]
+        D1[container-publishing.md] & D2[QUADLET-DEPLOYMENT.md] & D3[deploy/CLAUDE.md]
+    end
+```
+
+```mermaid
+flowchart LR
+    subgraph W1["Wave 1 (parallel)"]
+        A[devops-A: labels] --> F1[5 .container files]
+        B[devops-B: timer wiring] --> F2[override.conf · Makefile · install.sh]
+        C[doc-writer-A: docs] --> F3[3 docs]
+    end
+    subgraph W2["Wave 2"]
+        V[verify-A: RED-GATE] --> G[grep SCs + secrets_drift/doc_drift/volumes_table]
+    end
+    F1 & F2 & F3 --> V
+```
+
+## Bootstrap Context
+
+Reference conventions (read before editing):
+- Label placement: `deploy/quadlet/factory-telegram.container.tmpl:14` (`Label=...` immediately after `Image=`).
+- Makefile target: `Makefile:188–199` (`quadlet-sync-install`) — preserve `cp factory-deploy-failure.service` (~194).
+- Host-timer idempotent pattern: `deploy/provision.sh:245–256` (model for install.sh, but drop the `is-active` guard).
+- Doc tables: `docs/ops/container-publishing.md:128–139` (Containers managed), `:171–185` (manual pull), `deploy/CLAUDE.md:103–108` (timer table).
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|----------------|-------|-------|
+| devops-A | T1 | 5 `deploy/quadlet/*.container` (+ nats negative assert) |
+| devops-B | T2, T3, T4 | `deploy/systemd/podman-auto-update.timer.d/override.conf`, `Makefile`, `deploy/install.sh` |
+| doc-writer-A | T5, T6, T7 | `docs/ops/container-publishing.md`, `docs/QUADLET-DEPLOYMENT.md`, `deploy/CLAUDE.md` |
+| verify-A | T8 | (read-only) gates + grep assertions |
+
+## Wave Structure
+
+2 waves, max 3 parallel agents. Elapsed ~1 session vs ~2 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | devops-A: T1 · devops-B: T2→T3→T4 · doc-writer-A: T5, T6, T7 |
+| 2 | Wave 1 done | 1 | verify-A: T8 (RED-GATE) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 labels | 5 files | bounded | 8 | — |
+| T2 drop-in | 1 new file | trivial | 2 | — |
+| T3 Makefile | 1 target | judgmental | 5 | — |
+| T4 install.sh | 1 insert | bounded | 3 | — |
+| T5 container-publishing.md | multi-section | judgmental | 6 | — |
+| T6 QUADLET-DEPLOYMENT.md | 1 section | judgmental | 5 | — |
+| T7 deploy/CLAUDE.md | 1 table row | bounded | 3 | — |
+| T8 verify gates | 3 gates + greps | judgmental | 6 | — |
+
+**Total estimated ops: ~38**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1 | 8 | labels | — |
+| devops-B | T2,T3,T4 | 10 | deploy-wiring | — (3 tasks ≤4, 1 subject) |
+| doc-writer-A | T5,T6,T7 | 14 | docs | — (3 tasks ≤4, 1 subject) |
+| verify-A | T8 | 6 | gates | — |
+
+## Consistency Report
+
+Covered: SC1→T1, SC2→T3, SC3→T2+T3, SC4→T4, SC5→T5, SC6→T5, SC7→T7, SC8→T6, SC10(gates)→T8.
+SC9 (prod-green, operator-run on M₁) — intentionally untraced to a code task; verified post-merge
+by operator, recorded on #1729. Documented in T6 runbook.
+Uncovered: none. Untraced: SC9 (by design). Exemptions: SC9.
+
+## Micro-Tasks
+
+### Slice V1 — AutoUpdate label coverage
+
+**T1** [devops-A · subject: labels · SC1 · V1 · GREEN · diff:2]
+Add `Label=io.containers.autoupdate=registry` into the `[Container]` section (immediately after
+the `Image=` line) of: `factory-hub.container`, `factory-clipool.container`,
+`factory-gh-helper.container`, `factory-turn-writer.container`, `factory-blobstore.container`.
+Do **not** touch `factory-nats.container` (pinned). Mirror placement from
+`factory-telegram.container.tmpl:14`.
+Verify: `grep -l 'autoupdate=registry' deploy/quadlet/*.container deploy/quadlet/*.container.tmpl | wc -l` → 7; `grep -L 'autoupdate=registry' deploy/quadlet/factory-nats.container` matches.
+
+### Slice V2 — Timer start + cadence
+
+**T2** [devops-B · subject: deploy-wiring · SC3 · V2 · GREEN · diff:1]
+Create `deploy/systemd/podman-auto-update.timer.d/override.conf`:
+```ini
+[Timer]
+OnCalendar=
+OnCalendar=*:0/5
+RandomizedDelaySec=0
+```
+(The empty `OnCalendar=` resets the apt-shipped `daily` value before setting the 5-min cadence.)
+Verify: `grep -q 'OnCalendar=\*:0/5' deploy/systemd/podman-auto-update.timer.d/override.conf`.
+
+**T3** [devops-B · subject: deploy-wiring · SC2,SC3 · V2 · GREEN · diff:3] (blockedBy T2)
+Edit `Makefile` `quadlet-sync-install` target: change the two `systemctl --user enable` lines
+(~197–198) to `enable --now`. Add before `daemon-reload`:
+`@mkdir -p "$(QUADLET_SYNC_DST)/podman-auto-update.timer.d"` then
+`@cp "$(QUADLET_SYNC_SRC)/podman-auto-update.timer.d/override.conf" "$(QUADLET_SYNC_DST)/podman-auto-update.timer.d/"`.
+**Preserve** the existing `cp factory-deploy-failure.service` line (~194).
+Verify: `grep -c 'enable --now factory' Makefile` → 2; `grep -q 'mkdir -p.*podman-auto-update.timer.d' Makefile`; `grep -q 'factory-deploy-failure.service' Makefile`.
+
+**T4** [devops-B · subject: deploy-wiring · SC4 · V2 · GREEN · diff:2] (blockedBy T3)
+In `deploy/install.sh`, after the sync-timer install (step 9, ~line 296), add an idempotent
+block: `run systemctl --user enable --now podman-auto-update.timer` (no `is-active` guard) +
+an `[ok]` echo. Match install.sh's `run`/`log`/`echo` style.
+Verify: `grep -q 'enable --now podman-auto-update.timer' deploy/install.sh`.
+
+### Slice V3 — Doc reconcile + runbook
+
+**T5** [doc-writer-A · subject: docs · SC5,SC6 · V3 · GREEN · diff:3]
+`docs/ops/container-publishing.md`: (a) "Containers managed" table → all 8 factory containers
+with correct AutoUpdate column — add `factory-gh-helper`, `factory-turn-writer`,
+`factory-blobstore`; remove cross-repo `voicecli-tts`/`voicecli-stt` rows (point a note at the
+voiceCLI repo); nats = none. (b) Fix stale "M₁ manual pull + restart" section (~171–185) to list
+all 7 service containers, aligned to `deploy/CLAUDE.md` converge order. (c) Document the 3-timer
+model + correct cadence; replace the bare "No manual intervention is needed after a staging
+merge" with a prerequisite-qualified statement (timers must be enabled).
+Verify: `! grep -q 'No manual intervention is needed' docs/ops/container-publishing.md`; table has gh-helper/turn-writer/blobstore, no voicecli rows.
+
+**T6** [doc-writer-A · subject: docs · SC7-runbook(→QUADLET) · V3 · GREEN · diff:3]
+`docs/QUADLET-DEPLOYMENT.md`: expand the existing "Auto-update not pulling" diagnostic entry
+(~line 384) into a full **M₁ remediation runbook** — idempotent commands: re-run
+`make quadlet-sync-install` (installs drop-in + `enable --now`), `systemctl --user enable --now
+podman-auto-update.timer`, `daemon-reload`, then verify (`podman auto-update --dry-run` → 7,
+`is-enabled`/`is-active` for the 3 timers). Note operator records output on #1729.
+Verify: section contains `podman auto-update --dry-run` + all three timer names.
+
+**T7** [doc-writer-A · subject: docs · SC7 · V3 · GREEN · diff:2]
+`deploy/CLAUDE.md`: add a `podman-auto-update.timer` row to the timer table (~103–108)
+(host-static, installed by provision.sh/install.sh, pulls images for registry-labelled
+containers) and retitle "Two systemd user timers" → "Three systemd user timers".
+Verify: `grep -q 'podman-auto-update.timer' deploy/CLAUDE.md`.
+
+### RED-GATE V-final
+
+**T8** [verify-A · subject: gates · SC1-8,SC10 · GREEN · diff:3] (blockedBy T1,T3,T4,T5,T6,T7)
+Run all SC grep assertions (T1–T7 verify commands) + the three pre-push gates that touch these
+paths: `bash tools/check_secrets_drift.sh`, `python tools/check_doc_drift.py`,
+`bash tools/check_volumes_table.sh`. All must pass. Report any failure with file:line.
+Verify: all gates exit 0; all SC greps satisfied.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. blockedBy refs T-numbers, not session IDs. -->
+
+### Wave 1 — no deps, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | labels |
+| T2 | devops-B | — | deploy-wiring |
+| T3 | devops-B | T2 | deploy-wiring |
+| T4 | devops-B | T3 | deploy-wiring |
+| T5 | doc-writer-A | — | docs |
+| T6 | doc-writer-A | — | docs |
+| T7 | doc-writer-A | — | docs |
+
+### Wave 2 — after Wave 1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T8 | verify-A | T1,T3,T4,T5,T6,T7 | gates |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 13 — labels
+- T2: 14 — deploy-wiring
+- T3: 15 — deploy-wiring (blockedBy T2)
+- T4: 16 — deploy-wiring (blockedBy T3)
+- T5: 17 — docs
+- T6: 18 — docs
+- T7: 19 — docs
+- T8: 20 — gates (blockedBy T1,T3,T4,T5,T6,T7)

--- a/artifacts/specs/1729-m1-auto-deploy-dead-spec.mdx
+++ b/artifacts/specs/1729-m1-auto-deploy-dead-spec.mdx
@@ -1,0 +1,136 @@
+---
+title: "M₁ auto-deploy repair: AutoUpdate labels + timer start + doc reconcile"
+issue: 1729
+status: approved
+tier: F-lite
+date: 2026-06-04
+promoted_from: artifacts/frames/1729-m1-auto-deploy-dead-frame.mdx
+---
+
+## Context
+
+Source: [frame](../frames/1729-m1-auto-deploy-dead-frame.mdx) (analyze skipped, F-lite).
+M₁ auto-deploy is non-functional. Investigation found the units exist in-repo; the failure is a
+cluster of code defects + an operational gap + doc drift. This spec repairs the code paths so a
+fresh `install.sh` + host-provision greens M₁ and keeps it green, then reconciles the doc and
+ships an M₁ remediation runbook.
+
+The three-timer prod deploy model (the intended design, now made real):
+
+| Timer | Installed by | Role |
+|---|---|---|
+| `podman-auto-update.timer` (podman static unit) | `provision.sh` (host bootstrap) | Pulls new `:staging`/`:staging-svc` image digests for containers labelled `io.containers.autoupdate=registry` |
+| `factory-quadlet-sync.timer` | `make quadlet-sync-install` | `git pull --ff-only origin staging`; conditional `make converge` on `deploy/**`/Makefile/render changes |
+| `factory-post-autoupdate.timer` | `make quadlet-sync-install` | Detects image-digest change → full `make converge` (auth.conf regen + secret refresh + restarts) → carries ACL/auth.conf changes to NATS |
+
+## Goal
+
+A staging merge reaches M₁ with zero manual steps — image **and** quadlet/auth.conf — and the
+repo encodes the fix so re-provision/fresh-host reproduces a working state, not the outage.
+
+## Users
+
+- **Primary:** ops (Mickael) — eliminate per-merge manual M₁ pull/restart/authconf-regen.
+- **Secondary:** every contributor whose merged change must reach prod automatically.
+
+## Expected Behavior
+
+1. CI merges `staging` → `publish.yml` pushes `:staging` / `:staging-svc` images to GHCR.
+2. Within 5 min, `podman-auto-update.timer` pulls new digests for the **7** registry-labelled
+   containers (hub, telegram, discord, clipool, gh-helper, turn-writer, blobstore); `nats`
+   stays pinned-by-digest (no label).
+3. `factory-post-autoupdate.timer` observes the digest change → `make converge` →
+   auth.conf/secret/quadlet re-render + restart (NATS gets ACL changes via restart-not-HUP).
+4. `factory-quadlet-sync.timer` independently fast-forwards the git checkout + conditionally
+   re-installs quadlets when `deploy/**` changed.
+5. Operator verifies on M₁: `is-enabled podman-auto-update.timer` → `enabled`,
+   `is-active factory-quadlet-sync.timer` → `active`, `podman auto-update --dry-run` lists 7
+   registry-tracked containers.
+
+## Data Model & Consumers
+
+The "data" is the set of systemd units + the per-container AutoUpdate label that gates them.
+
+```mermaid
+classDiagram
+    class ContainerUnit {
+        +string name
+        +string Image  "ghcr.io/roxabi/factory:staging[-svc]"
+        +Label autoupdate  "io.containers.autoupdate=registry | (none)"
+    }
+    class PodmanAutoUpdateTimer {
+        +OnCalendar  "*:0/5 (via drop-in)"
+        +enabled_now bool
+    }
+    class FactorySyncTimer {
+        +OnCalendar "*:0/5"
+        +enabled_now bool
+    }
+    class FactoryPostAutoupdateTimer {
+        +OnCalendar "*:0/5"
+        +enabled_now bool
+    }
+    PodmanAutoUpdateTimer --> ContainerUnit : pulls if label=registry
+    FactoryPostAutoupdateTimer --> ContainerUnit : converge on digest change
+    FactorySyncTimer --> ContainerUnit : re-install on deploy/** change
+```
+
+```mermaid
+flowchart LR
+    GHCR[(GHCR :staging digest)] --> PAU[podman-auto-update.timer]
+    PAU -->|label=registry| PULL[pull + restart 7 containers]
+    PAU -.->|nats: no label| SKIP[nats untouched - pinned]
+    PULL --> PAT[factory-post-autoupdate.timer]
+    PAT --> CONV[make converge: authconf+secrets+restart]
+    REPO[(origin/staging git)] --> SYNC[factory-quadlet-sync.timer]
+    SYNC -->|deploy/** changed| QI[make quadlet-install]
+```
+
+Consumer summary:
+
+| Consumer | Reads | When | Status |
+|---|---|---|---|
+| `podman-auto-update.timer` | container `autoupdate` label + GHCR digest | every 5 min | this issue (label add + drop-in) |
+| `factory-post-autoupdate.timer` | image digest delta | every 5 min | this issue (start with `--now`) |
+| `factory-quadlet-sync.timer` | `origin/staging` HEAD + `deploy/**` diff | every 5 min | this issue (start with `--now`) |
+| operator runbook | timer state on M₁ | one-time remediation | this issue (doc) |
+
+## Breadboard
+
+| ID | Affordance | Handler / Location | Effect |
+|----|-----------|--------------------|--------|
+| C1 | `Label=io.containers.autoupdate=registry` | `deploy/quadlet/factory-{hub,clipool,gh-helper,turn-writer,blobstore}.container` `[Container]` | makes 5 currently-unlabelled containers registry-tracked (telegram+discord already labelled via `.container.tmpl`) |
+| C2 | `nats` stays unlabelled | `deploy/quadlet/factory-nats.container` | asserts pinned-by-digest container is NOT auto-updated (negative criterion) |
+| M1 | `enable --now` | `Makefile:quadlet-sync-install` (lines ~197–198) | start sync + post-autoupdate timers immediately, not just on reboot. **Must preserve the existing `cp factory-deploy-failure.service` line (~194) when editing the target.** |
+| D1 | `podman-auto-update.timer.d/override.conf` | `deploy/systemd/podman-auto-update.timer.d/override.conf` (new) + installed by `quadlet-sync-install` | sets `OnCalendar=*:0/5`. **`quadlet-sync-install` currently does flat `cp` of unit files — it must add `mkdir -p "$(QUADLET_SYNC_DST)/podman-auto-update.timer.d"` before copying the drop-in, then `daemon-reload` (already present).** Ownership: the drop-in is installed by `quadlet-sync-install` (single source — not "or documented"). |
+| I1 | enable host timer idempotently | `deploy/install.sh` (after step 9, ~line 296) | `install.sh` has **no** `podman-auto-update.timer` block today. Add `systemctl --user enable --now podman-auto-update.timer` **without** an `is-active` guard (stronger idempotent form than provision.sh — handles enabled-but-stopped). A plain `install.sh` then greens the host timer without a full re-provision. |
+| DOC1 | reconcile mechanism + container table | `docs/ops/container-publishing.md` | (a) "Containers managed" table → all 8 factory containers w/ correct AutoUpdate column: add `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`; remove/relocate cross-repo `voicecli-tts`/`voicecli-stt` rows (separate repo); nats = none. (b) Fix stale "M₁ manual pull + restart" section (lists 4 — add gh-helper/turn-writer/blobstore, align to deploy/CLAUDE.md converge order). (c) Document the 3-timer model + correct cadence; replace bare "no manual intervention" with a prerequisite-qualified statement. |
+| DOC2 | M₁ remediation runbook | `docs/QUADLET-DEPLOYMENT.md` — expand the existing "Auto-update not pulling" diagnostic entry (~line 384) | exact idempotent commands to green the live M₁ host once (install drop-in, `enable --now` all 3 timers, verify). QUADLET-DEPLOYMENT.md is the M₁ ops runbook; container-publishing.md is CI/GHCR-pattern oriented. |
+| DOC3 | 3rd-timer row | `deploy/CLAUDE.md` "Two systemd user timers" table (~lines 103–108) | add `podman-auto-update.timer` row (host-static, installed by provision.sh/install.sh) + retitle "Three systemd user timers". |
+
+## Slices
+
+| # | Slice | Affordances | Independently demo-able |
+|---|-------|-------------|--------------------------|
+| 1 | **AutoUpdate label coverage** | C1, C2 | `grep -lc 'autoupdate=registry' deploy/quadlet/*.container deploy/quadlet/*.container.tmpl` → 7 files match (5 static + 2 tmpl); `factory-nats.container` absent |
+| 2 | **Timer start + cadence** | M1, D1, I1 | `quadlet-sync-install` uses `enable --now` + `mkdir -p .d/` + drop-in copy (preserves deploy-failure cp); `install.sh` enables host timer idempotently |
+| 3 | **Doc reconcile + runbook** | DOC1, DOC2, DOC3 | container-publishing.md table = 8 factory containers, no cross-repo rows; QUADLET-DEPLOYMENT.md runbook copy-pasteable; deploy/CLAUDE.md shows 3 timers |
+
+## Success Criteria
+
+> Note: the frame's Premise Validity says "all 8 container units carry the AutoUpdate label" — that was imprecise. `factory-nats` is **pinned-by-digest and intentionally excluded**, so the correct target is **7 labelled** (hub, telegram, discord, clipool, gh-helper, turn-writer, blobstore) and nats unlabelled. The frame's "<8 registry-tracked" failure condition becomes "<7" below.
+
+- [ ] All 7 non-nats container units (`hub, telegram, discord, clipool, gh-helper, turn-writer, blobstore`) carry `io.containers.autoupdate=registry`; `factory-nats` does **not**. Verify: `grep -l 'autoupdate=registry' deploy/quadlet/*.container deploy/quadlet/*.container.tmpl | wc -l` → 7, and `grep -L 'autoupdate=registry' deploy/quadlet/factory-nats.container` matches.
+- [ ] `make quadlet-sync-install` uses `systemctl --user enable --now` for both `factory-quadlet-sync.timer` and `factory-post-autoupdate.timer`; the `cp factory-deploy-failure.service` line is preserved (idempotent target).
+- [ ] `deploy/systemd/podman-auto-update.timer.d/override.conf` exists with `OnCalendar=*:0/5`, and `quadlet-sync-install` `mkdir -p`s the `.d/` dir and copies it (single install path — `quadlet-sync-install`, not optional). Verify: `grep -A2 'mkdir -p.*podman-auto-update.timer.d' Makefile`.
+- [ ] `deploy/install.sh` runs `systemctl --user enable --now podman-auto-update.timer` (no `is-active` guard) idempotently — a plain install greens the host timer without re-provision. Verify: `grep 'enable --now podman-auto-update.timer' deploy/install.sh`.
+- [ ] `docs/ops/container-publishing.md` "Containers managed" table lists all 8 factory containers with correct AutoUpdate column (gh-helper + turn-writer + blobstore added; nats = none); cross-repo `voicecli-tts`/`voicecli-stt` rows removed or relocated; the stale "M₁ manual pull + restart" section lists all 7 service containers.
+- [ ] `docs/ops/container-publishing.md` no longer contains the bare phrase "No manual intervention is needed after a staging merge" — it is replaced by a prerequisite-qualified statement naming the 3 timers. Verify: `! grep -q 'No manual intervention is needed' docs/ops/container-publishing.md`.
+- [ ] `deploy/CLAUDE.md` timer table documents all 3 timers (adds `podman-auto-update.timer` row; title reflects three).
+- [ ] `docs/QUADLET-DEPLOYMENT.md` "Auto-update not pulling" entry is expanded into idempotent M₁ remediation commands (install drop-in, `enable --now` all 3 timers, verify); cross-referenced from #1729.
+- [ ] **Prod-green (operator, post-merge):** after running the runbook on M₁, `podman auto-update --dry-run` lists 7 registry-tracked containers, `systemctl --user is-enabled podman-auto-update.timer` → `enabled`, `is-active factory-quadlet-sync.timer` → `active`. Operator records the output as a comment on #1729. (Not CI-verifiable — the PR cannot mutate M₁; this is the falsifiability anchor.)
+- [ ] `secrets_drift` + `volumes_table` + `doc_drift` pre-push gates pass with the quadlet/doc edits.
+
+## Follow-up (out of scope — open as separate issue)
+
+- **`factory-post-autoupdate.sh` tracks only `:staging-svc`.** It hardcodes `IMAGE=ghcr.io/roxabi/factory:staging-svc` and compares only that digest. `factory-clipool` + `factory-gh-helper` use `:staging` (no `-svc`); a `:staging`-only rebuild won't trigger `make converge` (podman auto-update still pulls+restarts them via label, but the auth.conf/secret converge path won't fire). Pre-existing bug, not introduced here — file a follow-up; this spec's prod-green criterion uses `:staging-svc`-carrying services for its converge assertion.

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -100,16 +100,18 @@ deploy verb for M₁. It reconciles the running system with the desired state de
 
 ### Trigger wiring
 
-Two systemd user timers drive convergence **automatically**:
+Three systemd user timers drive convergence **automatically**:
 
 | Timer | Period | Service | Role |
 |---|---|---|---|
+| `podman-auto-update.timer` | `*:0/5` (5 min) | `podman-auto-update.service` | Host-static apt unit (installed by `provision.sh`/`install.sh`); drop-in sets `OnCalendar=*:0/5`. Polls GHCR digests for containers labelled `io.containers.autoupdate=registry`; pulls and restarts on new digest. |
 | `factory-quadlet-sync.timer` | `*:0/5` (5 min) | `factory-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, Makefile, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
 | `factory-post-autoupdate.timer` | `*:0/5` (5 min) | `factory-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). |
 
+`podman-auto-update` handles **image pulls** (CI-driven, registry-labelled containers).
 `factory-quadlet-sync` handles **unit/template changes** (code-driven).
-`factory-post-autoupdate` handles **image digest changes** (CI-driven).
-Both are required for fully hands-off deploys.
+`factory-post-autoupdate` handles **post-pull convergence** (restarts + auth.conf regen).
+All three are required for fully hands-off deploys.
 
 ### Failure notification path
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -295,4 +295,10 @@ echo "  [ok]   BotStore seeded"
 log "Installing factory-quadlet-sync timer + service ..."
 run make quadlet-sync-install
 
+# ── 10. Enable host podman-auto-update timer ────────────────────────────────
+
+log "Enabling podman-auto-update.timer (5-min cadence) ..."
+run systemctl --user enable --now podman-auto-update.timer
+echo "  [ok]   podman-auto-update.timer enabled"
+
 log "Done. Services NOT restarted — run: systemctl --user start factory-nats factory-hub factory-telegram factory-discord factory-clipool factory-gh-helper factory-turn-writer factory-blobstore"

--- a/deploy/quadlet/factory-blobstore.container
+++ b/deploy/quadlet/factory-blobstore.container
@@ -12,6 +12,7 @@ StartLimitBurst=5
 # as factory-hub.container. Dedicated blobstore image blocked until Protocol v2 + ≥3
 # cross-repo consumers; see analysis §Shape A rationale.
 Image=ghcr.io/roxabi/factory:staging-svc
+Label=io.containers.autoupdate=registry
 ContainerName=factory-blobstore
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/quadlet/factory-clipool.container
+++ b/deploy/quadlet/factory-clipool.container
@@ -11,6 +11,7 @@ StartLimitBurst=5
 
 [Container]
 Image=ghcr.io/roxabi/factory:staging
+Label=io.containers.autoupdate=registry
 ContainerName=factory-clipool
 # Pod= moves network + user namespace ownership to factory-gh.pod.
 # UserNS=keep-id:uid=1500 is now declared on the pod (factory-gh.pod [Pod] section)

--- a/deploy/quadlet/factory-gh-helper.container
+++ b/deploy/quadlet/factory-gh-helper.container
@@ -12,6 +12,7 @@ StartLimitBurst=5
 # Same image as clipool — factory-gh user (uid 1501) + factory-tokenuser group (gid 1502)
 # are baked into the image at Dockerfile lines 49–51. No separate helper image needed.
 Image=ghcr.io/roxabi/factory:staging
+Label=io.containers.autoupdate=registry
 ContainerName=factory-gh-helper
 Pod=factory-gh.pod
 ReadOnly=true

--- a/deploy/quadlet/factory-hub.container
+++ b/deploy/quadlet/factory-hub.container
@@ -11,6 +11,7 @@ StartLimitBurst=5
 # (CI tag-by-SHA strategy). Upstream registry images (e.g. nats.container)
 # are pinned by digest directly.
 Image=ghcr.io/roxabi/factory:staging-svc
+Label=io.containers.autoupdate=registry
 ContainerName=factory-hub
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/quadlet/factory-turn-writer.container
+++ b/deploy/quadlet/factory-turn-writer.container
@@ -7,6 +7,7 @@ StartLimitBurst=5
 
 [Container]
 Image=ghcr.io/roxabi/factory:staging-svc
+Label=io.containers.autoupdate=registry
 ContainerName=factory-turn-writer
 Network=roxabi.network
 # Hardening — defense in depth (see issue #652).

--- a/deploy/systemd/podman-auto-update.timer.d/override.conf
+++ b/deploy/systemd/podman-auto-update.timer.d/override.conf
@@ -1,0 +1,4 @@
+[Timer]
+OnCalendar=
+OnCalendar=*:0/5
+RandomizedDelaySec=0

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -497,11 +497,14 @@ make quadlet-sync-install   # installs drop-in + systemctl --user enable --now f
 
 ### 2. Enable/start the three timers
 
+Run `daemon-reload` first so the drop-in override is loaded before the timers are activated. Then restart `podman-auto-update.timer` so any changed `OnCalendar=` schedule takes effect on an already-active timer.
+
 ```bash
+systemctl --user daemon-reload
 systemctl --user enable --now podman-auto-update.timer
 systemctl --user enable --now factory-quadlet-sync.timer
 systemctl --user enable --now factory-post-autoupdate.timer
-systemctl --user daemon-reload
+systemctl --user restart podman-auto-update.timer
 ```
 
 ### 3. Verify timer state

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -481,7 +481,55 @@ systemctl --user status podman-auto-update.timer
 | NATS auth failure in logs | Stale auth.conf | `make nats-regen-authconf` + restart NATS |
 | `factory-gh-helper` fails | Missing `factory-gh-pem` | Install PEM secret (see above) |
 | Container restart loop | `RestartSec=10` applies — check logs | `journalctl --user -u <svc> -n 50` |
-| Auto-update not pulling | Timer inactive | `systemctl --user start podman-auto-update.timer` |
+| Auto-update not pulling | Timer inactive or misconfigured | See M₁ auto-update remediation runbook below |
+
+## M₁ auto-update remediation runbook
+
+Run when `podman auto-update` has stopped pulling new images (all three timers must be
+enabled and active for fully hands-off deploys):
+
+### 1. Re-install the drop-in + enable the quadlet-sync timer
+
+```bash
+cd ~/projects/roxabi-factory
+make quadlet-sync-install   # installs drop-in + systemctl --user enable --now factory-quadlet-sync.timer
+```
+
+### 2. Enable/start the three timers
+
+```bash
+systemctl --user enable --now podman-auto-update.timer
+systemctl --user enable --now factory-quadlet-sync.timer
+systemctl --user enable --now factory-post-autoupdate.timer
+systemctl --user daemon-reload
+```
+
+### 3. Verify timer state
+
+Check all three timers are enabled and active:
+
+```bash
+systemctl --user is-enabled podman-auto-update.timer factory-quadlet-sync.timer factory-post-autoupdate.timer
+systemctl --user is-active  podman-auto-update.timer factory-quadlet-sync.timer factory-post-autoupdate.timer
+```
+
+Expected output: three lines of `enabled` then three lines of `active`.
+
+### 4. Verify registry tracking
+
+```bash
+podman auto-update --dry-run
+```
+
+Expected: 7 containers listed with `registry` tracking (`factory-hub`, `factory-telegram`,
+`factory-discord`, `factory-clipool`, `factory-gh-helper`, `factory-turn-writer`,
+`factory-blobstore`). `factory-nats` must NOT appear — it is pinned by digest with no
+autoupdate label.
+
+### 5. Record output on issue #1729
+
+Copy the output of `podman auto-update --dry-run` and the three `is-enabled`/`is-active`
+results as a comment on issue #1729. This is the SC9 prod-green verification check.
 
 ## Pitfall: double-quotes in HealthCmd= are dropped by the Quadlet generator
 

--- a/docs/ops/container-publishing.md
+++ b/docs/ops/container-publishing.md
@@ -150,8 +150,8 @@ All three must be enabled and active for fully automatic deploys. Check with
 | `factory-discord` | `ghcr.io/roxabi/factory:staging-svc` | registry |
 | `factory-clipool` | `ghcr.io/roxabi/factory:staging` | registry |
 | `factory-gh-helper` | `ghcr.io/roxabi/factory:staging` | registry |
-| `factory-turn-writer` | `ghcr.io/roxabi/factory:staging` | registry |
-| `factory-blobstore` | `ghcr.io/roxabi/factory:staging` | registry |
+| `factory-turn-writer` | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| `factory-blobstore` | `ghcr.io/roxabi/factory:staging-svc` | registry |
 
 > `factory-nats` is pinned by digest and carries no `io.containers.autoupdate=registry` label — it is intentionally excluded from the auto-update cycle; bump manually.
 > voiceCLI units are managed by the voiceCLI repo and its own Quadlet manifests — see that repo for its auto-update configuration.
@@ -189,8 +189,11 @@ podman auto-update
 
 If auto-update is disabled or you need an immediate deploy without waiting for the timer:
 
+CI publishes both tags in parallel: `:staging` is used by `factory-clipool` and `factory-gh-helper`; `:staging-svc` is used by `factory-hub`, `factory-telegram`, `factory-discord`, `factory-turn-writer`, and `factory-blobstore`. Both must be pulled for a complete manual refresh.
+
 ```bash
 podman pull ghcr.io/roxabi/factory:staging
+podman pull ghcr.io/roxabi/factory:staging-svc
 systemctl --user daemon-reload
 systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool \
   factory-turn-writer factory-gh-helper factory-blobstore

--- a/docs/ops/container-publishing.md
+++ b/docs/ops/container-publishing.md
@@ -107,7 +107,22 @@ Switching between the two is a one-line edit to the `.container` file followed b
 ## Auto-Update Flow
 
 Since #929, prod (M₁) uses `podman auto-update` to automatically pull new images and restart
-containers. No manual intervention is needed after a staging merge.
+containers. Auto-deploy holds *provided the three timers described below are enabled and active
+on M₁*. See `docs/QUADLET-DEPLOYMENT.md` (M₁ auto-update remediation runbook) if any timer
+is inactive.
+
+### Three-timer model
+
+Three systemd `--user` timers on M₁ drive fully hands-off deploys, each firing every 5 minutes:
+
+| Timer | Role |
+|---|---|
+| `podman-auto-update.timer` | Polls GHCR digests for containers labelled `io.containers.autoupdate=registry`; pulls and restarts on new digest. Static apt unit; drop-in sets `OnCalendar=*:0/5`. |
+| `factory-quadlet-sync.timer` | `git pull --ff-only origin staging`; on `deploy/**` changes runs `make converge` (Quadlet unit/template updates). |
+| `factory-post-autoupdate.timer` | Detects image-digest changes produced by `podman-auto-update`; on change triggers the full `make converge` (auth.conf regen + secret refresh + restarts). |
+
+All three must be enabled and active for fully automatic deploys. Check with
+`systemctl --user is-enabled` and `is-active` for each timer name.
 
 ### How it works
 
@@ -129,14 +144,17 @@ containers. No manual intervention is needed after a staging merge.
 
 | Container | Image | AutoUpdate |
 |---|---|---|
-| factory-hub | `ghcr.io/roxabi/factory:staging-svc` | registry |
-| factory-telegram | `ghcr.io/roxabi/factory:staging-svc` | registry |
-| factory-discord | `ghcr.io/roxabi/factory:staging-svc` | registry |
-| factory-clipool | `ghcr.io/roxabi/factory:staging` | registry |
-| factory-gh-helper | `ghcr.io/roxabi/factory:staging` | registry |
-| voicecli-tts | `ghcr.io/roxabi/voicecli-tts:staging` | registry |
-| voicecli-stt | `ghcr.io/roxabi/voicecli-stt:staging` | registry |
-| factory-nats | pinned by digest | none (pinned) |
+| `factory-nats` | pinned by digest | none (pinned) |
+| `factory-hub` | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| `factory-telegram` | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| `factory-discord` | `ghcr.io/roxabi/factory:staging-svc` | registry |
+| `factory-clipool` | `ghcr.io/roxabi/factory:staging` | registry |
+| `factory-gh-helper` | `ghcr.io/roxabi/factory:staging` | registry |
+| `factory-turn-writer` | `ghcr.io/roxabi/factory:staging` | registry |
+| `factory-blobstore` | `ghcr.io/roxabi/factory:staging` | registry |
+
+> `factory-nats` is pinned by digest and carries no `io.containers.autoupdate=registry` label — it is intentionally excluded from the auto-update cycle; bump manually.
+> voiceCLI units are managed by the voiceCLI repo and its own Quadlet manifests — see that repo for its auto-update configuration.
 
 ### Verify
 
@@ -174,18 +192,24 @@ If auto-update is disabled or you need an immediate deploy without waiting for t
 ```bash
 podman pull ghcr.io/roxabi/factory:staging
 systemctl --user daemon-reload
-systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool
+systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool \
+  factory-turn-writer factory-gh-helper factory-blobstore
 ```
 
-Verify all four units are healthy:
+Verify all seven service units are healthy (converge order matches `make converge` step 7):
 
 ```bash
-systemctl --user is-active factory-hub factory-telegram factory-discord factory-clipool
+systemctl --user is-active \
+  factory-hub factory-telegram factory-discord factory-clipool \
+  factory-turn-writer factory-gh-helper factory-blobstore
 curl -fsS localhost:8443/health
 ```
 
 `is-active` prints `active` for each unit on success. The health endpoint is served by
 `factory-hub` on `127.0.0.1:8443` (published via PublishPort in the Quadlet unit).
+
+> `factory-nats` is excluded from this restart sequence — it is pinned by digest and managed
+> separately. See `docs/QUADLET-DEPLOYMENT.md` for NATS rotation procedures.
 
 ---
 


### PR DESCRIPTION
## Summary
- M₁ auto-deploy was dead: `podman-auto-update.timer` disabled and the factory sync timers installed-but-never-started, so staging merges silently stopped reaching prod. Root cause was a cluster of latent repo defects, not missing units.
- **AutoUpdate label coverage:** added `Label=io.containers.autoupdate=registry` to the 5 static quadlet units (hub, clipool, gh-helper, turn-writer, blobstore). `factory-nats` left unlabelled (pinned by digest); telegram/discord `.tmpl` already had it → 7 registry-tracked containers.
- **Timer start + cadence:** `make quadlet-sync-install` now uses `enable --now` (was bare `enable` → dormant) and installs a `podman-auto-update.timer.d/override.conf` drop-in setting `OnCalendar=*:0/5`; `install.sh` enables `podman-auto-update.timer` on the host.
- **Doc reconcile:** `container-publishing.md` (8-container table, 3-timer model, dropped the unqualified "no manual intervention" claim), `QUADLET-DEPLOYMENT.md` (M₁ remediation runbook), `deploy/CLAUDE.md` (third-timer row).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1729: M₁ auto-deploy is dead | OPEN (bug, P1-high) |
| Frame | [1729-…-frame.mdx](artifacts/frames/1729-m1-auto-deploy-dead-frame.mdx) | Present |
| Spec | [1729-…-spec.mdx](artifacts/specs/1729-m1-auto-deploy-dead-spec.mdx) | Present |
| Plan | [1729-…-plan.mdx](artifacts/plans/1729-m1-auto-deploy-dead-plan.mdx) | Present |
| Implementation | 3 commits on `feat/1729-m1-auto-deploy-dead` | Complete |
| Verification | SC greps 15/15 · secrets_drift / doc_drift / volumes_table exit 0 | Passed |

## Test Plan
- [ ] `grep -l autoupdate=registry deploy/quadlet/*.container deploy/quadlet/*.container.tmpl | wc -l` → 7; `factory-nats.container` unlabelled
- [ ] `grep -c 'enable --now factory' Makefile` → 2; drop-in `mkdir -p` present; `factory-deploy-failure.service` cp preserved
- [ ] **Prod-green (SC9, operator on M₁):** run the QUADLET-DEPLOYMENT.md remediation runbook → `podman auto-update --dry-run` reports 7 registry-tracked; `is-enabled`/`is-active` for all 3 timers; record output on #1729

## Notes
- Pure infra + docs; no Python delta (ruff/pyright/pytest non-applicable). Relevant pre-push gates green.
- Follow-up (out of scope): `factory-post-autoupdate.sh` only inspects `:staging-svc` image digests — a `:staging`-only digest change would not trigger `make converge`. Filing a separate issue.

Fixes #1729

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
