### PR TITLE
ci(contracts-bump): remove deprecated workflow_call PAT declaration

### DIFF
--- a/.github/workflows/contracts-bump.yml
+++ b/.github/workflows/contracts-bump.yml
@@ -18,11 +18,6 @@ on:
         description: "Space-separated packages to upgrade (e.g. 'roxabi-contracts roxabi-nats')"
         required: true
         type: string
-    secrets:
-      PAT:
-        # DEPRECATED — unused since the roxabi-ci App migration (#1850). Kept optional
-        # until callers stop passing it (llmCLI#119), then removed entirely (#1852).
-        required: false
   workflow_dispatch:
     inputs:
       satellite_repo:

--- a/docs/ops/contracts-bump-callers.md
+++ b/docs/ops/contracts-bump-callers.md
@@ -40,8 +40,6 @@ jobs:
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats"
-    secrets:
-      PAT: ${{ secrets.PAT }}
 ```
 
 ### `Roxabi/voiceCLI`
@@ -63,8 +61,6 @@ jobs:
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats roxabi-blobs"
-    secrets:
-      PAT: ${{ secrets.PAT }}
 ```
 
 > Note: voiceCLI CI runs `uv sync --dev --extra all` (no `--frozen`), unlike llmCLI/imageCLI
@@ -90,8 +86,6 @@ jobs:
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats roxabi-blobs"
-    secrets:
-      PAT: ${{ secrets.PAT }}
 ```
 
 ---
@@ -103,7 +97,7 @@ For each satellite repo, verify the following before merging the caller workflow
 - [ ] `wire-breaking` label exists in the satellite repo (check `gh label list --repo Roxabi/<sat>`)
 - [ ] `reviewed` label exists in the satellite repo
 - [ ] `auto-merge.yml` workflow exists in the satellite repo and triggers on `reviewed` label
-- [ ] `secrets.PAT` is set in the satellite repo's Actions secrets (repo scope, covering `Roxabi/roxabi-factory`)
+- [ ] org variable `ROXABI_CI_APP_ID` + org secret `ROXABI_CI_APP_PRIVATE_KEY` are visible to the satellite repo (org visibility: all — private repos need repo-level copies, GitHub Free does not propagate org secrets to private repos)
 - [ ] `staging` branch exists and is the default branch in the satellite repo
 
 ---


### PR DESCRIPTION
## Summary
- Remove the now-unused `on.workflow_call.secrets.PAT` declaration (optional since #1855, internal usage migrated in #1850).
- Scrub the 3 caller templates in `docs/ops/contracts-bump-callers.md` + replace the PAT prerequisite with the roxabi-ci App org var/secret visibility check.
- Final step of #1852 — after this + the caller PRs (Roxabi/llmCLI#120 ✅, Roxabi/voiceCLI#196, Roxabi/imageCLI#112), nothing in the org references `secrets.PAT` at runtime → org PAT revocable.

⚠️ **Merge order**: only after voiceCLI#196 + imageCLI#112 — auto-merge armed once they land.

Fixes #1852

---
Generated with [Claude Code](https://claude.com/claude-code)