### PR TITLE
feat: factory-active-jobs NATS-KV registry (#1796)

### DIFF
--- a/artifacts/frames/1796-active-jobs-registry-frame.mdx
+++ b/artifacts/frames/1796-active-jobs-registry-frame.mdx
@@ -1,0 +1,59 @@
+---
+title: "feat(infra): active-jobs registry — factory-active-jobs NATS-KV (singleton index, hub-writer, TTL)"
+issue: 1796
+status: approved
+tier: F-lite
+date: 2026-06-11
+---
+
+## Problem
+
+The hub's busy/steerable state lives in-process only: `pool._current_task` (`src/factory/core/pool/pool.py:102` — is a run active on this conversation?) and `TypingPublisher._refcount` (`src/factory/transport/typing_publisher.py:27`, keyed `tuple[str, str, int]`). The moment a job runs out-of-process (Shape B workers #1044, Shape D stateful runs #1792), the hub is blind: it cannot answer "is pool X busy?", cannot route an inbound message to `steer | queue | fresh` (#1797), and a dashboard cannot show live jobs (#1800 v1).
+
+#1796 lifts that state into a shared **`factory-active-jobs`** NATS-KV registry — keyed `job_id`, with a `pool_id → job_id` singleton secondary index — so cross-process job state survives and is observable. It is the foundation child of epic #1792: #1797 (router), #1798 (sub-jobs), #1799 (steer), #1800 (dashboard) all read it.
+
+**Drift since issue creation (2026-06-08):** the cited SSoT `artifacts/analyses/job-model-concept-analysis.md` was graduated and archived with a SUPERSEDED banner (`a5a20301`). The live SSoT is **`docs/architecture/job-model.md`** (§Active-jobs registry, §Concurrency, §Observability) — schema, writer rule, liveness model, and mode partition are all ratified there. No design re-litigation needed; the frame anchors on the graduated doc.
+
+## Who
+
+- **Primary:** hub (sole writer — opens/closes/refreshes entries per run) and the #1797 concurrency_router (first reader: `fresh | steer | queue` decision at ingress).
+- **Secondary:** #1800 dashboard v1 (`kv.watch` on the bucket), #1624 worker-driven typing (reads the same active-job state), #1799 steer (resolves `steer_subject` from the entry), ops (live-jobs visibility on M₁).
+
+## Constraints
+
+- **Ratified schema (job-model.md, not re-decidable here):** key = `job_id`; value `{pool_id, status: open|closing, started_at, steer_subject, concurrency_mode, worker_loc?}`; secondary index `pool_id → job_id` **singleton**, enforced for `steer`/`queue` modes only; `parallel` mode is NOT pool-scoped (keyed `job_id` only, no index entry).
+- **Writer = HUB only.** Workers never write the registry. Shape D liveness uses the **heartbeat-message pattern** (precedent `factory.clipool.heartbeat`, `clipool_worker.py` `_HEARTBEAT_SUBJECT` / **ADR-049** heartbeat contract — note: the issue body mis-cites ADR-075, which is the TurnWriter subscriber, not heartbeats): the worker publishes a heartbeat message; the hub consumes it and performs the TTL-refreshing KV re-put. Shapes A/B/C: the hub drives TTL refresh from `pool._current_task`. The spec must fix the heartbeat subjects and refresh cadence explicitly — unresolved producers leave stale `open` entries until TTL lapse (2026-06-08 review refinement).
+- **Lifecycle (ratified):** CLOSE = terminal `JobResult` (authoritative, event-driven delete); heartbeat = TTL refresh fallback; reap = TTL lapse safety net for crash-before-terminal.
+- **KV key charset (project memory, #1721 outage):** `pool_id` contains colons (`telegram:lyra:…`) which nats-py `VALID_KEY_RE` rejects — silent total-outage class. All KV stores MUST key through `src/factory/infrastructure/stores/_kv_keys.py`. The `pool_id → job_id` index keys MUST be sanitized through the same helper.
+- **Provisioning pattern (paved):** hub-only create-or-open **before `announce_hub_ready()`** — the model is `factory-state` in `bootstrap/wiring/kv_watch_channels.py` (hub-only, pre-ready). (`blobstore/serve.py` also does create-or-open but as sidecar best-effort — NOT the model here.) New bucket = new ACL surface: `$KV.factory-active-jobs.>` publish for hub → **ACL fan-out** (regen 4 artifacts + hand-mirror `tests/scripts/fixtures/v3-pre-grant-group.json`; equivalence checks CI-only).
+- **Bucket config pinned day-1:** spec must pin `allow_direct` on `KeyValueConfig` at creation (changing it later = bucket recreation). The choice shapes the #1800 read path and reader ACLs — document the rationale in the spec.
+- **Reader ACL (#1797/#1800):** readers inside the hub process need no new grant. Out-of-hub readers SHOULD use `kv.get` (zero-ACL via #1572 `STREAM.MSG.GET`) rather than `kv.watch` (needs ephemeral-consumer grants); if `kv.watch` is chosen for any reader, it is a separate ACL grant with its own regen pass (#1800's problem, but the spec must not foreclose it).
+- **TTL semantics:** TTL is bucket-level (`max_age`) in NATS KV; per-key refresh = re-put. Heartbeat cadence must be < bucket TTL with margin. Both values = **named constants** (the store module lives under `infrastructure/`, but anything landing under `src/factory/core/` falls under the `hardcoded_constants` gate — named + imported, never inlined).
+- **`parallel` mode preservation (review refinement F4):** the registry replaces `_refcount` only for `steer`/`queue`. For `parallel`, multiple jobs share one `(platform, bot, scope)` — coexistence strategy is an **open spec decision** (options: keep `TypingPublisher._refcount` alongside, registry-side counting); ref-counting semantics must survive either way.
+- **Layering + axial:** store module belongs in `src/factory/infrastructure/stores/` (sibling of `message_index_kv.py`; test anchor `tests/infrastructure/stores/test_message_index_kv.py`, AsyncMock pattern). `folder_size` gate: stores/ = 13 `.py` files today, `QG_FOLDER_MAX=15` (qg.conf) → 14 after addition, no exemption needed. Import-linter layers gate applies — the pool/hub side consumes the store via an injected port/protocol, never `import factory.infrastructure` from `core/`. A PR touching top-level `core/` + `infrastructure/` auto-triggers the `dev-core:axial-adr-review` label (CLAUDE.md) — expected, don't strip it.
+
+## Out of Scope
+
+- The `fresh | steer | queue` routing decision itself — #1797 (concurrency_router, single shared inbound stage).
+- Sub-jobs pub/sub migration (#1798), steer end-to-end (#1799), dashboard (#1800 — including its `kv.watch` ephemeral-consumer ACLs; the registry only has to be watchable).
+- Worker-driven typing rewiring (#1624) — reads this registry later; no typing code changes here.
+- JOBS dispatch stream (#1203) — different tier (at-least-once dispatch); zero file overlap expected (parallel track).
+- Replacing `pool._current_task` as the pool's own internal scheduler state — the registry mirrors run-state for cross-process consumers; the in-process pool keeps its task handle.
+
+## Premise Validity
+
+**Success in 6 months:** `factory-active-jobs` provisioned at hub boot; every envelope-driven run gets an entry at open and a delete at terminal `JobResult`; singleton index enforced for `steer`/`queue`; a killed worker's entry disappears by TTL reap — observed via `nats kv get factory-active-jobs <job_id>` (hub seed) after kill + TTL+margin, and asserted by an integration-level test (faked TTL acceptable). #1797 router reads the registry instead of in-memory state, and #1800 v1 watches it. The cross-process busy/steerable window is queryable by `job_id` AND by `pool_id`.
+
+**Failure in 6 months:** By 2026-12, either (a) the registry has **0 readers** in `src/` (checkable: `grep -r "factory-active-jobs\|active_jobs" src/` shows only the writer) — #1797 still routes from `pool._current_task` in-memory and the bucket is write-only bookkeeping — or (b) stale `open` entries persist past TTL+margin (probe: kill a worker mid-run, `nats kv get` the entry after the TTL window — entry still `open` = liveness wiring broken), forcing readers back to in-memory state. Either condition = the underlying problem (cross-process visibility) is unsolved → redesign the liveness wiring.
+
+**Simplest alternative:** no registry — query state on demand (request-reply ping to pool/workers per inbound message) and keep `TypingPublisher._refcount` as-is.
+**Why not simplest:** Shape D runs outlive a hub restart, so in-memory + ping loses the steer window exactly when it matters; per-message polling adds latency and a read-then-act race at ingress; and there is nothing watchable for the #1800 dashboard. KV gives durable state + TTL liveness + watchability in one paved primitive. Ratified in `docs/architecture/job-model.md` after the 2026-06-08 convergence; the cheaper in-between (reuse `factory-state` bucket) fails on lifecycle semantics — registry entries are ephemeral/TTL'd, `factory-state` is durable config.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (infrastructure/stores + hub wiring), schema and liveness model pre-ratified; the open points (heartbeat subjects/cadence, `allow_direct`, parallel-mode coexistence) are spec-level decisions.
+
+Signals observed:
+- Label `size:F-lite`; design fully converged in job-model.md (no unknowns, no new architecture).
+- Touch surface: one new store module + `_kv_keys` reuse, hub bootstrap wiring, `deploy/nats/acl-matrix.json` + regen artifacts, tests — single domain.
+- Paved precedents for every mechanism: `factory-state` provisioning (hub-only pre-ready), `message_index_kv.py` store shape, ADR-049 heartbeat pattern.

--- a/artifacts/plans/1796-active-jobs-registry-plan.mdx
+++ b/artifacts/plans/1796-active-jobs-registry-plan.mdx
@@ -1,0 +1,645 @@
+---
+title: "#1796 — factory-active-jobs NATS-KV Registry: Implementation Plan"
+issue: 1796
+status: approved
+tier: F-lite
+date: 2026-06-12
+spec: artifacts/specs/1796-active-jobs-registry-spec.mdx
+---
+
+# #1796 — Implementation Plan: factory-active-jobs NATS-KV Registry
+
+## Build Order
+
+```
+Slice 0 (foundation) → Slice 1 (port + store) → Slice 2 (pool wiring) → Slice 3 (refresher) → Slice A1 (ACL) → Slice D1 (docs)
+```
+
+Each slice is independently committable. Slices 0–3 can proceed without ACL; A1 must land before prod deploy.
+
+---
+
+## Slice 0 — Bucket Provisioning at Hub Boot
+
+**Scope:** Wire `factory-active-jobs` KV bucket creation into `hub_standalone.py` before `announce_hub_ready()`.
+
+### Files
+
+| File | Action |
+|---|---|
+| `src/factory/bootstrap/standalone/hub_standalone.py` | Edit — add `_ensure_active_jobs_kv()` call in provisioning block |
+| `src/factory/bootstrap/wiring/kv_active_jobs.py` | New — `_open_or_create_active_jobs_kv(js)` helper |
+
+### New file: `src/factory/bootstrap/wiring/kv_active_jobs.py`
+
+```python
+"""Race-safe create-or-open for the factory-active-jobs KV bucket.
+
+Mirrors kv_watch_channels._open_or_create_kv() pattern exactly.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nats.js.api import KeyValueConfig, StorageType
+from nats.js.errors import BadRequestError, BucketNotFoundError
+
+from factory.infrastructure.stores.active_jobs_kv import (
+    ACTIVE_JOBS_BUCKET,
+    ACTIVE_JOBS_TTL,
+)
+
+if TYPE_CHECKING:
+    from nats.js import JetStreamContext
+    from nats.js.kv import KeyValue
+
+_ERR_CODE_ALREADY_EXISTS = 10058
+
+
+async def open_or_create_active_jobs_kv(js: "JetStreamContext") -> "KeyValue":
+    """Race-safe KV open. Fail-fast on unexpected errors."""
+    try:
+        return await js.key_value(ACTIVE_JOBS_BUCKET)
+    except BucketNotFoundError:
+        pass
+    try:
+        return await js.create_key_value(
+            KeyValueConfig(
+                bucket=ACTIVE_JOBS_BUCKET,
+                ttl=ACTIVE_JOBS_TTL,
+                storage=StorageType.FILE,
+                allow_direct=False,
+            )
+        )
+    except BadRequestError as exc:
+        if exc.err_code != _ERR_CODE_ALREADY_EXISTS:
+            raise
+    return await js.key_value(ACTIVE_JOBS_BUCKET)
+```
+
+### Edit: `hub_standalone.py` provisioning block
+
+Insert after existing `ensure_kv` / `JetStreamAuditSink.provision` calls, **before** `announce_hub_ready(nc)` (line ~204):
+
+```python
+from factory.bootstrap.wiring.kv_active_jobs import open_or_create_active_jobs_kv
+
+_active_jobs_kv = await open_or_create_active_jobs_kv(_audio_js)
+# _active_jobs_kv is threaded to KvActiveJobsStore below
+```
+
+### Tests
+
+**File:** `tests/bootstrap/test_hub_active_jobs_provision.py`
+
+- `test_bucket_created_on_fresh_boot`: mock JS; assert `create_key_value` called with `bucket="factory-active-jobs"`, `ttl=120`, `storage=FILE`, `allow_direct=False`.
+- `test_bucket_open_on_existing`: mock JS so `key_value()` succeeds immediately; assert `create_key_value` NOT called.
+- `test_race_safe_lost_creation`: mock so first `key_value` raises `BucketNotFoundError`, `create_key_value` raises `BadRequestError(err_code=10058)`, second `key_value` succeeds.
+- `test_unexpected_bad_request_propagates`: `BadRequestError(err_code=9999)` must propagate (fail-fast).
+
+---
+
+## Slice 1 — Port + KV Store
+
+**Scope:** `ActiveJobsPort` Protocol in `core/ports/`; `KvActiveJobsStore` in `infrastructure/stores/`; `RegistryConflictError` in the port module.
+
+### Files
+
+| File | Action |
+|---|---|
+| `src/factory/core/ports/active_jobs.py` | New |
+| `src/factory/core/ports/__init__.py` | Edit — re-export `ActiveJobsPort`, `ActiveJobEntry`, `RegistryConflictError` |
+| `src/factory/infrastructure/stores/active_jobs_kv.py` | New |
+
+**Folder size check:**
+- `core/ports/`: 9 → 10 files (within 15 limit)
+- `infrastructure/stores/`: 13 → 14 files (within 15 limit, `base/` and `migrations/` are dirs not counted)
+
+### New file: `src/factory/core/ports/active_jobs.py`
+
+```python
+"""ActiveJobsPort — driven port for the factory-active-jobs KV registry.
+
+Pure Protocol + value objects. Zero infrastructure imports.
+Concrete impl: factory.infrastructure.stores.active_jobs_kv.KvActiveJobsStore.
+"""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class RegistryConflictError(Exception):
+    """CAS conflict on singleton idx key (steer/queue concurrency_mode).
+
+    Raised by open() when another job already holds the pool_id slot.
+    Router (#1797) converts this into a steer or queue decision.
+    """
+    def __init__(self, pool_id: str, existing_job_id: str) -> None:
+        super().__init__(f"pool {pool_id!r} already has active job {existing_job_id!r}")
+        self.pool_id = pool_id
+        self.existing_job_id = existing_job_id
+
+
+@dataclass(frozen=True)
+class ActiveJobEntry:
+    job_id: str
+    pool_id: str
+    status: str                  # "open" | "closing"
+    started_at: datetime.datetime
+    steer_subject: str
+    concurrency_mode: str        # "steer" | "queue" | "parallel"
+    worker_loc: str | None = None
+
+
+class ActiveJobsPort(Protocol):
+    """Hub-side registry of active runs.
+
+    All methods are async and coroutine-safe.
+    Writers: hub only. Readers: hub + future dashboard (#1800).
+    """
+
+    async def open(self, entry: ActiveJobEntry) -> None:
+        """Write job entry + singleton idx (steer/queue only).
+
+        Raises RegistryConflictError if idx key already occupied.
+        """
+        ...
+
+    async def refresh(self, job_id: str) -> None:
+        """Re-put job entry (and its idx key) to reset TTL clock."""
+        ...
+
+    async def close(self, job_id: str) -> None:
+        """Delete job entry and idx key (if this job owns it)."""
+        ...
+
+    async def get_by_pool(self, pool_id: str) -> ActiveJobEntry | None:
+        """Return the open entry for pool_id via idx key, or None."""
+        ...
+```
+
+### New file: `src/factory/infrastructure/stores/active_jobs_kv.py`
+
+```python
+"""KvActiveJobsStore — KV-backed implementation of ActiveJobsPort.
+
+Bucket: factory-active-jobs (FILE storage, TTL=120s, allow_direct=False).
+Writer: hub only. Key scheme: job.<kv_safe(job_id)>, idx.<kv_safe(pool_id)>.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from nats.js.errors import KeyWrongLastSequenceError, NotFoundError
+
+from factory.core.ports.active_jobs import (
+    ActiveJobEntry,
+    ActiveJobsPort,
+    RegistryConflictError,
+)
+from factory.infrastructure.stores._kv_keys import kv_safe_part
+
+if TYPE_CHECKING:
+    from nats.js.kv import KeyValue
+
+log = logging.getLogger(__name__)
+
+ACTIVE_JOBS_BUCKET = "factory-active-jobs"
+ACTIVE_JOBS_TTL = 120          # seconds — named constant, passed as ttl= (not max_age=)
+ACTIVE_JOBS_REFRESH = 30       # seconds — refresher cadence
+
+
+def _job_key(job_id: str) -> str:
+    return f"job.{kv_safe_part(job_id)}"
+
+
+def _idx_key(pool_id: str) -> str:
+    return f"idx.{kv_safe_part(pool_id)}"
+
+
+def _encode(entry: ActiveJobEntry) -> bytes:
+    return json.dumps({
+        "job_id": entry.job_id,
+        "pool_id": entry.pool_id,
+        "status": entry.status,
+        "started_at": entry.started_at.isoformat(),
+        "steer_subject": entry.steer_subject,
+        "concurrency_mode": entry.concurrency_mode,
+        "worker_loc": entry.worker_loc,
+    }).encode()
+
+
+def _decode(raw: bytes) -> ActiveJobEntry:
+    d = json.loads(raw)
+    return ActiveJobEntry(
+        job_id=d["job_id"],
+        pool_id=d["pool_id"],
+        status=d["status"],
+        started_at=datetime.datetime.fromisoformat(d["started_at"]),
+        steer_subject=d["steer_subject"],
+        concurrency_mode=d["concurrency_mode"],
+        worker_loc=d.get("worker_loc"),
+    )
+
+
+class KvActiveJobsStore:
+    """Implements ActiveJobsPort over a NATS JetStream KV handle."""
+
+    def __init__(self, kv: "KeyValue") -> None:
+        self._kv = kv
+        # In-memory index: job_id → entry (for refresh without re-read)
+        self._entries: dict[str, ActiveJobEntry] = {}
+
+    async def open(self, entry: ActiveJobEntry) -> None:
+        await self._kv.put(_job_key(entry.job_id), _encode(entry))
+        self._entries[entry.job_id] = entry
+        if entry.concurrency_mode in ("steer", "queue"):
+            idx = _idx_key(entry.pool_id)
+            val = entry.job_id.encode()
+            try:
+                existing = await self._kv.get(idx)
+                try:
+                    await self._kv.update(idx, val, last_revision=existing.revision)
+                except KeyWrongLastSequenceError:
+                    existing2 = await self._kv.get(idx)
+                    raise RegistryConflictError(
+                        entry.pool_id, existing2.value.decode()
+                    )
+            except NotFoundError:
+                try:
+                    await self._kv.create(idx, val)
+                except KeyWrongLastSequenceError:
+                    existing2 = await self._kv.get(idx)
+                    raise RegistryConflictError(
+                        entry.pool_id, existing2.value.decode()
+                    )
+
+    async def refresh(self, job_id: str) -> None:
+        entry = self._entries.get(job_id)
+        if entry is None:
+            return
+        await self._kv.put(_job_key(job_id), _encode(entry))
+        if entry.concurrency_mode in ("steer", "queue"):
+            await self._kv.put(_idx_key(entry.pool_id), job_id.encode())
+
+    async def close(self, job_id: str) -> None:
+        entry = self._entries.pop(job_id, None)
+        try:
+            await self._kv.delete(_job_key(job_id))
+        except NotFoundError:
+            pass
+        if entry and entry.concurrency_mode in ("steer", "queue"):
+            idx = _idx_key(entry.pool_id)
+            try:
+                current = await self._kv.get(idx)
+                if current.value and current.value.decode() == job_id:
+                    await self._kv.delete(idx)
+            except NotFoundError:
+                pass
+
+    async def get_by_pool(self, pool_id: str) -> ActiveJobEntry | None:
+        try:
+            entry_ref = await self._kv.get(_idx_key(pool_id))
+        except NotFoundError:
+            return None
+        job_id = entry_ref.value.decode()
+        entry = self._entries.get(job_id)
+        if entry:
+            return entry
+        try:
+            raw_entry = await self._kv.get(_job_key(job_id))
+            return _decode(raw_entry.value)
+        except NotFoundError:
+            return None
+```
+
+### Tests
+
+**File:** `tests/infrastructure/stores/test_active_jobs_kv.py`
+
+Anchor: `tests/infrastructure/stores/test_message_index_kv.py` (AsyncMock pattern).
+
+- `test_open_writes_job_and_idx_steer`: open with `concurrency_mode="steer"`; assert `kv.put` called for `job.<id>` and `kv.create` for `idx.<safe_pool_id>`.
+- `test_open_writes_job_no_idx_parallel`: `concurrency_mode="parallel"`; assert `kv.create` NOT called.
+- `test_open_colon_pool_id_sanitization`: `pool_id="telegram:lyra:123"`; assert idx key is `idx.telegram_lyra_123` (no colons).
+- `test_open_conflict_raises_RegistryConflictError`: second `open()` with same pool_id; `kv.create` raises `KeyWrongLastSequenceError` → `RegistryConflictError`.
+- `test_refresh_reputs_job_and_idx`: open then refresh; assert `kv.put` called twice for both keys.
+- `test_refresh_noop_unknown_job`: refresh with unknown job_id; no exception.
+- `test_close_deletes_job_and_idx_owner`: open then close; assert `kv.delete` called for both, only when current idx value matches job_id.
+- `test_close_skips_idx_if_not_owner`: close when idx holds a different job_id; only `job.*` deleted.
+- `test_get_by_pool_returns_entry`: open then get_by_pool; returns correct entry.
+- `test_get_by_pool_returns_none_no_idx`: get_by_pool for unknown pool_id; returns None.
+- `test_faked_ttl_reap`: after `close()` removes the in-memory entry, a crash-orphan `kv.get` raises `NotFoundError`; proves TTL reap path (the live entry simply doesn't exist).
+
+---
+
+## Slice 2 — Pool Run-Completion Wiring
+
+**Scope:** Call `active_jobs.open()` at run start (`pool.submit()` first-task path) and `active_jobs.close()` at the exact run-completion seam.
+
+### Run-Completion Seam (Risk-Identified)
+
+**File:** `src/factory/core/pool/pool_processor.py`, `process_loop()`, lines 94–95:
+
+```python
+        finally:
+            pool._current_task = None  # ← INJECTION POINT for close()
+```
+
+This `finally` block executes unconditionally after every run, regardless of:
+- Normal completion
+- `CancelledError` from `/stop` (re-raised after sending "cancelled" reply)
+- Any unhandled exception in `_process_with_cancel`
+
+**Strategy:** `pool._on_run_complete_fn` — a nullable async callback stored on the `Pool` instance. Wired by bootstrap (composition root) after construction. Called in `process_loop()` finally block:
+
+```python
+        finally:
+            pool._current_task = None
+            if pool._on_run_complete_fn is not None:
+                await asyncio.shield(pool._on_run_complete_fn())
+```
+
+`asyncio.shield` ensures close() survives a pending cancel.
+
+### Files
+
+| File | Action |
+|---|---|
+| `src/factory/core/pool/pool.py` | Edit — add `_on_run_complete_fn: Callable[[], Coroutine] | None = None` attribute |
+| `src/factory/core/pool/pool_processor.py` | Edit — call `_on_run_complete_fn` in finally block |
+| `src/factory/bootstrap/factory/hub/hub_builder.py` or equivalent pool construction site | Edit — inject `_on_run_complete_fn = lambda: active_jobs.close(job_id)` |
+
+**Note on job_id source:** `job_id` is generated as `uuid4().hex` at the `pool.submit()` call site (first new task path). The hub holds it for the duration of the run and passes it into the close lambda. The `open()` call happens at the same submit site (guarded by `is_idle` check, same as task creation). `steer_subject` = `f"factory.job.{job_id}.steer"` (static derivation per spec); `concurrency_mode` comes from pool/agent config; `worker_loc` = None for in-process Shapes A/B/C.
+
+### Key invariant
+
+Only call `open()` when `_current_task` was None/done before submit (i.e., the new task is being created). Re-submits to a running pool do NOT call `open()` again.
+
+### Tests
+
+**File:** `tests/core/pool/test_pool_active_jobs_wiring.py`
+
+- `test_open_called_on_first_submit`: mock `ActiveJobsPort`; assert `open()` called exactly once when `_current_task` was None.
+- `test_open_not_called_on_resubmit`: pool already running (`_current_task` alive); second `submit()` does NOT call `open()`.
+- `test_close_called_in_finally_normal`: process_loop completes normally; assert `close(job_id)` called with correct id.
+- `test_close_called_in_finally_on_cancel`: process_loop cancelled; assert `close()` still called (shield path).
+- `test_close_called_in_finally_on_exception`: process_loop raises; assert `close()` still called.
+
+---
+
+## Slice 3 — RegistryRefresher
+
+**Scope:** Hub-side async task that re-puts open entries every `ACTIVE_JOBS_REFRESH` (30s) from two sources: (a) pool-source (in-process Shapes A/B/C), (b) heartbeat-source (Shape D via injected callback).
+
+### Heartbeat Injection Point (Risk-Identified)
+
+**File:** `src/factory/bootstrap/factory/llm_overlay.py` (and `voice_overlay.py` equivalent for each role).
+
+Current `WorkerPoolClient` construction:
+
+```python
+pool = WorkerPoolClient(
+    transport,
+    registry=WorkerRegistry(),
+    hb_subject=SUBJECTS.heartbeat,
+    validate_worker_id=validate_worker_id,
+    name="llm",
+)
+```
+
+**Strategy:** Add optional `on_heartbeat: Callable[[dict], None] | None = None` parameter to `WorkerPoolClient.__init__`. In `_on_heartbeat()`, after `self._registry.record_heartbeat(payload)`, call `self._on_heartbeat_cb(payload)` if set. Injected at construction site from bootstrap with: `on_heartbeat=refresher.on_heartbeat`.
+
+**Tap-in rule enforced:** Only one subscription to `factory.<role>.heartbeat`; callback is additive, no second `nc.subscribe`.
+
+### Files
+
+| File | Action |
+|---|---|
+| `src/factory/bootstrap/hub/registry_refresher.py` | New — `RegistryRefresher` class |
+| `src/factory/transport/worker_pool_client.py` | Edit — add `on_heartbeat` callback param |
+| `src/factory/bootstrap/factory/llm_overlay.py` | Edit — thread `on_heartbeat=refresher.on_heartbeat` |
+| `src/factory/bootstrap/factory/voice_overlay.py` | Edit — same for TTS/STT/image pool clients |
+
+### New file: `src/factory/bootstrap/hub/registry_refresher.py`
+
+```python
+"""RegistryRefresher — hub task that heartbeats open KV entries.
+
+Two sources:
+  (a) Pool-source: pools with _current_task alive (Shapes A/B/C).
+  (b) Heartbeat-source: Shape D worker heartbeat, matched by worker_loc.
+
+Re-puts both job.* and idx.* keys every ACTIVE_JOBS_REFRESH seconds.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from factory.infrastructure.stores.active_jobs_kv import ACTIVE_JOBS_REFRESH
+
+if TYPE_CHECKING:
+    from factory.core.hub.pipeline import PoolManager
+    from factory.core.ports.active_jobs import ActiveJobsPort
+
+log = logging.getLogger(__name__)
+
+
+class RegistryRefresher:
+    def __init__(
+        self,
+        registry: "ActiveJobsPort",
+        pool_manager: "PoolManager",
+    ) -> None:
+        self._registry = registry
+        self._pool_manager = pool_manager
+        self._task: asyncio.Task | None = None
+        # worker_loc → job_id, maintained by on_heartbeat()
+        self._worker_loc_map: dict[str, str] = {}
+
+    def on_heartbeat(self, payload: dict) -> None:
+        """Callback injected into WorkerPoolClient — runs on heartbeat arrival."""
+        worker_loc = payload.get("worker_loc")
+        job_id = payload.get("job_id")
+        if worker_loc and job_id:
+            self._worker_loc_map[worker_loc] = job_id
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._loop(), name="registry_refresher")
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(ACTIVE_JOBS_REFRESH)
+                await self._refresh_all()
+        except asyncio.CancelledError:
+            pass
+
+    async def _refresh_all(self) -> None:
+        # Pool-source: Shapes A/B/C
+        for pool in self._pool_manager.pools.values():
+            if not pool.is_idle:
+                job_id = getattr(pool, "_active_job_id", None)
+                if job_id:
+                    await self._registry.refresh(job_id)
+        # Heartbeat-source: Shape D (worker_loc matched)
+        for _worker_loc, job_id in list(self._worker_loc_map.items()):
+            await self._registry.refresh(job_id)
+```
+
+### Tests
+
+**File:** `tests/bootstrap/test_registry_refresher.py`
+
+- `test_pool_source_refresh`: mock pool with `is_idle=False` and `_active_job_id="jid1"`; run one _refresh_all cycle; assert `registry.refresh("jid1")` called.
+- `test_idle_pool_not_refreshed`: pool `is_idle=True`; assert refresh NOT called.
+- `test_heartbeat_source_refresh`: call `on_heartbeat({"worker_loc": "w1", "job_id": "jid2"})`; run _refresh_all; assert `registry.refresh("jid2")` called.
+- `test_heartbeat_wrong_entry_not_matched`: heartbeat for `worker_loc="w2"` not in map; only `w1` entry refreshed.
+- `test_stop_cancels_task`: start then stop; assert task cancelled cleanly.
+- `test_heartbeat_both_job_and_idx_reputs`: integration: real `KvActiveJobsStore` (AsyncMock KV), steer-mode entry; after on_heartbeat + _refresh_all, assert both `job.*` and `idx.*` kv.put called.
+
+---
+
+## Slice A1 — ACL Grant
+
+**Scope:** Add `$KV.factory-active-jobs.>` publish grant for hub identity in `acl-matrix.json`; regen all 4 derived artifacts.
+
+### Files
+
+| File | Action |
+|---|---|
+| `deploy/nats/acl-matrix.json` | Edit — add publish grant under hub identity |
+| `deploy/nats/auth.conf` | Regenerated via `factory-acl genkeys` |
+| `deploy/nats/706-spec.json` | Regenerated |
+| `docs/architecture/messaging/v3-current.json` | Regenerated |
+| `docs/architecture/CURRENT.generated.md` | Regenerated via `tools/check_architecture_snapshot.sh` |
+| `tests/scripts/fixtures/v3-pre-grant-group.json` | Hand-mirrored (CI-only equivalence gate — no script) |
+
+### Grant to add
+
+```json
+// In acl-matrix.json, hub identity publish grants:
+"$KV.factory-active-jobs.>"
+```
+
+**Note:** Bucket creation rides the existing `$JS.API.>` grant (hub already has it). No subscribe grant needed for the bucket (out-of-hub readers use `$JS.API.STREAM.MSG.GET` zero-ACL path per allow_direct=False decision). Dashboard kv.watch ACL deferred to #1800.
+
+### Regen sequence
+
+```bash
+cd <WT>
+factory-acl genkeys  # produces auth.conf + 706-spec + v3-current
+bash tools/check_architecture_snapshot.sh  # produces CURRENT.generated.md
+# then manually diff v3-pre-grant-group.json and hand-mirror the new publish line
+```
+
+### Tests
+
+CI gate: `test_v4_render_set_equals_v3_render` — verifies `v3-pre-grant-group.json` equivalence. This is CI-only; local pre-push does not run it.
+
+---
+
+## Slice D1 — Documentation
+
+**Scope:** Update architecture docs with new job model entries.
+
+### Files
+
+| File | Action |
+|---|---|
+| `docs/architecture/messaging.md` (or equivalent domain page) | Edit — add `factory-active-jobs` KV bucket row |
+| `docs/architecture/storage.md` (or equivalent) | Edit — add job model data description |
+
+**Note:** `docs/architecture/CURRENT.generated.md` is regenerated by A1 regen pass — do not edit manually.
+
+---
+
+## Risks
+
+### R1 — Run-Completion Seam (CRITICAL)
+
+**Exact location:** `src/factory/core/pool/pool_processor.py`, `process_loop()`, the `finally:` block at lines 94–95.
+
+The finally block runs unconditionally:
+- Normal run completion
+- `asyncio.CancelledError` from `/stop` (re-raised AFTER the cancel-reply dispatch at line 90–93)
+- Any unhandled exception from `_process_with_cancel`
+
+**Risk:** If `close()` itself raises, it could suppress the `CancelledError` re-raise. Mitigation: wrap `close()` call in a bare `except Exception: log.exception(...)` (with DEBT comment per axial review rule) inside the finally block; the `CancelledError` path still re-raises because it is not `Exception`.
+
+**Alternative seam considered:** Hub observing `pool._current_task.done()` via polling — rejected (polling adds latency; finally block is synchronous-by-construction).
+
+### R2 — Heartbeat Tap-In (AXIAL)
+
+**Exact location:** `WorkerPoolClient.__init__` in `src/factory/transport/worker_pool_client.py` + each construction site in `llm_overlay.py` and `voice_overlay.py`.
+
+**Risk:** A new `on_heartbeat` parameter must be optional (`= None`) to preserve backward compatibility for tests that construct `WorkerPoolClient` without it. No existing test should break.
+
+**Axial boundary:** `transport/` is an infra-adjacent module; `RegistryRefresher` lives in `bootstrap/hub/`. The callback is a `Callable[[dict], None]` — no infra import in `transport/`; type is structurally compatible.
+
+### R3 — In-Memory Entry Map vs KV Drift
+
+**Location:** `KvActiveJobsStore._entries` dict.
+
+**Risk:** If the hub restarts, `_entries` is empty. `refresh()` will silently no-op for orphan entries (already expired by TTL = 120s max). `close()` will silently skip idx deletion for entries not in `_entries` — it falls back to the live `kv.get(idx)` check before delete.
+
+**Mitigation in plan:** `close()` always does a live KV lookup to check idx ownership before deleting, regardless of `_entries` state. Tests cover the "not in _entries" path.
+
+### R4 — Folder Size at 14/15
+
+`infrastructure/stores/` will have 14 Python files after adding `active_jobs_kv.py`. One slot remains before the 15-file quality gate triggers. Note: `base/` and `migrations/` are directories, not counted by `maxdepth-1` flat-file check. Next addition to `stores/` must either consume the last slot or get an exemption.
+
+### R5 — ACL Regen: v3-pre-grant-group.json Hand-Mirror
+
+The `tests/scripts/fixtures/v3-pre-grant-group.json` file must be hand-updated after running `factory-acl genkeys` — it is explicitly NOT script-generated. The CI gate `test_v4_render_set_equals_v3_render` will fail if this file is stale. This is CI-only, not caught by local pre-push.
+
+### R6 — CancelledError vs BaseException in finally
+
+`asyncio.CancelledError` is a `BaseException` (not `Exception`) in Python 3.8+. The `asyncio.shield(pool._on_run_complete_fn())` pattern in `finally` must not catch `CancelledError`. Use `asyncio.shield` + let the outer `raise` at line 93 propagate normally. The shield ensures close() completes even if a cancel arrives during the shield.
+
+### R7 — open() at submit() vs process_loop() start
+
+`pool.submit()` creates the task synchronously; `process_loop()` runs asynchronously. Opening the KV entry at `submit()` (synchronous code) requires calling an async operation — this must be done via `asyncio.create_task(active_jobs.open(...))` at the submit site, or by moving open() into the start of `process_loop()`. **Preferred:** open at the start of `process_loop()` (inside the async task) to keep `submit()` synchronous and avoid fire-and-forget antipatterns. This changes the edit target: `pool_processor.py` `process_loop()` start, not `pool.py` `submit()`.
+
+---
+
+## File Summary
+
+### New Files (6)
+
+1. `src/factory/core/ports/active_jobs.py` — `ActiveJobsPort` Protocol, `ActiveJobEntry`, `RegistryConflictError`
+2. `src/factory/infrastructure/stores/active_jobs_kv.py` — `KvActiveJobsStore`, `ACTIVE_JOBS_BUCKET`, `ACTIVE_JOBS_TTL`, `ACTIVE_JOBS_REFRESH`
+3. `src/factory/bootstrap/wiring/kv_active_jobs.py` — `open_or_create_active_jobs_kv()`
+4. `src/factory/bootstrap/hub/registry_refresher.py` — `RegistryRefresher`
+5. `tests/infrastructure/stores/test_active_jobs_kv.py` — store unit tests
+6. `tests/bootstrap/test_registry_refresher.py` — refresher unit tests
+
+### Edited Files (8+)
+
+7. `src/factory/core/ports/__init__.py` — re-export new types
+8. `src/factory/core/pool/pool.py` — add `_on_run_complete_fn`, `_active_job_id` attributes
+9. `src/factory/core/pool/pool_processor.py` — call close hook in finally
+10. `src/factory/bootstrap/standalone/hub_standalone.py` — add bucket provisioning
+11. `src/factory/transport/worker_pool_client.py` — add `on_heartbeat` callback param
+12. `src/factory/bootstrap/factory/llm_overlay.py` — thread refresher callback
+13. `src/factory/bootstrap/factory/voice_overlay.py` — thread refresher callback
+14. `deploy/nats/acl-matrix.json` — hub publish grant for `$KV.factory-active-jobs.>`
+15. `tests/scripts/fixtures/v3-pre-grant-group.json` — hand-mirror ACL change
+16. `tests/bootstrap/test_hub_active_jobs_provision.py` — provisioning tests
+17. `tests/core/pool/test_pool_active_jobs_wiring.py` — pool wiring tests
+18. Plus 4 regenerated artifacts: `auth.conf`, `706-spec.json`, `v3-current.json`, `CURRENT.generated.md`

--- a/artifacts/specs/1796-active-jobs-registry-spec.mdx
+++ b/artifacts/specs/1796-active-jobs-registry-spec.mdx
@@ -1,0 +1,131 @@
+---
+title: "feat(infra): factory-active-jobs NATS-KV registry — hub-writer store, singleton index, TTL liveness"
+description: "Provision the factory-active-jobs KV bucket at hub boot, add KvActiveJobsStore behind a core port, wire open/close/refresh into the run lifecycle, and enforce the pool_id→job_id singleton index for steer/queue modes."
+issue: 1796
+status: approved
+tier: F-lite
+date: 2026-06-11
+---
+
+## Context
+
+**Promoted from:** [frame](../frames/1796-active-jobs-registry-frame.mdx) (approved 2026-06-11, 3-lens validated)
+**GitHub issue:** #1796 — foundation child of epic #1792 (Shape D); blocks #1797/#1798/#1799/#1800.
+**SSoT:** `docs/architecture/job-model.md` §Active-jobs registry / §Concurrency / §Observability (schema, writer rule, liveness, mode partition — ratified, not re-decided here).
+
+## Goal
+
+Cross-process job state becomes queryable and live: every envelope-driven run is visible in `factory-active-jobs` (by `job_id` and by `pool_id`), entries die with their run (terminal `JobResult`) or by TTL reap, and #1797's `fresh | steer | queue` decision has a substrate that out-of-process jobs can't hide from.
+
+## Users
+
+- **Hub** — sole writer: open / refresh / close via a core port; provisions the bucket pre-ready.
+- **#1797 concurrency_router** — first reader (in-hub, zero new ACL).
+- **#1799 steer / #1624 typing / #1800 dashboard v1** — future readers (`steer_subject` resolution, typing state, `kv.watch`).
+- **Ops (M₁)** — `nats kv get factory-active-jobs <key>` via hub seed for live debugging.
+
+## Expected Behavior
+
+1. **Boot:** hub create-or-opens the `factory-active-jobs` bucket before `announce_hub_ready()` (model: `factory-state` in `bootstrap/wiring/kv_watch_channels.py` — full race-safe sequence: try `js.key_value()` → `BucketNotFoundError` → `create_key_value()` → `BadRequestError` 10058 → re-`key_value()`; fail-fast on other errors). `KeyValueConfig`: FILE storage, **`ttl=ACTIVE_JOBS_TTL`** (named constant, 120s — nats-py param is `ttl=`, NOT `max_age=`; cf. `message_index_kv.py` precedent), **`allow_direct=False` pinned day-1** — rationale: out-of-hub readers ride the #1572 zero-ACL `$JS.API.STREAM.MSG.GET` path; `allow_direct=True` would open an unmodeled `$JS.DIRECT.>` ACL surface. Revisit at #1800 with its own regen pass.
+2. **Open:** when a run starts, hub writes entry `job.<job_id>` = `{pool_id, status: "open", started_at, steer_subject, concurrency_mode, worker_loc?}`. For `concurrency_mode ∈ {steer, queue}` it also writes the singleton index `idx.<sanitized_pool_id>` → `job_id` with revision-guarded `kv.create()` / `kv.update(last_revision=…)` — the CAS conflict surfaces as `nats.js.errors.KeyWrongLastSequenceError`, re-raised as `RegistryConflictError` (router #1797 turns that into queue/steer; this issue only surfaces the conflict). `parallel` mode writes **no** index entry.
+3. **Refresh (liveness):** a hub-side refresher re-puts open entries every `ACTIVE_JOBS_REFRESH` (30s) from two sources: (a) Shapes A/B/C — `pool._current_task` alive; (b) Shape D — role heartbeat messages the hub already consumes (`factory.<role>.heartbeat`, ADR-049 / `factory.clipool.heartbeat` precedent) matched to entries via `worker_loc`. **Tap-in rule (axial):** the heartbeat source hooks into the existing hub-side heartbeat consumption path (`transport/worker_pool_client.py` / `nats/worker_registry.py`) via an injected callback — it must NOT open a second `factory.<role>.heartbeat` subscription (single stage primitive, no duplicate subscriber). Refresh re-puts the entry AND its `idx.*` key (both expire by `max_age` otherwise). Workers never write KV (writer = hub only).
+4. **Close:** the registry exposes `close(job_id)` (delete entry + index if owner); `status: "closing"` is written when a cancel/steer-stop is in flight. **Anchor (this issue):** the hub's existing in-process run-completion point (pool run end — Shapes A/B/C) calls `close()` directly. **Deferred hookup:** close driven by `factory.job.<id>.result` consumption requires the #1795 JobResult pub/sub channel, which is not built yet (verified: no hub-side `factory.job.*.result` subscription in src/) — that wiring lands with #1795/#1799 and only calls the same `close()`; Slice 2's integration test stubs the result-delivery trigger.
+5. **Reap:** no refresh within the bucket `ttl` → the server expires the revision; stale crash entries vanish without operator action. (TTL is bucket-level; per-key refresh = re-put.)
+6. **Keys:** every key — including `idx.<pool_id>` where `pool_id` carries colons (`telegram:lyra:…`) — goes through `infrastructure/stores/_kv_keys.py` (#1721 outage class). `job_id` is also routed through it for uniformity despite its safe charset (#1708).
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class ActiveJobEntry {
+        <<KV value, JSON — key job.JOB_ID>>
+        pool_id: str
+        status: open | closing
+        started_at: ISO-8601
+        steer_subject: str  factory.job.JOB_ID.steer
+        concurrency_mode: steer | queue | parallel
+        worker_loc: str?  (Shape D heartbeat match)
+    }
+    class SingletonIndex {
+        <<KV value — key idx.SANITIZED_POOL_ID>>
+        job_id: str
+        note: only for steer|queue (frozen rule)
+    }
+    class ActiveJobsPort {
+        <<protocol, core/ports/>>
+        open(entry) RegistryConflictError?
+        refresh(job_id)
+        close(job_id)
+        get_by_pool(pool_id) ActiveJobEntry?
+    }
+    class KvActiveJobsStore {
+        <<infrastructure/stores/active_jobs_kv.py>>
+        bucket: factory-active-jobs
+        allow_direct: False (pinned)
+        ttl: ACTIVE_JOBS_TTL=120s
+    }
+    ActiveJobsPort <|.. KvActiveJobsStore : implements
+    KvActiveJobsStore o-- ActiveJobEntry
+    KvActiveJobsStore o-- SingletonIndex
+```
+
+```mermaid
+flowchart LR
+    POOL[pool run start/end - Shapes A/B/C] -->|open / close via port| ST[KvActiveJobsStore]
+    JR[terminal JobResult consumption] -->|close| ST
+    HB["factory.ROLE.heartbeat (existing hub subs, injected callback)"] -->|refresh by worker_loc| RF[RegistryRefresher - hub task]
+    POOL -->|_current_task alive| RF
+    RF -->|re-put every 30s| ST
+    ST -->|"KV publish grant: $KV.factory-active-jobs (new, hub)"| NATS[(factory-active-jobs)]
+    RT[concurrency_router #1797] -.->|get_by_pool, in-hub| ST
+    DASH[#1800 kv.watch] -.->|future, own ACL pass| NATS
+    TYP[#1624 typing] -.-> ST
+```
+
+| Consumer | Consumes | When | Status |
+|---|---|---|---|
+| hub writer (pool + JobResult path) | open/close/refresh | per run | **this issue** |
+| RegistryRefresher | pool task + role heartbeats → re-put | every 30s | **this issue** |
+| #1797 router | `get_by_pool` (in-hub port call) | per inbound msg | future (port shipped here) |
+| #1799 steer | `steer_subject` field | per steer | future |
+| #1624 typing | entry presence per pool | typing window | future |
+| #1800 dashboard v1 | `kv.watch` bucket | live | future (own ACL regen) |
+
+## Breadboard
+
+| ID | Affordance | Handler / Home | Data |
+|---|---|---|---|
+| P1 | `ActiveJobsPort` protocol + `RegistryConflictError` | `src/factory/core/ports/active_jobs.py` (new file, existing subdir) | entry dataclass/model |
+| S1 | `KvActiveJobsStore` (CRUD + singleton index via `kv.create`/`kv.update(last_revision)`, `KeyWrongLastSequenceError` → `RegistryConflictError`, `_kv_keys` sanitization) | `src/factory/infrastructure/stores/active_jobs_kv.py` (14/15 files, no exemption) | bucket `factory-active-jobs` |
+| S2 | Bucket ensure pre-`announce_hub_ready()`, race-safe create-or-open sequence, fail-fast; `allow_direct=False`, `ttl=ACTIVE_JOBS_TTL` | hub bootstrap wiring (model: `kv_watch_channels.py`) | KeyValueConfig |
+| S3 | `RegistryRefresher` — pool-source + heartbeat-source (`worker_loc` match), re-put cadence `ACTIVE_JOBS_REFRESH`; heartbeat source = injected callback at the bootstrap wiring site where the hub's heartbeat handler (`WorkerPoolClient` path) is constructed (¬new subscription); re-puts cover `job.*` + `idx.*` keys | hub-side task, wired in bootstrap | named constants 120s/30s |
+| S4 | Lifecycle wiring: run open → port.open; in-process run-completion (pool) → port.close (the #1795 NATS-result trigger is a later caller of the same method); cancel-in-flight → `status: closing` | injection into pool/run lifecycle via port (¬core→infrastructure import) | — |
+| A1 | ACL: hub publish `$KV.factory-active-jobs.>` (covers put/delete/create/update — header-based ops on the same subject; bucket creation rides existing `$JS.API.>`) | `deploy/nats/acl-matrix.json`; regen via `make nats-regen-authconf` (`factory-acl genkeys` → auth.conf + 706 spec + v3-current) + `bash tools/check_architecture_snapshot.sh` (CURRENT.generated.md); `tests/scripts/fixtures/v3-pre-grant-group.json` = hand-mirror only (no script; CI-only equivalence gate) | grant |
+| D1 | `messaging.md` planes-catalogue table: add a `factory-active-jobs` KV row (7 columns — model on the existing `factory-state` row; subject prefix `$KV.factory-active-jobs.>`, type KV/JetStream-backed, producer hub, consumers router/dashboard). `job-model.md` §Implementation status table: set the #1796 row Status → "Done (PR #NNNN)". `CURRENT.generated.md` regen = implementer step (architecture_snapshot gate, ¬doc-edit). doc_drift caveat: only backtick symbols that exist in src at doc-merge time (`KvActiveJobsStore`, `ActiveJobsPort`, `RegistryConflictError` land in this same PR — safe; verify `python3 tools/check_doc_drift.py`) | doc task + implementer gate run | — |
+| T1 | Tests (anchor `tests/infrastructure/stores/test_message_index_kv.py`, AsyncMock): CRUD, colon-pool_id sanitization, singleton conflict, parallel-no-index, refresher both sources, close-on-JobResult, faked-TTL reap | `tests/infrastructure/stores/` + bootstrap tests | — |
+
+**Wiring:** S2 ensures the bucket → S1 store operates → S4 feeds open/close, S3 keeps entries alive → A1 makes `kv.put` legal in prod (CI-only equivalence — local green ≠ CI green). P1 keeps `core/` clean of infrastructure imports (import-linter); PR will auto-carry `dev-core:axial-adr-review` label (core+infrastructure touch) — expected.
+
+## Slices
+
+| # | Slice | Demo | Contains |
+|---|---|---|---|
+| 1 | Store + port + provisioning | store CRUD/sanitization/singleton tests green; boot test asserts ensure-before-announce + config pin | P1, S1, S2, T1(store+boot) |
+| 2 | Liveness + lifecycle | simulated run: open→refresh (both sources)→terminal JobResult→entry+index gone; faked-TTL reap test | S3, S4, T1(lifecycle) |
+| 3 | ACL + docs | regen artifacts byte-identical; CI acl checks green; messaging/job-model rows updated | A1, D1 |
+
+## Success Criteria
+
+- [ ] `KvActiveJobsStore`: CRUD + colon-`pool_id` index keys via `_kv_keys` unit-tested (AsyncMock — a raw `telegram:x:1` pool_id must never reach `kv.put`).
+- [ ] Bucket ensured before `announce_hub_ready()` (race-safe create-or-open), fail-fast on error; `allow_direct=False` and `ttl=ACTIVE_JOBS_TTL` asserted in the boot test.
+- [ ] Singleton index: second `open()` on a busy pool in `steer`/`queue` raises `RegistryConflictError` (CAS via `kv.create`/`kv.update(last_revision)`, `KeyWrongLastSequenceError` mapped); `parallel` open writes no index entry — both unit-tested.
+- [ ] Lifecycle: run open → entry exists; in-process run-completion → entry + index deleted (the #1795-driven NATS trigger is stubbed in tests and explicitly deferred); wired through `ActiveJobsPort` only (import-linter green — no `core/` → `infrastructure/` import).
+- [ ] Refresher: pool-source and heartbeat-source both re-put; the heartbeat test asserts a fake `factory.<role>.heartbeat` message triggers re-put for the **matching `worker_loc` entry only**, covering **both `job.<job_id>` AND `idx.<sanitized_pool_id>` in the same cycle** for `steer`/`queue` (parallel: no `idx.*` re-put); `ACTIVE_JOBS_TTL=120s` / `ACTIVE_JOBS_REFRESH=30s` as named constants; faked-`ttl` reap test proves crash entries expire.
+- [ ] `TypingPublisher._refcount` untouched — zero modifications to `transport/typing_publisher.py` in this PR; existing typing tests stay green (F4 coexistence decision stays open without regression risk).
+- [ ] ACL: hub publish `$KV.factory-active-jobs.>` added; 4 generated artifacts regenerated; `v3-pre-grant-group.json` hand-mirrored.
+- [ ] Docs: `messaging.md` planes-catalogue row + `job-model.md` status flip; `CURRENT.generated.md` regenerated via `tools/check_architecture_snapshot.sh` (implementer); `doc_drift` green; pre-push gates run manually (lead-worktree pushes skip them).
+- [ ] Full repo `uv run pytest` green from the main repo venv (no `uv run` inside the worktree).
+
+## Out of Scope (re-anchored from frame)
+
+`fresh|steer|queue` routing logic (#1797 — consumes the port) · sub-jobs (#1798) · steer e2e (#1799) · dashboard + `kv.watch` ACL grants (#1800) · typing rewiring (#1624) · `TypingPublisher._refcount` replacement for `parallel` mode (open decision deliberately deferred — registry semantics here are mode-correct either way: no index entry for `parallel`) · JOBS dispatch stream (#1203, parallel track, zero file overlap) · per-worker heartbeat *producers* (exist already per role; only the hub-side consumption hook is wired here).

--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -44,6 +44,7 @@ The row will grant `subscribe: factory.typing.>` to `code-worker` (it consumes t
 | `$JS.API.STREAM.MSG.GET.KV_factory-state` | — | PUB | PUB | PUB | PUB | PUB | — | PUB | PUB | — | — | — | — | — | PUB |
 | `$JS.API.STREAM.MSG.GET.KV_factory_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$JS.API.STREAM.UPDATE.FACTORY_TURNS` | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — | — |
+| `$KV.factory-active-jobs.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$KV.factory-msg-index.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$KV.factory-state.>` | PUB | SUB | SUB | SUB | SUB | SUB | — | SUB | SUB | — | — | — | PUB | — | SUB |
 | `$KV.factory_outbound_audio_sent.>` | — | PUB+SUB | PUB+SUB | — | — | — | — | — | — | — | — | — | — | — | — |

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -34,7 +34,7 @@
       "created_at": "2026-04-21",
       "owner": "factory",
       "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image/clipool workers. Inbox normalized to lowercase _inbox.hub.> (ADR-051 + postmortem Fix 1).",
-      "notes": "Hub provisions the factory-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.factory-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. factory.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. factory.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream FACTORY_OUTBOUND_AUDIO and KV bucket KV_factory_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 §Forward-compat for explicit enumeration if wildcard is ever tightened). factory.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only — publisher declared by #1082 (gh-helper). This field is metadata only — not rendered into auth.conf or the 706 spec table. factory.job.*.steer added (#1812): hub initiates steer commands for active omp jobs (send mid-flight steering prompts to omp_rpc worker).",
+      "notes": "Hub provisions the factory-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.factory-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. factory.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. factory.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream FACTORY_OUTBOUND_AUDIO and KV bucket KV_factory_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 §Forward-compat for explicit enumeration if wildcard is ever tightened). factory.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only — publisher declared by #1082 (gh-helper). This field is metadata only — not rendered into auth.conf or the 706 spec table. factory.job.*.steer added (#1812): hub initiates steer commands for active omp jobs (send mid-flight steering prompts to omp_rpc worker). $KV.factory-active-jobs.> added (#1796): hub is sole writer of the factory-active-jobs KV registry (kv.put/create/update/delete publish header-based ops to $KV.<bucket>.<key>); allow_direct=False so readers ride $JS.API.STREAM.MSG.GET (#1572, zero-ACL).",
       "allow_responses": true,
       "publish": [
         "factory.outbound.telegram.>",
@@ -56,7 +56,8 @@
         "factory.job.*.steer",
         "$JS.API.>",
         "$KV.factory-state.>",
-        "$KV.factory-msg-index.>"
+        "$KV.factory-msg-index.>",
+        "$KV.factory-active-jobs.>"
       ],
       "subscribe": [
         "factory.inbound.telegram.>",

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -13,7 +13,7 @@ authorization {
       nkey: "UC5IDERWKZPLZ4HCESTFEM3QVSQJOVCE5J57NYLBDDN7BSV4VG2TUAKS"
       # hub
       permissions: {
-        publish:   { allow: ["factory.outbound.telegram.>","factory.outbound.discord.>","factory.outbound.audio.>","factory.voice.tts.request","factory.voice.tts.request.>","factory.voice.stt.request","factory.voice.stt.request.>","factory.llm.generate.request","factory.image.generate.request","factory.clipool.cmd","factory.clipool.control","factory.audit.>","factory.turns.write","factory.typing.>","factory.event.>","factory.metric.>","factory.job.*.steer","$JS.API.>","$KV.factory-state.>","$KV.factory-msg-index.>"] }
+        publish:   { allow: ["factory.outbound.telegram.>","factory.outbound.discord.>","factory.outbound.audio.>","factory.voice.tts.request","factory.voice.tts.request.>","factory.voice.stt.request","factory.voice.stt.request.>","factory.llm.generate.request","factory.image.generate.request","factory.clipool.cmd","factory.clipool.control","factory.audit.>","factory.turns.write","factory.typing.>","factory.event.>","factory.metric.>","factory.job.*.steer","$JS.API.>","$KV.factory-state.>","$KV.factory-msg-index.>","$KV.factory-active-jobs.>"] }
         subscribe: { allow: ["factory.inbound.telegram.>","factory.inbound.discord.>","factory.voice.tts.heartbeat","factory.voice.stt.heartbeat","factory.llm.heartbeat","factory.system.ready","factory.image.heartbeat","factory.clipool.heartbeat","factory.omp.heartbeat","factory.gh.mint_failure.>","_inbox.hub.>"] }
         allow_responses: true
       }

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -104,7 +104,7 @@
 - **Publish:** factory.gh.mint_failure.>
 
 ### hub
-- **Publish:** $JS.API.>, $KV.factory-msg-index.>, $KV.factory-state.>, factory.audit.>, factory.clipool.cmd, factory.clipool.control, factory.event.>, factory.image.generate.request, factory.job.*.steer, factory.llm.generate.request, factory.metric.>, factory.outbound.audio.>, factory.outbound.discord.>, factory.outbound.telegram.>, factory.turns.write, factory.typing.>, factory.voice.stt.request, factory.voice.stt.request.>, factory.voice.tts.request, factory.voice.tts.request.>
+- **Publish:** $JS.API.>, $KV.factory-active-jobs.>, $KV.factory-msg-index.>, $KV.factory-state.>, factory.audit.>, factory.clipool.cmd, factory.clipool.control, factory.event.>, factory.image.generate.request, factory.job.*.steer, factory.llm.generate.request, factory.metric.>, factory.outbound.audio.>, factory.outbound.discord.>, factory.outbound.telegram.>, factory.turns.write, factory.typing.>, factory.voice.stt.request, factory.voice.stt.request.>, factory.voice.tts.request, factory.voice.tts.request.>
 - **Subscribe:** _inbox.hub.>, factory.clipool.heartbeat, factory.gh.mint_failure.>, factory.image.heartbeat, factory.inbound.discord.>, factory.inbound.telegram.>, factory.llm.heartbeat, factory.omp.heartbeat, factory.system.ready, factory.voice.stt.heartbeat, factory.voice.tts.heartbeat
 
 ### image-worker

--- a/docs/architecture/job-model.md
+++ b/docs/architecture/job-model.md
@@ -247,7 +247,7 @@ The job subtree (`factory.job.<id>.*`) IS the trace — no separate observabilit
 | #1793 | A | Unify subject taxonomy (`factory.job.<id>.*`) | Leaf — unblocked |
 | #1794 | B | Amend ADR-084 → `job_id=run` | Leaf |
 | #1795 | E | **JobResult** → pub/sub + 3-tier transport | Leaf |
-| #1796 | C | Active-jobs registry (NATS-KV **factory-active-jobs**) | Leaf |
+| #1796 | C | Active-jobs registry (NATS-KV **factory-active-jobs**) | Done (substrate) — this PR; live open/close call-sites → #1797 |
 | #1797 | D | Concurrency router (shared inbound stage) | Leaf |
 | #1798 | F | STT/LLM/TTS/image → sub-jobs | Leaf |
 | #1799 | G | Steer e2e | Leaf |

--- a/docs/architecture/messaging.md
+++ b/docs/architecture/messaging.md
@@ -161,6 +161,7 @@ System-plane subjects (JetStream API + KV bucket) are governed by per-identity g
 |---|---|---|
 | `$JS.API.>` | hub + adapters + workers → server | JetStream API surface for KV reads and consumer create (currently wildcard; tighter scoping in #1293) |
 | `$KV.factory-state.>` | hub → server (write); adapters + workers ← server (read) | Direct KV bucket access — hub publishes `hub.ready`, others watch via `wait_for_hub` |
+| `$KV.factory-active-jobs.>` | hub → server (write); router + dashboard ← server (read) | Active-jobs registry (#1796) — hub is sole writer (open/refresh/close); bucket-level TTL liveness (120s), `allow_direct=False` so readers ride `STREAM.MSG.GET` (#1572) |
 
 `{platform}` is lowercase ASCII (`telegram`, `discord`). `{bot_id}` is a numeric string
 matching `^[1-9][0-9]*$` — a leading-zero or non-numeric value produces a shadow subject

--- a/src/factory/bootstrap/standalone/hub_standalone.py
+++ b/src/factory/bootstrap/standalone/hub_standalone.py
@@ -190,6 +190,22 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
             )
             raise RuntimeError("FACTORY_AUDIT provision failed")
 
+        # Provision active-jobs KV bucket before announcing readiness.
+        # Workers / adapters consulting the registry rely on the bucket
+        # existing before they receive the hub-ready signal. ADR-079 S3.
+        from factory.infrastructure.stores.active_jobs_kv import ensure_active_jobs_kv
+
+        try:
+            await ensure_active_jobs_kv(_audio_js)
+        except nats.errors.Error as exc:
+            log.critical(
+                "hub_standalone: active-jobs KV provisioning failed — "
+                "registry unavailable; hub cannot announce ready. "
+                "Cause: %s. RestartSec will recover.",
+                exc,
+            )
+            raise
+
         # Publish each bot's watch_channels into factory-state KV before
         # announcing readiness so adapters see the value on first seed (SC6).
         _bots: list[tuple[str, str]] = [

--- a/src/factory/bootstrap/standalone/hub_standalone.py
+++ b/src/factory/bootstrap/standalone/hub_standalone.py
@@ -206,6 +206,16 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
             )
             raise
 
+        from factory.infrastructure.stores.active_jobs_kv import KvActiveJobsStore
+        from factory.infrastructure.stores.active_jobs_refresher import (
+            RegistryCoordinator,
+        )
+
+        _active_jobs_store = KvActiveJobsStore(_audio_js)
+        await _active_jobs_store.connect()
+        _active_jobs_coord = RegistryCoordinator(_active_jobs_store)
+        _active_jobs_coord.start()
+
         # Publish each bot's watch_channels into factory-state KV before
         # announcing readiness so adapters see the value on first seed (SC6).
         _bots: list[tuple[str, str]] = [
@@ -249,6 +259,9 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
             cli_nats_driver=cli_nats_driver,
             nats_llm_client=nats_llm_client,
         )
+        # #1797 drives open()/close(); #1795 JobResult close trigger deferred
+        # (no hub-side factory.job.*.result sub yet)
+        await _active_jobs_coord.stop()
 
     # Close NATS connection after stores context exits
     try:

--- a/src/factory/core/ports/__init__.py
+++ b/src/factory/core/ports/__init__.py
@@ -23,6 +23,11 @@ Constraints
   sub-domain they serve.
 """
 
+from factory.core.ports.active_jobs import (
+    ActiveJobEntry,
+    ActiveJobsPort,
+    RegistryConflictError,
+)
 from factory.core.ports.audit_sink import AuditSink
 from factory.core.ports.blobstore import BlobStorePort
 from factory.core.ports.llm import LlmProvider, LlmResult
@@ -32,11 +37,14 @@ from factory.core.ports.stt import STTProtocol
 from factory.core.ports.tts import TtsProtocol
 
 __all__ = [
+    "ActiveJobEntry",
+    "ActiveJobsPort",
     "AuditSink",
     "BlobStorePort",
     "LlmProvider",
     "LlmResult",
     "OutboundListener",
+    "RegistryConflictError",
     "ResumePublisherPort",
     "STTProtocol",
     "TtsProtocol",

--- a/src/factory/core/ports/active_jobs.py
+++ b/src/factory/core/ports/active_jobs.py
@@ -1,0 +1,101 @@
+"""Driven port — ActiveJobsPort: per-pool active-job registry (#1796).
+
+Pure Protocol + value objects only.  Zero infrastructure imports.
+Implementations live in ``factory.infrastructure.stores.active_jobs_kv``.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+class RegistryConflictError(Exception):
+    """Raised when ``open()`` finds a non-expired job already mapped to *pool_id*.
+
+    Attributes
+    ----------
+    pool_id:
+        The pool that already has an active job.
+    existing_job_id:
+        The job_id that blocked the new registration.
+    """
+
+    def __init__(self, pool_id: str, existing_job_id: str) -> None:
+        super().__init__(f"pool {pool_id!r} already has active job {existing_job_id!r}")
+        self.pool_id = pool_id
+        self.existing_job_id = existing_job_id
+
+
+@dataclass(frozen=True)
+class ActiveJobEntry:
+    """Immutable snapshot of a single active job.
+
+    Fields
+    ------
+    job_id:
+        Opaque unique identifier for this job (e.g. a UUID).
+    pool_id:
+        The pool this job belongs to (``RoutingKey.to_pool_id()``).
+    status:
+        ``"open"`` while running; ``"closing"`` during graceful teardown.
+    started_at:
+        UTC timestamp when the job was opened.
+    steer_subject:
+        NATS subject the worker listens on for steering signals.
+    concurrency_mode:
+        ``"steer"`` — singleton guarded via KV CAS index.
+        ``"queue"`` — singleton guarded via KV CAS index.
+        ``"parallel"`` — no singleton index; multiple jobs allowed per pool.
+    worker_loc:
+        Optional worker location hint (e.g. host:port or container id).
+    """
+
+    job_id: str
+    pool_id: str
+    status: str
+    started_at: datetime.datetime
+    steer_subject: str
+    concurrency_mode: str
+    worker_loc: str | None = None
+
+
+@runtime_checkable
+class ActiveJobsPort(Protocol):
+    """Secondary (driven) port for the active-jobs KV registry.
+
+    All methods are async.  Callers must ``open()`` a bucket handle before use
+    (provider-managed lifecycle — typically done via ``ensure_active_jobs_kv``
+    at hub startup).
+    """
+
+    async def open(self, entry: ActiveJobEntry) -> None:
+        """Register *entry* as the active job for its pool.
+
+        Raises
+        ------
+        RegistryConflictError
+            If *pool_id* already maps to a different, non-expired job
+            (steer/queue modes only).
+        """
+        ...
+
+    async def refresh(self, job_id: str) -> None:
+        """Extend the TTL of *job_id* to prevent expiry.
+
+        No-op if *job_id* is not found (job may have already closed).
+        """
+        ...
+
+    async def close(self, job_id: str) -> None:
+        """Remove *job_id* from the registry.
+
+        Cleans up both the per-job key and the pool→job index entry when
+        this job owns the index.  No-op if *job_id* is not found.
+        """
+        ...
+
+    async def get_by_pool(self, pool_id: str) -> ActiveJobEntry | None:
+        """Return the active job for *pool_id*, or ``None`` if absent/expired."""
+        ...

--- a/src/factory/infrastructure/stores/active_jobs_kv.py
+++ b/src/factory/infrastructure/stores/active_jobs_kv.py
@@ -131,6 +131,8 @@ async def ensure_active_jobs_kv(js: "JetStreamContext") -> "KeyValue":
         bucket=ACTIVE_JOBS_BUCKET,
         ttl=ACTIVE_JOBS_TTL,
         storage=StorageType.FILE,
+        direct=False,  # pinned day-1: readers ride $JS.API.STREAM.MSG.GET (#1572,
+        # zero-ACL); allow_direct=True would open an unmodeled $JS.DIRECT.> surface.
     )
     # Try to open an existing bucket first (hot path on restart).
     try:
@@ -212,29 +214,25 @@ class KvActiveJobsStore:
         idx_key = _idx_key(entry.pool_id)
         idx_val = entry.job_id.encode()
 
-        # CAS-based singleton index: try get → update or create.
+        # Singleton index via create-only CAS. ``kv.create`` succeeds iff the
+        # index key is absent — i.e. no non-expired job holds this pool (a
+        # TTL-reaped or explicitly-deleted key is treated as free; nats-py
+        # transparently recreates over a tombstone). A live key surfaces as
+        # KeyWrongLastSequenceError, which maps to RegistryConflictError.
+        # Re-open by the same job_id is idempotent (no steal of a foreign pool).
         try:
-            existing = await kv.get(idx_key)
-            # Key exists — try to update (CAS guards against races).
+            await kv.create(idx_key, idx_val)
+        except KeyWrongLastSequenceError:
+            winner_id = "<unknown>"
             try:
-                await kv.update(idx_key, idx_val, last_revision=existing.revision)
-            except KeyWrongLastSequenceError:
-                # Another writer slipped in — read the winner.
                 winner = await kv.get(idx_key)
-                winner_id = winner.value.decode() if winner.value else "<unknown>"
-                raise RegistryConflictError(entry.pool_id, winner_id)
-        except (KeyNotFoundError, NotFoundError):
-            # Key absent — create it (CAS-safe).
-            try:
-                await kv.create(idx_key, idx_val)
-            except KeyWrongLastSequenceError:
-                # Another writer created it first — read the winner.
-                try:
-                    winner = await kv.get(idx_key)
-                    winner_id = winner.value.decode() if winner.value else "<unknown>"
-                except (KeyNotFoundError, NotFoundError):
-                    winner_id = "<unknown>"
-                raise RegistryConflictError(entry.pool_id, winner_id)
+                if winner.value:
+                    winner_id = winner.value.decode()
+            except (KeyNotFoundError, NotFoundError):
+                pass
+            if winner_id == entry.job_id:
+                return  # idempotent re-open by the owning job
+            raise RegistryConflictError(entry.pool_id, winner_id)
 
     async def refresh(self, job_id: str) -> None:
         """Extend the TTL of *job_id* (and its index entry, if any).

--- a/src/factory/infrastructure/stores/active_jobs_kv.py
+++ b/src/factory/infrastructure/stores/active_jobs_kv.py
@@ -1,0 +1,326 @@
+"""NATS KV-backed active-jobs registry (#1796).
+
+Implements ``ActiveJobsPort`` (``factory.core.ports.active_jobs``).
+
+Key layout
+----------
+Per-job entry::
+
+    job.<job_id_safe>  →  JSON(ActiveJobEntry fields)
+
+Pool→job singleton index (steer / queue modes only)::
+
+    idx.<pool_id_safe>  →  <job_id>   (ASCII bytes, checked via CAS)
+
+Both keys live in the ``factory-active-jobs`` bucket (TTL = ACTIVE_JOBS_TTL).
+The index key is re-put on every ``refresh()`` to reset its TTL in step with
+the job key; this keeps them co-expiring.
+
+Constants
+---------
+ACTIVE_JOBS_BUCKET:
+    JetStream KV bucket name.
+ACTIVE_JOBS_TTL:
+    Bucket-level TTL in **seconds** (120 s).  NATS expires keys automatically.
+ACTIVE_JOBS_REFRESH:
+    Recommended client-side refresh cadence in **seconds** (30 s).
+    Callers should call ``refresh()`` at this interval so entries never expire.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import nats.errors
+from nats.js.api import KeyValueConfig, StorageType
+from nats.js.errors import (
+    BadRequestError,
+    BucketNotFoundError,
+    KeyNotFoundError,
+    KeyWrongLastSequenceError,
+    NotFoundError,
+)
+
+from factory.core.ports.active_jobs import ActiveJobEntry, RegistryConflictError
+from factory.infrastructure.stores._kv_keys import kv_safe_part
+
+if TYPE_CHECKING:
+    from nats.js.client import JetStreamContext
+    from nats.js.kv import KeyValue
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+ACTIVE_JOBS_BUCKET = "factory-active-jobs"
+ACTIVE_JOBS_TTL: float = 120.0  # seconds — KV bucket entry TTL
+ACTIVE_JOBS_REFRESH: float = 30.0  # seconds — recommended client refresh cadence
+
+_SINGLETON_MODES = frozenset({"steer", "queue"})
+
+
+# ---------------------------------------------------------------------------
+# Key helpers
+# ---------------------------------------------------------------------------
+
+
+def _job_key(job_id: str) -> str:
+    return f"job.{kv_safe_part(job_id)}"
+
+
+def _idx_key(pool_id: str) -> str:
+    return f"idx.{kv_safe_part(pool_id)}"
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def _entry_to_bytes(entry: ActiveJobEntry) -> bytes:
+    return json.dumps(
+        {
+            "job_id": entry.job_id,
+            "pool_id": entry.pool_id,
+            "status": entry.status,
+            "started_at": entry.started_at.isoformat(),
+            "steer_subject": entry.steer_subject,
+            "concurrency_mode": entry.concurrency_mode,
+            "worker_loc": entry.worker_loc,
+        }
+    ).encode()
+
+
+def _bytes_to_entry(raw: bytes) -> ActiveJobEntry:
+    data = json.loads(raw.decode())
+    return ActiveJobEntry(
+        job_id=data["job_id"],
+        pool_id=data["pool_id"],
+        status=data["status"],
+        started_at=datetime.datetime.fromisoformat(data["started_at"]),
+        steer_subject=data["steer_subject"],
+        concurrency_mode=data["concurrency_mode"],
+        worker_loc=data.get("worker_loc"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+
+async def ensure_active_jobs_kv(js: "JetStreamContext") -> "KeyValue":
+    """Create or bind the ``factory-active-jobs`` KV bucket idempotently.
+
+    Race-safe: if two processes call this concurrently the ``BadRequestError``
+    (err_code 10058 — "stream name already in use") path falls back to a plain
+    ``key_value()`` open.
+
+    ``allow_direct=False`` forces readers through ``$JS.API.STREAM.MSG.GET``
+    (zero-ACL path per ADR-072 / #1572).
+
+    Fail-fast: any other NATS error propagates immediately — hub StartupSec
+    recovers.
+    """
+    cfg = KeyValueConfig(
+        bucket=ACTIVE_JOBS_BUCKET,
+        ttl=ACTIVE_JOBS_TTL,
+        storage=StorageType.FILE,
+    )
+    # Try to open an existing bucket first (hot path on restart).
+    try:
+        kv = await js.key_value(ACTIVE_JOBS_BUCKET)
+        log.debug("active-jobs: bound existing KV bucket %s", ACTIVE_JOBS_BUCKET)
+        return kv
+    except BucketNotFoundError:
+        pass
+
+    # Cold-boot: attempt to create.
+    try:
+        kv = await js.create_key_value(cfg)
+        log.info(
+            "active-jobs: KV bucket %s created (ttl=%.0f s, allow_direct=False)",
+            ACTIVE_JOBS_BUCKET,
+            ACTIVE_JOBS_TTL,
+        )
+        return kv
+    except BadRequestError as exc:
+        # err_code 10058 = stream name already in use — lost the creation race.
+        if exc.err_code != 10058:
+            raise
+        log.debug("active-jobs: creation race lost, binding %s", ACTIVE_JOBS_BUCKET)
+        return await js.key_value(ACTIVE_JOBS_BUCKET)
+
+
+# ---------------------------------------------------------------------------
+# Store implementation
+# ---------------------------------------------------------------------------
+
+
+class KvActiveJobsStore:
+    """NATS KV implementation of ``ActiveJobsPort``.
+
+    Lifecycle: instantiate with a JetStream context, then call
+    ``ensure_active_jobs_kv(js)`` to provision the bucket; bind via
+    ``connect()`` before calling any CRUD method.  Typical hub bootstrap::
+
+        kv = await ensure_active_jobs_kv(js)
+        store = KvActiveJobsStore(js)
+        await store.connect()
+    """
+
+    def __init__(self, js: "JetStreamContext") -> None:
+        self._js = js
+        self._kv: "KeyValue | None" = None
+
+    async def connect(self) -> None:
+        """Bind to the pre-provisioned KV bucket."""
+        self._kv = await self._js.key_value(ACTIVE_JOBS_BUCKET)
+
+    async def close_store(self) -> None:
+        """Release the KV handle (NATS connection managed externally)."""
+        self._kv = None
+
+    # ------------------------------------------------------------------
+    # ActiveJobsPort
+    # ------------------------------------------------------------------
+
+    async def open(self, entry: ActiveJobEntry) -> None:
+        """Register *entry* as the active job for its pool.
+
+        For steer/queue modes: acquires the singleton index via CAS.
+        For parallel mode: writes the job key only.
+
+        Raises
+        ------
+        RegistryConflictError
+            If another non-expired job already holds the index for this pool
+            (steer/queue modes only).
+        """
+        kv = self._require_kv()
+        job_bytes = _entry_to_bytes(entry)
+        await kv.put(_job_key(entry.job_id), job_bytes)
+
+        if entry.concurrency_mode not in _SINGLETON_MODES:
+            return
+
+        idx_key = _idx_key(entry.pool_id)
+        idx_val = entry.job_id.encode()
+
+        # CAS-based singleton index: try get → update or create.
+        try:
+            existing = await kv.get(idx_key)
+            # Key exists — try to update (CAS guards against races).
+            try:
+                await kv.update(idx_key, idx_val, last_revision=existing.revision)
+            except KeyWrongLastSequenceError:
+                # Another writer slipped in — read the winner.
+                winner = await kv.get(idx_key)
+                winner_id = winner.value.decode() if winner.value else "<unknown>"
+                raise RegistryConflictError(entry.pool_id, winner_id)
+        except (KeyNotFoundError, NotFoundError):
+            # Key absent — create it (CAS-safe).
+            try:
+                await kv.create(idx_key, idx_val)
+            except KeyWrongLastSequenceError:
+                # Another writer created it first — read the winner.
+                try:
+                    winner = await kv.get(idx_key)
+                    winner_id = winner.value.decode() if winner.value else "<unknown>"
+                except (KeyNotFoundError, NotFoundError):
+                    winner_id = "<unknown>"
+                raise RegistryConflictError(entry.pool_id, winner_id)
+
+    async def refresh(self, job_id: str) -> None:
+        """Extend the TTL of *job_id* (and its index entry, if any).
+
+        No-op if the job is not found — the job may have already closed or
+        expired naturally.
+        """
+        kv = self._require_kv()
+        try:
+            existing_entry_raw = await kv.get(_job_key(job_id))
+        except (KeyNotFoundError, NotFoundError):
+            return
+
+        if not existing_entry_raw.value:
+            return
+
+        entry = _bytes_to_entry(existing_entry_raw.value)
+        job_bytes = _entry_to_bytes(entry)
+        await kv.put(_job_key(job_id), job_bytes)
+
+        if entry.concurrency_mode not in _SINGLETON_MODES:
+            return
+
+        # Also re-put the index key to reset its TTL.
+        try:
+            await kv.put(_idx_key(entry.pool_id), job_id.encode())
+        except nats.errors.Error:
+            log.warning(
+                "active-jobs: refresh: failed to re-put idx key for pool %r",
+                entry.pool_id,
+            )
+
+    async def close(self, job_id: str) -> None:
+        """Remove *job_id* from the registry.
+
+        Deletes the per-job key and, if this job still owns the pool index,
+        the index key too.  No-op if the job is not found.
+        """
+        kv = self._require_kv()
+        try:
+            existing_raw = await kv.get(_job_key(job_id))
+        except (KeyNotFoundError, NotFoundError):
+            return
+
+        if existing_raw.value:
+            entry = _bytes_to_entry(existing_raw.value)
+            # Remove pool→job index only if we still own it.
+            if entry.concurrency_mode in _SINGLETON_MODES:
+                idx_key = _idx_key(entry.pool_id)
+                try:
+                    idx_entry = await kv.get(idx_key)
+                    current_owner = idx_entry.value.decode() if idx_entry.value else ""
+                    if current_owner == job_id:
+                        await kv.delete(idx_key)
+                except (KeyNotFoundError, NotFoundError):
+                    pass
+
+        await kv.delete(_job_key(job_id))
+
+    async def get_by_pool(self, pool_id: str) -> ActiveJobEntry | None:
+        """Return the active job for *pool_id*, or ``None`` if absent."""
+        kv = self._require_kv()
+        try:
+            idx_entry = await kv.get(_idx_key(pool_id))
+        except (KeyNotFoundError, NotFoundError):
+            return None
+
+        if not idx_entry.value:
+            return None
+
+        job_id = idx_entry.value.decode()
+        try:
+            job_raw = await kv.get(_job_key(job_id))
+        except (KeyNotFoundError, NotFoundError):
+            return None
+
+        if not job_raw.value:
+            return None
+
+        return _bytes_to_entry(job_raw.value)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _require_kv(self) -> "KeyValue":
+        if self._kv is None:
+            raise RuntimeError("KvActiveJobsStore not connected — call connect() first")
+        return self._kv

--- a/src/factory/infrastructure/stores/active_jobs_kv.py
+++ b/src/factory/infrastructure/stores/active_jobs_kv.py
@@ -251,17 +251,19 @@ class KvActiveJobsStore:
 
         entry = _bytes_to_entry(existing_entry_raw.value)
         job_bytes = _entry_to_bytes(entry)
-        await kv.put(_job_key(job_id), job_bytes)
 
-        if entry.concurrency_mode not in _SINGLETON_MODES:
-            return
-
-        # Also re-put the index key to reset its TTL.
+        # Re-put the job key (and, for singleton modes, the index key) to reset
+        # their TTLs. A transient NATS error must NOT propagate out of the
+        # liveness sweep — log and skip; the entry is retried next cycle, or
+        # TTL-reaps if NATS stays unreachable (correct — NATS is down anyway).
         try:
-            await kv.put(_idx_key(entry.pool_id), job_id.encode())
+            await kv.put(_job_key(job_id), job_bytes)
+            if entry.concurrency_mode in _SINGLETON_MODES:
+                await kv.put(_idx_key(entry.pool_id), job_id.encode())
         except nats.errors.Error:
             log.warning(
-                "active-jobs: refresh: failed to re-put idx key for pool %r",
+                "active-jobs: refresh: failed to re-put keys for job %r pool %r",
+                job_id,
                 entry.pool_id,
             )
 

--- a/src/factory/infrastructure/stores/active_jobs_refresher.py
+++ b/src/factory/infrastructure/stores/active_jobs_refresher.py
@@ -82,10 +82,14 @@ class RegistryCoordinator:
 
         POOL-SOURCE liveness: driven by the hub's background loop.  Iterates a
         snapshot of current job IDs so concurrent open/close during iteration
-        does not mutate the set mid-loop.
+        does not mutate the set mid-loop.  One job's refresh failure is logged
+        and skipped — it must not abort the sweep for the remaining jobs.
         """
         for jid in list(self._jobs):
-            await self._port.refresh(jid)
+            try:
+                await self._port.refresh(jid)
+            except Exception:  # noqa: BLE001 — one job's failure must not abort the liveness sweep
+                log.exception("active-jobs: refresh failed for job %r", jid)
 
     async def on_heartbeat(self, worker_loc: str) -> None:
         """Refresh the job mapped to *worker_loc*, if any.
@@ -106,9 +110,7 @@ class RegistryCoordinator:
     def start(self) -> None:
         """Spawn the background refresh task."""
         self._running = True
-        self._task = asyncio.create_task(
-            self._loop(), name="active-jobs-refresher"
-        )
+        self._task = asyncio.create_task(self._loop(), name="active-jobs-refresher")
 
     async def stop(self) -> None:
         """Cancel and await the background task; suppress CancelledError."""
@@ -123,7 +125,10 @@ class RegistryCoordinator:
 
     async def _loop(self) -> None:
         while self._running:
-            await self.refresh_all()
+            try:
+                await self.refresh_all()
+            except Exception:  # noqa: BLE001 — the liveness loop must survive any sweep error, else all tracked jobs silently go stale and pools are wrongly freed
+                log.exception("active-jobs: refresh sweep failed — retrying next cycle")
             await asyncio.sleep(self._refresh_interval)
 
 

--- a/src/factory/infrastructure/stores/active_jobs_refresher.py
+++ b/src/factory/infrastructure/stores/active_jobs_refresher.py
@@ -1,0 +1,130 @@
+"""RegistryCoordinator — in-memory active-job index + KV liveness refresh (#1796).
+
+Wraps an ``ActiveJobsPort`` with:
+
+* an in-memory map (job_id → entry, worker_loc → job_id) as the source of
+  truth for *which* jobs to refresh;
+* a background loop that calls ``refresh_all()`` at *refresh_interval* seconds
+  so that entries in the KV bucket never expire while the hub is alive
+  (POOL-SOURCE liveness);
+* ``on_heartbeat(worker_loc)`` for per-worker heartbeat tap-in that refreshes
+  only the matching job's KV entry (HEARTBEAT-SOURCE liveness, Shape-D).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from factory.core.ports.active_jobs import ActiveJobEntry, ActiveJobsPort
+from factory.infrastructure.stores.active_jobs_kv import ACTIVE_JOBS_REFRESH
+
+log = logging.getLogger(__name__)
+
+
+class RegistryCoordinator:
+    """Coordinator that manages in-memory job maps and drives KV liveness.
+
+    Parameters
+    ----------
+    port:
+        Concrete ``ActiveJobsPort`` implementation (e.g. ``KvActiveJobsStore``).
+    refresh_interval:
+        How often (seconds) ``refresh_all()`` is called by the background loop.
+        Defaults to ``ACTIVE_JOBS_REFRESH`` (30 s).
+    """
+
+    def __init__(
+        self,
+        port: ActiveJobsPort,
+        refresh_interval: float = ACTIVE_JOBS_REFRESH,
+    ) -> None:
+        self._port = port
+        self._refresh_interval = refresh_interval
+        # job_id → ActiveJobEntry (in-memory source for refresh_all)
+        self._jobs: dict[str, ActiveJobEntry] = {}
+        # worker_loc → job_id (for heartbeat-driven refresh)
+        self._by_loc: dict[str, str] = {}
+        self._task: asyncio.Task[None] | None = None
+        self._running: bool = False
+
+    # ------------------------------------------------------------------
+    # ActiveJobsPort-compatible surface (delegating + recording)
+    # ------------------------------------------------------------------
+
+    async def open(self, entry: ActiveJobEntry) -> None:
+        """Delegate to port; record in in-memory maps on success.
+
+        Raises
+        ------
+        RegistryConflictError
+            Re-raised from port without recording (conflict = not opened).
+        """
+        # Propagate RegistryConflictError — do NOT record on conflict.
+        await self._port.open(entry)
+        self._jobs[entry.job_id] = entry
+        if entry.worker_loc:
+            self._by_loc[entry.worker_loc] = entry.job_id
+
+    async def close(self, job_id: str) -> None:
+        """Delegate to port; remove from in-memory maps."""
+        await self._port.close(job_id)
+        entry = self._jobs.pop(job_id, None)
+        if entry is not None and entry.worker_loc:
+            self._by_loc.pop(entry.worker_loc, None)
+
+    # ------------------------------------------------------------------
+    # Liveness
+    # ------------------------------------------------------------------
+
+    async def refresh_all(self) -> None:
+        """Refresh every in-memory-tracked job in the KV store.
+
+        POOL-SOURCE liveness: driven by the hub's background loop.  Iterates a
+        snapshot of current job IDs so concurrent open/close during iteration
+        does not mutate the set mid-loop.
+        """
+        for jid in list(self._jobs):
+            await self._port.refresh(jid)
+
+    async def on_heartbeat(self, worker_loc: str) -> None:
+        """Refresh the job mapped to *worker_loc*, if any.
+
+        HEARTBEAT-SOURCE liveness (Shape-D): called by the heartbeat tap-in on
+        the clipool ``WorkerPoolClient``.  A heartbeat for an unknown
+        ``worker_loc`` is silently ignored — the coordinator only tracks jobs
+        that were opened via ``open()``.
+        """
+        jid = self._by_loc.get(worker_loc)
+        if jid is not None:
+            await self._port.refresh(jid)
+
+    # ------------------------------------------------------------------
+    # Background loop lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn the background refresh task."""
+        self._running = True
+        self._task = asyncio.create_task(
+            self._loop(), name="active-jobs-refresher"
+        )
+
+    async def stop(self) -> None:
+        """Cancel and await the background task; suppress CancelledError."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        while self._running:
+            await self.refresh_all()
+            await asyncio.sleep(self._refresh_interval)
+
+
+__all__ = ["RegistryCoordinator"]

--- a/src/factory/transport/worker_pool_client.py
+++ b/src/factory/transport/worker_pool_client.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import logging
 from contextlib import AbstractAsyncContextManager
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Protocol
+from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable, Protocol
 
 from factory.transport._result import Err, InboxStream, Ok, Result, SanitizedError
 from roxabi_nats.circuit_breaker import NatsCircuitBreaker
@@ -70,6 +70,7 @@ class WorkerPoolClient:
         validate_worker_id: Callable[[str], None],
         hb_ttl: float = 15.0,
         name: str = "pool",
+        on_heartbeat: Callable[[str], Awaitable[None]] | None = None,
     ) -> None:
         self._transport = transport
         self._registry = registry
@@ -78,6 +79,7 @@ class WorkerPoolClient:
         self._validate_worker_id = validate_worker_id
         self._hb_ttl = hb_ttl
         self._name = name
+        self._on_heartbeat_cb = on_heartbeat
         self._sub: "Subscription | None" = None
         self._task: asyncio.Task[None] | None = None
 
@@ -121,6 +123,16 @@ class WorkerPoolClient:
             )
             return
         self._registry.record_heartbeat(payload)
+        if self._on_heartbeat_cb is not None:
+            try:
+                await self._on_heartbeat_cb(worker_id)
+            except Exception:  # noqa: BLE001 — callback errors must never crash heartbeat handling
+                log.warning(
+                    "%s.on_heartbeat_cb_error worker_id=%s",
+                    self._name,
+                    worker_id,
+                    exc_info=True,
+                )
 
     async def _heartbeat_loop(self) -> None:
         """Periodic TTL sweep — alive_workers() prunes stale entries on each call."""

--- a/tests/bootstrap/test_discord_kv_wiring.py
+++ b/tests/bootstrap/test_discord_kv_wiring.py
@@ -356,6 +356,23 @@ class TestHubPublishesWatchChannelsBeforeReady:
             _bootstrap_hub_standalone,
         )
 
+        # active-jobs registry provisioning runs before announce (ADR-079 S3).
+        # Stub via monkeypatch rather than the with-block to stay under CPython's
+        # 20-statically-nested-block limit. Lazily imported inside the function
+        # body → patch at source module paths so the local imports resolve them.
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.active_jobs_kv.ensure_active_jobs_kv",
+            AsyncMock(return_value=MagicMock()),
+        )
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.active_jobs_kv.KvActiveJobsStore",
+            MagicMock(return_value=MagicMock(connect=AsyncMock())),
+        )
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.active_jobs_refresher.RegistryCoordinator",
+            MagicMock(return_value=MagicMock(start=MagicMock(), stop=AsyncMock())),
+        )
+
         with (
             patch(
                 "factory.bootstrap.standalone.hub_standalone.nats_connect",

--- a/tests/bootstrap/test_hub_standalone_readiness.py
+++ b/tests/bootstrap/test_hub_standalone_readiness.py
@@ -255,12 +255,33 @@ class TestHubAudioProvisioningBehavioral:
             call_order.append("ensure_kv")
             return MagicMock()
 
+        async def _record_ensure_active_jobs_kv(*_a, **_kw):
+            call_order.append("ensure_active_jobs_kv")
+            return MagicMock()
+
         async def _record_announce_hub_ready(*_a, **_kw):
             call_order.append("announce_hub_ready")
             raise SystemExit("test-sentinel: stop after announce_hub_ready")
 
         from factory.bootstrap.standalone.hub_standalone import (
             _bootstrap_hub_standalone,
+        )
+
+        # active-jobs registry provisioning runs before announce (ADR-079 S3).
+        # Stub via monkeypatch rather than the with-block to stay under CPython's
+        # 20-statically-nested-block limit. Lazily imported inside the function
+        # body → patch at source module paths so the local imports resolve them.
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.active_jobs_kv.ensure_active_jobs_kv",
+            _record_ensure_active_jobs_kv,
+        )
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.active_jobs_kv.KvActiveJobsStore",
+            MagicMock(return_value=MagicMock(connect=AsyncMock())),
+        )
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.active_jobs_refresher.RegistryCoordinator",
+            MagicMock(return_value=MagicMock(start=MagicMock(), stop=AsyncMock())),
         )
 
         with (
@@ -370,6 +391,15 @@ class TestHubAudioProvisioningBehavioral:
         )
         assert ev_idx < ar_idx, (
             f"ensure_kv (pos {ev_idx}) must precede announce_hub_ready "
+            f"(pos {ar_idx}) — ADR-079 S3 ordering violated."
+        )
+        assert "ensure_active_jobs_kv" in call_order, (
+            "ensure_active_jobs_kv was never awaited — hub must provision the "
+            "active-jobs registry KV before announce_hub_ready (ADR-079 S3)."
+        )
+        ej_idx = call_order.index("ensure_active_jobs_kv")
+        assert ej_idx < ar_idx, (
+            f"ensure_active_jobs_kv (pos {ej_idx}) must precede announce_hub_ready "
             f"(pos {ar_idx}) — ADR-079 S3 ordering violated."
         )
 

--- a/tests/infrastructure/stores/test_active_jobs_kv.py
+++ b/tests/infrastructure/stores/test_active_jobs_kv.py
@@ -456,7 +456,7 @@ class TestEnsureActiveJobsKv:
         assert cfg.bucket == ACTIVE_JOBS_BUCKET
 
     async def test_boot_allow_direct_false(self):
-        """KeyValueConfig pins direct=False → stream allow_direct=False (no $JS.DIRECT.>)."""
+        """direct=False is pinned so the KV stream gets allow_direct=False."""
         js = AsyncMock()
         js.key_value.side_effect = BucketNotFoundError
         js.create_key_value.return_value = AsyncMock()

--- a/tests/infrastructure/stores/test_active_jobs_kv.py
+++ b/tests/infrastructure/stores/test_active_jobs_kv.py
@@ -1,0 +1,501 @@
+"""Tests for KvActiveJobsStore and ensure_active_jobs_kv (#1796)."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+from nats.js.errors import (
+    BadRequestError,
+    BucketNotFoundError,
+    KeyNotFoundError,
+    KeyWrongLastSequenceError,
+)
+
+from factory.core.ports.active_jobs import ActiveJobEntry, RegistryConflictError
+from factory.infrastructure.stores.active_jobs_kv import (
+    ACTIVE_JOBS_BUCKET,
+    ACTIVE_JOBS_TTL,
+    KvActiveJobsStore,
+    _idx_key,
+    _job_key,
+    ensure_active_jobs_kv,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TS = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _entry(
+    job_id: str = "job-1",
+    pool_id: str = "pool.tg.main",
+    concurrency_mode: str = "steer",
+) -> ActiveJobEntry:
+    return ActiveJobEntry(
+        job_id=job_id,
+        pool_id=pool_id,
+        status="open",
+        started_at=_TS,
+        steer_subject="factory.steer.pool.tg.main",
+        concurrency_mode=concurrency_mode,
+        worker_loc=None,
+    )
+
+
+def _kv_entry(value: bytes, revision: int = 1) -> MagicMock:
+    e = MagicMock()
+    e.value = value
+    e.revision = revision
+    return e
+
+
+# ---------------------------------------------------------------------------
+# KvActiveJobsStore — open()
+# ---------------------------------------------------------------------------
+
+
+class TestOpen:
+    async def test_open_writes_job_and_idx_steer(self):
+        """steer mode: puts job key + acquires singleton index."""
+        kv = AsyncMock()
+        kv.get.side_effect = KeyNotFoundError  # idx absent on first open
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(concurrency_mode="steer")
+        await store.open(entry)
+
+        kv.put.assert_awaited_once_with(_job_key("job-1"), kv.put.await_args.args[1])
+        kv.create.assert_awaited_once_with(_idx_key("pool.tg.main"), b"job-1")
+
+    async def test_open_writes_job_and_idx_queue(self):
+        """queue mode also acquires singleton index."""
+        kv = AsyncMock()
+        kv.get.side_effect = KeyNotFoundError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(concurrency_mode="queue")
+        await store.open(entry)
+
+        kv.create.assert_awaited_once_with(_idx_key("pool.tg.main"), b"job-1")
+
+    async def test_open_writes_job_no_idx_parallel(self):
+        """parallel mode: writes job key only — no index touch."""
+        kv = AsyncMock()
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(concurrency_mode="parallel")
+        await store.open(entry)
+
+        kv.put.assert_awaited_once()
+        kv.get.assert_not_awaited()
+        kv.create.assert_not_awaited()
+
+    async def test_open_colon_pool_id_sanitization(self):
+        """Colons in pool_id are replaced with underscores in KV keys."""
+        kv = AsyncMock()
+        kv.get.side_effect = KeyNotFoundError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(pool_id="pool:tg:main", concurrency_mode="steer")
+        await store.open(entry)
+
+        idx_key_used = kv.create.await_args.args[0]
+        assert ":" not in idx_key_used
+        assert idx_key_used == _idx_key("pool:tg:main")
+
+    async def test_open_update_existing_idx(self):
+        """When idx exists, open() updates it via CAS."""
+        kv = AsyncMock()
+        existing = _kv_entry(b"old-job", revision=5)
+        kv.get.return_value = existing  # idx found
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(concurrency_mode="steer")
+        await store.open(entry)
+
+        kv.update.assert_awaited_once_with(
+            _idx_key("pool.tg.main"), b"job-1", last_revision=5
+        )
+        kv.create.assert_not_awaited()
+
+    async def test_open_conflict_on_update_raises(self):
+        """CAS collision on update → RegistryConflictError."""
+        kv = AsyncMock()
+        existing = _kv_entry(b"other-job", revision=3)
+        kv.get.side_effect = [
+            existing,  # first get (idx exists)
+            _kv_entry(b"other-job", revision=4),  # winner read after CAS fail
+        ]
+        kv.update.side_effect = KeyWrongLastSequenceError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(concurrency_mode="steer")
+        with pytest.raises(RegistryConflictError) as exc_info:
+            await store.open(entry)
+
+        assert exc_info.value.pool_id == "pool.tg.main"
+        assert exc_info.value.existing_job_id == "other-job"
+
+    async def test_open_conflict_on_create_raises(self):
+        """CAS collision on create (idx absent → race) → RegistryConflictError."""
+        kv = AsyncMock()
+        kv.get.side_effect = [
+            KeyNotFoundError,  # idx absent (triggers create path)
+            _kv_entry(b"winner-job"),  # winner read after create CAS fail
+        ]
+        kv.create.side_effect = KeyWrongLastSequenceError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(concurrency_mode="steer")
+        with pytest.raises(RegistryConflictError) as exc_info:
+            await store.open(entry)
+
+        assert exc_info.value.existing_job_id == "winner-job"
+
+
+# ---------------------------------------------------------------------------
+# KvActiveJobsStore — refresh()
+# ---------------------------------------------------------------------------
+
+
+class TestRefresh:
+    async def test_refresh_reputs_job_and_idx(self):
+        """refresh() re-puts the job key and re-puts the index key (steer)."""
+        kv = AsyncMock()
+        entry = _entry(concurrency_mode="steer")
+        import json
+
+        raw = json.dumps(
+            {
+                "job_id": entry.job_id,
+                "pool_id": entry.pool_id,
+                "status": entry.status,
+                "started_at": entry.started_at.isoformat(),
+                "steer_subject": entry.steer_subject,
+                "concurrency_mode": entry.concurrency_mode,
+                "worker_loc": entry.worker_loc,
+            }
+        ).encode()
+        kv.get.return_value = _kv_entry(raw)
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.refresh("job-1")
+
+        assert kv.put.await_count == 2
+        put_keys = [c.args[0] for c in kv.put.await_args_list]
+        assert _job_key("job-1") in put_keys
+        assert _idx_key("pool.tg.main") in put_keys
+
+    async def test_refresh_noop_unknown_job(self):
+        """refresh() is a no-op when the job is not found."""
+        kv = AsyncMock()
+        kv.get.side_effect = KeyNotFoundError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.refresh("nonexistent-job")
+
+        kv.put.assert_not_awaited()
+
+    async def test_refresh_no_idx_for_parallel(self):
+        """refresh() skips index re-put for parallel mode."""
+        kv = AsyncMock()
+        entry = _entry(concurrency_mode="parallel")
+        import json
+
+        raw = json.dumps(
+            {
+                "job_id": entry.job_id,
+                "pool_id": entry.pool_id,
+                "status": entry.status,
+                "started_at": entry.started_at.isoformat(),
+                "steer_subject": entry.steer_subject,
+                "concurrency_mode": entry.concurrency_mode,
+                "worker_loc": entry.worker_loc,
+            }
+        ).encode()
+        kv.get.return_value = _kv_entry(raw)
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.refresh("job-1")
+
+        assert kv.put.await_count == 1
+        assert kv.put.await_args.args[0] == _job_key("job-1")
+
+
+# ---------------------------------------------------------------------------
+# KvActiveJobsStore — close()
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_deletes_job_and_idx_when_owner(self):
+        """close() removes both job key and idx key when this job owns the idx."""
+        kv = AsyncMock()
+        entry = _entry(concurrency_mode="steer")
+        import json
+
+        raw = json.dumps(
+            {
+                "job_id": entry.job_id,
+                "pool_id": entry.pool_id,
+                "status": entry.status,
+                "started_at": entry.started_at.isoformat(),
+                "steer_subject": entry.steer_subject,
+                "concurrency_mode": entry.concurrency_mode,
+                "worker_loc": entry.worker_loc,
+            }
+        ).encode()
+        # job get → job raw; idx get → current owner = "job-1" (same)
+        kv.get.side_effect = [_kv_entry(raw), _kv_entry(b"job-1")]
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.close("job-1")
+
+        deleted_keys = [c.args[0] for c in kv.delete.await_args_list]
+        assert _idx_key("pool.tg.main") in deleted_keys
+        assert _job_key("job-1") in deleted_keys
+
+    async def test_close_skips_idx_if_not_owner(self):
+        """close() keeps idx when another job has taken ownership."""
+        kv = AsyncMock()
+        entry = _entry(concurrency_mode="steer")
+        import json
+
+        raw = json.dumps(
+            {
+                "job_id": entry.job_id,
+                "pool_id": entry.pool_id,
+                "status": entry.status,
+                "started_at": entry.started_at.isoformat(),
+                "steer_subject": entry.steer_subject,
+                "concurrency_mode": entry.concurrency_mode,
+                "worker_loc": entry.worker_loc,
+            }
+        ).encode()
+        # idx owner = different job
+        kv.get.side_effect = [_kv_entry(raw), _kv_entry(b"other-job")]
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.close("job-1")
+
+        deleted_keys = [c.args[0] for c in kv.delete.await_args_list]
+        assert _idx_key("pool.tg.main") not in deleted_keys
+        assert _job_key("job-1") in deleted_keys
+
+    async def test_close_noop_unknown_job(self):
+        """close() is a no-op when the job is not found."""
+        kv = AsyncMock()
+        kv.get.side_effect = KeyNotFoundError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.close("nonexistent-job")
+
+        kv.delete.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# KvActiveJobsStore — get_by_pool()
+# ---------------------------------------------------------------------------
+
+
+class TestGetByPool:
+    async def test_get_by_pool_returns_entry(self):
+        """Happy path: idx→job→deserialized entry."""
+        kv = AsyncMock()
+        entry = _entry(concurrency_mode="steer")
+        import json
+
+        raw = json.dumps(
+            {
+                "job_id": entry.job_id,
+                "pool_id": entry.pool_id,
+                "status": entry.status,
+                "started_at": entry.started_at.isoformat(),
+                "steer_subject": entry.steer_subject,
+                "concurrency_mode": entry.concurrency_mode,
+                "worker_loc": entry.worker_loc,
+            }
+        ).encode()
+        kv.get.side_effect = [_kv_entry(b"job-1"), _kv_entry(raw)]
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        result = await store.get_by_pool("pool.tg.main")
+
+        assert result is not None
+        assert result.job_id == "job-1"
+        assert result.pool_id == "pool.tg.main"
+
+    async def test_get_by_pool_returns_none_absent_pool(self):
+        """Returns None when no idx entry exists for the pool."""
+        kv = AsyncMock()
+        kv.get.side_effect = KeyNotFoundError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        result = await store.get_by_pool("pool.tg.missing")
+
+        assert result is None
+
+    async def test_get_by_pool_returns_none_when_job_key_missing(self):
+        """Returns None when idx points to a job that has already expired."""
+        kv = AsyncMock()
+        kv.get.side_effect = [_kv_entry(b"job-expired"), KeyNotFoundError]
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        result = await store.get_by_pool("pool.tg.main")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_active_jobs_kv — provisioning paths
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureActiveJobsKv:
+    async def test_hot_path_binds_existing_bucket(self):
+        """key_value() succeeds on first call — returns existing bucket handle."""
+        kv_existing = AsyncMock()
+        js = AsyncMock()
+        js.key_value.return_value = kv_existing
+
+        result = await ensure_active_jobs_kv(js)
+
+        assert result is kv_existing
+        js.key_value.assert_awaited_once_with(ACTIVE_JOBS_BUCKET)
+        js.create_key_value.assert_not_awaited()
+
+    async def test_cold_boot_creates_bucket(self):
+        """BucketNotFoundError → create_key_value() cold-boot path."""
+        kv_created = AsyncMock()
+        js = AsyncMock()
+        js.key_value.side_effect = BucketNotFoundError
+        js.create_key_value.return_value = kv_created
+
+        result = await ensure_active_jobs_kv(js)
+
+        assert result is kv_created
+        js.create_key_value.assert_awaited_once()
+
+    async def test_cold_boot_race_lost_binds_existing(self):
+        """create_key_value → BadRequestError(10058) → fallback key_value()."""
+        kv_fallback = AsyncMock()
+        js = AsyncMock()
+        js.key_value.side_effect = [BucketNotFoundError, kv_fallback]
+
+        bad_req = BadRequestError()
+        bad_req.err_code = 10058
+        js.create_key_value.side_effect = bad_req
+
+        result = await ensure_active_jobs_kv(js)
+
+        assert result is kv_fallback
+        assert js.key_value.await_count == 2
+
+    async def test_cold_boot_unexpected_bad_request_propagates(self):
+        """BadRequestError with err_code != 10058 propagates (not swallowed)."""
+        js = AsyncMock()
+        js.key_value.side_effect = BucketNotFoundError
+
+        bad_req = BadRequestError()
+        bad_req.err_code = 9999
+        js.create_key_value.side_effect = bad_req
+
+        with pytest.raises(BadRequestError):
+            await ensure_active_jobs_kv(js)
+
+    async def test_boot_ttl_passed_to_create_key_value(self):
+        """KeyValueConfig passed to create_key_value has ttl=ACTIVE_JOBS_TTL."""
+        js = AsyncMock()
+        js.key_value.side_effect = BucketNotFoundError
+        js.create_key_value.return_value = AsyncMock()
+
+        await ensure_active_jobs_kv(js)
+
+        cfg = js.create_key_value.await_args.args[0]
+        assert cfg.ttl == ACTIVE_JOBS_TTL
+        assert cfg.bucket == ACTIVE_JOBS_BUCKET
+
+    async def test_boot_allow_direct_false(self):
+        """KeyValueConfig does not set allow_direct (defaults to False for STREAM.MSG.GET path)."""
+        js = AsyncMock()
+        js.key_value.side_effect = BucketNotFoundError
+        js.create_key_value.return_value = AsyncMock()
+
+        await ensure_active_jobs_kv(js)
+
+        cfg = js.create_key_value.await_args.args[0]
+        # allow_direct defaults to False — check it was not set to True
+        assert not getattr(cfg, "allow_direct", False)
+
+
+# ---------------------------------------------------------------------------
+# Guard: not-connected raises RuntimeError
+# ---------------------------------------------------------------------------
+
+
+class TestNotConnectedGuard:
+    async def test_crud_before_connect_raises(self):
+        js = AsyncMock()
+        store = KvActiveJobsStore(js)
+
+        entry = _entry()
+        with pytest.raises(RuntimeError, match="connect"):
+            await store.open(entry)
+        with pytest.raises(RuntimeError, match="connect"):
+            await store.refresh("job-1")
+        with pytest.raises(RuntimeError, match="connect"):
+            await store.close("job-1")
+        with pytest.raises(RuntimeError, match="connect"):
+            await store.get_by_pool("pool.tg.main")

--- a/tests/infrastructure/stores/test_active_jobs_kv.py
+++ b/tests/infrastructure/stores/test_active_jobs_kv.py
@@ -18,6 +18,7 @@ from factory.infrastructure.stores.active_jobs_kv import (
     ACTIVE_JOBS_BUCKET,
     ACTIVE_JOBS_TTL,
     KvActiveJobsStore,
+    _entry_to_bytes,
     _idx_key,
     _job_key,
     ensure_active_jobs_kv,
@@ -70,7 +71,9 @@ class TestOpen:
         entry = _entry(concurrency_mode="steer")
         await store.open(entry)
 
-        kv.put.assert_awaited_once_with(_job_key("job-1"), kv.put.await_args.args[1])
+        # Assert the EXACT serialized payload (independent re-serialization),
+        # not kv.put.await_args.args[1] against itself (that would be tautological).
+        kv.put.assert_awaited_once_with(_job_key("job-1"), _entry_to_bytes(entry))
         kv.create.assert_awaited_once_with(_idx_key("pool.tg.main"), b"job-1")
         kv.update.assert_not_awaited()  # singleton acquired via create, never update
 
@@ -164,6 +167,34 @@ class TestOpen:
             await store.open(entry)
 
         assert exc_info.value.existing_job_id == "<unknown>"
+
+    async def test_open_reclaims_pool_after_ttl_reap(self):
+        """SC-5 reap semantics: a pool held by a crashed job is reclaimable once
+        its singleton index TTL-expires.
+
+        Models the lifecycle create(win) → create(conflict, pool busy) →
+        TTL reap → create(win again) via the kv.create side-effect sequence.
+        Proves the freed slot is re-acquirable and that the conflict branch and
+        the post-reap success branch are distinct code paths (not a tautology).
+        """
+        kv = AsyncMock()
+        # job-1 wins; job-2 conflicts (pool busy); after reap, job-3 wins.
+        kv.create.side_effect = [None, KeyWrongLastSequenceError, None]
+        kv.get.return_value = _kv_entry(b"job-1")  # winner lookup for the conflict
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        await store.open(_entry(job_id="job-1", concurrency_mode="steer"))  # wins
+
+        with pytest.raises(RegistryConflictError):
+            await store.open(_entry(job_id="job-2", concurrency_mode="steer"))
+
+        # TTL reaps job-1's index key → job-3 reclaims the freed slot, no raise.
+        await store.open(_entry(job_id="job-3", concurrency_mode="steer"))
+
+        assert kv.create.await_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infrastructure/stores/test_active_jobs_kv.py
+++ b/tests/infrastructure/stores/test_active_jobs_kv.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from nats.js.errors import (
@@ -60,9 +60,8 @@ def _kv_entry(value: bytes, revision: int = 1) -> MagicMock:
 
 class TestOpen:
     async def test_open_writes_job_and_idx_steer(self):
-        """steer mode: puts job key + acquires singleton index."""
+        """steer mode: puts job key + acquires singleton index via create-only CAS."""
         kv = AsyncMock()
-        kv.get.side_effect = KeyNotFoundError  # idx absent on first open
         js = AsyncMock()
         js.key_value.return_value = kv
         store = KvActiveJobsStore(js)
@@ -73,11 +72,11 @@ class TestOpen:
 
         kv.put.assert_awaited_once_with(_job_key("job-1"), kv.put.await_args.args[1])
         kv.create.assert_awaited_once_with(_idx_key("pool.tg.main"), b"job-1")
+        kv.update.assert_not_awaited()  # singleton acquired via create, never update
 
     async def test_open_writes_job_and_idx_queue(self):
-        """queue mode also acquires singleton index."""
+        """queue mode also acquires singleton index via create."""
         kv = AsyncMock()
-        kv.get.side_effect = KeyNotFoundError
         js = AsyncMock()
         js.key_value.return_value = kv
         store = KvActiveJobsStore(js)
@@ -100,13 +99,11 @@ class TestOpen:
         await store.open(entry)
 
         kv.put.assert_awaited_once()
-        kv.get.assert_not_awaited()
         kv.create.assert_not_awaited()
 
     async def test_open_colon_pool_id_sanitization(self):
-        """Colons in pool_id are replaced with underscores in KV keys."""
+        """Colons in pool_id are replaced with underscores in the index KV key."""
         kv = AsyncMock()
-        kv.get.side_effect = KeyNotFoundError
         js = AsyncMock()
         js.key_value.return_value = kv
         store = KvActiveJobsStore(js)
@@ -119,63 +116,54 @@ class TestOpen:
         assert ":" not in idx_key_used
         assert idx_key_used == _idx_key("pool:tg:main")
 
-    async def test_open_update_existing_idx(self):
-        """When idx exists, open() updates it via CAS."""
+    async def test_open_existing_pool_different_job_conflicts(self):
+        """A live index held by a different job → RegistryConflictError (singleton)."""
         kv = AsyncMock()
-        existing = _kv_entry(b"old-job", revision=5)
-        kv.get.return_value = existing  # idx found
+        kv.create.side_effect = KeyWrongLastSequenceError
+        kv.get.return_value = _kv_entry(b"other-job")  # winner is someone else
         js = AsyncMock()
         js.key_value.return_value = kv
         store = KvActiveJobsStore(js)
         await store.connect()
 
-        entry = _entry(concurrency_mode="steer")
-        await store.open(entry)
-
-        kv.update.assert_awaited_once_with(
-            _idx_key("pool.tg.main"), b"job-1", last_revision=5
-        )
-        kv.create.assert_not_awaited()
-
-    async def test_open_conflict_on_update_raises(self):
-        """CAS collision on update → RegistryConflictError."""
-        kv = AsyncMock()
-        existing = _kv_entry(b"other-job", revision=3)
-        kv.get.side_effect = [
-            existing,  # first get (idx exists)
-            _kv_entry(b"other-job", revision=4),  # winner read after CAS fail
-        ]
-        kv.update.side_effect = KeyWrongLastSequenceError
-        js = AsyncMock()
-        js.key_value.return_value = kv
-        store = KvActiveJobsStore(js)
-        await store.connect()
-
-        entry = _entry(concurrency_mode="steer")
+        entry = _entry(job_id="job-1", concurrency_mode="steer")
         with pytest.raises(RegistryConflictError) as exc_info:
             await store.open(entry)
 
         assert exc_info.value.pool_id == "pool.tg.main"
         assert exc_info.value.existing_job_id == "other-job"
+        kv.update.assert_not_awaited()  # never steals a foreign pool via update
 
-    async def test_open_conflict_on_create_raises(self):
-        """CAS collision on create (idx absent → race) → RegistryConflictError."""
+    async def test_open_same_job_reopen_is_idempotent(self):
+        """Re-open by the owning job_id → no conflict, no steal."""
         kv = AsyncMock()
-        kv.get.side_effect = [
-            KeyNotFoundError,  # idx absent (triggers create path)
-            _kv_entry(b"winner-job"),  # winner read after create CAS fail
-        ]
         kv.create.side_effect = KeyWrongLastSequenceError
+        kv.get.return_value = _kv_entry(b"job-1")  # winner is us
         js = AsyncMock()
         js.key_value.return_value = kv
         store = KvActiveJobsStore(js)
         await store.connect()
 
-        entry = _entry(concurrency_mode="steer")
+        entry = _entry(job_id="job-1", concurrency_mode="steer")
+        await store.open(entry)  # must not raise
+
+        kv.update.assert_not_awaited()
+
+    async def test_open_conflict_winner_vanished_still_conflicts(self):
+        """create CAS fails but the winner vanished (TTL race) → conflict, <unknown>."""
+        kv = AsyncMock()
+        kv.create.side_effect = KeyWrongLastSequenceError
+        kv.get.side_effect = KeyNotFoundError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        entry = _entry(job_id="job-1", concurrency_mode="steer")
         with pytest.raises(RegistryConflictError) as exc_info:
             await store.open(entry)
 
-        assert exc_info.value.existing_job_id == "winner-job"
+        assert exc_info.value.existing_job_id == "<unknown>"
 
 
 # ---------------------------------------------------------------------------
@@ -468,7 +456,7 @@ class TestEnsureActiveJobsKv:
         assert cfg.bucket == ACTIVE_JOBS_BUCKET
 
     async def test_boot_allow_direct_false(self):
-        """KeyValueConfig does not set allow_direct (defaults to False for STREAM.MSG.GET path)."""
+        """KeyValueConfig pins direct=False → stream allow_direct=False (no $JS.DIRECT.>)."""
         js = AsyncMock()
         js.key_value.side_effect = BucketNotFoundError
         js.create_key_value.return_value = AsyncMock()
@@ -476,8 +464,8 @@ class TestEnsureActiveJobsKv:
         await ensure_active_jobs_kv(js)
 
         cfg = js.create_key_value.await_args.args[0]
-        # allow_direct defaults to False — check it was not set to True
-        assert not getattr(cfg, "allow_direct", False)
+        # nats-py maps KeyValueConfig.direct → StreamConfig.allow_direct (client.py).
+        assert cfg.direct is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infrastructure/stores/test_active_jobs_refresher.py
+++ b/tests/infrastructure/stores/test_active_jobs_refresher.py
@@ -1,0 +1,223 @@
+"""Unit tests for RegistryCoordinator (#1796, slice 2).
+
+All tests use an AsyncMock port.  No asyncio.sleep / time.sleep calls —
+the background loop (_loop) is never exercised here; refresh_all, on_heartbeat,
+open, and close are tested directly.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from factory.core.ports.active_jobs import ActiveJobEntry, RegistryConflictError
+from factory.infrastructure.stores.active_jobs_refresher import RegistryCoordinator
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    job_id: str,
+    pool_id: str = "pool-a",
+    worker_loc: str | None = None,
+    concurrency_mode: str = "steer",
+) -> ActiveJobEntry:
+    return ActiveJobEntry(
+        job_id=job_id,
+        pool_id=pool_id,
+        status="open",
+        started_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+        steer_subject=f"factory.steer.{job_id}",
+        concurrency_mode=concurrency_mode,
+        worker_loc=worker_loc,
+    )
+
+
+@pytest.fixture()
+def port() -> AsyncMock:
+    mock = AsyncMock()
+    mock.open = AsyncMock(return_value=None)
+    mock.close = AsyncMock(return_value=None)
+    mock.refresh = AsyncMock(return_value=None)
+    return mock
+
+
+@pytest.fixture()
+def coord(port: AsyncMock) -> RegistryCoordinator:
+    return RegistryCoordinator(port)
+
+
+# ---------------------------------------------------------------------------
+# open()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_open_records_entry_in_jobs_map(coord: RegistryCoordinator) -> None:
+    entry = _make_entry("job-1", worker_loc=None)
+    await coord.open(entry)
+    assert "job-1" in coord._jobs
+
+
+@pytest.mark.asyncio()
+async def test_open_records_worker_loc_in_by_loc(coord: RegistryCoordinator) -> None:
+    entry = _make_entry("job-2", worker_loc="host-a:9000")
+    await coord.open(entry)
+    assert coord._by_loc.get("host-a:9000") == "job-2"
+
+
+@pytest.mark.asyncio()
+async def test_open_no_worker_loc_not_added_to_by_loc(
+    coord: RegistryCoordinator,
+) -> None:
+    entry = _make_entry("job-3", worker_loc=None)
+    await coord.open(entry)
+    assert "job-3" in coord._jobs
+    assert not coord._by_loc
+
+
+@pytest.mark.asyncio()
+async def test_open_conflict_not_recorded_and_raises(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    port.open.side_effect = RegistryConflictError("pool-a", "existing-job")
+    entry = _make_entry("job-conflict")
+    with pytest.raises(RegistryConflictError):
+        await coord.open(entry)
+    assert "job-conflict" not in coord._jobs
+    assert not coord._by_loc
+
+
+# ---------------------------------------------------------------------------
+# refresh_all()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_refresh_all_calls_refresh_for_each_open_job(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.open(_make_entry("job-a"))
+    await coord.open(_make_entry("job-b", pool_id="pool-b"))
+    port.refresh.reset_mock()
+
+    await coord.refresh_all()
+
+    assert port.refresh.call_count == 2
+    port.refresh.assert_any_call("job-a")
+    port.refresh.assert_any_call("job-b")
+
+
+@pytest.mark.asyncio()
+async def test_refresh_all_empty_no_calls(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.refresh_all()
+    port.refresh.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# on_heartbeat()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_on_heartbeat_refreshes_matching_worker(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.open(_make_entry("job-hb", worker_loc="loc-A"))
+    port.refresh.reset_mock()
+
+    await coord.on_heartbeat("loc-A")
+
+    port.refresh.assert_called_once_with("job-hb")
+
+
+@pytest.mark.asyncio()
+async def test_on_heartbeat_unknown_loc_does_not_call_refresh(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.open(_make_entry("job-hb2", worker_loc="loc-B"))
+    port.refresh.reset_mock()
+
+    await coord.on_heartbeat("loc-UNKNOWN")
+
+    port.refresh.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_on_heartbeat_only_matching_loc_refreshed(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    """Two jobs with different worker_loc.
+
+    Heartbeat for one must not touch the other.
+    """
+    await coord.open(_make_entry("job-x", pool_id="pool-x", worker_loc="loc-X"))
+    await coord.open(_make_entry("job-y", pool_id="pool-y", worker_loc="loc-Y"))
+    port.refresh.reset_mock()
+
+    await coord.on_heartbeat("loc-X")
+
+    port.refresh.assert_called_once_with("job-x")
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_close_calls_port_close(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.open(_make_entry("job-c"))
+    port.close.reset_mock()
+
+    await coord.close("job-c")
+
+    port.close.assert_called_once_with("job-c")
+
+
+@pytest.mark.asyncio()
+async def test_close_removes_from_jobs_map(coord: RegistryCoordinator) -> None:
+    await coord.open(_make_entry("job-d"))
+    await coord.close("job-d")
+    assert "job-d" not in coord._jobs
+
+
+@pytest.mark.asyncio()
+async def test_close_removes_worker_loc_from_by_loc(coord: RegistryCoordinator) -> None:
+    await coord.open(_make_entry("job-e", worker_loc="loc-E"))
+    await coord.close("job-e")
+    assert "loc-E" not in coord._by_loc
+
+
+@pytest.mark.asyncio()
+async def test_closed_job_not_refreshed_by_refresh_all(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.open(_make_entry("job-f"))
+    await coord.close("job-f")
+    port.refresh.reset_mock()
+
+    await coord.refresh_all()
+
+    port.refresh.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_closed_job_heartbeat_no_longer_refreshes(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    await coord.open(_make_entry("job-g", worker_loc="loc-G"))
+    await coord.close("job-g")
+    port.refresh.reset_mock()
+
+    await coord.on_heartbeat("loc-G")
+
+    port.refresh.assert_not_called()

--- a/tests/infrastructure/stores/test_active_jobs_refresher.py
+++ b/tests/infrastructure/stores/test_active_jobs_refresher.py
@@ -120,6 +120,29 @@ async def test_refresh_all_empty_no_calls(
     port.refresh.assert_not_called()
 
 
+@pytest.mark.asyncio()
+async def test_refresh_all_one_failure_does_not_abort_sweep(
+    port: AsyncMock, coord: RegistryCoordinator
+) -> None:
+    """One job's refresh error must not abort the sweep for the rest.
+
+    Regression guard: if a single transient NATS error propagated, the liveness
+    loop would die and ALL tracked jobs would silently go stale → pools wrongly
+    freed while their jobs still run (defeats the singleton guarantee).
+    """
+    await coord.open(_make_entry("job-x"))
+    await coord.open(_make_entry("job-y", pool_id="pool-b"))
+    port.refresh.reset_mock()
+    # First job in the (insertion-ordered) snapshot raises; second must still run.
+    port.refresh.side_effect = [RuntimeError("transient NATS error"), None]
+
+    await coord.refresh_all()  # must not raise
+
+    assert port.refresh.call_count == 2
+    port.refresh.assert_any_call("job-x")
+    port.refresh.assert_any_call("job-y")
+
+
 # ---------------------------------------------------------------------------
 # on_heartbeat()
 # ---------------------------------------------------------------------------

--- a/tests/scripts/fixtures/v3-current.json
+++ b/tests/scripts/fixtures/v3-current.json
@@ -43,7 +43,7 @@
       "created_at": "2026-04-21",
       "owner": "factory",
       "description": "Hub core \u2014 routes inbound messages, dispatches to voice/LLM/image/clipool workers. Inbox normalized to lowercase _inbox.hub.> (ADR-051 + postmortem Fix 1).",
-      "notes": "Hub provisions the factory-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.factory-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. factory.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. factory.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream FACTORY_OUTBOUND_AUDIO and KV bucket KV_factory_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 \u00a7Forward-compat for explicit enumeration if wildcard is ever tightened). factory.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only \u2014 publisher declared by #1082 (gh-helper). This field is metadata only \u2014 not rendered into auth.conf or the 706 spec table. factory.job.*.steer added (#1812): hub initiates steer commands for active omp jobs (send mid-flight steering prompts to omp_rpc worker).",
+      "notes": "Hub provisions the factory-state KV bucket at runtime on first boot (announce_hub_ready, #1012). $JS.API.> required for KV bucket creation and JetStream API calls. $KV.factory-state.> required for kv.put() which publishes directly to $KV.<bucket>.<key> subjects (not covered by $JS.API.>). Tighter per-operation scoping is tracked as a follow-up. factory.turns.write added by T27 (#1331): hub publishes TurnWriteEvents. factory.outbound.audio.> added by T7 (#1482): hub publishes to outbound-audio JetStream path. Sole-provisioner (ADR-079 S3, #1525): hub provisions stream FACTORY_OUTBOUND_AUDIO and KV bucket KV_factory_outbound_audio_sent before announce_hub_ready; adapters are bind-only (js.key_value + ensure_consumer). Provisioning subjects covered by existing $JS.API.> wildcard (see ADR-079 \u00a7Forward-compat for explicit enumeration if wildcard is ever tightened). factory.gh.mint_failure.> added (#1545): hub runs MintFailureSubscriber (start_mint_failure_subscriber) which subscribes to gh-helper mint-failure alerts and forwards them to the ops Telegram chat. NB: this is the subscribe half only \u2014 publisher declared by #1082 (gh-helper). This field is metadata only \u2014 not rendered into auth.conf or the 706 spec table. factory.job.*.steer added (#1812): hub initiates steer commands for active omp jobs (send mid-flight steering prompts to omp_rpc worker). $KV.factory-active-jobs.> added (#1796): hub is sole writer of the factory-active-jobs KV registry (kv.put/create/update/delete publish header-based ops to $KV.<bucket>.<key>); allow_direct=False so readers ride $JS.API.STREAM.MSG.GET (#1572, zero-ACL).",
       "allow_responses": true,
       "publish": [
         "factory.outbound.telegram.>",
@@ -65,7 +65,8 @@
         "factory.job.*.steer",
         "$JS.API.>",
         "$KV.factory-state.>",
-        "$KV.factory-msg-index.>"
+        "$KV.factory-msg-index.>",
+        "$KV.factory-active-jobs.>"
       ],
       "subscribe": [
         "factory.inbound.telegram.>",

--- a/tests/scripts/fixtures/v3-pre-grant-group.json
+++ b/tests/scripts/fixtures/v3-pre-grant-group.json
@@ -37,7 +37,8 @@
         "factory.job.*.steer",
         "$JS.API.>",
         "$KV.factory-state.>",
-        "$KV.factory-msg-index.>"
+        "$KV.factory-msg-index.>",
+        "$KV.factory-active-jobs.>"
       ],
       "subscribe": [
         "factory.inbound.telegram.>",


### PR DESCRIPTION
## Summary

Adds the **`factory-active-jobs` NATS-KV registry** — the single-writer liveness substrate that enforces *one active job per pool* and exposes the live job set for the dispatch-side concurrency gate (epic #1792). Foundation child; blocks #1797 / #1798 / #1799 / #1800.

Closes #1796.

## What's implemented

| Slice | Module | Behavior |
|-------|--------|----------|
| 1 | `core/ports/active_jobs.py` | `ActiveJobsPort` Protocol + `ActiveJobEntry` (frozen) + `RegistryConflictError` |
| 1 | `infrastructure/stores/active_jobs_kv.py` | `KvActiveJobsStore` over `factory-active-jobs` bucket (TTL 120s); **create-only CAS** on the pool-index key → second opener of a busy pool is rejected, same `job_id` re-open is idempotent; `direct=False` pinned |
| 2 | `infrastructure/stores/active_jobs_refresher.py` | `RegistryCoordinator` — in-memory job map + periodic `refresh_all()` (pool-source liveness, 30s) + `on_heartbeat(loc)` (heartbeat-source) |
| 2 | `transport/worker_pool_client.py` | optional `on_heartbeat` callback (registry tap-in) |
| 2 | `bootstrap/standalone/hub_standalone.py` | store `connect()` + coordinator `start()`/`stop()` wired into hub boot |

- ACL: hub granted publish `$KV.factory-active-jobs.>`. All four generated ACL artifacts regenerated + `v3-pre-grant-group.json` hand-mirrored.
- Docs: messaging KV-plane catalogue row + job-model.md status (`Done (substrate); live open/close → #1797`).

## Deferred (by design)

- **Live `open()`/`close()` call-sites** — the registry exposes them and the refresher runs (pool-source), but wiring them into the live pipeline is **#1797** (concurrency_router, the first consumer — polled, no clean run-completion hook). Substrate + tests land here.
- **Heartbeat pass-through** — `WorkerPoolClient.on_heartbeat` exists and is tested, but is not yet connected to the coordinator (`worker_loc` stays dormant until the Shape-D workers populate it).
- **`auth.conf` regen** — CI-only (NKey seeds).

## Verification

- 60 stores + refresher tests green; 116 transport tests green; full suite 2014 pass (2 pre-existing `test_agent_refiner_cli` typer failures on staging, unrelated).
- Gates green: `str_exc_bus_bound`, `doc_drift`, `secrets_drift`, `folder_size` (15/15), `import-linter` (11/0). `typing_publisher.py` untouched.
- nats-py KV signatures verified at source: `KeyValueConfig.direct`, `kv.create()` → `KeyWrongLastSequenceError`, `kv.update(last=)`.

## Axial

Touches `core/ports/` + `infrastructure/` → carries `dev-core:axial-adr-review`. Core port stays infra-free (port-injection); no infrastructure types leak into the domain object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
