### PR TITLE
fix(tools): point sweep_candidates at roxabi-factory (post-lyra rename)

### DIFF
--- a/tools/sweep_candidates.py
+++ b/tools/sweep_candidates.py
@@ -2,7 +2,7 @@
 
 /goal `sweep_candidates.py --json --top 1` → empty when no candidate
 ================================================================
-Run a sequential sweep of small, unblocked, ready issues in roxabi/lyra.
+Run a sequential sweep of small, unblocked, ready issues in roxabi/roxabi-factory.
 
 Rules:
 - Max 1 issue in flight at all times (1 worktree, 1 PR, no parallel batches)
@@ -35,7 +35,7 @@ import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-REPO = "roxabi/lyra"
+REPO = "roxabi/roxabi-factory"
 MIN_NUMBER = 1000
 
 # Priority sort order: lower = higher priority
@@ -91,7 +91,7 @@ def _gh_graphql(query: str) -> dict:
 def fetch_issues() -> list[dict]:
     query = """
     query {
-      repository(owner: "roxabi", name: "lyra") {
+      repository(owner: "roxabi", name: "roxabi-factory") {
         issues(
           first: 100, states: OPEN,
           orderBy: {field: CREATED_AT, direction: DESC}
@@ -247,7 +247,7 @@ def has_open_pr_for_issue(issue_number: int, prs: list[dict]) -> bool:
 
 
 def worktree_exists() -> bool:
-    """Check if any .claude/worktrees/ directory exists for lyra."""
+    """Check if any .claude/worktrees/ directory exists for this repo."""
     wt_root = Path(__file__).resolve().parents[1] / ".claude" / "worktrees"
     if not wt_root.exists():
         return False


### PR DESCRIPTION
## What
`tools/sweep_candidates.py` still targeted the pre-rename repo name `roxabi/lyra` (rename #1671 lyra→roxabi-factory). Fixes 4 refs: the **GraphQL `repository(owner, name)` query** (functional — GraphQL resolves by current name with no redirect, so it queried a dead name → null result), the `REPO` const (used in REST `--repo` + issue URLs), and 2 docstrings.

## Why
Surfaced during an auto-memory cleanup: a memory note flagged "update repo ref" but the script itself was the stale SSoT. Per code=doc, fixed the script and dropped the redundant memory.

## Scope
`tools/sweep_candidates.py` only — +4/−4. No `src/` / gate / deploy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)