### PR TITLE
feat(contracts): WorkEnvelope + job_id invariant — work/infra envelope split (#1619)

### DIFF
--- a/artifacts/frames/1619-workenvelope-split-frame.mdx
+++ b/artifacts/frames/1619-workenvelope-split-frame.mdx
@@ -1,0 +1,172 @@
+---
+title: "feat(contracts): WorkEnvelope + job_id invariant — split work vs infra envelope"
+issue: 1619
+status: approved
+tier: F-lite
+date: 2026-06-11
+---
+
+## Problem
+
+Every NATS message in the factory today subclasses `ContractEnvelope`, which
+carries `trace_id` (mandatory, universal) but no `job_id`. Work-bearing messages
+(`llm`, `voice`, `image`, `turns`, `jobs`, `cli` work ops) and infra messages
+(heartbeats, lifecycle, metrics) live under the same base type. The result is that
+"this message belongs to a unit of work and carries a stable run identity" is a
+runtime convention — not a type-level guarantee. Operators and the obs pipeline
+must guess or probe per model.
+
+ADR-084 (accepted, implemented-by: this issue) resolves this by splitting the
+envelope: a `WorkEnvelope(ContractEnvelope)` subclass carries mandatory `job_id`
+(`min_length=1`) + nullable `parent_job_id`; infra messages stay on bare
+`ContractEnvelope` (`trace_id` only). Work models are reparented to
+`WorkEnvelope`; infra models are left untouched. The boundary is enforced by a
+new subject→envelope test in the spirit of the existing importlinter contracts.
+
+The timing is driven by the M1 milestone: the downstream issues that build on
+the job identity tree (#1620 ingress mint, #1621 `request_id` fold, #1796
+active-jobs registry, #1797–#1799) all treat `job_id` presence on work messages
+as an upstream invariant. Without this change every downstream issue must
+defensively handle the "no `job_id`" case, or silently assume it; landing this
+now closes that gap for the entire M1 fleet before ingress wiring begins.
+
+## Who
+
+- **Primary:** contributors and tooling that consume work-plane NATS messages
+  and need a stable `job_id` to thread a run end-to-end (hub → harness →
+  satellite → outbound).
+- **Secondary:** #1620 (ingress mint), #1621 (`request_id` fold), #1796
+  (active-jobs registry) — all blocked on `WorkEnvelope` existing as an
+  importable type in `roxabi-contracts`.
+
+## Constraints
+
+- **`WorkEnvelope` is additive at the base-class level** (`extra="ignore"`,
+  `ContractEnvelope` compat preserved) — minor version bump per ADR-049
+  rules. However, reparenting existing domain models (llm, voice, image, turns,
+  cli) **introduces a new required field** (`job_id`) — this is a breaking
+  change for those domains; each domain coordinates its own minor bump.
+  `jobs/*` is the clean exception: `JobEnvelope`/`JobResult`/`JobProgress`
+  already carry `job_id` locally; reparenting is non-breaking there.
+- **`JobEnvelope` field collision:** `JobEnvelope` already declares `job_id`
+  and `parent_job_id` as local fields. After reparent to `WorkEnvelope` these
+  become inherited — the local declarations must be removed or Pydantic v2
+  raises a field-redefinition error. `JobResult` and `JobProgress` only declare
+  `job_id` locally (no `parent_job_id`); both local `job_id` fields must be
+  removed post-reparent, and `parent_job_id` is then additive-inherited.
+- **`CONTRACT_VERSION` stays `"1"`:** `job_id`/`parent_job_id` are not
+  security-bearing; an additive minor bump does not change the envelope
+  constant. `test_contract_version_current_value` explicitly locks it to `"1"`
+  — do not change this constant.
+- **CliChunkEvent / CliControlAck classification gap:** ADR-084 classification
+  table covers `CliCmdPayload`, `CliControlCmd`, `CliHeartbeat` — but
+  `CliChunkEvent` (streaming response, carries `pool_id` + `event_type`) and
+  `CliControlAck` (op response, carries `ok`/`resumed`) are absent. Both are
+  likely WORK (response side of work ops), but the spec MUST add explicit rows
+  before `cli/models.py` is edited. Misclassification breaks the invariant
+  silently.
+- **Coordinate with #1009 (cli minor bump):** ADR-084 mandates combining the
+  `cli` reparent with the `session_id` → `cli_session_id` rename from #1009
+  into a single `cli` minor bump to avoid two satellite-coordination events.
+  Do not merge `cli/models.py` changes independently of #1009 unless explicitly
+  approved by the architect.
+- **Cross-issue coordination with #1782:** `#1782` touches `_nats_utils.py`
+  (promotes `_validate_subject_segment` to public, collapses
+  `_SAFE_WORKER_ID_RE`). `#1619` imports `validate_job_token` from
+  `_nats_utils` for the `WorkEnvelope.job_id` field validator. If #1782 merges
+  first, check that `validate_job_token` export is unaffected. If #1782 merges
+  after, prefer the new public name.
+- **`__init__.py` coordination with #1791:** `#1791` audits domain `__init__`
+  re-export surfaces; `WorkEnvelope` must be exported from
+  `roxabi_contracts.__init__` in this PR. Coordinate `__all__` additions if
+  both PRs land in the same release cycle.
+- **doc_drift gate:** new backtick-quoted symbols in docs/ must exist in `src/`
+  at push time. `WorkEnvelope` is UNBUILT until this PR lands; do not add a
+  backtick reference to `WorkEnvelope` in domain pages outside
+  `docs/architecture/adr/**` (ADR files are exempt).
+- **file_length gate:** `packages/roxabi-contracts` files are outside
+  `src/factory/**` and exempt from the 300 SLOC gate. No exemption entry
+  needed.
+- **`inbound`/`outbound` scope item:** the issue scope lists "inbound/outbound
+  messages". `InboundMessage` (message.py:97) and `OutboundMessage`
+  (message.py:257) are Python `@dataclass` types — not Pydantic models, not
+  `ContractEnvelope` subclasses — and are internal hub abstractions. They are
+  out of scope. The `outbound/` contracts submodule has no Pydantic models yet
+  (schemas arrive in a later minor bump per the submodule comment). Either
+  clarify the scope item or treat as a forward-compat note: any new
+  outbound Pydantic model must land as a `WorkEnvelope` subclass from creation.
+- **Harness wire (#1490):** harness models are absent from `roxabi-contracts` as
+  expected. The scope item is a forward-compat note: new harness wire models
+  added before #1619 closes must land as `WorkEnvelope` subclasses. Not a
+  current blocker.
+
+## Out of Scope
+
+- Root `job_id` mint at ingress in inbound adapters — that is #1620.
+- `request_id` → `job_id` fold in voice/llm builders — that is #1621.
+- Subject taxonomy migration (`factory.results.*` → `factory.job.<id>.result`) — that is
+  #1793 (not yet landed).
+- Wiring `job_id` as an OTel span id into the observability pipeline — that is
+  part of epic #1622 / #667.
+- `cli_session_id` rename in `CliCmdPayload` / `CliControlCmd` — that is #1009
+  (to be co-landed in the same `cli` minor bump, but owned by #1009).
+- Subject charset SSoT consolidation in `_nats_utils.py` — that is #1782.
+- `__init__` re-export audit across all domain submodules — that is #1791.
+- Changes to `InboundMessage` / `OutboundMessage` dataclasses in
+  `src/factory/core/messaging/message.py` — internal hub abstractions, not
+  contract models.
+
+## Premise Validity
+
+**Success in 6 months:** `WorkEnvelope` is importable from `roxabi_contracts`
+and all 14 work-plane models (`JobEnvelope`, `JobResult`, `JobProgress`,
+`LlmRequest`, `LlmChunkEvent`, `LlmResponse`, `TtsRequest`, `TtsResponse`,
+`SttRequest`, `SttResponse`, `ImageRequest`, `ImageResponse`, `TurnWriteEvent`,
+`CliCmdPayload`, `CliControlCmd`) subclass it; the subject→envelope enforcement
+test is green in CI; `#1620` (ingress mint) can set `job_id` on outbound work
+messages without a contract change; no WORK-class model remains on bare
+`ContractEnvelope`.
+
+**Failure in 6 months:** A new work-plane model lands directly on
+`ContractEnvelope` (missing `job_id`) because the PR author looked at the old
+base class and copied it; OR `job_id` is optional in at least one reparented
+model because the field-validator was not wired — observable: `grep -r
+"ContractEnvelope" packages/roxabi-contracts/src | grep -v "WorkEnvelope\|Heartbeat\|Lifecycle\|LyraEvent\|LyraMetric\|MintFailure"` returns hits on work models; OR the subject→envelope test does not exist in `packages/roxabi-contracts/tests/`.
+
+**Simplest alternative:** Add `job_id: str | None = None` as an optional field
+directly on `ContractEnvelope` (ADR-084 Option B — nullable everywhere).
+
+**Why not simplest:** Optional `job_id` on the base provides no type-level
+guarantee — "is this a work message with a valid job_id?" stays a runtime guess.
+Infra heartbeats/lifecycle would carry a semantically meaningless optional field.
+The obs pipeline and active-jobs registry (M1 #1796) need presence guaranteed
+by type, not by convention. ADR-084 explicitly ruled out Option B.
+
+_(champs dérivés du contexte — à valider à la review humaine)_
+
+## Complexity
+
+**Tier: F-lite** — clear scope across one package (`roxabi-contracts`), all
+files known, no unknowns in the reparent logic itself; blocked by two
+classification gaps (CliChunkEvent/CliControlAck, outbound scope) that require
+explicit resolution before impl but are resolvable within the issue.
+
+Signals observed:
+- 11 files in scope (all within `packages/roxabi-contracts/`): `envelope.py`,
+  `__init__.py`, `jobs/models.py`, `llm/models.py`, `voice/models.py`,
+  `image/models.py`, `turns/models.py`, `cli/models.py`,
+  `tests/test_envelope.py`, `tests/test_work_envelope_subjects.py` (new),
+  `CHANGELOG.md`.
+- Single domain (`roxabi-contracts` package) — no `src/factory/**` code changes,
+  no bootstrap wiring, no cross-layer concern.
+- Classification pass is required (14 WORK models + 7 INFRA stay-list confirmed)
+  but fully enumerated; zero unknown models in scope.
+- Two pre-impl spec gaps must be resolved before touching `cli/models.py`:
+  (1) explicit ADR-084 rows for `CliChunkEvent` and `CliControlAck`;
+  (2) clarification of the `inbound/outbound` scope item.
+- Three cross-issue coordination points (#1009, #1782, #1791) require merge-order
+  awareness but none blocks the non-cli portions of this PR.
+- Pydantic v2 field-redefinition trap on `JobEnvelope` is understood and
+  explicitly handled (remove local `job_id` + `parent_job_id` declarations).
+- New test file (`test_work_envelope_subjects.py`) follows an established pattern
+  already used by `test_voice_subjects.py` / `test_image_subjects.py`.

--- a/artifacts/specs/1619-workenvelope-split-spec.mdx
+++ b/artifacts/specs/1619-workenvelope-split-spec.mdx
@@ -1,0 +1,463 @@
+---
+title: "feat(contracts): WorkEnvelope + job_id invariant — split work vs infra envelope"
+issue: 1619
+status: approved
+tier: F-lite
+date: 2026-06-11
+frame: artifacts/frames/1619-workenvelope-split-frame.mdx
+adr: docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+---
+
+## Context
+
+`ContractEnvelope` is the universal base for all NATS contract models in
+`roxabi-contracts`. It carries `contract_version`, `trace_id`, `issued_at`, and
+`ConfigDict(extra="ignore")`. It does not carry `job_id`. Work-bearing messages
+(LLM, voice, image, turns, jobs, cli work ops) and infra messages (heartbeats,
+lifecycle) live on the same base class. "This message belongs to a unit of work"
+is a runtime convention — not a type guarantee.
+
+ADR-084 resolves this by introducing `WorkEnvelope(ContractEnvelope)`, which
+adds mandatory `job_id: str` (min_length=1, validated by `validate_job_token`)
+and nullable `parent_job_id: str | None`. All 17 work-plane models are reparented
+to `WorkEnvelope` (15 confirmed pre-spec + `CliChunkEvent` + `CliControlAck`
+resolved as WORK via OQ-1); 9 infra models stay on bare `ContractEnvelope`. A new
+subject→envelope enforcement test replaces convention with assertion. `CONTRACT_VERSION`
+stays `"1"` (additive minor bump; neither field is security-bearing).
+
+The M1 downstream issues (#1620 ingress mint, #1621 request_id fold, #1796
+active-jobs registry) treat `job_id` presence on work messages as an upstream
+invariant. This PR closes that gap before ingress wiring begins.
+
+---
+
+## Goal
+
+Introduce `WorkEnvelope(ContractEnvelope)` in `roxabi-contracts`, reparent all
+work-plane contract models to it, remove now-redundant local `job_id`/`parent_job_id`
+declarations from the jobs family, and enforce the work/infra split with a
+subject→envelope test.
+
+---
+
+## Users
+
+| Persona | Need |
+|---|---|
+| Downstream issue authors (#1620, #1621, #1796) | `WorkEnvelope` importable from `roxabi_contracts`; `isinstance(msg, WorkEnvelope)` reliable |
+| Contributors adding new work-plane models | Clear type-level signal: subclass `WorkEnvelope`, not `ContractEnvelope` |
+| Observability / active-jobs registry | `job_id` presence on all work messages guaranteed by type, not runtime probe |
+
+---
+
+## Expected Behavior
+
+### EB-1 — WorkEnvelope class
+
+`WorkEnvelope(ContractEnvelope)` is defined in
+`packages/roxabi-contracts/src/roxabi_contracts/envelope.py` and exported from
+`roxabi_contracts.__init__` (+ `__all__`). It carries:
+
+- `job_id: Annotated[str, StringConstraints(min_length=1)]` — mandatory,
+  field validator reuses `validate_job_token` from
+  `roxabi_contracts._nats_utils` (regex `[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*`).
+- `parent_job_id: str | None = None` — nullable, same validator on non-null.
+
+It inherits `model_config = ConfigDict(extra="ignore")` from `ContractEnvelope`.
+It adds no other fields (tracing, timing, version all inherited).
+
+### EB-2 — Jobs family reparent (non-breaking)
+
+`JobEnvelope`, `JobResult`, `JobProgress` in `jobs/models.py` all reparent from
+`ContractEnvelope` to `WorkEnvelope`.
+
+- `JobEnvelope` already declares `job_id: str` and `parent_job_id: str | None`
+  locally. Both local declarations MUST be removed post-reparent; Pydantic v2
+  raises `PydanticUserError` for field-redefinition.
+  Additionally, remove the redundant job-token validators that `WorkEnvelope`
+  now owns:
+  - `@field_validator("job_id", "job_name")` / `_validate_job_tokens`: change to
+    `@field_validator("job_name")` only (remove `"job_id"` from the decorator — it
+    is already validated by `WorkEnvelope`; keep `"job_name"` validation in place).
+  - Remove `@field_validator("parent_job_id")` / `_validate_parent_job_id` entirely
+    (`WorkEnvelope` handles `parent_job_id` validation).
+- `JobResult` and `JobProgress` already declare `job_id: str` locally. The local
+  declaration MUST be removed; `parent_job_id` is then additive-inherited.
+  Additionally:
+  - Remove `@field_validator("job_id")` / `_validate_job_id` from both `JobResult`
+    and `JobProgress` (validation migrated to `WorkEnvelope`).
+- Wire compatibility: `job_id` was already required on these models; reparenting
+  does not change serialized shape. This is non-breaking for the jobs domain.
+
+### EB-3 — LLM / voice / image / turns reparent
+
+The following models reparent from `ContractEnvelope` to `WorkEnvelope`:
+
+| Domain | Model(s) | Note |
+|---|---|---|
+| `llm` | `LlmRequest`, `LlmChunkEvent`, `LlmResponse` | `LifecycleRequest`, `LifecycleResponse` stay on `ContractEnvelope` (INFRA) |
+| `voice` | `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse` | All 4 — carry `request_id`, are work ops |
+| `image` | `ImageRequest`, `ImageResponse` | `ImageHeartbeat` stays on `ContractEnvelope` (INFRA) |
+| `turns` | `TurnWriteEvent` | Sole model in turns — carries `pool_id`, `session_id`, is a work event |
+
+These models gain a new required field (`job_id`) on the wire. This is a
+breaking change for each domain; each requires a coordinated minor version bump
+in the same PR. `#1620` (ingress mint) populates `job_id` at inbound dispatch.
+
+### EB-4 — CLI classification (gap resolution)
+
+ADR-084 classification table has three explicit rows for the cli domain:
+`CliCmdPayload` → WORK, `CliControlCmd` → WORK, `CliHeartbeat` → INFRA.
+
+Two models are absent from the ADR-084 table. This spec resolves the gap:
+
+| Model | Classification | Rationale |
+|---|---|---|
+| `CliChunkEvent` | WORK | Response side of a work op (cli execution); carries `pool_id` + `event_type`; tied to a running cli session |
+| `CliControlAck` | WORK | Acknowledgement of a work control op (`ok`/`resumed`); reply to `CliControlCmd` |
+
+Both are reparented to `WorkEnvelope` in S3 (same cli minor bump as #1009).
+`CliHeartbeat` stays on `ContractEnvelope` (INFRA, no change).
+
+Coordinate with #1009: the `cli` reparent MUST co-land with the
+`lyra_session_id` → `cli_session_id` rename in a single `cli` minor bump.
+Do not merge `cli/models.py` changes independently.
+
+### EB-5 — Subject→envelope enforcement test
+
+A new test file `packages/roxabi-contracts/tests/test_work_envelope_subjects.py`
+asserts:
+
+- All subjects listed in the `WORK_SUBJECTS` test fixture deserialize to an
+  instance of `WorkEnvelope` (via `roxabi_nats.deserialize()`).
+- All subjects listed in `INFRA_SUBJECTS` deserialize to `ContractEnvelope` but
+  NOT `WorkEnvelope`.
+- The union of `WORK_SUBJECTS` and `INFRA_SUBJECTS` equals the set of all
+  `SUBJECTS` constants exported by every domain submodule that defines a `SUBJECTS`
+  singleton. Domains that do NOT export a `SUBJECTS` singleton are excluded from
+  the union scan with explicit rationale:
+  - `audit/` — no `subjects.py`; subjects are dynamic (built via `subject_for()`
+    classmethod); excluded from the union scan.
+  - `outbound/` — exports `OutboundAudioSubjects` class and `STREAM_AUDIO`
+    constant, not a `SUBJECTS` singleton; excluded from the union scan.
+  `INFRA_SUBJECTS` must include subjects from all INFRA-classified singleton
+  domains: `factory.llm.lifecycle.*`, `factory.image.heartbeat`,
+  `factory.cli.heartbeat`, `factory.event.>`, `factory.metric.>`,
+  `factory.gh.mint_failure` (prefix), `factory.verify.deny` (prefix).
+
+This test is CI-only (requires `[testing]` extra) and follows the pattern of
+`test_voice_subjects.py` / `test_image_subjects.py`.
+
+### EB-6 — Version bump
+
+`packages/roxabi-contracts/CHANGELOG.md` receives a minor version entry
+documenting:
+
+- Addition of `WorkEnvelope` to `envelope.py` and `__init__.py`.
+- Reparenting of `jobs/*` (non-breaking), `llm/*`, `voice/*`, `image/*`,
+  `turns/*`, `cli/*` models (breaking per domain — new required `job_id` field).
+- Entry for `CliChunkEvent`/`CliControlAck` classification.
+
+### EB-7 — Infra stay-list (no-touch)
+
+The following models remain on bare `ContractEnvelope` with no change:
+
+| Domain | Model | Note |
+|---|---|---|
+| `llm` | `LifecycleRequest`, `LifecycleResponse` | Infra lifecycle — not work ops |
+| `image` | `ImageHeartbeat` | Heartbeat — not work op |
+| `cli` | `CliHeartbeat` | Heartbeat — not work op |
+| `audit` | `BlobAuditEvent`, `SecurityEvent` | Audit trail — no job_id invariant applies |
+| `event` | `LyraEvent`, `LyraMetric` | Internal observability events — not work ops |
+| `gh` | `MintFailureEvent` | Infra alert — not a work op |
+
+All `ContractEnvelope` subclasses in `packages/roxabi-contracts/src/` are
+accounted for across WORK (EB-3, EB-4) and INFRA (this table). Verified by
+`grep -rn "(ContractEnvelope)" packages/roxabi-contracts/src/`.
+
+---
+
+## Data Model & Consumers
+
+### Class hierarchy
+
+```mermaid
+classDiagram
+    class ContractEnvelope {
+        +contract_version: str
+        +trace_id: str
+        +issued_at: datetime
+        extra="ignore"
+    }
+    class WorkEnvelope {
+        +job_id: str [validate_job_token]
+        +parent_job_id: str | None
+    }
+
+    ContractEnvelope <|-- WorkEnvelope
+
+    WorkEnvelope <|-- JobEnvelope
+    WorkEnvelope <|-- JobResult
+    WorkEnvelope <|-- JobProgress
+
+    WorkEnvelope <|-- LlmRequest
+    WorkEnvelope <|-- LlmChunkEvent
+    WorkEnvelope <|-- LlmResponse
+
+    WorkEnvelope <|-- TtsRequest
+    WorkEnvelope <|-- TtsResponse
+    WorkEnvelope <|-- SttRequest
+    WorkEnvelope <|-- SttResponse
+
+    WorkEnvelope <|-- ImageRequest
+    WorkEnvelope <|-- ImageResponse
+
+    WorkEnvelope <|-- TurnWriteEvent
+
+    WorkEnvelope <|-- CliCmdPayload
+    WorkEnvelope <|-- CliControlCmd
+    WorkEnvelope <|-- CliChunkEvent
+    WorkEnvelope <|-- CliControlAck
+
+    ContractEnvelope <|-- LifecycleRequest
+    ContractEnvelope <|-- LifecycleResponse
+    ContractEnvelope <|-- ImageHeartbeat
+    ContractEnvelope <|-- CliHeartbeat
+    ContractEnvelope <|-- BlobAuditEvent
+    ContractEnvelope <|-- SecurityEvent
+    ContractEnvelope <|-- LyraEvent
+    ContractEnvelope <|-- LyraMetric
+    ContractEnvelope <|-- MintFailureEvent
+```
+
+### Consumer map
+
+```mermaid
+flowchart TD
+    A[roxabi-contracts\nWorkEnvelope] --> B[factory hub\ncore/messaging]
+    A --> C[#1620\ningress mint\njob_id @ inbound dispatch]
+    A --> D[#1621\nrequest_id fold\nvoice / llm builders]
+    A --> E[#1796\nactive-jobs registry\njob_id lookup]
+    A --> F[voiceCLI / llmCLI / imageCLI\nvia git-tag pin]
+```
+
+### Consumer deserialization invariant
+
+All consumers MUST call `roxabi_nats.deserialize(WorkEnvelope, msg)` (or the
+appropriate subclass), NOT `WorkEnvelope.model_validate_json(msg.data)` directly.
+Direct Pydantic calls bypass the 1 MB byte-size gate in `roxabi-nats` (per
+`roxabi-contracts` CLAUDE.md). This invariant is unchanged by this PR.
+
+---
+
+## Breadboard
+
+Affordance IDs use `S*` prefix (backend-only; no UI layer).
+
+| ID | Affordance | Slice |
+|---|---|---|
+| S1-a | `WorkEnvelope` class in `envelope.py` | S1 |
+| S1-b | `WorkEnvelope` exported from `__init__.py` + `__all__` | S1 |
+| S1-c | `JobEnvelope` / `JobResult` / `JobProgress` reparented; local `job_id` / `parent_job_id` removed | S1 |
+| S1-d | `test_envelope.py` — `WorkEnvelope` round-trip tests + field validator tests | S1 |
+| S2-a | `LlmRequest`, `LlmChunkEvent`, `LlmResponse` reparented | S2 |
+| S2-b | `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse` reparented | S2 |
+| S2-c | `ImageRequest`, `ImageResponse` reparented (`ImageHeartbeat` untouched) | S2 |
+| S2-d | `TurnWriteEvent` reparented | S2 |
+| S3-a | `CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`, `CliControlAck` reparented (`CliHeartbeat` untouched) | S3 |
+| S3-b | `test_work_envelope_subjects.py` — full subject→envelope enforcement | S3 |
+| S3-c | `CHANGELOG.md` minor version entry | S3 |
+
+---
+
+## Slices
+
+### S1 — WorkEnvelope class + jobs family reparent
+
+**Files:** `envelope.py`, `__init__.py`, `jobs/models.py`, `tests/test_envelope.py`
+
+1. Add `WorkEnvelope(ContractEnvelope)` to `envelope.py`:
+   - Import `validate_job_token` from `._nats_utils`.
+   - Declare `job_id: Annotated[str, StringConstraints(min_length=1)]`.
+   - Declare `parent_job_id: str | None = None`.
+   - Add `@field_validator("job_id", "parent_job_id", mode="before")` that calls
+     `validate_job_token(v)` and **returns `v`** — do NOT `return validate_job_token(v)`
+     because `validate_job_token` returns `None` (see `_nats_utils.py` line 39).
+     Skip the call and return `v` unchanged when `v is None` (for `parent_job_id`).
+     Note: `StringConstraints(min_length=1)` on `job_id` is belt-and-suspenders
+     with the regex (both enforce non-empty; either would catch `job_id=""`).
+
+2. Add `WorkEnvelope` to `__init__.py` imports and `__all__`.
+3. In `jobs/models.py`:
+   - Change `JobEnvelope(ContractEnvelope)` → `JobEnvelope(WorkEnvelope)`.
+   - Remove local `job_id: str` declaration.
+   - Remove local `parent_job_id: str | None = None` declaration.
+   - Change `JobResult(ContractEnvelope)` → `JobResult(WorkEnvelope)`.
+   - Remove local `job_id: str` declaration from `JobResult`.
+   - Change `JobProgress(ContractEnvelope)` → `JobProgress(WorkEnvelope)`.
+   - Remove local `job_id: str` declaration from `JobProgress`.
+4. Add tests to `tests/test_envelope.py`:
+   - `test_work_envelope_accepts_valid_job_id` — round-trip with `job_id="run-001"`.
+   - `test_work_envelope_rejects_empty_job_id` — `ValidationError` on `job_id=""`.
+   - `test_work_envelope_rejects_invalid_chars` — `ValidationError` on `job_id="bad id"` (space).
+   - `test_work_envelope_parent_job_id_nullable` — `parent_job_id=None` accepted.
+   - `test_work_envelope_parent_job_id_validated` — `parent_job_id="bad id"` raises.
+   - `test_job_envelope_inherits_job_id` — `JobEnvelope` serializes `job_id` correctly.
+   - `test_job_result_inherits_job_id` — `JobResult` has `job_id` from `WorkEnvelope`.
+   - `test_job_progress_inherits_job_id` — `JobProgress` has `job_id` from `WorkEnvelope`.
+
+**Acceptance:** all existing `tests/jobs/` tests green; new envelope tests green.
+
+---
+
+### S2 — LLM / voice / image / turns reparent
+
+**Files:** `llm/models.py`, `voice/models.py`, `image/models.py`, `turns/models.py`
+
+For each file:
+- Change the three WORK model base classes from `ContractEnvelope` to `WorkEnvelope`.
+- Update the import line: `from roxabi_contracts.envelope import ContractEnvelope, WorkEnvelope`.
+- Do NOT touch INFRA models (`LifecycleRequest`, `LifecycleResponse`, `ImageHeartbeat`).
+
+Specific changes:
+
+| File | Models reparented | Models left |
+|---|---|---|
+| `llm/models.py` | `LlmRequest`, `LlmChunkEvent`, `LlmResponse` | `LifecycleRequest`, `LifecycleResponse` |
+| `voice/models.py` | `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse` | — |
+| `image/models.py` | `ImageRequest`, `ImageResponse` | `ImageHeartbeat` |
+| `turns/models.py` | `TurnWriteEvent` | — |
+
+**Acceptance:** `pytest packages/roxabi-contracts/tests/ -x` green (existing test
+suite); `isinstance(LlmRequest(..., job_id="test"), WorkEnvelope)` asserts True in a REPL.
+
+---
+
+### S3 — CLI reparent + enforcement test + version bump
+
+**Coordination gate:** do NOT merge `cli/models.py` changes until #1009
+(`lyra_session_id` → `cli_session_id` rename) is ready to land in the same PR.
+The combined diff constitutes the single `cli` minor bump per ADR-084.
+
+**Files:** `cli/models.py`, `tests/test_work_envelope_subjects.py` (new),
+`tests/test_envelope.py` (addendum), `CHANGELOG.md`
+
+1. In `cli/models.py`:
+   - Change base of `CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`,
+     `CliControlAck` from `ContractEnvelope` to `WorkEnvelope`.
+   - Leave `CliHeartbeat` on `ContractEnvelope`.
+   - Co-land `lyra_session_id` → `cli_session_id` rename (owned by #1009).
+2. Create `tests/test_work_envelope_subjects.py`:
+   - Define `WORK_SUBJECTS: frozenset[str]` — all subject constants from WORK models
+     (`factory.jobs.*`, `factory.llm.*` work subjects, `factory.voice.*`,
+     `factory.image.generate.*`, `factory.turns.write`, `factory.cli.*` work subjects).
+   - Define `INFRA_SUBJECTS: frozenset[str]` — `factory.llm.lifecycle.*`,
+     `factory.image.heartbeat`, `factory.cli.heartbeat`,
+     `factory.event.>`, `factory.metric.>`,
+     `factory.gh.mint_failure` (prefix), `factory.verify.deny` (prefix).
+   - Domains excluded from union scan: `audit/` (no `SUBJECTS` singleton — uses
+     `subject_for()` classmethod) and `outbound/` (exports `OutboundAudioSubjects`
+     class + `STREAM_AUDIO`, not a `SUBJECTS` singleton). Document exclusions inline.
+   - `test_all_subjects_covered`: `WORK_SUBJECTS | INFRA_SUBJECTS` == all `SUBJECTS`
+     singletons exported by `roxabi_contracts.*` (excluding `audit/` and `outbound/`
+     per documented rationale above).
+   - `test_work_subjects_deserialize_to_work_envelope`: for each subject in
+     `WORK_SUBJECTS`, a synthetic fixture message round-trips to an instance of
+     `WorkEnvelope` (deserialize via `roxabi_nats.deserialize()`).
+   - `test_infra_subjects_not_work_envelope`: for each subject in `INFRA_SUBJECTS`,
+     deserialized model is `ContractEnvelope` but NOT `WorkEnvelope`.
+3. In `CHANGELOG.md`:
+   - Add minor version entry with:
+     - New `WorkEnvelope` class (additive).
+     - jobs reparent (non-breaking).
+     - llm/voice/image/turns/cli reparent (breaking per domain — new required `job_id`).
+     - `CliChunkEvent` / `CliControlAck` classified as WORK (EB-4).
+     - `cli_session_id` rename from #1009 (breaking for cli domain, co-landed).
+
+**Acceptance:** full `pytest packages/roxabi-contracts/tests/ -x` green including
+new enforcement test;
+`grep -rn "(ContractEnvelope)" packages/roxabi-contracts/src/roxabi_contracts/{llm,voice,image,turns,cli,jobs}/models.py | grep -v "LifecycleRequest\|LifecycleResponse\|ImageHeartbeat\|CliHeartbeat"` returns zero lines (all WORK models in those domains now on `WorkEnvelope`);
+`grep "LifecycleRequest\|LifecycleResponse\|ImageHeartbeat\|CliHeartbeat" packages/roxabi-contracts/src/roxabi_contracts/*/models.py` still shows `ContractEnvelope` as base;
+`lyra_session_id` does not appear in `cli/models.py` after S3 merges.
+
+---
+
+## Success Criteria
+
+All criteria are binary (pass / fail).
+
+| # | Criterion |
+|---|---|
+| SC-1 | `from roxabi_contracts import WorkEnvelope` succeeds with no import error. |
+| SC-2 | `issubclass(WorkEnvelope, ContractEnvelope)` is `True`. |
+| SC-3 | `WorkEnvelope(contract_version="1", trace_id="t", issued_at=datetime.now(tz=timezone.utc), job_id="")` raises `ValidationError`. (Import: `from datetime import datetime, timezone`) |
+| SC-4 | All 15 non-cli work-plane models for S1+S2 (`JobEnvelope`, `JobResult`, `JobProgress`, `LlmRequest`, `LlmChunkEvent`, `LlmResponse`, `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse`, `ImageRequest`, `ImageResponse`, `TurnWriteEvent`, `CliCmdPayload`, `CliControlCmd`) pass `issubclass(M, WorkEnvelope)`. (SC-5 covers the 2 OQ-1 additions from S3.) |
+| SC-5 | `CliChunkEvent` and `CliControlAck` pass `issubclass(M, WorkEnvelope)`. |
+| SC-6 | `LifecycleRequest`, `LifecycleResponse`, `ImageHeartbeat`, `CliHeartbeat` do NOT pass `issubclass(M, WorkEnvelope)`. |
+| SC-7 | `test_work_envelope_subjects.py::test_all_subjects_covered` is green (union coverage). |
+| SC-8 | `test_work_envelope_subjects.py::test_work_subjects_deserialize_to_work_envelope` is green. |
+| SC-9 | `test_work_envelope_subjects.py::test_infra_subjects_not_work_envelope` is green. |
+| SC-10 | `CONTRACT_VERSION` is still `"1"` (locked by `test_contract_version_current_value`). |
+| SC-11 | All pre-existing tests in `packages/roxabi-contracts/tests/` are green. |
+
+---
+
+## Open Questions
+
+| # | Question | Owner | Status |
+|---|---|---|---|
+| OQ-1 | **CliChunkEvent / CliControlAck classification** — both classified as WORK in this spec (EB-4). If the architect disagrees, cli reparent must be deferred until ADR-084 is updated. | Architect | **Resolved as WORK** in this spec — confirm at review |
+| OQ-2 | **Outbound scope item** — the issue lists "inbound/outbound messages" but no Pydantic models exist in the outbound submodule yet. Treating as a forward-compat note: any future outbound Pydantic model must land as `WorkEnvelope`. Confirm scope interpretation. | Issue author | **Treat as forward-compat** in this spec — confirm at review |
+
+---
+
+## Pre-check
+
+**Testable criteria:** All 11 Success Criteria reference observable code properties
+or test outcomes; none is prose-only.
+
+**Dangling refs:**
+- `validate_job_token` — confirmed present in `_nats_utils.py`; not touched by
+  this PR. If #1782 renames it: update the import in `envelope.py`.
+- `test_voice_subjects.py` / `test_image_subjects.py` — confirmed pattern exists;
+  `test_work_envelope_subjects.py` follows same structure.
+- `lyra_session_id` in `CliCmdPayload` — confirmed in `cli/models.py`; rename
+  owned by #1009 and co-landed in S3.
+
+**Ambiguity (≤5):**
+1. `CliChunkEvent` / `CliControlAck` classification — resolved as WORK (OQ-1).
+2. Outbound scope — resolved as forward-compat note (OQ-2).
+3. `parent_job_id` validator on `WorkEnvelope` — specified as same regex,
+   applied only to non-null values (mode="before" with None guard).
+4. `audit/` + `outbound/` exclusion from SC-7 union scan — resolved: `audit/`
+   has no `SUBJECTS` singleton; `outbound/` exports a class + `STREAM_AUDIO`,
+   not a singleton. Both excluded with inline rationale in the test fixture.
+
+**Slice coverage:** S1 (WorkEnvelope + jobs, non-breaking) → S2 (llm/voice/image/turns,
+breaking per domain) → S3 (cli + enforcement + version bump, gated by #1009).
+Each slice is independently merge-able after its predecessor is green in CI.
+S1 unblocks #1620/#1621/#1796 immediately.
+
+**Edge completeness:**
+- Pydantic v2 field-redefinition trap: handled in S1 EB-2 (explicit remove of
+  local declarations from `JobEnvelope`, `JobResult`, `JobProgress`).
+- `validate_job_token` returns `None` trap: S1 step 1 explicitly requires
+  `validate_job_token(v); return v` — returning `validate_job_token(v)` would
+  silently assign `None` to `job_id` via mode="before" validator.
+- Redundant validators: S1 EB-2 explicitly removes `_validate_job_tokens`,
+  `_validate_parent_job_id`, and `_validate_job_id` from the jobs family.
+  `@field_validator("job_name")` in `JobEnvelope` is retained (not redundant).
+- `extra="ignore"` inheritance: `WorkEnvelope` inherits via `ContractEnvelope`
+  without redeclaration; confirmed by Pydantic v2 `model_config` inheritance rules.
+- `CONTRACT_VERSION` constant: no change (SC-10 locks it via existing test).
+- `doc_drift` gate: `WorkEnvelope` is UNBUILT until S1 merges; no backtick
+  reference added in any non-ADR docs page in this PR.
+- `file_length` gate: `packages/roxabi-contracts/**` is outside `src/factory/**`;
+  exempt from 300 SLOC gate; no exemption entry needed.
+- #1782 coordination: if #1782 lands first and renames `validate_job_token`,
+  update the import in `envelope.py` only; no other change needed.
+- #1791 coordination: `WorkEnvelope` added to `__init__.__all__` in S1; if #1791
+  reorganizes `__all__` structure, merge after S1 or rebase on S1.
+- SC-7 union scan: `audit/` and `outbound/` are excluded from the `SUBJECTS`
+  singleton scan (EB-5). All other 8 domains with `SUBJECTS` singletons are
+  covered (`jobs`, `llm`, `voice`, `image`, `turns`, `event`, `gh`, `verify`).

--- a/artifacts/specs/1619-workenvelope-split-spec.mdx
+++ b/artifacts/specs/1619-workenvelope-split-spec.mdx
@@ -19,11 +19,13 @@ is a runtime convention — not a type guarantee.
 
 ADR-084 resolves this by introducing `WorkEnvelope(ContractEnvelope)`, which
 adds mandatory `job_id: str` (min_length=1, validated by `validate_job_token`)
-and nullable `parent_job_id: str | None`. All 17 work-plane models are reparented
-to `WorkEnvelope` (15 confirmed pre-spec + `CliChunkEvent` + `CliControlAck`
-resolved as WORK via OQ-1); 9 infra models stay on bare `ContractEnvelope`. A new
-subject→envelope enforcement test replaces convention with assertion. `CONTRACT_VERSION`
-stays `"1"` (additive minor bump; neither field is security-bearing).
+and nullable `parent_job_id: str | None`. 13 work-plane models are reparented
+to `WorkEnvelope` in this PR (S1+S2: jobs, llm, voice, image, turns); 4 CLI work
+models (`CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`, `CliControlAck`)
+classified as WORK via OQ-1/EB-4 but deferred to #1838 (gate: #1009 rename);
+9 infra models stay on bare `ContractEnvelope`. A new model-classification
+enforcement test replaces convention with assertion. `CONTRACT_VERSION` stays `"1"`
+(additive minor bump; neither field is security-bearing).
 
 The M1 downstream issues (#1620 ingress mint, #1621 request_id fold, #1796
 active-jobs registry) treat `job_id` presence on work messages as an upstream
@@ -116,12 +118,15 @@ Two models are absent from the ADR-084 table. This spec resolves the gap:
 | `CliChunkEvent` | WORK | Response side of a work op (cli execution); carries `pool_id` + `event_type`; tied to a running cli session |
 | `CliControlAck` | WORK | Acknowledgement of a work control op (`ok`/`resumed`); reply to `CliControlCmd` |
 
-Both are reparented to `WorkEnvelope` in S3 (same cli minor bump as #1009).
+Both are classified as WORK here. Their actual reparent to `WorkEnvelope` is
+**deferred to #1838**, gated on #1009 (`lyra_session_id` → `cli_session_id`
+rename) to keep the `cli` minor bump atomic.
 `CliHeartbeat` stays on `ContractEnvelope` (INFRA, no change).
 
-Coordinate with #1009: the `cli` reparent MUST co-land with the
-`lyra_session_id` → `cli_session_id` rename in a single `cli` minor bump.
-Do not merge `cli/models.py` changes independently.
+The 4 CLI WORK models (`CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`,
+`CliControlAck`) are tracked in `PENDING_MODELS` in
+`test_work_envelope_subjects.py` and must NOT subclass `WorkEnvelope` until
+#1838 lands. Do not merge `cli/models.py` changes in this PR.
 
 ### EB-5 — Subject→envelope enforcement test
 
@@ -214,10 +219,10 @@ classDiagram
 
     WorkEnvelope <|-- TurnWriteEvent
 
-    WorkEnvelope <|-- CliCmdPayload
-    WorkEnvelope <|-- CliControlCmd
-    WorkEnvelope <|-- CliChunkEvent
-    WorkEnvelope <|-- CliControlAck
+    ContractEnvelope <|-- CliCmdPayload
+    ContractEnvelope <|-- CliControlCmd
+    ContractEnvelope <|-- CliChunkEvent
+    ContractEnvelope <|-- CliControlAck
 
     ContractEnvelope <|-- LifecycleRequest
     ContractEnvelope <|-- LifecycleResponse
@@ -264,7 +269,7 @@ Affordance IDs use `S*` prefix (backend-only; no UI layer).
 | S2-b | `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse` reparented | S2 |
 | S2-c | `ImageRequest`, `ImageResponse` reparented (`ImageHeartbeat` untouched) | S2 |
 | S2-d | `TurnWriteEvent` reparented | S2 |
-| S3-a | `CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`, `CliControlAck` reparented (`CliHeartbeat` untouched) | S3 |
+| S3-a | `CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`, `CliControlAck` reparented (`CliHeartbeat` untouched) — **deferred to #1838** (gate: #1009) | S3 |
 | S3-b | `test_work_envelope_subjects.py` — full subject→envelope enforcement | S3 |
 | S3-c | `CHANGELOG.md` minor version entry | S3 |
 
@@ -333,21 +338,20 @@ suite); `isinstance(LlmRequest(..., job_id="test"), WorkEnvelope)` asserts True 
 
 ---
 
-### S3 — CLI reparent + enforcement test + version bump
+### S3 — Classification enforcement test + version bump (CLI reparent deferred)
 
-**Coordination gate:** do NOT merge `cli/models.py` changes until #1009
-(`lyra_session_id` → `cli_session_id` rename) is ready to land in the same PR.
-The combined diff constitutes the single `cli` minor bump per ADR-084.
+> **Note:** The CLI reparent (`CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`,
+> `CliControlAck`) is **deferred to #1838**, gated on #1009
+> (`lyra_session_id` → `cli_session_id` rename) which must co-land in the same
+> `cli` minor bump (ADR-084).  The 4 models are classified as WORK in EB-4 and
+> tracked as `PENDING_MODELS` in `test_work_envelope_subjects.py`.
+>
+> **Do NOT merge `cli/models.py` in this PR.**
 
-**Files:** `cli/models.py`, `tests/test_work_envelope_subjects.py` (new),
+**Files:** `tests/test_work_envelope_subjects.py` (new),
 `tests/test_envelope.py` (addendum), `CHANGELOG.md`
 
-1. In `cli/models.py`:
-   - Change base of `CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`,
-     `CliControlAck` from `ContractEnvelope` to `WorkEnvelope`.
-   - Leave `CliHeartbeat` on `ContractEnvelope`.
-   - Co-land `lyra_session_id` → `cli_session_id` rename (owned by #1009).
-2. Create `tests/test_work_envelope_subjects.py`:
+1. Create `tests/test_work_envelope_subjects.py`:
    - Define `WORK_SUBJECTS: frozenset[str]` — all subject constants from WORK models
      (`factory.jobs.*`, `factory.llm.*` work subjects, `factory.voice.*`,
      `factory.image.generate.*`, `factory.turns.write`, `factory.cli.*` work subjects).
@@ -391,12 +395,12 @@ All criteria are binary (pass / fail).
 | SC-1 | `from roxabi_contracts import WorkEnvelope` succeeds with no import error. |
 | SC-2 | `issubclass(WorkEnvelope, ContractEnvelope)` is `True`. |
 | SC-3 | `WorkEnvelope(contract_version="1", trace_id="t", issued_at=datetime.now(tz=timezone.utc), job_id="")` raises `ValidationError`. (Import: `from datetime import datetime, timezone`) |
-| SC-4 | All 15 non-cli work-plane models for S1+S2 (`JobEnvelope`, `JobResult`, `JobProgress`, `LlmRequest`, `LlmChunkEvent`, `LlmResponse`, `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse`, `ImageRequest`, `ImageResponse`, `TurnWriteEvent`, `CliCmdPayload`, `CliControlCmd`) pass `issubclass(M, WorkEnvelope)`. (SC-5 covers the 2 OQ-1 additions from S3.) |
-| SC-5 | `CliChunkEvent` and `CliControlAck` pass `issubclass(M, WorkEnvelope)`. |
+| SC-4 | All 13 work-plane models reparented in this PR (`JobEnvelope`, `JobResult`, `JobProgress`, `LlmRequest`, `LlmChunkEvent`, `LlmResponse`, `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse`, `ImageRequest`, `ImageResponse`, `TurnWriteEvent`) pass `issubclass(M, WorkEnvelope)`. (`CliCmdPayload` and `CliControlCmd` are PENDING — deferred to #1838.) |
+| SC-5 | `CliChunkEvent` and `CliControlAck` are PENDING (deferred to #1838, gated on #1009) — `issubclass(M, WorkEnvelope)` is currently `False` for both; they remain on `ContractEnvelope` until #1838 lands. |
 | SC-6 | `LifecycleRequest`, `LifecycleResponse`, `ImageHeartbeat`, `CliHeartbeat` do NOT pass `issubclass(M, WorkEnvelope)`. |
-| SC-7 | `test_work_envelope_subjects.py::test_all_subjects_covered` is green (union coverage). |
-| SC-8 | `test_work_envelope_subjects.py::test_work_subjects_deserialize_to_work_envelope` is green. |
-| SC-9 | `test_work_envelope_subjects.py::test_infra_subjects_not_work_envelope` is green. |
+| SC-7 | `test_work_envelope_subjects.py::test_completeness_coverage` is green (count-based: 13 WORK + 9 INFRA + 4 PENDING = 26). |
+| SC-8 | `test_work_envelope_subjects.py::test_work_model_is_subclass_of_work_envelope` is green (parametrized over 13 WORK models). |
+| SC-9 | `test_work_envelope_subjects.py::test_non_work_model_not_subclass_of_work_envelope` is green (parametrized over 9 INFRA + 4 PENDING models). |
 | SC-10 | `CONTRACT_VERSION` is still `"1"` (locked by `test_contract_version_current_value`). |
 | SC-11 | All pre-existing tests in `packages/roxabi-contracts/tests/` are green. |
 

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -174,5 +174,7 @@ let: job  := one entry → full processing (internal multi-turn + steer + stream
 **What did NOT change:** Option C (WorkEnvelope/ContractEnvelope split, mandatory `job_id`
 min_length=1, nullable `parent_job_id` None at root) is ratified and unchanged.
 
+**Implementation note (#1619):** within CONTRACT_VERSION "1", `job_id` deserializes with a transitional default-mint shim — pre-#1619 wire messages (lock-pinned satellite responses, JetStream-persisted backlogs) keep validating, per ADR-049 forward-compat. In-repo producers set `job_id` explicitly. Satellites echo it after their lock bump (#1840). Flip to hard-required rides the next CONTRACT_VERSION bump (#1841).
+
 Living SSoT: `docs/architecture/job-model.md`.
 

--- a/packages/roxabi-contracts/CHANGELOG.md
+++ b/packages/roxabi-contracts/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.9.0] (2026-06-11)
+
+### Features
+
+* **contracts:** add `WorkEnvelope` base class with `job_id` + `parent_job_id` — work-plane/infra-plane split ([#1619](https://github.com/Roxabi/roxabi-factory/issues/1619)). TRANSITIONAL: `job_id` carries a `default_factory` so pre-#1619 wire messages without the field still parse; flip to hard-required tracked in [#1841](https://github.com/Roxabi/roxabi-factory/issues/1841).
+* **contracts:** export `new_job_id()` from top-level `roxabi_contracts` — 32-char hex UUID, NATS-subject-safe.
+* **contracts:** reparent 13 domain models to `WorkEnvelope`: `JobEnvelope`, `JobResult`, `JobProgress`, `LlmRequest`, `LlmChunkEvent`, `LlmResponse`, `TtsRequest`, `TtsResponse`, `SttRequest`, `SttResponse`, `ImageRequest`, `ImageResponse`, `TurnWriteEvent`. Infra-plane models (`LifecycleRequest/Response`, `ImageHeartbeat`, `CliHeartbeat`, `BlobAuditEvent`, `SecurityEvent`, `LyraEvent/Metric`, `MintFailureEvent`) remain on `ContractEnvelope` by design. CLI models (`CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck`) deferred to [#1838](https://github.com/Roxabi/roxabi-factory/issues/1838).
+* **contracts:** add enforcement tests locking the WORK/INFRA/PENDING classification invariants (`tests/test_work_envelope_subjects.py`).
+
+
 ## [0.4.0](https://github.com/Roxabi/lyra/compare/roxabi-contracts/v0.3.0...roxabi-contracts/v0.4.0) (2026-05-19)
 
 

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-contracts"
-version = "0.7.0"
+version = "0.9.0"
 description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/__init__.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError, version
 from .audit import SecurityEvent
 from .blob_errors import BlobNotFoundError, BlobStoreServerError
 from .blob_ref import BlobRef
-from .envelope import CONTRACT_VERSION, ContractEnvelope
+from .envelope import CONTRACT_VERSION, ContractEnvelope, WorkEnvelope, new_job_id
 
 try:
     __version__: str = version("roxabi-contracts")
@@ -26,5 +26,7 @@ __all__ = [
     "CONTRACT_VERSION",
     "ContractEnvelope",
     "SecurityEvent",
+    "WorkEnvelope",
     "__version__",
+    "new_job_id",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
@@ -3,10 +3,13 @@
 See docs/architecture/adr/049-roxabi-contracts-shared-schema-package.mdx.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Annotated
+from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
 
 #
 # ADR-044 (absorbed into ADR-049) — single source of truth for the wire-protocol
@@ -54,3 +57,46 @@ class ContractEnvelope(BaseModel):
     contract_version: str
     trace_id: Annotated[str, StringConstraints(min_length=1)]
     issued_at: datetime
+
+
+def new_job_id() -> str:
+    """Mint a fresh job id (32-char hex, URL-safe, NATS-subject-safe)."""
+    return uuid4().hex
+
+
+class WorkEnvelope(ContractEnvelope):
+    """Work-bearing envelope; carries a stable job identity.
+
+    All work-plane NATS messages (llm, voice, image, turns, jobs) subclass
+    ``WorkEnvelope``. Infra messages (heartbeats, lifecycle, metrics) stay on
+    bare ``ContractEnvelope`` (ADR-084).
+
+    ``job_id`` is TRANSITIONAL: a ``default_factory`` is provided so that
+    pre-#1619 wire messages that omit ``job_id`` still parse. The default
+    will be removed (hard-required) in #1841 once all producers are updated.
+
+    ``parent_job_id`` links composite-job children back to their root — ``None``
+    for top-level jobs.
+    """
+
+    # TRANSITIONAL: default_factory keeps pre-#1619 wire messages parseable.
+    # Flip to hard-required (remove default) in #1841.
+    job_id: str = Field(default_factory=new_job_id)
+    parent_job_id: str | None = None
+
+    @field_validator("job_id", mode="before")
+    @classmethod
+    def _validate_job_id(cls, v: str) -> str:
+        from roxabi_contracts._nats_utils import validate_job_token  # local import avoids circularity
+
+        validate_job_token(v)
+        return v  # validate_job_token returns None — must return v, not its result
+
+    @field_validator("parent_job_id", mode="before")
+    @classmethod
+    def _validate_parent_job_id(cls, v: str | None) -> str | None:
+        if v is not None:
+            from roxabi_contracts._nats_utils import validate_job_token  # local import avoids circularity
+
+            validate_job_token(v)
+        return v

--- a/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
@@ -87,7 +87,9 @@ class WorkEnvelope(ContractEnvelope):
     @field_validator("job_id", mode="before")
     @classmethod
     def _validate_job_id(cls, v: str) -> str:
-        from roxabi_contracts._nats_utils import validate_job_token  # local import avoids circularity
+        from roxabi_contracts._nats_utils import (
+            validate_job_token,
+        )  # local import avoids circularity
 
         validate_job_token(v)
         return v  # validate_job_token returns None — must return v, not its result
@@ -96,7 +98,9 @@ class WorkEnvelope(ContractEnvelope):
     @classmethod
     def _validate_parent_job_id(cls, v: str | None) -> str | None:
         if v is not None:
-            from roxabi_contracts._nats_utils import validate_job_token  # local import avoids circularity
+            from roxabi_contracts._nats_utils import (
+                validate_job_token,
+            )  # local import avoids circularity
 
             validate_job_token(v)
         return v

--- a/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/envelope.py
@@ -81,7 +81,9 @@ class WorkEnvelope(ContractEnvelope):
 
     # TRANSITIONAL: default_factory keeps pre-#1619 wire messages parseable.
     # Flip to hard-required (remove default) in #1841.
-    job_id: str = Field(default_factory=new_job_id)
+    job_id: Annotated[str, StringConstraints(min_length=1)] = Field(
+        default_factory=new_job_id
+    )
     parent_job_id: str | None = None
 
     @field_validator("job_id", mode="before")

--- a/packages/roxabi-contracts/src/roxabi_contracts/image/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/image/models.py
@@ -1,8 +1,9 @@
 """Image-domain NATS contract models.
 
-Pure Pydantic. No NATS imports. No transport logic. Every model subclasses
-ContractEnvelope, which provides (contract_version, trace_id, issued_at)
-plus ConfigDict(extra="ignore") for forward-compat.
+Pure Pydantic. No NATS imports. No transport logic. Work models (ImageRequest,
+ImageResponse) subclass WorkEnvelope, which provides (contract_version,
+trace_id, issued_at, job_id) plus ConfigDict(extra="ignore") for forward-compat
+(ADR-084). ImageHeartbeat is an infra model and stays on ContractEnvelope.
 
 Mirrors the voice-domain shape. See spec #763 and issue #806 for the
 alignment rationale on optional-but-invariant fields on response models.

--- a/packages/roxabi-contracts/src/roxabi_contracts/image/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/image/models.py
@@ -15,11 +15,11 @@ from typing import Annotated, Literal, Self
 from pydantic import StringConstraints, model_validator
 
 from roxabi_contracts.blob_ref import BlobRef
-from roxabi_contracts.envelope import ContractEnvelope
+from roxabi_contracts.envelope import ContractEnvelope, WorkEnvelope
 from roxabi_contracts.errors import WorkerError
 
 
-class ImageRequest(ContractEnvelope):
+class ImageRequest(WorkEnvelope):
     """Image generation request.
 
     Canonical subject: ``factory.image.generate.request``.
@@ -42,7 +42,7 @@ class ImageRequest(ContractEnvelope):
     embedding_path: str | None = None
 
 
-class ImageResponse(ContractEnvelope):
+class ImageResponse(WorkEnvelope):
     """Image generation response.
 
     Success-path invariant (enforced by ``_enforce_success_invariant``):

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -12,23 +12,24 @@ from typing import Annotated, Any, Literal, Self
 from pydantic import Field, StringConstraints, field_validator, model_validator
 
 from roxabi_contracts._nats_utils import validate_job_token, validate_nats_subject
-from roxabi_contracts.envelope import ContractEnvelope
+from roxabi_contracts.envelope import WorkEnvelope
 from roxabi_contracts.errors import WorkerError
 
 __all__ = ["JobEnvelope", "JobResult", "JobProgress"]
 
 
-class JobEnvelope(ContractEnvelope):
-    """Job submission envelope. Canonical subject: factory.jobs.<job_name>."""
+class JobEnvelope(WorkEnvelope):
+    """Job submission envelope. Canonical subject: factory.jobs.<job_name>.
 
-    job_id: str
+    ``job_id`` and ``parent_job_id`` are inherited from ``WorkEnvelope`` (ADR-084).
+    """
+
     job_name: str
     payload: dict[str, Any]
     reply_to: str
-    parent_job_id: str | None = None
     composite_depth: Annotated[int, Field(ge=0, le=3)] = 0
 
-    @field_validator("job_id", "job_name")
+    @field_validator("job_name")
     @classmethod
     def _validate_job_tokens(cls, v: str) -> str:
         validate_job_token(v)
@@ -45,27 +46,16 @@ class JobEnvelope(ContractEnvelope):
         validate_nats_subject(v)
         return v
 
-    @field_validator("parent_job_id")
-    @classmethod
-    def _validate_parent_job_id(cls, v: str | None) -> str | None:
-        if v is not None:
-            validate_job_token(v)
-        return v
 
+class JobResult(WorkEnvelope):
+    """Job reply envelope. Sent to reply_to subject on completion.
 
-class JobResult(ContractEnvelope):
-    """Job reply envelope. Sent to reply_to subject on completion."""
+    ``job_id`` inherited from ``WorkEnvelope`` (ADR-084).
+    """
 
-    job_id: str
     status: Literal["success", "error"]
     data: dict[str, Any] | None = None
     error: WorkerError | None = None
-
-    @field_validator("job_id")
-    @classmethod
-    def _validate_job_id(cls, v: str) -> str:
-        validate_job_token(v)
-        return v
 
     @model_validator(mode="after")
     def _enforce_status_invariant(self) -> Self:
@@ -78,16 +68,12 @@ class JobResult(ContractEnvelope):
         return self
 
 
-class JobProgress(ContractEnvelope):
-    """Job progress event. Published to factory.progress.<job_id> (best-effort)."""
+class JobProgress(WorkEnvelope):
+    """Job progress event. Published to factory.progress.<job_id> (best-effort).
 
-    job_id: str
+    ``job_id`` inherited from ``WorkEnvelope`` (ADR-084).
+    """
+
     step: Annotated[str, StringConstraints(min_length=1)]
     pct: Annotated[float | None, Field(ge=0.0, le=100.0)] = None
     detail: dict[str, Any] | None = None
-
-    @field_validator("job_id")
-    @classmethod
-    def _validate_job_id(cls, v: str) -> str:
-        validate_job_token(v)
-        return v

--- a/packages/roxabi-contracts/src/roxabi_contracts/llm/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/llm/models.py
@@ -14,11 +14,11 @@ from typing import Annotated, Literal, Optional, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
-from roxabi_contracts.envelope import ContractEnvelope
+from roxabi_contracts.envelope import ContractEnvelope, WorkEnvelope
 from roxabi_contracts.errors import WorkerError
 
 
-class LlmRequest(ContractEnvelope):
+class LlmRequest(WorkEnvelope):
     """LLM generation request. Canonical subject: ``factory.llm.generate.request``."""
 
     request_id: Annotated[str, StringConstraints(pattern=r"^[A-Za-z0-9_-]{1,128}$")]
@@ -30,7 +30,7 @@ class LlmRequest(ContractEnvelope):
     temperature: float | None = None
 
 
-class LlmChunkEvent(ContractEnvelope):
+class LlmChunkEvent(WorkEnvelope):
     """Streaming chunk event. Published per SSE token to the reply inbox.
 
     Terminal chunk: ``done=True``, ``delta=None``, ``duration_ms`` set.
@@ -46,7 +46,7 @@ class LlmChunkEvent(ContractEnvelope):
     worker_error: WorkerError | None = None
 
 
-class LlmResponse(ContractEnvelope):
+class LlmResponse(WorkEnvelope):
     """Non-streaming generation response.
 
     Success-path invariant (enforced by ``_enforce_success_invariant``):

--- a/packages/roxabi-contracts/src/roxabi_contracts/turns/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/turns/models.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from roxabi_contracts.envelope import ContractEnvelope
+from roxabi_contracts.envelope import WorkEnvelope
 
 # Forward-compat config for nested payload classes. Top-level envelope
 # (TurnWriteEvent) inherits extra="ignore" from ContractEnvelope; we mirror
@@ -73,7 +73,7 @@ TurnWritePayload = Annotated[
 # --- Envelope ---
 
 
-class TurnWriteEvent(ContractEnvelope):
+class TurnWriteEvent(WorkEnvelope):
     """Event published to factory.turns.write.
 
     Idempotence strategy (per kind):

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
@@ -1,8 +1,8 @@
 """Voice-domain NATS contract models.
 
 Pure Pydantic. No NATS imports. No transport logic. Every model subclasses
-ContractEnvelope, which provides (contract_version, trace_id, issued_at)
-plus ConfigDict(extra="ignore") for forward-compat.
+WorkEnvelope, which provides (contract_version, trace_id, issued_at, job_id)
+plus ConfigDict(extra="ignore") for forward-compat (ADR-084).
 
 See artifacts/specs/763-port-voice-domain-spec.mdx §Known drift for the
 rationale on optional-but-invariant fields on response models.

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
@@ -15,7 +15,7 @@ from typing import Annotated, Self
 from pydantic import StringConstraints, model_validator
 
 from roxabi_contracts.blob_ref import BlobRef
-from roxabi_contracts.envelope import ContractEnvelope, WorkEnvelope
+from roxabi_contracts.envelope import WorkEnvelope
 from roxabi_contracts.errors import WorkerError
 
 

--- a/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/voice/models.py
@@ -15,11 +15,11 @@ from typing import Annotated, Self
 from pydantic import StringConstraints, model_validator
 
 from roxabi_contracts.blob_ref import BlobRef
-from roxabi_contracts.envelope import ContractEnvelope
+from roxabi_contracts.envelope import ContractEnvelope, WorkEnvelope
 from roxabi_contracts.errors import WorkerError
 
 
-class TtsRequest(ContractEnvelope):
+class TtsRequest(WorkEnvelope):
     """TTS synthesis request. Canonical subject: ``factory.voice.tts.request``."""
 
     request_id: Annotated[str, StringConstraints(min_length=1)]
@@ -42,7 +42,7 @@ class TtsRequest(ContractEnvelope):
     chunk_size: int | None = None
 
 
-class TtsResponse(ContractEnvelope):
+class TtsResponse(WorkEnvelope):
     """TTS synthesis response.
 
     Success-path invariant (enforced by ``_enforce_success_invariant``):
@@ -72,7 +72,7 @@ class TtsResponse(ContractEnvelope):
         return self
 
 
-class SttRequest(ContractEnvelope):
+class SttRequest(WorkEnvelope):
     """STT transcription request. Canonical subject: ``factory.voice.stt.request``."""
 
     request_id: Annotated[str, StringConstraints(min_length=1)]
@@ -90,7 +90,7 @@ class SttRequest(ContractEnvelope):
     task: str | None = None
 
 
-class SttResponse(ContractEnvelope):
+class SttResponse(WorkEnvelope):
     """STT transcription response.
 
     Success-path invariant (enforced by ``_enforce_success_invariant``):

--- a/packages/roxabi-contracts/tests/test_envelope.py
+++ b/packages/roxabi-contracts/tests/test_envelope.py
@@ -10,6 +10,8 @@ from roxabi_contracts import (
     WorkEnvelope,
     new_job_id,
 )
+from roxabi_contracts.jobs.models import JobEnvelope
+from roxabi_contracts.turns.models import TurnWriteEvent
 
 
 def test_contract_version_is_positive_digit() -> None:
@@ -122,7 +124,7 @@ def test_work_envelope_explicit_job_id_accepted() -> None:
 
 
 def test_work_envelope_empty_job_id_raises() -> None:
-    """Empty string is explicitly passed — must raise (SC-13)."""
+    """Empty string is explicitly passed — must raise (SC-3)."""
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
@@ -163,3 +165,52 @@ def test_work_envelope_wire_compat_missing_job_id() -> None:
     }
     env = WorkEnvelope.model_validate(payload)
     assert len(env.job_id) == 32  # auto-minted
+
+
+# ---------------------------------------------------------------------------
+# Wire-compat: concrete WorkEnvelope subclasses parse without job_id
+# ---------------------------------------------------------------------------
+
+
+def test_turn_write_event_wire_compat_missing_job_id() -> None:
+    """TurnWriteEvent (concrete WorkEnvelope) parses without job_id — TRANSITIONAL.
+
+    Forward-compat invariant: a pre-#1619 TurnWriteEvent wire message that
+    omits job_id must still deserialize cleanly.  The minted id confirms the
+    default_factory is exercised on the subclass, not only on the base class.
+    """
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    payload = {
+        "contract_version": "1",
+        "trace_id": "t-turn-wire",
+        "issued_at": "2026-04-16T12:00:00+00:00",
+        "event_id": str(uuid4()),
+        "pool_id": "pool:tg:chat:1",
+        "session_id": "sess-wire-0001",
+        "platform": "telegram",
+        "user_id": "u:wire:1",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "payload": {"kind": "start_session"},
+        # job_id intentionally absent
+    }
+    event = TurnWriteEvent.model_validate(payload)
+    assert event.job_id
+    assert len(event.job_id) == 32
+
+
+def test_job_envelope_wire_compat_missing_job_id() -> None:
+    """JobEnvelope (concrete WorkEnvelope) parses without job_id — TRANSITIONAL."""
+    payload = {
+        "contract_version": "1",
+        "trace_id": "t-job-wire",
+        "issued_at": "2026-04-16T12:00:00+00:00",
+        "job_name": "summarize",
+        "payload": {},
+        "reply_to": "_INBOX.test",
+        # job_id intentionally absent
+    }
+    env = JobEnvelope.model_validate(payload)
+    assert env.job_id
+    assert len(env.job_id) == 32

--- a/packages/roxabi-contracts/tests/test_envelope.py
+++ b/packages/roxabi-contracts/tests/test_envelope.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 
 import pytest
 
-from roxabi_contracts import CONTRACT_VERSION, ContractEnvelope, WorkEnvelope, new_job_id
+from roxabi_contracts import (
+    CONTRACT_VERSION,
+    ContractEnvelope,
+    WorkEnvelope,
+    new_job_id,
+)
 
 
 def test_contract_version_is_positive_digit() -> None:

--- a/packages/roxabi-contracts/tests/test_envelope.py
+++ b/packages/roxabi-contracts/tests/test_envelope.py
@@ -1,8 +1,10 @@
-"""Tests for roxabi_contracts.envelope.ContractEnvelope."""
+"""Tests for roxabi_contracts.envelope.ContractEnvelope and WorkEnvelope."""
 
 from datetime import datetime, timezone
 
-from roxabi_contracts import CONTRACT_VERSION, ContractEnvelope
+import pytest
+
+from roxabi_contracts import CONTRACT_VERSION, ContractEnvelope, WorkEnvelope, new_job_id
 
 
 def test_contract_version_is_positive_digit() -> None:
@@ -77,3 +79,82 @@ def test_extra_fields_silently_dropped() -> None:
     assert env.contract_version == "1"
     assert not hasattr(env, "future_field")
     assert not hasattr(env, "another_unknown")
+
+
+# ---------------------------------------------------------------------------
+# WorkEnvelope tests
+# ---------------------------------------------------------------------------
+
+
+def _base_fields() -> dict:
+    return {
+        "contract_version": "1",
+        "trace_id": "t-001",
+        "issued_at": datetime.now(timezone.utc),
+    }
+
+
+def test_work_envelope_is_subclass_of_contract_envelope() -> None:
+    assert issubclass(WorkEnvelope, ContractEnvelope)
+
+
+def test_new_job_id_returns_32_char_hex() -> None:
+    jid = new_job_id()
+    assert isinstance(jid, str)
+    assert len(jid) == 32
+    assert all(c in "0123456789abcdef" for c in jid)
+
+
+def test_work_envelope_auto_mints_job_id_when_omitted() -> None:
+    """TRANSITIONAL: job_id defaults via new_job_id() when not supplied."""
+    env = WorkEnvelope(**_base_fields())
+    assert len(env.job_id) == 32
+
+
+def test_work_envelope_explicit_job_id_accepted() -> None:
+    env = WorkEnvelope(**_base_fields(), job_id="abc123")
+    assert env.job_id == "abc123"
+
+
+def test_work_envelope_empty_job_id_raises() -> None:
+    """Empty string is explicitly passed — must raise (SC-13)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        WorkEnvelope(**_base_fields(), job_id="")
+
+
+def test_work_envelope_invalid_job_id_raises() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        WorkEnvelope(**_base_fields(), job_id="bad..token")
+
+
+def test_work_envelope_parent_job_id_default_none() -> None:
+    env = WorkEnvelope(**_base_fields())
+    assert env.parent_job_id is None
+
+
+def test_work_envelope_parent_job_id_accepted() -> None:
+    env = WorkEnvelope(**_base_fields(), parent_job_id="parent-001")
+    assert env.parent_job_id == "parent-001"
+
+
+def test_work_envelope_invalid_parent_job_id_raises() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        WorkEnvelope(**_base_fields(), parent_job_id="bad token!")
+
+
+def test_work_envelope_wire_compat_missing_job_id() -> None:
+    """Pre-#1619 wire message without job_id must parse (TRANSITIONAL default)."""
+    payload = {
+        "contract_version": "1",
+        "trace_id": "t-wire",
+        "issued_at": "2026-04-16T12:00:00+00:00",
+        # no job_id — pre-#1619 wire message
+    }
+    env = WorkEnvelope.model_validate(payload)
+    assert len(env.job_id) == 32  # auto-minted

--- a/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
+++ b/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
@@ -1,0 +1,202 @@
+"""Enforcement tests: WorkEnvelope / INFRA classification invariants (#1619).
+
+These tests lock the WORK / INFRA / PENDING model classification so that:
+  - Any new domain model is forced into one of the three buckets.
+  - WORK models are guaranteed to subclass WorkEnvelope.
+  - INFRA and PENDING models are guaranteed NOT to subclass WorkEnvelope.
+  - Wire-compat is verified: a WorkEnvelope payload without job_id still parses.
+  - The empty-job_id invariant is explicitly tested.
+
+PENDING models (#1838) still sit on ContractEnvelope; they remain classified
+here so additions are caught by the completeness test before the follow-up
+reparent lands.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from roxabi_contracts import WorkEnvelope
+from roxabi_contracts.audit import SecurityEvent
+from roxabi_contracts.audit.blobs import BlobAuditEvent
+from roxabi_contracts.cli.models import (
+    CliChunkEvent,
+    CliCmdPayload,
+    CliControlAck,
+    CliControlCmd,
+    CliHeartbeat,
+)
+from roxabi_contracts.event.models import LyraEvent, LyraMetric
+from roxabi_contracts.gh.models import MintFailureEvent
+from roxabi_contracts.image.models import ImageHeartbeat, ImageRequest, ImageResponse
+from roxabi_contracts.jobs.models import JobEnvelope, JobProgress, JobResult
+from roxabi_contracts.llm.models import (
+    LifecycleRequest,
+    LifecycleResponse,
+    LlmChunkEvent,
+    LlmRequest,
+    LlmResponse,
+)
+from roxabi_contracts.turns.models import TurnWriteEvent
+from roxabi_contracts.voice.models import (
+    SttRequest,
+    SttResponse,
+    TtsRequest,
+    TtsResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Classification tables
+# ---------------------------------------------------------------------------
+
+#: 13 domain models that carry a job identity → MUST subclass WorkEnvelope.
+WORK_MODELS = {
+    JobEnvelope,
+    JobResult,
+    JobProgress,
+    LlmRequest,
+    LlmChunkEvent,
+    LlmResponse,
+    TtsRequest,
+    TtsResponse,
+    SttRequest,
+    SttResponse,
+    ImageRequest,
+    ImageResponse,
+    TurnWriteEvent,
+}
+
+#: 9 infra-plane models — deliberate ContractEnvelope, no job identity.
+INFRA_MODELS = {
+    LifecycleRequest,
+    LifecycleResponse,
+    ImageHeartbeat,
+    CliHeartbeat,
+    BlobAuditEvent,
+    SecurityEvent,
+    LyraEvent,
+    LyraMetric,
+    MintFailureEvent,
+}
+
+#: 4 CLI models deferred to #1838 — currently ContractEnvelope.
+PENDING_MODELS = {
+    CliCmdPayload,
+    CliControlCmd,
+    CliChunkEvent,
+    CliControlAck,
+}
+
+ALL_CLASSIFIED = WORK_MODELS | INFRA_MODELS | PENDING_MODELS
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _base_fields() -> dict:
+    """Minimum fields shared by all ContractEnvelope subclasses."""
+    return {
+        "contract_version": "1",
+        "trace_id": "testrace0001",
+        "issued_at": datetime.now(timezone.utc),
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) Completeness
+# ---------------------------------------------------------------------------
+
+
+def test_completeness_no_duplicate_across_buckets() -> None:
+    """Each model appears in exactly one bucket."""
+    assert not (WORK_MODELS & INFRA_MODELS), "overlap: WORK ∩ INFRA"
+    assert not (WORK_MODELS & PENDING_MODELS), "overlap: WORK ∩ PENDING"
+    assert not (INFRA_MODELS & PENDING_MODELS), "overlap: INFRA ∩ PENDING"
+
+
+def test_completeness_coverage() -> None:
+    """ALL_CLASSIFIED covers the expected count: 13 WORK + 9 INFRA + 4 PENDING = 26."""
+    assert len(WORK_MODELS) == 13, f"expected 13 WORK models, got {len(WORK_MODELS)}"
+    assert len(INFRA_MODELS) == 9, f"expected 9 INFRA models, got {len(INFRA_MODELS)}"
+    assert len(PENDING_MODELS) == 4, (
+        f"expected 4 PENDING models, got {len(PENDING_MODELS)}"
+    )
+    assert len(ALL_CLASSIFIED) == 26
+
+
+# ---------------------------------------------------------------------------
+# (b) WORK ⇒ issubclass WorkEnvelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model_cls", sorted(WORK_MODELS, key=lambda c: c.__name__))
+def test_work_model_is_subclass_of_work_envelope(model_cls) -> None:
+    """Every WORK model MUST inherit from WorkEnvelope."""
+    assert issubclass(model_cls, WorkEnvelope), (
+        f"{model_cls.__name__} is classified as WORK but does not subclass WorkEnvelope"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) INFRA + PENDING ⇒ NOT issubclass WorkEnvelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    sorted(INFRA_MODELS | PENDING_MODELS, key=lambda c: c.__name__),
+)
+def test_non_work_model_not_subclass_of_work_envelope(model_cls) -> None:
+    """INFRA and PENDING models MUST NOT inherit from WorkEnvelope."""
+    assert not issubclass(model_cls, WorkEnvelope), (
+        f"{model_cls.__name__} is classified as INFRA/PENDING but subclasses WorkEnvelope"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) Wire-compat: WorkEnvelope parses without job_id (TRANSITIONAL)
+# ---------------------------------------------------------------------------
+
+
+def test_work_envelope_wire_compat_omitted_job_id() -> None:
+    """Pre-#1619 wire messages without job_id MUST still deserialize.
+
+    TRANSITIONAL invariant: job_id carries a default_factory so old
+    producers are not broken.  The flip to hard-required is tracked in
+    #1841.
+    """
+    payload = {
+        "contract_version": "1",
+        "trace_id": "compat-trace-0001",
+        "issued_at": "2026-06-01T00:00:00+00:00",
+        # job_id intentionally absent
+    }
+    env = WorkEnvelope.model_validate(payload)
+    # A fresh job_id was minted by default_factory.
+    assert env.job_id
+    assert len(env.job_id) == 32
+    assert env.job_id.isalnum()
+
+
+# ---------------------------------------------------------------------------
+# (e) job_id="" raises ValidationError
+# ---------------------------------------------------------------------------
+
+
+def test_work_envelope_empty_job_id_raises() -> None:
+    """An explicit empty string for job_id MUST be rejected.
+
+    SC-13: producers MUST supply a non-empty job_id.  Passing an empty
+    string (a common default-sentinel mistake) is a contract violation
+    that must surface loudly, not silently produce a useless job identity.
+    """
+    with pytest.raises(ValidationError):
+        WorkEnvelope(
+            **_base_fields(),
+            job_id="",
+        )

--- a/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
+++ b/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
@@ -154,7 +154,8 @@ def test_work_model_is_subclass_of_work_envelope(model_cls) -> None:
 def test_non_work_model_not_subclass_of_work_envelope(model_cls) -> None:
     """INFRA and PENDING models MUST NOT inherit from WorkEnvelope."""
     assert not issubclass(model_cls, WorkEnvelope), (
-        f"{model_cls.__name__} is classified as INFRA/PENDING but subclasses WorkEnvelope"
+        f"{model_cls.__name__} is classified as INFRA/PENDING"
+        " but subclasses WorkEnvelope"
     )
 
 

--- a/src/factory/adapters/discord/discord_threads.py
+++ b/src/factory/adapters/discord/discord_threads.py
@@ -59,5 +59,3 @@ async def restore_hot_threads(
         bot_id,
     )
     return owned
-
-

--- a/src/factory/bootstrap/bootstrap_stores.py
+++ b/src/factory/bootstrap/bootstrap_stores.py
@@ -62,9 +62,7 @@ def _copy_indices(
     ).fetchall()
     for (idx_sql,) in idx_rows:
         if not _DDL_INDEX_RE.match(idx_sql):
-            log.warning(
-                "Skipping unexpected DDL from sqlite_master: %r", idx_sql[:80]
-            )
+            log.warning("Skipping unexpected DDL from sqlite_master: %r", idx_sql[:80])
             continue
         try:
             dst.execute(idx_sql)

--- a/src/factory/inbound/session_builder.py
+++ b/src/factory/inbound/session_builder.py
@@ -52,10 +52,7 @@ class SessionBuilder:
             return msg
 
         # Discriminate path: Discord with thread_store present uses meta inspection.
-        _discord_thread = (
-            isinstance(meta, DiscordMeta)
-            and meta.thread_id is not None
-        )
+        _discord_thread = isinstance(meta, DiscordMeta) and meta.thread_id is not None
         if _discord_thread:
             # (d) Discord owned thread — claim-routing only; resume is hub-side path-3.
             return await self._build_thread_path(msg, ctx)
@@ -95,5 +92,3 @@ class SessionBuilder:
             _ = (_th, _bid, session_id, pool_id)  # suppress unused-capture lint
 
         return dataclasses.replace(msg, session_update_fn=_thread_update_fn)
-
-

--- a/src/factory/llm/cli_nats_codec.py
+++ b/src/factory/llm/cli_nats_codec.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 from factory.core.messaging.events import LlmEvent, ResultLlmEvent, TextLlmEvent
 from factory.core.ports.llm import LlmResult
 from factory.transport._result import Err, Result, SanitizedError
+from roxabi_contracts import new_job_id
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.errors import KNOWN_CODES, WorkerError
 from roxabi_contracts.llm import LlmChunkEvent, LlmRequest, LlmResponse
@@ -86,6 +87,7 @@ class CliNatsCodec:
             contract_version=CONTRACT_VERSION,
             trace_id=trace_id,
             issued_at=datetime.now(timezone.utc),
+            job_id=new_job_id(),
             request_id=str(uuid4()).replace("-", "")[:32],
             messages=wire_messages,
             model=model_cfg.model,

--- a/src/factory/nats/audio/nats_tts_codec.py
+++ b/src/factory/nats/audio/nats_tts_codec.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 
 from factory.core.ports.tts import SynthesisResult
 from factory.transport._result import Err, Result, SanitizedError
+from roxabi_contracts import new_job_id
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.voice import TtsRequest, TtsResponse
 from roxabi_contracts.voice.constants import TTS_CONFIG_FIELDS
@@ -52,6 +53,7 @@ class TtsCodec:
             "contract_version": CONTRACT_VERSION,
             "trace_id": str(uuid4()),
             "issued_at": datetime.now(timezone.utc),
+            "job_id": new_job_id(),
             "request_id": str(uuid4()),
             "text": text,
             "language": language,

--- a/src/factory/nats/image/nats_image_codec.py
+++ b/src/factory/nats/image/nats_image_codec.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 from pydantic import ValidationError
 
 from factory.transport._result import Err, Result, SanitizedError
+from roxabi_contracts import new_job_id
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.image import ImageRequest, ImageResponse
 
@@ -87,6 +88,7 @@ class ImageCodec:
             contract_version=CONTRACT_VERSION,
             trace_id=str(uuid4()),
             issued_at=datetime.now(timezone.utc),
+            job_id=new_job_id(),
             request_id=str(uuid4()),
             prompt=prompt,
             engine=engine,

--- a/src/factory/nats/stt/nats_stt_codec.py
+++ b/src/factory/nats/stt/nats_stt_codec.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 
 from factory.core.ports.stt import TranscriptionResult
 from factory.transport._result import Err, Result, SanitizedError
-from roxabi_contracts import BlobRef
+from roxabi_contracts import BlobRef, new_job_id
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.voice import SttRequest, SttResponse
 
@@ -51,6 +51,7 @@ class SttCodec:
             contract_version=CONTRACT_VERSION,
             trace_id=str(uuid4()),
             issued_at=datetime.now(timezone.utc),
+            job_id=new_job_id(),
             request_id=str(uuid4()),
             blob_ref=blob_ref,
             mime_type=mime,

--- a/src/factory/transport/turn_publisher.py
+++ b/src/factory/transport/turn_publisher.py
@@ -26,6 +26,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from roxabi_contracts import new_job_id
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.turns import (
     SUBJECTS,
@@ -85,6 +86,7 @@ class TurnPublisher:
                 contract_version=CONTRACT_VERSION,
                 trace_id=trace_id,
                 issued_at=now,
+                job_id=new_job_id(),
                 pool_id=pool_id,
                 session_id=session_id,
                 platform=platform,
@@ -116,6 +118,7 @@ class TurnPublisher:
                 contract_version=CONTRACT_VERSION,
                 trace_id=trace_id,
                 issued_at=now,
+                job_id=new_job_id(),
                 pool_id=pool_id,
                 session_id=session_id,
                 platform=platform,
@@ -141,6 +144,7 @@ class TurnPublisher:
                 contract_version=CONTRACT_VERSION,
                 trace_id=trace_id,
                 issued_at=now,
+                job_id=new_job_id(),
                 pool_id=pool_id,
                 session_id=session_id,
                 platform=platform,
@@ -167,6 +171,7 @@ class TurnPublisher:
                 contract_version=CONTRACT_VERSION,
                 trace_id=trace_id,
                 issued_at=now,
+                job_id=new_job_id(),
                 pool_id=pool_id,
                 session_id=session_id,
                 platform=platform,
@@ -193,6 +198,7 @@ class TurnPublisher:
                 contract_version=CONTRACT_VERSION,
                 trace_id=trace_id,
                 issued_at=now,
+                job_id=new_job_id(),
                 pool_id=pool_id,
                 session_id=session_id,
                 platform=platform,

--- a/tests/bootstrap/test_discord_kv_wiring.py
+++ b/tests/bootstrap/test_discord_kv_wiring.py
@@ -456,4 +456,3 @@ class TestHubPublishesWatchChannelsBeforeReady:
             f"publish_watch_channels (pos {pub_idx}) must precede "
             f"announce_hub_ready (pos {ready_idx}) — SC6 ordering violated"
         )
-

--- a/tests/bootstrap/test_kv_watch_channels.py
+++ b/tests/bootstrap/test_kv_watch_channels.py
@@ -38,8 +38,7 @@ def _make_js(kv: MagicMock) -> MagicMock:
 
 
 def _make_kv(get_return=None, get_side_effect=None) -> MagicMock:
-    """Build a kv mock whose kv.get() returns *get_return* or raises *get_side_effect*.
-    """
+    """Build a kv mock: kv.get() returns *get_return* or raises *get_side_effect*."""
     kv = MagicMock()
     if get_side_effect is not None:
         kv.get = AsyncMock(side_effect=get_side_effect)
@@ -94,8 +93,7 @@ class TestSeedWatchChannels:
         assert result == frozenset()
 
     async def test_skips_non_int_channel_id_in_mixed_value(self) -> None:
-        """(c) entry value=b'["x",3]' → 'x' skipped, only 3 survives → frozenset({3}).
-        """
+        """(c) entry=b'["x",3]' → 'x' skipped, only 3 survives → frozenset({3})."""
         # Arrange
         entry = _make_entry(b'["x", 3]')
         kv = _make_kv(get_return=entry)

--- a/tests/infrastructure/turn_writer/test_writer.py
+++ b/tests/infrastructure/turn_writer/test_writer.py
@@ -31,7 +31,7 @@ import pytest
 
 from factory.infrastructure.stores.turn_store import TurnStore
 from factory.infrastructure.turn_writer.writer import TurnWriter
-from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.envelope import CONTRACT_VERSION, new_job_id
 from roxabi_contracts.turns import (
     EndSessionPayload,
     IncrementResumeCountPayload,
@@ -69,6 +69,7 @@ def _event(  # noqa: PLR0913
         trace_id=_TRACE_ID,
         issued_at=_now(),
         event_id=event_id or uuid4(),
+        job_id=new_job_id(),
         pool_id=pool_id,
         session_id=session_id,
         platform=platform,

--- a/tests/integration/test_crash_recovery.py
+++ b/tests/integration/test_crash_recovery.py
@@ -31,7 +31,7 @@ import pytest
 
 from factory.infrastructure.stores.turn_store import TurnStore
 from factory.infrastructure.turn_writer.writer import TurnWriter
-from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.envelope import CONTRACT_VERSION, new_job_id
 from roxabi_contracts.turns import (
     IncrementResumeCountPayload,
     StartSessionPayload,
@@ -89,6 +89,7 @@ def _event(  # noqa: PLR0913
         trace_id=_TRACE_ID,
         issued_at=_now(),
         event_id=event_id or uuid4(),
+        job_id=new_job_id(),
         pool_id=pool_id,
         session_id=session_id,
         platform=platform,

--- a/tests/nats/test_nats_add_identity_restart.py
+++ b/tests/nats/test_nats_add_identity_restart.py
@@ -107,19 +107,19 @@ def test_reload_runs_when_state_added() -> None:
     ), "podman secret create factory-nats-test-identity not called"
 
     # factory-nats-auth was removed (bind-mount now) — must NOT appear.
-    assert not any(
-        "factory-nats-auth" in line for line in podman_lines
-    ), "podman must NOT create factory-nats-auth (it is a bind-mount, not a secret)"
+    assert not any("factory-nats-auth" in line for line in podman_lines), (
+        "podman must NOT create factory-nats-auth (it is a bind-mount, not a secret)"
+    )
 
     # SIGHUP reload — not restart.
-    assert any(
-        "reload factory-nats" in line for line in systemctl_lines
-    ), "systemctl reload factory-nats not called"
+    assert any("reload factory-nats" in line for line in systemctl_lines), (
+        "systemctl reload factory-nats not called"
+    )
 
     # 0-fan-out invariant: no client services restarted (#1719 core point).
-    assert not any(
-        "restart " in line for line in systemctl_lines
-    ), "systemctl restart must NOT be called (0-fan-out contract)"
+    assert not any("restart " in line for line in systemctl_lines), (
+        "systemctl restart must NOT be called (0-fan-out contract)"
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -176,16 +176,16 @@ def test_reload_runs_when_noop_but_secret_missing() -> None:
     ), "podman secret create factory-nats-test-identity not called"
 
     # factory-nats-auth is a bind-mount — must NOT be created.
-    assert not any(
-        "factory-nats-auth" in line for line in podman_lines
-    ), "podman must NOT create factory-nats-auth (it is a bind-mount, not a secret)"
+    assert not any("factory-nats-auth" in line for line in podman_lines), (
+        "podman must NOT create factory-nats-auth (it is a bind-mount, not a secret)"
+    )
 
     # SIGHUP reload — not restart.
-    assert any(
-        "reload factory-nats" in line for line in systemctl_lines
-    ), "systemctl reload factory-nats not called"
+    assert any("reload factory-nats" in line for line in systemctl_lines), (
+        "systemctl reload factory-nats not called"
+    )
 
     # 0-fan-out invariant: no client services restarted.
-    assert not any(
-        "restart " in line for line in systemctl_lines
-    ), "systemctl restart must NOT be called (0-fan-out contract)"
+    assert not any("restart " in line for line in systemctl_lines), (
+        "systemctl restart must NOT be called (0-fan-out contract)"
+    )

--- a/tests/tools/test_emit_secrets_manifest.py
+++ b/tests/tools/test_emit_secrets_manifest.py
@@ -393,9 +393,7 @@ class TestOwnerFactoryFilter:
             "QUADLET_TOML": str(work / "deploy" / "quadlet.toml"),
             "POLICY_TOML": str(work / "deploy" / "secrets-policy.toml"),
             "QUADLET_DIR": str(work / "deploy" / "quadlet"),
-            "MANIFEST_SH": str(
-                work / "deploy" / "generated" / "secrets-manifest.sh"
-            ),
+            "MANIFEST_SH": str(work / "deploy" / "generated" / "secrets-manifest.sh"),
             "ACL_MATRIX": str(work / "deploy" / "nats" / "acl-matrix.json"),
         }
 


### PR DESCRIPTION
## Summary

- Add `WorkEnvelope(ContractEnvelope)` with `job_id` (TRANSITIONAL `default_factory`) and `parent_job_id`; export `new_job_id()` from top-level `roxabi_contracts`
- Reparent 13 WORK models to `WorkEnvelope`: `JobEnvelope/Result/Progress`, `LlmRequest/ChunkEvent/Response`, `Tts/SttRequest/Response`, `ImageRequest/Response`, `TurnWriteEvent`
- Leave 9 INFRA models on `ContractEnvelope` by design; defer 4 CLI models to #1838
- Wire 5 producers to pass `job_id=new_job_id()` explicitly: `cli_nats_codec`, `turn_publisher` (×5), `nats_image_codec`, `nats_stt_codec`, `nats_tts_codec`
- Add enforcement tests locking WORK/INFRA/PENDING classification (30 tests in `test_work_envelope_subjects.py`)
- Bump `roxabi-contracts` `0.7.0` → `0.9.0`; CHANGELOG entry added

## TRANSITIONAL notes

`job_id` carries `default_factory=new_job_id` so pre-#1619 wire messages without the field still deserialize. Flip to hard-required tracked in **#1841**.

CLI models (`CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`, `CliControlAck`) remain on `ContractEnvelope` (PENDING) — reparent deferred to **#1838**.

⚠ merge AFTER #1782

Closes #1619

## Test plan

- [ ] `uv run --frozen pytest packages/roxabi-contracts/` — all 30 enforcement tests + existing envelope tests pass
- [ ] `uv run --frozen pytest` (full repo) — no regressions
- [ ] `uv run --frozen ruff check .` — clean
- [ ] `uv run --frozen ruff format --check .` — clean
- [ ] Pre-push gates: `test_sleep`, `debt_expiry`, `doc_drift`, `architecture_snapshot`, `import_layers`, `file_exemptions`, `hardcoded_constants` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>