### PR TITLE
fix(deploy): #1735 converge.sh — _do_converge order + rotate auth secret

### DIFF
--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -92,11 +92,12 @@ deploy verb for M₁. It reconciles the running system with the desired state de
 2. **Pull** — `git pull origin staging` in `~/projects/roxabi-factory` (and `~/projects/voiceCLI` if present).
 3. **Install Quadlet units** — `make quadlet-install NO_RESTART=1` (renders units, copies to `~/.config/containers/systemd`, `daemon-reload`, seeds BotStore).
 4. **Regenerate auth.conf** — `factory-acl genkeys --regen-authconf` (renders `nkeys/` → `auth.conf`).
-5. **Install secrets** — `make quadlet-secrets-install` (recreates Podman secrets from host key files).
-6. **Restart NATS** — `systemctl --user restart factory-nats` (mount-typed secrets require container restart, not HUP, to refresh). Waits for `is-active`.
-7. **Restart lyra clients** — `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-turn-writer`, `factory-gh-helper`, `factory-blobstore` (only if already active; any failure aborts the converge).
-8. **Restart voiceCLI** — `voicecli-tts`, `voicecli-stt` (if voiceCLI directory exists).
-9. **Record stamp** — writes the new convergence fingerprint to `~/.roxabi/factory/.converge-stamp`.
+5. **Rotate auth secret** — `podman secret create --replace factory-nats-auth <nkeys>/auth.conf` (unconditional; ensures the new auth.conf is in the Podman secret store before NATS restarts).
+6. **Install secrets** — `make quadlet-secrets-install` (recreates remaining Podman secrets from host key files; `factory-nats-auth` already replaced in step 5).
+7. **Restart NATS** — `systemctl --user restart factory-nats` (mount-typed secrets require container restart, not HUP, to refresh). Waits for `is-active`.
+8. **Restart lyra clients** — `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-turn-writer`, `factory-gh-helper`, `factory-blobstore` (only if already active; any failure aborts the converge).
+9. **Restart voiceCLI** — `voicecli-tts`, `voicecli-stt` (if voiceCLI directory exists).
+10. **Record stamp** — writes the new convergence fingerprint to `~/.roxabi/factory/.converge-stamp`.
 
 ### Trigger wiring
 

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 source "$(dirname "$0")/lib/deploy-common.sh"
 
 # Guard against concurrent runs (exit 0 if locked)
-with_deploy_lock _do_converge
+# NOTE: with_deploy_lock is called at the END of this file, after _do_converge is defined.
 
 _do_converge() {
     # 1) Change-gate: already converged?
@@ -41,7 +41,13 @@ _do_converge() {
     echo "==> NATS: regenerating auth.conf..."
     factory-acl genkeys --regen-authconf
 
-    # 6) Install secrets
+    # 5a) Rotate factory-nats-auth Podman secret so NATS picks up the new auth.conf
+    #     on the upcoming restart (type=mount secrets are stale until container restart;
+    #     --replace here ensures the new tmpfs content is ready before step 7).
+    echo "==> NATS: rotating factory-nats-auth secret..."
+    podman secret create --replace factory-nats-auth "${FACTORY_NKEYS_DIR}/auth.conf"
+
+    # 6) Install remaining secrets (skips factory-nats-auth — already replaced above)
     echo "==> NATS: installing Podman secrets..."
     bash "${FACTORY_DIR}/deploy/install.sh" --secrets-only
 
@@ -76,3 +82,5 @@ _do_converge() {
 
     echo "==> Converge complete."
 }
+
+with_deploy_lock _do_converge


### PR DESCRIPTION
## Summary

- **D1**: `with_deploy_lock _do_converge` was called at line 12 before `_do_converge()` was defined (line 14), causing `command not found` / exit 127 on every `make converge` run. Fix: move the invocation to the end of the file.
- **D2'**: `converge.sh` step 6 called `deploy/install.sh --secrets-only` which skips existing secrets (only `--replace`s under `--force`). After `factory-acl genkeys --regen-authconf` regenerates `auth.conf`, the new content never reached the `factory-nats-auth` Podman secret, so NATS kept loading the stale ACL grants. Fix: add an unconditional `podman secret create --replace factory-nats-auth <nkeys>/auth.conf` between auth regen and the NATS restart (only the auth secret is replaced; other secrets are unchanged).
- **docs**: updated `deploy/CLAUDE.md` convergence sequence to document the new step 5 (rotate auth secret) and renumber subsequent steps 6–10.

Fixes #1735

## Test plan

- [ ] `bash -n deploy/converge.sh` exits 0 (verified locally)
- [ ] `bash -n deploy/lib/deploy-common.sh` exits 0 (verified locally)
- [ ] Live `make converge` on M₁ — cannot verify without prod access (see risks below)
- [ ] Confirm `factory-nats-auth` secret content matches new `auth.conf` after converge

## Risks / not done

- Live converge run on M₁ not executed (no prod access from worktree). Manual verification required on first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)