### PR TITLE
feat(ci): add bus-bound str(exc) quality gate

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -118,3 +118,8 @@ quality_gates:
     stage: pre-push
     script: tools/check_volumes_table.sh
     description: verify deployment.md Volumes table prose matches Volume= directives in adapter quadlet templates
+
+  str_exc_bus_bound:
+    enabled: true
+    script: tools/check_str_exc_bus_bound.sh
+    description: block str(exc)/f"{exc}"/repr(exc) from flowing into SanitizedError construction or NATS-bus-bound message fields (SanitizedError discipline #1212, ADR-073)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: "Check hardcoded constants (new numeric literals in src/factory/core/)"
         run: bash tools/check_hardcoded_constants.sh
 
+      - name: "Check bus-bound str(exc) (SanitizedError discipline #1212, ADR-073)"
+        run: bash tools/check_str_exc_bus_bound.sh
+
       - name: Test hardcoded-constants gate
         run: bash tests/tools/test_check_hardcoded_constants.sh
 

--- a/docs/architecture/adr/073-axial-stage-of-pipeline-decomposition.mdx
+++ b/docs/architecture/adr/073-axial-stage-of-pipeline-decomposition.mdx
@@ -89,7 +89,23 @@ telegram = Pipeline(
 Architectural commitments already encoded in code structure:
 
 - `Result[T, E]` return type — callers cannot ignore errors; no exception propagation path.
-- `SanitizedError` boundary — single site in `transport/`, never re-constructed downstream.
+- **SanitizedError boundary — multi-site (sanctioned list).** Construction is permitted at
+  exactly five locations; all others require `dev-core:axial-adr-review`:
+
+  | Site | Layer | Justification |
+  |------|-------|---------------|
+  | `src/factory/transport/` (6 sites) | transport | Canonical boundary — original intent |
+  | `src/factory/outbound/error_handler.py` | outbound | Platform-SDK exception boundary; `type(exc).__name__` only — documented in `outbound/CLAUDE.md` |
+  | `src/factory/core/processors/stream_processor.py` (×2) | core/processors | Infrastructure exception + WorkerError bridge; async-generator context prevents delegation; `_we.message` pre-scrubbed by `_scrub_cli_error_text()` |
+  | `src/factory/core/cli/cli_streaming_parser.py` | core/cli | CLI→bus boundary; f-string uses `type(exc).__name__` only |
+
+  **Enforcement:** `tools/check_str_exc_bus_bound.sh` (quality gate, pre-commit) blocks
+  `str(exc)` / `f"{exc}"` / `repr(exc)` from flowing into `SanitizedError` construction or
+  NATS-bus-bound message fields in the five bus-bound path scopes. Escape hatch:
+  `# str-exc-ok: <reason>`.
+
+  The invariant is: `SanitizedError.message` NEVER carries raw `str(exc)`. The number of
+  construction sites is secondary to this invariant being enforced mechanically.
 - Layering: `transport → streaming → core/processors → adapters/outbound → bootstrap`
   (enforced by `.importlinter` `clean-architecture-layers` contract).
 - Per-subsystem CLAUDE.md files (streaming, transport, inbound, outbound, …) own their

--- a/src/factory/outbound/CLAUDE.md
+++ b/src/factory/outbound/CLAUDE.md
@@ -71,8 +71,9 @@ The architectural-decision record for the stage-axis pivot is deferred to Phase 
 (#1284, epic #1277 final cleanup phase). Until then, the SSoT is
 `artifacts/analyses/1277-stage-axis-refactor-strategy.mdx`.
 
-## DEBT: enforcement-deferred
+## Enforcement: bus-bound str(exc) gate
 
-A pre-commit grep check for bus-bound `str(exc)` patterns on outbound paths was scoped
-out of #1279 — the merge-time AC grep in the spec is the sole gate for this PR.
-Follow-up issue should add a `tools/check_outbound_str_exc.sh` pre-commit hook.
+`tools/check_str_exc_bus_bound.sh` (quality gate, pre-commit) covers `src/factory/outbound/`
+as one of its five bus-bound scan roots. It blocks `str(exc)` / `f"{exc}"` / `repr(exc)` from
+flowing into `SanitizedError` construction or NATS-bus-bound message fields. Escape hatch:
+`# str-exc-ok: <reason>` on the offending line. Debt from #1279 retired by #1835.

--- a/tools/check_str_exc_bus_bound.sh
+++ b/tools/check_str_exc_bus_bound.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check_str_exc_bus_bound.sh — block str(exc) / f"{exc}" from flowing into
+# SanitizedError construction or NATS-bus-bound message fields.
+# Escape hatch: add "# str-exc-ok: <reason>" on the offending line.
+# EXIT CODES: 0=clean, 1=violations, 2=script error
+
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || { echo "ERROR: not a git repository" >&2; exit 2; }
+cd "$REPO_ROOT"
+
+SCAN_ROOTS="${STR_EXC_SCAN_ROOTS:-src/factory/transport/ src/factory/outbound/ src/factory/core/processors/ src/factory/core/cli/ src/factory/streaming/}"
+
+# Build find args for existing dirs only
+FIND_DIRS=()
+for d in $SCAN_ROOTS; do
+    [ -d "$d" ] && FIND_DIRS+=("$d")
+done
+if [ ${#FIND_DIRS[@]} -eq 0 ]; then
+    echo "check_str_exc_bus_bound: no scan roots found — OK" ; exit 0
+fi
+
+VIOLATIONS="$(
+    find "${FIND_DIRS[@]}" -type f -name "*.py" -print0 \
+    | sort -z \
+    | xargs -0 grep -En \
+        'message=str\(exc|message=f"[^"]*\{exc|message=repr\(exc|message=format\(exc|from_message\(str\(exc|from_message\(f"[^"]*\{exc' \
+        2>/dev/null || true \
+    | grep -v '# str-exc-ok:' \
+    | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' \
+    || true
+)"
+
+if [ -z "$VIOLATIONS" ]; then
+    echo "check_str_exc_bus_bound: no bus-bound str(exc) patterns found — OK"
+    exit 0
+fi
+
+echo "" >&2
+echo "FAIL: bus-bound str(exc) patterns found (SanitizedError discipline #1212):" >&2
+while IFS= read -r v; do
+    [ -n "$v" ] || continue
+    filepath="${v%%:*}"
+    echo "  $v" >&2
+    echo "::error file=${filepath}::bus-bound str(exc) — use type(exc).__name__ or SanitizedError.from_message() with pre-scrubbed text; add '# str-exc-ok: <reason>' if intentional"
+done <<< "$VIOLATIONS"
+cnt="$(printf '%s\n' "$VIOLATIONS" | grep -c .)"
+echo "" >&2
+echo "Found ${cnt} bus-bound str(exc) violation(s)." >&2
+echo "Remediation: use type(exc).__name__ (never leaks internals) or SanitizedError.from_message() for pre-scrubbed upstream text." >&2
+exit 1


### PR DESCRIPTION
## Summary

- Add `tools/check_str_exc_bus_bound.sh` — pre-commit gate blocking `str(exc)` / `f"{exc}"` / `repr(exc)` from flowing into `SanitizedError` construction or NATS-bus-bound message fields across 5 bus-bound path scopes (transport, outbound, core/processors, core/cli, streaming). Exit 0=clean, 1=violations, 2=script error. Escape hatch: `# str-exc-ok: <reason>`.
- Register gate in `.claude/stack.yml` as `str_exc_bus_bound` (no `stage` = pre-commit default).
- Wire into `.github/workflows/ci.yml` after `check_hardcoded_constants.sh`.
- Update `docs/architecture/adr/073-axial-stage-of-pipeline-decomposition.mdx` line 92: replace single-site SanitizedError sentence with sanctioned multi-site table + enforcement pointer.
- Retire `DEBT: enforcement-deferred` in `src/factory/outbound/CLAUDE.md` — replaced with pointer to the new gate (debt from #1279 resolved).

## Gate results (local)

| Gate | Result |
|------|--------|
| `check_str_exc_bus_bound.sh` | no violations — OK |
| `check_test_sleep.sh` | OK |
| `check_debt_expiry.sh` | OK |
| `lint-imports` | 11 kept, 0 broken |
| `check_doc_drift.py` | 0 new violations |
| `check-qg-conf-drift.sh` | qg.conf matches stack.yml |
| `ruff check .` | 0 new errors |
| `pyright` | 0 errors |
| `pytest tests/ -x -q` | 4747 passed, 14 skipped, 1 xfailed |

## Test plan

- [ ] CI green on all stages (lint, typecheck, unit, coverage)
- [ ] `check_str_exc_bus_bound.sh` step passes in CI
- [ ] No axial-review label triggered (no cross-layer boundary changes, no `except Exception` added)

Closes #1835

🤖 Generated with [Claude Code](https://claude.com/claude-code)