### PR TITLE
fix(outbound): bound OutboundDispatcher._queue — maxsize=50, drop-oldest + overflow log

### DIFF
--- a/docs/architecture/adapters.md
+++ b/docs/architecture/adapters.md
@@ -185,6 +185,10 @@ runs post-NATS inside the hub process. See `ARCHITECTURE.md §Inbound Message Pi
   PlatformContext migration is required before any third platform is added.
 - Hub starts and serves text traffic independently of voice adapter availability.
 - `prefs_store.close()` must be in the graceful shutdown sequence.
+- `OutboundDispatcher._queue` is bounded at `OUTBOUND_QUEUE_MAXSIZE` (50 items). When
+  full, the oldest item is dropped before enqueueing the new one (drop-oldest policy).
+  Dropped items have their async iterators drained and emit a structured warning log with
+  `event=outbound_queue_overflow`. No user-facing notification is sent on overflow.
 
 ---
 
@@ -196,8 +200,6 @@ runs post-NATS inside the hub process. See `ARCHITECTURE.md §Inbound Message Pi
   Option D); render_audio() is present but lifecycle is not.
 - `platform_meta: dict` → PlatformContext typed migration is partial; hard prerequisite
   before a third platform adapter is added.
-- `OutboundDispatcher._queue` is unbounded; `queue_maxsize` constructor parameter and a
-  sensible default are recommended but not yet added.
 - Startup-time stale temp-file sweep of `FACTORY_AUDIO_TMP` on hub restart is deferred.
 - Multi-agent `AgentTTSConfig` — until Option B is verified at `AudioPipeline` /
   TTSService call sites, multi-agent deployments should log a warning when two agents

--- a/src/factory/core/hub/outbound/outbound_dispatcher.py
+++ b/src/factory/core/hub/outbound/outbound_dispatcher.py
@@ -22,12 +22,14 @@ from ...messaging.message import (
     OutboundMessage,
     RoutingContext,
 )
+from ...messaging.utils.callbacks import unwrap_callback
 from ._dispatch import dispatch_outbound_item
 from .outbound_errors import (
     _CIRCUIT_NOTIFY_DEBOUNCE,
     _ITEM,
     _NOTIFY_TS_REAP_THRESHOLD,
     _SCOPE_REAP_THRESHOLD,
+    OUTBOUND_QUEUE_MAXSIZE,
     try_notify_user,
 )
 
@@ -44,20 +46,21 @@ class OutboundDispatcher:
     Create with platform_name/adapter/circuit, then call start()/stop().
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         platform_name: str,
         adapter: "ChannelAdapter",
         circuit: CircuitBreaker | None = None,
         circuit_registry: CircuitRegistry | None = None,
         bot_id: str = "main",
+        queue_maxsize: int = OUTBOUND_QUEUE_MAXSIZE,
     ) -> None:
         self._platform_name = platform_name
         self._bot_id = bot_id
         self._adapter = adapter
         self._circuit = circuit
         self._circuit_registry = circuit_registry
-        self._queue: asyncio.Queue[_ITEM] = asyncio.Queue()
+        self._queue: asyncio.Queue[_ITEM] = asyncio.Queue(maxsize=queue_maxsize)
         self._worker: asyncio.Task[None] | None = None
         # Per-chat last circuit-open notification timestamp for debouncing (Fix 3)
         self._circuit_notify_ts: dict[str, float] = {}
@@ -84,8 +87,75 @@ class OutboundDispatcher:
             return False
         return True
 
+    def _maybe_drop_oldest(self) -> None:
+        """Drop the oldest item when the queue is at capacity (drop-oldest policy).
+
+        Called by every enqueue_* method before put_nowait(). When full, dequeues
+        the head item, schedules async cleanup (iterator drain + callback), and
+        emits a structured warning log.
+        """
+        if self._queue.qsize() < self._queue.maxsize:
+            return
+        try:
+            item = self._queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return  # race: worker drained it first
+        self._queue.task_done()
+        kind: str = item[0]
+        log.warning(
+            '{"event": "outbound_queue_overflow", "platform": "%s", "bot_id": "%s",'
+            ' "dropped_kind": "%s", "qsize": %d}',
+            self._platform_name,
+            self._bot_id,
+            kind,
+            self._queue.qsize(),
+        )
+        # Schedule async cleanup (iterator drain + callback) as a fire-and-forget task.
+        # Guard: no-op when called outside a running event loop (unit-test context).
+        try:
+            task = asyncio.get_running_loop().create_task(
+                self._drop_item_async(item, kind),
+                name=f"outbound-drop-{self._platform_name}",
+            )
+        except RuntimeError:
+            # No running event loop — item dropped synchronously; iterator not drained.
+            # Acceptable in test/non-async contexts; never happens in production.
+            return
+
+        def _on_drop_done(t: asyncio.Task[None]) -> None:
+            self._scope_tasks.discard(t)
+            if not t.cancelled() and (exc := t.exception()) is not None:
+                log.error(
+                    "OutboundDispatcher[%s] drop task exception: %s",
+                    self._platform_name,
+                    exc,
+                    exc_info=exc,
+                )
+
+        task.add_done_callback(_on_drop_done)
+        self._scope_tasks.add(task)
+
+    async def _drop_item_async(self, item: _ITEM, kind: str) -> None:
+        """Drain iterator and fire callback for a dropped overflow item."""
+        # Drain async iterators to prevent generator leaks
+        if kind in ("streaming", "audio_stream", "voice_stream"):
+            async for _ in item[2]:
+                pass
+        # Fire _on_dispatched callback with reply_message_id=None (mirrors circuit-open)
+        cb_target = None
+        if kind == "send":
+            cb_target = item[2]
+        elif kind == "streaming":
+            cb_target = item[3]  # outbound (may be None)
+        if cb_target is not None:
+            cb_target.metadata["reply_message_id"] = None
+            _cb = unwrap_callback(cb_target.metadata, "_on_dispatched", pop=True)
+            if _cb is not None:
+                await _cb(cb_target)
+
     def enqueue(self, msg: InboundMessage, response: OutboundMessage) -> None:
-        """Enqueue a non-streaming response for delivery (fire-and-forget)."""
+        """Enqueue a non-streaming response for delivery (drop-oldest on overflow)."""
+        self._maybe_drop_oldest()
         self._queue.put_nowait(("send", msg, response))
 
     def enqueue_streaming(
@@ -94,11 +164,13 @@ class OutboundDispatcher:
         chunks: AsyncIterator[RenderEvent],
         outbound: OutboundMessage | None = None,
     ) -> None:
-        """Enqueue a streaming response for delivery (fire-and-forget)."""
+        """Enqueue a streaming response for delivery (drop-oldest on overflow)."""
+        self._maybe_drop_oldest()
         self._queue.put_nowait(("streaming", msg, chunks, outbound))
 
     def enqueue_audio(self, inbound: InboundMessage, audio: OutboundAudio) -> None:
-        """Enqueue an audio response for delivery (fire-and-forget)."""
+        """Enqueue an audio response for delivery (drop-oldest on overflow)."""
+        self._maybe_drop_oldest()
         self._queue.put_nowait(("audio", inbound, audio))
 
     def enqueue_audio_stream(
@@ -106,7 +178,8 @@ class OutboundDispatcher:
         inbound: InboundMessage,
         chunks: AsyncIterator[OutboundAudioChunk],
     ) -> None:
-        """Enqueue a streaming audio response for delivery (fire-and-forget)."""
+        """Enqueue a streaming audio response for delivery (drop-oldest on overflow)."""
+        self._maybe_drop_oldest()
         self._queue.put_nowait(("audio_stream", inbound, chunks))
 
     def enqueue_voice_stream(
@@ -114,13 +187,15 @@ class OutboundDispatcher:
         inbound: InboundMessage,
         chunks: AsyncIterator[OutboundAudioChunk],
     ) -> None:
-        """Enqueue a voice stream for delivery (fire-and-forget)."""
+        """Enqueue a voice stream for delivery (drop-oldest on overflow)."""
+        self._maybe_drop_oldest()
         self._queue.put_nowait(("voice_stream", inbound, chunks))
 
     def enqueue_attachment(
         self, inbound: InboundMessage, attachment: OutboundAttachment
     ) -> None:
-        """Enqueue an attachment for delivery (fire-and-forget)."""
+        """Enqueue an attachment for delivery (drop-oldest on overflow)."""
+        self._maybe_drop_oldest()
         self._queue.put_nowait(("attachment", inbound, attachment))
 
     async def start(self) -> None:

--- a/src/factory/core/hub/outbound/outbound_errors.py
+++ b/src/factory/core/hub/outbound/outbound_errors.py
@@ -23,6 +23,7 @@ _CIRCUIT_OPEN_MSG = "⚠️ I'm temporarily unavailable. Please try again in a m
 _CIRCUIT_NOTIFY_DEBOUNCE = 60.0  # seconds between circuit-open notifications per chat
 _SCOPE_REAP_THRESHOLD = 256  # const-ok: reap idle scope locks above this size
 _NOTIFY_TS_REAP_THRESHOLD = 512  # const-ok: reap stale notify timestamps above this
+OUTBOUND_QUEUE_MAXSIZE = 50  # const-ok: bounded queue — drop-oldest on overflow
 
 # Queue item shapes (heterogeneous tuple — see OutboundDispatcher._dispatch_item):
 #   ("send",         InboundMessage, OutboundMessage)

--- a/tests/core/test_outbound_dispatcher_overflow.py
+++ b/tests/core/test_outbound_dispatcher_overflow.py
@@ -13,11 +13,19 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from factory.core.hub.outbound.outbound_dispatcher import OutboundDispatcher
 from factory.core.hub.outbound.outbound_errors import OUTBOUND_QUEUE_MAXSIZE
-from factory.core.messaging.message import OutboundAudio, OutboundMessage
+from factory.core.messaging.message import (
+    OutboundAudio,
+    OutboundAudioChunk,
+    OutboundMessage,
+)
+from factory.core.messaging.render_events import RenderEvent
 
 from .conftest import make_dispatcher_msg
 
@@ -158,7 +166,7 @@ class TestStreamingIteratorDrain:
         dispatcher.enqueue(msg, OutboundMessage.from_text("placeholder"))
         # Now enqueue a streaming item that will trigger drop-oldest of the placeholder
         # and put the streaming item in the queue
-        chunks_gen = _gen_with_sentinel()
+        chunks_gen = cast(AsyncIterator[RenderEvent], _gen_with_sentinel())
         dispatcher.enqueue_streaming(msg, chunks_gen)
         # Queue: [streaming(chunks_gen)]
 
@@ -186,7 +194,9 @@ class TestStreamingIteratorDrain:
         # Fill the queue with a plain send first
         dispatcher.enqueue(msg, OutboundMessage.from_text("placeholder"))
         # Enqueue audio_stream, which evicts the placeholder
-        dispatcher.enqueue_audio_stream(msg, _audio_gen())
+        dispatcher.enqueue_audio_stream(
+            msg, cast(AsyncIterator[OutboundAudioChunk], _audio_gen())
+        )
         # Enqueue one more item to evict the audio_stream item
         dispatcher.enqueue(msg, OutboundMessage.from_text("evict-audio"))
 
@@ -195,6 +205,33 @@ class TestStreamingIteratorDrain:
 
         assert "audio-done" in drained, (
             "audio_stream iterator was not drained after drop"
+        )
+
+    async def test_dropped_voice_stream_iterator_drained(self) -> None:
+        """A dropped 'voice_stream' item has its AsyncIterator fully consumed."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=1)
+        msg = make_dispatcher_msg()
+
+        drained: list[str] = []
+
+        async def _voice_gen() -> AsyncIterator[object]:
+            yield object()
+            drained.append("voice-done")
+
+        # Fill the queue with a plain send first
+        dispatcher.enqueue(msg, OutboundMessage.from_text("placeholder"))
+        # Enqueue voice_stream, which evicts the placeholder
+        dispatcher.enqueue_voice_stream(
+            msg, cast(AsyncIterator[OutboundAudioChunk], _voice_gen())
+        )
+        # Enqueue one more item to evict the voice_stream item
+        dispatcher.enqueue(msg, OutboundMessage.from_text("evict-voice"))
+
+        await asyncio.sleep(0)  # event-based
+        await asyncio.sleep(0)  # event-based
+
+        assert "voice-done" in drained, (
+            "voice_stream iterator was not drained after drop"
         )
 
 
@@ -231,6 +268,36 @@ class TestQueueEmptyRace:
         # queue is empty and maxsize=2 — qsize (0) < maxsize (2) → early return
         dispatcher._maybe_drop_oldest()  # noqa: SLF001
         assert dispatcher._queue.qsize() == 0  # noqa: SLF001
+
+    def test_queue_empty_race_exercises_except_branch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_nowait raising QueueEmpty (worker stole the items between the
+        qsize check and the dequeue) is tolerated and the new item still lands."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=2)
+        msg = make_dispatcher_msg()
+        queue = dispatcher._queue  # noqa: SLF001
+
+        dispatcher.enqueue(msg, OutboundMessage.from_text("first"))
+        dispatcher.enqueue(msg, OutboundMessage.from_text("second"))
+
+        original_get_nowait = queue.get_nowait
+
+        def _racing_get_nowait() -> object:
+            # Simulate the worker draining the queue between the qsize check
+            # and get_nowait: empty it for real, then raise like asyncio.Queue.
+            while queue.qsize():
+                original_get_nowait()
+                queue.task_done()
+            raise asyncio.QueueEmpty
+
+        monkeypatch.setattr(queue, "get_nowait", _racing_get_nowait)
+        # qsize (2) >= maxsize (2) → _maybe_drop_oldest reaches get_nowait,
+        # which raises QueueEmpty; the enqueue must survive and land the item.
+        dispatcher.enqueue(msg, OutboundMessage.from_text("new"))
+        monkeypatch.undo()
+
+        assert queue.qsize() == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_outbound_dispatcher_overflow.py
+++ b/tests/core/test_outbound_dispatcher_overflow.py
@@ -1,0 +1,267 @@
+"""Tests for OutboundDispatcher bounded-queue / drop-oldest overflow behaviour.
+
+Coverage:
+- overflow drops OLDEST item, not newest
+- dropped streaming iterator is fully drained (async gen with sentinel)
+- qsize never exceeds maxsize after overflow
+- QueueEmpty race in _maybe_drop_oldest is tolerated silently
+- nominal path (no overflow) unchanged
+- OUTBOUND_QUEUE_MAXSIZE constant is 50
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+from factory.core.hub.outbound.outbound_dispatcher import OutboundDispatcher
+from factory.core.hub.outbound.outbound_errors import OUTBOUND_QUEUE_MAXSIZE
+from factory.core.messaging.message import OutboundAudio, OutboundMessage
+
+from .conftest import make_dispatcher_msg
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stopped_dispatcher(maxsize: int = 3) -> tuple[MagicMock, OutboundDispatcher]:
+    """Return an adapter mock + a dispatcher that has NOT been started.
+
+    Using a small maxsize keeps the tests fast and O(1) in enqueue calls.
+    The worker is NOT started so items stay in the queue — we inspect queue
+    state synchronously without any async delivery.
+    """
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_streaming = AsyncMock()
+    dispatcher = OutboundDispatcher(
+        platform_name="telegram",
+        adapter=adapter,
+        queue_maxsize=maxsize,
+    )
+    return adapter, dispatcher
+
+
+async def _drain_to_completion(gen: AsyncGenerator) -> list:
+    """Exhaust an async generator, collecting yielded values."""
+    items = []
+    async for item in gen:
+        items.append(item)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Queue maxsize constant
+# ---------------------------------------------------------------------------
+
+
+class TestQueueMaxsizeConstant:
+    def test_default_maxsize_is_50(self) -> None:
+        assert OUTBOUND_QUEUE_MAXSIZE == 50
+
+    def test_dispatcher_maxsize_matches_constant(self) -> None:
+        _, dispatcher = _make_stopped_dispatcher(maxsize=OUTBOUND_QUEUE_MAXSIZE)
+        assert dispatcher._queue.maxsize == OUTBOUND_QUEUE_MAXSIZE  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Nominal path — no overflow
+# ---------------------------------------------------------------------------
+
+
+class TestNominalNoOverflow:
+    def test_enqueue_below_capacity_no_drop(self) -> None:
+        """Items below maxsize are enqueued without any drop."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=4)
+        msg = make_dispatcher_msg()
+        for _ in range(4):
+            dispatcher.enqueue(msg, OutboundMessage.from_text("hi"))
+        assert dispatcher._queue.qsize() == 4  # noqa: SLF001
+
+    def test_enqueue_at_capacity_does_not_exceed_maxsize(self) -> None:
+        """After overflow, qsize never exceeds maxsize."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=2)
+        msg = make_dispatcher_msg()
+        # Fill to capacity
+        dispatcher.enqueue(msg, OutboundMessage.from_text("first"))
+        dispatcher.enqueue(msg, OutboundMessage.from_text("second"))
+        assert dispatcher._queue.qsize() == 2  # noqa: SLF001
+        # Overflow — oldest dropped, size stays at 2
+        dispatcher.enqueue(msg, OutboundMessage.from_text("third"))
+        assert dispatcher._queue.qsize() == 2  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Drop-oldest semantics
+# ---------------------------------------------------------------------------
+
+
+class TestDropOldest:
+    def test_overflow_drops_oldest_keeps_newest(self) -> None:
+        """When queue is full, the HEAD item is removed, not the incoming one."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=2)
+        msg = make_dispatcher_msg()
+        out_first = OutboundMessage.from_text("first")
+        out_second = OutboundMessage.from_text("second")
+        out_third = OutboundMessage.from_text("third")
+
+        dispatcher.enqueue(msg, out_first)
+        dispatcher.enqueue(msg, out_second)
+        # Queue: [first, second] — full
+        dispatcher.enqueue(msg, out_third)
+        # Queue: [second, third] — first was dropped
+
+        # Peek at the queue without consuming via get_nowait
+        item_a = dispatcher._queue.get_nowait()  # noqa: SLF001
+        item_b = dispatcher._queue.get_nowait()  # noqa: SLF001
+        # item_a should be second (oldest surviving), item_b should be third
+        assert item_a[2] is out_second
+        assert item_b[2] is out_third
+
+    def test_multiple_overflows_always_keep_newest(self) -> None:
+        """Each successive overflow drops the current oldest item."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=1)
+        msg = make_dispatcher_msg()
+        out_a = OutboundMessage.from_text("a")
+        out_b = OutboundMessage.from_text("b")
+        out_c = OutboundMessage.from_text("c")
+
+        dispatcher.enqueue(msg, out_a)  # queue: [a]
+        dispatcher.enqueue(msg, out_b)  # overflow: drop a → [b]
+        dispatcher.enqueue(msg, out_c)  # overflow: drop b → [c]
+
+        item = dispatcher._queue.get_nowait()  # noqa: SLF001
+        assert item[2] is out_c
+
+
+# ---------------------------------------------------------------------------
+# Streaming iterator drain
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingIteratorDrain:
+    async def test_dropped_streaming_item_iterator_drained(self) -> None:
+        """A dropped 'streaming' item has its AsyncIterator fully consumed."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=1)
+        msg = make_dispatcher_msg()
+
+        drained: list[str] = []
+
+        async def _gen_with_sentinel() -> AsyncIterator[str]:
+            yield "token-1"
+            yield "token-2"
+            drained.append("done")
+
+        # Fill the queue with a non-streaming item first
+        dispatcher.enqueue(msg, OutboundMessage.from_text("placeholder"))
+        # Now enqueue a streaming item that will trigger drop-oldest of the placeholder
+        # and put the streaming item in the queue
+        chunks_gen = _gen_with_sentinel()
+        dispatcher.enqueue_streaming(msg, chunks_gen)
+        # Queue: [streaming(chunks_gen)]
+
+        # Now trigger overflow: enqueue another item so the streaming one gets dropped
+        dispatcher.enqueue(msg, OutboundMessage.from_text("evict-streaming"))
+        # _maybe_drop_oldest() will drop the streaming item → should drain chunks_gen
+
+        # Drain is a fire-and-forget asyncio task — yield the event loop
+        await asyncio.sleep(0)  # event-based
+        await asyncio.sleep(0)  # event-based
+
+        assert "done" in drained, "streaming iterator was not drained after drop"
+
+    async def test_dropped_audio_stream_iterator_drained(self) -> None:
+        """A dropped 'audio_stream' item has its AsyncIterator fully consumed."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=1)
+        msg = make_dispatcher_msg()
+
+        drained: list[str] = []
+
+        async def _audio_gen() -> AsyncIterator[object]:
+            yield object()
+            drained.append("audio-done")
+
+        # Fill the queue with a plain send first
+        dispatcher.enqueue(msg, OutboundMessage.from_text("placeholder"))
+        # Enqueue audio_stream, which evicts the placeholder
+        dispatcher.enqueue_audio_stream(msg, _audio_gen())
+        # Enqueue one more item to evict the audio_stream item
+        dispatcher.enqueue(msg, OutboundMessage.from_text("evict-audio"))
+
+        await asyncio.sleep(0)  # event-based
+        await asyncio.sleep(0)  # event-based
+
+        assert "audio-done" in drained, (
+            "audio_stream iterator was not drained after drop"
+        )
+
+
+# ---------------------------------------------------------------------------
+# QueueEmpty race
+# ---------------------------------------------------------------------------
+
+
+class TestQueueEmptyRace:
+    def test_maybe_drop_oldest_tolerates_concurrent_drain(self) -> None:
+        """If worker drains the queue before _maybe_drop_oldest runs get_nowait,
+        no exception is raised and the new item is still enqueued."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=2)
+        msg = make_dispatcher_msg()
+
+        # Fill queue to capacity then manually drain it (simulates worker racing)
+        dispatcher.enqueue(msg, OutboundMessage.from_text("first"))
+        dispatcher.enqueue(msg, OutboundMessage.from_text("second"))
+        # Drain the queue externally (worker raced us)
+        dispatcher._queue.get_nowait()  # noqa: SLF001
+        dispatcher._queue.task_done()  # noqa: SLF001
+        dispatcher._queue.get_nowait()  # noqa: SLF001
+        dispatcher._queue.task_done()  # noqa: SLF001
+        assert dispatcher._queue.qsize() == 0  # noqa: SLF001
+
+        # Now enqueue — qsize < maxsize, so _maybe_drop_oldest returns immediately
+        # (no QueueEmpty raised)
+        dispatcher.enqueue(msg, OutboundMessage.from_text("new"))
+        assert dispatcher._queue.qsize() == 1  # noqa: SLF001
+
+    def test_maybe_drop_oldest_direct_race(self) -> None:
+        """_maybe_drop_oldest called directly when queue is empty does nothing."""
+        _, dispatcher = _make_stopped_dispatcher(maxsize=2)
+        # queue is empty and maxsize=2 — qsize (0) < maxsize (2) → early return
+        dispatcher._maybe_drop_oldest()  # noqa: SLF001
+        assert dispatcher._queue.qsize() == 0  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# qsize invariant
+# ---------------------------------------------------------------------------
+
+
+class TestQsizeInvariant:
+    def test_qsize_never_exceeds_maxsize_under_burst(self) -> None:
+        """Enqueue 3× maxsize items — qsize must stay ≤ maxsize at all times."""
+        maxsize = 5
+        _, dispatcher = _make_stopped_dispatcher(maxsize=maxsize)
+        msg = make_dispatcher_msg()
+
+        for i in range(maxsize * 3):
+            dispatcher.enqueue(msg, OutboundMessage.from_text(f"item-{i}"))
+            assert dispatcher._queue.qsize() <= maxsize
+
+    def test_qsize_never_exceeds_maxsize_mixed_kinds(self) -> None:
+        """Mixed enqueue kinds also never exceed maxsize."""
+        maxsize = 3
+
+        async def _noop_gen() -> AsyncIterator[object]:
+            return
+            yield  # make it an async generator
+
+        _, dispatcher = _make_stopped_dispatcher(maxsize=maxsize)
+        msg = make_dispatcher_msg()
+
+        for _ in range(6):
+            dispatcher.enqueue(msg, OutboundMessage.from_text("s"))
+            assert dispatcher._queue.qsize() <= maxsize
+            dispatcher.enqueue_audio(msg, MagicMock(spec=OutboundAudio))
+            assert dispatcher._queue.qsize() <= maxsize


### PR DESCRIPTION
## Summary

- Bound `OutboundDispatcher._queue` with `maxsize=OUTBOUND_QUEUE_MAXSIZE` (50, defined in `outbound_errors.py`)
- Added `_maybe_drop_oldest()` called in all 6 `enqueue_*` methods: drops queue HEAD on full, drains async iterators (streaming/audio_stream/voice_stream), fires `_on_dispatched` callback with `reply_message_id=None` (mirrors circuit-open semantics), tolerates `QueueEmpty` race with worker
- Emits structured `outbound_queue_overflow` warning log (platform, bot_id, dropped_kind, qsize)
- No user notification on overflow (intentional)
- Docs: `adapters.md` Key Invariant gap filled

Closes #1834

## Fix applied during ship

`_maybe_drop_oldest` used `asyncio.create_task()` unconditionally, which raises `RuntimeError: no running event loop` in synchronous test context. Fixed to use `asyncio.get_running_loop().create_task()` guarded with `except RuntimeError` — no-op when no loop (unit tests); always runs in production where the dispatcher is started inside an async context.

## Test plan

- [x] `tests/core/test_outbound_dispatcher_overflow.py` — 12 tests, all pass
  - `OUTBOUND_QUEUE_MAXSIZE == 50`
  - drop-oldest ordering (newest survives)
  - streaming/audio_stream iterator drained after drop
  - QueueEmpty race tolerated silently
  - qsize never exceeds maxsize under burst + mixed kinds

## Gates

- ruff format + check: PASS
- pytest (scoped): 12/12 PASS
- pyright: 0 errors
- lint-imports: 11 contracts kept, 0 broken
- check_test_sleep: OK
- check_debt_expiry: OK
- check_doc_drift: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)