### PR TITLE
fix(bootstrap): provision FACTORY_AUDIT stream in hub_standalone bootstrap

### DIFF
--- a/src/factory/bootstrap/standalone/hub_standalone.py
+++ b/src/factory/bootstrap/standalone/hub_standalone.py
@@ -178,6 +178,18 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
             )
             raise
 
+        from factory.infrastructure.audit import JetStreamAuditSink
+
+        _audit_sink = JetStreamAuditSink()
+        await _audit_sink.provision(nc)
+        if _audit_sink._degraded:  # noqa: SLF001
+            log.critical(
+                "hub_standalone: FACTORY_AUDIT stream provision failed — "
+                "security audit degraded for this process lifetime. "
+                "RestartSec will recover."
+            )
+            raise RuntimeError("FACTORY_AUDIT provision failed")
+
         # Publish each bot's watch_channels into factory-state KV before
         # announcing readiness so adapters see the value on first seed (SC6).
         _bots: list[tuple[str, str]] = [

--- a/src/factory/infrastructure/audit/jetstream_sink.py
+++ b/src/factory/infrastructure/audit/jetstream_sink.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from nats.js.client import JetStreamContext
 
 log = logging.getLogger(__name__)
-_security_log = logging.getLogger("lyra.security")
+_security_log = logging.getLogger("factory.security")
 
 _SUBJECT_PREFIX = "factory.audit.security"
 _SUBJECT_PRIVILEGED = f"{_SUBJECT_PREFIX}.privileged"

--- a/tests/bootstrap/test_discord_kv_wiring.py
+++ b/tests/bootstrap/test_discord_kv_wiring.py
@@ -342,6 +342,9 @@ class TestHubPublishesWatchChannelsBeforeReady:
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         raw_config = _hub_test_config()
         mock_nc, fake_open_stores = _make_hub_stubs()
+        mock_nc.jetstream.return_value = MagicMock(
+            add_stream=AsyncMock(), update_stream=AsyncMock()
+        )
 
         call_order: list[str] = []
 

--- a/tests/bootstrap/test_hub_standalone_readiness.py
+++ b/tests/bootstrap/test_hub_standalone_readiness.py
@@ -242,6 +242,9 @@ class TestHubAudioProvisioningBehavioral:
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         raw_config = _test_config()
         mock_nc, fake_open_stores = _make_hub_stubs()
+        mock_nc.jetstream.return_value = MagicMock(
+            add_stream=AsyncMock(), update_stream=AsyncMock()
+        )
 
         call_order: list[str] = []
 

--- a/tests/core/test_cli_spawn_audit.py
+++ b/tests/core/test_cli_spawn_audit.py
@@ -230,11 +230,11 @@ class TestJetStreamAuditSinkEmit:
             pid=1,
         )
 
-        with caplog.at_level(logging.WARNING, logger="lyra.security"):
+        with caplog.at_level(logging.WARNING, logger="factory.security"):
             await sink.emit(event)  # must not raise
 
-        # Publish failure routes to lyra.security with "AUDIT: emit failed" prefix
-        security_records = [r for r in caplog.records if r.name == "lyra.security"]
+        # Publish failure routes to factory.security with "AUDIT: emit failed" prefix
+        security_records = [r for r in caplog.records if r.name == "factory.security"]
         assert len(security_records) == 1
         assert security_records[0].message.startswith("AUDIT: emit failed")
 
@@ -265,13 +265,13 @@ class TestJetStreamAuditSinkEmit:
             pid=2,
         )
 
-        with caplog.at_level(logging.WARNING, logger="lyra.security"):
+        with caplog.at_level(logging.WARNING, logger="factory.security"):
             await sink.emit(event)
 
-        security_records = [r for r in caplog.records if r.name == "lyra.security"]
+        security_records = [r for r in caplog.records if r.name == "factory.security"]
         assert len(security_records) == 1
-        # Degraded mode must route exclusively to lyra.security
-        assert all(r.name == "lyra.security" for r in security_records)
+        # Degraded mode must route exclusively to factory.security
+        assert all(r.name == "factory.security" for r in security_records)
         import json
 
         # Message format: "AUDIT DEGRADED [<subject>]: <json>"

--- a/tests/core/test_jetstream_audit_provision.py
+++ b/tests/core/test_jetstream_audit_provision.py
@@ -203,10 +203,10 @@ class TestJetStreamAuditSinkSubjectRouting:
         sink._js = js  # type: ignore[attr-defined]
 
         event = _make_event(skip_permissions=True)
-        with caplog.at_level(logging.WARNING, logger="lyra.security"):
+        with caplog.at_level(logging.WARNING, logger="factory.security"):
             await sink.emit(event)  # type: ignore[arg-type]
 
         js.publish.assert_not_awaited()
-        security_records = [r for r in caplog.records if r.name == "lyra.security"]
+        security_records = [r for r in caplog.records if r.name == "factory.security"]
         assert len(security_records) == 1
         assert _SUBJECT_PRIVILEGED in security_records[0].message


### PR DESCRIPTION
## Summary

- `hub_standalone.py` provisioned audio streams but never called `JetStreamAuditSink.provision()` — `FACTORY_AUDIT` was never created in the standalone hub path, silently dropping all security audit events since the #1670 cutover (2026-06-03)
- Add fail-fast audit provision block after audio provisioning, before `announce_hub_ready`
- Fix logger-name drift: `lyra.security` → `factory.security` in `jetstream_sink.py` (#1670 follow-up)

## Root cause

`JetStreamAuditSink.provision()` was only wired in `unified.py` via `_init_clipool`. The `factory hub` subcommand uses `_bootstrap_hub_standalone()` which had no audit provisioning.

## Test plan

- [ ] Hub restart on M1 → `/jsz` shows `FACTORY_AUDIT` stream with subjects `factory.audit.>`
- [ ] Security event emitted to `factory.audit.security.privileged` (privileged action)
- [ ] No `AUDIT DEGRADED` log at boot

Closes #1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)