### PR TITLE
feat(contracts): unify jobs taxonomy — factory.job.<id>.* (retire results/progress siblings) (#1793)

### DIFF
--- a/docs/architecture/messaging.md
+++ b/docs/architecture/messaging.md
@@ -125,7 +125,7 @@ NATS type (Core vs JetStream), the durability contract, and the keying shape:
 **Distinguish from sibling subjects** — these are NOT typing-plane members despite the
 surface resemblance:
 
-- `factory.progress.<job_id>` (#1044, future) — job-internal progress, keyed on `job_id`, not on
+- `factory.job.<job_id>.progress` (#1044, #1793) — job-internal progress, keyed on `job_id`, not on
   `WorkScope`.
 - `factory.clipool.heartbeat` and the `*.heartbeat` family — internal liveness, control-plane.
 - `$KV.factory-state.hub.ready` — persistent flag in JetStream KV, watched by adapters.

--- a/packages/roxabi-contracts/CHANGELOG.md
+++ b/packages/roxabi-contracts/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.10.0] (2026-06-11)
+
+### Features
+
+* **contracts/jobs:** unify jobs subject taxonomy — rename `factory.results.<job_id>` → `factory.job.<job_id>.result` and `factory.progress.<job_id>` → `factory.job.<job_id>.progress` ([#1793](https://github.com/Roxabi/roxabi-factory/issues/1793)). Updates `jobs_result()` and `jobs_progress()` return values and docstrings.
+* **contracts/jobs:** add `jobs_steer()`, `jobs_opened()`, `jobs_closed()` subject helpers for the full `factory.job.<id>.*` subtree ([#1793](https://github.com/Roxabi/roxabi-factory/issues/1793)). Exposes `jobs_steer`, `jobs_opened`, `jobs_closed` from `roxabi_contracts.jobs`.
+* **contracts/jobs:** remove retired `_Subjects.result_prefix` and `_Subjects.progress_prefix` fields; add `_Subjects.job_prefix` (`"factory.job"`).
+
+### BREAKING CHANGES
+
+* `jobs_result(job_id)` and `jobs_progress(job_id)` return different subject strings. Any caller pinned to `factory.results.*` or `factory.progress.*` wire subjects must update to the new `factory.job.<id>.*` pattern. Confirmed 0 in-repo callers at time of release.
+
+
 ## [0.9.0] (2026-06-11)
 
 ### Features

--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -122,10 +122,13 @@ from roxabi_contracts.jobs import JobEnvelope, JobResult, JobProgress, jobs_subm
 | Subject | Model | Transport | Purpose |
 |---|---|---|---|
 | `factory.jobs.<job_name>` | `JobEnvelope` | JetStream durable | Submit a job |
-| `factory.results.<job_id>` | `JobResult` | Core NATS reply | Job completion reply |
-| `factory.progress.<job_id>` | `JobProgress` | Core NATS pub/sub | Streaming progress (best-effort) |
+| `factory.job.<job_id>.result` | `JobResult` | Core NATS reply | Job completion reply |
+| `factory.job.<job_id>.progress` | `JobProgress` | Core NATS pub/sub | Streaming progress (best-effort) |
+| `factory.job.<job_id>.steer` | — | Core NATS pub/sub | Runtime steering commands |
+| `factory.job.<job_id>.opened` | — | Core NATS pub/sub | Lifecycle open event |
+| `factory.job.<job_id>.closed` | — | Core NATS pub/sub | Lifecycle close event |
 
-Subject strings are produced by the helpers `jobs_submit(job_name)`, `jobs_result(job_id)`, and `jobs_progress(job_id)`. Each helper validates its argument via `validate_job_token` (rejects empty strings and NATS wildcard characters).
+Subject strings are produced by the helpers `jobs_submit(job_name)`, `jobs_result(job_id)`, `jobs_progress(job_id)`, `jobs_steer(job_id)`, `jobs_opened(job_id)`, and `jobs_closed(job_id)`. Each helper validates its argument via `validate_job_token` (rejects empty strings and NATS wildcard characters).
 
 ### Models
 

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-contracts"
-version = "0.9.0"
+version = "0.10.0"
 description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/__init__.py
@@ -8,8 +8,11 @@ fixtures submodule is test-only — import explicitly as
 from roxabi_contracts.jobs.models import JobEnvelope, JobProgress, JobResult
 from roxabi_contracts.jobs.subjects import (
     SUBJECTS,
+    jobs_closed,
+    jobs_opened,
     jobs_progress,
     jobs_result,
+    jobs_steer,
     jobs_submit,
 )
 
@@ -18,7 +21,10 @@ __all__ = [
     "JobProgress",
     "JobResult",
     "SUBJECTS",
+    "jobs_closed",
+    "jobs_opened",
     "jobs_progress",
     "jobs_result",
+    "jobs_steer",
     "jobs_submit",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -69,7 +69,7 @@ class JobResult(WorkEnvelope):
 
 
 class JobProgress(WorkEnvelope):
-    """Job progress event. Published to factory.progress.<job_id> (best-effort).
+    """Job progress event. Published to factory.job.<job_id>.progress (best-effort).
 
     ``job_id`` inherited from ``WorkEnvelope`` (ADR-084).
     """

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/subjects.py
@@ -10,6 +10,9 @@ __all__ = [
     "jobs_submit",
     "jobs_result",
     "jobs_progress",
+    "jobs_steer",
+    "jobs_opened",
+    "jobs_closed",
 ]
 
 
@@ -24,8 +27,7 @@ class _Subjects:
     """
 
     submit_prefix: Literal["factory.jobs"] = "factory.jobs"
-    result_prefix: Literal["factory.results"] = "factory.results"
-    progress_prefix: Literal["factory.progress"] = "factory.progress"
+    job_prefix: Literal["factory.job"] = "factory.job"
 
 
 SUBJECTS = _Subjects()
@@ -38,12 +40,30 @@ def jobs_submit(job_name: str) -> str:
 
 
 def jobs_result(job_id: str) -> str:
-    """Result subject: factory.results.<job_id>."""
+    """Result subject: factory.job.<job_id>.result."""
     validate_job_token(job_id)
-    return f"factory.results.{job_id}"
+    return f"factory.job.{job_id}.result"
 
 
 def jobs_progress(job_id: str) -> str:
-    """Progress subject: factory.progress.<job_id>."""
+    """Progress subject: factory.job.<job_id>.progress."""
     validate_job_token(job_id)
-    return f"factory.progress.{job_id}"
+    return f"factory.job.{job_id}.progress"
+
+
+def jobs_steer(job_id: str) -> str:
+    """Steer subject: factory.job.<job_id>.steer."""
+    validate_job_token(job_id)
+    return f"factory.job.{job_id}.steer"
+
+
+def jobs_opened(job_id: str) -> str:
+    """Lifecycle open event subject: factory.job.<job_id>.opened."""
+    validate_job_token(job_id)
+    return f"factory.job.{job_id}.opened"
+
+
+def jobs_closed(job_id: str) -> str:
+    """Lifecycle close event subject: factory.job.<job_id>.closed."""
+    validate_job_token(job_id)
+    return f"factory.job.{job_id}.closed"

--- a/packages/roxabi-contracts/tests/test_jobs_models.py
+++ b/packages/roxabi-contracts/tests/test_jobs_models.py
@@ -17,8 +17,11 @@ from roxabi_contracts.jobs import (
     JobEnvelope,
     JobProgress,
     JobResult,
+    jobs_closed,
+    jobs_opened,
     jobs_progress,
     jobs_result,
+    jobs_steer,
     jobs_submit,
 )
 from roxabi_contracts.jobs.fixtures import (
@@ -249,13 +252,28 @@ def test_subjects_jobs_submit() -> None:
 
 
 def test_subjects_jobs_result() -> None:
-    """jobs_result produces factory.results.<job_id>."""
-    assert jobs_result("job-uuid-1234") == "factory.results.job-uuid-1234"
+    """jobs_result produces factory.job.<job_id>.result."""
+    assert jobs_result("job-uuid-1234") == "factory.job.job-uuid-1234.result"
 
 
 def test_subjects_jobs_progress() -> None:
-    """jobs_progress produces factory.progress.<job_id>."""
-    assert jobs_progress("job-uuid-1234") == "factory.progress.job-uuid-1234"
+    """jobs_progress produces factory.job.<job_id>.progress."""
+    assert jobs_progress("job-uuid-1234") == "factory.job.job-uuid-1234.progress"
+
+
+def test_subjects_jobs_steer() -> None:
+    """jobs_steer produces factory.job.<job_id>.steer."""
+    assert jobs_steer("job-uuid-1234") == "factory.job.job-uuid-1234.steer"
+
+
+def test_subjects_jobs_opened() -> None:
+    """jobs_opened produces factory.job.<job_id>.opened."""
+    assert jobs_opened("job-uuid-1234") == "factory.job.job-uuid-1234.opened"
+
+
+def test_subjects_jobs_closed() -> None:
+    """jobs_closed produces factory.job.<job_id>.closed."""
+    assert jobs_closed("job-uuid-1234") == "factory.job.job-uuid-1234.closed"
 
 
 def test_job_envelope_accepts_inbox_reply_to() -> None:
@@ -278,6 +296,15 @@ def test_job_envelope_accepts_inbox_reply_to() -> None:
         pytest.param(jobs_progress, "bad*token", id="progress-asterisk"),
         pytest.param(jobs_progress, "bad>token", id="progress-greater-than"),
         pytest.param(jobs_progress, "", id="progress-empty-string"),
+        pytest.param(jobs_steer, "bad*token", id="steer-asterisk"),
+        pytest.param(jobs_steer, "bad>token", id="steer-greater-than"),
+        pytest.param(jobs_steer, "", id="steer-empty-string"),
+        pytest.param(jobs_opened, "bad*token", id="opened-asterisk"),
+        pytest.param(jobs_opened, "bad>token", id="opened-greater-than"),
+        pytest.param(jobs_opened, "", id="opened-empty-string"),
+        pytest.param(jobs_closed, "bad*token", id="closed-asterisk"),
+        pytest.param(jobs_closed, "bad>token", id="closed-greater-than"),
+        pytest.param(jobs_closed, "", id="closed-empty-string"),
         pytest.param(jobs_submit, ".leading-dot", id="submit-leading-dot"),
         pytest.param(jobs_submit, "a..b", id="submit-consecutive-dots"),
         pytest.param(jobs_submit, "trailing.", id="submit-trailing-dot"),


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| `subjects.py` | Removed `result_prefix`/`progress_prefix` fields; added `job_prefix: Literal["factory.job"]`; renamed return values of `jobs_result()`/`jobs_progress()` to `factory.job.<id>.result/.progress`; added `jobs_steer()`, `jobs_opened()`, `jobs_closed()` helpers |
| `models.py` | Updated `JobProgress` docstring to reference new `factory.job.<job_id>.progress` subject |
| `jobs/__init__.py` | Re-exports all five helpers in `__all__` |
| `README.md` | Subject table updated with new subjects + new facet rows |
| `CHANGELOG.md` | New `## [0.10.0]` entry documenting rename + new helpers |
| `pyproject.toml` | Version bumped `0.9.0 → 0.10.0` |
| `docs/architecture/messaging.md` | Line 128 updated to `factory.job.<job_id>.progress (#1044, #1793)` |
| ACL matrix | **Not touched** — ACL grants for `factory.job.*.*` are #1812's responsibility |

## Quality Gates

| Gate | Result |
|---|---|
| `ruff format --check` (contracts) | PASS |
| `ruff check` (contracts) | PASS |
| `pyright` (changed files) | 0 errors, 0 warnings |
| `pytest packages/roxabi-contracts/` | 446 passed |
| `check_test_sleep.sh` | PASS |
| `check_debt_expiry.sh` | PASS |
| `check_doc_drift.py` | PASS (0 violations) |
| `check_architecture_snapshot.sh` | PASS (no drift) |
| `check_str_exc_bus_bound.sh` | PASS |
| `lint-imports` | 11 kept, 0 broken |
| `check_hardcoded_constants.sh` | PASS |
| `check_duplicate_test_basenames.sh` | PASS |
| SC1 grep `factory.results` in `.py` | PASS (0 hits) |
| SC2 grep `factory.progress` in `.py` | PASS (0 hits) |

Note: `ruff format --check .` (full tree) reports 1 pre-existing violation in `tests/bootstrap/test_bootstrap_lifecycle.py` (not touched by this branch, same failure on `staging` base). Scoped check on all changed files passes cleanly.

Pyright pre-existing errors in `tests/test_work_envelope_subjects.py` (`__name__` on untyped pytest params) are baseline failures on `staging`; unchanged file, not introduced by this branch.

## Notes

- No alias layer added per spec §Expected Behavior point 5 (Strategy B: canonical names unchanged, return values change only).
- ADR-076 archive lines 114/185/272 and `job-model.md` lines 110–111 intentionally NOT updated — historical migration records, excluded from SC1/SC2 (spec Out-of-Scope).
- This PR is a hard prerequisite for #1812 (OmpWorker).

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)