### PR TITLE
fix(deploy): factory-post-autoupdate tracks both image tags (#1733)

### DIFF
--- a/deploy/factory-post-autoupdate.sh
+++ b/deploy/factory-post-autoupdate.sh
@@ -1,42 +1,63 @@
 #!/usr/bin/env bash
-# deploy/factory-post-autoupdate.sh — poll image digest and trigger converge on change
+# deploy/factory-post-autoupdate.sh — poll image digests and trigger converge on change
 #
-# Triggered by factory-post-autoupdate.timer (5 min). Idempotent: if digests match,
-# exits 0. On digest change, pulls the new image and runs the full converge.
+# Triggered by factory-post-autoupdate.timer (5 min). Idempotent: if every tracked
+# image digest matches local, exits 0. If ANY image digest drifted, pulls the
+# drifted image(s) and runs a single full converge.
+#
+# Tracks both runtime image tags:
+#   :staging-svc  — service runtime (hub, adapters, turn-writer, blobstore)
+#   :staging      — agent runtime (clipool, gh-helper)
+# A change to EITHER must trigger converge: a staging merge can rebuild only one
+# tag while still carrying an auth.conf/ACL change that NATS needs a restart
+# (not HUP) to pick up. See #1733.
 
 set -euo pipefail
 
 source "$(dirname "$0")/lib/deploy-common.sh"
 
-IMAGE="ghcr.io/roxabi/factory:staging-svc"
+IMAGES=(
+    "ghcr.io/roxabi/factory:staging-svc"
+    "ghcr.io/roxabi/factory:staging"
+)
 
 # ── Digest comparison ────────────────────────────────────────────────────────
 
 remote_digest() {
-    skopeo inspect "docker://${IMAGE}" | jq -r '.Digest'
+    skopeo inspect "docker://$1" | jq -r '.Digest'
 }
 
 local_digest() {
-    podman images --format '{{.Digest}}' "${IMAGE}" 2>/dev/null || true
+    podman images --format '{{.Digest}}' "$1" 2>/dev/null | head -n1 || true
 }
 
 main() {
-    local remote_digest_val local_digest_val
+    local drifted=()
 
-    remote_digest_val=$(remote_digest)
-    local_digest_val=$(local_digest)
+    for image in "${IMAGES[@]}"; do
+        local remote_digest_val local_digest_val
+        remote_digest_val=$(remote_digest "${image}")
+        local_digest_val=$(local_digest "${image}")
 
-    if [ -n "${local_digest_val}" ] && [ "${remote_digest_val}" = "${local_digest_val}" ]; then
-        echo "Image digest unchanged (${IMAGE}) — nothing to do."
+        if [ -n "${local_digest_val}" ] && [ "${remote_digest_val}" = "${local_digest_val}" ]; then
+            echo "Image digest unchanged (${image})."
+        else
+            echo "Image digest drift detected (${image}):"
+            echo "  remote: ${remote_digest_val}"
+            echo "  local:  ${local_digest_val:-<not present>}"
+            drifted+=("${image}")
+        fi
+    done
+
+    if [ "${#drifted[@]}" -eq 0 ]; then
+        echo "All tracked image digests unchanged — nothing to do."
         exit 0
     fi
 
-    echo "Image digest drift detected:"
-    echo "  remote: ${remote_digest_val}"
-    echo "  local:  ${local_digest_val:-<not present>}"
-
-    echo "==> Pulling ${IMAGE}..."
-    podman pull "${IMAGE}"
+    for image in "${drifted[@]}"; do
+        echo "==> Pulling ${image}..."
+        podman pull "${image}"
+    done
 
     # Converge stamp does not include image digest, so invalidate it
     # to force a full converge (restarts, auth.conf refresh, etc.).

--- a/deploy/factory-post-autoupdate.sh
+++ b/deploy/factory-post-autoupdate.sh
@@ -28,7 +28,9 @@ remote_digest() {
 }
 
 local_digest() {
-    podman images --format '{{.Digest}}' "$1" 2>/dev/null | head -n1 || true
+    # image inspect returns exactly one digest (or errors when absent) — no
+    # multi-line ambiguity from `podman images` listing dangling layers.
+    podman image inspect --format '{{.Digest}}' "$1" 2>/dev/null || true
 }
 
 main() {


### PR DESCRIPTION
## Summary
- `factory-post-autoupdate.sh` now tracks **both** runtime image tags — `:staging-svc` (service runtime: hub, adapters, turn-writer, blobstore) **and** `:staging` (agent runtime: clipool, gh-helper) — instead of only `:staging-svc`.
- If **either** image digest drifts from local, it pulls the drifted image(s) and runs a single `make converge`. Previously a `:staging`-only rebuild updated the container via `podman-auto-update` but skipped converge, so an auth.conf/ACL change riding that image would never reach NATS (which needs restart-not-HUP).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1733: factory-post-autoupdate.sh only inspects :staging-svc digests | OPEN |
| Implementation | 1 commit on `feat/1733-post-autoupdate-all-tags` | Complete |
| Verification | `bash -n` ✅ · shellcheck n/a (not installed) · no test framework for deploy bash (S-tier manual) | Passed |

## Test Plan
- [ ] `bash -n deploy/factory-post-autoupdate.sh` → syntax OK
- [ ] Dry mental trace: only `:staging` digest differs → drifted=[`:staging`] → pulls it → `rm CONVERGE_STAMP` → `make converge` runs once
- [ ] Both digests match local → "All tracked image digests unchanged — nothing to do." → exit 0
- [ ] Both drift → both pulled, single converge (no double-converge)

Fixes #1733

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
