### PR TITLE
fix(omp): start omp_rpc client + drive its sync API off the event loop

### DIFF
--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -101,6 +100,21 @@ def _verify_digest(omp_bin: Path) -> None:
         raise DigestMismatchError(actual=actual, expected=_PINNED_SHA256)
 
 
+def _log_publish_result(task: asyncio.Task[Any]) -> None:
+    """Done-callback for a NATS publish scheduled from an omp_rpc listener thread.
+
+    asyncio task results are otherwise dropped on the floor — without this a failed
+    publish (NATS down, ACL denial) would vanish silently. Logs the exception type
+    locally only; no bus exposure, so ADR-073 does not apply here (#1876).
+    """
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc is not None:
+        log.warning("rpc_bridge: scheduled NATS publish failed", exc_info=exc)
+
+
 class RpcBridge:
     """Bridge between omp_rpc.RpcClient and NATS publish calls.
 
@@ -115,7 +129,7 @@ class RpcBridge:
         self,
         omp_bin: Path = _OMP_BIN,
         *,
-        provider: str | None = None,
+        provider: str | None = _DEFAULT_PROVIDER,
         model: str | None = None,
     ) -> None:
         _verify_digest(omp_bin)
@@ -123,10 +137,13 @@ class RpcBridge:
         # Import deferred: omp_rpc is a container image dep, absent from pyproject.toml.
         import omp_rpc  # type: ignore[import-not-found]
 
+        # provider/model are constructor kwargs only — no env axis. The runtime
+        # model list comes from deploy/omp/models.yml (via PI_CODING_AGENT_DIR),
+        # not from OMP_PROVIDER/OMP_MODEL env vars (#1876).
         self._client: omp_rpc.RpcClient = omp_rpc.RpcClient(
             executable=str(omp_bin),
-            provider=provider or os.environ.get("OMP_PROVIDER", _DEFAULT_PROVIDER),
-            model=model or os.environ.get("OMP_MODEL"),
+            provider=provider,
+            model=model,
             no_session=True,
         )
         self._nc: NatsClient | None = None
@@ -165,6 +182,8 @@ class RpcBridge:
         """
         self._current_job_id = job_id
         self._in_prompt_await = True
+        # _on_agent_end (sets _result_sent=True) fires on the stdout thread before
+        # prompt_and_wait returns — arm the guard before subscribing to steer.
         self._result_sent = False
         nc = self._nc
 
@@ -211,9 +230,13 @@ class RpcBridge:
         loop = self._loop
         if nc is None or loop is None:
             return
-        loop.call_soon_threadsafe(
-            lambda: asyncio.ensure_future(nc.publish(subject, payload))
-        )
+
+        def _spawn() -> None:
+            # Runs on the loop thread (via call_soon_threadsafe) — create_task is safe.
+            task = asyncio.create_task(nc.publish(subject, payload))
+            task.add_done_callback(_log_publish_result)
+
+        loop.call_soon_threadsafe(_spawn)
 
     # ------------------------------------------------------------------
     # omp_rpc callbacks

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +33,9 @@ log = logging.getLogger(__name__)
 
 _PINNED_SHA256 = "b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b"
 _OMP_BIN = Path("/opt/omp/omp")  # image-build constant — NEVER from env
+_DEFAULT_PROVIDER = (
+    "litellm"  # routes through factory LiteLLM proxy (deploy/omp/models.yml)
+)
 
 
 class DigestMismatchError(Exception):
@@ -110,14 +114,24 @@ class RpcBridge:
     def __init__(
         self,
         omp_bin: Path = _OMP_BIN,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
     ) -> None:
         _verify_digest(omp_bin)
 
         # Import deferred: omp_rpc is a container image dep, absent from pyproject.toml.
         import omp_rpc  # type: ignore[import-not-found]
 
-        self._client: omp_rpc.RpcClient = omp_rpc.RpcClient()
+        self._client: omp_rpc.RpcClient = omp_rpc.RpcClient(
+            executable=str(omp_bin),
+            provider=provider or os.environ.get("OMP_PROVIDER", _DEFAULT_PROVIDER),
+            model=model or os.environ.get("OMP_MODEL"),
+            no_session=True,
+        )
         self._nc: NatsClient | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._started: bool = False
         self._in_prompt_await: bool = False
         self._result_sent: bool = False
 
@@ -127,14 +141,19 @@ class RpcBridge:
         Must be called after NATS connection is established and
         before any run() call. Callback registration order is
         mandated by the omp_rpc API (confirmed in spike #1807):
-          on_message_update → on_tool_execution_start → on_agent_end
-          → new_session() (MUST be last)
+          start() → on_message_update → on_tool_execution_start → on_agent_end
+          → new_session() (MUST be last; requires process running — #1875)
         """
         self._nc = nc
+        self._loop = asyncio.get_running_loop()
+        await asyncio.to_thread(
+            self._client.start
+        )  # spawns omp subprocess + ready handshake — MUST precede new_session (#1875)
+        self._started = True
         self._client.on_message_update(self._on_message_update)
         self._client.on_tool_execution_start(self._on_tool_execution_start)
         self._client.on_agent_end(self._on_agent_end)
-        await self._client.new_session()
+        await asyncio.to_thread(self._client.new_session)
 
     async def run(self, prompt: str, job_id: str) -> None:
         """Run a prompt through omp_rpc; publishes progress and result to NATS.
@@ -154,13 +173,13 @@ class RpcBridge:
                 log.debug("rpc_bridge: steer message dropped — no active job")
                 return
             text = msg.data.decode("utf-8", errors="replace")
-            await self._client.steer(text)
+            await asyncio.to_thread(self._client.steer, text)
 
         steer_sub = None
         if nc is not None:
             steer_sub = await nc.subscribe(jobs_steer(job_id), cb=_handle_steer_msg)
         try:
-            await self._client.prompt_and_wait(prompt)
+            await asyncio.to_thread(self._client.prompt_and_wait, prompt)
         finally:
             self._in_prompt_await = False
             if steer_sub is not None:
@@ -172,7 +191,29 @@ class RpcBridge:
             raise SteerViolationError(
                 "steer() called while prompt_and_wait is in flight"
             )
-        await self._client.steer(text)
+        await asyncio.to_thread(self._client.steer, text)
+
+    async def aclose(self) -> None:
+        """Stop the omp_rpc subprocess. Idempotent; no-op if never started."""
+        if not self._started:
+            return
+        self._started = False
+        await asyncio.to_thread(self._client.stop)
+
+    def _schedule_publish(self, subject: str, payload: bytes) -> None:
+        """Schedule a NATS publish from an omp_rpc listener thread.
+
+        omp_rpc invokes listeners on its stdout-reader daemon thread, which has no
+        running event loop — marshal back onto the captured loop via
+        call_soon_threadsafe (#1875).
+        """
+        nc = self._nc
+        loop = self._loop
+        if nc is None or loop is None:
+            return
+        loop.call_soon_threadsafe(
+            lambda: asyncio.ensure_future(nc.publish(subject, payload))
+        )
 
     # ------------------------------------------------------------------
     # omp_rpc callbacks
@@ -180,9 +221,8 @@ class RpcBridge:
 
     def _on_message_update(self, event: Any) -> None:
         """Translate on_message_update → factory.job.<job_id>.progress."""
-        nc = self._nc
         job_id = getattr(self, "_current_job_id", None)
-        if nc is None or job_id is None:
+        if job_id is None:
             return
         partial_text = getattr(event, "text", None)
         payload = _make_progress(
@@ -192,15 +232,12 @@ class RpcBridge:
             partial_text=partial_text,
             detail={"partial_text": partial_text},
         )
-        asyncio.get_running_loop().call_soon(
-            lambda: asyncio.ensure_future(nc.publish(jobs_progress(job_id), payload))
-        )
+        self._schedule_publish(jobs_progress(job_id), payload)
 
     def _on_tool_execution_start(self, event: Any) -> None:
         """Translate on_tool_execution_start → factory.job.<job_id>.progress."""
-        nc = self._nc
         job_id = getattr(self, "_current_job_id", None)
-        if nc is None or job_id is None:
+        if job_id is None:
             return
         tool_name = getattr(event, "tool_name", None)
         tool_id = getattr(event, "tool_id", None)
@@ -213,15 +250,12 @@ class RpcBridge:
             tool_id=tool_id,
             detail={"tool_name": tool_name, "tool_id": tool_id},
         )
-        asyncio.get_running_loop().call_soon(
-            lambda: asyncio.ensure_future(nc.publish(jobs_progress(job_id), payload))
-        )
+        self._schedule_publish(jobs_progress(job_id), payload)
 
     def _on_agent_end(self, event: Any) -> None:
         """Translate on_agent_end → factory.job.<job_id>.result (success)."""
-        nc = self._nc
         job_id = getattr(self, "_current_job_id", None)
-        if nc is None or job_id is None:
+        if job_id is None:
             return
         if self._result_sent:
             log.debug(
@@ -234,9 +268,7 @@ class RpcBridge:
             {"result": result_data} if result_data is not None else {}
         )
         payload = _make_result(job_id, status="success", data=data)
-        asyncio.get_running_loop().call_soon(
-            lambda: asyncio.ensure_future(nc.publish(jobs_result(job_id), payload))
-        )
+        self._schedule_publish(jobs_result(job_id), payload)
 
     async def publish_error(self, job_id: str, exc: BaseException) -> None:
         """Publish a JobResult(status=error) for a failed job.

--- a/src/factory/adapters/omp/omp_worker.py
+++ b/src/factory/adapters/omp/omp_worker.py
@@ -98,7 +98,11 @@ class OmpWorker(NatsAdapterBase):
             for sig in (signal.SIGTERM, signal.SIGINT):
                 loop.add_signal_handler(sig, stop.set)
 
-        await self.run_embedded(nc, stop)
+        try:
+            await self.run_embedded(nc, stop)
+        finally:
+            # Stop the omp_rpc subprocess on shutdown (idempotent).
+            await self._bridge.aclose()
 
     # ------------------------------------------------------------------
     # NatsAdapterBase overrides

--- a/src/factory/adapters/omp/omp_worker.py
+++ b/src/factory/adapters/omp/omp_worker.py
@@ -4,9 +4,10 @@ Subscribes to factory.jobs.omp (queue group omp-workers), translates
 job envelopes into omp_rpc.RpcClient.prompt_and_wait() calls, and
 publishes JobProgress / JobResult events back onto the bus.
 
-Thread model: single asyncio event loop; omp_rpc callbacks fire
-synchronously inside prompt_and_wait and schedule NATS publishes via
-asyncio.get_event_loop().call_soon (safe from non-async callbacks).
+Thread model: omp_rpc invokes listener callbacks on its own
+omp-rpc-stdout daemon thread (no running event loop there); the bridge
+marshals each NATS publish back onto the worker's event loop via
+loop.call_soon_threadsafe (see RpcBridge._schedule_publish).
 
 SanitizedError discipline (ADR-073): all bus-bound error message
 fields carry type(exc).__name__ only — see _classify_exception in

--- a/tests/adapters/omp/test_omp_worker.py
+++ b/tests/adapters/omp/test_omp_worker.py
@@ -8,7 +8,10 @@ asyncio_mode = "auto" is configured project-wide in pyproject.toml.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from factory.adapters.omp.omp_worker import OmpWorker
 
@@ -247,3 +250,64 @@ class TestRun:
 
         # register must precede run_embedded
         assert call_order.index("register") < call_order.index("run_embedded")
+
+    async def test_run_closes_bridge_after_loop(self) -> None:
+        """aclose() must run after the loop, in order register < loop < aclose."""
+        bridge = _make_bridge()
+        worker = _make_worker(bridge)
+
+        call_order: list[str] = []
+
+        async def mock_nats_connect(*a, **kw):  # noqa: ARG001
+            return AsyncMock()
+
+        async def mock_register(nc):  # noqa: ARG001
+            call_order.append("register")
+
+        async def mock_run_embedded(nc, stop):  # noqa: ARG001
+            call_order.append("run_embedded")
+
+        async def mock_aclose():
+            call_order.append("aclose")
+
+        bridge.register.side_effect = mock_register
+        bridge.aclose.side_effect = mock_aclose
+
+        with (
+            patch(
+                "factory.adapters.omp.omp_worker.nats_connect",
+                side_effect=mock_nats_connect,
+            ),
+            patch.object(worker, "run_embedded", side_effect=mock_run_embedded),
+        ):
+            stop = asyncio.Event()
+            stop.set()
+            await worker.run("nats://localhost:4222", stop=stop)
+
+        assert call_order == ["register", "run_embedded", "aclose"]
+        bridge.aclose.assert_awaited_once()
+
+    async def test_run_closes_bridge_when_loop_raises(self) -> None:
+        """aclose() runs via the finally block even when the loop raises."""
+        bridge = _make_bridge()
+        worker = _make_worker(bridge)
+
+        async def mock_nats_connect(*a, **kw):  # noqa: ARG001
+            return AsyncMock()
+
+        async def boom(nc, stop):  # noqa: ARG001
+            raise RuntimeError("loop crashed")
+
+        with (
+            patch(
+                "factory.adapters.omp.omp_worker.nats_connect",
+                side_effect=mock_nats_connect,
+            ),
+            patch.object(worker, "run_embedded", side_effect=boom),
+        ):
+            stop = asyncio.Event()
+            stop.set()
+            with pytest.raises(RuntimeError, match="loop crashed"):
+                await worker.run("nats://localhost:4222", stop=stop)
+
+        bridge.aclose.assert_awaited_once()

--- a/tests/adapters/omp/test_omp_worker.py
+++ b/tests/adapters/omp/test_omp_worker.py
@@ -25,6 +25,7 @@ def _make_bridge() -> MagicMock:
     bridge.register = AsyncMock()
     bridge.run = AsyncMock()
     bridge.publish_error = AsyncMock()
+    bridge.aclose = AsyncMock()
     return bridge
 
 

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -15,6 +15,7 @@ import asyncio
 import hashlib
 import json
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -61,9 +62,14 @@ def _make_fake_binary(
 def _stub_omp_rpc_module() -> tuple[ModuleType, MagicMock]:
     """Install a stub omp_rpc in sys.modules; return (module, RpcClient mock)."""
     client_instance = MagicMock()
-    client_instance.new_session = AsyncMock()
-    client_instance.prompt_and_wait = AsyncMock()
-    client_instance.steer = AsyncMock()
+    # omp_rpc is synchronous + thread-based — the bridge invokes these via
+    # asyncio.to_thread, so the stubs are plain (sync) MagicMocks, never
+    # AsyncMock (#1875).
+    client_instance.start = MagicMock()
+    client_instance.stop = MagicMock()
+    client_instance.new_session = MagicMock()
+    client_instance.prompt_and_wait = MagicMock()
+    client_instance.steer = MagicMock()
     client_instance.on_message_update = MagicMock()
     client_instance.on_tool_execution_start = MagicMock()
     client_instance.on_agent_end = MagicMock()
@@ -227,7 +233,7 @@ class TestRun:
         bridge, nc, client = bridge_and_nc
         await bridge.register(nc)
         await bridge.run(prompt="hello", job_id=_JOB_ID)
-        client.prompt_and_wait.assert_awaited_once_with("hello")
+        client.prompt_and_wait.assert_called_once_with("hello")
 
     async def test_run_sets_current_job_id(self, bridge_and_nc) -> None:
         bridge, nc, _client = bridge_and_nc
@@ -268,7 +274,7 @@ class TestSteer:
         await bridge.register(nc)
         bridge._in_prompt_await = False
         await bridge.steer(_JOB_ID, "nudge")
-        client.steer.assert_awaited_once_with("nudge")
+        client.steer.assert_called_once_with("nudge")
 
 
 # ---------------------------------------------------------------------------
@@ -511,22 +517,23 @@ class TestSteerBridge:
         nc.subscribe = _mock_subscribe
         await bridge.register(nc)
 
-        # Start run in background so _in_prompt_await is True during handler call
-        async def _slow_prompt_and_wait(prompt: str) -> None:
-            await asyncio.sleep(0.01)  # event-based
-
-        client.prompt_and_wait.side_effect = _slow_prompt_and_wait
+        # prompt_and_wait is sync, run via asyncio.to_thread — gate it on a
+        # threading.Event so _in_prompt_await is still True when the steer handler
+        # fires in this loop thread, then release it.
+        release = threading.Event()
+        client.prompt_and_wait.side_effect = lambda prompt: release.wait(1.0)
         run_task = asyncio.ensure_future(bridge.run(prompt="hello", job_id=_JOB_ID))
 
-        # Give run() time to subscribe and enter prompt_and_wait
+        # Give run() time to subscribe and enter the prompt_and_wait thread.
         await asyncio.sleep(0)  # event-based
-        # Call the captured steer handler
+        # Call the captured steer handler while the job is in flight.
         assert captured_handler, "subscribe callback not captured"
         msg = SimpleNamespace(data=b"steer this way")
         await captured_handler[0](msg)
+        release.set()
 
         await run_task
-        client.steer.assert_awaited_once_with("steer this way")
+        client.steer.assert_called_once_with("steer this way")
 
     async def test_steer_bridge_drops_message_when_inactive(
         self, bridge_and_nc
@@ -552,7 +559,7 @@ class TestSteerBridge:
         msg = SimpleNamespace(data=b"late steer")
         await captured_handler[0](msg)
 
-        client.steer.assert_not_awaited()
+        client.steer.assert_not_called()
 
     async def test_steer_bridge_no_subscribe_when_nc_is_none(
         self, bridge_and_nc
@@ -565,3 +572,152 @@ class TestSteerBridge:
         await bridge.run(prompt="hello", job_id=_JOB_ID)
         # publish-less: nc.subscribe never called since nc was None at subscribe time
         assert nc.subscribe.await_count == 0  # nc mock still clean
+
+
+# ---------------------------------------------------------------------------
+# TestStartLifecycle — falsification tests for #1875 fix
+# ---------------------------------------------------------------------------
+
+
+class _StatefulFakeRpcClient:
+    """Mirrors omp_rpc.RpcClient's start→new_session contract: new_session()
+    and prompt_and_wait() raise (like the real _require_process) until start()
+    has run. Reproduces the #1875 crash deterministically."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.calls: list[Any] = []
+
+    def start(self) -> "_StatefulFakeRpcClient":
+        self.calls.append("start")
+        self.started = True
+        return self
+
+    def stop(self) -> None:
+        self.calls.append("stop")
+        self.started = False
+
+    def new_session(self, parent_session: Any = None) -> None:
+        self.calls.append("new_session")
+        if not self.started:
+            raise RuntimeError("RPC client is not started")
+
+    def prompt_and_wait(self, message: str, **kw: Any) -> None:
+        self.calls.append("prompt_and_wait")
+        if not self.started:
+            raise RuntimeError("RPC client is not started")
+
+    def steer(self, text: str) -> None:
+        self.calls.append(("steer", text))
+
+    def on_message_update(self, cb: Any) -> None: ...
+
+    def on_tool_execution_start(self, cb: Any) -> None: ...
+
+    def on_agent_end(self, cb: Any) -> None: ...
+
+
+@pytest.mark.asyncio
+class TestStartLifecycle:
+    """Verify that RpcBridge.register() calls start() before new_session() (#1875)."""
+
+    def setup_method(self) -> None:
+        _remove_omp_rpc_stub()
+
+    def teardown_method(self) -> None:
+        _remove_omp_rpc_stub()
+
+    def _make_bridge_with_fake(
+        self, tmp_path: Path
+    ) -> tuple["RpcBridge", "_StatefulFakeRpcClient"]:
+        """Return a bridge wired to a _StatefulFakeRpcClient via sys.modules stub."""
+        omp_bin, actual_sha = _make_fake_binary(tmp_path, matching_digest=True)
+        fake = _StatefulFakeRpcClient()
+        module = ModuleType("omp_rpc")
+        module.RpcClient = lambda **kw: fake.__init__(**kw) or fake  # type: ignore[attr-defined]
+        sys.modules["omp_rpc"] = module
+
+        with patch(
+            "factory.adapters.omp._rpc_bridge._PINNED_SHA256",
+            actual_sha,
+        ):
+            bridge = RpcBridge(omp_bin=omp_bin)
+        return bridge, fake
+
+    async def test_register_starts_client_before_new_session(
+        self, tmp_path: Path
+    ) -> None:
+        """start() MUST precede new_session() — the core #1875 regression."""
+        bridge, fake = self._make_bridge_with_fake(tmp_path)
+        nc = AsyncMock()
+        nc.subscribe = AsyncMock()
+
+        # register() must not raise — if start() is absent or reordered, fake raises
+        await bridge.register(nc)
+
+        assert "start" in fake.calls, "start() was never called"
+        start_idx = fake.calls.index("start")
+        new_session_idx = fake.calls.index("new_session")
+        assert start_idx < new_session_idx, (
+            f"start() (idx={start_idx}) must precede "
+            f"new_session() (idx={new_session_idx})"
+        )
+
+    async def test_aclose_stops_started_client(self, tmp_path: Path) -> None:
+        """aclose() after register() calls stop() and sets _started=False."""
+        bridge, fake = self._make_bridge_with_fake(tmp_path)
+        nc = AsyncMock()
+        nc.subscribe = AsyncMock()
+
+        await bridge.register(nc)
+        await bridge.aclose()
+
+        assert fake.calls[-1] == "stop"
+        assert bridge._started is False
+
+    async def test_aclose_noop_when_not_started(self, tmp_path: Path) -> None:
+        """aclose() before register() is a no-op — must not raise or call stop()."""
+        bridge, fake = self._make_bridge_with_fake(tmp_path)
+
+        await bridge.aclose()  # must not raise
+
+        assert "stop" not in fake.calls
+
+    async def test_constructs_client_with_executable_and_no_session(
+        self, tmp_path: Path
+    ) -> None:
+        """RpcClient must be constructed with executable, no_session=True, provider."""
+        omp_bin, actual_sha = _make_fake_binary(tmp_path, matching_digest=True)
+        received_kwargs: dict[str, Any] = {}
+
+        class _CapturingFake(_StatefulFakeRpcClient):
+            def __init__(self, **kw: Any) -> None:
+                received_kwargs.update(kw)
+                super().__init__(**kw)
+
+        module = ModuleType("omp_rpc")
+
+        def _factory(**kw: Any) -> _CapturingFake:
+            f = _CapturingFake(**kw)
+            return f
+
+        module.RpcClient = _factory  # type: ignore[attr-defined]
+        sys.modules["omp_rpc"] = module
+
+        with patch(
+            "factory.adapters.omp._rpc_bridge._PINNED_SHA256",
+            actual_sha,
+        ):
+            RpcBridge(omp_bin=omp_bin)
+
+        assert "executable" in received_kwargs, "executable kwarg missing"
+        assert received_kwargs["executable"].endswith("/omp"), (
+            f"executable should end with /omp, got: {received_kwargs['executable']}"
+        )
+        assert received_kwargs.get("no_session") is True, (
+            "no_session=True must be passed to RpcClient"
+        )
+        assert received_kwargs.get("provider") == "litellm", (
+            f"expected provider='litellm', got: {received_kwargs.get('provider')}"
+        )


### PR DESCRIPTION
## Summary
- `omp_rpc` is a **synchronous, thread-based** client; `RpcBridge` treated it as async. Five coupled defects fixed together so `factory-omp` boots and can run jobs (#1875).
- Root cause #1 (the filed crash): `register()` called `new_session()` without ever calling `start()` → `RpcError: RPC client is not started`. #2–5 are on the same boundary: sync methods were `await`ed, blocking calls ran on the event loop, listener callbacks called `asyncio.get_running_loop()` from omp_rpc's stdout-reader thread (no loop → publishes silently swallowed), and the client was constructed bare (no `executable`/`provider`/`model`/`no_session`).
- Fix: construct `RpcClient(executable=str(_OMP_BIN), provider=…, model=…, no_session=True)`; run `start`/`new_session`/`prompt_and_wait`/`steer`/`stop` via `asyncio.to_thread`; marshal callbacks back via `loop.call_soon_threadsafe`; `aclose()` the subprocess on worker shutdown.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1875 — fix(omp): RpcBridge never starts the omp_rpc client | OPEN |
| Implementation | 1 commit on `feat/1875-omp-rpcbridge-start` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (53 passed; 4 new lifecycle/falsification) + pre-push gates (test_sleep, import_layers, arch_snapshot) ✅ | Passed |

## Test Plan
- [ ] `pytest tests/adapters/omp/` green (53 passed locally)
- [ ] **Falsification (verified):** reverting only the bridge fix makes `test_register_starts_client_before_new_session` fail with `RuntimeError: RPC client is not started` — the exact #1875 crash
- [ ] Post-merge: `factory-omp` on M₁ reaches `active` + restart counter stays stable. Full job e2e still gated on llmCLI#114 (live LLM)

## Notes
- A `MagicMock` cannot catch this regression class (`mock.new_session()` never raises) — the new test uses a **stateful fake** that raises like the real `_require_process` until `start()` runs. CI mocked omp_rpc everywhere, which is why this was invisible.
- The container image builds **only post-merge** (`publish.yml` on push-to-staging); PR CI does not build the Dockerfile.

Fixes #1875

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
