### PR TITLE
feat(blobstore): age-based blob sweep (#1836)

### DIFF
--- a/deploy/systemd/factory-blobstore-sweep.service
+++ b/deploy/systemd/factory-blobstore-sweep.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Factory blobstore age-based sweep — delete blob refs older than 30d
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=podman exec factory-blobstore factory blobstore sweep --older-than 30d
+StandardOutput=journal
+StandardError=journal

--- a/deploy/systemd/factory-blobstore-sweep.timer
+++ b/deploy/systemd/factory-blobstore-sweep.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Factory blobstore age-based sweep — daily at 03:00
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+Unit=factory-blobstore-sweep.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/architecture/adr/067-blobstore-abstraction-flat-fs-content-addressed.mdx
+++ b/docs/architecture/adr/067-blobstore-abstraction-flat-fs-content-addressed.mdx
@@ -9,6 +9,8 @@ status: accepted
 
 > **Partially superseded by ADR-068 (Ecosystem Service Plane)** — §single-host and §workers-direct-FS scopes are subsumed by the Ecosystem Service Plane Protocol rule. The BlobStore backend choice below remains in force; the access pattern is governed by ADR-068.
 
+> **Partially superseded by #1836 (age-based sweep)** — v1 never-delete policy (§GC interface) replaced by age-based sweep. `FsBlobStore.sweep_older_than(cutoff_ts)` + `factory blobstore sweep --older-than 30d` CLI; daily host-level timer in `deploy/systemd/`; 7d minimum guard.
+
 
 ## Status
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -286,6 +286,7 @@ guard pattern is gone; the bus is either injected or absent. → ADR-022 (amende
   backup. SQLite `.backup` API or WAL checkpoint before FS snapshot is mandatory if a
   backup cron is added. Not yet implemented.
 - Blob mount inode/disk alerts (threshold 80%) are specified in ADR-067 but not yet wired.
+- ~~Blob retention: v1 policy was never-delete (ADR-067 §GC interface).~~ Age-based sweep now implemented (#1836): `FsBlobStore.sweep_older_than(cutoff_ts)` + `factory blobstore sweep --older-than 30d` CLI. Host-level daily timer at 03:00 in `deploy/systemd/factory-blobstore-sweep.{service,timer}`. Hard guard: minimum 7d (FACTORY_OUTBOUND_AUDIO JetStream MaxAge is 24h; 7d provides margin).
 - v1 BlobStore is single-host but ecosystem-transparent: cross-host consumers use `HttpBlobStore`
   (V8 HTTP service); MinIO swap is triggered only by disk pressure, HA need, or S3 demand. → ADR-068
 - TurnStore + L3 memory (including L1 sessions — `pool_sessions` table in `turns.db`) use direct-write to SQLite (co-located, ADR-068 pattern α deviation). Tolerated until either (a) the TurnStore α-refactor issue (#1331) lands, OR (b) a 3rd adapter is added on top of TurnStore — whichever comes first (ADR-073 three-strikes rule).

--- a/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
@@ -342,3 +342,64 @@ class FsBlobStore:
                             f"unlink failed for content_hash={content_hash[:12]}…: "
                             f"{e.strerror or 'OSError'}"
                         ) from e
+
+    async def sweep_older_than(self, cutoff_ts: float) -> tuple[int, int]:
+        """Delete all blob refs whose `ingested_at` is older than `cutoff_ts`.
+
+        Calls :meth:`delete` for each stale ref so ref-counting is respected:
+        a file is only unlinked when its last ref is removed.
+
+        Args:
+            cutoff_ts: POSIX timestamp (UTC). Refs with ``ingested_at < cutoff_ts``
+                are swept. Must be at least 7 days in the past (guard against
+                accidental in-flight consumer data loss — FACTORY_OUTBOUND_AUDIO
+                JetStream MaxAge is 24 h; 7 d gives ample margin).
+
+        Returns:
+            ``(refs_deleted, files_unlinked)`` — files_unlinked counts content-
+            addressed files whose last ref was removed during this sweep.
+
+        Raises:
+            BlobWriteError: if the database query or a delete operation fails.
+        """
+        conn, _lock = self._require_open()
+        refs_deleted = 0
+        files_unlinked = 0
+        # Snapshot all stale IDs up-front (avoids cursor invalidation while we
+        # mutate blob_refs inside delete()).
+        cursor = await conn.execute(
+            "SELECT id FROM blob_refs WHERE ingested_at < ?",
+            (cutoff_ts,),
+        )
+        stale_ids: list[int] = [int(row[0]) for row in await cursor.fetchall()]
+        await cursor.close()
+
+        for blob_ref_id in stale_ids:
+            # Probe remaining refs BEFORE delete to detect last-ref removal.
+            # delete() is the authoritative ref-counted path (commit-before-unlink).
+            cursor = await conn.execute(
+                "SELECT content_hash FROM blob_refs WHERE id = ?",
+                (blob_ref_id,),
+            )
+            ref_row = await cursor.fetchone()
+            await cursor.close()
+            if ref_row is None:
+                # Already removed by a concurrent sweep — skip.
+                continue
+            content_hash = str(ref_row[0])
+
+            cursor = await conn.execute(
+                "SELECT COUNT(*) FROM blob_refs WHERE content_hash = ?",
+                (content_hash,),
+            )
+            count_row = await cursor.fetchone()
+            await cursor.close()
+            remaining_before = int(count_row[0]) if count_row is not None else 0
+
+            await self.delete(blob_ref_id)
+            refs_deleted += 1
+            if remaining_before == 1:
+                # This was the last ref → file was unlinked by delete().
+                files_unlinked += 1
+
+        return refs_deleted, files_unlinked

--- a/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
+++ b/packages/roxabi-blobs/src/roxabi_blobs/fs_store.py
@@ -365,11 +365,16 @@ class FsBlobStore:
         conn, _lock = self._require_open()
         refs_deleted = 0
         files_unlinked = 0
+        # Convert cutoff to ISO-8601 string: ingested_at is stored as TEXT via
+        # datetime.isoformat() (e.g. '2026-06-11T08:30:48.822502+00:00').
+        # Binding a POSIX float would compare TEXT vs REAL — TEXT affinity makes
+        # '2...' always > '1...' so the WHERE never matches (production no-op).
+        cutoff_iso = datetime.fromtimestamp(cutoff_ts, tz=UTC).isoformat()
         # Snapshot all stale IDs up-front (avoids cursor invalidation while we
         # mutate blob_refs inside delete()).
         cursor = await conn.execute(
             "SELECT id FROM blob_refs WHERE ingested_at < ?",
-            (cutoff_ts,),
+            (cutoff_iso,),
         )
         stale_ids: list[int] = [int(row[0]) for row in await cursor.fetchall()]
         await cursor.close()

--- a/packages/roxabi-blobs/tests/test_sweep.py
+++ b/packages/roxabi-blobs/tests/test_sweep.py
@@ -1,0 +1,131 @@
+"""`sweep_older_than` semantics — age-based blob retention (#1836).
+
+Invariants:
+  - Refs whose ingested_at < cutoff_ts are deleted (ref-counted).
+  - File survives when a second ref to the same content_hash is younger than
+    the cutoff (partial sweep — only the old ref is removed).
+  - File is unlinked when all refs to a content_hash are swept.
+  - Empty store returns (0, 0) — no-op.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from roxabi_blobs import FsBlobStore
+
+
+async def _put_with_ts(
+    store: FsBlobStore, data: bytes, ingested_at: float, source: str = "src"
+) -> int:
+    """Put `data` then back-date its `ingested_at` to `ingested_at` (POSIX float).
+
+    Returns the blob_ref_id.
+    """
+    ref = await store.put(data, mime="text/plain", source=source)
+    conn = store._conn  # type: ignore[attr-defined]
+    assert conn is not None
+    await conn.execute(
+        "UPDATE blob_refs SET ingested_at = ? WHERE content_hash = ? AND source = ?",
+        (ingested_at, ref.content_hash, source),
+    )
+    await conn.commit()
+    # Retrieve the assigned id.
+    cursor = await conn.execute(
+        "SELECT id FROM blob_refs"
+        " WHERE content_hash = ? AND source = ?"
+        " ORDER BY id DESC LIMIT 1",
+        (ref.content_hash, source),
+    )
+    row = await cursor.fetchone()
+    await cursor.close()
+    assert row is not None
+    return int(row[0])
+
+
+@pytest.mark.asyncio
+async def test_sweep_empty_store_is_noop(store: FsBlobStore) -> None:
+    cutoff = time.time()
+    refs_deleted, files_unlinked = await store.sweep_older_than(cutoff)
+    assert refs_deleted == 0
+    assert files_unlinked == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_file_survives_when_younger_ref_exists(
+    store: FsBlobStore, sample_bytes: bytes
+) -> None:
+    """Second ref to the same content_hash is younger → file must survive."""
+    old_ts = time.time() - 200.0
+    now_ts = time.time()
+    cutoff = time.time() - 100.0  # old_ts is before cutoff; now_ts is after
+
+    # Same content ingested twice with different timestamps.
+    await _put_with_ts(store, sample_bytes, old_ts, source="old")
+    await _put_with_ts(store, sample_bytes, now_ts, source="new")
+
+    # Determine content_hash and expected file path.
+    conn = store._conn  # type: ignore[attr-defined]
+    assert conn is not None
+    cursor = await conn.execute("SELECT content_hash FROM blobs LIMIT 1")
+    row = await cursor.fetchone()
+    await cursor.close()
+    assert row is not None
+    content_hash = str(row[0])
+    file_path = store.root / content_hash[:2] / content_hash
+
+    assert file_path.exists(), "file must exist before sweep"
+
+    refs_deleted, files_unlinked = await store.sweep_older_than(cutoff)
+
+    assert refs_deleted == 1, "only the old ref should be deleted"
+    assert files_unlinked == 0, "file must survive because younger ref still exists"
+    assert file_path.exists(), "file must still be on disk"
+
+    # Confirm one blob_refs row remains.
+    cursor = await conn.execute("SELECT COUNT(*) FROM blob_refs")
+    count_row = await cursor.fetchone()
+    await cursor.close()
+    assert count_row is not None
+    assert int(count_row[0]) == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_all_refs_unlinks_file(
+    store: FsBlobStore, sample_bytes: bytes
+) -> None:
+    """When all refs are older than the cutoff, file must be unlinked."""
+    old_ts = time.time() - 200.0
+    cutoff = time.time() - 100.0
+
+    await _put_with_ts(store, sample_bytes, old_ts, source="only")
+
+    conn = store._conn  # type: ignore[attr-defined]
+    assert conn is not None
+    cursor = await conn.execute("SELECT content_hash FROM blobs LIMIT 1")
+    row = await cursor.fetchone()
+    await cursor.close()
+    assert row is not None
+    content_hash = str(row[0])
+    file_path = store.root / content_hash[:2] / content_hash
+
+    assert file_path.exists(), "file must exist before sweep"
+
+    refs_deleted, files_unlinked = await store.sweep_older_than(cutoff)
+
+    assert refs_deleted == 1
+    assert files_unlinked == 1
+    assert not file_path.exists(), "file must be unlinked after final ref is swept"
+
+    # Both tables must be empty.
+    cursor = await conn.execute("SELECT COUNT(*) FROM blob_refs")
+    count_row = await cursor.fetchone()
+    await cursor.close()
+    assert count_row is not None and int(count_row[0]) == 0
+
+    cursor = await conn.execute("SELECT COUNT(*) FROM blobs")
+    count_row = await cursor.fetchone()
+    await cursor.close()
+    assert count_row is not None and int(count_row[0]) == 0

--- a/packages/roxabi-blobs/tests/test_sweep.py
+++ b/packages/roxabi-blobs/tests/test_sweep.py
@@ -11,6 +11,7 @@ Invariants:
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
 
 import pytest
 
@@ -20,16 +21,20 @@ from roxabi_blobs import FsBlobStore
 async def _put_with_ts(
     store: FsBlobStore, data: bytes, ingested_at: float, source: str = "src"
 ) -> int:
-    """Put `data` then back-date its `ingested_at` to `ingested_at` (POSIX float).
+    """Put `data` then back-date its `ingested_at` to an ISO-8601 string.
+
+    Matches the format produced by production put() (datetime.isoformat()).
+    Storing a raw float would mask the TEXT-vs-REAL affinity bug in sweep_older_than.
 
     Returns the blob_ref_id.
     """
     ref = await store.put(data, mime="text/plain", source=source)
     conn = store._conn  # type: ignore[attr-defined]
     assert conn is not None
+    ingested_at_iso = datetime.fromtimestamp(ingested_at, tz=UTC).isoformat()
     await conn.execute(
         "UPDATE blob_refs SET ingested_at = ? WHERE content_hash = ? AND source = ?",
-        (ingested_at, ref.content_hash, source),
+        (ingested_at_iso, ref.content_hash, source),
     )
     await conn.commit()
     # Retrieve the assigned id.

--- a/src/factory/blobstore/cli.py
+++ b/src/factory/blobstore/cli.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import re
+import time
 from pathlib import Path
 
 import typer
@@ -9,10 +12,31 @@ import uvicorn
 
 from factory.blobstore.serve import build_app
 from factory.paths import factory_data_dir
+from roxabi_blobs import FsBlobStore
 
 blobstore_app = typer.Typer(name="blobstore", help="BlobStore HTTP service.")
 
 _DEFAULT_TOKEN_PATH = Path("/run/secrets/lyra_blobstore_token")
+
+# Minimum sweep window — FACTORY_OUTBOUND_AUDIO JetStream MaxAge is 24 h;
+# in-flight consumers may still hold references.  7 d gives margin.
+_MIN_SWEEP_DAYS = 7
+_DURATION_RE = re.compile(r"^(\d+)(d|h)$")
+
+
+def _parse_duration_secs(value: str) -> float:
+    """Parse a duration string like ``30d`` or ``48h`` into seconds.
+
+    Raises :class:`typer.BadParameter` on invalid input.
+    """
+    m = _DURATION_RE.match(value.strip())
+    if not m:
+        raise typer.BadParameter(
+            f"Invalid duration '{value}'. Use Nd (days) or Nh (hours), e.g. '30d'."
+        )
+    amount = int(m.group(1))
+    unit = m.group(2)
+    return float(amount * 86400 if unit == "d" else amount * 3600)
 
 
 @blobstore_app.command()
@@ -31,4 +55,41 @@ def serve(
         build_app(token_path=token_path, blob_root=blob_root),
         host=host,
         port=port,
+    )
+
+
+@blobstore_app.command()
+def sweep(
+    older_than: str = typer.Option(
+        "30d",
+        "--older-than",
+        help="Delete refs older than this duration (e.g. '30d', '168h'). Minimum 7d.",
+    ),
+) -> None:
+    """Delete blob refs older than the given duration.
+
+    Files are unlinked only when their last ref is removed (ref-counted).
+    Minimum sweep window is 7 days to protect in-flight consumers.
+    """
+    duration_secs = _parse_duration_secs(older_than)
+    min_secs = _MIN_SWEEP_DAYS * 86400
+    if duration_secs < min_secs:
+        typer.echo(
+            f"ERROR: --older-than must be at least {_MIN_SWEEP_DAYS}d "
+            f"({min_secs:.0f}s). Got {duration_secs:.0f}s ({older_than}).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    cutoff_ts = time.time() - duration_secs
+    blob_root = factory_data_dir() / "blobstore"
+
+    async def _run() -> tuple[int, int]:
+        async with FsBlobStore(blob_root) as store:
+            return await store.sweep_older_than(cutoff_ts)
+
+    refs_deleted, files_unlinked = asyncio.run(_run())
+    typer.echo(
+        f"Sweep complete: {refs_deleted} ref(s) deleted, "
+        f"{files_unlinked} file(s) unlinked (older-than={older_than})."
     )


### PR DESCRIPTION
## Summary

- `FsBlobStore.sweep_older_than(cutoff_ts)` — queries `blob_refs WHERE ingested_at < cutoff_ts`, calls `delete()` for each stale ref; file is unlinked only when its last ref is removed (ref-counting respected)
- `factory blobstore sweep --older-than 30d` CLI — Nd/Nh parsing, hard guard refusing cutoffs < 7d (FACTORY_OUTBOUND_AUDIO JetStream MaxAge is 24h; 7d provides margin)
- `deploy/systemd/factory-blobstore-sweep.{service,timer}` — host-level oneshot + daily 03:00 Persistent timer; runs `podman exec factory-blobstore factory blobstore sweep --older-than 30d`; consistent with `factory-post-autoupdate.*` pattern
- ADR-067 third blockquote updated: v1 never-delete policy partially superseded by #1836
- `docs/architecture/storage.md` open-gap note updated with implemented status

Note: 80% disk/inode alert wiring (ADR-067 §Alerts) is an existing open gap tracked in storage.md — monitoring-repo follow-up, out of scope for this issue.

Closes #1836

## Test plan

- [ ] `uv run pytest packages/roxabi-blobs/tests/test_sweep.py -q` — 3 tests: empty no-op, shared content_hash survives younger ref, all-refs unlinked
- [ ] `factory blobstore sweep --older-than 6d` exits code 1 (hard guard)
- [ ] `factory blobstore sweep --older-than 30d` completes against a real blobstore

## Gates run

| Gate | Result |
|---|---|
| ruff format + check --fix | PASS |
| pyright | PASS (0 errors) |
| pytest test_sweep.py | PASS (3/3) |
| lint-imports | PASS |
| check_test_sleep.sh | PASS |
| check_debt_expiry.sh | PASS |
| check_doc_drift.py | PASS |
| check_secrets_drift.sh | PASS |
| check_volumes_table.sh | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)