### PR TITLE
fix(deploy): store blobs at ~/.roxabi/factory/blobstore — retire /data symlink (#1744)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -281,49 +281,8 @@ fi
 # ── 5. Ensure data directories ──────────────────────────────────────────────
 
 log "Ensuring data directories ..."
-run mkdir -p /data/factory/blobs
-if [[ "$DRY_RUN" -eq 0 ]]; then
-  if ! findmnt /data/factory/blobs >/dev/null 2>&1; then
-    warn "/data/factory/blobs is not a mount point — add to /etc/fstab with noatime,nodiratime"
-  fi
-fi
-echo "  [ok]   /data/factory/blobs"
-# #13: guard against a pre-existing non-symlink directory at the blobstore target.
-# ln -sf silently fails to replace a directory — blobs would land in the wrong path.
-_blobstore_link="${HOME}/.roxabi/factory/blobstore"
-_blobstore_blocked=0
-if [[ -e "${_blobstore_link}" && ! -L "${_blobstore_link}" ]]; then
-  # Target exists and is NOT a symlink (i.e. a real directory or regular file).
-  if [[ -d "${_blobstore_link}" ]]; then
-    # Check if empty — safe to remove; non-empty requires operator action.
-    if [[ -z "$(ls -A "${_blobstore_link}" 2>/dev/null)" ]]; then
-      log "Removing empty directory ${_blobstore_link} to replace with symlink ..."
-      run rm -rf "${_blobstore_link}"
-    elif [[ "$DRY_RUN" -eq 1 ]]; then
-      warn "${_blobstore_link} is a non-empty directory — would BLOCK install (run without --dry-run to see full error)"
-      _blobstore_blocked=1
-    else
-      echo "ERROR: ${_blobstore_link} is a non-empty directory (not a symlink)." >&2
-      echo "       Blobs would be silently misplaced. Remediation:" >&2
-      echo "         1. Move existing blobs: sudo mv ${_blobstore_link}/* /data/factory/blobs/" >&2
-      echo "         2. Remove directory:    rmdir ${_blobstore_link}" >&2
-      echo "         3. Re-run install.sh" >&2
-      exit 1
-    fi
-  elif [[ "$DRY_RUN" -eq 1 ]]; then
-    warn "${_blobstore_link} exists and is not a symlink or directory — would BLOCK install"
-    _blobstore_blocked=1
-  else
-    echo "ERROR: ${_blobstore_link} exists and is not a symlink or directory." >&2
-    echo "       Remove it manually then re-run install.sh" >&2
-    exit 1
-  fi
-fi
-if [[ "$_blobstore_blocked" -eq 0 ]]; then
-  run ln -sf /data/factory/blobs "${_blobstore_link}"
-  echo "  [ok]   ${_blobstore_link} → /data/factory/blobs"
-fi
-unset _blobstore_link _blobstore_blocked
+run mkdir -p "${HOME}/.roxabi/factory/blobstore"
+echo "  [ok]   ${HOME}/.roxabi/factory/blobstore"
 run mkdir -p "${HOME}/.roxabi/factory/turn-writer"
 echo "  [ok]   ~/.roxabi/factory/turn-writer/"
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -284,7 +284,7 @@ log "Ensuring data directories ..."
 run mkdir -p "${HOME}/.roxabi/factory/blobstore"
 echo "  [ok]   ${HOME}/.roxabi/factory/blobstore"
 run mkdir -p "${HOME}/.roxabi/factory/turn-writer"
-echo "  [ok]   ~/.roxabi/factory/turn-writer/"
+echo "  [ok]   ${HOME}/.roxabi/factory/turn-writer/"
 
 # ── 6. Copy Quadlet units ────────────────────────────────────────────────────
 

--- a/deploy/quadlet/factory-blobstore.container
+++ b/deploy/quadlet/factory-blobstore.container
@@ -35,11 +35,11 @@ Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-blobstore.seed
 # (type=mount files are bound at container init; restart is mandatory — ADR-054).
 Secret=factory_blobstore_token,type=mount,uid=1500,gid=1500,mode=0400,target=/run/secrets/factory_blobstore_token
 # Blob data directory — bind-mount so data persists across container restarts.
-# Host path mirrors the FsBlobStore default (~/.roxabi/factory/blobstore); container path resolves
-# under the factory home (/home/factory/.roxabi/factory/blobstore via UserNS=keep-id).
+# Host path: %h/.roxabi/factory/blobstore (convention path, real directory — no symlink, no /data indirection).
+# Container path resolves under the factory home (/home/factory/.roxabi/factory/blobstore via UserNS=keep-id).
 # NOTE: Do NOT add inline # comments after Volume= values; Quadlet passes them to
 # Podman as mount-option strings (issue #1083).
-Volume=/data/factory/blobs:/home/factory/.roxabi/factory/blobstore:z
+Volume=%h/.roxabi/factory/blobstore:/home/factory/.roxabi/factory/blobstore:z
 # config.toml — required by the staging-svc image variant (svc-runtime entrypoint
 # reads config at startup; see docs/ops/container-publishing.md §svc-runtime).
 Volume=%h/.roxabi/factory/config.toml:/app/config.toml:ro,z

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -358,11 +358,11 @@ mandatory (ADR-054). Keep the prior source file as `.prev` until rotation is con
 
 ## Backing up the BlobStore
 
-> **Host vs container path:** `/data/factory/blobs` is the canonical host path. `~/.roxabi/factory/blobstore` is the container view (bind-mounted into `factory-blobstore` via `Volume=/data/factory/blobs:/home/factory/.roxabi/factory/blobstore:z`). All backup and restore commands below reference the canonical host path.
+> **Host vs container path:** `~/.roxabi/factory/blobstore` is both the canonical host path and the container view (bind-mounted via `Volume=%h/.roxabi/factory/blobstore:/home/factory/.roxabi/factory/blobstore:z`). All backup and restore commands below reference this path.
 
 The BlobStore consists of two parts that must be snapshotted in order: the SQLite index
-(`/data/factory/blobs/index.sqlite`) first, then the content-addressed shard tree
-(`/data/factory/blobs/`). Reversing the order risks capturing a `blob_refs` row
+(`~/.roxabi/factory/blobstore/index.sqlite`) first, then the content-addressed shard tree
+(`~/.roxabi/factory/blobstore/`). Reversing the order risks capturing a `blob_refs` row
 whose shard file was not yet in the snapshot — a phantom row at restore time.
 
 `FsBlobStore` uses a per-instance `asyncio.Lock`, not a global write-quiesce. A concurrent
@@ -373,12 +373,12 @@ row was NOT captured in the DB snapshot. The restore invariant handles this safe
 1. Snapshot the SQLite index (atomic per the SQLite `.backup` API):
    ```bash
    mkdir -p /tmp/blobstore-snapshot
-   sqlite3 /data/factory/blobs/index.sqlite ".backup '/tmp/blobstore-snapshot/index.sqlite'"
+   sqlite3 ~/.roxabi/factory/blobstore/index.sqlite ".backup '/tmp/blobstore-snapshot/index.sqlite'"
    ```
 
 2. Snapshot the shard tree together with the DB snapshot (use hardlinks to minimise disk usage):
    ```bash
-   cp -al /data/factory/blobs /tmp/blobstore-snapshot/blobs
+   cp -al ~/.roxabi/factory/blobstore /tmp/blobstore-snapshot/blobs
    ```
    For off-host backup, pipe through Restic or similar:
    ```bash
@@ -420,29 +420,6 @@ bug that the step-1-before-step-2 ordering prevents.
 
 → See `docs/architecture/storage.md` (BlobStore section) for the write-durability invariant
 that underpins this restore procedure.
-
-## Host-level mount requirements
-
-The `/data/factory/blobs` filesystem must be mounted with `noatime` and `nodiratime` on the host. This prevents every blob read (GET, HEAD, or consistency check) from updating the inode `atime`, which would otherwise generate unnecessary write I/O and accelerate SSD wear on the content-addressed shard tree.
-
-Verify current mount options:
-
-```bash
-findmnt -n -o OPTIONS /data/factory/blobs
-```
-
-If `noatime` is missing, update `/etc/fstab` and remount:
-
-```bash
-# Example fstab entry
-/dev/mapper/data-lyra-blobs  /data/factory/blobs  ext4  defaults,noatime,nodiratime  0  2
-```
-
-Apply without reboot:
-
-```bash
-sudo mount -o remount,noatime,nodiratime /data/factory/blobs
-```
 
 ## Diagnostic
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -151,8 +151,8 @@ The `wire_discord_adapters` function returns `(adapters, dispatchers, thread_sto
 
 Binary payloads (Telegram/Discord attachments, STT/TTS audio) are stored behind a `BlobStore`
 Protocol with three methods: `put`, `get`, `exists`. The v1 backend is `FsBlobStore`: a
-SHA-256-addressed flat-FS tree (`/data/factory/blobs/<sha[:2]>/<sha>`) plus a SQLite index at
-`/data/factory/blobs/index.sqlite` (two tables: `blobs` keyed by `content_hash`; `blob_refs` for
+SHA-256-addressed flat-FS tree (`~/.roxabi/factory/blobstore/<sha[:2]>/<sha>`) plus a SQLite index at
+`~/.roxabi/factory/blobstore/index.sqlite` (two tables: `blobs` keyed by `content_hash`; `blob_refs` for
 per-ingestion provenance). The backend runs on `factory-hub` role (M₁) and is exposed via a
 dedicated Quadlet container `factory-blobstore.container` (FastAPI on TCP `:8449`, image
 `ghcr.io/roxabi/factory` + `lyra blobstore serve` subcommand) — V8 issue #1330. Host paths:

--- a/docs/data-dirs.md
+++ b/docs/data-dirs.md
@@ -5,7 +5,7 @@ Lyra stores runtime data in two root locations:
 | Host path | Purpose | Container path |
 |---|---|---|
 | `~/.roxabi/factory/` | Application vault (databases, secrets, config, env) | `/home/factory/.roxabi/factory` (via `factory-data.volume`) |
-| `/data/factory/blobs/` | BlobStore shard tree + SQLite index | `/home/factory/.roxabi/factory/blobstore` (via bind-mount in `factory-blobstore.container`) |
+| `~/.roxabi/factory/blobstore/` | BlobStore shard tree + SQLite index | `/home/factory/.roxabi/factory/blobstore` (via bind-mount in `factory-blobstore.container`) |
 
 ---
 
@@ -23,13 +23,11 @@ Lyra stores runtime data in two root locations:
 | `nkeys/` | NATS nkey seeds and `auth.conf` | **Synced** |
 | `env/` | Quadlet env files (`hub.env`, `blobstore.env`) | **Synced** |
 | `nats/jetstream/` | JetStream persistent storage | **Excluded** (host-local, large WAL files) |
-| `blobstore/` | **Symlink / container view** — points to `/data/factory/blobs/` | **Excluded** (canonical path is `/data/factory/blobs/`) |
-
-**Note:** `~/.roxabi/factory/blobstore/` is a bind-mount view from the container perspective. The canonical host directory is `/data/factory/blobs/`. Backups and Syncthing exclusions must reference the canonical path.
+| `blobstore/` | BlobStore shard tree + SQLite index (real directory) | **Excluded** (large binary data — see Syncthing exclusions below) |
 
 ---
 
-## `/data/factory/blobs/` — BlobStore canonical host path
+## `~/.roxabi/factory/blobstore/` — BlobStore host path
 
 | Subdirectory / File | Purpose |
 |---|---|
@@ -55,8 +53,7 @@ Syncthing syncs `~/.roxabi/factory/` across M₁, M₂, and laptop. The followin
 | Path | Reason |
 |---|---|
 | `~/.roxabi/factory/nats/jetstream/` | Host-local JetStream WAL; large, not portable |
-| `~/.roxabi/factory/blobstore/` | Redirects to `/data/factory/blobs/`; large binary data |
-| `/data/factory/blobs/` | Canonical BlobStore host path; excluded from Syncthing |
+| `~/.roxabi/factory/blobstore/` | Large append-only binary data; high churn — excluded from Syncthing |
 
 Exclusion rule (add to `.stignore` in `~/.roxabi/factory/`):
 
@@ -65,5 +62,3 @@ Exclusion rule (add to `.stignore` in `~/.roxabi/factory/`):
 nats/jetstream
 blobstore
 ```
-
-The `/data/factory/blobs/` path is outside `~/.roxabi/factory/` so it does not need an `.stignore` rule — it is excluded by simply not adding it to Syncthing at all.

--- a/packages/roxabi-blobs/README.md
+++ b/packages/roxabi-blobs/README.md
@@ -11,7 +11,7 @@ Implements [ADR-067](../../docs/architecture/adr/067-blobstore-abstraction-flat-
 ```python
 from roxabi_blobs import BlobStore, BlobRef, BlobNotFoundError, BlobWriteError
 
-async with FsBlobStore(root=Path("/data/factory/blobs")) as store:
+async with FsBlobStore(root=Path.home() / ".roxabi/factory/blobstore") as store:
     ref = await store.put(data, mime="audio/ogg", source="telegram")
     bytes_back = await store.get(ref.store_key)
     found = await store.exists(ref.content_hash)

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -211,17 +211,25 @@ class TestBlobstoreDataDir:
         combined = result.stdout + result.stderr
         # §5: `run mkdir -p <HOME>/.roxabi/factory/blobstore` → [dry-run] mkdir -p ...
         # and `echo "  [ok]   <HOME>/.roxabi/factory/blobstore"` (always printed)
+        # Pin to the §5 path token (.roxabi/factory/blobstore with slash) so the
+        # filter excludes unrelated lines like "factory-blobstore.service enabled"
+        # which use a hyphen instead.
         blobstore_lines = [
             line
             for line in combined.splitlines()
-            if "blobstore" in line and ("mkdir" in line or "[ok]" in line)
+            if ".roxabi/factory/blobstore" in line
+            and ("mkdir" in line or "[ok]" in line)
         ]
         assert blobstore_lines, (
             "Dry-run must log a mkdir or [ok] line for the blobstore data dir.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
-        assert "mkdir" in combined and "blobstore" in combined, (
-            "Dry-run output must mention both 'mkdir' and 'blobstore'.\n"
+        assert any(
+            "[dry-run] mkdir" in line and ".roxabi/factory/blobstore" in line
+            for line in combined.splitlines()
+        ), (
+            "Dry-run must emit '[dry-run] mkdir ... .roxabi/factory/blobstore'"
+            " (§5 mkdir absent).\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
 

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -2,9 +2,8 @@
 
 Contract map:
   A — dry-run lists all 7 factory-nats-* (incl. factory-nats-gh-helper — the #9 miss)
-  B — blob symlink guard (#13): non-empty non-symlink dir at blobstore target
-      → dry-run warns with remediation hint
-  C — empty non-symlink dir at blobstore target → dry-run logs rm action
+  B — blobstore data dir: dry-run logs mkdir of ~/.roxabi/factory/blobstore;
+      pre-existing content never blocks
   D — missing nkeys dir → exits 1 (pre-condition gate)
 
 Implementation note: deploy/install.sh uses $HOME for all data paths.
@@ -191,97 +190,68 @@ class TestDryRunListsAllNatsSecrets:
 
 
 # ---------------------------------------------------------------------------
-# Section B — blob symlink guard: non-empty non-symlink dir → warn in dry-run
+# Section B — blobstore data dir: mkdir logged; pre-existing content never blocks
 # ---------------------------------------------------------------------------
 
 
-class TestBlobSymlinkGuardDryRun:
-    """#13: non-empty non-symlink blobstore dir → dry-run emits WARN."""
+class TestBlobstoreDataDir:
+    """§5 creates ~/.roxabi/factory/blobstore as a plain dir; no guard logic."""
 
-    def test_nonempty_dir_triggers_warn_in_dry_run(self, tmp_path: Path) -> None:
-        """Dry-run warns when blobstore is a non-empty real directory."""
+    def test_blobstore_dir_is_created(self, tmp_path: Path) -> None:
+        """Fresh HOME with no blobstore dir: dry-run logs mkdir for blobstore."""
         _create_stub_seeds(tmp_path)
-
-        blobstore_dir = tmp_path / ".roxabi" / "factory" / "blobstore"
-        blobstore_dir.mkdir(parents=True, exist_ok=True)
-        (blobstore_dir / "existing-blob.bin").write_bytes(b"data")
+        # No blobstore dir pre-created — let install.sh handle it.
 
         result = _run_install_dry_run(tmp_path)
 
+        assert result.returncode == 0, (
+            f"install.sh --dry-run exited {result.returncode}.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
         combined = result.stdout + result.stderr
-        assert (
-            "WARN" in combined or "warn" in combined.lower() or "BLOCK" in combined
-        ), (
-            "Dry-run must warn about non-empty blobstore dir blocking install.\n"
+        # §5: `run mkdir -p <HOME>/.roxabi/factory/blobstore` → [dry-run] mkdir -p ...
+        # and `echo "  [ok]   <HOME>/.roxabi/factory/blobstore"` (always printed)
+        blobstore_lines = [
+            line
+            for line in combined.splitlines()
+            if "blobstore" in line and ("mkdir" in line or "[ok]" in line)
+        ]
+        assert blobstore_lines, (
+            "Dry-run must log a mkdir or [ok] line for the blobstore data dir.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
-        assert "blobstore" in combined.lower(), (
-            "Warning must mention blobstore.\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-
-    def test_nonempty_dir_warning_communicates_block(self, tmp_path: Path) -> None:
-        """Dry-run warning for non-empty blobstore dir uses 'BLOCK' text."""
-        _create_stub_seeds(tmp_path)
-
-        blobstore_dir = tmp_path / ".roxabi" / "factory" / "blobstore"
-        blobstore_dir.mkdir(parents=True, exist_ok=True)
-        (blobstore_dir / "data.bin").write_bytes(b"\x00" * 16)
-
-        result = _run_install_dry_run(tmp_path)
-
-        combined = result.stdout + result.stderr
-        # Script text: "would BLOCK install (run without --dry-run to see full error)"
-        assert "BLOCK" in combined or "non-empty" in combined.lower(), (
-            "Dry-run must communicate that non-empty dir blocks live install.\n"
+        assert "mkdir" in combined and "blobstore" in combined, (
+            "Dry-run output must mention both 'mkdir' and 'blobstore'.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
 
-    def test_empty_dir_at_blobstore_dry_runs_rm(self, tmp_path: Path) -> None:
-        """Empty non-symlink dir at blobstore: dry-run logs rm or ln action.
+    def test_preexisting_nonempty_blobstore_does_not_block(
+        self, tmp_path: Path
+    ) -> None:
+        """Pre-existing blobs in blobstore dir must never block dry-run.
 
-        The live path removes the empty dir; dry-run logs the action without
-        executing.
+        §5 removed the symlink guard entirely.  A real dir with content is
+        the expected production state — install must not error or warn on it.
         """
         _create_stub_seeds(tmp_path)
 
         blobstore_dir = tmp_path / ".roxabi" / "factory" / "blobstore"
         blobstore_dir.mkdir(parents=True, exist_ok=True)
-        # Empty directory — safe to remove per install.sh logic.
+        (blobstore_dir / "existing-blob.bin").write_bytes(b"\x00" * 64)
 
         result = _run_install_dry_run(tmp_path)
 
         combined = result.stdout + result.stderr
-        # Script must log the rm or subsequent ln action.
-        assert "[dry-run] rm" in combined or "[dry-run] ln" in combined, (
-            "Dry-run must log the rm or ln action for blobstore symlink.\n"
+        assert result.returncode == 0, (
+            "Dry-run must exit 0 even when blobstore dir is non-empty.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
-
-
-# ---------------------------------------------------------------------------
-# Section C — dry-run proceeds normally when blobstore target is a symlink
-# ---------------------------------------------------------------------------
-
-
-class TestBlobSymlinkGuardSymlink:
-    """When blobstore target is already a symlink, dry-run must not warn."""
-
-    def test_existing_symlink_does_not_trigger_guard(self, tmp_path: Path) -> None:
-        """If blobstore is already a symlink, dry-run proceeds without error."""
-        _create_stub_seeds(tmp_path)
-
-        blobstore_link = tmp_path / ".roxabi" / "factory" / "blobstore"
-        blobstore_link.parent.mkdir(parents=True, exist_ok=True)
-        fake_target = tmp_path / "blobs"
-        fake_target.mkdir()
-        blobstore_link.symlink_to(fake_target)
-
-        result = _run_install_dry_run(tmp_path)
-
-        # Should not produce blobstore-guard ERROR
-        assert result.returncode == 0, (
-            "Dry-run must succeed when blobstore is already a symlink.\n"
+        assert "BLOCK" not in combined, (
+            "Dry-run must NOT emit 'BLOCK' for a non-empty blobstore dir.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "would BLOCK" not in combined, (
+            "Dry-run must NOT emit 'would BLOCK' for a non-empty blobstore dir.\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
 
@@ -385,8 +355,7 @@ declare -A SECRET_POLICY=(
         )
         combined = result.stderr + result.stdout
         assert "refusing" in combined.lower() or "unexpected" in combined.lower(), (
-            "stderr must mention refusing/unexpected line.\n"
-            f"stderr:\n{result.stderr}"
+            f"stderr must mention refusing/unexpected line.\nstderr:\n{result.stderr}"
         )
         assert not sentinel.exists(), (
             "Sentinel file was created — injected command executed! Parser is broken."


### PR DESCRIPTION
## Summary
- Retire the `/data/factory/blobs` host path + the `~/.roxabi/factory/blobstore` symlink redirect. Blobs now live **directly** at the data-dir convention path `~/.roxabi/factory/blobstore` (real dir, no indirection). Only the host source of the quadlet `Volume=` changes; container-side path (`/home/factory/.roxabi/factory/blobstore`, uid 1500) is unchanged.
- Operator decision: the dedicated-volume rationale (`/dev/mapper/data-lyra-blobs`, noatime) was never realized on M₁ (`findmnt` fails — `/data` is just a dir on root fs), and the split design diverged into two stale stores that blocked `install.sh` (#1740). Simplify to one canonical in-home path.
- `install.sh` §5 drops the `/data` mkdir + `findmnt` warn + the non-symlink-dir guard/`ln -s` block → single idempotent `mkdir -p ~/.roxabi/factory/blobstore`. Docs (data-dirs, QUADLET-DEPLOYMENT, storage) repointed; noatime/fstab section removed.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1744: retire /data blobstore symlink | OPEN |
| Implementation | 1 commit on `feat/1744-blobstore-retire-data-symlink` | Complete |
| Verification | `/data/factory/blobs` residual grep = 0 · volumes_table ✅ · secrets_drift ✅ · `bash -n install.sh` ✅ | Passed |

## Test Plan
- [ ] CI green (volumes_table + secrets_drift gates)
- [ ] Post-merge M₁ deploy: blobstore healthy on `~/.roxabi/factory/blobstore`, `/data/factory/blobs` removed (closes #1740 via timer install in the same `install.sh` run)

Closes #1744

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)