### PR TITLE
ci: replace shared org PAT with roxabi-ci GitHub App tokens

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,13 +32,22 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reviewed')
     timeout-minutes: 5
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
   update-behind-prs:
@@ -47,6 +56,15 @@ jobs:
     if: github.event_name == 'push'
     timeout-minutes: 5
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -66,7 +84,7 @@ jobs:
               --method PUT -f expected_head_sha="$SHA" || true
           done
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
 
   close-linked-issues:
     name: Close linked issues

--- a/.github/workflows/contracts-bump.yml
+++ b/.github/workflows/contracts-bump.yml
@@ -43,6 +43,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       # Step 1: Checkout the satellite repo at staging.
       # Uses explicit repository: input to handle both workflow_call (satellite context)
       # and workflow_dispatch (factory context where github.repository = roxabi-factory).
@@ -51,7 +60,7 @@ jobs:
         with:
           repository: ${{ inputs.satellite_repo }}
           ref: staging
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app.outputs.token }}
           fetch-depth: 0
 
       # Step 2: Capture OLD_CONTRACTS_SHA from uv.lock BEFORE any upgrade runs.
@@ -173,7 +182,7 @@ jobs:
             echo "wire_breaking=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           OLD_CONTRACTS_SHA: ${{ steps.old-sha.outputs.old_sha }}
 
       # Step 6: Idempotency — skip if a bump PR is already open for this satellite this week.
@@ -196,7 +205,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           SATELLITE_REPO: ${{ inputs.satellite_repo }}
 
       # Step 7: Compute branch name, gather factory changelog, create branch + commit + PR.
@@ -288,7 +297,7 @@ jobs:
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           echo "Created PR: ${PR_URL}"
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           SATELLITE_REPO_INPUT: ${{ inputs.satellite_repo }}
           OLD_CONTRACTS_SHA: ${{ steps.old-sha.outputs.old_sha }}
           NEW_CONTRACTS_SHA: ${{ steps.wire-guard.outputs.new_sha }}
@@ -316,6 +325,6 @@ jobs:
             || echo "::warning::Failed to apply label '${LABEL}' to ${PR_URL} — ensure D3 labels exist in the satellite repo."
           echo "Applied label '${LABEL}' to ${PR_URL}"
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_URL_INPUT: ${{ steps.create-pr.outputs.pr_url }}
           WIRE_BREAKING: ${{ steps.wire-guard.outputs.wire_breaking }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -27,6 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - name: Fetch dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2.5.0
@@ -39,5 +48,5 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr edit "$PR_URL" --add-label reviewed
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
+      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
+      - name: Mint app token (roxabi-ci)
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.ROXABI_CI_APP_ID }}
+          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace the long-lived org-wide `secrets.PAT` with ephemeral installation tokens minted by the `roxabi-ci` GitHub App (`actions/create-github-app-token` v3.2.0, SHA-pinned). Org-wide migration wave — pilot validated on Roxabi/roxabi-plugins#284.
- Covers auto-merge, contracts-bump, dependabot-automerge (org Dependabot secret already set) and release-please.

## Test Plan
- [ ] CI green (workflow YAML only)
- [ ] Auto-merge enabled by `roxabi-ci[bot]` after the `reviewed` label (validates the mint in this repo)

---
Generated with [Claude Code](https://claude.com/claude-code)