### PR TITLE
fix(omp): mount writable tmpfs at /home/factory/.omp (EROFS crash-loop)

### DIFF
--- a/deploy/quadlet/factory-omp.container
+++ b/deploy/quadlet/factory-omp.container
@@ -20,6 +20,10 @@ Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-omp.seed
 Secret=factory-litellm-key,type=mount,target=factory-litellm-key.tok,uid=1500,gid=1500,mode=0400
 Environment=LITELLM_API_KEY_FILE=/run/secrets/factory-litellm-key.tok
 Tmpfs=/tmp
+# omp mkdir's $HOME/.omp at boot for its file-log transport (makeFileTransport);
+# ReadOnly=true makes that EROFS without a writable mount (#1877). Ephemeral is
+# correct — no_session=True means no session state to persist; logs go to journald.
+Tmpfs=/home/factory/.omp:mode=0755
 Volume=%h/projects/roxabi-factory/deploy/omp:/home/factory/.config/omp-pi:ro,Z
 Environment=PI_CODING_AGENT_DIR=/home/factory/.config/omp-pi
 # Workspace — mirrors host ~/projects so the git ownership probe finds its target


### PR DESCRIPTION
## Summary
- `factory-omp` crash-looped on `EROFS: read-only file system, mkdir '/home/factory/.omp'` one frame past the #1875 fix — the omp binary creates `$HOME/.omp` at boot for its file-log transport (`makeFileTransport → ensureDir`), but `ReadOnly=true` left no writable mount there → `RpcProcessExitError`, exit 1, systemd auto-restart loop.
- Adds `Tmpfs=/home/factory/.omp:mode=0755`, mirroring `factory-clipool`'s `Tmpfs=/home/factory/.config/git:mode=0755` convention for writable scratch under a ReadOnly home. Ephemeral is correct: `no_session=True` → no session state to persist; logs go to journald.

## Test Plan
- [ ] CI deploy gates green (`secrets_drift`, `volumes_table`, `quadlet_manifest_install`)
- [ ] After merge + auto-converge on M₁: `systemctl --user is-active factory-omp` → `active/running` (no restart loop)
- [ ] `journalctl --user -u factory-omp` shows no EROFS; omp reaches idle (boot needs no live LLM — `deploy/omp/models.yml` skips discovery)

Local: 3 deploy gates green; `Tmpfs=` syntax byte-identical in form to clipool's proven unit. Job-execution e2e still separately gated on llmCLI#114.

Fixes #1877

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
