### PR TITLE
fix(ops): default NATS_UNIT to factory-nats.service in check-nats-acls.sh

### DIFF
--- a/tools/check-nats-acls.sh
+++ b/tools/check-nats-acls.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Stream journalctl for NATS permission violations after an ACL reload.
 #
-# Usage: scripts/check-nats-acls.sh [--since <timestamp>] [--window <seconds>]
-# Env:   NATS_UNIT=lyra-nats.service   (override systemd unit name; Quadlet container)
+# Usage: tools/check-nats-acls.sh [--since <timestamp>] [--window <seconds>]
+# Env:   NATS_UNIT=factory-nats.service   (override systemd unit name; Quadlet container)
 set -euo pipefail
 SINCE=""
 WINDOW="${WINDOW:-90}"
-NATS_UNIT="${NATS_UNIT:-lyra-nats.service}"
+NATS_UNIT="${NATS_UNIT:-factory-nats.service}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --since)  SINCE="$2"; shift 2 ;;


### PR DESCRIPTION
## Summary

- The NATS unit was renamed `lyra-nats` → `factory-nats` in the #1670 cutover; `check-nats-acls.sh` still defaulted to `lyra-nats.service`, causing the ACL post-reload check to silently watch a non-existent unit.
- The script also moved from `scripts/` to `tools/` in the same cutover; the usage comment retained the stale `scripts/` path.
- Both stale references (`NATS_UNIT` default + usage comment + env comment) updated to `factory-nats.service` / `tools/check-nats-acls.sh`. Surfaced during #1710 cutover verification recon.

## Test plan

- [ ] Confirm `tools/check-nats-acls.sh` runs against `factory-nats.service` on M₁ without `NATS_UNIT` override
- [ ] Confirm existing `NATS_UNIT` env-var override still respected (no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)