### PR TITLE
ci(deploy): auto-merge dependabot patch/minor + keep all open PRs current

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Update all reviewed PRs targeting this branch
+      - name: Update all open non-draft PRs targeting this branch
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          PRS=$(gh pr list --base "$BRANCH" --label reviewed --state open --json number,headRefOid --jq '.[]')
+          PRS=$(gh pr list --base "$BRANCH" --state open --json number,headRefOid,isDraft --jq '.[] | select(.isDraft | not)')
           if [ -z "$PRS" ]; then
-            echo "No reviewed PRs targeting $BRANCH"
+            echo "No open non-draft PRs targeting $BRANCH"
             exit 0
           fi
           echo "$PRS" | while IFS= read -r pr; do

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,43 @@
+# Auto-merge Dependabot PRs by feeding them into the existing reviewed-label
+# machinery in auto-merge.yml. Runs in pull_request_target context so the PAT
+# Actions secret is available — Dependabot-triggered runs receive only Dependabot
+# secrets, not Actions secrets, so a normal pull_request trigger could not use PAT.
+#
+# SAFE: never checks out or executes PR code. It only reads dependabot metadata via
+# the API and applies a label. No `actions/checkout`, no run of PR-authored scripts.
+#
+# Cascade: dependabot opens PR -> (patch|minor) -> add `reviewed` label via PAT ->
+#   PAT-applied label fires auto-merge.yml `labeled` event -> arms GitHub auto-merge
+#   -> update-behind-prs keeps it current on each staging push -> merges when green.
+# Major bumps are NOT labelled -> they wait for human review.
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reviewed-label:
+    name: Label dependabot patch/minor reviewed
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add reviewed label (patch/minor only)
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr edit "$PR_URL" --add-label reviewed
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Root cause

Two gaps in the existing automation:

1. **Dependabot PRs never got `reviewed`** — the `auto-merge.yml` machinery only arms PRs that already carry the `reviewed` label. Dependabot opened PRs but nothing ever applied that label, so they sat indefinitely waiting for a human click.

2. **Strict up-to-date requirement re-staled everything** — `update-behind-prs` only rebased `--label reviewed` PRs. Any PR without that label would fall behind on every `staging` push and fail the branch-protection up-to-date gate.

## What this PR does

**Part 1 — new `dependabot-automerge.yml`**

Runs on `pull_request_target` (required: `pull_request` runs cannot access Actions secrets under Dependabot — they only receive Dependabot secrets). The workflow is label-only and safe: no `actions/checkout`, no execution of PR-authored code.

Cascade:
```
dependabot opens PR
  → fetch-metadata classifies bump type
  → patch/minor → add `reviewed` label via PAT
  → label fires auto-merge.yml `labeled` event
  → arms GitHub auto-merge (merge commit)
  → update-behind-prs keeps it current on each staging push
  → merges when all required status checks pass
```

Major bumps are **not** labelled and wait for human review.

`dependabot/fetch-metadata` is pinned to commit SHA `21025c705c08248db411dc16f3619e6b5f9ea21a` (v2) per repo convention.

**Part 2 — broaden `update-behind-prs` in `auto-merge.yml`**

Changed `gh pr list` from `--label reviewed` to all open non-draft PRs (`select(.isDraft | not)`). Draft PRs are excluded to avoid churning WIP branches. The `update-branch` API call (merge-update, additive — no force-push) is unchanged.

## Validation

- YAML parses clean (`python3 -c "import yaml…"`)
- `actionlint` not installed locally; CI will gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)