### PR TITLE
chore(deploy): stagger factory-post-autoupdate timer +2min to dedupe converge

### DIFF
--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -107,11 +107,11 @@ Three systemd user timers drive convergence **automatically**:
 |---|---|---|---|
 | `podman-auto-update.timer` | `*:0/5` (5 min) | `podman-auto-update.service` | Host-static apt unit (installed by `provision.sh`/`install.sh`); drop-in sets `OnCalendar=*:0/5`. Polls GHCR digests for containers labelled `io.containers.autoupdate=registry`; pulls and restarts on new digest. |
 | `factory-quadlet-sync.timer` | `*:0/5` (5 min) | `factory-quadlet-sync.service` | Pulls `origin/staging` for lyra. If `deploy/quadlet/**`, Makefile, or `tools/render_quadlet.py` changed, runs `make quadlet-install` (conditional, no full converge). |
-| `factory-post-autoupdate.timer` | `*:0/5` (5 min) | `factory-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). |
+| `factory-post-autoupdate.timer` | `*:2/5` (5 min, offset +2 min — #1751) | `factory-post-autoupdate.service` | Checks whether `podman-auto-update` has pulled a new image digest. On digest change, triggers the full `make converge` sequence (including auth.conf regen + secret refresh + restarts). Fires 2 min after `factory-quadlet-sync` so the `.converge-stamp` short-circuit in `converge.sh` deduplicates the two converge runs when both are triggered on the same staging merge. |
 
 `podman-auto-update` handles **image pulls** (CI-driven, registry-labelled containers).
-`factory-quadlet-sync` handles **unit/template changes** (code-driven).
-`factory-post-autoupdate` handles **post-pull convergence** (restarts + auth.conf regen).
+`factory-quadlet-sync` handles **unit/template changes** (code-driven); fires at `*:0/5`.
+`factory-post-autoupdate` handles **post-pull convergence** (restarts + auth.conf regen); fires at `*:2/5` (2 min later) so the stamp short-circuit prevents a redundant converge when quadlet-sync already ran.
 All three are required for fully hands-off deploys.
 
 ### Failure notification path

--- a/deploy/systemd/factory-post-autoupdate.timer
+++ b/deploy/systemd/factory-post-autoupdate.timer
@@ -2,7 +2,9 @@
 Description=Lyra post-autoupdate timer — check every 5 minutes
 
 [Timer]
-OnCalendar=*:0/5
+# Staggered +2 min after factory-quadlet-sync (fires at *:0/5) so the stamp
+# short-circuit in converge.sh deduplicates the two converge runs — #1751.
+OnCalendar=*:2/5
 Persistent=true
 Unit=factory-post-autoupdate.service
 


### PR DESCRIPTION
## Summary

- `factory-quadlet-sync.timer` and `factory-post-autoupdate.timer` both fired at `*:0/5`, racing on `/run/user/$UID/factory-deploy.lock` when a staging merge triggered both.
- Fix: shift `factory-post-autoupdate` to `*:2/5` (2 min later).
- The dedup is free: `converge.sh` is fingerprint-gated against `~/.roxabi/factory/.converge-stamp`. When quadlet-sync converges at `:00`, it writes the stamp; post-autoupdate firing at `:02` sees `fingerprint == stamp` → `is_converged=CONVERGED` → exits without taking the lock. No redundant restart, no race.

**Files changed:** `deploy/systemd/factory-post-autoupdate.timer` (OnCalendar), `deploy/CLAUDE.md` (timer table + prose).
No logic changes to `converge.sh` or `factory-post-autoupdate.sh`.

Closes #1751

## M₁ apply (manual, post-merge)

After merging, apply on M₁ with either:

```bash
# Option A — full idempotent install (recommended)
cd ~/projects/roxabi-factory && git pull && bash deploy/install.sh

# Option B — minimal timer-only refresh
cp deploy/systemd/factory-post-autoupdate.timer ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user restart factory-post-autoupdate.timer
```

Verify with: `systemctl --user list-timers factory-post-autoupdate.timer`
Expected: next trigger at a `:02`/`:07`/`:12`… minute boundary.

## Test plan

- [ ] Confirm `systemctl --user list-timers` on M₁ shows `factory-post-autoupdate.timer` next-elapse at `*:2/5` after apply
- [ ] Confirm no lock-contention errors in `journalctl --user -u factory-post-autoupdate.service` after next staging merge
- [ ] Confirm `factory-quadlet-sync.timer` still fires at `*:0/5` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)