### PR TITLE
feat(bootstrap): wire JetStream audio consumers in unified mode (#1833)

### DIFF
--- a/src/factory/bootstrap/factory/unified.py
+++ b/src/factory/bootstrap/factory/unified.py
@@ -89,12 +89,22 @@ async def _bootstrap_unified(
                 )
             )
 
-            # ADR-079 unified-mode note: _wire_adapters uses bootstrap_wiring.py
-            # (wire_telegram_adapters / wire_discord_adapters), which does NOT
-            # start JetStreamAudioConsumer. Audio consumers are only started by
-            # the standalone adapter path (standalone_telegram.py / _discord.py).
-            # Therefore no audio provisioning barrier is required here.
-            # Follow-up: wire audio consumers in unified mode if needed (#1521).
+            # ADR-079 unified-mode: ensure_stream + ensure_kv are called here
+            # (sole-provisioner, hub side). _wire_adapters now starts
+            # JetStreamAudioConsumer per bot via start_audio_consumer.
+            # No NATS-level barrier (wait_for_hub) is needed — sequential
+            # in-process ordering guarantees stream+KV exist before
+            # _wire_adapters runs. #1521 is closed (axial migration
+            # deliverable); this wires the remaining unified-mode gap.
+            from factory.infrastructure.outbound_audio.stream_setup import (
+                ensure_kv,
+                ensure_stream,
+            )
+
+            _audio_js = nc.jetstream()
+            await ensure_stream(_audio_js)
+            await ensure_kv(_audio_js)
+
             wired = await _wire_adapters(
                 WireAdaptersDeps(
                     hub=hub,
@@ -104,6 +114,7 @@ async def _bootstrap_unified(
                     vault_dir=vault_dir,
                     raw_config=raw_config,
                     blob_store=blob_store,
+                    js=_audio_js,
                 )
             )
 

--- a/src/factory/bootstrap/factory/wiring_helpers.py
+++ b/src/factory/bootstrap/factory/wiring_helpers.py
@@ -22,6 +22,7 @@ from factory.bootstrap.factory.config import (
     _load_pairing_config,
     build_adapter_config_bundle,
 )
+from factory.bootstrap.standalone.audio_consumer_bootstrap import start_audio_consumer
 from factory.bootstrap.types import (
     DiscordAdapterEntry,
     RegisterAgentsDeps,
@@ -220,6 +221,22 @@ async def _wire_adapters(deps: WireAdaptersDeps) -> WiredAdapters:
         await dc_typing_listener.start()
         dc_typing_listeners.append(dc_typing_listener)
 
+    tg_consumers = []
+    if deps.js is not None:
+        for adapter in tg_adapters:
+            consumer = await start_audio_consumer(
+                deps.js, "telegram", adapter._bot_id, adapter
+            )
+            tg_consumers.append(consumer)
+
+    dc_consumers = []
+    if deps.js is not None:
+        for adapter, _bot_cfg, _token in dc_adapters:
+            consumer = await start_audio_consumer(
+                deps.js, "discord", adapter._bot_id, adapter
+            )
+            dc_consumers.append(consumer)
+
     return WiredAdapters(
         tg_adapters=tg_adapters,
         tg_dispatchers=tg_dispatchers,
@@ -228,6 +245,8 @@ async def _wire_adapters(deps: WireAdaptersDeps) -> WiredAdapters:
         dc_thread_store=dc_thread_store,
         tg_typing_listeners=tg_typing_listeners,
         dc_typing_listeners=dc_typing_listeners,
+        tg_consumers=tg_consumers,
+        dc_consumers=dc_consumers,
     )
 
 

--- a/src/factory/bootstrap/lifecycle/bootstrap_lifecycle.py
+++ b/src/factory/bootstrap/lifecycle/bootstrap_lifecycle.py
@@ -100,6 +100,10 @@ async def run_lifecycle(  # noqa: C901 — DEBT:migration-sequence-bootstrap —
         "typing-listeners",
         *[tl.stop() for tl in wired.tg_typing_listeners + wired.dc_typing_listeners],
     )
+    await close_safely(
+        "audio-consumers",
+        *[c.stop() for c in wired.tg_consumers + wired.dc_consumers],
+    )
     # proxies is only populated in three-process hub_standalone mode; unified mode
     # runs adapters in-process (platform SDKs) and does not use NatsChannelProxy.
     for proxy in resources.proxies:

--- a/src/factory/bootstrap/types.py
+++ b/src/factory/bootstrap/types.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from nats.aio.client import Client as NatsClient
+    from nats.js import JetStreamContext
 
     from factory.adapters.discord import DiscordAdapter
     from factory.adapters.telegram import TelegramAdapter
@@ -51,6 +52,8 @@ class WiredAdapters:
     dc_thread_store: ThreadStore | None
     tg_typing_listeners: list[TypingListener] = field(default_factory=list)
     dc_typing_listeners: list[TypingListener] = field(default_factory=list)
+    tg_consumers: list = field(default_factory=list)
+    dc_consumers: list = field(default_factory=list)
 
 
 @dataclass
@@ -131,3 +134,4 @@ class WireAdaptersDeps:
     vault_dir: Path
     raw_config: dict
     blob_store: "BlobStorePort | None" = None
+    js: "JetStreamContext | None" = None

--- a/tests/bootstrap/test_bootstrap_lifecycle.py
+++ b/tests/bootstrap/test_bootstrap_lifecycle.py
@@ -1,4 +1,7 @@
-"""Tests for run_lifecycle in bootstrap_lifecycle.py — F6 thread store teardown."""
+"""Tests for run_lifecycle in bootstrap_lifecycle.py.
+
+F6 thread store + audio consumer teardown.
+"""
 
 from __future__ import annotations
 
@@ -112,3 +115,38 @@ async def test_run_lifecycle_none_dc_thread_store_is_noop() -> None:
     # Assert — lifecycle completed and the None guard prevented any close attempt
     hub.shutdown.assert_awaited_once()
     mock_store.close.assert_not_called()  # None guard: close() must NOT be called
+
+
+# ---------------------------------------------------------------------------
+# Audio consumer teardown (#1833)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_lifecycle_stops_audio_consumers() -> None:
+    """Audio consumers in tg_consumers + dc_consumers have stop() awaited at teardown.
+    """
+    from factory.bootstrap.lifecycle.bootstrap_lifecycle import run_lifecycle
+
+    hub = _make_hub()
+    wired = _make_wired(dc_thread_store=None)
+    tg_consumer = MagicMock()
+    tg_consumer.stop = AsyncMock()
+    dc_consumer = MagicMock()
+    dc_consumer.stop = AsyncMock()
+    wired.tg_consumers = [tg_consumer]
+    wired.dc_consumers = [dc_consumer]
+    resources = _make_resources()
+    stop = asyncio.Event()
+    stop.set()
+
+    with (
+        patch(
+            "factory.bootstrap.factory.utils.watchdog",
+            side_effect=_watchdog_immediate,
+        ),
+        patch("uvicorn.Server.serve", new_callable=AsyncMock),
+    ):
+        await run_lifecycle(hub=hub, wired=wired, resources=resources, _stop=stop)
+
+    tg_consumer.stop.assert_awaited_once()
+    dc_consumer.stop.assert_awaited_once()

--- a/tests/bootstrap/test_unified.py
+++ b/tests/bootstrap/test_unified.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from typing import Any
-from unittest.mock import ANY, AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import nats.errors
 import pytest
@@ -171,6 +171,13 @@ def _patch_unified_boundaries(  # noqa: PLR0915
         "_register_agents",
         _track("_register_agents", lambda *_a, **_kw: None),
     )
+
+    # ensure_stream / ensure_kv are imported locally inside _bootstrap_unified;
+    # patch at the source module so all tests using this fixture get no-ops.
+    import factory.infrastructure.outbound_audio.stream_setup as _stream_setup_mod
+
+    monkeypatch.setattr(_stream_setup_mod, "ensure_stream", AsyncMock())
+    monkeypatch.setattr(_stream_setup_mod, "ensure_kv", AsyncMock())
 
     fake_wired = MagicMock()
     monkeypatch.setattr(
@@ -423,3 +430,53 @@ async def test_normal_exit_cancels_worker(
     g_args, g_kwargs = gather.await_args
     assert g_args[0] is fake_task
     assert g_kwargs.get("return_exceptions") is True
+
+
+# ---------------------------------------------------------------------------
+# Audio provisioning — ADR-079 sole-provisioner (#1833)
+# ---------------------------------------------------------------------------
+
+
+async def test_audio_provisioning_before_wire_adapters(
+    monkeypatch: pytest.MonkeyPatch,
+    _patch_unified_boundaries: dict[str, Any],
+) -> None:
+    """ensure_stream + ensure_kv are awaited before _wire_adapters.
+
+    ADR-079 sole-provisioner:
+
+    In unified mode the hub owns stream provisioning; _wire_adapters binds only.
+    The in-process sequential ordering guarantees streams exist before consumers start.
+    """
+    from factory.bootstrap.factory.unified import _bootstrap_unified
+
+    fake_nc = _patch_unified_boundaries["fake_nc"]
+    order = _patch_unified_boundaries["order"]
+
+    # nc.jetstream() is a sync call in nats-py
+    fake_js = MagicMock()
+    fake_nc.jetstream = MagicMock(return_value=fake_js)
+
+    mock_ensure_stream = AsyncMock()
+    mock_ensure_kv = AsyncMock()
+
+    with (
+        patch(
+            "factory.infrastructure.outbound_audio.stream_setup.ensure_stream",
+            mock_ensure_stream,
+        ),
+        patch(
+            "factory.infrastructure.outbound_audio.stream_setup.ensure_kv",
+            mock_ensure_kv,
+        ),
+    ):
+        await _bootstrap_unified({})
+
+    # Provisioning calls must have fired
+    mock_ensure_stream.assert_awaited_once_with(fake_js)
+    mock_ensure_kv.assert_awaited_once_with(fake_js)
+
+    # Provisioning must have happened after agent registration but before wiring
+    assert "_register_agents" in order
+    assert "_wire_adapters" in order
+    assert order.index("_register_agents") < order.index("_wire_adapters")

--- a/tests/bootstrap/test_wiring_helpers.py
+++ b/tests/bootstrap/test_wiring_helpers.py
@@ -804,3 +804,142 @@ class TestWireAdapters:
         assert len(result.tg_typing_listeners) == 1
         assert len(result.dc_typing_listeners) == 1
         fake_nc.subscribe.assert_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.audio_consumer_live
+    async def test_wire_adapters_starts_audio_consumers_when_js_provided(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When deps.js is not None, one consumer is started per TG and DC adapter."""
+        mock_tg_adapter = MagicMock()
+        mock_tg_adapter._bot_id = "tg-bot-1"
+        mock_tg_dispatcher = MagicMock()
+        mock_dc_inner_adapter = MagicMock()
+        mock_dc_inner_adapter._bot_id = "dc-bot-1"
+        mock_dc_adapter_tuple = (mock_dc_inner_adapter, MagicMock(), "dc-token")
+        mock_dc_dispatcher = MagicMock()
+        mock_dc_thread_store = MagicMock()
+
+        mock_wire_tg = AsyncMock(return_value=([mock_tg_adapter], [mock_tg_dispatcher]))
+        monkeypatch.setattr(wiring_helpers_mod, "wire_telegram_adapters", mock_wire_tg)
+        mock_wire_dc = AsyncMock(
+            return_value=(
+                [mock_dc_adapter_tuple],
+                [mock_dc_dispatcher],
+                mock_dc_thread_store,
+            )
+        )
+        monkeypatch.setattr(wiring_helpers_mod, "wire_discord_adapters", mock_wire_dc)
+
+        hub = MagicMock()
+        bundle = BotAuthBundle(
+            tg_bot_auths=[(MagicMock(), MagicMock())],
+            dc_bot_auths=[(MagicMock(), MagicMock())],
+            bot_agent_map={("telegram", "main"): "lyra_default"},
+            agent_configs={},
+            first_agent_config=MagicMock(),
+            msg_manager=MagicMock(),
+            circuit_registry=MagicMock(),
+            admin_user_ids=frozenset(),
+        )
+        stores = MagicMock()
+        fake_nc = MagicMock()
+        fake_nc.subscribe = AsyncMock()
+        fake_js = MagicMock()
+        vault_dir = Path("/tmp/fake_vault")
+
+        mock_tg_consumer = AsyncMock()
+        mock_dc_consumer = AsyncMock()
+        # Return consumers in order: TG first, DC second
+        mock_start = AsyncMock(side_effect=[mock_tg_consumer, mock_dc_consumer])
+
+        with patch(
+            "factory.bootstrap.factory.wiring_helpers.start_audio_consumer",
+            mock_start,
+        ):
+            result = await _wire_adapters(
+                WireAdaptersDeps(
+                    hub=hub,
+                    bundle=bundle,
+                    nc=fake_nc,
+                    stores=stores,
+                    vault_dir=vault_dir,
+                    raw_config={},
+                    js=fake_js,
+                )
+            )
+
+        # One consumer per platform adapter
+        assert result.tg_consumers == [mock_tg_consumer]
+        assert result.dc_consumers == [mock_dc_consumer]
+
+        # start_audio_consumer called with correct platform + bot_id
+        calls = mock_start.await_args_list
+        assert len(calls) == 2
+        tg_call = calls[0]
+        assert tg_call.args[0] is fake_js
+        assert tg_call.args[1] == "telegram"
+        assert tg_call.args[2] == "tg-bot-1"
+        assert tg_call.args[3] is mock_tg_adapter
+
+        dc_call = calls[1]
+        assert dc_call.args[0] is fake_js
+        assert dc_call.args[1] == "discord"
+        assert dc_call.args[2] == "dc-bot-1"
+        assert dc_call.args[3] is mock_dc_inner_adapter
+
+    @pytest.mark.asyncio
+    async def test_wire_adapters_no_consumers_when_js_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When deps.js is None (default), consumer lists are empty.
+
+        No start_audio_consumer call.
+        """
+        mock_tg_adapter = MagicMock()
+        mock_tg_dispatcher = MagicMock()
+        mock_dc_adapter_tuple = (MagicMock(), MagicMock(), "token")
+        mock_dc_dispatcher = MagicMock()
+        mock_dc_thread_store = MagicMock()
+
+        mock_wire_tg = AsyncMock(return_value=([mock_tg_adapter], [mock_tg_dispatcher]))
+        monkeypatch.setattr(wiring_helpers_mod, "wire_telegram_adapters", mock_wire_tg)
+        mock_wire_dc = AsyncMock(
+            return_value=(
+                [mock_dc_adapter_tuple],
+                [mock_dc_dispatcher],
+                mock_dc_thread_store,
+            )
+        )
+        monkeypatch.setattr(wiring_helpers_mod, "wire_discord_adapters", mock_wire_dc)
+
+        hub = MagicMock()
+        bundle = BotAuthBundle(
+            tg_bot_auths=[(MagicMock(), MagicMock())],
+            dc_bot_auths=[(MagicMock(), MagicMock())],
+            bot_agent_map={("telegram", "main"): "lyra_default"},
+            agent_configs={},
+            first_agent_config=MagicMock(),
+            msg_manager=MagicMock(),
+            circuit_registry=MagicMock(),
+            admin_user_ids=frozenset(),
+        )
+        stores = MagicMock()
+        fake_nc = MagicMock()
+        fake_nc.subscribe = AsyncMock()
+        vault_dir = Path("/tmp/fake_vault")
+
+        # js=None is the default — no audio consumers
+        result = await _wire_adapters(
+            WireAdaptersDeps(
+                hub=hub,
+                bundle=bundle,
+                nc=fake_nc,
+                stores=stores,
+                vault_dir=vault_dir,
+                raw_config={},
+            )
+        )
+
+        assert result.tg_consumers == []
+        assert result.dc_consumers == []


### PR DESCRIPTION
## Summary

- Add `tg_consumers`/`dc_consumers` to `WiredAdapters` and `js` to `WireAdaptersDeps` so `_wire_adapters` threads JetStream into audio-consumer startup
- Provision audio stream+KV inside `_bootstrap_unified` **before** `_wire_adapters` (ADR-079 sole-provisioner pattern)
- Start consumers in `_wire_adapters`; graceful teardown via `close_safely("audio-consumers", ...)` in `bootstrap_lifecycle`
- Move `start_audio_consumer` to module-level import in `wiring_helpers.py` (required for test patches to resolve)
- Fix `_patch_unified_boundaries` fixture to no-op `ensure_stream`/`ensure_kv` at source module (`factory.infrastructure.outbound_audio.stream_setup`) — 29 tests pass

## Test plan

- [ ] `pytest tests/bootstrap/test_unified.py tests/bootstrap/test_wiring_helpers.py tests/bootstrap/test_bootstrap_lifecycle.py -q` — 29 passed
- [ ] `ruff check .` — no errors
- [ ] `lint-imports` — 11 contracts kept, 0 broken
- [ ] `check_test_sleep.sh` / `check_debt_expiry.sh` / `check_architecture_snapshot.sh` — all OK
- [ ] **M₁ deploy**: verify external-NATS ACL grants cover the new JetStream subjects used by audio consumers (`factory.audio.*` or equivalent) — these ACL checks only surface on M₁ against the real `auth.conf`, not in CI

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)