### PR TITLE
ci(contracts-bump): make workflow_call PAT secret optional

### DIFF
--- a/.github/workflows/contracts-bump.yml
+++ b/.github/workflows/contracts-bump.yml
@@ -20,7 +20,9 @@ on:
         type: string
     secrets:
       PAT:
-        required: true
+        # DEPRECATED — unused since the roxabi-ci App migration (#1850). Kept optional
+        # until callers stop passing it (llmCLI#119), then removed entirely (#1852).
+        required: false
   workflow_dispatch:
     inputs:
       satellite_repo:


### PR DESCRIPTION
## Summary
- `on.workflow_call.secrets.PAT` → `required: false` (declaration kept, marked DEPRECATED).
- Step 1 of #1852: the reusable workflow stopped using the PAT internally in #1850 (roxabi-ci App token); the caller llmCLI still passes it, so the interface must become optional **before** llmCLI drops it (Roxabi/llmCLI#119) and before the org PAT secret is deleted.

## Sequence
1. **this PR** — PAT optional (zero-risk, backward compatible)
2. Roxabi/llmCLI#119 — caller stops passing `secrets: PAT`
3. follow-up — remove the declaration + scrub `docs/ops/contracts-bump-callers.md` templates → closes #1852

Part of #1852

---
Generated with [Claude Code](https://claude.com/claude-code)