### PR TITLE
docs: fix pre-existing error/deploy doc-rot + lyra-send runtime path (#1703)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,23 +97,18 @@ class SignalAdapter(OutboundAdapterBase):
     async def send(self, original_msg: InboundMessage, outbound: OutboundMessage) -> None:
         ...
 
-    def _make_streaming_callbacks(self, original_msg, outbound) -> PlatformCallbacks:
-        return PlatformCallbacks(
-            send_placeholder=...,
-            edit_placeholder_text=...,
-            edit_placeholder_tool=...,
-            send_message=...,
-            send_fallback=...,
-            chunk_text=...,
-            start_typing=...,
-            cancel_typing=...,
-        )
+    def _make_emitter(
+        self,
+        original_msg: InboundMessage,
+        outbound: OutboundMessage | None,
+    ) -> OutboundEmitter:
+        ...
 
     def _start_typing(self, scope_id): ...
     def _cancel_typing(self, scope_id): ...
 ```
 
-`send_streaming()` is provided by `OutboundAdapterBase` — do not override it. Platform-specific streaming behaviour belongs in `_make_streaming_callbacks()`.
+`send_streaming()` is provided by `OutboundAdapterBase` — do not override it. Platform-specific streaming behaviour belongs in `_make_emitter()`.
 
 See `src/factory/adapters/_shared.py` for shared normalization helpers and render functions (audio, attachments).
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -81,7 +81,7 @@ make lyra reload        # restart containers
 
 **Graceful drain** — on restart, the running container finishes any in-flight Claude CLI turns (up to 60 s) before stopping. Conversations that complete within the window are transparent to users; only turns that outlast 60 s receive a "please resend" notification.
 
-**Deploy log** — every run is appended to `~/.local/state/factory/logs/deploy.log`.
+**Deploy log** — deploy runs log to journald (the converge services use `StandardOutput=journal`). Inspect with `journalctl --user -u factory-quadlet-sync` or `journalctl --user -u factory-post-autoupdate`.
 
 ## 2. Configure environment
 

--- a/docs/architecture/architecture-patterns.md
+++ b/docs/architecture/architecture-patterns.md
@@ -297,7 +297,7 @@ User-visible errors are handled at two distinct sites, each using domain-specifi
 
 Cross-layer exceptions (`StreamChunkTimeout`, `WorkerUnavailableError`, `HubUnavailableError`, `ScrapeFailed`, `VaultWriteFailed`) live in `factory.core.exceptions` to avoid downward imports — they are raised in outer layers but defined in core.
 
-NullMessageManager replaces `if hub._msg_manager is None: return _DROP` guards, making misconfiguration observable instead of silently dropping messages. → ADR-058
+ADR-058 specifies a `NullMessageManager` to replace the `if hub._msg_manager is None: return _DROP` guards (making misconfiguration observable instead of silently dropping messages), but it is **not yet implemented** — the live pattern remains the `_DROP` guard in `SttMiddleware`. → ADR-058 <!-- drift-ignore -->
 
 ### Generic error reply placement
 

--- a/docs/standards/backend-patterns.md
+++ b/docs/standards/backend-patterns.md
@@ -98,7 +98,7 @@ Every platform adapter must implement `ChannelAdapter` (defined in `core/hub/hub
 | `render_audio_stream(chunks, inbound)` | Stream TTS audio chunks |
 | `render_attachment(msg, inbound)` | Send an attachment |
 
-Do NOT override `send_streaming()` in a concrete adapter — it is a concrete method on `OutboundAdapterBase` that delegates to `StreamingSession`. Platform differences belong in `_make_streaming_callbacks()`.
+Do NOT override `send_streaming()` in a concrete adapter — it is a concrete method on `OutboundAdapterBase` that drives the `OutboundEmitter` returned by `_make_emitter()`. Platform differences belong in `_make_emitter()`.
 
 ### Inbound push
 
@@ -318,7 +318,7 @@ NEVER add business logic to `Hub` — it belongs in Middleware, Pool, or Agent.
 
 NEVER call store async methods before `connect()` or from synchronous code.
 
-NEVER override `send_streaming()` in a concrete adapter — put differences in `_make_streaming_callbacks()`.
+NEVER override `send_streaming()` in a concrete adapter — put differences in `_make_emitter()`.
 
 NEVER put platform-specific code in `core/` — that belongs in `adapters/`.
 

--- a/plugins/lyra-send/skills/send/SKILL.md
+++ b/plugins/lyra-send/skills/send/SKILL.md
@@ -52,7 +52,7 @@ python3 - <<'EOF'
 from pathlib import Path
 import sqlite3, json
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 conn = sqlite3.connect(factory_dir / 'turns.db')
 # Show recent unique telegram chat IDs with last message preview
 rows = conn.execute("""
@@ -81,7 +81,7 @@ python3 - <<'EOF'
 from pathlib import Path
 import sqlite3, json
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 conn = sqlite3.connect(factory_dir / 'turns.db')
 rows = conn.execute("""
     SELECT platform_meta, content, created_at
@@ -121,7 +121,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
 conn = sqlite3.connect(factory_dir / 'config.db')
@@ -150,7 +150,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
 conn = sqlite3.connect(factory_dir / 'config.db')
@@ -181,7 +181,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
 conn = sqlite3.connect(factory_dir / 'config.db')
@@ -210,7 +210,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
 conn = sqlite3.connect(factory_dir / 'config.db')
@@ -241,7 +241,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
 conn = sqlite3.connect(factory_dir / 'config.db')
@@ -271,7 +271,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 import sqlite3, requests
 
-factory_dir = Path.home() / '.lyra'
+factory_dir = Path.home() / '.roxabi' / 'factory'
 key = (factory_dir / 'keyring.key').read_bytes()
 f = Fernet(key)
 conn = sqlite3.connect(factory_dir / 'config.db')


### PR DESCRIPTION
Fixes the 4 pre-existing doc-rot items from #1703 (surfaced in the #1702 review, out of #1674's rename scope). Doc-only — no code/wire touched.

| # | File(s) | Was | Now |
|---|---------|-----|-----|
| 1 | `docs/standards/backend-patterns.md` (101, 321) · `CONTRIBUTING.md` (100-110, 116) | `_make_streaming_callbacks()` / `StreamingSession` (removed in S7 #1501) | `_make_emitter()` → `OutboundEmitter`; CONTRIBUTING example realigned to the real abstract signature (`_base_outbound.py`) |
| 2 | `docs/architecture/architecture-patterns.md` (300) | `NullMessageManager` described as implemented (ADR-058) | reworded to **specified-but-unimplemented**; live pattern stays the `_DROP` guard in `SttMiddleware` (+ `<!-- drift-ignore -->`) |
| 3 | `docs/DEPLOYMENT.md` (84) | runs appended to never-written `~/.local/state/factory/logs/deploy.log` | journald pointer (`journalctl --user -u factory-quadlet-sync` / `factory-post-autoupdate`) |
| 4 | `plugins/lyra-send/skills/send/SKILL.md` (×8) | `Path.home() / '.lyra'` (non-existent path) | `~/.roxabi/factory` — verified canonical via `plugins/lyra-send/CLAUDE.md` |

Ground truth verified live (symbols in `src/`, `converge.sh` has no `tee`, token dir on M₁). `tools/check_doc_drift.py` → **PASS** (0 new violations).

Closes #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)