### PR TITLE
fix(deploy): #1738 drop --wait from converge NATS restart (hang)

### DIFF
--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -52,8 +52,15 @@ _do_converge() {
     bash "${FACTORY_DIR}/deploy/install.sh" --secrets-only
 
     # 7) Restart NATS (mount-typed secret refresh requires restart)
+    #    NB: plain restart, NOT `restart --wait` — `--wait` blocks until the unit
+    #    *deactivates*, which never happens for a long-running daemon, so it hung the
+    #    entire converge (#1738). The is-active poll below is the readiness gate.
     echo "==> NATS: restarting factory-nats..."
-    systemctl --user restart --wait factory-nats
+    systemctl --user restart factory-nats
+    for _ in $(seq 1 10); do
+        systemctl --user is-active --quiet factory-nats && break
+        sleep 1
+    done
     systemctl --user is-active --quiet factory-nats \
         || { echo "ERROR: factory-nats failed to reach active state"; exit 1; }
 


### PR DESCRIPTION
## Summary
`deploy/converge.sh` step 7 used `systemctl --user restart --wait factory-nats`. `--wait` blocks until the unit *deactivates* — which never happens for a long-running daemon — so the converge hung indefinitely, holding the `flock` deploy lock and never reaching the client restarts or the stamp. This was masked by the #1718 `_do_converge` ordering bug until #1735 fixed it and the converge first ran end-to-end (during the #1721 M₁ redeploy).

Fix: drop `--wait`; NATS restarts in seconds. The existing `is-active --quiet` check is kept as the readiness gate, now wrapped in a bounded 10s poll. `deploy/CLAUDE.md` step 7 already documented the no-`--wait` form — this aligns the script to the doc.

## Test Plan
- [x] `bash -n deploy/converge.sh` passes
- [ ] `make converge` on M₁ runs to completion (writes `.converge-stamp`, no hung `systemctl`)

Fixes #1738

---
Generated with [Claude Code](https://claude.com/claude-code)