### PR TITLE
chore(harness): omp → factory LiteLLM :18091 via models.yml override

### DIFF
--- a/artifacts/spikes/1807/RUNBOOK.md
+++ b/artifacts/spikes/1807/RUNBOOK.md
@@ -134,7 +134,7 @@ rm -rf /tmp/omp_spike_1807
 
 ## Known gaps / risks for live run
 
-1. **No baseUrl env override**: To route to M1 LiteLLM from M2, ssh tunnel or run on M1.
+1. **No baseUrl env override** *(superseded 2026-06-10 — `models.yml` overrides baseUrl, see `deploy/omp/README.md`)*: To route to M1 LiteLLM from M2, ssh tunnel or run on M1.
 2. **omp image footprint**: ~450–700 MB compressed for full pi-runtime image. Quadlet integration
    is a heavyweight commitment — not a single-binary drop-in.
 3. **steer timing non-determinism**: `steer(interruptMode="immediate")` applies between tool

--- a/artifacts/spikes/1807/RUNBOOK.md
+++ b/artifacts/spikes/1807/RUNBOOK.md
@@ -68,6 +68,12 @@ uv pip install -e /home/mickael/projects/external_repos/oh-my-pi/python/omp-rpc
 | `LITELLM_API_KEY` | (unset) | Optional — LiteLLM `allowUnauthenticated: true` |
 | `OMP_LITELLM_BASE_URL` | `http://localhost:4000/v1` | **Informational only** — no env-var override path exists into omp's `LiteLLMModelManagerConfig.baseUrl`. See note below. |
 
+> **SUPERSEDED 2026-06-10 (#1811):** the "hard-coded baseUrl" claim below is wrong —
+> `localhost:4000/v1` is only a default (`config?.baseUrl ?? …`). omp's
+> `models.yml` (`providers.litellm.baseUrl`, config dir relocatable via
+> `PI_CODING_AGENT_DIR`) overrides it with priority 1. See `deploy/omp/README.md`.
+> The env-var part stays true: no `LITELLM_BASE_URL` env var exists.
+
 **LITELLM_BASE_URL gap**: The LiteLLM `baseUrl` is hard-coded in
 `packages/ai/src/provider-models/openai-compat.ts:2191` at TS-constructor level.
 No env var (`LITELLM_BASE_URL` does not exist in the codebase). To override from M2

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Scope
 
 Container deployment artifacts for Lyra on prod (`roxabituwer`, M₁).
-Subdirs: `quadlet/` | `nats/` | `scripts/` | `lib/` | `factory-gh/` | `systemd/`
+Subdirs: `quadlet/` | `nats/` | `scripts/` | `lib/` | `factory-gh/` | `systemd/` | `omp/` (omp runtime config → factory LiteLLM, #1811 — see `omp/README.md`)
 
 ¬docker, ¬docker-compose for prod. Runtime stack: **Podman 5.x (native on Ubuntu 26.04 LTS)
 + Quadlet generators + systemd user units**.

--- a/deploy/omp/README.md
+++ b/deploy/omp/README.md
@@ -1,0 +1,55 @@
+# deploy/omp/ — omp (oh-my-pi) runtime config for the factory LiteLLM route
+
+Origin: #1811 (Option D, decided 2026-06-10). Parent: #1490 (pluggable harness
+runtime — omp alongside clipool).
+
+## What lives here
+
+| File | Role |
+|---|---|
+| `models.yml` | omp provider override — points the built-in `litellm` provider at the factory LiteLLM proxy (`:18091`, tailnet) with an explicit model catalog |
+
+## How omp picks this up
+
+omp reads its config from `~/.omp/agent/` by default. The **`PI_CODING_AGENT_DIR`**
+env var relocates that whole directory — the worker container mounts a directory
+containing this `models.yml` and sets `PI_CODING_AGENT_DIR` to it. No omp source
+patch, no port forward.
+
+Override precedence inside omp (verified against oh-my-pi source, 2026-06-10):
+`models.yml` provider `baseUrl` > discovered > bundled default
+(`packages/coding-agent/src/config/model-registry.ts` — overrides map, priority 1;
+default `http://localhost:4000/v1` is a `config?.baseUrl ?? …` fallback in
+`packages/ai/src/provider-models/openai-compat.ts`).
+
+## Env surface
+
+| Variable | Consumer | Semantics |
+|---|---|---|
+| `PI_CODING_AGENT_DIR` | omp (`packages/utils/src/dirs.ts`) | Absolute path of the config dir containing `models.yml`. Mount target for this file in the worker unit. |
+| `LITELLM_API_KEY` | omp `litellm` provider | The proxy bearer key. `models.yml` references it **by name** (`apiKey: LITELLM_API_KEY` = env-name-or-literal semantics) — the value enters the container via the #1812 secret mount, never via this repo. |
+
+## Why an explicit `models:` list
+
+omp's built-in catalog discovery resolves the fetch URL from models it already
+knows, not from the overrides map — so an override-only entry would still
+discover against `localhost:4000` (chicken-and-egg). The explicit list both
+dodges that and makes the worker deterministic (no discovery round-trip at
+session start, no behaviour change when the proxy catalog moves).
+
+Trade-off: the list **replaces** discovery. Adding a model to the LiteLLM proxy
+requires adding its id here. Current catalog = the four models served by the
+factory proxy (`/v1/models`, 2026-06-10).
+
+## Validation (gate for #1811)
+
+One-shot re-run of the spike PoC (`artifacts/spikes/1807/omp_rpc_poc.py`) with
+`PI_CODING_AGENT_DIR` pointing at a directory containing this `models.yml` —
+all 4 probes (text/tool/steer/abort) must PASS against the factory proxy
+`:18091` with **no TCP forward**. Result recorded on #1811.
+
+## Boundary
+
+Quadlet integration — S7 secret mount for `LITELLM_API_KEY`, env wiring,
+volume-mounting this file into the omp worker unit, ACL identities — is
+**#1812** (`OmpWorker`). This directory only proves the config pattern.

--- a/deploy/omp/README.md
+++ b/deploy/omp/README.md
@@ -27,7 +27,7 @@ default `http://localhost:4000/v1` is a `config?.baseUrl ?? …` fallback in
 | Variable | Consumer | Semantics |
 |---|---|---|
 | `PI_CODING_AGENT_DIR` | omp (`packages/utils/src/dirs.ts`) | Absolute path of the config dir containing `models.yml`. Mount target for this file in the worker unit. |
-| `LITELLM_API_KEY` | omp `litellm` provider | The proxy bearer key. `models.yml` references it **by name** (`apiKey: LITELLM_API_KEY` = env-name-or-literal semantics) — the value enters the container via the #1812 secret mount, never via this repo. |
+| `LITELLM_API_KEY` | omp `litellm` provider | The proxy bearer key. `models.yml` references it **by name** (`apiKey: LITELLM_API_KEY` = env-name-or-literal semantics) — the value enters the container via the #1812 secret mount, never via this repo. ⚠ Fallback: if the env var is **unset**, omp sends the literal string `LITELLM_API_KEY` as the bearer (`resolveApiKeyConfig` — passes omp's non-empty check, rejected by the proxy) → auth failures with a config that looks correct. #1812 must verify injection before relying on proxy auth. |
 
 ## Why an explicit `models:` list
 

--- a/deploy/omp/models.yml
+++ b/deploy/omp/models.yml
@@ -1,0 +1,31 @@
+# deploy/omp/models.yml — omp (oh-my-pi) provider override → factory LiteLLM proxy (#1811, Option D)
+#
+# Mounted into the omp config dir (relocated via PI_CODING_AGENT_DIR) so the
+# built-in `litellm` provider targets the factory proxy on :18091 instead of
+# its default http://localhost:4000/v1. Pure config — no TCP forward, no
+# upstream patch (options A/B/C superseded; see issue #1811).
+#
+# Invariants:
+# - `apiKey` holds an ENV VAR NAME, not a secret value. omp resolves
+#   `LITELLM_API_KEY` from the environment at runtime — safe to commit.
+# - The explicit `models:` list is REQUIRED, not cosmetic: omp's built-in
+#   discovery resolves the catalog URL from already-known models, not from
+#   this override, so an override-only entry would still discover against
+#   localhost:4000 (chicken-and-egg). Listed models inherit the provider
+#   baseUrl/api; missing capability metadata (context window, cost) backfills
+#   from omp's bundled references on id match.
+# - This list REPLACES discovery: a model added to the proxy is invisible to
+#   omp until it is added here.
+# - Quadlet wiring (secret mount, env injection, volume mount into the worker
+#   unit) is #1812's scope — this file only proves the config pattern.
+
+providers:
+  litellm:
+    baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/v1
+    api: openai-completions
+    apiKey: LITELLM_API_KEY
+    models:
+      - id: deepseek-v4-pro
+      - id: kimi-k2.6
+      - id: grok-4
+      - id: grok-4-fast


### PR DESCRIPTION
## Summary
- **Option D (#1811, decided 2026-06-10):** route omp's built-in `litellm` provider to the factory LiteLLM proxy (`:18091`, tailnet FQDN) by pure config — `deploy/omp/models.yml` mounted via `PI_CODING_AGENT_DIR`. No TCP forward (old Option B), no upstream PR (A), no patched build (C).
- Explicit `models:` list is load-bearing: omp's built-in discovery resolves its catalog URL from already-known models, not the overrides map — an override-only entry would still discover against `localhost:4000` (chicken-and-egg, see `deploy/omp/README.md`).
- `apiKey: LITELLM_API_KEY` = env-name semantics — no secret value in the repo.
- `deploy/CLAUDE.md` registers the new `omp/` subdir; spike RUNBOOK gets a SUPERSEDED banner on its stale "baseUrl hard-coded" claim.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1811: omp → factory LiteLLM :18091 via models.yml provider override (Option D) | Open |
| Implementation | 1 commit on `feat/1811-omp-litellm-override` | Complete |
| Verification | Lint ✅ · gates (secrets_drift, doc_drift, volumes_table) ✅ · Tests n/a (config/docs only) | Passed |

## Test Plan
- [x] **Validation gate (issue deliverable):** `omp_rpc_poc.py --all` with `PI_CODING_AGENT_DIR` → dir containing this `models.yml`, no listener on `:4000` → **4/4 probes PASS** (text/tool/steer/abort). Evidence: [#1811 comment](https://github.com/Roxabi/roxabi-factory/issues/1811#issuecomment-4667561675)
- [x] Caveat: PASS run targeted M₂'s llmcli proxy (identical stack/port) — M₁'s upstream creds are dead (Roxabi/llmCLI#114); M₁ proxy-layer connectivity itself confirmed
- [ ] #1812 re-validates against M₁ once upstream creds re-authed (Quadlet wiring scope)

Fixes #1811

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`