### PR TITLE
docs(adr): renumber duplicate ADR-084 (documentation-architecture) → ADR-086

### DIFF
--- a/docs/architecture/adr/080-architecture-knowledge-ssot-2tier-doc-drift-gate.mdx
+++ b/docs/architecture/adr/080-architecture-knowledge-ssot-2tier-doc-drift-gate.mdx
@@ -1,13 +1,13 @@
 ---
 title: "ADR-080: Architecture Knowledge SSoT — Generated Current-State + Doc-Drift Gate"
 description: Two-tier architecture-knowledge model — code-generated current-state vs hand-authored intent — bridged by a CI doc-drift gate that makes silent rot loud.
-status: superseded by ADR-084
+status: superseded by ADR-086
 ---
 
 > **Current truth** → [`docs/architecture/ARCHITECTURE.md`](../../ARCHITECTURE.md){#current-truth}
 > This ADR is preserved as a decision record. For up-to-date state and invariants, read the domain page.
 
-> **Superseded by ADR-084.** See [`ADR-084`](084-documentation-architecture.mdx) for the unified meta-documentation plane successor.
+> **Superseded by ADR-086.** See [`ADR-086`](086-documentation-architecture.mdx) for the unified meta-documentation plane successor.
 
 ## Status
 

--- a/docs/architecture/adr/081-architecture-inventory-semantic-code-oracle.mdx
+++ b/docs/architecture/adr/081-architecture-inventory-semantic-code-oracle.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ADR-081: Architecture inventory via a semantic CodeInventory oracle (not per-gate textual heuristics)"
 description: Replaces the textual resolver in the ADR-080 doc-drift gate with a small in-tree semantic oracle that answers identifier existence exactly and deterministically from authoritative sources.
-status: superseded by ADR-084
+status: superseded by ADR-086
 ---
 
 > **Current truth** → [`docs/architecture/ARCHITECTURE.md`](../../ARCHITECTURE.md){#current-truth}

--- a/docs/architecture/adr/086-documentation-architecture.mdx
+++ b/docs/architecture/adr/086-documentation-architecture.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ADR-084: Documentation Architecture — SSoT & Semantic Code Oracle"
+title: "ADR-086: Documentation Architecture — SSoT & Semantic Code Oracle"
 description: "Unified meta-documentation for architecture knowledge SSoT, 2-tier drift gate, and semantic code oracle"
 status: accepted
 ---

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -6,7 +6,7 @@
     "073-axial-stage-of-pipeline-decomposition",
     "080-architecture-knowledge-ssot-2tier-doc-drift-gate",
     "081-architecture-inventory-semantic-code-oracle",
-    "084-documentation-architecture",
+    "086-documentation-architecture",
     "---Messaging & NATS---",
     "001-routing-key-platform-bot-id-user-id",
     "002-hub-impl-contracts-dispatch-pool-deprecation",


### PR DESCRIPTION
## Summary

Two distinct ADRs shared the number 084, creating an ambiguous collision:

- `084-workenvelope-job-id-invariant.mdx` — "ADR-084: WorkEnvelope — the job_id invariant" — canonical, referenced by issues #1619, #1794, #1793. **Keeps 084.**
- `084-documentation-architecture.mdx` — "ADR-084: Documentation Architecture — SSoT & Semantic Code Oracle" — the mis-numbered duplicate. **Renumbered → ADR-086** (085 was the previous highest; 086 is free).

## Files changed

| File | Change |
|---|---|
| `docs/architecture/adr/084-documentation-architecture.mdx` | Renamed → `086-documentation-architecture.mdx` |
| `docs/architecture/adr/086-documentation-architecture.mdx` | Title updated: ADR-084 → ADR-086 |
| `docs/architecture/adr/meta.json` | Entry `084-documentation-architecture` → `086-documentation-architecture` |
| `docs/architecture/adr/080-architecture-knowledge-ssot-2tier-doc-drift-gate.mdx` | `status: superseded by ADR-084` → ADR-086; inline link updated |
| `docs/architecture/adr/081-architecture-inventory-semantic-code-oracle.mdx` | `status: superseded by ADR-084` → ADR-086 |

**Refs deliberately left at 084** (WorkEnvelope context, correct):
- `artifacts/analyses/workenvelope-job-id-invariant.md` — "Promote to an ADR — ADR-084"
- `artifacts/analyses/493-tool-domain-nature-consolidation.mdx` — "ADR-084's work/infra cut (does it carry `job_id`)"
- `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` — the canonical WorkEnvelope ADR itself

## Gate results

- `check_doc_drift.py` — **PASS** (0 new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)