### PR TITLE
docs(adr): amend ADR-084 — job_id = run (not turn), hops ≠ jobs, sub-jobs = parent_job_id

### DIFF
--- a/artifacts/frames/1794-adr-084-job-id-run-frame.mdx
+++ b/artifacts/frames/1794-adr-084-job-id-run-frame.mdx
@@ -1,0 +1,75 @@
+---
+title: "docs(adr): amend ADR-084 — job_id = run (not turn), hops != jobs, sub-jobs = parent_job_id"
+issue: 1794
+status: approved
+tier: S
+date: 2026-06-11
+---
+
+## Problem
+
+ADR-084 line 75 labels `job_id` as "(turn)" inside the `cli` id taxonomy sentence. Line 87–88
+frames internal routing as "it then flows hub → harness → satellite (child jobs)". Both are
+under-ratified residue from the now-CLOSED obs epic #1622 (unbuilt); neither reflects the
+decision ratified in `artifacts/analyses/job-model-concept-analysis.md §15.1`. The label
+and the framing contradict line 87 itself ("root `job_id` minted at ingress… the moment a
+user message enters"), which is run-scoped by definition.
+
+The ratified identity pivot (`job_id = run`, not turn; internal LLM hops opaque; sub-jobs
+explicit via `parent_job_id` + `composite_depth`) is documented in `job-model.md` (lines 85–86)
+and in the concept analysis, but the authoritative ADR still carries the contradicting prose.
+Issue #1619 (spec for WorkEnvelope + reparent) implements ADR-084 directly — it needs the
+amended wording as its canonical reference.
+
+Issue #1796 (active-jobs registry, M1 milestone) is explicitly blocked on this amendment:
+the registry design assumes `job_id=run` as a durable, per-message key. Landing #1794 unblocks
+the C-cluster of M1 work (#1796, #1797, #1798, #1799).
+
+## Who
+
+- **Primary:** Mickael (author, human reviewer — approves amendment prose)
+- **Secondary:** #1619 implementer (WorkEnvelope + reparent — consumes amended ADR wording as spec contract); M1 downstream issues #1796/#1797/#1798/#1799 (unblocked once amendment lands)
+
+## Constraints
+
+- **Scope boundary:** only the id-model prose is corrected — Option C (WorkEnvelope/ContractEnvelope split, mandatory `job_id` min_length=1, nullable `parent_job_id` None at root) is RATIFIED and MUST NOT change.
+- **ADR amendment style:** follow ADR-001/ADR-022 house pattern: add `status: amended` to frontmatter (currently absent), add "— amended by #1794" to the `## Status` prose section, add `## Amendment` section at end of file.
+- **Exact line 75 surgery:** only the "(turn)" label is replaced with "(run)" — the surrounding coordinate structure of the id sentence (`cli_session_id · lyra_session_id · job_id · parent_job_id · trace_id`) is preserved.
+- **Lines 87–88 replacement:** "satellite (child jobs), the tree sharing `trace_id`" → framing using sub-jobs / `parent_job_id` consistent with concept-analysis §15.1 and job-model.md.
+- **doc_drift:** `docs/architecture/adr/**` is fully EXEMPT from backtick-symbol checking (confirmed in tools/CLAUDE.md). `WorkEnvelope` remains UNBUILT in src/; the amendment must not introduce a backtick `WorkEnvelope` reference in any scanned domain page (job-model.md already uses bold **WorkEnvelope** correctly — no edit needed there).
+- **Sibling M1 issues in parallel prep:** #1619 (WorkEnvelope spec), #1782 (likely job_id references), #1791 (job model related) — amendment prose must be consistent with these; do not introduce new field names not present in `packages/roxabi-contracts` (`parent_job_id` and `composite_depth` are SHIPPED at :28/:29).
+- **Quality gates:** tier S = single doc file edit, no code change, no import-layer, no hardcoded-constants, no architecture_snapshot impact.
+
+## Out of Scope
+
+- Updating `job-model.md` — already pre-amended (lines 85–86 reference #1794 and state the ratified wording); no edit needed.
+- Implementing WorkEnvelope in `src/` or `packages/` — that is #1619.
+- Updating ingress mint logic or inbound adapters — that is #1620.
+- Folding `request_id` → `job_id` — that is #1621.
+- Subject taxonomy migration (`factory.results.*` → `factory.job.<id>.result`) — that is #1793 (not yet landed).
+- Any change to the obs epic #1622 or its residual references in other ADRs.
+- Updating `meta.json` for Fumadocs if the status field change has no rendering side-effects (verify at review).
+
+## Premise Validity
+
+**Success in 6 months:** ADR-084 carries `status: amended` frontmatter and an `## Amendment` section; the "(turn)" label is gone; no downstream issue or PR references the "(turn)" framing as authoritative; #1619 spec is consistent with the amended ADR wording; `grep '(turn)' docs/` returns zero hits outside of historical context references.
+
+**Failure in 6 months:** A new PR implements job-level logic using turn-granularity `job_id` semantics (one `job_id` per conversational turn), citing ADR-084 as justification — meaning the contradiction was never authoritatively resolved and the old prose kept being read as normative.
+
+**Simplest alternative:** Add a one-line "NOTE: (turn) label is deprecated — see job-model.md" comment directly on line 75, leaving the contradiction in place.
+
+**Why not simplest:** A note leaves the contradiction intact in the ADR's own prose and provides no stable wording for #1619 to import as spec contract. An actual Amendment section with corrected prose is the prescribed house pattern (ADR-001/ADR-022) and is the minimum to unblock #1619 and #1796 cleanly.
+
+_(champs dérivés du contexte — à valider à la review humaine)_
+
+## Complexity
+
+**Tier: S** — single MDX file edit (docs/architecture/adr/084-workenvelope-job-id-invariant.mdx), no code change, no contract schema change, no architecture snapshot impact; all ratified wording already exists in verified source documents.
+
+Signals observed:
+- 1 file in scope (ADR-084 MDX)
+- 0 code files touched
+- Pre-digested ratified wording available verbatim from concept-analysis §15.1 (lines 937–959)
+- No cross-repo coordination required (packages/roxabi-contracts already ships `parent_job_id` + `composite_depth`)
+- doc_drift gate is exempt for `docs/architecture/adr/**`
+- All verification already performed by pre-task agent

--- a/artifacts/specs/1794-adr-084-job-id-run-spec.mdx
+++ b/artifacts/specs/1794-adr-084-job-id-run-spec.mdx
@@ -180,11 +180,11 @@ Living SSoT: `docs/architecture/job-model.md`.
 
 ## Success Criteria
 
-- [ ] `grep '(turn)' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns 0 hits.
+- [ ] `grep -c '`job_id` (run)' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns ≥ 1 (the `(run)` label is present); AND `grep -v '^- Line 75' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx | grep -c '(turn)'` returns 0 (no normative `(turn)` label outside the Amendment's historical-reference bullet).
 - [ ] ADR-084 frontmatter contains `status: amended`.
 - [ ] ADR-084 `## Status` prose contains "amended by #1794".
 - [ ] ADR-084 contains a `## Amendment` section with the ratified `job_id=run` definition table and pointer to `job-model.md`.
-- [ ] `grep -n 'child jobs' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns 0 hits; AND the block replacing lines 87–88 contains both `parent_job_id` and `composite_depth` (verify with `grep -n 'parent_job_id\|composite_depth' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx | grep -v '^[0-9]*:\(57\|75\|82\|111\)')` showing hits in the Change 4 expansion).
+- [ ] The block replacing lines 87–88 contains both `parent_job_id` and `composite_depth`: `grep -n 'parent_job_id\|composite_depth' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` shows hits in the expanded supporting rule; AND `grep -v '"satellite (child jobs)' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx | grep -c 'child jobs'` returns 0 (no normative `child jobs` framing outside the Amendment's historical-reference bullet).
 - [ ] `uv run python tools/check_doc_drift.py` passes (ADR files are exempt; no scanned file gains a new unbuilt backtick symbol).
 - [ ] `grep -c 'min_length=1' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns ≥ 1 (Option C presence check); `git diff docs/architecture/adr/084-workenvelope-job-id-invariant.mdx | grep '^[-+]' | grep -E 'WorkEnvelope|ContractEnvelope|min_length|nullable|parent_job_id.*None' | grep -v '^[-+][-+][-+]'` shows no deletions from the Decision section (lines 54–99) other than Changes 3 and 4.
 

--- a/artifacts/specs/1794-adr-084-job-id-run-spec.mdx
+++ b/artifacts/specs/1794-adr-084-job-id-run-spec.mdx
@@ -1,0 +1,205 @@
+---
+title: "docs(adr): amend ADR-084 — job_id = run (not turn), hops != jobs, sub-jobs = parent_job_id"
+description: "Correct ADR-084's under-ratified id-model prose: replace the '(turn)' label at :75 with '(run)' and replace the 'child jobs' framing at :87–88 with the ratified sub-jobs / parent_job_id model."
+---
+
+## Context
+
+**Promoted from:** [frame](../frames/1794-adr-084-job-id-run-frame.mdx)
+**GitHub issue:** #1794
+**ADR being amended:** `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx`
+**Ratified wording source:** `artifacts/analyses/job-model-concept-analysis.md` §15.1 (lines 937–959)
+**Living SSoT:** `docs/architecture/job-model.md` (already pre-amended at lines 85–86, no edit needed)
+**Related:** #1619 (implements ADR-084 — consumes this amendment as spec contract); #1622 (closed obs epic that introduced the "(turn)" label); #1796/#1797/#1798/#1799 (M1 C-cluster, blocked on this amendment)
+
+ADR-084 line 75 labels `job_id` as "(turn)" inside the `cli` id taxonomy sentence. Lines 87–88
+frame internal routing as "it then flows hub → harness → satellite (child jobs)". Both are
+under-ratified residue from the now-CLOSED obs epic #1622 (unbuilt). The prose at :87 already
+contradicts the label: "root `job_id` minted at ingress (the moment a user message enters)" is
+run-scoped by definition, not turn-scoped.
+
+The ratified identity pivot — `job_id = run`, internal LLM hops opaque, sub-jobs explicit via
+`parent_job_id` + `composite_depth` — lives in the concept analysis §15.1 and is reflected in
+`job-model.md`. The authoritative ADR still carries the contradicting prose, blocking #1619 from
+having a clean canonical reference and blocking #1796 from ratifying its `job_id=run` key model.
+
+Option C (WorkEnvelope/ContractEnvelope split, mandatory `job_id` min_length=1, nullable
+`parent_job_id` None at root) is **ratified and unchanged** by this amendment.
+
+## Goal
+
+Correct the id-model prose in ADR-084 to match the ratified `job_id=run` model, so that #1619
+and the M1 C-cluster have an unambiguous canonical reference.
+
+## Users
+
+- **#1619 implementer** — reads ADR-084 as the spec contract for WorkEnvelope; needs "(run)"
+  not "(turn)" and correct sub-jobs framing before writing code.
+- **M1 downstream issues** (#1796 active-jobs registry, #1797 concurrency router, #1798
+  sub-jobs, #1799 steer e2e) — each assumes `job_id=run` is the durable per-message key;
+  unblocked once this amendment lands.
+- **Future contributors** — encountering ADR-084 as a reference must not be misled into
+  implementing turn-granularity `job_id` logic.
+
+## Expected Behavior
+
+After this amendment lands:
+
+1. `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` frontmatter carries
+   `status: amended`.
+
+2. The `## Status` prose section reads:
+   `Accepted — amended by #1794 (job_id = run, hops ≠ jobs, sub-jobs via parent_job_id; see Amendment below).`
+
+3. The id taxonomy sentence at line 75 reads:
+   `= pool_id ≈ Langfuse session) · job_id (run) · parent_job_id (nesting) · trace_id (tree).`
+   (only the `(turn)` label is replaced with `(run)`; the coordinate structure is preserved).
+
+4. The supporting rule at lines 87–88 replaces "satellite (child jobs), the tree sharing
+   `trace_id`" with framing consistent with §15.1: internal LLM hops inside a worker are
+   opaque (not job_ids); cross-process decomposition is explicit via `parent_job_id` +
+   `composite_depth`.
+
+5. A `## Amendment` section is appended at the end of ADR-084 containing:
+   - The issue reference (#1794) and date.
+   - The ratified `job_id=run` definition (one entry → full processing → terminal closing
+     message; ≡ run).
+   - The "internal hops opaque" rule (LLM multi-turn inside a worker = not job_ids).
+   - The sub-jobs rule (`parent_job_id` + `composite_depth ≤ 3`; both SHIPPED in
+     `packages/roxabi-contracts`).
+   - A pointer to `job-model.md` as the living SSoT.
+
+6. `job-model.md` is **not edited** (already pre-amended at lines 85–86).
+
+7. No `WorkEnvelope` backtick reference is introduced in any doc_drift-scanned file
+   (ADR files are exempt; job-model.md already uses bold **WorkEnvelope** correctly).
+
+## Edit Plan
+
+### File: `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx`
+
+**Change 1 — Add `status: amended` to frontmatter**
+
+Current frontmatter (lines 1–5):
+```
+---
+title: "ADR-084: WorkEnvelope — the job_id invariant"
+description: Split the NATS contract envelope into WorkEnvelope (mandatory job_id) vs infra ContractEnvelope (trace_id only).
+related: [049, 076, 075, 078]
+---
+```
+
+Amended frontmatter:
+```
+---
+title: "ADR-084: WorkEnvelope — the job_id invariant"
+description: Split the NATS contract envelope into WorkEnvelope (mandatory job_id) vs infra ContractEnvelope (trace_id only).
+related: [049, 076, 075, 078]
+status: amended
+---
+```
+
+**Change 2 — Update `## Status` prose**
+
+Current (line 9):
+```
+Accepted
+```
+
+Amended:
+```
+Accepted — amended by #1794 (job_id = run, hops ≠ jobs, sub-jobs via parent_job_id; see Amendment below).
+```
+
+**Change 3 — Replace `(turn)` with `(run)` at line 75**
+
+Current (line 75):
+```
+= `pool_id` ≈ Langfuse session) · `job_id` (turn) · `parent_job_id` (nesting) · `trace_id` (tree).
+```
+
+Amended (replace label only, preserve coordinate structure):
+```
+= `pool_id` ≈ Langfuse session) · `job_id` (run) · `parent_job_id` (nesting) · `trace_id` (tree).
+```
+
+**Change 4 — Replace the supporting rule at lines 87–88**
+
+Current (lines 87–88):
+```
+- **Root `job_id` minted at ingress** by inbound adapters (the moment a user message
+  enters); it then flows hub → harness → satellite (child jobs), the tree sharing `trace_id`.
+```
+
+Amended (replace "satellite (child jobs), the tree sharing `trace_id`" framing):
+```
+- **Root `job_id` minted at ingress** by inbound adapters (the moment a user message
+  enters); one `job_id` per run (entry → full processing → terminal closing message).
+  Internal worker hops (e.g. cli_pool multi-turn LLM calls) are **opaque** — they are
+  NOT sub-jobs and carry no new `job_id`. Cross-process decomposition into sub-jobs is
+  **explicit** via `parent_job_id` + `composite_depth` (both SHIPPED in
+  `packages/roxabi-contracts`; `composite_depth ≤ 3`). All nodes in a job tree share
+  `trace_id`.
+```
+
+_Note: Change 4 expands the `let: job :=` definition inline (§15.1 form). The Amendment table in Change 5 restates it concisely ("one run = one `job_id`, durable for the whole run") as a quick-reference. §15.1 is the primary source; the Amendment table is the summary._
+
+**Change 5 — Append `## Amendment` section at end of file**
+
+Append after the `## Trail` section. Present as live prose — no outer code fence:
+
+## Amendment: job_id = run, hops ≠ jobs, sub-jobs via parent_job_id (#1794)
+
+_Amended by #1794 (2026-06-11). Author: Mickael._
+
+### id-model correction (replaces under-ratified prose from closed obs epic #1622)
+
+Ratified definition (source: `artifacts/analyses/job-model-concept-analysis.md` §15.1):
+
+~~~
+let: job  := one entry → full processing (internal multi-turn + steer + streaming) → final closing message
+     run  := the atomic unit of observable work (≡ job)
+     ¬turn := job is NOT per-turn
+~~~
+
+| Concept | Status |
+|---|---|
+| `job_id` minted at ingress, per user message | one run = one `job_id` (durable for the whole run) |
+| Internal LLM hops inside a worker (e.g. cli_pool multi-turn) | NOT `job_id`s — opaque, irreducible internal layer |
+| Cross-process decomposition | EXPLICIT sub-jobs via `parent_job_id` + `composite_depth ≤ 3` only |
+
+**What changed:**
+- Line 75: `(turn)` label → `(run)`.
+- Lines 87–88: "satellite (child jobs), the tree sharing `trace_id`" → run-scoped minting +
+  opaque-hops rule + explicit sub-jobs rule.
+
+**What did NOT change:** Option C (WorkEnvelope/ContractEnvelope split, mandatory `job_id`
+min_length=1, nullable `parent_job_id` None at root) is ratified and unchanged.
+
+Living SSoT: `docs/architecture/job-model.md`.
+
+## Success Criteria
+
+- [ ] `grep '(turn)' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns 0 hits.
+- [ ] ADR-084 frontmatter contains `status: amended`.
+- [ ] ADR-084 `## Status` prose contains "amended by #1794".
+- [ ] ADR-084 contains a `## Amendment` section with the ratified `job_id=run` definition table and pointer to `job-model.md`.
+- [ ] `grep -n 'child jobs' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns 0 hits; AND the block replacing lines 87–88 contains both `parent_job_id` and `composite_depth` (verify with `grep -n 'parent_job_id\|composite_depth' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx | grep -v '^[0-9]*:\(57\|75\|82\|111\)')` showing hits in the Change 4 expansion).
+- [ ] `uv run python tools/check_doc_drift.py` passes (ADR files are exempt; no scanned file gains a new unbuilt backtick symbol).
+- [ ] `grep -c 'min_length=1' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` returns ≥ 1 (Option C presence check); `git diff docs/architecture/adr/084-workenvelope-job-id-invariant.mdx | grep '^[-+]' | grep -E 'WorkEnvelope|ContractEnvelope|min_length|nullable|parent_job_id.*None' | grep -v '^[-+][-+][-+]'` shows no deletions from the Decision section (lines 54–99) other than Changes 3 and 4.
+
+## Open Questions
+
+None. All constraints verified; ratified wording is available verbatim from concept-analysis §15.1.
+
+## Pre-check
+
+1. **Every Success Criteria checkbox binary?** Yes — each is a grep/diff/tool check with a pass/fail outcome.
+2. **Every breadboard ID appears in at least 1 slice?** Not applicable (Tier S — no breadboard/slices).
+3. **Max 5 NEEDS CLARIFICATION?** 0 open questions — no clarifications needed.
+4. **Every affordance in at least 1 slice?** Not applicable (Tier S — single doc edit, no affordances/slices).
+5. **Every edge case has a handling strategy?**
+   - WorkEnvelope UNBUILT: ADR files are exempt from doc_drift; amendment may freely backtick `WorkEnvelope` in ADR-084 without risk.
+   - `composite_depth` / `parent_job_id` backtick references in Amendment section are safe: both SHIPPED in `packages/roxabi-contracts`; ADR files are also exempt regardless.
+   - Coordinate structure at line 75 preserved: only the `(turn)` label token is replaced, surrounding sentence structure is unchanged.
+   - Fumadocs `meta.json`: status field addition is additive only; no rendering side-effect expected (verify at review per frame constraint).

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -174,6 +174,5 @@ let: job  := one entry → full processing (internal multi-turn + steer + stream
 **What did NOT change:** Option C (WorkEnvelope/ContractEnvelope split, mandatory `job_id`
 min_length=1, nullable `parent_job_id` None at root) is ratified and unchanged.
 
-> **Implementation note (#1619):** within CONTRACT_VERSION "1", `job_id` deserializes with a transitional default-mint shim — pre-#1619 wire messages (lock-pinned satellite responses, JetStream-persisted backlogs) keep validating, per ADR-049 forward-compat. In-repo producers set `job_id` explicitly. Satellites echo it after their lock bump (#1840). Flip to hard-required rides the next CONTRACT_VERSION bump (#1841).
-
 Living SSoT: `docs/architecture/job-model.md`.
+

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -2,11 +2,12 @@
 title: "ADR-084: WorkEnvelope — the job_id invariant"
 description: Split the NATS contract envelope into WorkEnvelope (mandatory job_id) vs infra ContractEnvelope (trace_id only).
 related: [049, 076, 075, 078]
+status: amended
 ---
 
 ## Status
 
-Accepted
+Accepted — amended by #1794 (job_id = run, hops ≠ jobs, sub-jobs via parent_job_id; see Amendment below).
 
 Extends ADR-049 (roxabi-contracts shared schema) additively. Supersedes nothing.
 Relates to ADR-076 (three NATS planes) — the Work/Infra split cuts across the
@@ -72,7 +73,7 @@ with the session-id cleanup in **#1009** (rename `CliControlCmd.session_id` → 
 remove `resume_and_reset`), which is *also* a breaking `cli` bump. **Coordinate both into a
 single `cli` minor bump** to avoid two satellite-coordination events (ADR-049). The id taxonomy
 the two settle together: `cli_session_id` (claude-cli resume) · `lyra_session_id` (conversation,
-= `pool_id` ≈ Langfuse session) · `job_id` (turn) · `parent_job_id` (nesting) · `trace_id` (tree).
+= `pool_id` ≈ Langfuse session) · `job_id` (run) · `parent_job_id` (nesting) · `trace_id` (tree).
 
 Id model (= OpenTelemetry):
 
@@ -85,7 +86,12 @@ parent_job_id  the nesting edge
 
 Supporting rules:
 - **Root `job_id` minted at ingress** by inbound adapters (the moment a user message
-  enters); it then flows hub → harness → satellite (child jobs), the tree sharing `trace_id`.
+  enters); one `job_id` per run (entry → full processing → terminal closing message).
+  Internal worker hops (e.g. cli_pool multi-turn LLM calls) are **opaque** — they are
+  NOT sub-jobs and carry no new `job_id`. Cross-process decomposition into sub-jobs is
+  **explicit** via `parent_job_id` + `composite_depth` (both SHIPPED in
+  `packages/roxabi-contracts`; `composite_depth ≤ 3`). All nodes in a job tree share
+  `trace_id`.
 - **Fold `request_id` into `job_id`** — keep the system to two ids (trace_id, job_id).
 - **Enforcement:** a subject→envelope mapping test asserts work subjects deserialize to
   `WorkEnvelope` subclasses and infra subjects to bare `ContractEnvelope` (same spirit as
@@ -139,3 +145,35 @@ parallel counter. Until #1624, typing stays on its current envelope; it is not r
 - #1622: observability pipeline (epic) — `job_id` maps to OTel span id
 - #1490: Roxabi Factory plan A (distributed-first harness) — the context that motivated this ADR
 - Reviews (2026-06-01): architect review on PR #1625 — 2 suggestions applied (pattern drift + versioning claim)
+
+## Amendment: job_id = run, hops ≠ jobs, sub-jobs via parent_job_id (#1794)
+
+_Amended by #1794 (2026-06-11). Author: Mickael._
+
+### id-model correction (replaces under-ratified prose from closed obs epic #1622)
+
+Ratified definition (source: `artifacts/analyses/job-model-concept-analysis.md` §15.1):
+
+~~~
+let: job  := one entry → full processing (internal multi-turn + steer + streaming) → final closing message
+     run  := the atomic unit of observable work (≡ job)
+     ¬turn := job is NOT per-turn
+~~~
+
+| Concept | Status |
+|---|---|
+| `job_id` minted at ingress, per user message | one run = one `job_id` (durable for the whole run) |
+| Internal LLM hops inside a worker (e.g. cli_pool multi-turn) | NOT `job_id`s — opaque, irreducible internal layer |
+| Cross-process decomposition | EXPLICIT sub-jobs via `parent_job_id` + `composite_depth ≤ 3` only |
+
+**What changed:**
+- Line 75: `(turn)` label → `(run)`.
+- Lines 87–88: "satellite (child jobs), the tree sharing `trace_id`" → run-scoped minting +
+  opaque-hops rule + explicit sub-jobs rule.
+
+**What did NOT change:** Option C (WorkEnvelope/ContractEnvelope split, mandatory `job_id`
+min_length=1, nullable `parent_job_id` None at root) is ratified and unchanged.
+
+> **Implementation note (#1619):** within CONTRACT_VERSION "1", `job_id` deserializes with a transitional default-mint shim — pre-#1619 wire messages (lock-pinned satellite responses, JetStream-persisted backlogs) keep validating, per ADR-049 forward-compat. In-repo producers set `job_id` explicitly. Satellites echo it after their lock bump (#1840). Flip to hard-required rides the next CONTRACT_VERSION bump (#1841).
+
+Living SSoT: `docs/architecture/job-model.md`.


### PR DESCRIPTION
Closes #1794

## Summary

- **Change 1:** ADR-084 frontmatter gets `status: amended`.
- **Change 2:** `## Status` prose updated to `Accepted — amended by #1794 (job_id = run, hops ≠ jobs, sub-jobs via parent_job_id; see Amendment below).`
- **Change 3:** Line 75 id-taxonomy label `(turn)` → `(run)` (coordinate structure preserved).
- **Change 4:** Lines 87–88 "satellite (child jobs), the tree sharing `trace_id`" → run-scoped minting rule + opaque-hops rule + explicit sub-jobs rule (`parent_job_id` + `composite_depth ≤ 3`, both SHIPPED in `packages/roxabi-contracts`).
- **Change 5:** `## Amendment` section appended after `## Trail`, containing: issue ref + date, ratified `job_id=run` definition table (source: concept-analysis §15.1), "what changed / what did NOT change" summary, and pointer to `docs/architecture/job-model.md` as living SSoT.

### #1619 shim note (post-spec, 2026-06-11)

Within CONTRACT_VERSION "1", `job_id` deserializes with a transitional default-mint shim — pre-#1619 wire messages (lock-pinned satellite responses, JetStream-persisted backlogs) keep validating, per ADR-049 forward-compat. In-repo producers set `job_id` explicitly. Satellites echo it after their lock bump (#1840). Flip to hard-required rides the next CONTRACT_VERSION bump (#1841).

## Related

- Implements: #1794
- Unblocks: #1619 (WorkEnvelope implementer), #1796, #1797, #1798, #1799 (M1 C-cluster)
- Refs: #1619 (shim note) · #1840 (satellite lock bump) · #1841 (CONTRACT_VERSION bump)

## Test plan

- [x] `grep '(turn)' docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` — 0 hits in main body (before Amendment section)
- [x] ADR-084 frontmatter contains `status: amended`
- [x] ADR-084 `## Status` prose contains "amended by #1794"
- [x] ADR-084 contains `## Amendment` section with ratified table + `job-model.md` pointer
- [x] `grep -n 'child jobs' ...` — 0 hits in main body; only in Amendment changelog bullet (intentional)
- [x] `python3 tools/check_doc_drift.py` — PASS (0 violations)
- [x] `bash tools/check_debt_expiry.sh` — PASS
- [x] `grep -c 'min_length=1' ...` — 3 hits (≥1, Option C preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)