### PR TITLE
feat(omp-base): carrier image for pinned omp-linux-x64 v15.10.8

### DIFF
--- a/.github/workflows/omp-base.yml
+++ b/.github/workflows/omp-base.yml
@@ -1,0 +1,104 @@
+name: omp-base
+on:
+  pull_request:
+    paths: ['deploy/omp-base/**']
+  push:
+    branches: [staging]
+    paths: ['deploy/omp-base/**']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Parse and validate pins from Containerfile
+        id: pins
+        run: |
+          VER=$(grep '^ARG OMP_VERSION=' deploy/omp-base/Containerfile | cut -d= -f2)
+          SHA=$(grep '^ARG OMP_SHA256=' deploy/omp-base/Containerfile | cut -d= -f2)
+          if [[ ! "$VER" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: OMP_VERSION '${VER}' does not match ^v[0-9]+\.[0-9]+\.[0-9]+$" >&2
+            exit 1
+          fi
+          if [[ ! "$SHA" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "ERROR: OMP_SHA256 '${SHA}' does not match ^[0-9a-f]{64}$" >&2
+            exit 1
+          fi
+          TAG="${VER#v}"
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build smoke stage
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: deploy/omp-base
+          file: deploy/omp-base/Containerfile
+          target: smoke
+          load: true
+          tags: omp-smoke:${{ steps.pins.outputs.tag }}
+          cache-from: type=gha,scope=omp-base
+          cache-to: type=gha,mode=max,scope=omp-base
+
+      - name: Verify smoke binary version
+        run: |
+          docker run --rm omp-smoke:${{ steps.pins.outputs.tag }} omp --version \
+            | grep -Fx "omp/${{ steps.pins.outputs.tag }}"
+
+  publish:
+    if: github.ref == 'refs/heads/staging'
+    needs: build-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Parse and validate pins from Containerfile
+        id: pins
+        run: |
+          VER=$(grep '^ARG OMP_VERSION=' deploy/omp-base/Containerfile | cut -d= -f2)
+          SHA=$(grep '^ARG OMP_SHA256=' deploy/omp-base/Containerfile | cut -d= -f2)
+          if [[ ! "$VER" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: OMP_VERSION '${VER}' does not match ^v[0-9]+\.[0-9]+\.[0-9]+$" >&2
+            exit 1
+          fi
+          if [[ ! "$SHA" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "ERROR: OMP_SHA256 '${SHA}' does not match ^[0-9a-f]{64}$" >&2
+            exit 1
+          fi
+          TAG="${VER#v}"
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build carrier stage
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: deploy/omp-base
+          file: deploy/omp-base/Containerfile
+          target: carrier
+          load: true
+          tags: ghcr.io/roxabi/factory-omp-base:${{ steps.pins.outputs.tag }}
+          cache-from: type=gha,scope=omp-base
+
+      - name: Immutability guard — skip push if tag already published
+        run: |
+          TAG="${{ steps.pins.outputs.tag }}"
+          IMAGE="ghcr.io/roxabi/factory-omp-base:${TAG}"
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "::warning::tag ${TAG} already published, skipping push (content change requires a version bump)"
+            exit 0
+          fi
+          docker push "${IMAGE}"

--- a/.github/workflows/omp-base.yml
+++ b/.github/workflows/omp-base.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-smoke:
@@ -16,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # duplicated in the publish job — separate runners share no step context
       - name: Parse and validate pins from Containerfile
         id: pins
         run: |
@@ -63,9 +63,13 @@ jobs:
     if: github.ref == 'refs/heads/staging'
     needs: build-smoke
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # re-parsed: separate runner, no shared step context with build-smoke
       - name: Parse and validate pins from Containerfile
         id: pins
         run: |

--- a/.github/workflows/omp-base.yml
+++ b/.github/workflows/omp-base.yml
@@ -1,10 +1,10 @@
 name: omp-base
 on:
   pull_request:
-    paths: ['deploy/omp-base/**']
+    paths: ['deploy/omp-base/**', '.github/workflows/omp-base.yml']
   push:
     branches: [staging]
-    paths: ['deploy/omp-base/**']
+    paths: ['deploy/omp-base/**', '.github/workflows/omp-base.yml']
 
 permissions:
   contents: read
@@ -21,6 +21,14 @@ jobs:
         run: |
           VER=$(grep '^ARG OMP_VERSION=' deploy/omp-base/Containerfile | cut -d= -f2)
           SHA=$(grep '^ARG OMP_SHA256=' deploy/omp-base/Containerfile | cut -d= -f2)
+          if [[ -z "$VER" ]]; then
+            echo "ERROR: could not parse OMP_VERSION from deploy/omp-base/Containerfile (line must match '^ARG OMP_VERSION=<value>')" >&2
+            exit 1
+          fi
+          if [[ -z "$SHA" ]]; then
+            echo "ERROR: could not parse OMP_SHA256 from deploy/omp-base/Containerfile (line must match '^ARG OMP_SHA256=<value>')" >&2
+            exit 1
+          fi
           if [[ ! "$VER" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "ERROR: OMP_VERSION '${VER}' does not match ^v[0-9]+\.[0-9]+\.[0-9]+$" >&2
             exit 1
@@ -63,6 +71,14 @@ jobs:
         run: |
           VER=$(grep '^ARG OMP_VERSION=' deploy/omp-base/Containerfile | cut -d= -f2)
           SHA=$(grep '^ARG OMP_SHA256=' deploy/omp-base/Containerfile | cut -d= -f2)
+          if [[ -z "$VER" ]]; then
+            echo "ERROR: could not parse OMP_VERSION from deploy/omp-base/Containerfile (line must match '^ARG OMP_VERSION=<value>')" >&2
+            exit 1
+          fi
+          if [[ -z "$SHA" ]]; then
+            echo "ERROR: could not parse OMP_SHA256 from deploy/omp-base/Containerfile (line must match '^ARG OMP_SHA256=<value>')" >&2
+            exit 1
+          fi
           if [[ ! "$VER" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "ERROR: OMP_VERSION '${VER}' does not match ^v[0-9]+\.[0-9]+\.[0-9]+$" >&2
             exit 1
@@ -81,9 +97,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Immutability guard — check published tag before building
+        id: guard
+        run: |
+          TAG="${{ steps.pins.outputs.tag }}"
+          IMAGE="ghcr.io/roxabi/factory-omp-base:${TAG}"
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "::warning::tag ${TAG} already published, skipping build+push (content change requires a version bump)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        if: steps.guard.outputs.skip != 'true'
 
       - name: Build carrier stage
+        if: steps.guard.outputs.skip != 'true'
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: deploy/omp-base
@@ -92,13 +122,8 @@ jobs:
           load: true
           tags: ghcr.io/roxabi/factory-omp-base:${{ steps.pins.outputs.tag }}
           cache-from: type=gha,scope=omp-base
+          cache-to: type=gha,mode=max,scope=omp-base
 
-      - name: Immutability guard — skip push if tag already published
-        run: |
-          TAG="${{ steps.pins.outputs.tag }}"
-          IMAGE="ghcr.io/roxabi/factory-omp-base:${TAG}"
-          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
-            echo "::warning::tag ${TAG} already published, skipping push (content change requires a version bump)"
-            exit 0
-          fi
-          docker push "${IMAGE}"
+      - name: Push carrier image
+        if: steps.guard.outputs.skip != 'true'
+        run: docker push "ghcr.io/roxabi/factory-omp-base:${{ steps.pins.outputs.tag }}"

--- a/artifacts/frames/1810-factory-omp-base-frame.mdx
+++ b/artifacts/frames/1810-factory-omp-base-frame.mdx
@@ -1,0 +1,87 @@
+---
+title: "factory-omp-base image — bake prebuilt omp-linux-x64 binary"
+issue: 1810
+status: approved
+tier: F-lite
+date: 2026-06-10
+---
+
+## Problem
+
+The `omp_rpc` harness runtime (spike #1807 GREEN, ratified 2026-06-10) needs the
+`omp` binary available inside the M₁ Quadlet stack before the OmpWorker (#1812)
+can exist. oh-my-pi ships a prebuilt standalone `omp-linux-x64` ELF (~175 MB;
+exactly 183,777,408 B) via GitHub releases — no `bun install`, `node_modules`,
+or Rust toolchain at runtime. Upstream is alpha with daily churn from a solo
+maintainer, so the binary must be **pinned by sha256 and verified at image
+build**, with bumps gated by an integration test in factory CI.
+
+Without this image, #1812 (OmpWorker, F-full) and #1813 (runtime-selection) are
+blocked — and they are the path off the Anthropic programmatic-billing cliff
+(2026-06-15) for NATS job workers.
+
+## Who
+
+- **Primary:** OmpWorker container (#1812) — builds its runtime stage `FROM`
+  this image; inherits a verified, immutable omp binary layer.
+- **Secondary:** operators bumping the omp pin — single-PR flow with CI digest
+  verification instead of manual host provisioning.
+
+## Constraints
+
+- Pin anchor: `omp-linux-x64` **v15.10.8**, 183,777,408 B, sha256
+  `b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b`. The
+  GitHub-release download MUST be verified against this digest at build
+  (guards upstream retag — alpha, solo maintainer).
+- Container conventions: `docs/ops/container-publishing.md` — pinned base,
+  non-root UID 1500 (ADR-053), no build tools in final image, GHCR via
+  `ghcr.io/roxabi/*`.
+- Image home decision (2026-06-10): **dedicated image in roxabi-factory** —
+  `deploy/omp-base/Containerfile` + path-triggered publish workflow →
+  `ghcr.io/roxabi/factory-omp-base:<omp-version>` (immutable tag = omp
+  version). Built only on pin bump, NOT on every staging push — keeps the
+  175 MB layer out of the hot publish path and lets the bump-gating
+  integration test live in the same repo as `omp_rpc` consumers.
+- `deploy/omp/models.yml` (#1811) is the runtime config the eventual worker
+  mounts via `PI_CODING_AGENT_DIR` — this image does not embed it.
+
+## Out of Scope
+
+- **Quadlet unit + `deploy/quadlet.toml` component entry + secrets** → #1812.
+  `secrets_drift` CHECKs (b)+(c) hard-couple any toml component to the
+  generated secrets-manifest and an acl-matrix identity; the omp-worker
+  identity + `factory.jobs.omp` contracts are #1812's scope. The issue's
+  S7/S8/S12 checkbox is conditioned on "the same PR that adds the Quadlet
+  unit" — that is #1812's PR. A unit shipped now would crash-loop (no worker
+  entrypoint exists).
+- OmpWorker code, `omp-rpc` Python dependency wiring, NATS ACL fan-out → #1812.
+- Runtime selection clipool⟷omp → #1813.
+- roxabi-ml-base changes — image home is roxabi-factory (decision above).
+
+## Premise Validity
+
+**Success in 6 months:** OmpWorker runs on M₁ from an image whose runtime stage
+is `FROM ghcr.io/roxabi/factory-omp-base:<ver>`; omp pin bumps are single PRs
+that CI gates with digest verification + an omp_rpc integration test; job
+workers run without Anthropic programmatic billing.
+
+**Failure in 6 months:** by 2026-12, zero Quadlet units reference
+`factory-omp-base` (image built but unconsumed), OR the pin is frozen at
+v15.10.8 with ≥3 open upstream-breakage issues (fork churn unmanageable) →
+retire the image, fall back to clipool-only runtime.
+
+**Simplest alternative:** bind-mount the binary from the M₁ host
+(`/opt/omp/omp-linux-x64` volume into existing containers).
+**Why not simplest:** no digest verification at deploy time; M₁ host becomes a
+manually-provisioned snowflake outside `factory-quadlet-sync` git convergence;
+violates the image-only deploy standard (auto-update pulls images, not host
+files).
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (devops/CI), no unknowns; the
+spike already proved the binary runs standalone.
+
+Signals observed: `size:F-lite` label; ~4–6 files (Containerfile, workflow,
+ops doc, CLAUDE.md registry); one domain; reference patterns exist
+(`publish.yml`, roxabi-ml-base `build-base.yml`).

--- a/artifacts/plans/1810-factory-omp-base-plan.mdx
+++ b/artifacts/plans/1810-factory-omp-base-plan.mdx
@@ -1,0 +1,208 @@
+---
+title: "Plan: factory-omp-base image — bake prebuilt omp-linux-x64 binary"
+issue: 1810
+spec: artifacts/specs/1810-factory-omp-base-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: 2026-06-10T00:00:00Z
+---
+
+## Summary
+
+Four micro-tasks across 2 agents: devops-A writes the 3-stage Containerfile
+then the 2-job publish workflow; doc-writer-A writes the bump-runbook README
+and updates the deploy/CLAUDE.md registry. Both spec slices ship in one PR
+(slice 2 builds directly on slice 1's Containerfile).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph deploy/omp-base/Containerfile
+    ARGS[ARG OMP_VERSION / OMP_SHA256<br/>pin SSoT] --> DL[download stage<br/>debian:12-slim + curl --retry 3<br/>sha256sum -c]
+    DL --> CAR[carrier stage<br/>FROM scratch<br/>/opt/omp/omp 0755]
+    CAR --> SMK[smoke stage<br/>debian:12-slim<br/>COPY --from=carrier + RUN omp --version]
+  end
+  subgraph .github/workflows/omp-base.yml
+    PARSE[validated ARG parse<br/>semver + 64-hex regex, fail loud] --> BS[build-smoke job<br/>--target smoke --load<br/>assert omp/VERSION]
+    BS --> PUB[publish job — staging only<br/>--target carrier<br/>manifest-inspect guard → push]
+  end
+  ARGS -.parsed by.-> PARSE
+  PUB --> GHCR[(ghcr.io/roxabi/factory-omp-base:15.10.8)]
+  GHCR -.#1812 COPY --from.-> W[OmpWorker runtime stage]
+```
+
+```mermaid
+flowchart LR
+  subgraph files
+    CF[deploy/omp-base/Containerfile]
+    WF[.github/workflows/omp-base.yml]
+    RM[deploy/omp-base/README.md]
+    CM[deploy/CLAUDE.md]
+  end
+  WF -->|greps ARG defaults| CF
+  RM -->|documents| CF
+  RM -->|documents| WF
+  CM -->|indexes| RM
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| devops-A | T1, T2 | deploy/omp-base/Containerfile · .github/workflows/omp-base.yml |
+| doc-writer-A | T3, T4 | deploy/omp-base/README.md · deploy/CLAUDE.md |
+
+tester: **skipped (exemption)** — no pytest-reachable surface; verification is
+build-native (negative sha test, smoke stage, workflow greps) and embedded in
+each task's verify command + `/validate`.
+
+## Wave Structure
+
+2 waves, max 2 parallel agents.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 2 ∥ | devops-A: T1 · doc-writer-A: T3→T4 |
+| 2 | T1 done | 1 | devops-A: T2 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 Containerfile + local verify | 1 file + 3 builds | judgmental | 10 | — |
+| T2 workflow | 1 file + lint greps | judgmental | 6 | — |
+| T3 README | 1 file | bounded | 3 | — |
+| T4 CLAUDE.md line + gates | 1 edit + 2 gate runs | trivial | 3 | — |
+
+**Total estimated ops: 22**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1, T2 | 16 | containerfile, workflow | — |
+| doc-writer-A | T3, T4 | 6 | runbook, registry | — |
+
+## Consistency Report
+
+7/7 success criteria covered, 6/6 breadboard nodes traced, 0 uncovered.
+SC1+SC2←T1 · SC3+SC4+SC5←T2 · SC6←T3+T4 · SC7←T4 verify.
+N1+N2←T1 · N3+N4←T2 · N5←T3 · N6←T4.
+Exemption: no RED phase / RED-GATE sentinels — infra-only change, no test
+framework surface (see Agents note).
+
+## Micro-Tasks
+
+### V1 — carrier image builds + verifies locally
+
+**T1 — Write `deploy/omp-base/Containerfile` (3 stages)** · devops-A · GREEN · diff 2 · ~8 min
+- File: `deploy/omp-base/Containerfile`
+- Shape:
+  ```dockerfile
+  ARG OMP_VERSION=v15.10.8
+  ARG OMP_SHA256=b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b
+  FROM debian:12-slim AS download
+  ARG OMP_VERSION
+  ARG OMP_SHA256
+  RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+  RUN curl -fL --retry 3 --retry-delay 5 \
+        "https://github.com/can1357/oh-my-pi/releases/download/${OMP_VERSION}/omp-linux-x64" \
+        -o /tmp/omp \
+   && echo "${OMP_SHA256}  /tmp/omp" | sha256sum -c - \
+   && chmod 0755 /tmp/omp
+
+  FROM scratch AS carrier
+  COPY --from=download /tmp/omp /opt/omp/omp
+  # ADR-053 carve-out: no USER — scratch carrier never executes (no ld-linux).
+
+  FROM debian:12-slim AS smoke
+  COPY --from=carrier /opt/omp/omp /usr/local/bin/omp
+  RUN omp --version
+  ```
+- Verify:
+  `podman build --target carrier -t omp-carrier-test deploy/omp-base` → exit 0;
+  `podman build --target smoke deploy/omp-base` → exit 0 (build-time exec proof);
+  `podman build --target carrier --build-arg OMP_SHA256=$(printf 'a%.0s' {1..64}) deploy/omp-base` → **non-zero exit** (sha mismatch);
+  `podman run --rm omp-carrier-test 2>&1 | grep -qi 'no command\|exec'` ∨ inspect: `podman image inspect omp-carrier-test --format '{{.RootFS.Layers | len}}'` → 1 layer.
+- Expected: positive builds green, corrupted-sha build fails at `sha256sum -c`.
+- Spec trace: SC1, SC2 · N1, N2
+
+### V2 — CI gate + publish + docs
+
+**T2 — Write `.github/workflows/omp-base.yml` (2 jobs)** · devops-A · GREEN · diff 3 · ~8 min · blockedBy T1
+- File: `.github/workflows/omp-base.yml`
+- Shape: `on: pull_request + push: branches [staging], paths: ['deploy/omp-base/**']`;
+  `permissions: contents: read, packages: write`;
+  job `build-smoke`: checkout (SHA-pinned per publish.yml) → parse step
+  (`grep '^ARG OMP_VERSION=' deploy/omp-base/Containerfile | cut -d= -f2` +
+  regex validation `^v[0-9]+\.[0-9]+\.[0-9]+$` / `^[0-9a-f]{64}$`, `exit 1` on
+  mismatch, expose via `$GITHUB_OUTPUT`) → setup-buildx →
+  build `--target smoke --load` w/ `cache-from/to type=gha,scope=omp-base` →
+  `docker run --rm <smoke-tag> omp --version | grep -Fx "omp/${VER#v}"`;
+  job `publish`: `if: github.ref == 'refs/heads/staging'`, `needs: build-smoke`,
+  re-parse → login-action (SHA-pinned) → build `--target carrier --load` →
+  guard: `docker manifest inspect ghcr.io/roxabi/factory-omp-base:${VER#v}`
+  exit 0 → `::warning::tag exists, skipping push` + exit 0; else tag + push.
+- Verify:
+  `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/omp-base.yml'))"` → exit 0;
+  `grep -c 'b877091c' .github/workflows/omp-base.yml` → 0;
+  `grep -Ec 'uses: [^@]+@[0-9a-f]{40}' .github/workflows/omp-base.yml` ≥ 3;
+  `grep -q 'needs: build-smoke' …` → exit 0.
+- Expected: valid YAML, no literal pin copy, all actions SHA-pinned.
+- Spec trace: SC3, SC4, SC5 · N3, N4
+
+**T3 — Write `deploy/omp-base/README.md`** · doc-writer-A · GREEN · diff 1 · ~5 min · [P]
+- File: `deploy/omp-base/README.md`
+- Shape: sections — Purpose (carrier image, immutable tag = omp version);
+  Pin SSoT (the two ARGs, current pin v15.10.8 + sha); Bump procedure
+  (edit 2 ARGs → PR → CI build-smoke gates → merge publishes new tag →
+  #1812 bumps its `COPY --from` ref; deep omp_rpc e2e on bump = #1812 CI);
+  Consumption (`COPY --from=ghcr.io/roxabi/factory-omp-base:15.10.8
+  /opt/omp/omp /usr/local/bin/omp`, consumer must be glibc-based — ldd:
+  libc/libm/libpthread/libdl); Immutability guard semantics (tag exists →
+  skip+warn, content change ⇒ version bump); ADR-053 carve-out (no USER in
+  scratch carrier).
+- Verify: `grep -q 'Bump procedure\|bump' deploy/omp-base/README.md && grep -q 'COPY --from' deploy/omp-base/README.md` → exit 0.
+- Spec trace: SC6 · N5
+
+**T4 — Update `deploy/CLAUDE.md` scope line + run untouched-gates check** · doc-writer-A · GREEN · diff 1 · ~3 min · blockedBy T3
+- File: `deploy/CLAUDE.md` (append `omp-base/` to the Scope line, pattern of #1811's `omp/` entry)
+- Verify: `grep -q 'omp-base/' deploy/CLAUDE.md` → exit 0;
+  `python3 tools/check_doc_drift.py` → exit 0;
+  `bash tools/check_secrets_drift.sh` → exit 0 (proves SC7: secrets surface untouched).
+- Spec trace: SC6, SC7 · N6
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | containerfile |
+| T3 | doc-writer-A | — | runbook |
+
+### Wave 2 — after Wave 1
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | devops-A | T1 | workflow |
+| T4 | doc-writer-A | T3 | registry |
+
+## Ref Patterns
+
+- `.github/workflows/publish.yml` — action SHA pins, permissions block, GHCR login
+- `~/projects/roxabi-ml-base/.github/workflows/build-base.yml` — standalone path-triggered structure
+- `Dockerfile` (repo root) — apt hygiene (`--no-install-recommends` + rm lists same RUN)
+- `deploy/omp/README.md` — sibling README tone/structure (#1811)
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 24 — containerfile
+- T2: 25 — workflow
+- T3: 26 — runbook
+- T4: 27 — registry

--- a/artifacts/specs/1810-factory-omp-base-spec.mdx
+++ b/artifacts/specs/1810-factory-omp-base-spec.mdx
@@ -1,0 +1,160 @@
+---
+title: "factory-omp-base image — bake prebuilt omp-linux-x64 binary"
+issue: 1810
+status: approved
+tier: F-lite
+date: 2026-06-10
+promoted_from: artifacts/frames/1810-factory-omp-base-frame.mdx
+---
+
+## Context
+
+Promoted from [frame](../frames/1810-factory-omp-base-frame.mdx) (approved
+2026-06-10). Spike #1807 proved the `omp_rpc` runtime end-to-end; #1811 landed
+the LiteLLM provider override (`deploy/omp/models.yml`). This issue ships the
+binary-carrier image that unblocks the OmpWorker (#1812).
+
+Image home decision (frame): dedicated image in roxabi-factory, built **only on
+pin bump**, never on the hot `:staging` publish path.
+
+## Goal
+
+Publish `ghcr.io/roxabi/factory-omp-base:<omp-version>` — an immutable,
+digest-verified carrier of the pinned `omp-linux-x64` binary — with a
+single-PR bump procedure gated by CI verification.
+
+## Users
+
+- **#1812 OmpWorker image build:** `COPY --from=ghcr.io/roxabi/factory-omp-base:15.10.8 /opt/omp/omp /usr/local/bin/omp`
+  into its runtime stage (glibc-based, e.g. `base-svc` lineage).
+- **Operator bumping the pin:** edits two ARG lines, opens a PR; CI proves the
+  new binary downloads, matches its digest, and executes before merge.
+
+## Expected Behavior
+
+1. `deploy/omp-base/Containerfile` holds the pin as build-arg defaults
+   (**single SSoT**):
+   `ARG OMP_VERSION=v15.10.8` and
+   `ARG OMP_SHA256=b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b`.
+   Three named stages:
+   - **download stage** (pinned `debian:12-slim` + ca-certificates/curl):
+     fetch `https://github.com/can1357/oh-my-pi/releases/download/${OMP_VERSION}/omp-linux-x64`
+     (asset verified live 2026-06-10: 183,777,408 B) with
+     `curl -fL --retry 3 --retry-delay 5`, then
+     `echo "${OMP_SHA256}  omp-linux-x64" | sha256sum -c -` — mismatch fails
+     the build (guards upstream retag).
+   - **`carrier` stage** (`FROM scratch`, the published target): `COPY` the
+     verified binary to `/opt/omp/omp` (mode 0755). No shell, no build tools.
+     The binary is glibc-linked (verified `ldd`: libc/libm/libpthread/libdl
+     only) → it **cannot execute inside the carrier** (no `ld-linux`);
+     consumers must be glibc-based. ADR-053 carve-out: no `USER` directive —
+     a scratch carrier never executes, there is no user context.
+   - **`smoke` stage** (`FROM debian:12-slim AS smoke`):
+     `COPY --from=carrier /opt/omp/omp /usr/local/bin/omp` — intra-build
+     stage reference, no daemon round-trip. CI runs this stage's image and
+     asserts `omp --version` == `omp/${OMP_VERSION#v}` (live output verified:
+     `omp/15.10.8`).
+2. `.github/workflows/omp-base.yml` — standalone workflow (ml-base
+   `build-base.yml` **structure** — standalone, version-pinned, not the
+   reusable `publish-container.yml@v1` which derives tags from
+   staging/release-please; action pinning follows `publish.yml` convention —
+   full commit SHA + `# vX` comment). Two jobs:
+   - **`build-smoke`** (PR + staging-push, `paths: deploy/omp-base/**`):
+     parse pin from Containerfile ARG defaults with **strict validation**
+     (`OMP_VERSION` must match `^v[0-9]+\.[0-9]+\.[0-9]+$`, `OMP_SHA256`
+     must match `^[0-9a-f]{64}$`, else fail loud — kills the
+     silent-empty-tag failure mode), buildx `--target smoke --load`, run
+     smoke container, assert version. Pushes nothing. GHA layer cache
+     (`type=gha`) so the 183 MB download layer is reused across runs.
+   - **`publish`** (staging-push only, `needs: build-smoke`): re-build
+     `--target carrier` (cheap — layers cached from build-smoke), then
+     **immutability guard** — after GHCR login, `docker manifest inspect
+     ghcr.io/roxabi/factory-omp-base:<ver>`; exit 0 (tag exists) →
+     `::warning::` annotation + skip push + job exits 0 (a content change
+     requires a version bump; identical re-runs stay green); exit 1 (absent)
+     → push `:<ver>` (leading `v` stripped, matching factory tag
+     convention). No `:latest`, no floating tags — consumers pin explicitly.
+3. **Bump procedure** (`deploy/omp-base/README.md`): edit the two ARGs → PR →
+   CI verifies download/digest/smoke → merge to staging publishes the new tag
+   → #1812 bumps its `COPY --from` reference in a follow-up commit. Deep
+   omp_rpc integration on bump (e2e SHA-pin guard) is **#1812 scope** — its CI
+   tests exercise the runtime; this issue's gate is
+   download-integrity + executes + version-match.
+4. Nothing in `deploy/quadlet.toml`, `deploy/quadlet/`, or secrets changes —
+   `secrets_drift`, `volumes_table`, `architecture_snapshot` gates are
+   untouched by design (frame: out of scope, #1812).
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+  class PinAnchor {
+    <<frozen>>
+    +OMP_VERSION: string = v15.10.8
+    +OMP_SHA256: string = b877091c..7c7b
+    SSoT = Containerfile ARG defaults
+  }
+  class CarrierImage {
+    <<frozen>>
+    +registry: ghcr.io/roxabi/factory-omp-base
+    +tag: 15.10.8 (immutable, = OMP_VERSION sans v)
+    +path: /opt/omp/omp (0755)
+    no shell, no libc — FROM scratch
+  }
+  class UpstreamRelease {
+    <<mutable>>
+    +repo: can1357/oh-my-pi
+    +asset: omp-linux-x64 (183777408 B)
+    alpha, solo maintainer — untrusted
+  }
+  PinAnchor --> UpstreamRelease : selects + verifies
+  PinAnchor --> CarrierImage : tags
+  UpstreamRelease --> CarrierImage : binary (post-sha256 only)
+```
+
+```mermaid
+flowchart LR
+  CF[deploy/omp-base/Containerfile] -->|build-args SSoT| WF[omp-base.yml workflow]
+  WF -->|PR: build + smoke, no push| CI[CI gate]
+  WF -->|staging push: guard + push| GHCR[(ghcr.io/roxabi/factory-omp-base:15.10.8)]
+  GHCR -.->|"COPY --from (#1812)"| OMPRT[omp-runtime stage, factory Dockerfile]
+  OMPRT -.->|"Quadlet unit (#1812)"| M1[M₁ factory-omp-worker]
+```
+
+| Consumer | Consumes | When | Status |
+|---|---|---|---|
+| CI smoke test | `/opt/omp/omp` → `--version` | every PR touching `deploy/omp-base/**` | this issue |
+| GHCR publish job | built image + pin tag | staging push on same paths | this issue |
+| #1812 omp-runtime stage | `COPY --from=…:15.10.8 /opt/omp/omp` | factory image build | future (dashed) |
+| #1812 e2e SHA-pin guard | pin ARGs + omp_rpc session | bump PRs | future (dashed) |
+
+## Breadboard
+
+| ID | Affordance | Handler / mechanism | Data |
+|---|---|---|---|
+| N1 | Containerfile download stage | `curl -fL --retry 3 --retry-delay 5` + `sha256sum -c` | OMP_VERSION, OMP_SHA256 args |
+| N2 | Containerfile `carrier` + `smoke` stages | `FROM scratch` + `COPY --chmod=0755` · `debian:12-slim AS smoke` w/ `COPY --from=carrier` | `/opt/omp/omp` |
+| N3 | Workflow `build-smoke` job | validated ARG parse → buildx `--target smoke --load` → run + version assert | exit 0 ⟺ digest+version match |
+| N4 | Workflow `publish` job | `needs: build-smoke` → `--target carrier` → `docker manifest inspect` guard → push | tag `:<ver>` |
+| N5 | README bump runbook | 2-ARG edit → PR → merge | pin lifecycle |
+| N6 | deploy/CLAUDE.md scope line | registry update | doc network |
+
+Wiring: N1→N2 (verified binary only) · N1/N2→N3 (PR gate) · N3→N4 (publish
+only after same-workflow build succeeds) · N5 documents N1+N4 · N6 indexes N5.
+
+## Slices
+
+| # | Slice | Demo | Contains |
+|---|---|---|---|
+| 1 | Carrier image builds + verifies locally | `podman build deploy/omp-base` succeeds; corrupting OMP_SHA256 fails the build | N1, N2 |
+| 2 | CI gate + publish + docs | PR run green (build+smoke, no push); staging merge publishes `:15.10.8` to GHCR; README + CLAUDE.md landed | N3, N4, N5, N6 |
+
+## Success Criteria
+
+- [ ] `podman build --target carrier deploy/omp-base` succeeds; the same build with a corrupted `OMP_SHA256` build-arg **fails** at the verify step
+- [ ] `carrier` target is `FROM scratch` containing exactly `/opt/omp/omp` (mode 0755) — no shell, no package manager
+- [ ] PR touching `deploy/omp-base/**` runs `build-smoke`: validated ARG parse + `--target smoke --load` + assert `omp --version` == `omp/<OMP_VERSION sans v>`; job pushes nothing
+- [ ] Merge to staging runs `publish`: tag absent → push `ghcr.io/roxabi/factory-omp-base:15.10.8`; tag present → skip push, emit `::warning::` annotation, **exit 0** (immutability guard; identical re-runs stay green)
+- [ ] Pin SSoT is the two Containerfile ARG defaults; workflow parse validates `^v[0-9]+\.[0-9]+\.[0-9]+$` / `^[0-9a-f]{64}$` and fails loud on mismatch; `grep -c 'b877091c' .github/workflows/omp-base.yml` == 0 (no literal pin copy in the workflow)
+- [ ] `deploy/omp-base/README.md` documents the bump procedure + #1812 consumption pattern (`COPY --from`); `deploy/CLAUDE.md` scope line updated
+- [ ] `git diff` touches no `deploy/quadlet*` path and no secrets surface — `secrets_drift` / `volumes_table` gates pass unchanged

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Scope
 
 Container deployment artifacts for Lyra on prod (`roxabituwer`, M₁).
-Subdirs: `quadlet/` | `nats/` | `scripts/` | `lib/` | `factory-gh/` | `systemd/` | `omp/` (omp runtime config → factory LiteLLM, #1811 — see `omp/README.md`)
+Subdirs: `quadlet/` | `nats/` | `scripts/` | `lib/` | `factory-gh/` | `systemd/` | `omp/` (omp runtime config → factory LiteLLM, #1811 — see `omp/README.md`) | `omp-base/` (omp binary carrier image → `ghcr.io/roxabi/factory-omp-base`, #1810 — see `omp-base/README.md`)
 
 ¬docker, ¬docker-compose for prod. Runtime stack: **Podman 5.x (native on Ubuntu 26.04 LTS)
 + Quadlet generators + systemd user units**.

--- a/deploy/omp-base/Containerfile
+++ b/deploy/omp-base/Containerfile
@@ -1,9 +1,13 @@
 ARG OMP_VERSION=v15.10.8
 ARG OMP_SHA256=b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b
-FROM debian:12-slim AS download
+
+# apt layer isolated from the pin ARGs so a version bump never re-runs apt-get.
+FROM debian:12-slim AS base-tools
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+FROM base-tools AS download
 ARG OMP_VERSION
 ARG OMP_SHA256
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 RUN curl -fL --retry 3 --retry-delay 5 \
       "https://github.com/can1357/oh-my-pi/releases/download/${OMP_VERSION}/omp-linux-x64" \
       -o /tmp/omp \

--- a/deploy/omp-base/Containerfile
+++ b/deploy/omp-base/Containerfile
@@ -15,7 +15,7 @@ RUN curl -fL --retry 3 --retry-delay 5 \
  && chmod 0755 /tmp/omp
 
 FROM scratch AS carrier
-COPY --from=download /tmp/omp /opt/omp/omp
+COPY --chmod=0755 --from=download /tmp/omp /opt/omp/omp
 # ADR-053 carve-out: no USER — scratch carrier never executes (no ld-linux).
 
 FROM debian:12-slim AS smoke

--- a/deploy/omp-base/Containerfile
+++ b/deploy/omp-base/Containerfile
@@ -1,0 +1,19 @@
+ARG OMP_VERSION=v15.10.8
+ARG OMP_SHA256=b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b
+FROM debian:12-slim AS download
+ARG OMP_VERSION
+ARG OMP_SHA256
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+RUN curl -fL --retry 3 --retry-delay 5 \
+      "https://github.com/can1357/oh-my-pi/releases/download/${OMP_VERSION}/omp-linux-x64" \
+      -o /tmp/omp \
+ && echo "${OMP_SHA256}  /tmp/omp" | sha256sum -c - \
+ && chmod 0755 /tmp/omp
+
+FROM scratch AS carrier
+COPY --from=download /tmp/omp /opt/omp/omp
+# ADR-053 carve-out: no USER — scratch carrier never executes (no ld-linux).
+
+FROM debian:12-slim AS smoke
+COPY --from=carrier /opt/omp/omp /usr/local/bin/omp
+RUN omp --version

--- a/deploy/omp-base/README.md
+++ b/deploy/omp-base/README.md
@@ -1,6 +1,7 @@
 # deploy/omp-base/ — omp binary carrier image
 
-Origin: #1810 (pin + carrier image). Parent: #1807 (agent-runtime eval, omp ratified 2026-06-10).
+Origin: #1810 (pin + carrier image). Parent: #1490 (pluggable harness
+runtime — omp alongside clipool; ratified 2026-06-10 via spike #1807).
 
 ## Purpose
 

--- a/deploy/omp-base/README.md
+++ b/deploy/omp-base/README.md
@@ -21,16 +21,10 @@ carrier image lifecycle independent of factory application releases.
 
 ## Pin SSoT
 
-The two `ARG` defaults in `deploy/omp-base/Containerfile` are the **sole pin SSoT** for this
-image. The workflow reads them — no literal pin lives in the workflow file.
-
-| ARG | Value |
-|---|---|
-| `OMP_VERSION` | `v15.10.8` |
-| `OMP_SHA256` | `b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b` |
-
-Asset: `omp-linux-x64`, 183,777,408 B — from
-[github.com/can1357/oh-my-pi releases](https://github.com/can1357/oh-my-pi/releases).
+The two `ARG` defaults at the top of [`Containerfile`](Containerfile) are the **sole pin SSoT**
+for this image — `OMP_VERSION` (release tag) and `OMP_SHA256` (digest of the `omp-linux-x64`
+asset from [github.com/can1357/oh-my-pi releases](https://github.com/can1357/oh-my-pi/releases)).
+The workflow reads them — no literal pin lives in the workflow file, and none is duplicated here.
 
 The SHA256 is verified at build time (`sha256sum -c`) before the binary is admitted into the
 image. A mismatch fails the CI job immediately.

--- a/deploy/omp-base/README.md
+++ b/deploy/omp-base/README.md
@@ -1,0 +1,79 @@
+# deploy/omp-base/ — omp binary carrier image
+
+Origin: #1810 (pin + carrier image). Parent: #1807 (agent-runtime eval, omp ratified 2026-06-10).
+
+## Purpose
+
+`ghcr.io/roxabi/factory-omp-base:<omp-version>` is an **immutable binary-carrier image** that
+contains exactly one file: `/opt/omp/omp` (mode 0755), copied from the official
+[oh-my-pi](https://github.com/can1357/oh-my-pi) release asset `omp-linux-x64`.
+
+The image is built `FROM scratch` — no OS layer, no shell, no entrypoint. It never runs
+directly; consumer images pull the binary out via a `COPY --from=` stage.
+
+The tag is the omp version without the `v` prefix (e.g. `15.10.8`). Tags are **immutable** —
+content changes require a version bump (see Immutability guard below).
+
+**Build trigger:** `.github/workflows/omp-base.yml` fires only on path `deploy/omp-base/**`.
+It is **never** triggered by the hot `:staging` publish path (`publish.yml`). This keeps the
+carrier image lifecycle independent of factory application releases.
+
+## Pin SSoT
+
+The two `ARG` defaults in `deploy/omp-base/Containerfile` are the **sole pin SSoT** for this
+image. The workflow reads them — no literal pin lives in the workflow file.
+
+| ARG | Value |
+|---|---|
+| `OMP_VERSION` | `v15.10.8` |
+| `OMP_SHA256` | `b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b` |
+
+Asset: `omp-linux-x64`, 183,777,408 B — from
+[github.com/can1357/oh-my-pi releases](https://github.com/can1357/oh-my-pi/releases).
+
+The SHA256 is verified at build time (`sha256sum -c`) before the binary is admitted into the
+image. A mismatch fails the CI job immediately.
+
+## Bump procedure
+
+1. Update the two `ARG` defaults in `Containerfile` — `OMP_VERSION` and `OMP_SHA256`.
+2. Open a PR targeting `staging`. The path-trigger on `deploy/omp-base/**` fires
+   `.github/workflows/omp-base.yml`.
+3. CI `build-smoke` gates:
+   - Downloads the new asset.
+   - Verifies the SHA256 digest.
+   - Runs `omp --version` (smoke stage in the Containerfile).
+4. Merge to `staging` → workflow publishes `ghcr.io/roxabi/factory-omp-base:<new-version>`.
+5. Open a follow-up commit on **#1812** that bumps the `COPY --from` ref in the OmpWorker
+   consumer image to the new tag.
+
+Deep omp_rpc e2e validation on bump is **#1812 CI scope**, not this repo's CI.
+
+## Consumption
+
+Consumer images (e.g. the OmpWorker stage in #1812) copy the binary out of the carrier:
+
+```dockerfile
+COPY --from=ghcr.io/roxabi/factory-omp-base:15.10.8 /opt/omp/omp /usr/local/bin/omp
+```
+
+**Runtime requirement:** the consumer image MUST be glibc-based. The `omp-linux-x64` binary
+links only against `libc`, `libm`, `libpthread`, and `libdl` — it cannot run in a
+scratch or musl (Alpine) environment.
+
+## Immutability guard
+
+The publish job checks `docker manifest inspect` post-login before pushing:
+
+- Tag **already exists** → emit `::warning::` + skip push + exit 0.
+- Tag **does not exist** → push proceeds normally.
+
+Any content change to the binary or Containerfile MUST be accompanied by a version bump.
+There is no `:latest` tag and no floating tag — all references are pinned semver.
+
+## ADR-053 carve-out
+
+The carrier image (`FROM scratch AS carrier`) has no `USER` directive. This is intentional:
+the scratch stage never executes — there is no `ld-linux`, no process, no user context.
+The non-root runtime requirement (ADR-053) applies to the **consumer's runtime stage**,
+which is tracked in **#1812** (`OmpWorker`).

--- a/docs/ops/container-publishing.md
+++ b/docs/ops/container-publishing.md
@@ -327,6 +327,7 @@ Steps for a new Roxabi project (voiceCLI, 2ndBrain, imageCLI, llmCLI) to adopt t
 ## Cross-references
 
 - `.github/workflows/publish.yml` — lyra caller workflow
+- `.github/workflows/omp-base.yml` — path-triggered build+publish for the omp binary carrier image (`ghcr.io/roxabi/factory-omp-base`, immutable version tags); separate from the main bake pipeline — see `deploy/omp-base/README.md`
 - `Roxabi/.github/.github/workflows/publish-container.yml@v1` — reusable workflow (upstream)
 - `deploy/quadlet/factory-hub.container` — `Image=` reference example
 - `deploy/quadlet/factory-telegram.container` — `Image=` reference example


### PR DESCRIPTION
## Summary
- New `deploy/omp-base/Containerfile` — 3-stage build: **download** (curl `--retry 3` + `sha256sum -c` against the pinned digest), **carrier** (`FROM scratch`, exactly `/opt/omp/omp` 0755), **smoke** (debian-based, build-time `RUN omp --version` exec proof — the glibc-linked binary cannot execute in scratch).
- New `.github/workflows/omp-base.yml` — path-triggered (`deploy/omp-base/**`) standalone workflow: `build-smoke` job gates every PR (validated ARG parse + smoke assert, pushes nothing); `publish` job (staging only, `needs: build-smoke`) pushes `ghcr.io/roxabi/factory-omp-base:15.10.8` behind a `docker manifest inspect` immutability guard (tag exists → `::warning::` + exit 0).
- Pin SSoT = the two Containerfile ARG defaults (`OMP_VERSION=v15.10.8`, sha256 `b877091c…7c7b`); the workflow parses them with strict regex validation — no literal pin copy in the workflow. All actions SHA-pinned (build-push-action `4f58ea79…` verified = upstream v6.9.0 tag).
- `deploy/omp-base/README.md` bump runbook + #1812 consumption pattern; `deploy/CLAUDE.md` scope line registered.
- Out of scope by design: Quadlet unit, `deploy/quadlet.toml` entry, secrets, ACL identity → #1812 (`secrets_drift` CHECKs b+c hard-couple those surfaces).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1810: factory-omp-base image — bake prebuilt omp-linux-x64 binary | OPEN (P1) |
| Frame | [1810-factory-omp-base-frame.mdx](artifacts/frames/1810-factory-omp-base-frame.mdx) | Present (approved) |
| Analysis | — | Absent (F-lite — frame sufficient) |
| Spec | [1810-factory-omp-base-spec.mdx](artifacts/specs/1810-factory-omp-base-spec.mdx) | Present (approved) |
| Plan | [1810-factory-omp-base-plan.mdx](artifacts/plans/1810-factory-omp-base-plan.mdx) | Present |
| Implementation | 8 commits on `feat/1810-factory-omp-base` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5565 passed; 0 new — no pytest surface) | Passed |

## Test Plan
- [x] `podman build --target carrier deploy/omp-base` → exit 0 (verified locally)
- [x] `podman build --target smoke deploy/omp-base` → exit 0, build log shows `omp/15.10.8` (verified locally)
- [x] Corrupted `OMP_SHA256` build-arg → build fails at `sha256sum -c` (verified locally)
- [x] Carrier image = 1 layer (`podman image inspect` RootFS)
- [x] `grep -c 'b877091c' .github/workflows/omp-base.yml` == 0; actions SHA-pinned; `doc_drift` + `secrets_drift` gates green
- [ ] CI `build-smoke` green on this PR (pushes nothing)
- [ ] After merge: `publish` pushes `ghcr.io/roxabi/factory-omp-base:15.10.8`; re-run stays green via `::warning::` skip

Fixes #1810

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
