### PR TITLE
fix(omp): bridge LITELLM_API_KEY_FILE→LITELLM_API_KEY for proxy auth + prune dead upstreams

### DIFF
--- a/deploy/omp/models.yml
+++ b/deploy/omp/models.yml
@@ -18,6 +18,7 @@
 #   omp until it is added here.
 # - Quadlet wiring (secret mount, env injection, volume mount into the worker
 #   unit) is #1812's scope — this file only proves the config pattern.
+# - dead upstreams pruned (kimi-k2.6 = Fireworks sub terminated llmCLI#116; deepseek-v4-pro = NVIDIA NIM PoC dropped 2026-06-13, #1881)
 
 providers:
   litellm:
@@ -25,7 +26,5 @@ providers:
     api: openai-completions
     apiKey: LITELLM_API_KEY
     models:
-      - id: deepseek-v4-pro
-      - id: kimi-k2.6
       - id: grok-4
       - id: grok-4-fast

--- a/src/factory/bootstrap/standalone/worker_standalone.py
+++ b/src/factory/bootstrap/standalone/worker_standalone.py
@@ -28,6 +28,25 @@ from roxabi_nats.connect import scrub_nats_url
 log = logging.getLogger(__name__)
 
 
+def _export_secret_file(file_var: str, value_var: str) -> None:
+    """Bridge a Podman type=mount secret file into a plain env var.
+
+    omp_rpc resolves models.yml `apiKey: LITELLM_API_KEY` from the process
+    environment, but the key is delivered as a tmpfs secret file referenced by
+    *file_var* (LITELLM_API_KEY_FILE) per the deploy/ secret-at-rest discipline.
+    Read the file once at boot and export *value_var* in-process only — never
+    persisted to disk or the unit file. No-op when *file_var* is unset (local/dev
+    omp uses the default localhost provider with no key).
+    """
+    path = os.environ.get(file_var)
+    if not path:
+        return
+    value = Path(path).read_text().strip()
+    if not value:
+        sys.exit(f"{file_var} points at an empty secret file: {path}")
+    os.environ[value_var] = value
+
+
 async def _bootstrap_clipool_standalone(raw_config: dict) -> None:
     """Wire a standalone CliPoolNatsWorker connected to NATS."""
     run_git_ownership_probe()
@@ -139,6 +158,7 @@ async def _bootstrap_omp_standalone(raw_config: dict) -> None:  # noqa: ARG001
     The digest gate inside RpcBridge.__init__ will raise DigestMismatchError
     if the binary does not match the pinned SHA-256.
     """
+    _export_secret_file("LITELLM_API_KEY_FILE", "LITELLM_API_KEY")
     run_git_ownership_probe()
     nats_url = os.environ.get("NATS_URL")
     if not nats_url:

--- a/tests/bootstrap/test_export_secret_file.py
+++ b/tests/bootstrap/test_export_secret_file.py
@@ -1,0 +1,55 @@
+"""Tests for _export_secret_file — Podman secret-file → env-var bridge (#1881)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_secret_file_is_stripped_and_exported(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """File with surrounding whitespace is stripped and exported into env."""
+    from factory.bootstrap.standalone.worker_standalone import _export_secret_file
+
+    secret_file = tmp_path / "factory-litellm-key.tok"
+    secret_file.write_text("  sk-abc\n")
+
+    monkeypatch.setenv("LITELLM_API_KEY_FILE", str(secret_file))
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+
+    _export_secret_file("LITELLM_API_KEY_FILE", "LITELLM_API_KEY")
+
+    import os
+
+    assert os.environ["LITELLM_API_KEY"] == "sk-abc"
+
+
+def test_unset_file_var_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LITELLM_API_KEY_FILE unset → no-op, LITELLM_API_KEY is not created."""
+    from factory.bootstrap.standalone.worker_standalone import _export_secret_file
+
+    monkeypatch.delenv("LITELLM_API_KEY_FILE", raising=False)
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+
+    _export_secret_file("LITELLM_API_KEY_FILE", "LITELLM_API_KEY")
+
+    import os
+
+    assert "LITELLM_API_KEY" not in os.environ
+
+
+def test_empty_secret_file_exits(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Empty/whitespace-only secret file → SystemExit with clear message."""
+    from factory.bootstrap.standalone.worker_standalone import _export_secret_file
+
+    secret_file = tmp_path / "factory-litellm-key.tok"
+    secret_file.write_text("   \n")
+
+    monkeypatch.setenv("LITELLM_API_KEY_FILE", str(secret_file))
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _export_secret_file("LITELLM_API_KEY_FILE", "LITELLM_API_KEY")
+
+    assert "LITELLM_API_KEY_FILE" in str(exc_info.value)
+    assert str(secret_file) in str(exc_info.value)


### PR DESCRIPTION
## What

Unblocks **end-to-end factory-omp jobs**. Two changes:

1. **Bridge `LITELLM_API_KEY_FILE` → `LITELLM_API_KEY`** in `_bootstrap_omp_standalone`. The omp Quadlet delivers the proxy key as a `type=mount` secret file, but omp_rpc resolves `models.yml` `apiKey: LITELLM_API_KEY` from the **process env var** — which was never set → every LLM call failed with HTTP 401 *"No API key provided"*. The new `_export_secret_file` helper reads the tmpfs file at boot and exports the value **in-process only** (never persisted to disk or the unit file — respects the `type=mount` secret-at-rest discipline).
2. **Prune dead upstreams** from `deploy/omp/models.yml`, leaving only `grok-4` + `grok-4-fast` (both verified live, HTTP 200):
   - `kimi-k2.6` — Fireworks/Kimi subscription terminated (llmCLI#116).
   - `deepseek-v4-pro` — NVIDIA NIM PoC, dropped by operator decision (no restore planned).

## Why it's evidence-complete

Live M₁ diagnosis (2026-06-13):
- `podman exec factory-omp env | grep -i litellm` → **only** `LITELLM_API_KEY_FILE` present, `LITELLM_API_KEY` absent.
- Proxy probe with the secret's **raw value**: `grok-4` / `grok-4-fast` → **HTTP 200** real completions; `kimi-k2.6` → 401 (Fireworks key revoked); `deepseek-v4-pro` → HTTP 000 (NVIDIA NIM hang).

So the key is valid and the grok upstream is healthy — the bridge is the only missing link between omp-idle and omp-executing.

## Tests / gates

- 3 unit tests for `_export_secret_file` (whitespace-strip export, unset→no-op, empty→`SystemExit`).
- `tests/bootstrap` → **253 passed**.
- All 13 CI-only pre-push gates green (ran manually): test_sleep, architecture_snapshot, debt_expiry, secrets_drift, str_exc_bus_bound, volumes_table, duplicate_test_basenames, file_exemptions, hardcoded_constants, no_runtime_toml_bots, quadlet_manifest_install, doc_drift, import_layers.
- ruff + pyright clean.

## Deploy note

No Quadlet/secret change required — the `factory-litellm-key` secret already exists on M₁ and the unit already mounts it. Once merged, `factory-quadlet-sync` + `podman-auto-update` converge the new image and omp can run jobs on grok end-to-end.

Closes #1881
Relates #1812 (completes the missed env-injection half of the omp wiring), #1811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)