### PR TITLE
fix(deploy): drop systemctl enable on generated blobstore unit (#1746)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -302,7 +302,6 @@ log "Reloading systemd user daemon ..."
 run systemctl --user daemon-reload
 echo "  [ok]   daemon-reload"
 
-
 # ── 8. Seed BotStore from config.toml (idempotent) ─────────────────────────
 # Required since #1416: Authenticator reads from BotStore, not config.toml.
 # Skipping this causes a hub crash-loop on first boot.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -302,9 +302,6 @@ log "Reloading systemd user daemon ..."
 run systemctl --user daemon-reload
 echo "  [ok]   daemon-reload"
 
-log "Enabling factory-blobstore.service ..."
-run systemctl --user enable factory-blobstore.service
-echo "  [ok]   factory-blobstore.service enabled"
 
 # ── 8. Seed BotStore from config.toml (idempotent) ─────────────────────────
 # Required since #1416: Authenticator reads from BotStore, not config.toml.

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -302,14 +302,21 @@ class TestBlobstoreServiceNotExplicitlyEnabled:
         #   run systemctl --user enable factory-blobstore.service
         # Under --dry-run `run` emits:
         #   [dry-run] systemctl --user enable factory-blobstore.service
-        # If this assertion fires, the line was re-added and must be removed.
-        bad = "systemctl --user enable factory-blobstore.service"
-        assert bad not in combined, (
-            "install.sh must NOT call `systemctl --user enable"
-            " factory-blobstore.service`.\n"
+        # Match any line that both enables AND names the blobstore unit, so the
+        # guard also catches re-introductions that append `--now` (the sibling
+        # §10 `enable --now podman-auto-update.timer` makes that variant likely).
+        offenders = [
+            line
+            for line in combined.splitlines()
+            if "enable" in line and "factory-blobstore.service" in line
+        ]
+        assert not offenders, (
+            "install.sh must NOT `systemctl --user enable` factory-blobstore.service"
+            " (any variant, incl. `--now`).\n"
             "Quadlet units auto-enable via [Install] WantedBy= at daemon-reload;\n"
             "explicit enable fails on generated units and aborts install.sh"
             " before §9/§10 (#1746).\n"
+            f"offending lines: {offenders}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
 

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -212,8 +212,8 @@ class TestBlobstoreDataDir:
         # §5: `run mkdir -p <HOME>/.roxabi/factory/blobstore` → [dry-run] mkdir -p ...
         # and `echo "  [ok]   <HOME>/.roxabi/factory/blobstore"` (always printed)
         # Pin to the §5 path token (.roxabi/factory/blobstore with slash) so the
-        # filter excludes unrelated lines like "factory-blobstore.service enabled"
-        # which use a hyphen instead.
+        # filter excludes unrelated lines like "factory-nats-blobstore already exists"
+        # which use a hyphen instead of a slash.
         blobstore_lines = [
             line
             for line in combined.splitlines()
@@ -260,6 +260,56 @@ class TestBlobstoreDataDir:
         )
         assert "would BLOCK" not in combined, (
             "Dry-run must NOT emit 'would BLOCK' for a non-empty blobstore dir.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section C — regression: blobstore Quadlet unit must NOT be explicitly enabled
+# ---------------------------------------------------------------------------
+
+
+class TestBlobstoreServiceNotExplicitlyEnabled:
+    """Guard against re-adding `systemctl enable factory-blobstore.service` (#1746).
+
+    Quadlet units are generator-managed: they auto-enable via [Install]
+    WantedBy=default.target at daemon-reload, exactly like every other factory-*
+    unit. `systemctl --user enable` on a generated unit fails with
+    "Unit ... is transient or generated", and under `set -euo pipefail` that
+    aborts install.sh before §9 (timer install) and §10 (auto-update enable).
+
+    Note: the dry-run wrapper only echoes commands; it cannot reproduce the live
+    failure (the `run` function prints "[dry-run] ..." instead of executing).
+    This test guards against the broken line being re-added, not the runtime abort.
+    """
+
+    def test_blobstore_service_not_explicitly_enabled(self, tmp_path: Path) -> None:
+        """Dry-run must NOT contain `systemctl --user enable factory-blobstore.service`.
+
+        Regression test for #1746: explicit enable on a Quadlet-generated unit
+        caused install.sh to abort under set -euo pipefail before §9/§10.
+        """
+        _create_stub_seeds(tmp_path)
+
+        result = _run_install_dry_run(tmp_path)
+
+        assert result.returncode == 0, (
+            f"install.sh --dry-run exited {result.returncode}.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        # The broken line was:
+        #   run systemctl --user enable factory-blobstore.service
+        # Under --dry-run `run` emits:
+        #   [dry-run] systemctl --user enable factory-blobstore.service
+        # If this assertion fires, the line was re-added and must be removed.
+        bad = "systemctl --user enable factory-blobstore.service"
+        assert bad not in combined, (
+            "install.sh must NOT call `systemctl --user enable"
+            " factory-blobstore.service`.\n"
+            "Quadlet units auto-enable via [Install] WantedBy= at daemon-reload;\n"
+            "explicit enable fails on generated units and aborts install.sh"
+            " before §9/§10 (#1746).\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
 


### PR DESCRIPTION
## Summary
- Remove the `systemctl --user enable factory-blobstore.service` call from `deploy/install.sh` (§8). Quadlet units are **generator-managed** and auto-enable via their `[Install] WantedBy=default.target` at `daemon-reload`; `systemctl enable` on such a unit fails `Unit … is transient or generated`, and under `set -euo pipefail` that **aborted install.sh before §9** (`make quadlet-sync-install`) **and §10** (auto-update enable) — the root cause of #1740 (the #1729 timers were never installed on M₁).
- `factory-blobstore.container` already carries `WantedBy=default.target`, so it auto-enables exactly like every other quadlet unit in the bundle (hub, telegram, discord, nats…), none of which are explicitly enabled.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1746: install.sh aborts at `systemctl enable` on generated quadlet unit | OPEN |
| Implementation | 1 commit on `feat/1746-install-enable-generated-unit` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new regression test) | Passed |

## Test Plan
- [ ] `uv run pytest tests/tools/test_install_dry_run.py -q` → all pass (11)
- [ ] New `test_blobstore_service_not_explicitly_enabled` fails if the enable line is re-added (mutation-proven)
- [ ] On a live M₁ box: a full `bash deploy/install.sh` run now reaches §9/§10 without aborting (validated manually 2026-06-04 during the #1740 deploy)

> Note: the dry-run pytest cannot reproduce the live failure (the `run` wrapper only echoes commands), so the new test guards against the broken line being re-added rather than the runtime abort itself.

Fixes #1746

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
