### PR TITLE
fix(omp): runtime closure — workspace mount + omp_rpc image pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ USER root
 # to dial the dispenser Unix socket. Smallest dep that handles UNIX-CONNECT cleanly;
 # BSD nc -U fallback in the shims is for hosts where socat is unavailable.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends socat \
+ && apt-get install -y --no-install-recommends socat git \
  && rm -rf /var/lib/apt/lists/*
 
 # UID 1500 pinned per ADR-053 (Quadlet container UID stability)
@@ -102,6 +102,22 @@ RUN test -x /usr/bin/gh \
  && chmod 0755 /opt/factory-gh/gh \
  || true
 ENV FACTORY_GH_BIN=/opt/factory-gh/gh
+
+# ── omp_rpc Python package (#1871) ─────────────────────────────────────────────
+# omp_rpc is deliberately kept OUT of uv.lock (alpha lib, pin-by-SHA pattern —
+# #1807/#1810). Install at image build time from the pinned commit that matches
+# OMP_VERSION=v15.10.8 / factory-omp-base:15.10.8. The commit SHA is locked here;
+# a version bump must update deploy/omp-base/Containerfile OMP_VERSION+OMP_SHA256,
+# src/factory/adapters/omp/_rpc_bridge.py _PINNED_SHA256, AND this pin — in lockstep.
+# uv is not present in agent-runtime (only in builder); bring the static binary from
+# the official astral-sh image so we can pip-install into /app/.venv without touching
+# the project lockfile.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN uv pip install --python /app/.venv/bin/python \
+      "git+https://github.com/can1357/oh-my-pi@4b5200a163060c057f1d886df15d7ef083a54a62#subdirectory=python/omp-rpc"
+# Build-time import smoke — fails the image build if omp_rpc is mis-installed or
+# the subdirectory path changes upstream. Closes the "declared but never importable" gap.
+RUN /app/.venv/bin/python -c "import omp_rpc"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ USER root
 # socat — required by the gh_token shim scripts (git-credential-factory-gh + factory-gh)
 # to dial the dispenser Unix socket. Smallest dep that handles UNIX-CONNECT cleanly;
 # BSD nc -U fallback in the shims is for hosts where socat is unavailable.
+# git — two consumers: (1) runtime — the omp ownership probe shells out to
+# `git rev-parse HEAD` (git_ownership_probe.py); (2) build — the omp_rpc `git+URL`
+# install below. Do NOT drop git while either consumer exists.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends socat git \
  && rm -rf /var/lib/apt/lists/*

--- a/deploy/quadlet/factory-omp.container
+++ b/deploy/quadlet/factory-omp.container
@@ -22,6 +22,10 @@ Environment=LITELLM_API_KEY_FILE=/run/secrets/factory-litellm-key.tok
 Tmpfs=/tmp
 Volume=%h/projects/roxabi-factory/deploy/omp:/home/factory/.config/omp-pi:ro,Z
 Environment=PI_CODING_AGENT_DIR=/home/factory/.config/omp-pi
+# Workspace — mirrors host ~/projects so the git ownership probe finds its target
+# (run_git_ownership_probe defaults to /home/factory/projects/roxabi-factory).
+# Same mount as factory-clipool; UserNS=keep-id:uid=1500,gid=1500 ensures correct ownership.
+Volume=%h/projects:/home/factory/projects:z
 Label=io.containers.autoupdate=registry
 
 [Service]


### PR DESCRIPTION
## Summary

Closes the two root causes behind the `factory-omp` crash-loop (restart >175, exit 1 every ~13s) found in the 2026-06-13 M₁ post-#1869 audit. Deploy wiring (#1867/#1869) was correct; the unit failed at **runtime** for two independent reasons:

- **RC1 — ownership-probe target absent.** `_bootstrap_omp_standalone` calls `run_git_ownership_probe()` with no args → defaults to `/home/factory/projects/roxabi-factory`, which the omp unit never mounted. **Fix:** add `Volume=%h/projects:/home/factory/projects:z` to `factory-omp.container`, mirroring `factory-clipool` exactly. `UserNS=keep-id:uid=1500,gid=1500` (self-declared on the standalone container; clipool inherits the equivalent from `factory-gh.pod`) maps host files to uid 1500 so the probe's ownership check passes.
- **RC2 — `omp_rpc` not in the image.** The deferred `import omp_rpc` (`_rpc_bridge.py`) had no installer: `uv sync --frozen --no-dev` covers pyproject only, and `omp_rpc` is deliberately kept **out** of `uv.lock` (alpha lib, pin-by-SHA — #1807/#1810). **Fix:** in the `agent-runtime` stage, `uv pip install` `omp_rpc` pinned at commit `4b5200a1` (== `v15.10.8`, the same omp version the binary carrier pins → matching RPC protocol), plus a build-time `RUN python -c "import omp_rpc"` smoke that fails the image build if the dep is mis-installed (closes the "declared-but-never-importable" gap class).

### Scope notes

- **e2e validation deferred to llmCLI#114.** A full "omp runs a job end-to-end" check needs a live LLM; M₁'s LiteLLM upstreams are currently dead (llmCLI#114). This PR lands the structural runtime fix so the next converge stops resuming the crash-loop.
- **Image build is post-merge.** `publish.yml` builds the image on **push to `staging`** (and release tags), not on PRs — so the `import omp_rpc` smoke runs on staging-publish after merge, not in this PR's CI. The exact pinned `uv pip install` + import was **pre-validated locally** against the real remote (resolved → built → installed `omp-rpc==0.1.0`, zero third-party deps).
- **Version-bump lockstep:** an omp version bump must update three pins together — `deploy/omp-base/Containerfile` (`OMP_VERSION`/`OMP_SHA256`), `_rpc_bridge.py` (`_PINNED_SHA256`), and the commit pin in `Dockerfile`. Documented inline.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1871: runtime closure (factory-omp crash-loop) | OPEN |
| Implementation | 1 commit on `feat/1871-omp-runtime-closure` | Complete |
| Verification | Gates ✅ (volumes_table, secrets_drift, quadlet_manifest_install) · install smoke ✅ pre-validated · no Python runtime code touched | Passed |

## Test Plan

- [ ] On M₁ after a converge: `systemctl --user status factory-omp` → active, restart counter stable >10 min.
- [ ] `podman exec factory-omp /app/.venv/bin/python -c "import omp_rpc"` → exits 0.
- [ ] `podman exec factory-omp ls /home/factory/projects/roxabi-factory` → probe target present, owned by uid 1500.
- [ ] Staging `publish` job green (the build-time `import omp_rpc` smoke executes there).
- [ ] Full job e2e — tracked under llmCLI#114 once M₁ LiteLLM upstreams recover.

Fixes #1871

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`