### PR TITLE
refactor(contracts): consolidate NATS subject-segment charset SSoT in _nats_utils

### DIFF
--- a/artifacts/frames/1782-subject-charset-ssot-frame.mdx
+++ b/artifacts/frames/1782-subject-charset-ssot-frame.mdx
@@ -1,0 +1,138 @@
+---
+title: "refactor(contracts): consolidate NATS subject-segment charset SSoT in _nats_utils"
+issue: 1782
+status: approved
+tier: S
+date: 2026-06-11
+---
+
+## Problem
+
+The single-segment NATS charset `[A-Za-z0-9_-]+` is defined as an inline
+literal in multiple independent locations that can silently drift. Two compiled
+regexes with identical patterns co-exist in `_nats_utils.py`
+(`_SAFE_WORKER_ID_RE` at line 16 and `_SAFE_SUBJECT_SEGMENT_RE` at line 52);
+`event/subjects.py` imports the constant but still wraps it in a local
+`_validate_segment` function rather than calling `_validate_subject_segment`
+directly; and `daemon.py:142,144` inlines the charset twice in
+`_safe_machine_name` because it cannot call the raising validator (its semantics
+are replace-not-raise).
+
+**Why now:** The drift was deferred from PR #1781 (#1708 upstream). The
+`_validate_subject_segment` function is already imported by four intra-package
+modules under its private underscore-prefixed name, meaning any future consumer
+reaching for a public symbol will either duplicate it again or import an
+ostensibly private API. Closing this before M1 lands jobs subjects
+(`factory.job.<id>.*` — #1793) prevents the segment-charset from being
+re-inlined a fifth time in the new job subject helpers.
+
+**Observable impact:** Purely internal — no wire protocol or external API
+change. The risk is future silent drift: if `_SAFE_WORKER_ID_RE` diverges from
+`_SAFE_SUBJECT_SEGMENT_RE` (e.g. a typo in one), `validate_worker_id` would
+accept IDs that `_validate_subject_segment` rejects (or vice versa), producing
+subjects that fail contract validation at publish time with no compile-time
+signal.
+
+## Who
+
+- **Primary:** contributors adding new domain subject modules — they encounter
+  four divergent spelling sites and no clearly authoritative constant to import.
+- **Secondary:** operators — a charset divergence would produce silent subject
+  injection or unexpected `ValueError` at runtime without any static-analysis
+  warning.
+
+## Constraints
+
+- **Sanitizer semantics preserved:** `daemon.py:_safe_machine_name` must
+  continue to *replace* bad characters (not raise). It may import the compiled
+  constant `_SAFE_SUBJECT_SEGMENT_RE` from `roxabi_contracts` to DRY the regex
+  string, but the fullmatch + sub logic must remain local. Importing
+  `_validate_subject_segment` and catching its `ValueError` is explicitly
+  forbidden — it inverts the design intent documented at daemon.py:131-141.
+- **daemon.py line budget:** `daemon.py` is currently 310 lines (no active
+  exemption in `tools/file_exemptions.txt`; the file SLOC metric puts it just
+  under the 300 SLOC gate). Any edit must not push it over 300 SLOC — prefer a
+  single import line replacing both inline literals.
+- **roxabi-contracts versioning:** promoting `_validate_subject_segment` to
+  public (`validate_subject_segment`) is an additive change → minor version bump
+  (0.7.0 → 0.8.0) per `packages/roxabi-contracts/CLAUDE.md` breaking-change
+  rules; `__all__` in `__init__.py` must not conflict with #1619
+  (`WorkEnvelope` additions) if both land in the same release.
+- **doc_drift gate:** any new backtick-quoted public symbol added to docs/ must
+  exist in `src/` at the time of the push; un-backtick unbuilt symbols.
+- **Error messages must not regress:** `_SAFE_WORKER_ID_RE` and
+  `_SAFE_SUBJECT_SEGMENT_RE` share the same regex but have *different* error
+  messages in their respective validators (`validate_worker_id` line 30 vs
+  `_validate_subject_segment` line 58); consolidating the compiled constant does
+  **not** require merging the error messages — keep both validators distinct.
+- **test match strings:** `test_event_subjects.py` uses `match="segment"` for
+  `per_service_event`/`per_service_metric` errors (lines 34, 39). Replacing
+  `_validate_segment` with a direct call to `_validate_subject_segment` is safe
+  because the error string is verbatim-identical. Verify no test matches on the
+  local function name string before removing.
+- **Cross-issue coordination:** `__init__.py` `__all__` is also touched by
+  #1619 (WorkEnvelope shim re-exports); coordinate if both target the same
+  release. #1791 covers domain `__init__` re-export surfaces — any rename of
+  `_validate_subject_segment` should be noted there.
+
+## Out of Scope
+
+- Merging `validate_worker_id` and `validate_subject_segment` into a single
+  function — they carry distinct error messages and semantics; collapsing them
+  would obscure call-site intent.
+- Changing `_SAFE_JOB_TOKEN_RE` (`[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*`) — it is
+  a different pattern (dots allowed) and is not a consolidation target.
+- Any change to the wire format or NATS subjects themselves.
+- Jobs subject namespace unification (#1793) — that issue may add new callers
+  of the public validator but its design is independent.
+- Satellite upgrade coordination for the minor version bump — additive-only,
+  no satellite breakage expected; Renovate rule handles lock updates.
+
+## Premise Validity
+
+**Success in 6 months:** `_nats_utils.py` contains exactly one compiled regex
+for the base segment charset (used by both `validate_worker_id` and
+`_validate_subject_segment`); `event/subjects.py` delegates to
+`_validate_subject_segment` rather than maintaining a local wrapper; `daemon.py`
+references the same compiled constant rather than two inline literals; a
+parametrized drift-guard test in `test_event_subjects.py` and new
+`_safe_machine_name` tests in `test_gh_daemon.py` cover charset rejection and
+sanitizer semantics; `roxabi-contracts` is tagged `v0.8.0`.
+
+**Failure in 6 months:** A new domain subject module is added and the author
+re-inlines `[A-Za-z0-9_-]+` because no obvious public validator exists (i.e.
+the four-site drift recurs), OR `_SAFE_WORKER_ID_RE` and `_SAFE_SUBJECT_SEGMENT_RE`
+diverge in pattern (observable: `validate_worker_id` accepts a string that
+`validate_subject_segment` rejects on the same input). Falsifiable: grep for
+`r"[A-Za-z0-9_-]+"` inline literals in src/ and packages/ returns > 0 hits
+outside `_nats_utils.py` and `daemon.py`.
+
+**Simplest alternative:** Add an `assert _SAFE_WORKER_ID_RE.pattern ==
+_SAFE_SUBJECT_SEGMENT_RE.pattern` at module load in `_nats_utils.py` and leave
+the two constants in place; add a docstring comment to `daemon.py` pointing at
+`_SAFE_SUBJECT_SEGMENT_RE` as the canonical reference.
+
+**Why not simplest:** The assert-equal approach leaves four spelling sites and a
+private validator name — contributors still have no clear public import path,
+and `event/subjects.py` still carries a duplicate wrapper function. The frame
+(and PR #1781 review) call for an actual SSoT, not a runtime parity check that
+only fails if the test suite exercises `_nats_utils` at import time.
+
+_(champs dérivés du contexte — à valider à la review humaine)_
+
+## Complexity
+
+**Tier: S** — all changes are within `roxabi-contracts` internal files plus a
+single import substitution in `daemon.py`; no architecture change, no new
+abstraction, no cross-layer boundary crossing.
+
+Signals observed:
+- ≤6 files touched, single package domain (`roxabi-contracts` + one tools
+  helper).
+- No unknown design decisions — the consolidation target (`_nats_utils.py`) and
+  the refactor direction are fully specified by the existing code structure.
+- The only non-trivial constraint (daemon sanitizer semantics) is already
+  documented inline at daemon.py:131-141 and is preserved by importing the
+  constant only, not the validator.
+- Two test files to extend with parametrized cases; both follow an established
+  pattern (`test_voice_subjects.py` / `test_image_subjects.py`).

--- a/artifacts/specs/1782-subject-charset-ssot-spec.mdx
+++ b/artifacts/specs/1782-subject-charset-ssot-spec.mdx
@@ -1,0 +1,147 @@
+---
+title: "refactor(contracts): consolidate NATS subject-segment charset SSoT in _nats_utils"
+description: "Eliminate all inline copies of [A-Za-z0-9_-]+ outside _nats_utils, promote the validator to public, and add a drift-guard test."
+---
+
+## Context
+**Promoted from:** [frame](../frames/1782-subject-charset-ssot-frame.mdx)
+**GitHub issue:** #1782
+**Upstream:** PR #1781 deferred this scope from #1708 (MintFailureEvent charset alignment).
+**Related:** #1619 (WorkEnvelope shim — touches `__init__.py __all__`); #1791 (domain `__init__` re-export surfaces); #1793 (jobs subjects, new potential callsite).
+
+## Goal
+
+Establish a single compiled regex constant and a public validator in `_nats_utils.py` that every consumer — intra-package modules, `event/subjects.py`, and `daemon.py` — references, so the `[A-Za-z0-9_-]+` charset cannot silently drift across definition sites.
+
+## Users
+
+- **Contributors adding domain subject modules** — currently encounter four divergent spelling sites; after this refactor they find one obvious public symbol to import.
+- **Operators** — a regex divergence between `_SAFE_WORKER_ID_RE` and `_SAFE_SUBJECT_SEGMENT_RE` would silently produce mismatched subject validation at runtime; a single constant eliminates that failure mode.
+
+## Expected Behavior
+
+After this refactor:
+
+1. `_nats_utils.py` introduces a chars-only constant `_SAFE_SEGMENT_CHARS = r"A-Za-z0-9_-"` and replaces the two separate compiled regexes with a single `_SAFE_SEGMENT_RE = re.compile(f"[{_SAFE_SEGMENT_CHARS}]+")`. Both `validate_worker_id` and `validate_subject_segment` (public rename) reference `_SAFE_SEGMENT_RE`. `_SAFE_WORKER_ID_RE` and `_SAFE_SUBJECT_SEGMENT_RE` are removed. The `_SAFE_SEGMENT_CHARS` constant is also exported so `daemon.py` can compose `re.sub` safely (see EB §4).
+
+2. `validate_subject_segment` (public, no leading underscore) is importable from `roxabi_contracts` via `__all__` and from `roxabi_contracts._nats_utils` directly. All four existing intra-package importers (`outbound/subjects.py`, `gh/subjects.py`, `verify/subjects.py`, `gh/models.py`) are updated from `_validate_subject_segment` to `validate_subject_segment`. Additionally, the **internal call at line 70 of `validate_nats_subject`** in `_nats_utils.py` itself must be updated from `_validate_subject_segment(segment)` to `validate_subject_segment(segment)` — failing to do so would leave a `NameError` at runtime on any full-subject validation path. The docstring of `validate_nats_subject` (line 65) must also be updated from `validates each segment via _validate_subject_segment` to `validates each segment via validate_subject_segment`.
+
+3. `event/subjects.py` drops its local `_validate_segment` wrapper and calls `validate_subject_segment` from `_nats_utils` directly. The import changes from `_SAFE_SUBJECT_SEGMENT_RE` to `validate_subject_segment` (note: `import re` must **stay** — it is still needed for the local `_SAFE_NAMESPACED_RE = re.compile(...)` at line 24); the local `re.fullmatch` branch inside `_validate_segment` is deleted. The existing `match="segment"` tests continue to pass because the error message string is identical.
+
+4. `daemon.py:_safe_machine_name` replaces the two inline regex literals — `r"[A-Za-z0-9_-]+"` (line 142, fullmatch) and `r"[^A-Za-z0-9_-]"` (line 144, negated-class `re.sub`) — with references to imported constants:
+   - `re.fullmatch(_SAFE_SEGMENT_RE, raw)` for the passthrough check (replaces line 142)
+   - `re.sub(f"[^{_SAFE_SEGMENT_CHARS}]", "_", raw)` for the replace branch (replaces line 144) — using `_SAFE_SEGMENT_CHARS` directly (the chars-only string without brackets or quantifier) avoids the double-bracket expansion bug that would occur with `.pattern`
+   - The fullmatch + sub logic remains local — `validate_subject_segment` (which raises) is **never** called from `daemon.py`. Import is `from roxabi_contracts._nats_utils import _SAFE_SEGMENT_RE, _SAFE_SEGMENT_CHARS`.
+
+5. `roxabi-contracts` is tagged `v0.8.0` (minor bump — additive public API addition). `__init__.py __all__` gains `"validate_subject_segment"`.
+
+6. A new parametrized test `test_segment_charset_rejection` in `test_event_subjects.py` asserts that `per_service_event` and `per_service_metric` reject a standard `_UNSAFE_SEGMENT_IDS` list (matching the voice/image pattern: dots, wildcards `*`, `>`, spaces, empty string). All use `match="NATS subject segment must match"` (the longer, distinctive leading phrase) rather than just `match="segment"` — this ensures a partial error-message truncation during the rename would surface as a test failure rather than a silent pass.
+
+7. New tests in `test_gh_daemon.py` cover `_safe_machine_name`: passthrough on clean input, replace-not-raise on dirty input, empty-string-after-replace yields `"unknown"`.
+
+8. `CHANGELOG.md` in `packages/roxabi-contracts/` records the public promotion of `validate_subject_segment` and the introduction of `_SAFE_SEGMENT_CHARS`.
+
+## Design Decisions
+
+### Site 2 status (event/subjects.py)
+
+`event/subjects.py` already imports `_SAFE_SUBJECT_SEGMENT_RE` (the constant) but
+still defines a local `_validate_segment` wrapper at lines 42–47 with a
+verbatim-duplicate error message. The import of the constant is present; the
+function deduplication is **not done**. This issue completes that deduplication
+by switching `event/subjects.py` to call `validate_subject_segment` directly and
+deleting `_validate_segment`.
+
+### Site 3: single constant strategy
+
+`_SAFE_WORKER_ID_RE` (line 16) and `_SAFE_SUBJECT_SEGMENT_RE` (line 52) are
+identical patterns. They are collapsed to two related constants:
+- `_SAFE_SEGMENT_CHARS = r"A-Za-z0-9_-"` — the raw character class body (no brackets, no quantifier)
+- `_SAFE_SEGMENT_RE = re.compile(f"[{_SAFE_SEGMENT_CHARS}]+")` — the compiled fullmatch regex
+
+`daemon.py`'s `re.sub` **cannot** compose from `_SAFE_SEGMENT_RE.pattern` because `.pattern`
+is `"[A-Za-z0-9_-]+"` (brackets + quantifier included), so
+`f"[^{_SAFE_SEGMENT_RE.pattern}]"` would expand to `"[^[A-Za-z0-9_-]+]"` —
+double bracket with a stray `+` inside the negated class. Python silently treats
+`[` and `+` as literal characters there, making the sub inert and passing dirty
+input through unchanged. `_SAFE_SEGMENT_CHARS` is the composable primitive.
+
+Both `validate_worker_id` and `validate_subject_segment` reference `_SAFE_SEGMENT_RE`;
+their error messages remain distinct (different wording at current lines 30 and
+58). The comment at line 50–51 ("keep paths independent") was written before the
+segment constant existed as a separate object; removing it resolves the stated
+concern without runtime risk.
+
+### daemon.py import feasibility
+
+Confirmed: `daemon.py` already imports `from roxabi_nats import nats_connect`
+(line 45) — non-stdlib deps are available. `roxabi-contracts` is a workspace dep
+in root `pyproject.toml` (line 81) and is present in the container image (same
+image as clipool). `tools/CLAUDE.md` prohibits hub/core imports at module level;
+`roxabi_contracts._nats_utils` is neither. Import is safe.
+
+### SLOC budget for daemon.py
+
+Total line count is 310; SLOC is ~251 (blank lines + docstrings account for the
+remainder). No active exemption entry in `tools/file_exemptions.txt` is needed.
+Adding one import line replaces two inline literal strings — net SLOC delta is
+approximately 0. No budget concern.
+
+### Public promotion and __all__
+
+`validate_subject_segment` is added to `roxabi_contracts.__all__` as an additive
+change → minor version bump 0.7.0 → 0.8.0. Coordinate with #1619 (WorkEnvelope
+additions) if both land in the same release: the `__all__` list grows, no
+conflict. #1791 (domain `__init__` re-export surfaces) should note the rename
+from `_validate_subject_segment` to `validate_subject_segment`.
+
+### Error message preservation
+
+`validate_worker_id` error message (line 30) and `validate_subject_segment`
+error message (line 58/59) are different strings and MUST remain different.
+Consolidating the constant does not touch error messages.
+
+## Final-state wiring table
+
+| Consumer | Imports from | What changes |
+|---|---|---|
+| `_nats_utils.py` | (defines) | `_SAFE_WORKER_ID_RE` + `_SAFE_SUBJECT_SEGMENT_RE` → `_SAFE_SEGMENT_CHARS` + `_SAFE_SEGMENT_RE`; `_validate_subject_segment` → `validate_subject_segment` (public rename); **update internal call at line 70 of `validate_nats_subject`** from `_validate_subject_segment(segment)` → `validate_subject_segment(segment)`; update docstring at line 65 |
+| `event/subjects.py` | `_nats_utils` | Drop `_validate_segment` wrapper; import `validate_subject_segment`; call it directly; keep `import re` (still needed for `_SAFE_NAMESPACED_RE`) |
+| `outbound/subjects.py` | `_nats_utils` | `_validate_subject_segment` → `validate_subject_segment` |
+| `gh/subjects.py` | `_nats_utils` | `_validate_subject_segment` → `validate_subject_segment` |
+| `verify/subjects.py` | `_nats_utils` | `_validate_subject_segment` → `validate_subject_segment` |
+| `gh/models.py` | `_nats_utils` | `_validate_subject_segment` → `validate_subject_segment` |
+| `daemon.py` | `roxabi_contracts._nats_utils` | Import `_SAFE_SEGMENT_RE, _SAFE_SEGMENT_CHARS`; replace `r"[A-Za-z0-9_-]+"` (line 142) with `_SAFE_SEGMENT_RE` and `r"[^A-Za-z0-9_-]"` (line 144, negated class) with `f"[^{_SAFE_SEGMENT_CHARS}]"`; fullmatch + sub logic stays local |
+| `__init__.py` | (exports) | Add `validate_subject_segment` to `__all__` |
+
+## What gets deleted
+
+- `_SAFE_WORKER_ID_RE` — removed from `_nats_utils.py`
+- `_SAFE_SUBJECT_SEGMENT_RE` — removed from `_nats_utils.py`
+- `_validate_segment` function in `event/subjects.py` (local wrapper, lines 42–47)
+- In `daemon.py:_safe_machine_name`: two distinct inline literals are replaced:
+  - Line 142: `r"[A-Za-z0-9_-]+"` (positive character class with quantifier, used in `re.fullmatch`)
+  - Line 144: `r"[^A-Za-z0-9_-]"` (negated character class without quantifier, used in `re.sub`) — note this is the semantic complement of line 142, not the same literal
+
+## Success Criteria
+
+- [ ] `grep -rn 'r"\[A-Za-z0-9_-\]+"' packages/` returns zero hits outside `_nats_utils.py`, AND `grep -rn 'r"\[A-Za-z0-9_-\]+"' src/factory/tools/` returns zero hits — scope is `packages/` and `src/factory/tools/` only; the four out-of-scope files (`cli_bot.py`, `adapters/nats/nats_outbound_listener.py`, `agent_cmd/platforms/_shared.py`, `nats/nats_channel_proxy.py`) contain `_BOT_ID_RE` and `bot_id` validation which is explicitly out of scope for this refactor and will survive unchanged. Additionally, `grep -rn 'r"\[\^A-Za-z0-9_-\]"' src/factory/tools/ packages/` returns zero hits (verifies line 144's negated-class literal is also replaced)
+- [ ] `_nats_utils.py` contains exactly one compiled base-segment regex (`_SAFE_SEGMENT_RE`) — `grep '_SAFE_WORKER_ID_RE\|_SAFE_SUBJECT_SEGMENT_RE' packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py` returns zero hits
+- [ ] `validate_subject_segment` (no leading underscore) is importable: `python -c "from roxabi_contracts import validate_subject_segment"` exits 0
+- [ ] `event/subjects.py` contains no `_validate_segment` definition — `grep '_validate_segment' packages/roxabi-contracts/src/roxabi_contracts/event/subjects.py` returns zero hits
+- [ ] `test_gh_daemon.py` gains parametrized `_safe_machine_name` tests: passthrough (clean input), replace-not-raise (dirty input), `"unknown"` fallback (input sanitizes to empty)
+- [ ] `test_event_subjects.py` gains `test_segment_charset_rejection` covering `_UNSAFE_SEGMENT_IDS` (dots, `*`, `>`, space, empty string) against `per_service_event`/`per_service_metric`; all use `match="NATS subject segment must match"` (distinctive leading phrase, not just `"segment"`)
+- [ ] `packages/roxabi-contracts/pyproject.toml` version is `0.8.0` and `packages/roxabi-contracts/CHANGELOG.md` records the public promotion of `validate_subject_segment` and introduction of `_SAFE_SEGMENT_CHARS`
+- [ ] `uv run pytest packages/roxabi-contracts/tests/ tests/tools/test_gh_daemon.py -x` exits 0
+
+## Open Questions
+
+None — all design decisions resolved above. The scope is fully specified.
+
+## Pre-check
+
+1. **All criteria binary?** Yes — each criterion is a grep-returns-zero, import-exits-0, pytest-exits-0, or version-string check. No vague wording.
+2. **Breadboard IDs in slices?** Tier S — breadboard/slices sections omitted per template guidance. N/A.
+3. **Max 5 NEEDS CLARIFICATION?** Zero open questions.
+4. **Every affordance in a slice?** N/A (Tier S).
+5. **Every edge case has a handling strategy?** Yes — daemon sanitizer semantics (replace-not-raise), SLOC budget, error message non-regression, `_SAFE_SEGMENT_CHARS` composition safety (`.pattern` bug explained and fixed), `match="NATS subject segment must match"` assertion robustness, `import re` retention in `event/subjects.py`, `validate_nats_subject` internal-call update at line 70, and `__all__` coordination with #1619 are all addressed in Design Decisions.

--- a/packages/roxabi-contracts/CHANGELOG.md
+++ b/packages/roxabi-contracts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.0](https://github.com/Roxabi/roxabi-factory/compare/roxabi-contracts/v0.7.0...roxabi-contracts/v0.8.0) (2026-06-11)
+
+
+### Features
+
+* **contracts:** consolidate NATS subject-segment charset SSoT in `_nats_utils` ([#1782](https://github.com/Roxabi/roxabi-factory/issues/1782)). Introduces `_SAFE_SEGMENT_CHARS` (chars-only, for sanitizer composition) and `_SAFE_SEGMENT_RE` (compiled full-match regex) as the single source of truth, removing two duplicate inline regexes across domain subjects modules. Promotes `_validate_subject_segment` → `validate_subject_segment` (public API) and re-exports it from the package root. Additive, non-security-bearing — existing callers that imported `_validate_subject_segment` by private name must update to `validate_subject_segment`.
+
+
 ## [0.4.0](https://github.com/Roxabi/lyra/compare/roxabi-contracts/v0.3.0...roxabi-contracts/v0.4.0) (2026-05-19)
 
 

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-contracts"
-version = "0.7.0"
+version = "0.8.0"
 description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
@@ -9,6 +9,7 @@ per-domain submodules (voice, image, memory, llm) arrive in later tags.
 
 from importlib.metadata import PackageNotFoundError, version
 
+from ._nats_utils import validate_subject_segment
 from .audit import SecurityEvent
 from .blob_errors import BlobNotFoundError, BlobStoreServerError
 from .blob_ref import BlobRef
@@ -27,4 +28,5 @@ __all__ = [
     "ContractEnvelope",
     "SecurityEvent",
     "__version__",
+    "validate_subject_segment",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/_nats_utils.py
@@ -1,19 +1,21 @@
 """Shared NATS-protocol utilities for domain subject modules.
 
-Domain-agnostic helpers (``validate_worker_id`` + the regex it uses) that
-enforce the NATS-subject-safe character class. Each per-domain
-``subjects.py`` re-exports ``validate_worker_id`` so callers keep
-importing from their domain module; the single implementation here
-prevents the two definitions from drifting.
+Domain-agnostic helpers that enforce the NATS-subject-safe character class.
+Each per-domain ``subjects.py`` re-exports the relevant validators so
+callers keep importing from their domain module; the single implementation
+here prevents charset definitions from drifting across modules.
 """
 
 import re
 
+# SSoT for the NATS-subject-safe character class.
+# ``_SAFE_SEGMENT_CHARS`` is the chars-only form (no brackets/quantifier)
+# so it can be composed into negated character classes (e.g. re.sub).
+# ``_SAFE_SEGMENT_RE`` is the compiled full-match regex.
 # NATS subject tokens are `.`-separated. ``*`` matches any single token and
-# ``>`` matches a subtree. A worker id that contains any of those characters
-# would inject wildcards into the published subject and let a subscriber
-# claim more traffic than intended. Restrict to alphanumeric + ``-`` + ``_``.
-_SAFE_WORKER_ID_RE = re.compile(r"[A-Za-z0-9_-]+")
+# ``>`` matches a subtree. Restrict to alphanumeric + ``-`` + ``_``.
+_SAFE_SEGMENT_CHARS = r"A-Za-z0-9_-"
+_SAFE_SEGMENT_RE = re.compile(f"[{_SAFE_SEGMENT_CHARS}]+")
 
 
 def validate_worker_id(worker_id: str) -> None:
@@ -25,7 +27,7 @@ def validate_worker_id(worker_id: str) -> None:
     on the PUBLISH path and by consumers on the heartbeat-receive path
     to keep the registry free of wildcard-injectable ids.
     """
-    if not _SAFE_WORKER_ID_RE.fullmatch(worker_id):
+    if not _SAFE_SEGMENT_RE.fullmatch(worker_id):
         raise ValueError(
             f"worker_id must match [A-Za-z0-9_-]+ (got {worker_id!r}); "
             "NATS wildcard / subtree characters (. * >) are rejected to "
@@ -47,13 +49,15 @@ def validate_job_token(token: str) -> None:
         )
 
 
-# Subject *segments* (post-split) must not contain dots; use _SAFE_WORKER_ID_RE
-# rather than _SAFE_JOB_TOKEN_RE to keep the two validation paths independent.
-_SAFE_SUBJECT_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]+")
+def validate_subject_segment(segment: str) -> None:
+    """Validate a single NATS subject segment (no dots allowed).
 
-
-def _validate_subject_segment(segment: str) -> None:
-    if not _SAFE_SUBJECT_SEGMENT_RE.fullmatch(segment):
+    Raises ``ValueError`` if ``segment`` contains anything outside
+    ``[A-Za-z0-9_-]``. Dots, wildcards (``* >``) and empty segments are
+    all rejected. Promoted to the public API so external consumers and
+    sanitizers can reuse the canonical charset check directly.
+    """
+    if not _SAFE_SEGMENT_RE.fullmatch(segment):
         raise ValueError(
             f"NATS subject segment must match [A-Za-z0-9_-]+ (got {segment!r}); "
             "dots, wildcards (* >) and empty segments are rejected"
@@ -62,9 +66,9 @@ def _validate_subject_segment(segment: str) -> None:
 
 def validate_nats_subject(subject: str) -> None:
     """Validate a full multi-segment NATS subject (e.g. _INBOX.abc123).
-    Splits on '.' and validates each segment via _validate_subject_segment
+    Splits on '.' and validates each segment via validate_subject_segment
     (no dots allowed per segment); rejects empty segments and wildcards."""
     if not subject:
         raise ValueError("NATS subject must not be empty")
     for segment in subject.split("."):
-        _validate_subject_segment(segment)
+        validate_subject_segment(segment)

--- a/packages/roxabi-contracts/src/roxabi_contracts/event/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/event/subjects.py
@@ -14,7 +14,7 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
-from roxabi_contracts._nats_utils import _SAFE_SUBJECT_SEGMENT_RE
+from roxabi_contracts._nats_utils import validate_subject_segment
 
 __all__ = ["SUBJECTS", "per_service_event", "per_service_metric"]
 
@@ -39,14 +39,6 @@ class _Subjects:
 SUBJECTS = _Subjects()
 
 
-def _validate_segment(segment: str) -> None:
-    if not _SAFE_SUBJECT_SEGMENT_RE.fullmatch(segment):
-        raise ValueError(
-            f"NATS subject segment must match [A-Za-z0-9_-]+ (got {segment!r}); "
-            "dots, wildcards (* >) and empty segments are rejected"
-        )
-
-
 def _validate_namespaced(token: str) -> None:
     if not _SAFE_NAMESPACED_RE.fullmatch(token):
         raise ValueError(
@@ -61,7 +53,7 @@ def per_service_event(service: str, kind: str) -> str:
     Raises ``ValueError`` if ``service`` contains characters outside
     ``[A-Za-z0-9_-]`` or if ``kind`` is not a valid namespaced token.
     """
-    _validate_segment(service)
+    validate_subject_segment(service)
     _validate_namespaced(kind)
     return f"factory.event.{service}.{kind}"
 
@@ -72,6 +64,6 @@ def per_service_metric(service: str, name: str) -> str:
     Raises ``ValueError`` if ``service`` contains characters outside
     ``[A-Za-z0-9_-]`` or if ``name`` is not a valid namespaced token.
     """
-    _validate_segment(service)
+    validate_subject_segment(service)
     _validate_namespaced(name)
     return f"factory.metric.{service}.{name}"

--- a/packages/roxabi-contracts/src/roxabi_contracts/gh/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/gh/models.py
@@ -13,7 +13,7 @@ from typing import Annotated
 
 from pydantic import Field, StringConstraints, field_validator
 
-from roxabi_contracts._nats_utils import _validate_subject_segment
+from roxabi_contracts._nats_utils import validate_subject_segment
 from roxabi_contracts.envelope import ContractEnvelope
 
 __all__ = ["MintFailureEvent"]
@@ -55,5 +55,5 @@ class MintFailureEvent(ContractEnvelope):
     def _validate_machine(cls, v: str) -> str:
         # machine is a single subject segment, not a dotted job token — reject
         # internal dots so it can never widen the 4-segment subject (#1708).
-        _validate_subject_segment(v)
+        validate_subject_segment(v)
         return v

--- a/packages/roxabi-contracts/src/roxabi_contracts/gh/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/gh/subjects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from roxabi_contracts._nats_utils import _validate_subject_segment
+from roxabi_contracts._nats_utils import validate_subject_segment
 
 __all__ = [
     "SUBJECTS",
@@ -31,7 +31,7 @@ def gh_mint_failure(machine: str) -> str:
     """Mint-failure subject: factory.gh.mint_failure.<machine>.
 
     ``machine`` must be a single subject segment (no dots) so the result is
-    always 4 segments — see ``_validate_subject_segment`` (#1708).
+    always 4 segments — see ``validate_subject_segment`` (#1708).
     """
-    _validate_subject_segment(machine)
+    validate_subject_segment(machine)
     return f"factory.gh.mint_failure.{machine}"

--- a/packages/roxabi-contracts/src/roxabi_contracts/outbound/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/outbound/subjects.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from roxabi_contracts._nats_utils import _validate_subject_segment
+from roxabi_contracts._nats_utils import validate_subject_segment
 
 __all__ = ["OutboundAudioSubjects", "STREAM_AUDIO"]
 
@@ -31,6 +31,6 @@ class OutboundAudioSubjects:
         Raises ``ValueError`` if either token contains characters outside
         ``[A-Za-z0-9_-]`` (NATS wildcard / subtree / dot injection guard).
         """
-        _validate_subject_segment(platform)
-        _validate_subject_segment(bot_id)
+        validate_subject_segment(platform)
+        validate_subject_segment(bot_id)
         return f"factory.outbound.audio.{platform}.{bot_id}"

--- a/packages/roxabi-contracts/src/roxabi_contracts/verify/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/verify/subjects.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from roxabi_contracts._nats_utils import _validate_subject_segment
+from roxabi_contracts._nats_utils import validate_subject_segment
 
 __all__ = [
     "SUBJECTS",
@@ -44,5 +44,5 @@ def verify_deny(identity: str) -> str:
     Raises ``ValueError`` if ``identity`` contains characters outside
     ``[A-Za-z0-9_-]`` (the acl-matrix identity charset).
     """
-    _validate_subject_segment(identity)
+    validate_subject_segment(identity)
     return f"{SUBJECTS.deny_prefix}.{identity}"

--- a/packages/roxabi-contracts/tests/test_event_subjects.py
+++ b/packages/roxabi-contracts/tests/test_event_subjects.py
@@ -53,3 +53,18 @@ def test_per_service_metric_rejects_consecutive_dots() -> None:
 def test_per_service_metric_rejects_empty() -> None:
     with pytest.raises(ValueError, match="token"):
         per_service_metric("hub", "")
+
+
+_UNSAFE_SEGMENT_IDS = ["hub.prod", "hub*", "hub>", "hub space", ""]
+
+
+@pytest.mark.parametrize("bad_id", _UNSAFE_SEGMENT_IDS)
+def test_segment_charset_rejection_event(bad_id: str) -> None:
+    with pytest.raises(ValueError, match="NATS subject segment must match"):
+        per_service_event(bad_id, "startup")
+
+
+@pytest.mark.parametrize("bad_id", _UNSAFE_SEGMENT_IDS)
+def test_segment_charset_rejection_metric(bad_id: str) -> None:
+    with pytest.raises(ValueError, match="NATS subject segment must match"):
+        per_service_metric(bad_id, "request.count")

--- a/packages/roxabi-contracts/tests/test_event_subjects.py
+++ b/packages/roxabi-contracts/tests/test_event_subjects.py
@@ -31,12 +31,12 @@ def test_per_service_metric() -> None:
 
 
 def test_per_service_event_rejects_dot_in_service() -> None:
-    with pytest.raises(ValueError, match="segment"):
+    with pytest.raises(ValueError, match="NATS subject segment must match"):
         per_service_event("hub.prod", "startup")
 
 
 def test_per_service_event_rejects_wildcard() -> None:
-    with pytest.raises(ValueError, match="segment"):
+    with pytest.raises(ValueError, match="NATS subject segment must match"):
         per_service_event("hub*", "startup")
 
 
@@ -59,12 +59,8 @@ _UNSAFE_SEGMENT_IDS = ["hub.prod", "hub*", "hub>", "hub space", ""]
 
 
 @pytest.mark.parametrize("bad_id", _UNSAFE_SEGMENT_IDS)
-def test_segment_charset_rejection_event(bad_id: str) -> None:
+def test_segment_charset_rejection(bad_id: str) -> None:
     with pytest.raises(ValueError, match="NATS subject segment must match"):
         per_service_event(bad_id, "startup")
-
-
-@pytest.mark.parametrize("bad_id", _UNSAFE_SEGMENT_IDS)
-def test_segment_charset_rejection_metric(bad_id: str) -> None:
     with pytest.raises(ValueError, match="NATS subject segment must match"):
         per_service_metric(bad_id, "request.count")

--- a/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
+++ b/packages/roxabi-nats/src/roxabi_nats/adapter_base.py
@@ -41,6 +41,7 @@ from nats.aio.client import Client as NATS
 # NatsAdapterBase uses _CONTRACT_VERSION directly from its canonical home.
 # The public name CONTRACT_VERSION is served via __getattr__ below so that
 # accessing it emits a DeprecationWarning per ADR-059 (V4).
+from roxabi_contracts._nats_utils import _SAFE_SEGMENT_CHARS
 from roxabi_contracts.envelope import CONTRACT_VERSION as _CONTRACT_VERSION
 from roxabi_nats._resolver import _EMPTY_RESOLVER, _TypeHintResolver
 from roxabi_nats._validate import validate_nats_token
@@ -123,7 +124,7 @@ class NatsAdapterBase(ABC):
         # NATS-safe alphabet so publish and subscribe sides agree on the same
         # subject token regardless of host.
         raw_id = f"{queue_group}-{socket.gethostname()}-{os.getpid()}"
-        self._worker_id = re.sub(r"[^A-Za-z0-9_-]", "_", raw_id)
+        self._worker_id = re.sub(f"[^{_SAFE_SEGMENT_CHARS}]", "_", raw_id)
         self._wait_ready_flag = wait_ready
         self._heartbeat_task: asyncio.Task | None = None
         self._resolver: _TypeHintResolver = (

--- a/src/factory/tools/gh_token/daemon.py
+++ b/src/factory/tools/gh_token/daemon.py
@@ -42,6 +42,7 @@ from factory.tools.gh_token.dispenser import Dispenser
 from factory.tools.gh_token.helper import JWTSigner, TokenCache
 from factory.tools.gh_token.mint_failure_publisher import MintFailurePublisher
 from factory.tools.gh_token.rate_limit import RateLimiter
+from roxabi_contracts._nats_utils import _SAFE_SEGMENT_CHARS, _SAFE_SEGMENT_RE
 from roxabi_nats import nats_connect
 
 if TYPE_CHECKING:
@@ -131,17 +132,17 @@ def _safe_machine_name(raw: str) -> str:
 
     A valid token contains only ``[A-Za-z0-9_-]`` characters (no dots, spaces,
     wildcards, or ``>``) — the same charset the contract enforces on
-    ``MintFailureEvent.machine`` via ``_validate_subject_segment`` (#1708). We
-    inline a *sanitizer* here rather than reusing the contract *validator*
-    because the daemon must never crash on a misconfigured ``FACTORY_MACHINE``:
+    ``MintFailureEvent.machine`` via ``validate_subject_segment`` (#1708). We
+    use a *sanitizer* here rather than the contract *validator* because the
+    daemon must never crash on a misconfigured ``FACTORY_MACHINE``:
     bad characters are replaced, not rejected.
 
     Invalid characters are replaced with ``_`` to preserve per-machine
     observability rather than collapsing all bad names to ``"unknown"`` (#26).
     """
-    if re.fullmatch(r"[A-Za-z0-9_-]+", raw):
+    if _SAFE_SEGMENT_RE.fullmatch(raw):
         return raw
-    return re.sub(r"[^A-Za-z0-9_-]", "_", raw) or "unknown"
+    return re.sub(f"[^{_SAFE_SEGMENT_CHARS}]", "_", raw) or "unknown"
 
 
 async def _connect_nats_publisher(

--- a/tests/tools/test_gh_daemon.py
+++ b/tests/tools/test_gh_daemon.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from factory.tools.gh_token.daemon import (
     DaemonConfigError,
     _load_config,
+    _safe_machine_name,
     run_daemon,
 )
 
@@ -252,3 +253,21 @@ async def test_daemon_unlinks_stale_socket_on_start(
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
+
+
+# ── _safe_machine_name ────────────────────────────────────────────────────────
+
+
+def test_safe_machine_name_passthrough() -> None:
+    """Clean input passes through unchanged."""
+    assert _safe_machine_name("roxabituwer") == "roxabituwer"
+
+
+def test_safe_machine_name_replaces_bad_chars() -> None:
+    """Bad characters (dots, spaces) are replaced with '_', not rejected."""
+    assert _safe_machine_name("my.host") == "my_host"
+
+
+def test_safe_machine_name_unknown_fallback() -> None:
+    """Empty string after replacement returns 'unknown' (empty raw input)."""
+    assert _safe_machine_name("") == "unknown"


### PR DESCRIPTION
## Summary

Closes #1782

Removes two duplicate inline `[A-Za-z0-9_-]+` regexes scattered across `_nats_utils.py` and consolidates them into a single source of truth.

| Constant | Type | Purpose |
|---|---|---|
| `_SAFE_SEGMENT_CHARS = r"A-Za-z0-9_-"` | chars-only string | compose negated char class `[^...]` in sanitizers |
| `_SAFE_SEGMENT_RE = re.compile(f"[{_SAFE_SEGMENT_CHARS}]+")` | compiled regex | fullmatch validation |

**Wiring changes:**
- `_validate_subject_segment` → `validate_subject_segment` (public); re-exported from `roxabi_contracts.__init__`
- `event/subjects.py`, `outbound/subjects.py`, `gh/subjects.py`, `verify/subjects.py`, `gh/models.py` — all updated to `validate_subject_segment`
- `daemon.py` — `_safe_machine_name` now imports `_SAFE_SEGMENT_RE` / `_SAFE_SEGMENT_CHARS` from the SSoT (replaces local `re.compile`)

**Version:** 0.7.0 → 0.8.0 (additive public API promotion, minor bump per contracts versioning rules)

> Merge BEFORE #1619 — #1619 adds new subjects that would benefit from having the public `validate_subject_segment` already available.

## Test plan

- [x] `uv run --frozen pytest packages/roxabi-contracts/tests/ -q` — 397 passed
- [x] `env -u NATS_URL uv run --frozen pytest tests/tools/ -q` — 274 passed, 1 skipped
- [x] `uv run --frozen pytest -x -q` (excl. NATS/hub/bootstrap integration) — 5096 passed
- [x] `uv run --frozen pyright` — 0 errors
- [x] `uv run --frozen lint-imports` — 11 contracts kept, 0 broken
- [x] `bash tools/check_test_sleep.sh` — OK
- [x] `bash tools/check_debt_expiry.sh` — OK
- [x] `python3 tools/check_doc_drift.py` — 0 violations
- [x] `bash tools/check_architecture_snapshot.sh` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)