### PR TITLE
ci(typing): fix matrix toggle no-op — read FACTORY_TYPING_ENABLED (#1712)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Run integration tests
         env:
           NATS_URL: nats://localhost:4222
-          LYRA_TYPING_ENABLED: ${{ matrix.typing_enabled }}
+          FACTORY_TYPING_ENABLED: ${{ matrix.typing_enabled }}
         run: uv run pytest tests/integration/ -v
 
       - name: Tear down Docker environment


### PR DESCRIPTION
## Summary
- `ci.yml` integration matrix set `LYRA_TYPING_ENABLED` but `src/factory/transport/typing_publisher.py` reads `FACTORY_TYPING_ENABLED` (renamed in #1669) → the env var the matrix set was never read.
- Both `integration (true|false)` legs ran with `FACTORY_TYPING_ENABLED` defaulting to `"true"`, so the typing-disabled leg never exercised the disabled path. One-line rename fixes the wiring.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1712: ci(typing) matrix toggle no-op | OPEN |
| Implementation | 1 commit on `feat/1712-ci-typing-env-var` | Complete |
| Verification | YAML valid · no stray `LYRA_TYPING_ENABLED` refs · `matrix.typing_enabled` correctly wired | Passed |

## Test Plan
- [ ] CI `integration (false)` leg now actually runs with `FACTORY_TYPING_ENABLED=false` (typing-disabled path exercised)
- [ ] CI `integration (true)` leg unchanged (still `true`)

Fixes #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)