### PR TITLE
ci(deps): reusable workflow to auto-bump satellites' roxabi-contracts/nats lock

### DIFF
--- a/.github/workflows/contracts-bump.yml
+++ b/.github/workflows/contracts-bump.yml
@@ -47,7 +47,7 @@ jobs:
       # Uses explicit repository: input to handle both workflow_call (satellite context)
       # and workflow_dispatch (factory context where github.repository = roxabi-factory).
       - name: Checkout satellite at staging
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.satellite_repo }}
           ref: staging
@@ -80,7 +80,7 @@ jobs:
 
       # Step 3: Install uv and run the lock upgrade.
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Upgrade packages in uv.lock
         run: |
@@ -108,7 +108,9 @@ jobs:
       - name: No-op exit
         if: steps.diff.outputs.changed == 'false'
         run: |
-          echo "::notice::No lock changes for ${{ inputs.satellite_repo }} — skipping PR."
+          echo "::notice::No lock changes for ${SATELLITE_REPO_INPUT} — skipping PR."
+        env:
+          SATELLITE_REPO_INPUT: ${{ inputs.satellite_repo }}
 
       # Step 5: Capture NEW_CONTRACTS_SHA and detect wire-breaking change.
       - name: Capture new contracts SHA and detect wire break
@@ -229,6 +231,13 @@ jobs:
           git config user.email "bot@roxabi.dev"
           git config user.name "Roxabi Bot"
 
+          # Guard against a stale remote branch from a previously closed/merged same-day PR.
+          # (The idempotency check above only catches *open* PRs.)
+          if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
+            BRANCH="${BRANCH}-run${{ github.run_attempt }}"
+            echo "::notice::Remote branch already exists (closed/merged PR?); using ${BRANCH} instead."
+          fi
+
           git checkout -b "${BRANCH}"
           git add uv.lock
           git commit -m "chore(deps): bump roxabi-contracts/nats lock ${OLD_SHORT}..${NEW_SHORT}${MSG_SUFFIX}"
@@ -253,7 +262,7 @@ jobs:
 
           if [ "${WIRE_BREAKING}" = "true" ]; then
             printf '## Wire-Breaking Change\n\n' >> "${PR_BODY_FILE}"
-            printf 'CONTRACT_VERSION bumped: `%s` -> `%s`. Wire-breaking change — human review required before merge.\n\n' \
+            printf '⚠ CONTRACT_VERSION bumped: `%s` → `%s`. Wire-breaking change — human review required before merge.\n\n' \
               "${OLD_VER}" "${NEW_VER}" >> "${PR_BODY_FILE}"
           fi
 
@@ -289,8 +298,11 @@ jobs:
           PACKAGES_INPUT: ${{ inputs.packages }}
 
       # Step 8: Apply label — wire-breaking (hold for review) or reviewed (auto-merge cascade).
+      # continue-on-error: true so a missing label (D3 prerequisite skipped) emits a warning
+      # rather than failing the job and leaving the PR unlabelled silently.
       - name: Apply label
         if: steps.diff.outputs.changed == 'true' && steps.existing-pr.outputs.skip == 'false' && steps.create-pr.outputs.pr_url != ''
+        continue-on-error: true
         run: |
           PR_URL="${PR_URL_INPUT}"
           if [ "${WIRE_BREAKING}" = "true" ]; then
@@ -298,10 +310,12 @@ jobs:
           else
             LABEL="reviewed"
           fi
-          gh pr edit "${PR_URL}" --add-label "${LABEL}" --repo "${SATELLITE_REPO}"
+          # --repo omitted: gh parses the repo from the PR URL, passing --repo is redundant
+          # and could diverge if the URL and SATELLITE_REPO ever differ.
+          gh pr edit "${PR_URL}" --add-label "${LABEL}" \
+            || echo "::warning::Failed to apply label '${LABEL}' to ${PR_URL} — ensure D3 labels exist in the satellite repo."
           echo "Applied label '${LABEL}' to ${PR_URL}"
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           PR_URL_INPUT: ${{ steps.create-pr.outputs.pr_url }}
-          SATELLITE_REPO: ${{ inputs.satellite_repo }}
           WIRE_BREAKING: ${{ steps.wire-guard.outputs.wire_breaking }}

--- a/.github/workflows/contracts-bump.yml
+++ b/.github/workflows/contracts-bump.yml
@@ -1,0 +1,307 @@
+# Reusable workflow — bump uv.lock for roxabi-contracts/nats/blobs in a satellite repo.
+#
+# Triggered by satellite callers (workflow_call) or manually (workflow_dispatch).
+# Wire-compatible bumps → `reviewed` label → satellite auto-merge.yml cascade.
+# CONTRACT_VERSION bump → `wire-breaking` label → human review required.
+#
+# Design decisions: DD-1 through DD-5 in artifacts/specs/1791-contracts-lock-bump-workflow-spec.mdx
+name: Contracts lock bump (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      satellite_repo:
+        description: "Satellite repo (e.g. Roxabi/llmCLI)"
+        required: true
+        type: string
+      packages:
+        description: "Space-separated packages to upgrade (e.g. 'roxabi-contracts roxabi-nats')"
+        required: true
+        type: string
+    secrets:
+      PAT:
+        required: true
+  workflow_dispatch:
+    inputs:
+      satellite_repo:
+        description: "Satellite repo (e.g. Roxabi/llmCLI)"
+        required: true
+        type: choice
+        options:
+          - Roxabi/llmCLI
+          - Roxabi/voiceCLI
+          - Roxabi/imageCLI
+      packages:
+        description: "Space-separated packages to upgrade (e.g. 'roxabi-contracts roxabi-nats')"
+        required: true
+        type: string
+
+jobs:
+  bump:
+    name: Bump ${{ inputs.satellite_repo }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      # Step 1: Checkout the satellite repo at staging.
+      # Uses explicit repository: input to handle both workflow_call (satellite context)
+      # and workflow_dispatch (factory context where github.repository = roxabi-factory).
+      - name: Checkout satellite at staging
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.satellite_repo }}
+          ref: staging
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+
+      # Step 2: Capture OLD_CONTRACTS_SHA from uv.lock BEFORE any upgrade runs.
+      # This is necessary for the wire-guard step (DD-4).
+      - name: Capture old contracts SHA
+        id: old-sha
+        run: |
+          # Extract the git source SHA for roxabi-contracts from the current uv.lock.
+          # uv.lock lists git sources as:   source = { git = "...", rev = "<sha>" }
+          # We grep for the stanza after "name = \"roxabi-contracts\"".
+          OLD_SHA=$(python3 - <<'EOF'
+          import re, pathlib
+          lock = pathlib.Path("uv.lock").read_text()
+          # Find the [[package]] block that contains roxabi-contracts
+          blocks = re.split(r'\n\[\[package\]\]\n', lock)
+          for block in blocks:
+              if 'name = "roxabi-contracts"' in block:
+                  m = re.search(r'rev\s*=\s*"([0-9a-f]{40})"', block)
+                  if m:
+                      print(m.group(1))
+                  break
+          EOF
+          )
+          echo "old_sha=${OLD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Old roxabi-contracts SHA: ${OLD_SHA:-<not found — contracts not yet in lock>}"
+
+      # Step 3: Install uv and run the lock upgrade.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Upgrade packages in uv.lock
+        run: |
+          PACKAGES="${PACKAGES_INPUT}"
+          for pkg in $PACKAGES; do
+            echo "Upgrading: $pkg"
+            uv lock --upgrade-package "$pkg"
+          done
+        env:
+          # env: indirection for script-injection hardening (all inputs via env vars only)
+          PACKAGES_INPUT: ${{ inputs.packages }}
+
+      # Step 4: Check if uv.lock actually changed.
+      - name: Check for lock changes
+        id: diff
+        run: |
+          if git diff --quiet -- uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No lock changes — skipping PR."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "uv.lock has changes — proceeding."
+          fi
+
+      - name: No-op exit
+        if: steps.diff.outputs.changed == 'false'
+        run: |
+          echo "::notice::No lock changes for ${{ inputs.satellite_repo }} — skipping PR."
+
+      # Step 5: Capture NEW_CONTRACTS_SHA and detect wire-breaking change.
+      - name: Capture new contracts SHA and detect wire break
+        id: wire-guard
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          NEW_SHA=$(python3 - <<'EOF'
+          import re, pathlib
+          lock = pathlib.Path("uv.lock").read_text()
+          blocks = re.split(r'\n\[\[package\]\]\n', lock)
+          for block in blocks:
+              if 'name = "roxabi-contracts"' in block:
+                  m = re.search(r'rev\s*=\s*"([0-9a-f]{40})"', block)
+                  if m:
+                      print(m.group(1))
+                  break
+          EOF
+          )
+          echo "new_sha=${NEW_SHA}" >> "$GITHUB_OUTPUT"
+          echo "New roxabi-contracts SHA: ${NEW_SHA:-<not in lock>}"
+
+          OLD_SHA="${OLD_CONTRACTS_SHA}"
+          # If either SHA is absent (contracts not in this lock), skip version check.
+          if [ -z "${OLD_SHA}" ] || [ -z "${NEW_SHA}" ]; then
+            echo "wire_breaking=false" >> "$GITHUB_OUTPUT"
+            echo "old_version=N/A" >> "$GITHUB_OUTPUT"
+            echo "new_version=N/A" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # If the SHA didn't change, no version bump possible.
+          if [ "${OLD_SHA}" = "${NEW_SHA}" ]; then
+            echo "wire_breaking=false" >> "$GITHUB_OUTPUT"
+            echo "old_version=unchanged" >> "$GITHUB_OUTPUT"
+            echo "new_version=unchanged" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract CONTRACT_VERSION from factory's envelope.py via the GitHub Contents API.
+          # DD-4: git show cannot be used — the satellite runner has no factory git objects.
+          ENVELOPE_PATH="packages/roxabi-contracts/src/roxabi_contracts/envelope.py"
+
+          OLD_VERSION=$(gh api \
+            "repos/Roxabi/roxabi-factory/contents/${ENVELOPE_PATH}?ref=${OLD_SHA}" \
+            --jq '.content' | base64 -d | grep '^CONTRACT_VERSION' | cut -d'"' -f2)
+
+          NEW_VERSION=$(gh api \
+            "repos/Roxabi/roxabi-factory/contents/${ENVELOPE_PATH}?ref=${NEW_SHA}" \
+            --jq '.content' | base64 -d | grep '^CONTRACT_VERSION' | cut -d'"' -f2)
+
+          echo "old_version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "CONTRACT_VERSION: ${OLD_VERSION} → ${NEW_VERSION}"
+
+          # Raw string comparison (DD-4: no semver parsing).
+          if [ "${OLD_VERSION}" != "${NEW_VERSION}" ]; then
+            echo "wire_breaking=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Wire-breaking CONTRACT_VERSION change detected: ${OLD_VERSION} → ${NEW_VERSION}"
+          else
+            echo "wire_breaking=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          OLD_CONTRACTS_SHA: ${{ steps.old-sha.outputs.old_sha }}
+
+      # Step 6: Idempotency — skip if a bump PR is already open for this satellite this week.
+      - name: Check for existing bump PR
+        id: existing-pr
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          SATELLITE_NAME="${SATELLITE_REPO##*/}"
+          SEARCH_TITLE="chore/bump-contracts-${SATELLITE_NAME}"
+          EXISTING=$(gh pr list \
+            --search "${SEARCH_TITLE} in:title" \
+            --state open \
+            --repo "${SATELLITE_REPO}" \
+            --json number,title \
+            --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Open bump PR #${EXISTING} already exists for ${SATELLITE_REPO} — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          SATELLITE_REPO: ${{ inputs.satellite_repo }}
+
+      # Step 7: Compute branch name, gather factory changelog, create branch + commit + PR.
+      - name: Create bump branch and PR
+        id: create-pr
+        if: steps.diff.outputs.changed == 'true' && steps.existing-pr.outputs.skip == 'false'
+        run: |
+          SATELLITE_REPO="${SATELLITE_REPO_INPUT}"
+          SATELLITE_NAME="${SATELLITE_REPO##*/}"
+          DATE=$(date -u +%Y%m%d)
+          BRANCH="chore/bump-contracts-${SATELLITE_NAME}-${DATE}"
+
+          OLD_SHA="${OLD_CONTRACTS_SHA}"
+          NEW_SHA="${NEW_CONTRACTS_SHA}"
+
+          # Short SHAs for commit message.
+          OLD_SHORT="${OLD_SHA:0:7}"
+          NEW_SHORT="${NEW_SHA:0:7}"
+
+          WIRE_BREAKING="${WIRE_BREAKING_FLAG}"
+          OLD_VER="${OLD_VERSION}"
+          NEW_VER="${NEW_VERSION}"
+
+          # Commit message suffix.
+          if [ "${WIRE_BREAKING}" = "true" ]; then
+            MSG_SUFFIX=" [WIRE BREAKING]"
+          else
+            MSG_SUFFIX=""
+          fi
+
+          # Configure git identity for the commit.
+          git config user.email "bot@roxabi.dev"
+          git config user.name "Roxabi Bot"
+
+          git checkout -b "${BRANCH}"
+          git add uv.lock
+          git commit -m "chore(deps): bump roxabi-contracts/nats lock ${OLD_SHORT}..${NEW_SHORT}${MSG_SUFFIX}"
+          git push origin "${BRANCH}"
+
+          # Fetch factory changelog via GitHub API (no extra checkout needed).
+          CHANGELOG=""
+          if [ -n "${OLD_SHA}" ] && [ -n "${NEW_SHA}" ] && [ "${OLD_SHA}" != "${NEW_SHA}" ]; then
+            CHANGELOG=$(gh api \
+              "repos/Roxabi/roxabi-factory/compare/${OLD_SHA}...${NEW_SHA}" \
+              --jq '[.commits[] | "- \(.sha[:7]) \(.commit.message | split("\n")[0])"] | join("\n")' \
+              2>/dev/null || echo "(could not fetch factory changelog)")
+          fi
+
+          # Build PR body — write to a temp file to avoid shell quoting issues.
+          PACKAGES_DISP="${PACKAGES_INPUT}"
+          PACKAGES_FMT=$(echo "$PACKAGES_DISP" | tr ' ' ', ')
+
+          PR_BODY_FILE=$(mktemp)
+
+          printf 'Automated weekly lock bump for `%s`.\n\n' "${PACKAGES_FMT}" >> "${PR_BODY_FILE}"
+
+          if [ "${WIRE_BREAKING}" = "true" ]; then
+            printf '## Wire-Breaking Change\n\n' >> "${PR_BODY_FILE}"
+            printf 'CONTRACT_VERSION bumped: `%s` -> `%s`. Wire-breaking change — human review required before merge.\n\n' \
+              "${OLD_VER}" "${NEW_VER}" >> "${PR_BODY_FILE}"
+          fi
+
+          if [ -n "${CHANGELOG}" ]; then
+            printf '## Factory commits (%s..%s)\n\n```\n%s\n```\n\n' \
+              "${OLD_SHORT}" "${NEW_SHORT}" "${CHANGELOG}" >> "${PR_BODY_FILE}"
+          fi
+
+          printf -- '---\n*Generated by [contracts-bump.yml](https://github.com/Roxabi/roxabi-factory/blob/staging/.github/workflows/contracts-bump.yml) — refs #1791.*\n' \
+            >> "${PR_BODY_FILE}"
+
+          # Create the PR.
+          PR_URL=$(gh pr create \
+            --repo "${SATELLITE_REPO}" \
+            --base staging \
+            --head "${BRANCH}" \
+            --title "chore(deps): bump roxabi-contracts/nats lock ${OLD_SHORT}..${NEW_SHORT}${MSG_SUFFIX}" \
+            --body-file "${PR_BODY_FILE}")
+
+          rm -f "${PR_BODY_FILE}"
+
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Created PR: ${PR_URL}"
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          SATELLITE_REPO_INPUT: ${{ inputs.satellite_repo }}
+          OLD_CONTRACTS_SHA: ${{ steps.old-sha.outputs.old_sha }}
+          NEW_CONTRACTS_SHA: ${{ steps.wire-guard.outputs.new_sha }}
+          WIRE_BREAKING_FLAG: ${{ steps.wire-guard.outputs.wire_breaking }}
+          OLD_VERSION: ${{ steps.wire-guard.outputs.old_version }}
+          NEW_VERSION: ${{ steps.wire-guard.outputs.new_version }}
+          PACKAGES_INPUT: ${{ inputs.packages }}
+
+      # Step 8: Apply label — wire-breaking (hold for review) or reviewed (auto-merge cascade).
+      - name: Apply label
+        if: steps.diff.outputs.changed == 'true' && steps.existing-pr.outputs.skip == 'false' && steps.create-pr.outputs.pr_url != ''
+        run: |
+          PR_URL="${PR_URL_INPUT}"
+          if [ "${WIRE_BREAKING}" = "true" ]; then
+            LABEL="wire-breaking"
+          else
+            LABEL="reviewed"
+          fi
+          gh pr edit "${PR_URL}" --add-label "${LABEL}" --repo "${SATELLITE_REPO}"
+          echo "Applied label '${LABEL}' to ${PR_URL}"
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          PR_URL_INPUT: ${{ steps.create-pr.outputs.pr_url }}
+          SATELLITE_REPO: ${{ inputs.satellite_repo }}
+          WIRE_BREAKING: ${{ steps.wire-guard.outputs.wire_breaking }}

--- a/artifacts/frames/1791-contracts-lock-bump-workflow-frame.mdx
+++ b/artifacts/frames/1791-contracts-lock-bump-workflow-frame.mdx
@@ -1,0 +1,132 @@
+---
+title: "infra: reusable workflow to auto-bump NATS satellites roxabi-contracts/nats lock"
+issue: 1791
+status: approved
+tier: S
+date: 2026-06-11
+---
+
+## Problem
+
+Satellite repos (`llmCLI`, `imageCLI`, `voiceCLI`) consume `roxabi-contracts`, `roxabi-nats`, and
+(where applicable) `roxabi-blobs` as git-source dependencies pinned to `branch=staging` via
+`[tool.uv.sources]`. dependabot (`pip` ecosystem — and the newer `uv` ecosystem as well, per
+confirmed open issues in dependabot-core) does **not** bump git-branch sources; there is no semver
+to resolve on a branch HEAD. The `uv.lock` SHA for these packages moves only on a manual
+`uv lock --upgrade-package`. Today all three satellites receive weekly dependabot PRs for every PyPI
+dependency *except* the one that governs wire compatibility.
+
+The gap was exposed during the #1708 charset-alignment audit: the three satellites were frozen on
+pre-fix contract SHAs (`e8578e52` / `08ed8d16`). They happened to be unaffected because `CONTRACT_VERSION`
+was unchanged and none imported the touched `gh.*` module — but the audit revealed that **lag is
+invisible until something breaks**. When #1619 (`WorkEnvelope` split), #1793 (subject taxonomy), or
+any future contract change lands, satellites can silently run stale wire contracts with no signal and
+no automated update path.
+
+The goal is a **shared reusable GitHub Actions workflow** (`workflow_call`, hosted in `roxabi-factory`
+as the contract producer) that each satellite invokes on a weekly schedule. The workflow upgrades the
+lock, detects no-op runs (frequent — contract churn is low), opens a PR with a meaningful body when
+changed, and routes the PR to either merge-on-green (wire-compatible bump) or human review
+(wire-breaking: `CONTRACT_VERSION` bumped).
+
+## Who
+
+- **Primary:** operators/maintainers — today a contract change landing in factory requires a manual
+  `uv lock --upgrade-package` in each of the three satellite repos; without this workflow that step
+  is silently skipped and satellites drift.
+- **Secondary:** the M1 job-model work (#1619 WorkEnvelope, #1793 subject taxonomy, #1795 JobResult,
+  #1798 Shape-D sub-jobs) — those issues drive contract churn; this workflow is the delivery pipe
+  that carries each contract change out to the worker repos automatically.
+
+## Constraints
+
+- **dependabot cannot substitute:** confirmed — all four repos use `package-ecosystem: pip` (not
+  `uv`); pip ecosystem cannot resolve `git+branch=staging` sources; `uv` ecosystem also has no
+  git-branch bumping per dependabot-core open issues. Custom cron workflow is required.
+- **No existing workflow_call infrastructure:** factory has zero `workflow_call` workflows as of
+  2026-06-11; the entire reusable workflow pattern is new to this repo.
+- **PAT secret name consistency:** `secrets.PAT` (no fallback) in factory, voiceCLI, imageCLI;
+  llmCLI outlier uses `secrets.PAT || github.token`. Workflow must use `secrets.PAT`; caller
+  satellites pass it explicitly (no `secrets: inherit` assumption).
+- **roxabi-blobs dependency asymmetry:** llmCLI does NOT depend on `roxabi-blobs`; voiceCLI has it
+  as `optional-dependencies.nats`; imageCLI has it as a core dependency. The reusable workflow must
+  accept an input list of packages to upgrade, or the satellite caller must pass the correct set.
+  Running `uv lock --upgrade-package roxabi-blobs` in llmCLI is a no-op but the asymmetry must be
+  documented.
+- **CONTRACT_VERSION is a string integer, not semver:** value is `"1"` at
+  `packages/roxabi-contracts/src/roxabi_contracts/envelope.py:16`. Breaking-change detection must
+  compare raw strings (`"1"` vs `"2"`), not parse as semver.
+  Extraction: `git show <sha>:packages/roxabi-contracts/src/roxabi_contracts/envelope.py | grep '^CONTRACT_VERSION'`
+- **wire-breaking label absent:** the `wire-breaking` label does not exist in any of the four repos
+  (factory, llmCLI, voiceCLI, imageCLI). Label creation in all three satellite repos is a
+  prerequisite to implementation.
+- **voiceCLI CI does not use --frozen:** voiceCLI's CI runs `uv sync --dev --extra all` (no
+  `--frozen`), unlike llmCLI and imageCLI which use `uv sync --frozen --all-extras`. A lock-bump PR
+  into voiceCLI must produce a valid `uv.lock`; the non-frozen sync will re-resolve on CI rather
+  than hard-fail, which means CI is a softer gate there. The spec should note this divergence.
+- **merge-on-green cascade:** `reviewed` label → `auto-merge.yml` `labeled` event (condition:
+  `pull_request.labels contains 'reviewed'`) → `gh pr merge --auto --merge` via `secrets.PAT`. This
+  is the existing infra to reuse; no new merge machinery needed.
+- **Cross-issue coordination (M1 sibling issues):**
+  - #1619 (`WorkEnvelope` split) — adds a new envelope field; `CONTRACT_VERSION` may or may not bump
+  - #1782 (NATS subject-segment charset consolidation) — `_nats_utils` refactor; no version bump expected
+  - #1793 (subject taxonomy unification — `factory.job.<id>.*`) — wire-subject rename; likely a `CONTRACT_VERSION` bump
+  - #1794 (ADR-084 amend: job_id = run) — docs only; no wire change
+  - This workflow is the delivery pipe for all of the above; it does not block any of them (manual
+    `uv lock --upgrade-package` remains the fallback throughout M1).
+- **Quality gates:** `doc_drift` — any new docs referencing workflow inputs/outputs must backtick
+  only symbols that exist in code. `file_length` does not apply (workflow YAML is not `src/**/*.py`).
+
+## Out of Scope
+
+- Adopting Renovate for git-source bumping (mentioned in `roxabi-contracts/CLAUDE.md` as a future
+  direction; this workflow is an explicit stop-gap until/unless Renovate is adopted).
+- Bumping PyPI dependencies (already covered by dependabot).
+- Auto-bumping within `roxabi-factory` itself (factory owns the packages; it does not consume them
+  as git-source deps).
+- Changing `CONTRACT_VERSION` semantics or the version scheme (it stays a string integer per ADR-044
+  absorbed into ADR-049).
+- `repository_dispatch` push-driven approach (Option 3) — workflow_call on a weekly cron is
+  sufficient and simpler; push-driven adds factory-side complexity for a use case where a day or two
+  of lag is acceptable.
+- Adding `uv` ecosystem to dependabot (does not solve the git-branch source problem).
+
+## Premise Validity
+
+**Success in 6 months:** Each of the three satellite repos (`llmCLI`, `imageCLI`, `voiceCLI`)
+receives an automated weekly PR whenever any of `roxabi-contracts`, `roxabi-nats`, `roxabi-blobs`
+(where applicable) advances on `staging`. Wire-compatible bumps auto-merge via merge-on-green
+(label `reviewed`). A `CONTRACT_VERSION` bump (when #1793 or a future breaking change lands) opens
+a PR labelled `wire-breaking` that is held for human review. Zero manual `uv lock --upgrade-package`
+runs required to track contract HEAD during M1 delivery.
+
+**Failure in 6 months:** After a `CONTRACT_VERSION` bump (e.g. #1793 subject taxonomy lands), at
+least one satellite is still running on the pre-bump lock for ≥ 7 days with no open PR flagging the
+drift — i.e. the weekly cron ran but either produced no PR (silent no-op false positive) or the
+`wire-breaking` label was never applied. Falsifiable: grep satellite `uv.lock` for
+`roxabi-contracts` SHA vs factory `staging` HEAD SHA; diff > 7 days with no open bump PR = failure.
+
+**Simplest alternative:** A single shared shell script in `roxabi-factory` that maintainers run
+manually in each satellite when a contract change lands (`uv lock --upgrade-package roxabi-contracts
+roxabi-nats roxabi-blobs && git commit && gh pr create`).
+
+**Why not simplest:** The problem is precisely that the manual step is invisible and silently skipped.
+The #1708 audit showed satellites were already frozen for multiple sprints with no signal. A manual
+script does not solve the automation gap; it just documents the gap.
+
+_(champs dérivés du contexte — à valider à la review humaine)_
+
+## Complexity
+
+**Tier: S** — single new file in `.github/workflows/` (factory-hosted reusable workflow) plus one
+caller workflow file per satellite repo; no source code changes, no architecture decisions, no new
+domain model.
+
+Signals observed:
+- 1 new workflow YAML in factory + 3 caller YAMLs in satellites = ≤4 files total across repos.
+- No `src/**/*.py` changes → `file_length`, `import_layers`, `hardcoded_constants` gates do not apply.
+- Single domain: CI/CD infrastructure.
+- Design decisions are bounded and resolved: `workflow_call` (not `repository_dispatch`); factory as
+  host; `secrets.PAT` explicit pass-through; per-satellite package list as workflow input; string
+  comparison for `CONTRACT_VERSION`.
+- No unknowns requiring analysis or spec beyond what is stated here.

--- a/artifacts/specs/1791-contracts-lock-bump-workflow-spec.mdx
+++ b/artifacts/specs/1791-contracts-lock-bump-workflow-spec.mdx
@@ -1,0 +1,270 @@
+---
+title: "infra: reusable workflow to auto-bump NATS satellites' roxabi-contracts/nats lock"
+description: "Factory-hosted reusable GitHub Actions workflow that bumps uv.lock for roxabi-contracts/nats/blobs in llmCLI, voiceCLI, imageCLI on a weekly schedule with wire-breaking detection."
+---
+
+## Context
+
+**Promoted from:** [frame](../frames/1791-contracts-lock-bump-workflow-frame.mdx)
+**GitHub issue:** #1791
+**Milestone:** M1 — Jobs and workers
+**Architecture SSoT:** `docs/architecture/job-model.md`
+**Related issues:** #1619 (WorkEnvelope split), #1793 (subject taxonomy), #1795 (JobResult), #1798 (Shape-D sub-jobs)
+
+Wire-protocol versioning is governed by `CONTRACT_VERSION` in
+`packages/roxabi-contracts/src/roxabi_contracts/envelope.py:16` (value `"1"`; string integer, ADR-044/ADR-049).
+Dependabot (`pip` ecosystem, confirmed) cannot bump git-branch sources — all three satellites pin
+`roxabi-contracts`, `roxabi-nats`, and (where applicable) `roxabi-blobs` via
+`[tool.uv.sources] branch = "staging"`. A weekly custom cron workflow is the only automated path.
+
+## Goal
+
+Provide a factory-hosted `workflow_call` + `workflow_dispatch` workflow that satellite repos invoke on a weekly schedule to bump their `uv.lock` for `roxabi-contracts`, `roxabi-nats`, and `roxabi-blobs`; wire-compatible bumps auto-merge via existing `reviewed`-label cascade; `CONTRACT_VERSION` bumps open a `wire-breaking`-labelled PR held for human review.
+
+## Users
+
+- **Operators / maintainers:** today a contract change landing in factory requires a manual `uv lock --upgrade-package` in each satellite; without this workflow that step is silently skipped. The workflow removes the manual step entirely.
+- **M1 delivery chain:** issues #1619, #1793, #1795, #1798 drive contract churn; this workflow is the automated delivery pipe that carries each change out to `llmCLI`, `voiceCLI`, `imageCLI` without operator action.
+
+## Design Decisions
+
+### DD-1: Reusable workflow hosted in factory (workflow_call)
+
+`roxabi-factory` is the contract producer and the natural authority for the reusable workflow. Each satellite caller invokes `Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml` via `uses:`. The workflow triggers are `workflow_call` (invoked by callers) and `workflow_dispatch` (manual one-off runs). The `repository_dispatch` push-driven alternative (Option 3, frame Out of Scope) is excluded: push-driven adds factory-side complexity for a use case where a day or two of lag is fully acceptable, and it requires an extra outbound webhook step on every `staging` push.
+
+### DD-2: Per-satellite package list as workflow input
+
+The `roxabi-blobs` dependency is asymmetric: llmCLI has no `roxabi-blobs` dependency; voiceCLI has it as an optional `nats` extra; imageCLI has it as a core dependency. A single hardcoded `uv lock --upgrade-package roxabi-contracts roxabi-nats roxabi-blobs` would be a harmless no-op for llmCLI, but it would obscure intent and make the workflow harder to reason about. Each satellite caller passes a `packages` input (space-separated list), e.g. `"roxabi-contracts roxabi-nats"` for llmCLI and `"roxabi-contracts roxabi-nats roxabi-blobs"` for voiceCLI/imageCLI. The reusable workflow iterates: `uv lock --upgrade-package <pkg>` for each package in the list.
+
+### DD-3: PAT secret passed explicitly — no secrets: inherit
+
+`secrets.PAT` (no fallback) is the convention in factory, voiceCLI, and imageCLI. llmCLI is an outlier (`secrets.PAT || github.token`) but the `||` fallback is not relied upon here. The reusable workflow declares `secrets: PAT` under `workflow_call` and satellite callers pass it explicitly (`secrets: PAT: ${{ secrets.PAT }}`). `secrets: inherit` is intentionally avoided: it is implicit, fragile across org-level secrets changes, and inconsistent with the explicit pass-through pattern already established in this repo's dependabot-automerge workflow.
+
+For `workflow_dispatch` triggered directly on factory: the PAT is read from factory's own repo secrets — `${{ secrets.PAT }}` resolves normally at runtime. GitHub Actions does not support a `secrets:` block on `workflow_dispatch` trigger definitions (only on `workflow_call`), so the `secrets: PAT: required: true` declaration in the YAML applies only under `workflow_call`; manual runs read it from the host-repo secret store directly.
+
+The PAT must have `repo` scope covering all three satellite repos (llmCLI, voiceCLI, imageCLI) to permit cross-repo branch creation, `gh pr create`, and `gh pr edit --add-label`. The org-level PAT already used for factory's dependabot-automerge workflow should satisfy this; verify before the first satellite deployment.
+
+### DD-4: CONTRACT_VERSION comparison — raw string, not semver; fetch via GitHub Contents API
+
+`CONTRACT_VERSION = "1"` is a string integer validated by `assert CONTRACT_VERSION.isdigit() and int(CONTRACT_VERSION) > 0`. Semver parsing must not be applied.
+
+The wire-guard step runs inside the satellite repo checkout — the runner has no access to factory's git object store. `git show <sha>:path` against a factory commit SHA will fail with `fatal: bad object`. The extraction mechanism is therefore the **GitHub Contents API** (no extra checkout needed):
+
+```bash
+# OLD_CONTRACTS_SHA captured from uv.lock BEFORE the upgrade (see D1 step ordering below)
+OLD_VERSION=$(gh api \
+  "repos/Roxabi/roxabi-factory/contents/packages/roxabi-contracts/src/roxabi_contracts/envelope.py?ref=${OLD_CONTRACTS_SHA}" \
+  --jq '.content' | base64 -d | grep '^CONTRACT_VERSION' | cut -d'"' -f2)
+
+NEW_VERSION=$(gh api \
+  "repos/Roxabi/roxabi-factory/contents/packages/roxabi-contracts/src/roxabi_contracts/envelope.py?ref=${NEW_CONTRACTS_SHA}" \
+  --jq '.content' | base64 -d | grep '^CONTRACT_VERSION' | cut -d'"' -f2)
+```
+
+If the extracted strings differ, the PR receives the `wire-breaking` label (human review required). If identical or if `roxabi-contracts` was not part of the bump, the PR receives the `reviewed` label (auto-merge cascade).
+
+### DD-5: Renovate is out of scope; this is an explicit stop-gap
+
+`packages/roxabi-contracts/CLAUDE.md` notes "pin by git tag; group roxabi-contracts and roxabi-nats in a single Renovate rule" as a future direction. This workflow is the stop-gap until/unless Renovate adopts git-branch source bumping. When Renovate is adopted, the caller workflows in satellites are removed and this reusable workflow is archived. No Renovate configuration is created here.
+
+## Expected Behavior
+
+### Weekly cron cycle — no-op path (most common)
+
+1. Cron fires in the satellite repo (e.g. every Monday 06:00 UTC).
+2. Caller workflow invokes `Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml` with inputs `packages: "roxabi-contracts roxabi-nats"` (llmCLI) and secret `PAT`.
+3. Factory-hosted workflow checks out the satellite repo at `staging`.
+4. Runs `uv lock --upgrade-package roxabi-contracts roxabi-nats` (iterating the package list).
+5. `git diff -- uv.lock` is empty — no packages advanced on `staging`.
+6. Workflow outputs `changed=false`, exits 0 with a green summary: "No lock changes — skipping PR."
+7. No branch, no PR, no label action. Total runtime: ~90 s.
+
+### Weekly cron cycle — wire-compatible bump path
+
+1–4. Same as no-op path.
+5. `git diff -- uv.lock` is non-empty; `CONTRACT_VERSION` in old vs new commit is identical (`"1" == "1"`).
+6. Workflow creates branch `chore/bump-contracts-<satellite>-<yyyymmdd>`, commits `uv.lock` with message `chore(deps): bump roxabi-contracts/nats lock <old_short>..<new_short>`.
+7. Opens PR against `staging` with body:
+   - Summary line: "Automated weekly lock bump for `roxabi-contracts`, `roxabi-nats`."
+   - `git log <old_sha>..<new_sha> -- packages/roxabi-contracts packages/roxabi-nats` output (factory-side, fetched via sparse checkout or API).
+   - "Closes #1791" omitted (this is a recurring workflow, not a one-time fix).
+8. Applies label `reviewed` to the PR.
+9. Satellite's `auto-merge.yml` fires on `labeled` event, arms GitHub auto-merge. Per-satellite merge strategy (verified): llmCLI = `--merge`; voiceCLI = `--squash` for standard PRs (merge-to-main promote PRs use `--merge`; bump PRs target `staging` → squash applies); imageCLI = `--squash`. The reusable workflow does NOT call `gh pr merge` — each satellite's own `auto-merge.yml` handles it.
+10. Satellite CI runs `uv sync --frozen --all-extras` (llmCLI, imageCLI) or `uv sync --dev --extra all` (voiceCLI, non-frozen) against the new lock; passes → merges.
+
+### Weekly cron cycle — wire-breaking path
+
+1–5. Same as wire-compatible path but `CONTRACT_VERSION` extracted from old commit (`"1"`) differs from new commit (`"2"`).
+6. Workflow creates branch and PR as above but with message suffix `[WIRE BREAKING]`.
+7. Applies label `wire-breaking` instead of `reviewed`.
+8. `auto-merge.yml` condition (`contains labels 'reviewed'`) is false — PR is NOT armed for auto-merge.
+9. PR sits in the satellite repo awaiting human review. PR body includes: "⚠ CONTRACT_VERSION bumped: `1` → `2`. Wire-breaking change — human review required before merge."
+10. Maintainer reviews, adds `reviewed` label after validating compatibility, auto-merge fires normally.
+
+### Manual one-off run (workflow_dispatch)
+
+Any maintainer can trigger `workflow_dispatch` on the factory-hosted workflow with two required inputs: `satellite_repo` (choose from the dropdown: `Roxabi/llmCLI`, `Roxabi/voiceCLI`, `Roxabi/imageCLI`) and `packages` (space-separated list matching the satellite's dependency set, e.g. `"roxabi-contracts roxabi-nats"`). Omitting either input causes an immediate input-validation failure. Useful after a hotfix lands in `roxabi-contracts` outside the weekly window.
+
+## Deliverables
+
+### D1 — Factory-hosted reusable workflow
+
+**File:** `.github/workflows/contracts-bump.yml`
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      satellite_repo:
+        description: "Satellite repo (e.g. Roxabi/llmCLI)"
+        required: true
+        type: string
+      packages:
+        description: "Space-separated packages to upgrade (e.g. 'roxabi-contracts roxabi-nats')"
+        required: true
+        type: string
+    secrets:
+      PAT:
+        required: true
+  workflow_dispatch:
+    inputs:
+      satellite_repo:
+        description: "Satellite repo (e.g. Roxabi/llmCLI)"
+        required: true
+        type: choice
+        options:
+          - Roxabi/llmCLI
+          - Roxabi/voiceCLI
+          - Roxabi/imageCLI
+      packages:
+        description: "Space-separated packages to upgrade (e.g. 'roxabi-contracts roxabi-nats')"
+        required: true
+        type: string
+```
+
+Key steps (pseudocode):
+1. Checkout satellite repo at `staging` via PAT using `repository: ${{ inputs.satellite_repo }}` explicitly — this ensures both `workflow_call` (satellite context) and `workflow_dispatch` (factory context, where `github.repository` = `Roxabi/roxabi-factory`) check out the correct satellite.
+2. Capture `OLD_CONTRACTS_SHA` (contracts git source SHA extracted from `uv.lock` **before** any upgrade runs).
+3. Install uv (`astral-sh/setup-uv`), run `uv lock --upgrade-package <pkg>` for each package in `inputs.packages`.
+4. Diff `uv.lock`; if empty → output `changed=false`, exit 0.
+5. Capture `NEW_CONTRACTS_SHA` from the updated `uv.lock`. Extract `CONTRACT_VERSION` for old and new SHAs via the GitHub Contents API (`gh api repos/Roxabi/roxabi-factory/contents/...?ref=<sha>` — `git show` cannot be used here; the satellite runner has no factory git objects). See DD-4 for exact commands.
+6. Derive `satellite_name` = `${{ inputs.satellite_repo }}` with org prefix stripped (`${satellite_repo##*/}`). Branch name: `chore/bump-contracts-<satellite_name>-<yyyymmdd>`. Check for an existing open PR (`gh pr list --search "chore/bump-contracts-<satellite_name> in:title" --state open --repo ${{ inputs.satellite_repo }}`) — if one exists, skip PR creation and exit 0.
+7. Create branch, commit, push, open PR via `gh pr create` against `${{ inputs.satellite_repo }}` with `GH_TOKEN: ${{ secrets.PAT }}`. PR body includes `git log <old_sha>..<new_sha> -- packages/roxabi-contracts packages/roxabi-nats` output fetched via `gh api` (factory context; no extra checkout needed).
+8. Apply label: `wire-breaking` if version bumped, else `reviewed`.
+
+### D2 — Satellite caller workflow stubs (one per satellite)
+
+**File:** `.github/workflows/contracts-bump-caller.yml` in each satellite repo.
+
+Branch names produced: `chore/bump-contracts-llmCLI-<yyyymmdd>`, `chore/bump-contracts-voiceCLI-<yyyymmdd>`, `chore/bump-contracts-imageCLI-<yyyymmdd>` (org prefix stripped via `${satellite_repo##*/}` inside D1 — no slash in branch name).
+
+**llmCLI** (no `roxabi-blobs` dependency):
+```yaml
+name: Bump contracts lock
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: ${{ github.repository }}
+      packages: "roxabi-contracts roxabi-nats"
+    secrets:
+      PAT: ${{ secrets.PAT }}
+```
+
+**voiceCLI** (`roxabi-blobs` as optional `nats` extra):
+```yaml
+name: Bump contracts lock
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: ${{ github.repository }}
+      packages: "roxabi-contracts roxabi-nats roxabi-blobs"
+    secrets:
+      PAT: ${{ secrets.PAT }}
+```
+
+**imageCLI** (`roxabi-blobs` as core dependency):
+```yaml
+name: Bump contracts lock
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: ${{ github.repository }}
+      packages: "roxabi-contracts roxabi-nats roxabi-blobs"
+    secrets:
+      PAT: ${{ secrets.PAT }}
+```
+
+Rolling out caller workflows to the three satellite repos = **separate PRs** after D1 merges. This issue (#1791) covers D1 only; satellite PRs are follow-up. SC-5, SC-6, SC-7 gate on those follow-up PRs — see Success Criteria scope note below.
+
+### D3 — wire-breaking label creation (hard prerequisite, blocks first workflow run)
+
+Labels must be created in `llmCLI`, `voiceCLI`, `imageCLI` before the first workflow run. The label `wire-breaking` (color `#b60205`, description "CONTRACT_VERSION bumped — human review required") must exist in all three satellite repos. **This D3 step is a hard prerequisite for any D2 satellite PR to be mergeable**: `gh pr edit --add-label wire-breaking` will fail with a 422 if the label does not exist. D3 must be tracked as a blocked-by dependency on each satellite caller PR.
+
+This is a one-time manual bootstrap step (not CI-verifiable by the workflow itself — SC-4 is a manual pre-flight check, not an automated gate):
+
+```bash
+for repo in Roxabi/llmCLI Roxabi/voiceCLI Roxabi/imageCLI; do
+  gh label create wire-breaking --color b60205 \
+    --description "CONTRACT_VERSION bumped — human review required" \
+    --repo "$repo"
+done
+```
+
+## Success Criteria
+
+**Scope note:** SC-1 through SC-4 are verifiable from D1 alone (factory PR). SC-5, SC-6, SC-7 require D2 satellite caller PRs and gate on those follow-up issues — they are listed here for completeness but cannot close this issue.
+
+### D1-verifiable (factory PR)
+- [ ] **SC-1** A no-op run (no packages advanced on `staging`) exits green in ≤ 3 minutes without opening a PR or applying any label.
+- [ ] **SC-2** A wire-compatible bump run opens exactly one PR in the satellite repo, commits only `uv.lock`, applies label `reviewed`, and the PR auto-merges once satellite CI passes (merge strategy is per-satellite — llmCLI: merge commit; voiceCLI standard PR: squash; imageCLI: squash).
+- [ ] **SC-3** A wire-breaking run (CONTRACT_VERSION old != new) opens a PR with label `wire-breaking` and does NOT apply label `reviewed`; the PR is not armed for auto-merge.
+- [ ] **SC-4** (manual pre-flight, not CI-gated) The `wire-breaking` label is created in all three satellite repos (`llmCLI`, `voiceCLI`, `imageCLI`) before the first workflow run; D3 must be completed and tracked as a blocked-by dependency on each satellite PR.
+
+### D2-dependent (satellite caller PRs — follow-up)
+- [ ] **SC-5** llmCLI caller passes `packages: "roxabi-contracts roxabi-nats"` (no `roxabi-blobs`); voiceCLI and imageCLI callers pass `packages: "roxabi-contracts roxabi-nats roxabi-blobs"`.
+- [ ] **SC-6** All three satellite repos have a caller workflow that invokes `Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging` on `schedule: cron "0 6 * * 1"`.
+- [ ] **SC-7** A manually triggered `workflow_dispatch` run on the factory-hosted workflow completes without error for each satellite (requires satellite caller workflows to exist and PAT cross-repo scope to be confirmed).
+
+## Open Questions
+
+None — all five design questions from the frame are resolved in the Design Decisions section above. This spec is ready for `/plan`.
+
+## Pre-check
+
+1. **Every Success Criteria binary?** Yes — each criterion is pass/fail with no vague wording. SC-5/6/7 are explicitly gated on follow-up satellite PRs and annotated accordingly.
+2. **Every breadboard ID appears in at least 1 slice?** N/A — Tier S spec; no breadboard/slice sections used.
+3. **Max 5 NEEDS CLARIFICATION?** 0 open questions — all resolved.
+4. **Every affordance in at least 1 slice?** N/A — Tier S; all affordances covered in Expected Behavior and Deliverables.
+5. **Every edge case has a handling strategy?**
+   - No-op path: explicit exit 0 + `changed=false` output.
+   - voiceCLI non-frozen CI: noted in Expected Behavior (non-frozen sync re-resolves; softer gate, still valid).
+   - llmCLI `roxabi-blobs` absent: handled via per-satellite package input (DD-2).
+   - `CONTRACT_VERSION` string integer comparison: DD-4 specifies raw string extraction + comparison, no semver parsing.
+   - PAT cross-repo access: DD-3 specifies explicit `secrets:` pass-through, no `inherit`; PAT must have `repo` scope for all satellites.
+   - `wire-breaking` label absent: D3 documents creation as hard prerequisite; SC-4 is a manual pre-flight check.
+   - Same-week double-run: D1 step 6 specifies a `gh pr list` idempotency check — if an open bump PR already exists for the satellite, the run skips PR creation and exits 0.
+   - `workflow_dispatch` repository context: D1 step 1 uses explicit `repository: ${{ inputs.satellite_repo }}` in `actions/checkout` to avoid silently checking out factory when triggered manually from factory context.
+   - Satellite branch naming slash: branch name uses org-stripped satellite name (`${satellite_repo##*/}`) — no embedded slash.
+   - `workflow_dispatch` secrets: PAT resolves from factory's own secret store on manual runs; `secrets:` block is only declared under `workflow_call` (GitHub limitation).
+
+**Tier/complexity note:** The source issue records `<!-- complexity: 5 -->` (F-lite threshold per triage). This spec classifies the work as Tier S based on deliverable scope: ≤4 new files (one reusable workflow + three caller stubs), single domain (CI/infra), no unknowns beyond cross-repo PAT scope (now documented). The complexity-5 score reflects coordination surface (3 satellite repos) and design unknowns present at triage time; those unknowns are resolved in DD-1 through DD-5. Rationale for Tier S override: all design decisions are made, implementation is purely mechanical YAML authoring. If D2 satellite PRs surface unexpected branch-protection or PAT-scope issues, the implementer should escalate to F-lite and re-plan.
+
+**Satellite `auto-merge.yml` pre-condition:** all three satellites have `auto-merge.yml` with `labeled` trigger and `contains labels 'reviewed'` condition (verified). Per-satellite merge command differs (see SC-2 note). The reusable workflow does not invoke `gh pr merge`; each satellite's own workflow handles it.

--- a/docs/ops/contracts-bump-callers.md
+++ b/docs/ops/contracts-bump-callers.md
@@ -1,0 +1,133 @@
+# Contracts lock-bump — satellite caller guide
+
+Reusable workflow: `.github/workflows/contracts-bump.yml` (hosted in `roxabi-factory`).
+
+Each satellite repo (`llmCLI`, `voiceCLI`, `imageCLI`) calls this workflow weekly to bump
+`uv.lock` for `roxabi-contracts`, `roxabi-nats`, and (where applicable) `roxabi-blobs`.
+
+Related: issue #1791, spec `artifacts/specs/1791-contracts-lock-bump-workflow-spec.mdx`.
+
+---
+
+## Behavior paths
+
+| Scenario | Outcome |
+|---|---|
+| `uv.lock` unchanged after upgrade | No-op — no PR created, workflow exits clean |
+| Packages changed, `CONTRACT_VERSION` same | PR created, label `reviewed` applied → auto-merge cascade |
+| Packages changed, `CONTRACT_VERSION` changed | PR created, label `wire-breaking` applied → held for human review |
+
+---
+
+## Per-satellite caller YAML
+
+### `Roxabi/llmCLI`
+
+`roxabi-blobs` is absent from `llmCLI`; only `roxabi-contracts` and `roxabi-nats` are bumped.
+
+```yaml
+# .github/workflows/bump-contracts.yml  (in Roxabi/llmCLI)
+name: Bump contracts lock
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: Roxabi/llmCLI
+      packages: "roxabi-contracts roxabi-nats"
+    secrets:
+      PAT: ${{ secrets.PAT }}
+```
+
+### `Roxabi/voiceCLI`
+
+`roxabi-blobs` is in `optional-dependencies.nats`; include it so the lock stays consistent.
+
+```yaml
+# .github/workflows/bump-contracts.yml  (in Roxabi/voiceCLI)
+name: Bump contracts lock
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: Roxabi/voiceCLI
+      packages: "roxabi-contracts roxabi-nats roxabi-blobs"
+    secrets:
+      PAT: ${{ secrets.PAT }}
+```
+
+> Note: voiceCLI CI runs `uv sync --dev --extra all` (no `--frozen`), unlike llmCLI/imageCLI
+> which use `--frozen`. A lock-bump PR into voiceCLI will still produce a valid `uv.lock`;
+> CI re-resolves instead of hard-failing — this is a softer gate.
+
+### `Roxabi/imageCLI`
+
+`roxabi-blobs` is a core dependency for `imageCLI`.
+
+```yaml
+# .github/workflows/bump-contracts.yml  (in Roxabi/imageCLI)
+name: Bump contracts lock
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: Roxabi/imageCLI
+      packages: "roxabi-contracts roxabi-nats roxabi-blobs"
+    secrets:
+      PAT: ${{ secrets.PAT }}
+```
+
+---
+
+## Prerequisites before activating a caller
+
+For each satellite repo, verify the following before merging the caller workflow PR:
+
+- [ ] `wire-breaking` label exists in the satellite repo (check `gh label list --repo Roxabi/<sat>`)
+- [ ] `reviewed` label exists in the satellite repo
+- [ ] `auto-merge.yml` workflow exists in the satellite repo and triggers on `reviewed` label
+- [ ] `secrets.PAT` is set in the satellite repo's Actions secrets (repo scope, covering `Roxabi/roxabi-factory`)
+- [ ] `staging` branch exists and is the default branch in the satellite repo
+
+---
+
+## Rollout checklist — follow-up PRs (#1840)
+
+Three follow-up PRs are needed, one per satellite (tracked in #1840):
+
+1. `Roxabi/llmCLI` — add `.github/workflows/bump-contracts.yml` (packages: `roxabi-contracts roxabi-nats`)
+2. `Roxabi/voiceCLI` — add `.github/workflows/bump-contracts.yml` (packages: `roxabi-contracts roxabi-nats roxabi-blobs`)
+3. `Roxabi/imageCLI` — add `.github/workflows/bump-contracts.yml` (packages: `roxabi-contracts roxabi-nats roxabi-blobs`)
+
+For each: verify prerequisites above → open PR against satellite `staging` → apply `reviewed` label → auto-merge.
+
+---
+
+## Manual trigger (factory)
+
+To manually trigger a bump for any satellite without waiting for the weekly cron:
+
+```bash
+gh workflow run contracts-bump.yml \
+  --repo Roxabi/roxabi-factory \
+  --ref staging \
+  -f satellite_repo=Roxabi/llmCLI \
+  -f packages="roxabi-contracts roxabi-nats"
+```

--- a/docs/ops/contracts-bump-callers.md
+++ b/docs/ops/contracts-bump-callers.md
@@ -26,7 +26,7 @@ Related: issue #1791, spec `artifacts/specs/1791-contracts-lock-bump-workflow-sp
 `roxabi-blobs` is absent from `llmCLI`; only `roxabi-contracts` and `roxabi-nats` are bumped.
 
 ```yaml
-# .github/workflows/bump-contracts.yml  (in Roxabi/llmCLI)
+# .github/workflows/contracts-bump-caller.yml  (in Roxabi/llmCLI)
 name: Bump contracts lock
 
 on:
@@ -38,7 +38,7 @@ jobs:
   bump:
     uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
     with:
-      satellite_repo: Roxabi/llmCLI
+      satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats"
     secrets:
       PAT: ${{ secrets.PAT }}
@@ -49,7 +49,7 @@ jobs:
 `roxabi-blobs` is in `optional-dependencies.nats`; include it so the lock stays consistent.
 
 ```yaml
-# .github/workflows/bump-contracts.yml  (in Roxabi/voiceCLI)
+# .github/workflows/contracts-bump-caller.yml  (in Roxabi/voiceCLI)
 name: Bump contracts lock
 
 on:
@@ -61,7 +61,7 @@ jobs:
   bump:
     uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
     with:
-      satellite_repo: Roxabi/voiceCLI
+      satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats roxabi-blobs"
     secrets:
       PAT: ${{ secrets.PAT }}
@@ -76,7 +76,7 @@ jobs:
 `roxabi-blobs` is a core dependency for `imageCLI`.
 
 ```yaml
-# .github/workflows/bump-contracts.yml  (in Roxabi/imageCLI)
+# .github/workflows/contracts-bump-caller.yml  (in Roxabi/imageCLI)
 name: Bump contracts lock
 
 on:
@@ -88,7 +88,7 @@ jobs:
   bump:
     uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
     with:
-      satellite_repo: Roxabi/imageCLI
+      satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats roxabi-blobs"
     secrets:
       PAT: ${{ secrets.PAT }}
@@ -112,9 +112,9 @@ For each satellite repo, verify the following before merging the caller workflow
 
 Three follow-up PRs are needed, one per satellite (tracked in #1840):
 
-1. `Roxabi/llmCLI` — add `.github/workflows/bump-contracts.yml` (packages: `roxabi-contracts roxabi-nats`)
-2. `Roxabi/voiceCLI` — add `.github/workflows/bump-contracts.yml` (packages: `roxabi-contracts roxabi-nats roxabi-blobs`)
-3. `Roxabi/imageCLI` — add `.github/workflows/bump-contracts.yml` (packages: `roxabi-contracts roxabi-nats roxabi-blobs`)
+1. `Roxabi/llmCLI` — add `.github/workflows/contracts-bump-caller.yml` (packages: `roxabi-contracts roxabi-nats`)
+2. `Roxabi/voiceCLI` — add `.github/workflows/contracts-bump-caller.yml` (packages: `roxabi-contracts roxabi-nats roxabi-blobs`)
+3. `Roxabi/imageCLI` — add `.github/workflows/contracts-bump-caller.yml` (packages: `roxabi-contracts roxabi-nats roxabi-blobs`)
 
 For each: verify prerequisites above → open PR against satellite `staging` → apply `reviewed` label → auto-merge.
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/contracts-bump.yml` — a `workflow_call` + `workflow_dispatch` reusable workflow hosted in factory that `llmCLI`, `voiceCLI`, and `imageCLI` invoke weekly to bump `uv.lock` for `roxabi-contracts`, `roxabi-nats`, and `roxabi-blobs`
- Add `docs/ops/contracts-bump-callers.md` — per-satellite caller YAML stubs + rollout checklist

Closes #1791

## Design decisions (DD-1..DD-5)

| # | Decision |
|---|---|
| DD-1 | Factory hosts the reusable workflow (`workflow_call`); satellites reference it at `@staging` |
| DD-2 | `secrets.PAT` passed explicitly per satellite; no `secrets: inherit` |
| DD-3 | Packages list as input: llmCLI = `roxabi-contracts roxabi-nats`; voiceCLI/imageCLI add `roxabi-blobs` |
| DD-4 | `CONTRACT_VERSION` extracted via GitHub Contents API (satellite runner has no factory git objects) |
| DD-5 | String comparison for `CONTRACT_VERSION` (no semver parsing; value is a string integer `"1"`) |

## Three behavior paths

| Scenario | Outcome |
|---|---|
| `uv.lock` unchanged after upgrade | No-op — no PR created, workflow exits clean |
| Packages changed, `CONTRACT_VERSION` same | PR created → `reviewed` label → auto-merge cascade via `auto-merge.yml` |
| Packages changed, `CONTRACT_VERSION` changed | PR created → `wire-breaking` label → held for human review |

## Security

All workflow inputs used in `run:` blocks are accessed through `env:` indirection (script-injection hardening).

## Rollout

Satellite caller PRs (3 follow-ups) tracked in #1840. See `docs/ops/contracts-bump-callers.md` for per-satellite YAML stubs and prerequisites checklist.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)