### PR TITLE
fix(cli): pass `-` stdin source to `podman secret create`

### DIFF
--- a/src/factory/cli_bot.py
+++ b/src/factory/cli_bot.py
@@ -62,8 +62,10 @@ def _read_env(var: str) -> bytes:
 
 
 def _podman_secret_create(name: str, content: bytes) -> None:
+    # `-` is the source argument telling podman to read the secret from stdin;
+    # without it `podman secret create` rejects the call (needs NAME FILE|-).
     subprocess.run(
-        ["podman", "secret", "create", "--replace", name],
+        ["podman", "secret", "create", "--replace", name, "-"],
         input=content,
         check=True,
     )

--- a/tests/cli/test_bot_secret.py
+++ b/tests/cli/test_bot_secret.py
@@ -90,7 +90,11 @@ class TestSecretInstall:
         assert "secret" in cmd
         assert "create" in cmd
         assert "--replace" in cmd
-        assert "factory-bot-telegram-demo" in cmd
+        # Command shape is `podman secret create --replace <name> -`:
+        # name second-to-last, `-` last (stdin source). Without the trailing
+        # `-`, podman rejects the call — this guards that regression.
+        assert cmd[-2] == "factory-bot-telegram-demo"
+        assert cmd[-1] == "-"
 
         # Token bytes must have been piped via stdin
         kwargs = call_args[1]
@@ -312,8 +316,8 @@ class TestSecretInstall:
         all_calls = mock_run.call_args_list
         cmds = [c[0][0] for c in all_calls]
 
-        # last positional arg is the secret name
-        secret_names = [cmd[-1] for cmd in cmds]
+        # secret name is the second-to-last arg (`-` stdin source is last)
+        secret_names = [cmd[-2] for cmd in cmds]
         assert "factory-bot-telegram-demo" in secret_names
         assert "factory-bot-telegram-demo-webhook" in secret_names
 
@@ -533,7 +537,7 @@ class TestE2EV1RedGate:
         assert mock_run.call_count == 2, (
             f"Expected 2 podman create calls, got {mock_run.call_count}"
         )
-        created_names = [c[0][0][-1] for c in mock_run.call_args_list]
+        created_names = [c[0][0][-2] for c in mock_run.call_args_list]
         assert "factory-bot-telegram-mybot" in created_names
         assert "factory-bot-telegram-mybot-webhook" in created_names
 


### PR DESCRIPTION
## Problem

`factory bot secret install <platform> <bot_id> --from-env VAR` was broken. `_podman_secret_create` (`cli_bot.py`) built:

```
podman secret create --replace <name>      # token piped via stdin
```

podman requires a source argument (`NAME FILE|-`). With the token on stdin but no `-`, podman rejects the call:

```
Error: accepts 2 arg(s), received 1
CalledProcessError: ... returned non-zero exit status 125
```

So the canonical bot-token rotation path failed for **every** bot — tokens had to be set with a manual `printf '%s' "$TOK" | podman secret create --replace <name> -` (discovered live during the 2026-06-12 Discord token rotation).

## Fix

- `cli_bot.py`: append `-` to the command → `podman secret create --replace <name> -`.
- `tests/cli/test_bot_secret.py`: the existing happy-path test only asserted name membership in the command, so the missing `-` shipped green. Now assert `cmd[-1] == "-"` (regression guard) and update the two assertions that relied on the secret name being the last arg (now second-to-last).

## Verify

```
uv run pytest tests/cli/test_bot_secret.py -q   # 21 passed
uv run ruff check / format --check               # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)