### PR TITLE
chore(deploy): #1801 rename Quadlet unit Description Lyra → Factory

### DIFF
--- a/deploy/quadlet/factory-blobstore.container
+++ b/deploy/quadlet/factory-blobstore.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra BlobStore HTTP service
+Description=Factory BlobStore HTTP service
 # Soft dependency — audit sink degrades to logger if NATS unreachable at startup;
 # blobstore can boot and serve HTTP traffic without NATS (see spec §Boot failure modes).
 After=factory-nats.service

--- a/deploy/quadlet/factory-clipool.container
+++ b/deploy/quadlet/factory-clipool.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra CliPool Worker
+Description=Factory CliPool Worker
 After=factory-nats.service
 After=factory-gh-pod.service
 # No Requires= on NATS — clipool connects directly; hub restarts must not cascade.

--- a/deploy/quadlet/factory-data.volume
+++ b/deploy/quadlet/factory-data.volume
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra data bind-mount — Hub (RW: auth.db, config.db, keyring.key) + TurnWriter sole writer turns.db (ADR-075). Hub mounts turns.db ro.
+Description=Factory data bind-mount — Hub (RW: auth.db, config.db, keyring.key) + TurnWriter sole writer turns.db (ADR-075). Hub mounts turns.db ro.
 # Bind-mount of %h/.roxabi/factory — used by the Hub container only (#943).
 # Adapters use per-file inline bind mounts (keyring.key, config.db, turns.db, discord.db)
 # to minimise blast radius on adapter compromise.

--- a/deploy/quadlet/factory-discord-data.volume
+++ b/deploy/quadlet/factory-discord-data.volume
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra Discord adapter private data — named volume for discord.db (#1721).
+Description=Factory Discord adapter private data — named volume for discord.db (#1721).
 # Named podman volume (podman-managed, no host bind) — used by the Discord adapter
 # container only.  Mounted at /home/factory/.roxabi/factory/discord inside
 # factory-discord, keeping discord.db isolated from the hub-shared factory-data.volume.

--- a/deploy/quadlet/factory-discord.container.tmpl
+++ b/deploy/quadlet/factory-discord.container.tmpl
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra Discord adapter
+Description=Factory Discord adapter
 # After= orders startup; no Requires=/BindsTo= so a hub restart does not
 # propagate a stop to the adapter. Adapters reconnect to NATS on their own
 # once the hub is back; tearing them down blocks auto-recovery.

--- a/deploy/quadlet/factory-gh-helper.container
+++ b/deploy/quadlet/factory-gh-helper.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra GitHub App token-mint helper (uid 1501)
+Description=Factory GitHub App token-mint helper (uid 1501)
 # Part of factory-gh.pod — must start before clipool connects to the dispenser.
 # BindsTo= ensures helper and clipool are stopped together; if the helper crashes
 # permanently the pod is torn down rather than leaving clipool without a token source.

--- a/deploy/quadlet/factory-gh.pod
+++ b/deploy/quadlet/factory-gh.pod
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra GitHub App pod (clipool + token-mint helper)
+Description=Factory GitHub App pod (clipool + token-mint helper)
 # Order after NATS: clipool needs NATS; helper only needs the tmpfs (available immediately).
 # No Requires= on clipool so a hub restart does not cascade.
 After=factory-nats.service

--- a/deploy/quadlet/factory-hub.container
+++ b/deploy/quadlet/factory-hub.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra Hub
+Description=Factory Hub
 After=factory-nats.service
 After=factory-blobstore.service
 Requires=factory-nats.service

--- a/deploy/quadlet/factory-jetstream.volume
+++ b/deploy/quadlet/factory-jetstream.volume
@@ -1,10 +1,10 @@
 [Unit]
-Description=Lyra JetStream persistent storage — bind-mount %h/.roxabi/factory/nats/jetstream into the NATS container
+Description=Factory JetStream persistent storage — bind-mount %h/.roxabi/factory/nats/jetstream into the NATS container
 # Provides durable backing for JetStream streams and KV buckets (factory-turns, factory-msg-index).
 # quadlet-install creates this directory automatically (install -d -m 0700).
 # On production (uid 1500): podman unshare chown 1500:1500 ~/.roxabi/factory/nats/jetstream
 # Moves JetStream state to a dedicated NATS subtree (~/.roxabi/factory/nats/) separate from
-# Lyra application files (auth.db, config.db, etc.) — hub has no reason to traverse
+# Factory application files (auth.db, config.db, etc.) — hub has no reason to traverse
 # into ~/.roxabi/factory/nats/, reducing the practical SELinux inode label conflict risk (ADR-068).
 
 [Volume]

--- a/deploy/quadlet/factory-nats.container
+++ b/deploy/quadlet/factory-nats.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra NATS server
+Description=Factory NATS server
 StartLimitIntervalSec=60
 StartLimitBurst=5
 

--- a/deploy/quadlet/factory-telegram.container.tmpl
+++ b/deploy/quadlet/factory-telegram.container.tmpl
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra Telegram adapter
+Description=Factory Telegram adapter
 # After= orders startup; no Requires=/BindsTo= so a hub restart does not
 # propagate a stop to the adapter. Adapters reconnect to NATS on their own
 # once the hub is back; tearing them down blocks auto-recovery.

--- a/deploy/quadlet/factory-turn-writer.container
+++ b/deploy/quadlet/factory-turn-writer.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra TurnWriter — JetStream subscriber for factory.turns.write
+Description=Factory TurnWriter — JetStream subscriber for factory.turns.write
 After=factory-nats.service
 Requires=factory-nats.service
 StartLimitIntervalSec=60


### PR DESCRIPTION
## Why
Final cosmetic residue of the `lyra` → `roxabi-factory` rename (#1671 Phase 4). Systemd unit `Description=` strings still rendered as `Lyra <service>` on M₁ (`Lyra Hub`, `Lyra NATS server`, …) despite `factory-*` unit names.

## What
Rename `Description=Lyra <x>` → `Description=Factory <x>` across all 12 Quadlet units (`.container` / `.volume` / `.pod` / `.tmpl`) + one comment in `factory-jetstream.volume`. Infra-facing text only — no functional/secret/volume directive changes.

**Kept (deliberate, #1671):** `lyra-harness` GitHub App identity (id 3619198) and the "Lyra GitHub App" runbook references — the App name is part of the kept-persona/identity set.

## Verify
Gates run locally green: `secrets_drift` ✅ · `volumes_table` ✅ · `doc_drift` ✅ · `architecture_snapshot` ✅. New Descriptions take effect on next `deploy.sh` + `daemon-reload` on M₁.

Refs #1801, #1671 (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)