### PR TITLE
chore(ci): re-pin node20 actions to node24 in publish + omp-base

### DIFF
--- a/.github/workflows/omp-base.yml
+++ b/.github/workflows/omp-base.yml
@@ -13,7 +13,7 @@ jobs:
   build-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # duplicated in the publish job — separate runners share no step context
       - name: Parse and validate pins from Containerfile
@@ -44,7 +44,7 @@ jobs:
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build smoke stage
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: deploy/omp-base
           file: deploy/omp-base/Containerfile
@@ -67,7 +67,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # re-parsed: separate runner, no shared step context with build-smoke
       - name: Parse and validate pins from Containerfile
@@ -95,7 +95,7 @@ jobs:
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Build carrier stage
         if: steps.guard.outputs.skip != 'true'
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: deploy/omp-base
           file: deploy/omp-base/Containerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Re-pin the three GitHub Actions still declaring **node20** to node24-compatible releases, ahead of GitHub's **2026-06-16** forced Node 24 switch (Node 20 runners removed 2026-09-16).
- `actions/checkout` v4 → **v6** (`de0fac2e`, already pinned by 7 other workflows — consistency win) · `docker/build-push-action` v6.9.0 → **v7.2.0** (`f9f3042f`) · `docker/login-action` v3 → **v4.2.0** (`650006c6`).
- Every new pin independently verified: the 40-char SHA matches the release tag's commit **and** `action.yml` at that SHA declares `runs.using: 'node24'`. Left untouched (already node24): `setup-buildx-action@d7f5e7f`, `bake-action@6614cfa`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1829 — re-pin node20 actions before Node 24 forced switch | OPEN |
| Implementation | 1 commit on `feat/1829-re-pin-node20-actions` (7 pin lines, 2 files) | Complete |
| Verification | YAML parses ✅ · pins resolve to release tags + node24 confirmed ✅ · no `src/` touched (ruff/pyright/pytest N/A) | Passed |

## Test Plan
- [ ] CI `publish` + `omp-base` workflows run green on this branch (the real gate for workflow YAML).
- [ ] `grep -rE '34e1148|4f58ea7|c94ce9fb' .github/workflows/` returns nothing (no node20 pins remain).

Fixes #1829

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`