### PR TITLE
feat(cli): session lifecycle cleanup + WorkEnvelope reparent — single cli minor bump (#1009, #1838)

### DIFF
--- a/artifacts/frames/1009-cli-session-lifecycle-frame.mdx
+++ b/artifacts/frames/1009-cli-session-lifecycle-frame.mdx
@@ -1,0 +1,168 @@
+---
+title: "Frame: feat(cli) session lifecycle cleanup + WorkEnvelope reparent"
+issues: ["#1009", "#1838"]
+tier: F-lite
+version_target: "roxabi-contracts 0.10.0"
+created: 2026-06-11
+status: approved
+---
+
+# Frame — cli session lifecycle cleanup + WorkEnvelope reparent
+
+**Closes:** #1009 + #1838 · **Tier:** F-lite · **Branch/PR:** single cli minor bump
+
+---
+
+## Problem
+
+Four cli contract models (`CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`,
+`CliControlAck`) are classified PENDING in `test_work_envelope_subjects.py` (#1619
+coordination): they still inherit `ContractEnvelope` instead of `WorkEnvelope`.
+This blocks the `job_id` invariant enforcement on the cli plane.
+
+Simultaneously, the cli control surface carries two hygiene issues from #1009:
+
+1. `CliControlCmd.session_id` is ambiguously named — it holds the Claude CLI resume
+   token (`cli_session_id`), colliding visually with `CliCmdPayload.lyra_session_id`
+   (conversation identity ≈ pool_id). ADR-084 §id-taxonomy names both explicitly;
+   the wire name has not yet been aligned.
+2. `resume_and_reset` is a dead control op: the op literal exists in `CliControlCmd`,
+   a handler branch exists in `clipool_worker.py`, and methods exist in `llm_client.py`
+   and `cli_pool.py` / `cli_pool_session.py` — but no caller invokes the path.
+   Removing it simplifies the op surface to `reset | switch_cwd`.
+3. Resume outcome is not logged after `resume_direct()` completes — there is no
+   confirmation trace when the worker successfully restores a session.
+4. `_lyra_sessions` dict is duplicated: `LlmClient` (NATS path, `llm_client.py:62`)
+   and `CliPoolSessionMixin` (local path, `cli_pool_session.py`) both own independent
+   maps. For the NATS path, `LlmClient` should be the single owner; the mixin copy is
+   redundant on that path.
+5. ADR-084 table (§Decision) lists 3 cli models (CliControlCmd, CliCmdPayload,
+   CliHeartbeat); it is missing `CliChunkEvent` and `CliControlAck`. The doc gap
+   means the doc_drift gate will fire on `CliChunkEvent`/`CliControlAck` subjects
+   unless the table is extended before reparenting.
+
+Because both #1009 (rename + op removal) and #1838 (reparent) are breaking `cli`
+minor bumps, ADR-084 mandates co-landing them in a single bump to avoid two
+satellite-coordination events.
+
+---
+
+## Who
+
+- **Primary domain:** `roxabi-contracts` (cli models), `factory.llm` (llm_client),
+  `factory.core.cli` (cli_pool, cli_pool_session), `factory.adapters.clipool` (clipool_worker)
+- **Test surfaces:** `packages/roxabi-contracts/tests/test_work_envelope_subjects.py`
+- **Doc surfaces:** `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx`
+- **Version surfaces:** `packages/roxabi-contracts/CHANGELOG.md`,
+  `packages/roxabi-contracts/pyproject.toml`
+- **No satellites involved:** `factory.clipool.{cmd,control,heartbeat}` are pure
+  NATS request-reply — no JetStream stream, no lock-pinned satellite consumer on cli
+  models. Only the hub (LlmClient) and the clipool worker communicate on these subjects.
+
+---
+
+## Constraints
+
+### Wire-compat (non-negotiable)
+
+- `WorkEnvelope.job_id` carries a `default_factory` shim (transitional, CONTRACT_VERSION
+  stays `"1"`). Do NOT remove the shim — hard-require is tracked in #1841.
+- The 4 cli models move to `WorkEnvelope` via reparent. No alias-field shim needed
+  (request-reply: hub sends → worker responds in the same request; no JetStream replay
+  risk; brief container skew window on M1 staging merge is acceptable for short-lived ops).
+
+### Id taxonomy — critical naming invariant
+
+`CliCmdPayload.lyra_session_id` is the **conversation identity** (≈ pool_id, Langfuse
+session). It MUST NOT be renamed. Only `CliControlCmd.session_id` is renamed to
+`cli_session_id`. ADR-084 lines 75–76 document both fields explicitly.
+
+`CliChunkEvent` also has a `session_id: str | None = None` field — this is the Claude
+CLI session token returned in stream events. It is on a different model from
+`CliControlCmd` and its name is unambiguous in context; it does NOT require renaming.
+
+### Test count assertions (atomic update)
+
+`test_work_envelope_subjects.py` lines 124/126/129 assert:
+- `WORK == 13`, `PENDING == 4`, `ALL == 26`
+
+After #1838 these become:
+- `WORK == 17`, `PENDING == 0`, `ALL == 26`
+
+The PENDING_MODELS set and the parametrize in
+`test_non_work_model_not_subclass_of_work_envelope` (currently `INFRA_MODELS | PENDING_MODELS`)
+must all be updated atomically with the model reparent — partial update breaks CI.
+
+### ADR-084 doc_drift gate
+
+`tools/check_doc_drift.py` enforces that all NATS subject constants referenced in
+`docs/architecture/` have actual src/ matches. `CliChunkEvent` and `CliControlAck` are
+not yet in the ADR-084 table. The table must be extended to 5 rows before the models
+are promoted to WORK (otherwise doc_drift fires on the new WORK subjects).
+
+### #1793 landing-order
+
+Issue #1793 is a jobs minor bump that also writes `packages/roxabi-contracts/CHANGELOG.md`
+and `pyproject.toml`. This PR (cli bump → 0.10.0) must land on top of #1793 or rebase
+on staging after #1793 merges. The version in this PR's pyproject.toml must be 0.10.0
+regardless of where #1793 lands relative to main version.
+
+### Quality gates
+
+- `file_length`: 300 SLOC max on `src/**/*.py` (check `llm_client.py` and
+  `cli_pool_session.py` after edits; exemptions in `tools/file_exemptions.txt`).
+- `str_exc_bus_bound`: `str(exc)` / `f"{exc}"` / `repr(exc)` may NOT flow into
+  `SanitizedError` construction or NATS-bus-bound message fields (ADR-073).
+- `architecture_snapshot`: stage:pre-push; run `tools/check_architecture_snapshot.sh`
+  manually before push (not enforced by `/validate`).
+
+---
+
+## Out of Scope
+
+| Deferred | Tracked |
+|---|---|
+| Hard-require `job_id` (remove `default_factory` shim) | #1841 |
+| Satellite contracts-bump rollout (voiceCLI, imageCLI, roxabi-vault lock bump) | #1840 |
+| Root `job_id` mint at inbound adapters | #1620 |
+| `lyra-data` named volume for clipool private store | separate |
+| `parent_job_id` / `composite_depth` usage on cli path | #1622 epic |
+| Typing-plane reclassification (#1624) | #1624 |
+
+---
+
+## Premise Validity
+
+| Premise | Evidence | Source | Confidence | Failure condition |
+|---|---|---|---|---|
+| All 4 PENDING models currently inherit `ContractEnvelope` | `class CliCmdPayload(ContractEnvelope)` etc. confirmed | `packages/roxabi-contracts/src/roxabi_contracts/cli/models.py` lines 1–71 | High | If any already inherits WorkEnvelope, reparent that model is a no-op — adjust PENDING_MODELS set only |
+| `CliControlCmd.session_id` is the only field requiring rename | `CliCmdPayload.lyra_session_id` is conversation identity (≠ cli session); `CliChunkEvent.session_id` is unambiguous stream-event field | ADR-084 lines 75–76; models.py confirmed | High | If CliChunkEvent.session_id causes confusion in worker dispatch, re-evaluate — but currently no rename needed |
+| `resume_and_reset` has no active callers | No production call sites in hub, agent, or inbound | `src/factory/llm/llm_client.py:160`, `src/factory/core/cli/cli_pool.py:155`, `src/factory/llm/drivers/cli.py:37` — method exists, no callers found | High | `grep -r "resume_and_reset" src/` — if callers appear, removal must be preceded by a deprecation cycle |
+| cli subjects are pure request-reply (no JetStream replay) | `factory.clipool.cmd/control/heartbeat` = NATS req-reply; confirmed in adapters/CLAUDE.md | adapters/CLAUDE.md clipool section | High | If a future PR adds a JetStream stream on cli subjects before this lands, re-evaluate alias-field shim |
+| `_lyra_sessions` local-path dict is redundant for NATS path | LlmClient owns `_lyra_sessions: dict[str, str]` at llm_client.py:62; CliPoolSessionMixin owns separate copy at cli_pool_session.py | llm_client.py:62, cli_pool_session.py:26 | Medium | If `ClaudeCliDriver` (single-process path) relies on mixin dict independently of LlmClient, unification scope narrows to NATS path only — mixin dict retained for local path |
+| #1793 is the only in-flight PR writing roxabi-contracts version files | Current `artifacts/analyses/backlog-review-2026-06-10.md` notes #1793 as open | Repo backlog | Medium | Check `gh pr list --state open` targeting `packages/roxabi-contracts/` before writing version — rebase if needed |
+
+---
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (cli contracts + clipool worker), no new
+architecture, no unknowns after code review.
+
+Estimated file surface (~11 files):
+
+| File | Change |
+|---|---|
+| `packages/roxabi-contracts/src/roxabi_contracts/cli/models.py` | Reparent 4 models: `ContractEnvelope` → `WorkEnvelope`; rename `CliControlCmd.session_id` → `cli_session_id`; remove `resume_and_reset` from op Literal |
+| `packages/roxabi-contracts/tests/test_work_envelope_subjects.py` | Move 4 models from PENDING_MODELS → WORK_MODELS; update count assertions (13→17, 4→0); narrow parametrize to `INFRA_MODELS` only |
+| `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` | Extend Decision table from 3 rows to 5 rows (add CliChunkEvent, CliControlAck) |
+| `src/factory/llm/llm_client.py` | Remove `resume_and_reset` method; rename `session_id=` kwarg to `cli_session_id=` in CliControlCmd construction sites; update `set_turn_store` docstring |
+| `src/factory/core/cli/cli_pool.py` | Remove `resume_and_reset` method |
+| `src/factory/core/cli/cli_pool_session.py` | Evaluate/remove `_lyra_sessions` dict if NATS-path unification confirmed; add resume outcome log in `_persist_cli_session` or `resume_direct` callsite |
+| `src/factory/llm/drivers/cli.py` | Remove `resume_and_reset` delegation |
+| `src/factory/adapters/clipool/clipool_worker.py` | Remove `resume_and_reset` handler branch; rename `cmd.session_id` → `cmd.cli_session_id` in control dispatch |
+| `packages/roxabi-contracts/CHANGELOG.md` | Document 0.10.0 breaking changes: rename + op removal + reparent |
+| `packages/roxabi-contracts/pyproject.toml` | Bump version 0.9.0 → 0.10.0 |
+| `packages/roxabi-contracts/src/roxabi_contracts/cli/__init__.py` | Re-export if needed after reparent (verify existing re-exports unchanged) |
+
+No new architecture. No new ADR. ADR-084 requires only a table amendment (2 rows).

--- a/artifacts/specs/1009-cli-session-lifecycle-spec.mdx
+++ b/artifacts/specs/1009-cli-session-lifecycle-spec.mdx
@@ -1,0 +1,586 @@
+---
+title: "Spec: feat(cli) session lifecycle cleanup + WorkEnvelope reparent"
+issues: ["#1009", "#1838"]
+tier: F-lite
+version_target: "roxabi-contracts next-minor above staging post-#1793 (0.11.0 if #1793 ships 0.10.0)"
+created: 2026-06-11
+status: approved
+---
+
+# Spec — cli session lifecycle cleanup + WorkEnvelope reparent
+
+**Closes:** #1009 + #1838 · **Tier:** F-lite · **Target version:** rule — next minor above staging HEAD at rebase time (this lane merges AFTER #1793; if #1793 ships 0.10.0, this is 0.11.0)
+
+---
+
+## Context
+
+Four cli contract models (`CliCmdPayload`, `CliControlCmd`, `CliChunkEvent`,
+`CliControlAck`) are classified PENDING in `test_work_envelope_subjects.py`
+because they still inherit `ContractEnvelope` instead of `WorkEnvelope`. This
+blocks `job_id` invariant enforcement on the cli plane (Batch #2 of #1619
+coordination).
+
+Simultaneously, issue #1009 identified five hygiene defects on the cli control
+surface:
+
+1. `CliControlCmd.session_id` is ambiguously named — it holds the Claude CLI
+   resume token, visually colliding with `CliCmdPayload.lyra_session_id`
+   (conversation identity). ADR-084 §id-taxonomy names both explicitly; the
+   wire field name has not yet been aligned.
+2. `resume_and_reset` is a LIVE wire op that the issue intends to retire:
+   `pool.resume_session()` is called from four production hub paths
+   (`path_validation.py:88,140`, `pool_processor.py:51`,
+   `session_commands.py:110`) → `simple_agent._maybe_register_resume` lambdas →
+   `LlmClient.resume_and_reset` → wire op → functional worker branch
+   (`clipool_worker.py:349` → `resume_direct`). The issue's premise ("resume
+   embedded in the cmd payload via `resume_session_id`") refers to a DORMANT
+   contract field: `CliCmdPayload.resume_session_id` exists (`cli/models.py:28`)
+   but no producer sets it and the NATS worker never reads it. Retiring the op
+   therefore means WIRING the embedded mechanism, not deleting dead code.
+3. Resume outcome is not logged after `resume_direct()` completes.
+4. `_lyra_sessions` dict is duplicated between `LlmClient` (`llm_client.py:62`)
+   and `CliPoolSessionMixin` (`cli_pool_session.py`). On the NATS path,
+   `LlmClient` should be the single owner.
+5. ADR-084 Decision table lists 3 cli models (CliControlCmd, CliCmdPayload,
+   CliHeartbeat) but is missing `CliChunkEvent` and `CliControlAck`, causing
+   `doc_drift` CI to fire if the reparent lands without extending the table.
+
+Because #1009 (rename + op removal) and #1838 (reparent) are both breaking cli
+minor bumps, ADR-084 mandates co-landing them in a single bump to avoid two
+satellite-coordination events.
+
+---
+
+## Goal
+
+Deliver the cli-domain contracts minor (next minor above post-#1793 staging) by:
+- Reparenting 4 PENDING models to `WorkEnvelope`
+- Renaming `CliControlCmd.session_id` → `cli_session_id`
+- Retiring the `resume_and_reset` wire op: producers stop sending (resume rides
+  the dormant `CliCmdPayload.resume_session_id` field instead); consumer
+  tolerance retained one minor per contracts deprecation policy
+- Unifying `_lyra_sessions` ownership on the NATS path
+- Extending ADR-084 table (doc_drift gate) and emitting a resume outcome log
+
+**Out of scope (deferred):**
+- Full `CliPool._lyra_sessions` removal: AC item 3 of #1009 specifies unification
+  on the NATS path only; the local-path dict (`CliPoolSessionMixin._lyra_sessions`)
+  is retained as required by `_persist_cli_session`. Complete removal would require
+  refactoring the local path — deferred to a separate issue.
+- `#1838` AC item: "ensure all cli job producers pass an explicit `job_id`" —
+  this is tracked as a follow-up to the transitional `default_factory` shim
+  retirement (#1841) and is NOT in scope here.
+
+---
+
+## Users
+
+| User | Interaction |
+|---|---|
+| Agent pool (NATS path) | Sends `CliCmdPayload`, `CliControlCmd` via `LlmClient` |
+| `CliPoolNatsWorker` | Receives contracts, routes to `CliPool`; returns `CliChunkEvent`, `CliControlAck` |
+| `ClaudeCliDriver` (single-process) | Uses `CliPool` directly; not on NATS path |
+| CI / quality gates | `test_work_envelope_subjects.py`, `doc_drift`, `str_exc_bus_bound` |
+
+---
+
+## Expected Behavior
+
+### Wire-compat stance
+
+`factory.clipool.{cmd,control,heartbeat}` are pure NATS request-reply (no
+JetStream stream, no lock-pinned satellite consumer). But the op is LIVE and
+factory containers update non-atomically on the M1 auto-update tick, so an
+old hub can send `op="resume_and_reset"` / `session_id=` to a new worker for a
+brief window. Per the contracts deprecation policy (deprecated one minor before
+removal), this PR keeps CONSUMER tolerance:
+- `"resume_and_reset"` STAYS in the `op` Literal, marked deprecated (docstring
+  + CHANGELOG); the worker `_dispatch_control` branch is RETAINED functional.
+- `cli_session_id` accepts the old wire name via
+  `validation_alias=AliasChoices("cli_session_id", "session_id")`
+  (serialization uses the new name).
+- Producers stop sending the op NOW. Mechanical removal (Literal value, alias,
+  worker branch) = follow-up issue created at ship time (sibling under epic
+  #1044, blocked-by #1009).
+`WorkEnvelope.job_id` retains its `default_factory` shim (CONTRACT_VERSION
+stays `"1"`); hard-require is tracked in #1841.
+
+### Rename resolution
+
+Three distinct `session_id`-family fields exist across cli models:
+
+| Field | Model | Rename? | Reason |
+|---|---|---|---|
+| `lyra_session_id` | `CliCmdPayload` | No | Conversation identity; explicit per ADR-084 |
+| `session_id` | `CliControlCmd` | Yes → `cli_session_id` (+ one-minor `AliasChoices` tolerance for the old name) | Holds Claude CLI resume token; rename removes ambiguity |
+| `session_id` | `CliChunkEvent` | No | Claude CLI stream event field; unambiguous in context |
+
+### Live-op retirement — migration to embedded resume
+
+The resume flow MUST keep working end-to-end; only its transport changes.
+
+**Today (NATS path):** hub middleware (`path_validation.py:88,140`,
+`pool_processor.py:51`, `session_commands.py:110`) → `pool.resume_session(sid)`
+→ `_session_resume_fn` lambda (`simple_agent.py:192`) →
+`ClaudeCliNatsDriver.resume_and_reset` (`drivers/cli.py:37`) →
+`LlmClient.resume_and_reset` (turn-store lookup lyra→cli token, then wire op)
+→ worker `_dispatch_control` → `pool.resume_direct(pool_id, cli_sid)` (queues
+the token in `_resume_session_ids`, consumed at next spawn,
+`cli_pool_spawn.py:131`).
+
+**After (NATS path):** `LlmClient` keeps the turn-store lookup but, instead of
+sending the control op, stashes the token in a pending-resume slot
+(`self._pending_resume[pool_id] = cli_sid`) and returns `True` iff a token was
+resolved. The next `CliCmdPayload` build (`llm_client.py:89,115`) carries
+`resume_session_id=self._pending_resume.pop(pool_id, None)`. Worker-side, the
+CMD handler reads `payload.resume_session_id` and, when set, seeds the pool via
+the existing `pool.resume_direct(pool_id, cli_sid)` BEFORE dispatching the send
+— reusing the queue-for-next-spawn mechanism the control op used.
+
+**Semantics change (document in CHANGELOG):** the bool returned through
+`pool.resume_session()` becomes "token resolved & queued" (application deferred
+to next spawn) instead of "worker acknowledged resume". `CliControlAck.resumed`
+stays for compat but is no longer produced by this flow.
+
+**Local path:** behaviour unchanged — `CliPool.resume_and_reset`
+(`cli_pool.py:155`, lambda at `simple_agent.py:186`) already queues for next
+spawn in-process. Implementor MAY rename it (e.g. `queue_resume`) so the
+`resume_and_reset` token disappears from producer paths; behaviour must not
+change.
+
+**Consumer tolerance (one minor):** the op Literal keeps
+`"resume_and_reset"` (deprecated) and the worker control branch stays
+functional — see Wire-compat stance.
+
+### Session-dict unification (NATS path)
+
+`LlmClient._lyra_sessions` remains the single owner for the NATS path.
+`ClaudeCliDriver.link_lyra_session` delegates to `LlmClient` instead of
+`CliPool` when in NATS mode. `CliPoolSessionMixin._lyra_sessions` is retained
+for the local (single-process) path where `_persist_cli_session` uses it for
+`TurnPublisher` lookup — full removal would break the local path.
+
+### Resume outcome log
+
+After `resume_direct()` completes in `clipool_worker.py`, emit:
+`log.info("clipool: resume %s pool=%s", "ok" if resumed else "cold-start", pool_id)`.
+This matches AC item 5 verbatim (`log.info`, `"ok"/"cold-start"` tokens, pool_id last).
+Any exception path must use `type(exc).__name__`, never `str(exc)` or `f"{exc}"`
+(`str_exc_bus_bound` gate).
+
+---
+
+## Data Model & Consumers
+
+### Class diagram — before and after
+
+```mermaid
+classDiagram
+    class ContractEnvelope {
+        +contract_version: str
+        +trace_id: str
+        +issued_at: datetime
+    }
+    class WorkEnvelope {
+        +job_id: str  # default_factory=new_job_id TRANSITIONAL
+    }
+    ContractEnvelope <|-- WorkEnvelope
+
+    %% BEFORE (#1838 pending)
+    class CliCmdPayload_BEFORE["CliCmdPayload (BEFORE)"] {
+        +pool_id: str
+        +lyra_session_id: str
+        +text: str
+        +model_cfg: dict
+        +system_prompt: str
+        +resume_session_id: str|None
+        +stream: bool
+    }
+    ContractEnvelope <|-- CliCmdPayload_BEFORE
+
+    class CliControlCmd_BEFORE["CliControlCmd (BEFORE)"] {
+        +pool_id: str
+        +op: Literal[reset, resume_and_reset, switch_cwd]
+        +session_id: str|None
+        +cwd: str|None
+    }
+    ContractEnvelope <|-- CliControlCmd_BEFORE
+
+    class CliChunkEvent_BEFORE["CliChunkEvent (BEFORE)"] {
+        +pool_id: str
+        +event_type: Literal[...]
+        +session_id: str|None
+        +done: bool
+        +worker_error: WorkerError|None
+    }
+    ContractEnvelope <|-- CliChunkEvent_BEFORE
+
+    class CliControlAck_BEFORE["CliControlAck (BEFORE)"] {
+        +pool_id: str
+        +ok: bool
+        +resumed: bool|None
+    }
+    ContractEnvelope <|-- CliControlAck_BEFORE
+
+    %% AFTER (this PR)
+    class CliCmdPayload {
+        +pool_id: str
+        +lyra_session_id: str
+        +text: str
+        +model_cfg: dict
+        +system_prompt: str
+        +resume_session_id: str|None
+        +stream: bool
+        +job_id: str  # inherited
+    }
+    WorkEnvelope <|-- CliCmdPayload
+
+    class CliControlCmd {
+        +pool_id: str
+        +op: Literal[reset, switch_cwd, resume_and_reset DEPRECATED]
+        +cli_session_id: str|None  # validation alias: session_id (one minor)
+        +cwd: str|None
+        +job_id: str  # inherited
+    }
+    WorkEnvelope <|-- CliControlCmd
+
+    class CliChunkEvent {
+        +pool_id: str
+        +event_type: Literal[...]
+        +session_id: str|None
+        +done: bool
+        +worker_error: WorkerError|None
+        +job_id: str  # inherited
+    }
+    WorkEnvelope <|-- CliChunkEvent
+
+    class CliControlAck {
+        +pool_id: str
+        +ok: bool
+        +resumed: bool|None
+        +job_id: str  # inherited
+    }
+    WorkEnvelope <|-- CliControlAck
+
+    class CliHeartbeat {
+        +worker_id: str
+        +pool_count: int
+    }
+    ContractEnvelope <|-- CliHeartbeat
+```
+
+**Diagram note:** unchanged fields are omitted for readability — `CliCmdPayload`
+also preserves `agent_name: str|None` and `agent_email: str|None`
+(`cli/models.py:30-31`); no field other than `CliControlCmd.session_id` is
+renamed, none is removed.
+
+### Control-plane flow
+
+```mermaid
+flowchart LR
+    LlmClient -->|CliControlCmd op=reset| control[factory.clipool.control]
+    LlmClient -->|CliControlCmd op=switch_cwd| control
+    control --> CliPoolNatsWorker
+    CliPoolNatsWorker -->|CliControlAck ok=True/False| LlmClient
+
+    LlmClient -->|CliCmdPayload| cmd[factory.clipool.cmd]
+    cmd --> CliPoolNatsWorker
+    CliPoolNatsWorker -->|CliChunkEvent stream| LlmClient
+```
+
+**Note:** flowchart shows NATS path only. Local path: `ClaudeCliDriver` → `CliPool`
+(in-process; no NATS subjects involved).
+
+### Consumer table
+
+| Producer | Subject | Model(s) sent | Model(s) received |
+|---|---|---|---|
+| `LlmClient` | `factory.clipool.cmd` | `CliCmdPayload` (now carries `resume_session_id` when a resume is pending) | `CliChunkEvent` (stream) |
+| `LlmClient` | `factory.clipool.control` | `CliControlCmd` | `CliControlAck` |
+| `CliPoolNatsWorker` | `factory.clipool.heartbeat` | `CliHeartbeat` | — |
+| `LlmClient` (Consumer) | NATS internal | — | `CliHeartbeat` (subscribe) |
+
+**Note:** `CliHeartbeat` stays on `ContractEnvelope` (INFRA classification, no
+job identity). All 4 PENDING models move to WORK; INFRA count stays at 9.
+
+---
+
+## Breadboard
+
+### S1 affordances — contracts
+
+| Affordance | Where | Input | Output |
+|---|---|---|---|
+| Reparent `CliCmdPayload` | `cli/models.py` | Class def | `(WorkEnvelope)` base |
+| Reparent `CliChunkEvent` | `cli/models.py` | Class def | `(WorkEnvelope)` base |
+| Reparent `CliControlCmd` | `cli/models.py` | Class def | `(WorkEnvelope)` base + rename `session_id`→`cli_session_id` with `AliasChoices` tolerance + deprecation note on `resume_and_reset` op literal (value retained one minor) |
+| Reparent `CliControlAck` | `cli/models.py` | Class def | `(WorkEnvelope)` base |
+| PENDING→WORK set move | `test_work_envelope_subjects.py` | 4 models in `PENDING_MODELS` | Moved to `WORK_MODELS`; `PENDING_MODELS = set()` |
+| Count assertions | `test_work_envelope_subjects.py:124-129` | `WORK==13, PENDING==4` | `WORK==17, PENDING==0` |
+| Parametrize narrow | `test_work_envelope_subjects.py:151` | `INFRA_MODELS \| PENDING_MODELS` | `INFRA_MODELS` only |
+| Contract invariant test | new test in `test_work_envelope_subjects.py` | `CliCmdPayload(lyra_session_id=X, pool_id=Y)` | Assert `lyra_session_id != pool_id` |
+| ADR-084 table extension | `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` | 3-row cli table | 5-row table (add `CliChunkEvent` → WORK, `CliControlAck` → WORK) |
+
+**Wiring prose:** The 4 reparent edits and the test count/set updates must land
+atomically — a partial reparent breaks CI on the
+`test_non_work_model_not_subclass_of_work_envelope` parametrize. The ADR-084
+table extension must land BEFORE or ATOMICALLY with the reparent to prevent
+`doc_drift` CI from firing. Import of `WorkEnvelope` in `cli/models.py` comes
+from `roxabi_contracts.envelope` (same module as `ContractEnvelope`).
+
+### S2 affordances — src wiring (embedded-resume migration)
+
+| Affordance | Where | Input | Output |
+|---|---|---|---|
+| Pending-resume slot | `llm_client.py` | `resume_and_reset` body (turn-store lookup RETAINED, ~line 160) | Lookup result stashed in `self._pending_resume[pool_id]`; control-op send + `CliControlCmd(... session_id=cli_sid)` construction (~line 183) deleted; returns True iff token resolved |
+| Payload carries token | `llm_client.py:89,115` | `CliCmdPayload` builds | `+ resume_session_id=self._pending_resume.pop(pool_id, None)` |
+| Worker reads embedded token | `clipool_worker.py` CMD handler | `payload.resume_session_id` | When set: `await self._pool.resume_direct(pool_id, cli_sid)` BEFORE dispatching the send |
+| Producer purge | `src/factory/llm/drivers/cli.py:37`, `simple_agent.py` lambdas | `resume_and_reset` naming on producer paths | Renamed/rewired (behaviour preserved); no producer constructs `op="resume_and_reset"` |
+| Local-path method rename (optional) | `src/factory/core/cli/cli_pool.py:155` | `CliPool.resume_and_reset` | MAY rename (e.g. `queue_resume`); behaviour unchanged |
+| Worker control branch RETAINED | `clipool_worker.py` `_dispatch_control` | `if cmd.op == "resume_and_reset"` branch | Kept functional one minor; field access becomes `cmd.cli_session_id` (alias covers old-hub payloads) |
+| Update `set_turn_store` docstring | `llm_client.py:130` | `"...in resume_and_reset"` | net removal of the `resume_and_reset` mention |
+| Add resume outcome log | `clipool_worker.py` after `resume_direct()` (both control-branch and embedded paths) | completion point | `log.info("clipool: resume %s pool=%s", "ok" if resumed else "cold-start", pool_id)` |
+
+**Wiring prose:** The turn-store lyra→cli token lookup currently inside
+`LlmClient.resume_and_reset` is the part that SURVIVES — only the wire transport
+changes (control op → embedded field). The `switch_cwd` construction (~line 200)
+uses `cwd=str(cwd)` — no session field, no change. `pool.resume_session()`
+callers in hub middleware are untouched: the lambda chain still resolves and
+queues, it just no longer round-trips a control op. The `str_exc_bus_bound`
+gate: any exception in the resume path must use `type(exc).__name__`, never
+`str(exc)` or `f"{exc}"`.
+
+### S3 affordances — unification + docs + version bump
+
+| Affordance | Where | Input | Output |
+|---|---|---|---|
+| NATS-path session unification | `src/factory/core/cli/cli_pool_session.py` | `_lyra_sessions` dict usage on NATS path | `ClaudeCliDriver.link_lyra_session` delegates to `LlmClient`; mixin dict retained for local-path `_persist_cli_session` |
+| CHANGELOG entry | `packages/roxabi-contracts/CHANGELOG.md` | post-#1793 head entry | next-minor section: rename (+alias), op deprecation + embedded-resume migration, reparent (breaking, cli minor) |
+| Version bump | `packages/roxabi-contracts/pyproject.toml` | post-#1793 value | next minor above staging HEAD at rebase time |
+
+**Wiring prose:** The `_lyra_sessions` mixin dict in `CliPoolSessionMixin` is
+used by `_persist_cli_session` (line 46, `cli_pool_session.py`) to look up
+`lyra_session_id` for TurnPublisher routing. On the local (single-process)
+path, `ClaudeCliDriver` calls `pool.link_lyra_session(pool_id, lyra_session_id)`
+which writes into the mixin dict — this path does NOT go through `LlmClient`.
+Unification scope: only the NATS path call site (`simple_agent.py:226-228`)
+must delegate through `LlmClient.link_lyra_session`; the mixin dict is not
+removed. Landing order: rebase on top of #1793 (jobs minor) before pushing so
+that `pyproject.toml` starts from #1793's version, then bump to the next minor
+(rule, not a hardcoded number: 0.11.0 if #1793 shipped 0.10.0).
+
+---
+
+## Slices
+
+### S1 — Contracts: rename + op removal + reparent + enforcement-test update
+
+**Independently demo-able:** `uv run pytest packages/roxabi-contracts/tests/` passes green.
+
+Files touched:
+- `packages/roxabi-contracts/src/roxabi_contracts/cli/models.py`
+- `packages/roxabi-contracts/tests/test_work_envelope_subjects.py`
+- `docs/architecture/adr/084-workenvelope-job-id-invariant.mdx`
+
+Changes:
+1. `cli/models.py`: import `WorkEnvelope` from `roxabi_contracts.envelope`.
+   Reparent `CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck`
+   from `ContractEnvelope` to `WorkEnvelope`. On `CliControlCmd`: rename field
+   `session_id` → `cli_session_id` with
+   `validation_alias=AliasChoices("cli_session_id", "session_id")` (one-minor
+   tolerance; serialization uses the new name); KEEP
+   `Literal["reset", "resume_and_reset", "switch_cwd"]` with a deprecation
+   docstring on `resume_and_reset` (removal = follow-up issue at ship).
+2. `test_work_envelope_subjects.py`: move the 4 cli models from `PENDING_MODELS`
+   to `WORK_MODELS`; set `PENDING_MODELS = set()` (or remove the set entirely
+   with comment noting graduation). Update count assertions:
+   `WORK==17`, `PENDING==0`, `ALL==26`. Narrow `test_non_work_model_not_subclass_of_work_envelope`
+   parametrize from `INFRA_MODELS | PENDING_MODELS` to `INFRA_MODELS`. Add
+   `test_cli_cmd_payload_lyra_session_id_not_pool_id` asserting the two fields
+   are distinct after construction (SC-6).
+3. `084-workenvelope-job-id-invariant.mdx`: extend Decision table from 3 rows
+   to 5 rows, adding `CliChunkEvent` (WORK — response side of work op) and
+   `CliControlAck` (WORK — ack of work control op); `CliHeartbeat` keeps its
+   explicit INFRA (excluded) row. Add a short note documenting the one-minor
+   deprecation of `resume_and_reset` + the `session_id` validation alias. This
+   must land BEFORE or atomically with the model reparent to keep `doc_drift`
+   green.
+
+**`cli/__init__.py` disposition:** `packages/roxabi-contracts/src/roxabi_contracts/cli/__init__.py`
+is a 18-line re-export file; verified no-op — no change required (re-exports
+remain valid after reparent, `WorkEnvelope` base is transparent to importers).
+
+**Must NOT do in S1:** touch any `src/factory/` files — keeps the slice
+reviewable in isolation.
+
+---
+
+### S2 — Src wiring: llm_client + clipool_worker cleanup
+
+**Independently demo-able:** `uv run pytest tests/` passes green; resume works
+end-to-end via the embedded field; `grep -rn "resume_and_reset" src/factory/llm/ src/factory/agents/`
+returns empty (producer paths purged — the worker tolerance branch and the
+optional local-pool rename are the only permitted survivors). **Note:** S1 must
+land first — `cmd.cli_session_id` (renamed field) must exist in the contracts
+package before `clipool_worker.py` compiles against it.
+
+Files touched:
+- `src/factory/llm/llm_client.py`
+- `src/factory/llm/drivers/cli.py`
+- `src/factory/core/cli/cli_pool.py`
+- `src/factory/adapters/clipool/clipool_worker.py`
+- `src/factory/agents/simple_agent.py`
+
+Changes:
+1. `llm_client.py`: REWIRE `resume_and_reset` (lines ~160–196) into the
+   pending-resume mechanism — keep the turn-store lyra→cli lookup, replace the
+   control-op send (and the `CliControlCmd(... session_id=cli_sid)` construction
+   at ~line 183) with `self._pending_resume[pool_id] = cli_sid`; return True iff
+   a token was resolved. Add `resume_session_id=self._pending_resume.pop(pool_id, None)`
+   to both `CliCmdPayload` builds (lines 89/115). Rename the method so the
+   `resume_and_reset` token leaves producer paths (suggestion: `queue_resume`).
+   Update `set_turn_store` docstring (net removal of the `resume_and_reset`
+   mention). The `switch_cwd` construction (~line 200) needs no change.
+2. `drivers/cli.py`: keep the delegation but follow the rename; docstring
+   updated (still: `pool.resume_session(sid)` → hub-side queue).
+3. `cli_pool.py`: local-path `resume_and_reset` behaviour unchanged; MAY rename
+   to match (update `simple_agent.py:186` lambda accordingly).
+4. `clipool_worker.py`: (a) CMD handler reads `payload.resume_session_id` —
+   when set, `await self._pool.resume_direct(pool_id, cli_sid)` before
+   dispatching the send; (b) `_dispatch_control` `resume_and_reset` branch is
+   RETAINED functional for one minor, field access updated to
+   `cmd.cli_session_id` (alias covers old-hub payloads); (c) add resume outcome
+   info log after `resume_direct()` (both paths — log level `info`, tokens
+   `"ok"/"cold-start"`, field `pool_id`).
+5. `simple_agent.py`: keep `_maybe_register_resume` and both
+   `register_session_callbacks(resume_fn=...)` call sites — the resume chain is
+   LIVE (hub middleware depends on it); only the method names it calls follow
+   the renames from items 1–3.
+
+**str_exc_bus_bound invariant:** any exception path in `_handle_control` must
+use `type(exc).__name__`, not `str(exc)` — the existing `_classify_exception`
+helper already follows this pattern (lines 56–77 of `clipool_worker.py`).
+
+---
+
+### S3 — Local-path unification + docs + version bump
+
+**Independently demo-able:** `uv run pytest` full suite passes; `pyproject.toml` version reads the next minor above the post-#1793 staging value; CHANGELOG entry present.
+
+Files touched:
+- `src/factory/core/cli/cli_pool_session.py`
+- `packages/roxabi-contracts/CHANGELOG.md`
+- `packages/roxabi-contracts/pyproject.toml`
+
+Changes:
+1. `cli_pool_session.py`: verify `ClaudeCliDriver.link_lyra_session` delegates
+   to `LlmClient` on the NATS path (`simple_agent.py:226-228`). The mixin's
+   `_lyra_sessions` dict MUST be retained for `_persist_cli_session` (local
+   path). The resume outcome log is part of S2 (`clipool_worker.py`) — no
+   log change needed here.
+2. `CHANGELOG.md`: add next-minor section before existing entries:
+   - Breaking: `CliControlCmd.session_id` renamed to `cli_session_id`
+     (old name accepted via validation alias for one minor)
+   - Deprecated: `resume_and_reset` op — producers migrated to embedded
+     `CliCmdPayload.resume_session_id`; worker tolerance retained one minor;
+     removal tracked in the ship-time follow-up issue
+   - Behaviour: resume acceptance semantics become "token resolved & queued"
+     (applied at next spawn)
+   - Breaking: `CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck`
+     reparented to `WorkEnvelope` (adds `job_id` field with transitional
+     `default_factory` shim)
+3. `pyproject.toml`: bump `version` to the next minor above the post-#1793
+   staging value (rebase on #1793 first to avoid conflict).
+
+---
+
+## Success Criteria
+
+All criteria are binary pass/fail. "Passes" = zero failures, zero warnings on
+the gated check.
+
+| # | Criterion | How to verify |
+|---|---|---|
+| SC-1 | `CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck` all inherit `WorkEnvelope` | `issubclass(CliCmdPayload, WorkEnvelope)` → True (and peers) |
+| SC-2 | `CliHeartbeat` still inherits `ContractEnvelope` (NOT `WorkEnvelope`) | `issubclass(CliHeartbeat, WorkEnvelope)` → False |
+| SC-3 | `CliControlCmd.op` still accepts `"resume_and_reset"` (deprecated, one-minor tolerance) and its docstring carries the deprecation note | `CliControlCmd(op="resume_and_reset", ...)` validates; `grep -i "deprecated" cli/models.py` hits the op |
+| SC-4 | `CliControlCmd` field is `cli_session_id`; old wire name still accepted via validation alias | `model_fields` contains `cli_session_id` not `session_id`; `CliControlCmd.model_validate({..., "session_id": "x"})` populates `cli_session_id == "x"`; serialization emits `cli_session_id` |
+| SC-5 | `CliChunkEvent.session_id` is unchanged (field still named `session_id`) | `CliChunkEvent.model_fields["session_id"]` exists |
+| SC-6 | `CliCmdPayload.lyra_session_id != pool_id` on construction (contract test) | `test_cli_cmd_payload_lyra_session_id_not_pool_id` passes |
+| SC-7 | `WORK_MODELS` count == 17, `PENDING_MODELS` count == 0, `ALL_CLASSIFIED` count == 26 | `test_completeness_coverage` passes |
+| SC-8 | `test_non_work_model_not_subclass_of_work_envelope` parametrize covers only INFRA (not PENDING) | Parametrize source = `INFRA_MODELS`; test passes for all 9 INFRA models |
+| SC-9 | ADR-084 Decision table has 5 cli rows (CliControlCmd, CliCmdPayload, CliHeartbeat, CliChunkEvent, CliControlAck) | `grep -c "| CliChunk\|CliControlAck" docs/architecture/adr/084-workenvelope-job-id-invariant.mdx` ≥ 2 |
+| SC-10 | `doc_drift` gate passes | `python3 tools/check_doc_drift.py` exits 0 |
+| SC-11 | No PRODUCER references to `resume_and_reset` remain (only the retained worker tolerance branch may survive in `src/`) | `grep -rn "resume_and_reset" src/factory/llm/ src/factory/agents/ src/factory/core/` returns empty; remaining hits ⊆ `clipool_worker.py` `_dispatch_control` |
+| SC-18 | Embedded resume works end-to-end: hub `pool.resume_session(sid)` → next `CliCmdPayload.resume_session_id` carries the resolved token → worker seeds `pool.resume_direct` before send | integration test in `tests/adapters/clipool/` asserts the chain with a fake pool |
+| SC-19 | No in-repo producer constructs `CliControlCmd(op="resume_and_reset")` | `grep -rn 'op="resume_and_reset"' src/` returns empty (worker branch only READS the op) |
+| SC-12 | No `str(exc)` / `f"{exc}"` / `repr(exc)` in NATS-bus-bound fields in touched files | `tools/check_str_exc_bus_bound.sh` exits 0 |
+| SC-13 | `CliCmdPayload` with no `job_id` still deserializes (wire-compat, `default_factory` retained) | `CliCmdPayload.model_validate({...no job_id...})` → valid; `job_id` minted by factory |
+| SC-14 | `packages/roxabi-contracts/pyproject.toml` version == next minor above the post-#1793 staging value | `grep '^version' packages/roxabi-contracts/pyproject.toml` vs `git show origin/staging:packages/roxabi-contracts/pyproject.toml` |
+| SC-15 | CHANGELOG head section documents rename+alias, op deprecation + embedded migration, semantics change, reparent | `grep -c "cli_session_id\|resume_and_reset\|WorkEnvelope" packages/roxabi-contracts/CHANGELOG.md` ≥ 3 |
+| SC-16 | `LlmClient.set_turn_store` docstring no longer references `resume_and_reset` (stale tail removed) | `grep "resume_and_reset" src/factory/llm/llm_client.py` returns empty |
+| SC-17 | Resume outcome logged after `resume_direct()` in `clipool_worker.py` | Log line present; uses `type(exc).__name__` not `str(exc)` in any error path |
+
+---
+
+## Open Questions
+
+None — all prior questions were resolved at lead arbitrage (2026-06-11):
+landing order is a rule (merge after #1793, version = next minor); the
+`simple_agent.py:226-228` dispatch seam was code-verified; the
+`resume_and_reset` caller graph was fully enumerated (live op → migration, see
+Live-op retirement section).
+
+### Impl checklist notes (not blockers)
+
+- **Pre-push gates are CI-only on lead worktree pushes**: run manually before
+  push — `tools/check_architecture_snapshot.sh`, `tools/check_test_sleep.sh`,
+  `tools/check_debt_expiry.sh`, import_layers, doc_drift (per memory note
+  `feedback-prepush-gates-skip-on-lead-worktree-push`).
+- **`file_length` gate**: `llm_client.py` ~212 lines pre-change; the rewire is
+  roughly size-neutral — verify it and `cli_pool.py`/`clipool_worker.py` stay
+  under 300 SLOC after edits.
+- **Ship-time follow-up issue**: create the mechanical-removal sibling (Literal
+  value + alias + worker branch) under epic #1044, blocked-by #1009, at ship.
+
+---
+
+## Pre-check
+
+Self-run of the 5 mandatory checks before returning this spec:
+
+1. **Testable criteria**: All 19 SC entries are binary pass/fail with a
+   verifiable command or assertion. SC-6 names the test function. SC-9 gives a
+   grep command. SC-11/SC-19 give scoped negative greps. SC-13 gives a Pydantic
+   call. SC-18 names the integration-test location. All criteria are objective.
+   (Revised at lead arbitrage 2026-06-11: live-op evidence reversed SC-3/SC-4
+   semantics, added SC-18/SC-19.)
+
+2. **Dangling refs**: Confirmed all file paths exist in the repo:
+   `packages/roxabi-contracts/src/roxabi_contracts/cli/models.py` (71 lines,
+   read), `tests/test_work_envelope_subjects.py` (204 lines, read),
+   `src/factory/llm/llm_client.py` (212 lines, read),
+   `src/factory/core/cli/cli_pool_session.py` (68 lines, read),
+   `src/factory/adapters/clipool/clipool_worker.py` (read). Line numbers cited
+   (160, 183, 130, 62, 92) verified against current file state. `084-workenvelope-job-id-invariant.mdx`
+   path confirmed in frame.
+
+3. **Ambiguity (max 5 open questions)**: Zero open questions remain (all
+   resolved at lead arbitrage with code evidence). The 3-session-id field
+   disambiguation is fully resolved inline in Expected Behavior and Data Model
+   sections with a decision table — not deferred.
+
+4. **Slice coverage**: S1 covers contracts/tests/docs (independently testable:
+   contracts pytest suite). S2 covers src wiring (independently testable: full
+   pytest + grep). S3 covers unification + CHANGELOG + version (independently
+   testable: pyproject.toml + changelog review). All 11 frame files are covered
+   across the 3 slices. Each slice produces a standalone green CI state.
+
+5. **Edge completeness**: Wire-compat (no `job_id` in old messages → SC-13;
+   old `session_id` wire name → SC-4 alias; old-hub `resume_and_reset` during
+   deploy skew → SC-3 tolerance branch); `CliChunkEvent.session_id` NOT renamed
+   (SC-5); `CliHeartbeat` stays ContractEnvelope (SC-2); embedded resume
+   end-to-end (SC-18) + producer purge (SC-19); `str_exc_bus_bound` gate
+   (SC-12); PENDING→WORK parametrize narrowing (SC-8); doc_drift pre-condition
+   ordering (S1 lands ADR table before reparent).

--- a/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
+++ b/docs/architecture/adr/084-workenvelope-job-id-invariant.mdx
@@ -64,9 +64,17 @@ The **`cli` domain is split**:
 
 | `cli` model | Envelope | Why |
 |---|---|---|
-| `CliControlCmd` | WorkEnvelope | per-turn control of the clipool worker; part of a job |
 | `CliCmdPayload` | WorkEnvelope | per-turn dispatch to the clipool worker; carries `lyra_session_id` → belongs to a job |
+| `CliChunkEvent` | WorkEnvelope | response side of a work op — streaming chunk or terminal event; correlates to the dispatching job |
+| `CliControlCmd` | WorkEnvelope | per-turn control of the clipool worker; part of a job |
+| `CliControlAck` | WorkEnvelope | ack of a work control op; correlated to the same job as `CliControlCmd` |
 | `CliHeartbeat` | ContractEnvelope | worker liveness — no job |
+
+**One-minor deprecations (S1 — #1009/#1838):** `CliControlCmd.session_id` is renamed to
+`cli_session_id`; the old wire name is accepted via `validation_alias=AliasChoices("cli_session_id",
+"session_id")` for one minor release. `CliControlCmd.op` retains the `resume_and_reset` literal
+for one minor; producers must migrate to `CliCmdPayload.resume_session_id`. Mechanical removal of
+both is tracked in the follow-up issue (sibling under epic #1044, blocked-by #1009).
 
 The `cli` reparent is a **breaking** `cli` minor bump (new required `job_id`). It overlaps
 with the session-id cleanup in **#1009** (rename `CliControlCmd.session_id` → `cli_session_id`,

--- a/packages/roxabi-contracts/CHANGELOG.md
+++ b/packages/roxabi-contracts/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.11.0] (2026-06-11)
+
+### Features
+
+* **contracts/cli:** reparent `CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck` from `ContractEnvelope` to `WorkEnvelope` ([#1009](https://github.com/Roxabi/roxabi-factory/issues/1009) / [#1838](https://github.com/Roxabi/roxabi-factory/issues/1838)). Adds `job_id` field with transitional `default_factory` shim — old wire messages without `job_id` still deserialize.
+* **contracts/cli:** rename `CliControlCmd.session_id` → `cli_session_id`; old wire name still accepted via `AliasChoices("cli_session_id", "session_id")` for one minor ([#1838](https://github.com/Roxabi/roxabi-factory/issues/1838)).
+
+### Deprecated
+
+* **contracts/cli:** `CliControlCmd.op = "resume_and_reset"` — producers migrated to embedded `CliCmdPayload.resume_session_id` field; worker tolerance retained for one minor; removal tracked in follow-up issue at ship.
+
+### Changed
+
+* **contracts/cli:** resume acceptance semantics changed — "token resolved & queued" (applied at next spawn), not an immediate inline reset via control op.
+
+### BREAKING CHANGES
+
+* `CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck` now inherit `WorkEnvelope` (adds mandatory `job_id`; transitional `default_factory` provides backward compat). Consumers that previously assumed `ContractEnvelope` base must update their type annotations.
+* `CliControlCmd.session_id` serialized name changed to `cli_session_id`. Old field name still accepted on ingress for one minor; serialization always emits the new name.
+
+
 ## [0.10.0] (2026-06-11)
 
 ### Features

--- a/packages/roxabi-contracts/pyproject.toml
+++ b/packages/roxabi-contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roxabi-contracts"
-version = "0.10.0"
+version = "0.11.0"
 description = "Shared Pydantic schemas for Lyra cross-project NATS contracts"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/roxabi-contracts/src/roxabi_contracts/cli/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/cli/models.py
@@ -46,6 +46,9 @@ class CliChunkEvent(WorkEnvelope):
     is_error: bool = False
     done: bool = False
     worker_error: WorkerError | None = None
+    # Set on the first chunk of a resumed turn so the hub can distinguish
+    # "resume applied" (True) from "cold-start" (False) in mixed-version rollouts.
+    resumed: bool | None = None
 
 
 class CliControlCmd(WorkEnvelope):
@@ -63,6 +66,7 @@ class CliControlCmd(WorkEnvelope):
     cli_session_id: str | None = Field(
         default=None,
         validation_alias=AliasChoices("cli_session_id", "session_id"),
+        serialization_alias="session_id",
     )
     cwd: str | None = None
 

--- a/packages/roxabi-contracts/src/roxabi_contracts/cli/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/cli/models.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from roxabi_contracts.envelope import ContractEnvelope
+from pydantic import AliasChoices, Field
+
+from roxabi_contracts.envelope import ContractEnvelope, WorkEnvelope
 from roxabi_contracts.errors import WorkerError
 
 __all__ = [
@@ -17,7 +19,7 @@ __all__ = [
 ]
 
 
-class CliCmdPayload(ContractEnvelope):
+class CliCmdPayload(WorkEnvelope):
     """Hub -> clipool: run a claude-cli command."""
 
     pool_id: str
@@ -31,7 +33,7 @@ class CliCmdPayload(ContractEnvelope):
     agent_email: str | None = None
 
 
-class CliChunkEvent(ContractEnvelope):
+class CliChunkEvent(WorkEnvelope):
     """Clipool -> hub: one streaming chunk or terminal event."""
 
     pool_id: str
@@ -46,16 +48,26 @@ class CliChunkEvent(ContractEnvelope):
     worker_error: WorkerError | None = None
 
 
-class CliControlCmd(ContractEnvelope):
-    """Hub -> clipool: control operation (reset, resume, cwd switch)."""
+class CliControlCmd(WorkEnvelope):
+    """Hub -> clipool: control operation (reset, resume, cwd switch).
+
+    The ``resume_and_reset`` op literal is DEPRECATED (one-minor tolerance).
+    Producers must migrate to the embedded ``CliCmdPayload.resume_session_id``
+    field. The worker tolerance branch is retained for one minor; mechanical
+    removal is tracked in the follow-up issue (sibling under epic #1044,
+    blocked-by #1009).
+    """
 
     pool_id: str
     op: Literal["reset", "resume_and_reset", "switch_cwd"]
-    session_id: str | None = None
+    cli_session_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("cli_session_id", "session_id"),
+    )
     cwd: str | None = None
 
 
-class CliControlAck(ContractEnvelope):
+class CliControlAck(WorkEnvelope):
     """Clipool -> hub: reply to CliControlCmd."""
 
     pool_id: str

--- a/packages/roxabi-contracts/tests/test_cli_models.py
+++ b/packages/roxabi-contracts/tests/test_cli_models.py
@@ -259,7 +259,7 @@ def test_cli_control_cmd_invalid_op() -> None:
 
 
 def test_cli_control_cmd_optional_fields() -> None:
-    """session_id and cwd are None by default; accepted when provided."""
+    """cli_session_id and cwd are None by default; old wire name 'session_id' accepted."""
     # Arrange
     payload_minimal = {**_ENVELOPE, "pool_id": "pool-ctrl", "op": "reset"}
     payload_full = {
@@ -267,7 +267,7 @@ def test_cli_control_cmd_optional_fields() -> None:
         "pool_id": "pool-ctrl",
         "op": "switch_cwd",
         "cwd": "/tmp/workspace",
-        "session_id": "sess-42",
+        "session_id": "sess-42",  # old wire name — accepted via AliasChoices one-minor
     }
 
     # Act
@@ -275,10 +275,10 @@ def test_cli_control_cmd_optional_fields() -> None:
     inst_full = CliControlCmd.model_validate(payload_full)
 
     # Assert
-    assert inst_min.session_id is None
+    assert inst_min.cli_session_id is None
     assert inst_min.cwd is None
     assert inst_full.cwd == "/tmp/workspace"
-    assert inst_full.session_id == "sess-42"
+    assert inst_full.cli_session_id == "sess-42"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/roxabi-contracts/tests/test_cli_models.py
+++ b/packages/roxabi-contracts/tests/test_cli_models.py
@@ -259,7 +259,7 @@ def test_cli_control_cmd_invalid_op() -> None:
 
 
 def test_cli_control_cmd_optional_fields() -> None:
-    """cli_session_id and cwd are None by default; old wire name 'session_id' accepted."""
+    """cli_session_id and cwd default to None; old wire name 'session_id' accepted."""
     # Arrange
     payload_minimal = {**_ENVELOPE, "pool_id": "pool-ctrl", "op": "reset"}
     payload_full = {

--- a/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
+++ b/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
@@ -154,8 +154,7 @@ def test_work_model_is_subclass_of_work_envelope(model_cls) -> None:
 def test_non_work_model_not_subclass_of_work_envelope(model_cls) -> None:
     """INFRA models MUST NOT inherit from WorkEnvelope."""
     assert not issubclass(model_cls, WorkEnvelope), (
-        f"{model_cls.__name__} is classified as INFRA"
-        " but subclasses WorkEnvelope"
+        f"{model_cls.__name__} is classified as INFRA but subclasses WorkEnvelope"
     )
 
 

--- a/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
+++ b/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
@@ -211,7 +211,7 @@ def test_work_envelope_empty_job_id_raises() -> None:
 def test_cli_cmd_payload_lyra_session_id_not_pool_id() -> None:
     """lyra_session_id and pool_id are distinct identity axes.
 
-    SC-9: the two ids belong to different granularity levels (conversation vs.
+    SC-6: the two ids belong to different granularity levels (conversation vs.
     worker slot) and MUST NOT be equal in a correctly constructed payload.
     """
     from roxabi_contracts.cli.models import CliCmdPayload

--- a/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
+++ b/packages/roxabi-contracts/tests/test_work_envelope_subjects.py
@@ -52,7 +52,7 @@ from roxabi_contracts.voice.models import (
 # Classification tables
 # ---------------------------------------------------------------------------
 
-#: 13 domain models that carry a job identity → MUST subclass WorkEnvelope.
+#: 17 domain models that carry a job identity → MUST subclass WorkEnvelope.
 WORK_MODELS = {
     JobEnvelope,
     JobResult,
@@ -67,6 +67,11 @@ WORK_MODELS = {
     ImageRequest,
     ImageResponse,
     TurnWriteEvent,
+    # cli models reparented from PENDING (#1838 → S1)
+    CliCmdPayload,
+    CliChunkEvent,
+    CliControlAck,
+    CliControlCmd,
 }
 
 #: 9 infra-plane models — deliberate ContractEnvelope, no job identity.
@@ -82,13 +87,8 @@ INFRA_MODELS = {
     MintFailureEvent,
 }
 
-#: 4 CLI models deferred to #1838 — currently ContractEnvelope.
-PENDING_MODELS = {
-    CliCmdPayload,
-    CliControlCmd,
-    CliChunkEvent,
-    CliControlAck,
-}
+#: PENDING bucket is empty after S1 graduates the 4 cli models (#1838).
+PENDING_MODELS: set = set()
 
 ALL_CLASSIFIED = WORK_MODELS | INFRA_MODELS | PENDING_MODELS
 
@@ -120,11 +120,11 @@ def test_completeness_no_duplicate_across_buckets() -> None:
 
 
 def test_completeness_coverage() -> None:
-    """ALL_CLASSIFIED covers the expected count: 13 WORK + 9 INFRA + 4 PENDING = 26."""
-    assert len(WORK_MODELS) == 13, f"expected 13 WORK models, got {len(WORK_MODELS)}"
+    """ALL_CLASSIFIED covers the expected count: 17 WORK + 9 INFRA + 0 PENDING = 26."""
+    assert len(WORK_MODELS) == 17, f"expected 17 WORK models, got {len(WORK_MODELS)}"
     assert len(INFRA_MODELS) == 9, f"expected 9 INFRA models, got {len(INFRA_MODELS)}"
-    assert len(PENDING_MODELS) == 4, (
-        f"expected 4 PENDING models, got {len(PENDING_MODELS)}"
+    assert len(PENDING_MODELS) == 0, (
+        f"expected 0 PENDING models, got {len(PENDING_MODELS)}"
     )
     assert len(ALL_CLASSIFIED) == 26
 
@@ -149,12 +149,12 @@ def test_work_model_is_subclass_of_work_envelope(model_cls) -> None:
 
 @pytest.mark.parametrize(
     "model_cls",
-    sorted(INFRA_MODELS | PENDING_MODELS, key=lambda c: c.__name__),
+    sorted(INFRA_MODELS, key=lambda c: c.__name__),
 )
 def test_non_work_model_not_subclass_of_work_envelope(model_cls) -> None:
-    """INFRA and PENDING models MUST NOT inherit from WorkEnvelope."""
+    """INFRA models MUST NOT inherit from WorkEnvelope."""
     assert not issubclass(model_cls, WorkEnvelope), (
-        f"{model_cls.__name__} is classified as INFRA/PENDING"
+        f"{model_cls.__name__} is classified as INFRA"
         " but subclasses WorkEnvelope"
     )
 
@@ -201,3 +201,27 @@ def test_work_envelope_empty_job_id_raises() -> None:
             **_base_fields(),
             job_id="",
         )
+
+
+# ---------------------------------------------------------------------------
+# (f) CliCmdPayload id taxonomy invariant
+# ---------------------------------------------------------------------------
+
+
+def test_cli_cmd_payload_lyra_session_id_not_pool_id() -> None:
+    """lyra_session_id and pool_id are distinct identity axes.
+
+    SC-9: the two ids belong to different granularity levels (conversation vs.
+    worker slot) and MUST NOT be equal in a correctly constructed payload.
+    """
+    from roxabi_contracts.cli.models import CliCmdPayload
+
+    payload = CliCmdPayload(
+        **_base_fields(),
+        pool_id="pool-abc",
+        lyra_session_id="sess-xyz",
+        text="hello",
+        model_cfg={},
+        system_prompt="system",
+    )
+    assert payload.lyra_session_id != payload.pool_id

--- a/src/factory/adapters/clipool/_worker_helpers.py
+++ b/src/factory/adapters/clipool/_worker_helpers.py
@@ -1,0 +1,74 @@
+"""Pure helpers for CliPoolNatsWorker — error classification + wire codec."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from roxabi_contracts.cli.models import CliChunkEvent, CliControlAck
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.errors import WorkerError
+
+
+def _classify_exception(exc: BaseException) -> WorkerError:
+    """Map an exception to a ``WorkerError`` with the appropriate code.
+
+    Code selection (per T13 / ADR-066 (absorbed into ADR-049)):
+    - ``asyncio.TimeoutError`` → ``cli.session_lost`` (retryable=True)
+    - ``UnicodeDecodeError`` / ``ValueError`` (parse/decode) → ``cli.parse``
+      (retryable=False)
+    - Any other exception → ``worker.crash`` (retryable=True)
+    """
+    import asyncio
+
+    # Sanitize bus-bound messages (#1215, sibling of #1212). Exception __str__
+    # can embed file paths, byte sequences, or arbitrary text from system
+    # errors — the bus-bound message keeps only the type name. Full traceback
+    # logging is owned by the callers (_handle_cmd_streaming/_handle_cmd_blocking
+    # both call log.exception before invoking this classifier).
+    if isinstance(exc, asyncio.TimeoutError):
+        return WorkerError(
+            code="cli.session_lost",
+            message=f"CLI session timed out: {type(exc).__name__}",
+            retryable=True,
+        )
+    if isinstance(exc, (UnicodeDecodeError, ValueError)):
+        return WorkerError(
+            code="cli.parse",
+            message=f"CLI parse/decode error: {type(exc).__name__}",
+            retryable=False,
+        )
+    return WorkerError(
+        code="worker.crash",
+        message=f"Unhandled worker exception: {type(exc).__name__}",
+        retryable=True,
+    )
+
+
+def _make_chunk(pool_id: str, **kwargs: Any) -> bytes:
+    """Serialise a CliChunkEvent to JSON bytes for NATS publish."""
+    import uuid
+    from datetime import datetime, timezone
+
+    event = CliChunkEvent(
+        contract_version=CONTRACT_VERSION,
+        trace_id=str(uuid.uuid4()),
+        issued_at=datetime.now(timezone.utc),
+        pool_id=pool_id,
+        **kwargs,
+    )
+    return event.model_dump_json().encode()
+
+
+def _make_ack(pool_id: str, **kwargs: Any) -> bytes:
+    """Serialise a CliControlAck to JSON bytes for NATS publish."""
+    import uuid
+    from datetime import datetime, timezone
+
+    ack = CliControlAck(
+        contract_version=CONTRACT_VERSION,
+        trace_id=str(uuid.uuid4()),
+        issued_at=datetime.now(timezone.utc),
+        pool_id=pool_id,
+        **kwargs,
+    )
+    return ack.model_dump_json().encode()

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -196,6 +196,14 @@ class CliPoolNatsWorker(NatsAdapterBase):
 
         model_cfg = ModelConfig.model_validate(cmd.model_cfg)
 
+        if cmd.resume_session_id:
+            resumed = await self._pool.resume_direct(cmd.pool_id, cmd.resume_session_id)
+            log.info(
+                "clipool: resume %s pool=%s",
+                "ok" if resumed else "cold-start",
+                cmd.pool_id,
+            )
+
         if cmd.stream:
             await self._handle_cmd_streaming(msg, cmd, model_cfg)
         else:
@@ -347,15 +355,20 @@ class CliPoolNatsWorker(NatsAdapterBase):
             return _make_ack(cmd.pool_id, ok=True)
 
         if cmd.op == "resume_and_reset":
-            if not cmd.session_id:
+            if not cmd.cli_session_id:
                 log.warning(
-                    "clipool_worker: resume_and_reset missing session_id"
+                    "clipool_worker: resume_and_reset missing cli_session_id"
                     " for pool_id=%r",
                     cmd.pool_id,
                 )
                 return _make_ack(cmd.pool_id, ok=False)
-            # cmd.session_id is the cli_session_id resolved by the hub driver.
-            resumed = await self._pool.resume_direct(cmd.pool_id, cmd.session_id)
+            # cmd.cli_session_id is the cli_session_id resolved by the hub driver.
+            resumed = await self._pool.resume_direct(cmd.pool_id, cmd.cli_session_id)
+            log.info(
+                "clipool: resume %s pool=%s",
+                "ok" if resumed else "cold-start",
+                cmd.pool_id,
+            )
             return _make_ack(cmd.pool_id, ok=True, resumed=resumed)
 
         if cmd.op == "switch_cwd":

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -196,21 +196,27 @@ class CliPoolNatsWorker(NatsAdapterBase):
 
         model_cfg = ModelConfig.model_validate(cmd.model_cfg)
 
+        resumed: bool | None = None
         if cmd.resume_session_id:
             resumed = await self._pool.resume_direct(cmd.pool_id, cmd.resume_session_id)
             log.info(
-                "clipool: resume %s pool=%s",
-                "ok" if resumed else "cold-start",
+                "clipool_worker: resume %s pool=%s",
+                "queued" if resumed else "cold-start",
                 cmd.pool_id,
             )
 
         if cmd.stream:
-            await self._handle_cmd_streaming(msg, cmd, model_cfg)
+            await self._handle_cmd_streaming(msg, cmd, model_cfg, resumed=resumed)
         else:
-            await self._handle_cmd_blocking(msg, cmd, model_cfg)
+            await self._handle_cmd_blocking(msg, cmd, model_cfg, resumed=resumed)
 
     async def _handle_cmd_streaming(
-        self, msg: Any, cmd: CliCmdPayload, model_cfg: ModelConfig
+        self,
+        msg: Any,
+        cmd: CliCmdPayload,
+        model_cfg: ModelConfig,
+        *,
+        resumed: bool | None = None,
     ) -> None:
         try:
             iterator = await self._pool.send_streaming(
@@ -241,13 +247,19 @@ class CliPoolNatsWorker(NatsAdapterBase):
                 )
             return
 
+        first_chunk = True
         async for event in iterator:
+            # Attach resume signal to the very first emitted chunk so the hub
+            # can detect "resume applied" (True) vs "cold-start" (False/None).
+            resume_extra: dict = {"resumed": resumed} if first_chunk else {}
+            first_chunk = False
             if isinstance(event, TextLlmEvent):
                 chunk = _make_chunk(
                     cmd.pool_id,
                     event_type="text",
                     text=event.text,
                     done=False,
+                    **resume_extra,
                 )
                 await self.reply(msg, chunk)
             elif isinstance(event, ToolUseLlmEvent):
@@ -262,6 +274,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
                     tool_id=event.tool_id,
                     tool_input=event.input,
                     done=False,
+                    **resume_extra,
                 )
                 await self.reply(msg, chunk)
             elif isinstance(event, ResultLlmEvent):
@@ -288,7 +301,12 @@ class CliPoolNatsWorker(NatsAdapterBase):
         )
 
     async def _handle_cmd_blocking(
-        self, msg: Any, cmd: CliCmdPayload, model_cfg: ModelConfig
+        self,
+        msg: Any,
+        cmd: CliCmdPayload,
+        model_cfg: ModelConfig,
+        *,
+        resumed: bool | None = None,
     ) -> None:
         try:
             result = await self._pool.send(
@@ -322,6 +340,7 @@ class CliPoolNatsWorker(NatsAdapterBase):
             is_error=bool(result.error),
             session_id=result.session_id or None,
             done=True,
+            resumed=resumed,
         )
         await self.reply(msg, chunk)
 

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -17,17 +17,19 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from factory.adapters.clipool._worker_helpers import (
+    _classify_exception,
+    _make_ack,
+    _make_chunk,
+)
 from factory.core.agent.agent_config import ModelConfig
 from factory.core.cli.cli_pool import CliPool
 from factory.core.messaging.events import ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
 from factory.core.messaging.utils.metrics import emit_populated_total
 from roxabi_contracts.cli.models import (
-    CliChunkEvent,
     CliCmdPayload,
-    CliControlAck,
     CliControlCmd,
 )
-from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.errors import WorkerError
 from roxabi_nats.adapter_base import NatsAdapterBase
 
@@ -40,71 +42,6 @@ _QUEUE_GROUP = "clipool-workers"
 _ENVELOPE_NAME = "CliCmdPayload"
 _SCHEMA_VERSION = 1
 _HEARTBEAT_INTERVAL = 30.0
-
-
-def _classify_exception(exc: BaseException) -> WorkerError:
-    """Map an exception to a ``WorkerError`` with the appropriate code.
-
-    Code selection (per T13 / ADR-066 (absorbed into ADR-049)):
-    - ``asyncio.TimeoutError`` → ``cli.session_lost`` (retryable=True)
-    - ``UnicodeDecodeError`` / ``ValueError`` (parse/decode) → ``cli.parse``
-      (retryable=False)
-    - Any other exception → ``worker.crash`` (retryable=True)
-    """
-    import asyncio
-
-    # Sanitize bus-bound messages (#1215, sibling of #1212). Exception __str__
-    # can embed file paths, byte sequences, or arbitrary text from system
-    # errors — the bus-bound message keeps only the type name. Full traceback
-    # logging is owned by the callers (_handle_cmd_streaming/_handle_cmd_blocking
-    # both call log.exception before invoking this classifier).
-    if isinstance(exc, asyncio.TimeoutError):
-        return WorkerError(
-            code="cli.session_lost",
-            message=f"CLI session timed out: {type(exc).__name__}",
-            retryable=True,
-        )
-    if isinstance(exc, (UnicodeDecodeError, ValueError)):
-        return WorkerError(
-            code="cli.parse",
-            message=f"CLI parse/decode error: {type(exc).__name__}",
-            retryable=False,
-        )
-    return WorkerError(
-        code="worker.crash",
-        message=f"Unhandled worker exception: {type(exc).__name__}",
-        retryable=True,
-    )
-
-
-def _make_chunk(pool_id: str, **kwargs: Any) -> bytes:
-    """Serialise a CliChunkEvent to JSON bytes for NATS publish."""
-    import uuid
-    from datetime import datetime, timezone
-
-    event = CliChunkEvent(
-        contract_version=CONTRACT_VERSION,
-        trace_id=str(uuid.uuid4()),
-        issued_at=datetime.now(timezone.utc),
-        pool_id=pool_id,
-        **kwargs,
-    )
-    return event.model_dump_json().encode()
-
-
-def _make_ack(pool_id: str, **kwargs: Any) -> bytes:
-    """Serialise a CliControlAck to JSON bytes for NATS publish."""
-    import uuid
-    from datetime import datetime, timezone
-
-    ack = CliControlAck(
-        contract_version=CONTRACT_VERSION,
-        trace_id=str(uuid.uuid4()),
-        issued_at=datetime.now(timezone.utc),
-        pool_id=pool_id,
-        **kwargs,
-    )
-    return ack.model_dump_json().encode()
 
 
 class CliPoolNatsWorker(NatsAdapterBase):

--- a/src/factory/agents/simple_agent.py
+++ b/src/factory/agents/simple_agent.py
@@ -176,20 +176,20 @@ class SimpleAgent(AgentBase):
         """Register session resume callback on the pool.
 
         Hub calls pool.resume_session(session_id) → delegates here →
-        CliPool.resume_and_reset(). Follows the same lazy-wiring pattern as
+        CliPool.queue_resume(). Follows the same lazy-wiring pattern as
         _maybe_register_reset.
         """
         _cli_pool = self._cli_pool  # narrow once; stable capture for lambda
         if _cli_pool is not None:
             _pool_id = pool.pool_id
             pool.register_session_callbacks(
-                resume_fn=lambda sid: _cli_pool.resume_and_reset(_pool_id, sid),
+                resume_fn=lambda sid: _cli_pool.queue_resume(_pool_id, sid),
             )
         elif self._cli_nats_driver is not None:
             _driver = self._cli_nats_driver
             _pool_id = pool.pool_id
             pool.register_session_callbacks(
-                resume_fn=lambda sid: _driver.resume_and_reset(_pool_id, sid),
+                resume_fn=lambda sid: _driver.queue_resume(_pool_id, sid),
             )
 
     def configure_pool(self, pool: Pool) -> None:

--- a/src/factory/core/cli/cli_pool.py
+++ b/src/factory/core/cli/cli_pool.py
@@ -180,8 +180,7 @@ class CliPool(  # noqa: E501 — DEBT:lint-residual
             return False
         if not SESSION_ID_RE.match(cli_sid):
             log.warning(
-                "[pool:%s] queue_resume: invalid persisted CLI session %r"
-                " — skipping",
+                "[pool:%s] queue_resume: invalid persisted CLI session %r — skipping",
                 pool_id,
                 cli_sid,
             )

--- a/src/factory/core/cli/cli_pool.py
+++ b/src/factory/core/cli/cli_pool.py
@@ -152,7 +152,7 @@ class CliPool(  # noqa: E501 — DEBT:lint-residual
         )
         return True
 
-    async def resume_and_reset(self, pool_id: str, session_id: str) -> bool:
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool:
         """Kill process; next _spawn() uses --resume <cli_session_id> (one-shot).
 
         *session_id* is the Lyra-internal UUID from the turn store.  This method
@@ -172,7 +172,7 @@ class CliPool(  # noqa: E501 — DEBT:lint-residual
                 cli_sid = await self._turn_store.get_cli_session_by_pool(pool_id)
         if cli_sid is None:
             log.info(
-                "[pool:%s] resume_and_reset: no persisted CLI session"
+                "[pool:%s] queue_resume: no persisted CLI session"
                 " — starting fresh (lyra_session=%s)",
                 pool_id,
                 session_id,
@@ -180,7 +180,7 @@ class CliPool(  # noqa: E501 — DEBT:lint-residual
             return False
         if not SESSION_ID_RE.match(cli_sid):
             log.warning(
-                "[pool:%s] resume_and_reset: invalid persisted CLI session %r"
+                "[pool:%s] queue_resume: invalid persisted CLI session %r"
                 " — skipping",
                 pool_id,
                 cli_sid,
@@ -190,7 +190,7 @@ class CliPool(  # noqa: E501 — DEBT:lint-residual
         entry = self._entries.get(pool_id)
         if entry is not None and entry.is_alive() and entry.session_id == cli_sid:
             log.info(
-                "[pool:%s] resume_and_reset: process already on CLI session %s — no-op",
+                "[pool:%s] queue_resume: process already on CLI session %s — no-op",
                 pool_id,
                 cli_sid,
             )
@@ -199,7 +199,7 @@ class CliPool(  # noqa: E501 — DEBT:lint-residual
         await self._kill(pool_id, preserve_session=False)
         self._resume_session_ids[pool_id] = cli_sid
         log.info(
-            "[pool:%s] resume_and_reset: will resume CLI session %s on next"
+            "[pool:%s] queue_resume: will resume CLI session %s on next"
             " spawn (lyra_session=%s)",
             pool_id,
             cli_sid,

--- a/src/factory/llm/drivers/cli.py
+++ b/src/factory/llm/drivers/cli.py
@@ -37,8 +37,9 @@ class ClaudeCliDriver:
     async def queue_resume(self, pool_id: str, session_id: str) -> bool:
         """Delegate session resume to CliPool.
 
-        Wired into pool._session_resume_fn by SimpleAgent._maybe_register_resume
-        so that pool.resume_session(sid) → CliPool.queue_resume(pool_id, sid).
+        Wired via pool.register_session_callbacks(resume_fn=...) in
+        SimpleAgent._maybe_register_resume so that
+        pool.resume_session(sid) → CliPool.queue_resume(pool_id, sid).
         Returns True if the resume was accepted, False if skipped.
         """
         return await self._pool.queue_resume(pool_id, session_id)

--- a/src/factory/llm/drivers/cli.py
+++ b/src/factory/llm/drivers/cli.py
@@ -34,14 +34,14 @@ class ClaudeCliDriver:
         """Delegate workspace switch to CliPool."""
         await self._pool.switch_cwd(pool_id, cwd)
 
-    async def resume_and_reset(self, pool_id: str, session_id: str) -> bool:
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool:
         """Delegate session resume to CliPool.
 
         Wired into pool._session_resume_fn by SimpleAgent._maybe_register_resume
-        so that pool.resume_session(sid) → CliPool.resume_and_reset(pool_id, sid).
+        so that pool.resume_session(sid) → CliPool.queue_resume(pool_id, sid).
         Returns True if the resume was accepted, False if skipped.
         """
-        return await self._pool.resume_and_reset(pool_id, session_id)
+        return await self._pool.queue_resume(pool_id, session_id)
 
     def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
         """Register the current Lyra session for CLI session mapping."""

--- a/src/factory/llm/llm_client.py
+++ b/src/factory/llm/llm_client.py
@@ -13,12 +13,9 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, AsyncIterator, Protocol
 from uuid import uuid4
 
-from pydantic import ValidationError
-
 from factory.core.messaging.events import LlmEvent, ResultLlmEvent
 from factory.core.ports.llm import LlmResult
-from factory.transport._result import Ok
-from roxabi_contracts.cli.models import CliControlAck, CliControlCmd
+from roxabi_contracts.cli.models import CliControlCmd
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.llm import SUBJECTS
 
@@ -61,6 +58,7 @@ class LlmClient:
         self._request_subject = request_subject or SUBJECTS.generate_request
         self._lyra_sessions: dict[str, str] = {}
         self._turn_store: _CliSessionStore | None = None
+        self._pending_resume: dict[str, str] = {}
 
     def is_alive(self, pool_id: str) -> bool:
         del pool_id
@@ -87,6 +85,7 @@ class LlmClient:
             stream=False,
             pool_id=pool_id,
             lyra_session_id=self._lyra_sessions.get(pool_id),
+            resume_session_id=self._pending_resume.pop(pool_id, None),
         )
         result = await self._pool.request_with_routing(
             lambda _: self._request_subject,
@@ -113,6 +112,7 @@ class LlmClient:
             stream=True,
             pool_id=pool_id,
             lyra_session_id=self._lyra_sessions.get(pool_id),
+            resume_session_id=self._pending_resume.pop(pool_id, None),
         )
         async for result in self._pool.stream_request(
             self._request_subject, payload, timeout=self._timeout
@@ -127,7 +127,7 @@ class LlmClient:
     # ── Control-plane methods (re-homed from CliNatsDriver, Slice S2) ────
 
     def set_turn_store(self, store: _CliSessionStore) -> None:
-        """Wire the session store for cli_session_id lookups in resume_and_reset."""
+        """Wire the session store for cli_session_id lookups in queue_resume."""
         self._turn_store = store
 
     def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
@@ -157,11 +157,15 @@ class LlmClient:
             _SUBJECT_CONTROL, payload, timeout=self._timeout
         )
 
-    async def resume_and_reset(self, pool_id: str, session_id: str) -> bool:
-        """Ask clipool worker to resume a prior session then reset.
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool:
+        """Resolve cli_session_id and stash it for the next CliCmdPayload.
 
-        Looks up cli_session_id from the hub TurnStore and passes it to the
-        worker directly (no TurnStore lookup on the worker side).
+        Looks up cli_session_id from the hub TurnStore and stores it in
+        _pending_resume[pool_id].  The stashed token is injected into the next
+        complete() or stream() call via CliCmdPayload.resume_session_id — no
+        separate NATS control message is sent.
+
+        Returns True iff a cli_session_id was resolved and stashed.
         """
         cli_sid: str | None = None
         if self._turn_store is not None:
@@ -174,26 +178,8 @@ class LlmClient:
                 pool_id,
             )
             return False
-        cmd = CliControlCmd(
-            contract_version=CONTRACT_VERSION,
-            trace_id=str(uuid4()),
-            issued_at=datetime.now(timezone.utc),
-            pool_id=pool_id,
-            op="resume_and_reset",
-            session_id=cli_sid,
-        )
-        payload = self._codec.encode_control(cmd)
-        result = await self._pool._transport.call(  # type: ignore[attr-defined]  # noqa: SLF001
-            _SUBJECT_CONTROL, payload, timeout=self._timeout
-        )
-        if not isinstance(result, Ok):
-            return False
-        try:
-            ack = CliControlAck.model_validate_json(result.value)
-            return bool(ack.resumed)
-        except ValidationError as exc:
-            log.warning("llm_client: CliControlAck parse failed: %r", exc)
-            return False
+        self._pending_resume[pool_id] = cli_sid
+        return True
 
     async def switch_cwd(self, pool_id: str, cwd: "Path") -> None:
         """Ask clipool worker to switch the working directory."""

--- a/src/factory/llm/llm_client.py
+++ b/src/factory/llm/llm_client.py
@@ -77,6 +77,9 @@ class LlmClient:
         *,
         messages: list[dict] | None = None,
     ) -> LlmResult:
+        # Pop before the call; re-stash on transport failure so the resume is
+        # not silently dropped when the worker is temporarily unreachable.
+        pending_resume = self._pending_resume.pop(pool_id, None)
         payload, trace_id = self._codec.encode(
             text,
             model_cfg,
@@ -85,14 +88,19 @@ class LlmClient:
             stream=False,
             pool_id=pool_id,
             lyra_session_id=self._lyra_sessions.get(pool_id),
-            resume_session_id=self._pending_resume.pop(pool_id, None),
+            resume_session_id=pending_resume,
         )
-        result = await self._pool.request_with_routing(
-            lambda _: self._request_subject,
-            payload,
-            max_attempts=1,
-            timeout=self._timeout,
-        )
+        try:
+            result = await self._pool.request_with_routing(
+                lambda _: self._request_subject,
+                payload,
+                max_attempts=1,
+                timeout=self._timeout,
+            )
+        except Exception:
+            if pending_resume is not None:
+                self._pending_resume.setdefault(pool_id, pending_resume)
+            raise
         return self._codec.decode(result, trace_id)
 
     async def stream(  # noqa: PLR0913 — LlmProvider protocol signature
@@ -104,6 +112,10 @@ class LlmClient:
         *,
         messages: list[dict] | None = None,
     ) -> AsyncIterator[LlmEvent]:
+        # Pop before the generator starts; re-stash on connection failure so
+        # the resume is not lost if the worker is unreachable on the first
+        # attempt (stream path: exception fires before any yield).
+        pending_resume = self._pending_resume.pop(pool_id, None)
         payload, _ = self._codec.encode(
             text,
             model_cfg,
@@ -112,17 +124,22 @@ class LlmClient:
             stream=True,
             pool_id=pool_id,
             lyra_session_id=self._lyra_sessions.get(pool_id),
-            resume_session_id=self._pending_resume.pop(pool_id, None),
+            resume_session_id=pending_resume,
         )
-        async for result in self._pool.stream_request(
-            self._request_subject, payload, timeout=self._timeout
-        ):
-            event = self._codec.decode_chunk(result)
-            if event is None:
-                continue
-            yield event
-            if isinstance(event, ResultLlmEvent):
-                return
+        try:
+            async for result in self._pool.stream_request(
+                self._request_subject, payload, timeout=self._timeout
+            ):
+                event = self._codec.decode_chunk(result)
+                if event is None:
+                    continue
+                yield event
+                if isinstance(event, ResultLlmEvent):
+                    return
+        except Exception:
+            if pending_resume is not None:
+                self._pending_resume.setdefault(pool_id, pending_resume)
+            raise
 
     # ── Control-plane methods (re-homed from CliNatsDriver, Slice S2) ────
 
@@ -165,7 +182,9 @@ class LlmClient:
         complete() or stream() call via CliCmdPayload.resume_session_id — no
         separate NATS control message is sent.
 
-        Returns True iff a cli_session_id was resolved and stashed.
+        Returns True iff a cli_session_id was resolved and stashed ("stash
+        accepted").  True does NOT mean the resume has been applied — the
+        worker applies it on the next CliCmdPayload it receives.
         """
         cli_sid: str | None = None
         if self._turn_store is not None:

--- a/tests/adapters/clipool/test_clipool_worker_resume.py
+++ b/tests/adapters/clipool/test_clipool_worker_resume.py
@@ -263,3 +263,142 @@ class TestNoTurnStoreInWorker:
         assert result.returncode == 1, (
             f"clipool_worker.py references TurnStore:\n{result.stdout}"
         )
+
+
+# ---------------------------------------------------------------------------
+# SC-18: _handle_cmd embedded-resume path (CliCmdPayload.resume_session_id)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCmdEmbeddedResume:
+    """SC-18 — _handle_cmd calls pool.resume_direct when resume_session_id is set."""
+
+    @pytest.mark.asyncio
+    async def test_handle_cmd_with_resume_session_id_calls_resume_direct(
+        self,
+    ) -> None:
+        """resume_session_id present → pool.resume_direct called before streaming."""
+        import asyncio
+
+        from factory.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+        # Arrange — fake pool with resume_direct + send_streaming
+        pool = MagicMock(spec=CliPool)
+        pool.resume_direct = AsyncMock(return_value=True)
+
+        # send_streaming must be an async generator
+        async def _fake_streaming(*_args, **_kwargs):
+            return
+            yield  # make it an async generator
+
+        pool.send_streaming = _fake_streaming
+
+        worker = CliPoolNatsWorker(pool)
+
+        # Minimal NATS msg double (reply needed for reply() call in _handle_cmd_streaming)
+        msg = MagicMock()
+        msg.reply = "_INBOX.test"
+
+        # Use asyncio.Event to synchronize instead of sleep
+        resume_called = asyncio.Event()
+        _orig = pool.resume_direct
+
+        async def _spy_resume(*args, **kwargs):
+            result = await _orig(*args, **kwargs)
+            resume_called.set()
+            return result
+
+        pool.resume_direct = _spy_resume
+
+        payload = {
+            "contract_version": "1",
+            "trace_id": "trace-sc18",
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "pool_id": "pool-1",
+            "text": "hello",
+            "model_cfg": {"backend": "claude-cli"},
+            "lyra_session_id": "lyra-session-test",
+            "system_prompt": "",
+            "resume_session_id": _VALID_CLI_SID,
+            "stream": True,
+        }
+
+        # Act
+        await worker._handle_cmd(msg, payload)
+
+        # Assert — resume_direct was called with correct args
+        assert resume_called.is_set(), "resume_direct was not called"
+
+    @pytest.mark.asyncio
+    async def test_handle_cmd_without_resume_session_id_skips_resume_direct(
+        self,
+    ) -> None:
+        """resume_session_id absent → pool.resume_direct NOT called."""
+        from factory.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+        pool = MagicMock(spec=CliPool)
+        pool.resume_direct = AsyncMock(return_value=True)
+
+        async def _fake_streaming(*_args, **_kwargs):
+            return
+            yield
+
+        pool.send_streaming = _fake_streaming
+
+        worker = CliPoolNatsWorker(pool)
+        msg = MagicMock()
+        msg.reply = "_INBOX.test"
+
+        payload = {
+            "contract_version": "1",
+            "trace_id": "trace-sc18b",
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "pool_id": "pool-1",
+            "text": "hello",
+            "model_cfg": {"backend": "claude-cli"},
+            "lyra_session_id": "lyra-session-test",
+            "system_prompt": "",
+            # resume_session_id deliberately omitted
+            "stream": True,
+        }
+
+        await worker._handle_cmd(msg, payload)
+
+        pool.resume_direct.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_cmd_resume_direct_called_with_pool_and_session(
+        self,
+    ) -> None:
+        """resume_direct receives pool_id and resume_session_id from payload."""
+        from factory.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+        pool = MagicMock(spec=CliPool)
+        pool.resume_direct = AsyncMock(return_value=False)
+
+        async def _fake_streaming(*_args, **_kwargs):
+            return
+            yield
+
+        pool.send_streaming = _fake_streaming
+
+        worker = CliPoolNatsWorker(pool)
+        msg = MagicMock()
+        msg.reply = "_INBOX.test"
+
+        payload = {
+            "contract_version": "1",
+            "trace_id": "trace-sc18c",
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "pool_id": "pool-resume-42",
+            "text": "world",
+            "model_cfg": {"backend": "claude-cli"},
+            "lyra_session_id": "lyra-session-test",
+            "system_prompt": "",
+            "resume_session_id": _ANOTHER_CLI_SID,
+            "stream": True,
+        }
+
+        await worker._handle_cmd(msg, payload)
+
+        pool.resume_direct.assert_awaited_once_with("pool-resume-42", _ANOTHER_CLI_SID)

--- a/tests/adapters/clipool/test_clipool_worker_resume.py
+++ b/tests/adapters/clipool/test_clipool_worker_resume.py
@@ -402,3 +402,43 @@ class TestHandleCmdEmbeddedResume:
         await worker._handle_cmd(msg, payload)
 
         pool.resume_direct.assert_awaited_once_with("pool-resume-42", _ANOTHER_CLI_SID)
+
+    @pytest.mark.asyncio
+    async def test_handle_cmd_blocking_with_resume_session_id_calls_resume_direct(
+        self,
+    ) -> None:
+        """stream=False + resume_session_id → pool.resume_direct called before send.
+
+        SC-18 (blocking variant): embedded resume path works for non-streaming
+        requests; pool.resume_direct is awaited with the payload's resume_session_id.
+        """
+        from factory.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+        pool = MagicMock(spec=CliPool)
+        pool.resume_direct = AsyncMock(return_value=True)
+        fake_result = MagicMock()
+        fake_result.error = None
+        fake_result.session_id = _VALID_CLI_SID
+        pool.send = AsyncMock(return_value=fake_result)
+
+        worker = CliPoolNatsWorker(pool)
+        msg = MagicMock()
+        msg.reply = "_INBOX.test"
+
+        payload = {
+            "contract_version": "1",
+            "trace_id": "trace-sc18d",
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "pool_id": "pool-1",
+            "text": "hello",
+            "model_cfg": {"backend": "claude-cli"},
+            "lyra_session_id": "lyra-session-test",
+            "system_prompt": "",
+            "resume_session_id": _VALID_CLI_SID,
+            "stream": False,
+        }
+
+        with patch.object(worker, "reply", new_callable=AsyncMock):
+            await worker._handle_cmd(msg, payload)
+
+        pool.resume_direct.assert_awaited_once_with("pool-1", _VALID_CLI_SID)

--- a/tests/adapters/clipool/test_clipool_worker_resume.py
+++ b/tests/adapters/clipool/test_clipool_worker_resume.py
@@ -295,7 +295,8 @@ class TestHandleCmdEmbeddedResume:
 
         worker = CliPoolNatsWorker(pool)
 
-        # Minimal NATS msg double (reply needed for reply() call in _handle_cmd_streaming)
+        # Minimal NATS msg double (reply needed for reply() call
+        # in _handle_cmd_streaming)
         msg = MagicMock()
         msg.reply = "_INBOX.test"
 

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -406,7 +406,7 @@ class TestSimpleAgentCliLifecycle:
     # ------------------------------------------------------------------
 
     async def test_t9b_resume_and_reset_routes_through_cli_pool(self) -> None:
-        """T9b: _session_resume_fn routes to cli_pool.queue_resume (S2 embedded path)."""
+        """T9b: _session_resume_fn routes to cli_pool.queue_resume (S2 embedded)."""
         # Arrange — provider has NO queue_resume method
         provider = MagicMock(spec=["complete", "stream", "is_alive"])
         cli_pool = MagicMock()
@@ -653,9 +653,7 @@ class TestSimpleAgentNatsLifecycle:
         result = await pool.resume_session("sess-nats-1")
 
         assert result is True
-        nats_driver.queue_resume.assert_called_once_with(
-            pool.pool_id, "sess-nats-1"
-        )
+        nats_driver.queue_resume.assert_called_once_with(pool.pool_id, "sess-nats-1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -402,15 +402,15 @@ class TestSimpleAgentCliLifecycle:
         cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/new/cwd"))
 
     # ------------------------------------------------------------------
-    # T9b — CB-wrapped resume_and_reset: resume fn → cli_pool.resume_and_reset
+    # T9b — resume fn → cli_pool.queue_resume (S2: embedded resume path)
     # ------------------------------------------------------------------
 
     async def test_t9b_resume_and_reset_routes_through_cli_pool(self) -> None:
-        """T9b: _session_resume_fn routes to cli_pool.resume_and_reset."""
-        # Arrange — provider has NO resume_and_reset method
+        """T9b: _session_resume_fn routes to cli_pool.queue_resume (S2 embedded path)."""
+        # Arrange — provider has NO queue_resume method
         provider = MagicMock(spec=["complete", "stream", "is_alive"])
         cli_pool = MagicMock()
-        cli_pool.resume_and_reset = AsyncMock(return_value=True)
+        cli_pool.queue_resume = AsyncMock(return_value=True)
 
         agent = make_agent_with_cli_pool(provider, cli_pool)
         pool = make_pool()
@@ -422,8 +422,8 @@ class TestSimpleAgentCliLifecycle:
         # Act
         await pool._session_resume_fn("sess-1")
 
-        # Assert — cli_pool.resume_and_reset called with pool_id and session id
-        cli_pool.resume_and_reset.assert_called_once_with(pool.pool_id, "sess-1")
+        # Assert — cli_pool.queue_resume called with pool_id and session id
+        cli_pool.queue_resume.assert_called_once_with(pool.pool_id, "sess-1")
 
     # ------------------------------------------------------------------
     # T10 — CB-wrapped link_lyra_session: process() → cli_pool.link_lyra_session
@@ -463,7 +463,7 @@ class TestSimpleAgentCliLifecycle:
         provider = MagicMock()
         provider.reset = AsyncMock()
         provider.switch_cwd = AsyncMock()
-        provider.resume_and_reset = AsyncMock(return_value=True)
+        provider.queue_resume = AsyncMock(return_value=True)
         provider.link_lyra_session = MagicMock()
         provider.complete = AsyncMock(
             return_value=LlmResult(result="ok", session_id="s1")
@@ -473,7 +473,7 @@ class TestSimpleAgentCliLifecycle:
         cli_pool = MagicMock()
         cli_pool.reset = AsyncMock()
         cli_pool.switch_cwd = AsyncMock()
-        cli_pool.resume_and_reset = AsyncMock(return_value=True)
+        cli_pool.queue_resume = AsyncMock(return_value=True)
         cli_pool.link_lyra_session = MagicMock()
 
         agent = make_agent_with_cli_pool(provider, cli_pool)
@@ -491,7 +491,7 @@ class TestSimpleAgentCliLifecycle:
         # Assert — all four went through cli_pool
         cli_pool.reset.assert_called_once_with(pool.pool_id)
         cli_pool.switch_cwd.assert_called_once_with(pool.pool_id, Path("/some/cwd"))
-        cli_pool.resume_and_reset.assert_called_once_with(pool.pool_id, "sess-42")
+        cli_pool.queue_resume.assert_called_once_with(pool.pool_id, "sess-42")
         cli_pool.link_lyra_session.assert_called_once_with(
             pool.pool_id, pool.session_id
         )
@@ -639,10 +639,10 @@ class TestSimpleAgentNatsLifecycle:
     # ------------------------------------------------------------------
 
     async def test_t9bn_resume_routes_through_nats_driver(self) -> None:
-        """T9bn: pool.resume_session() → nats_driver.resume_and_reset(pool_id, sid)."""
+        """T9bn: pool.resume_session() → nats_driver.queue_resume(pool_id, sid)."""
         provider = MagicMock(spec=["complete", "stream", "is_alive"])
         nats_driver = MagicMock()
-        nats_driver.resume_and_reset = AsyncMock(return_value=True)
+        nats_driver.queue_resume = AsyncMock(return_value=True)
 
         agent = make_agent_with_nats_driver(provider, nats_driver)
         pool = make_pool()
@@ -653,7 +653,7 @@ class TestSimpleAgentNatsLifecycle:
         result = await pool.resume_session("sess-nats-1")
 
         assert result is True
-        nats_driver.resume_and_reset.assert_called_once_with(
+        nats_driver.queue_resume.assert_called_once_with(
             pool.pool_id, "sess-nats-1"
         )
 

--- a/tests/bootstrap/test_bootstrap_lifecycle.py
+++ b/tests/bootstrap/test_bootstrap_lifecycle.py
@@ -123,8 +123,7 @@ async def test_run_lifecycle_none_dc_thread_store_is_noop() -> None:
 
 
 async def test_run_lifecycle_stops_audio_consumers() -> None:
-    """Audio consumers in tg_consumers + dc_consumers have stop() awaited at teardown.
-    """
+    """Audio consumers in tg_consumers/dc_consumers have stop() awaited at teardown."""
     from factory.bootstrap.lifecycle.bootstrap_lifecycle import run_lifecycle
 
     hub = _make_hub()

--- a/tests/core/test_cli_pool_state.py
+++ b/tests/core/test_cli_pool_state.py
@@ -75,15 +75,15 @@ class TestCliPoolSpawnCwd:
 
 
 # ---------------------------------------------------------------------------
-# T3.4 — CliPool.resume_and_reset() — reply-to-resume (#244)
+# T3.4 — CliPool.queue_resume() — reply-to-resume (#244)
 # ---------------------------------------------------------------------------
 
 
 class TestCliPoolResumeAndReset:
-    """CliPool.resume_and_reset() stores session_id for next spawn (T3.4, SC-5)."""
+    """CliPool.queue_resume() stores session_id for next spawn (T3.4, SC-5)."""
 
     async def test_resume_and_reset_sets_session_id(self) -> None:
-        """After resume_and_reset(), CLI session stored and process killed."""
+        """After queue_resume(), CLI session stored and process killed."""
         pool = CliPool()
         proc = make_fake_proc([])
         # Pre-populate a live entry so _kill has something to terminate
@@ -105,9 +105,9 @@ class TestCliPoolResumeAndReset:
         mock_store.get_cli_session = AsyncMock(return_value=_CLI_SESS)
         pool.set_turn_store(mock_store)
 
-        # Act — pipeline passes the Lyra session; resume_and_reset looks up
+        # Act — pipeline passes the Lyra session; queue_resume looks up
         # the CLI session from TurnStore.
-        await pool.resume_and_reset("pool:tg:chat:1", _LYRA_SESS)
+        await pool.queue_resume("pool:tg:chat:1", _LYRA_SESS)
 
         # Assert — CLI session stored for next spawn AND process killed
         assert pool._resume_session_ids.get("pool:tg:chat:1") == _CLI_SESS

--- a/tests/llm/test_llm_client_control.py
+++ b/tests/llm/test_llm_client_control.py
@@ -17,7 +17,6 @@ Slice S2 reality:
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -305,10 +304,14 @@ class TestQueueResume:
         from factory.transport._result import Err, SanitizedError
 
         fake_transport = _FakeTransport(call_return=Ok(b"{}"))
-        client, codec, pool = _make_client(fake_transport)
+        client, _, pool = _make_client(fake_transport)
 
         # Make request_with_routing return an Err (use a known code so decode succeeds)
-        err = Err(SanitizedError(code="transport.no_responders", message="forced", retryable=False))
+        err = Err(
+            SanitizedError(
+                code="transport.no_responders", message="forced", retryable=False
+            )
+        )
         pool.request_with_routing = AsyncMock(return_value=err)
 
         store = MagicMock()
@@ -330,7 +333,7 @@ class TestQueueResume:
     async def test_stream_pops_pending_resume(self) -> None:
         """After queue_resume stashes, stream() consumes it via resume_session_id."""
         fake_transport = _FakeTransport(call_return=Ok(b"{}"))
-        client, codec, pool = _make_client(fake_transport)
+        client, _, pool = _make_client(fake_transport)
 
         # stream_request must be an async generator; return empty one
         async def _empty_stream(*_args: object, **_kwargs: object):  # type: ignore[return]
@@ -349,7 +352,8 @@ class TestQueueResume:
         from factory.core.agent.agent_config import ModelConfig
 
         model_cfg = ModelConfig(backend="claude-cli")
-        # Exhaust the (empty) stream — stash is popped when body executes (first iteration)
+        # Exhaust the (empty) stream — stash is popped when body executes
+        # (first iteration)
         async for _ in client.stream("pool-8", "hello", model_cfg, "sys"):
             pass
 

--- a/tests/llm/test_llm_client_control.py
+++ b/tests/llm/test_llm_client_control.py
@@ -9,8 +9,9 @@ Slice S2 reality:
 - link_lyra_session / unlink_lyra_session are pure local dict mutations (no
   transport call) — mirrors the legacy CliNatsDriver behaviour. Tests assert
   the LOCAL state effect, not a network call.
-- reset / resume_and_reset / switch_cwd dispatch via transport.call (need ack);
-  set_turn_store delegates to codec.set_session_store.
+- reset / switch_cwd dispatch via transport.call (need ack);
+  queue_resume stashes cli_session_id into _pending_resume (no transport call);
+  set_turn_store wires the TurnStore for cli_session_id lookups.
 """
 
 from __future__ import annotations
@@ -25,9 +26,8 @@ import pytest
 
 from factory.llm.cli_nats_codec import CliNatsCodec
 from factory.llm.llm_client import LlmClient
-from factory.transport._result import Ok, SanitizedError
+from factory.transport._result import Ok
 from factory.transport.worker_pool_client import WorkerPoolClient
-from roxabi_contracts.cli.models import CliControlAck
 from roxabi_contracts.envelope import CONTRACT_VERSION
 
 _SUBJECT_CONTROL = "factory.clipool.control"
@@ -245,111 +245,112 @@ class TestSwitchCwd:
 
 
 # ---------------------------------------------------------------------------
-# resume_and_reset — True branch (cli_session_id found, ack.resumed=True)
+# queue_resume — stash cli_session_id for next complete()/stream() call
 # ---------------------------------------------------------------------------
 
 
-class TestResumeAndReset:
-    def _make_ack_bytes(self, *, resumed: bool, pool_id: str = "pool-5") -> bytes:
-        ack = CliControlAck(
-            contract_version=CONTRACT_VERSION,
-            trace_id="trace-ack",
-            issued_at=datetime.now(timezone.utc),
-            pool_id=pool_id,
-            ok=True,
-            resumed=resumed,
-        )
-        return ack.model_dump_json(exclude_none=True).encode()
-
+class TestQueueResume:
     @pytest.mark.asyncio
-    async def test_resume_and_reset_returns_true_when_ack_resumed_true(self) -> None:
+    async def test_queue_resume_stashes_and_returns_true(self) -> None:
+        """TurnStore returns cli_sid → stashed in _pending_resume, True returned."""
         # Arrange
-        ack_bytes = self._make_ack_bytes(resumed=True, pool_id="pool-5")
-        fake_transport = _FakeTransport(call_return=Ok(ack_bytes))
+        fake_transport = _FakeTransport()
         client, _, _ = _make_client(fake_transport)
 
-        # Wire a turn store that returns a known cli_session_id
         store = MagicMock()
         store.get_cli_session = AsyncMock(return_value="cli-sess-123")
         client.set_turn_store(store)
 
         # Act
-        result = await client.resume_and_reset("pool-5", "lyra-session-xyz")
+        result = await client.queue_resume("pool-5", "lyra-session-xyz")
 
-        # Assert
+        # Assert — stashed, no transport call
         assert result is True
-        fake_transport.call.assert_awaited_once()
-
-        subject_used, payload_used = (
-            fake_transport.call.call_args.args[0],
-            fake_transport.call.call_args.args[1],
-        )
-        assert subject_used == _SUBJECT_CONTROL
-        received = json.loads(payload_used)
-        assert received["op"] == "resume_and_reset"
-        assert received["pool_id"] == "pool-5"
-        assert received["session_id"] == "cli-sess-123"
+        assert client._pending_resume["pool-5"] == "cli-sess-123"
+        fake_transport.call.assert_not_awaited()
+        fake_transport.publish.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_resume_and_reset_returns_false_when_ack_resumed_false(self) -> None:
-        # Arrange
-        ack_bytes = self._make_ack_bytes(resumed=False, pool_id="pool-5")
-        fake_transport = _FakeTransport(call_return=Ok(ack_bytes))
-        client, _, _ = _make_client(fake_transport)
-
-        store = MagicMock()
-        store.get_cli_session = AsyncMock(return_value="cli-sess-456")
-        client.set_turn_store(store)
-
-        # Act
-        result = await client.resume_and_reset("pool-5", "lyra-session-xyz")
-
-        # Assert
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_resume_and_reset_returns_false_when_no_cli_session(self) -> None:
-        """When TurnStore returns None, no transport call is made."""
-        fake_transport = _FakeTransport(call_return=Ok(b"{}"))
+    async def test_queue_resume_returns_false_no_cli_session(self) -> None:
+        """TurnStore returns None → False, nothing stashed, no transport call."""
+        fake_transport = _FakeTransport()
         client, _, _ = _make_client(fake_transport)
 
         store = MagicMock()
         store.get_cli_session = AsyncMock(return_value=None)
         client.set_turn_store(store)
 
-        result = await client.resume_and_reset("pool-5", "lyra-session-xyz")
+        result = await client.queue_resume("pool-5", "lyra-session-xyz")
 
         assert result is False
-        # No network call because cli_session_id was not found
+        assert "pool-5" not in client._pending_resume
         fake_transport.call.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_resume_and_reset_returns_false_when_no_turn_store(self) -> None:
-        """When no TurnStore is wired, resume returns False without transport call."""
-        fake_transport = _FakeTransport(call_return=Ok(b"{}"))
+    async def test_queue_resume_returns_false_no_turn_store(self) -> None:
+        """No TurnStore wired → False, no transport call."""
+        fake_transport = _FakeTransport()
         client, _, _ = _make_client(fake_transport)
         # No set_turn_store call — _turn_store is None
 
-        result = await client.resume_and_reset("pool-5", "lyra-session-xyz")
+        result = await client.queue_resume("pool-5", "lyra-session-xyz")
 
         assert result is False
+        assert "pool-5" not in client._pending_resume
         fake_transport.call.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_resume_and_reset_returns_false_on_transport_err(self) -> None:
-        """When transport returns Err, resume_and_reset returns False."""
-        from factory.transport._result import Err
+    async def test_complete_pops_pending_resume(self) -> None:
+        """After queue_resume stashes, complete() consumes the stash."""
+        from factory.transport._result import Err, SanitizedError
 
-        err = SanitizedError(
-            code="transport.timeout", message="TimeoutError", retryable=True
-        )
-        fake_transport = _FakeTransport(call_return=Err(err))
-        client, _, _ = _make_client(fake_transport)
+        fake_transport = _FakeTransport(call_return=Ok(b"{}"))
+        client, codec, pool = _make_client(fake_transport)
+
+        # Make request_with_routing return an Err (use a known code so decode succeeds)
+        err = Err(SanitizedError(code="transport.no_responders", message="forced", retryable=False))
+        pool.request_with_routing = AsyncMock(return_value=err)
 
         store = MagicMock()
-        store.get_cli_session = AsyncMock(return_value="cli-sess-789")
+        store.get_cli_session = AsyncMock(return_value="cli-sess-abc")
         client.set_turn_store(store)
 
-        result = await client.resume_and_reset("pool-5", "lyra-session-xyz")
+        await client.queue_resume("pool-7", "lyra-session-xyz")
+        assert client._pending_resume.get("pool-7") == "cli-sess-abc"
 
-        assert result is False
+        from factory.core.agent.agent_config import ModelConfig
+
+        model_cfg = ModelConfig(backend="claude-cli")
+        # Pop happens before request_with_routing; stash is consumed even on Err
+        await client.complete("pool-7", "hello", model_cfg, "sys")
+
+        assert "pool-7" not in client._pending_resume
+
+    @pytest.mark.asyncio
+    async def test_stream_pops_pending_resume(self) -> None:
+        """After queue_resume stashes, stream() consumes it via resume_session_id."""
+        fake_transport = _FakeTransport(call_return=Ok(b"{}"))
+        client, codec, pool = _make_client(fake_transport)
+
+        # stream_request must be an async generator; return empty one
+        async def _empty_stream(*_args: object, **_kwargs: object):  # type: ignore[return]
+            return
+            yield  # make it an async generator
+
+        pool.stream_request = _empty_stream
+
+        store = MagicMock()
+        store.get_cli_session = AsyncMock(return_value="cli-sess-def")
+        client.set_turn_store(store)
+
+        await client.queue_resume("pool-8", "lyra-session-abc")
+        assert client._pending_resume.get("pool-8") == "cli-sess-def"
+
+        from factory.core.agent.agent_config import ModelConfig
+
+        model_cfg = ModelConfig(backend="claude-cli")
+        # Exhaust the (empty) stream — stash is popped when body executes (first iteration)
+        async for _ in client.stream("pool-8", "hello", model_cfg, "sys"):
+            pass
+
+        assert "pool-8" not in client._pending_resume


### PR DESCRIPTION
## Summary

| Area | Change |
|------|--------|
| **WorkEnvelope reparent** | `CliCmdPayload`, `CliChunkEvent`, `CliControlCmd`, `CliControlAck` now inherit `WorkEnvelope` (carry `job_id`); `CliHeartbeat` stays `ContractEnvelope` (INFRA) |
| **Embedded resume** | `CliCmdPayload.resume_session_id` carries CLI session token directly in LLM request; eliminates `resume_and_reset` wire round-trip |
| **`queue_resume()`** | Replaces `resume_and_reset` in `LlmClient`; resolves `lyra_session_id → cli_session_id` via TurnStore, stashes in `_pending_resume`; popped on next `complete()` / `stream()` call |
| **`resume_direct()`** | `CliPool` method; called in `clipool_worker` after receiving `CliCmdPayload.resume_session_id` |
| **Deprecation tolerance** | `CliControlCmd.op` Literal retains `"resume_and_reset"` + `AliasChoices("cli_session_id", "session_id")` + worker control branch KEPT functional (rolling-deploy compat) |
| **Version** | `0.11.0` |

## Quality gates

| Gate | Result |
|------|--------|
| ruff format + check | ✓ |
| pyright (changed files) | ✓ 0 errors |
| pytest full suite | ✓ 5675 passed, 14 skipped, 1 xfailed |
| test_sleep | ✓ |
| debt_expiry | ✓ |
| doc_drift | ✓ |
| architecture_snapshot | ✓ |
| str_exc_bus_bound | ✓ |
| import_layers (lint-imports) | ✓ 11 contracts kept, 0 broken |
| hardcoded_constants | ✓ |
| duplicate_test_basenames | ✓ |
| secrets_drift | ✓ |
| volumes_table | ✓ |

Closes #1009
Closes #1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)