### PR TITLE
feat(omp): OmpPool + native-session memory (#1813 slice V2)

### DIFF
--- a/artifacts/plans/1813-runtime-selection-v2-plan.mdx
+++ b/artifacts/plans/1813-runtime-selection-v2-plan.mdx
@@ -1,0 +1,790 @@
+---
+title: "Plan: runtime selection — OmpPool + native-session memory (slice V2)"
+issue: 1813
+spec: artifacts/specs/1813-runtime-selection-spec.mdx
+complexity: 8/10
+tier: F-full
+slice: V2
+generated: 2026-06-15
+---
+
+## Summary
+
+Slice V2 wires hub-driven native-session memory into the omp runtime by mirroring the exact pattern LlmClient uses for clipool: a `_turn_store`-backed `queue_resume` / `complete` backhaul loop that persists and resolves the `.jsonl` session_file as `provider_session_id` in `pool_sessions`. Axis A (dispatch unification) introduces two standalone `runtime_checkable` Protocols (`SessionAware`, `WorkspaceAware`) in `core/ports/llm.py`, replacing four separate `_cli_pool`/`_cli_nats_driver` branch sites in `simple_agent.py` with two resolved-once attributes. Axis B reuses the existing `cli_session_id` column and `TurnStoreSessionMixin` as-is (no migration), deferring the cosmetic rename to a filed follow-up. The worker gains `OmpPool` (warm `RpcClient` per `pool_id`, LRU-capped, `switch_session`/`new_session`+`get_state` cold-start), wired into `OmpWorker.handle()`; `OmpRpcDriver` gains real SessionAware methods mirroring LlmClient — NOT stubs.
+
+---
+
+## Architecture
+
+### Data-flow: hub-driven session round-trip
+
+```mermaid
+flowchart TD
+    CFG[config.db\nbackend=omp-rpc] --> HUB[hub dispatch\nresolve provider_session_id\nfrom pool_sessions]
+    HUB --> DRV[OmpRpcDriver.complete\nqueue_resume: pop _pending_resume\ninject provider_session_id into payload]
+    DRV -->|JobEnvelope\npool_id + provider_session_id| Q[factory.jobs.omp]
+    Q --> WRK[OmpWorker.handle\nextract pool_id + provider_session_id]
+    WRK --> POOL[OmpPool.acquire\npool_id + session_file]
+    POOL -->|warm hit| WC[warm RpcClient\nin-process session]
+    POOL -->|cold-start| CS{session_file?}
+    CS -->|yes| SW[switch_session\nresume existing context]
+    CS -->|no| NS[new_session\n+ get_state -> session_file]
+    WC --> RES[JobResult.data\nsession_file backhaul]
+    SW --> RES
+    NS --> RES
+    RES --> DRV2[OmpRpcDriver.complete\nread session_file from JobResult.data\npersist via _turn_store.set_cli_session\nkeyed by linked session_id]
+    DRV2 --> STORE[(pool_sessions\ncli_session_id / provider_session_id)]
+    STORE -.next-turn resolve.-> HUB
+```
+
+### File x function map
+
+```mermaid
+flowchart LR
+    subgraph core/ports/llm.py
+        SA[SessionAware Protocol\nlink_lyra_session\nreset\nqueue_resume]
+        WA[WorkspaceAware Protocol\nswitch_cwd]
+        ALL[__all__ export]
+    end
+
+    subgraph core/simple_agent.py
+        SB[_session_backend: SessionAware|None\n_workspace_backend: WorkspaceAware|None\nresolved in __init__ via isinstance]
+        RB[reset_backend\n_maybe_register_reset\n_maybe_register_resume\nlink call in process]
+    end
+
+    subgraph llm/drivers/omp_rpc.py
+        ORD[OmpRpcDriver\n_turn_store injected\n_pending_resume dict\n_lyra_sessions dict\nqueue_resume / reset / link_lyra_session\ncomplete: inject+backhaul session_file]
+    end
+
+    subgraph adapters/omp/omp_pool.py
+        OP[OmpPool\nclients dict pool_id→RpcClient\nacquire / release / aclose\nLRU cap=OMP_POOL_CAP]
+    end
+
+    subgraph adapters/omp/omp_worker.py
+        OW[OmpWorker.handle\nextract pool_id+provider_session_id\nsession_file in JobResult.data]
+    end
+
+    subgraph infrastructure/stores/turn_store_session.py
+        TSS[TurnStoreSessionMixin\nget_cli_session / _set_cli_session\nreused as-is for omp token]
+    end
+
+    subgraph roxabi_contracts / core/llm_types.py
+        JE[JobEnvelope.payload\n+pool_id +provider_session_id optional]
+        JR[JobResult.data\n+session_file optional]
+    end
+
+    subgraph tests
+        T_PROTO[test_llm_protocols.py\nfalsification evidence]
+        T_AGENT[test_simple_agent.py\nparametrized reset x3 backends]
+        T_OMP[test_omp_rpc_driver.py\nrecall + isolation + wire-compat]
+        T_POOL[test_omp_pool.py\nunit]
+        T_WRK[test_omp_worker.py\nunit]
+    end
+
+    SA --> SB
+    WA --> SB
+    SB --> RB
+    ORD -->|implements| SA
+    ORD --> TSS
+    ORD --> JE
+    ORD --> JR
+    OW --> OP
+    OW --> JE
+    OW --> JR
+    T_PROTO --> SA
+    T_PROTO --> WA
+    T_AGENT --> SB
+    T_OMP --> ORD
+    T_POOL --> OP
+    T_WRK --> OW
+```
+
+---
+
+## Agents
+
+| Instance | Type | Tasks | Subjects |
+|----------|------|-------|---------|
+| backend-dev-1 | backend-dev | T1, T2 | protocol, contract |
+| backend-dev-2 | backend-dev | T3, T4 | pool, worker |
+| backend-dev-3 | backend-dev | T5, T6 | bootstrap, resume |
+| backend-dev-4 | backend-dev | T7, T12 | dispatch, followup |
+| devops-1 | devops | T8, T9 | deploy, manifest |
+| tester-1 | tester | T10, T11 | tests, integration |
+
+---
+
+## Wave Structure
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| W1 | start | backend-dev-1, devops-1 | T1, T2, T8 |
+| W2 | T1+T2 done | backend-dev-2, backend-dev-3 | T3, T4, T5, T6 |
+| W3 | T3+T4+T5+T6 done | backend-dev-4 | T7 |
+| W4 | T8 done | devops-1 | T9 |
+| W5 | T6+T7 done | tester-1 | T10 |
+| W6 | T4+T5+T6+T7+T8+T9 done | tester-1 | T11 |
+| W7 | T7 done | backend-dev-4 | T12 |
+
+### Budget — per task
+
+| Task | Class | Est ops | Split? |
+|------|-------|---------|--------|
+| T1 | RED | 18 | N |
+| T2 | RED | 10 | N |
+| T3 | GREEN | 28 | N |
+| T4 | GREEN | 20 | N |
+| T5 | GREEN | 12 | N |
+| T6 | GREEN | 32 | N |
+| T7 | REFACTOR | 30 | N |
+| T8 | GREEN | 16 | N |
+| T9 | GREEN | 12 | N |
+| T10 | GREEN | 35 | N |
+| T11 | RED-GATE | 15 | N |
+| T12 | FOLLOW-UP | 6 | N |
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|---------|--------|
+| backend-dev-1 | T1, T2 | 28 | protocol, contract | N |
+| backend-dev-2 | T3, T4 | 48 | pool, worker | N |
+| backend-dev-3 | T5, T6 | 44 | bootstrap, resume | N |
+| backend-dev-4 | T7, T12 | 36 | dispatch, followup | N |
+| devops-1 | T8, T9 | 28 | deploy, manifest | N |
+| tester-1 | T10, T11 | 50 | tests, integration | N |
+
+---
+
+## Consistency Report
+
+**Spec Success Criteria covered: 11/16**
+
+| Criterion | Covered by |
+|-----------|-----------|
+| omp-rpc backend routes to OmpRpcDriver | T6, T7 |
+| ProviderRegistry resolves omp-rpc | T6 (providers.py wiring) |
+| OmpRpcDriver extends NatsDriverBase + satisfies LlmProvider | T1 (protocol) + T6 |
+| JobEnvelope.payload optional fields, wire-compat old envelope | T2, T10 |
+| job_id hub-minted, worker never publishes to factory.jobs.omp | T4, T10 |
+| Agent remembers context across turns via hub-resolved session token | T6, T10 |
+| No cross-conversation bleed | T3, T10 |
+| OmpPool concurrency (CliPool parity) | T3 (pool) — concurrency test deferred to Slice 3 |
+| Worker stays dumb executor (no config.db, no backend branching) | T4 |
+| clipool no-regression | T7, T10 |
+| Driver subscriptions torn down on completion/error | T6 |
+
+**Deferred / out-of-scope for Slice V2:**
+
+| Criterion | Reason |
+|-----------|--------|
+| stream() / JobProgress→LlmEvent | Slice 4 |
+| OmpPool wall-clock concurrency test | Slice 3 |
+| Per-job override (N6) | Slice 5; NEEDS-CLARIFICATION transport unresolved |
+| Parity runbook / flip gate (N8) | Slice 6 |
+| hub NATS progress grant (factory.job.*.progress) | Slice 4 |
+| Observability: runtime tag in turn log | Not in V2 scope |
+
+**Traces to N5/N10:**
+
+- N5 (native-session resume): fully addressed by T2 (contracts), T6 (OmpRpcDriver backhaul), T3 (OmpPool cold-start switch_session/new_session+get_state), T10 (recall+isolation tests).
+- N10 (OmpPool CliPool mirror): fully addressed by T3 (omp_pool.py), T4 (OmpWorker wiring), T5 (bootstrap injection).
+
+---
+
+## Micro-Tasks
+
+### Phase: RED
+
+#### T1 — SessionAware + WorkspaceAware protocols
+
+**Description:** Add two standalone `runtime_checkable` Protocols to `core/ports/llm.py`, export in `__all__`. Add protocol membership tests with falsification evidence (git-stash method -> assert isinstance FAILS -> stash pop -> assert PASS).
+
+**File paths:**
+- `src/factory/core/ports/llm.py` (modify)
+- `tests/core/test_llm_protocols.py` (new)
+
+**Code shape:**
+
+```python
+# src/factory/core/ports/llm.py  (add after LlmProvider/StreamingLlmProvider)
+
+@runtime_checkable
+class SessionAware(Protocol):
+    def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None: ...
+    async def reset(self, pool_id: str) -> None: ...
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool: ...
+
+@runtime_checkable
+class WorkspaceAware(Protocol):
+    async def switch_cwd(self, pool_id: str, cwd: Path) -> None: ...
+
+# Append to __all__: "SessionAware", "WorkspaceAware"
+```
+
+```python
+# tests/core/test_llm_protocols.py
+# Falsification: git stash omp_rpc.py -> run -> assert FAIL -> stash pop -> assert PASS
+# + assert isinstance(cli_pool, SessionAware)
+# + assert isinstance(cli_pool, WorkspaceAware)
+# + assert isinstance(llm_client, SessionAware)
+# + assert isinstance(llm_client, WorkspaceAware)
+# + assert isinstance(omp_rpc_driver, SessionAware)
+# + assert not isinstance(omp_rpc_driver, WorkspaceAware)
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/core/test_llm_protocols.py -v
+```
+**Expected:** All protocol membership assertions pass; falsification evidence documented inline.
+
+**Agent instance:** backend-dev-1 | **Subject:** protocol | **Spec trace:** N5, Success Criteria row 3 | **Difficulty:** 3/10 | [P] parallel with T2, T8
+
+---
+
+#### T2 — JobEnvelope.payload + JobResult.data convention + wire-compat tests
+
+**Description:** Add optional `pool_id`, `provider_session_id` to `JobEnvelope.payload` and optional `session_file` to `JobResult.data` (convention-only, untyped `dict[str,Any]`). Tests: old `{"prompt": str}`-only envelope validates; `session_file` round-trips through worker stub.
+
+**File paths:**
+- `packages/roxabi-contracts/` or `src/factory/core/llm_types.py` — confirm exact location of `JobEnvelope`/`JobResult` docstring/convention (read before editing)
+- `tests/llm/test_job_contracts.py` (new or extend existing)
+
+**Code shape:**
+
+```python
+# JobEnvelope.payload (dict[str, Any]) — convention update (docstring/comment):
+# Optional keys: pool_id: str, provider_session_id: str | None
+# Required: prompt: str  (old {"prompt": str} envelope still valid)
+
+# JobResult.data (dict[str, Any] | None) — convention update:
+# Optional key: session_file: str  (absent on old results — consumers must .get())
+```
+
+```python
+# tests/llm/test_job_contracts.py
+def test_old_envelope_validates():
+    env = JobEnvelope(job_id="j1", payload={"prompt": "hi"}, reply_to=None)
+    assert env.payload["prompt"] == "hi"
+    assert env.payload.get("pool_id") is None  # absent = wire-compat
+
+def test_session_file_roundtrip():
+    result = JobResult(job_id="j1", status="success",
+                       data={"result": "ok", "session_file": "/tmp/s.jsonl"})
+    assert result.data["session_file"] == "/tmp/s.jsonl"
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/llm/test_job_contracts.py -v
+```
+**Expected:** Wire-compat tests pass; old envelope without pool_id/provider_session_id accepted.
+
+**Agent instance:** backend-dev-1 | **Subject:** contract | **Spec trace:** N4, N5, Success Criteria row 4 | **Difficulty:** 2/10 | [P] parallel with T1, T8
+
+---
+
+### Phase: GREEN
+
+#### T3 — OmpPool (new omp_pool.py)
+
+**Description:** Implement `OmpPool` in `src/factory/adapters/omp/omp_pool.py`. Warm `RpcClient` per `pool_id`, `acquire(pool_id, session_file)` (warm hit reuse; cold-start: `switch_session(session_file)` if token present, else `new_session()` then `get_state()` to obtain minted `session_file`). `release(pool_id)`, `aclose()`. LRU evict beyond `OMP_POOL_CAP` env/config (default 4, NOT hardcoded). Unit tests covering warm-hit, cold-start-with-token, cold-start-no-token, LRU evict.
+
+**File paths:**
+- `src/factory/adapters/omp/omp_pool.py` (new)
+- `tests/adapters/omp/test_omp_pool.py` (new)
+
+**Code shape:**
+
+```python
+# src/factory/adapters/omp/omp_pool.py
+
+import os
+from collections import OrderedDict
+from pathlib import Path
+
+OMP_POOL_CAP_DEFAULT = 4
+
+class OmpPool:
+    def __init__(self, rpc_client_factory, cap: int | None = None) -> None:
+        self._factory = rpc_client_factory
+        self._cap = cap or int(os.environ.get("OMP_POOL_CAP", OMP_POOL_CAP_DEFAULT))
+        self._clients: OrderedDict[str, object] = OrderedDict()  # LRU order
+
+    async def acquire(self, pool_id: str, session_file: str | None) -> object:
+        if pool_id in self._clients:
+            self._clients.move_to_end(pool_id)  # LRU touch
+            return self._clients[pool_id]
+        # cold-start
+        client = self._factory()
+        if session_file:
+            await client.switch_session(session_file)
+        else:
+            await client.new_session()
+            state = await client.get_state()
+            # session_file now available via state.session_file
+        self._clients[pool_id] = client
+        self._clients.move_to_end(pool_id)
+        if len(self._clients) > self._cap:
+            oldest_id, oldest_client = self._clients.popitem(last=False)
+            await oldest_client.aclose()
+        return client
+
+    def release(self, pool_id: str) -> None:
+        pass  # warm client stays in pool; eviction is LRU
+
+    async def aclose(self) -> None:
+        for client in self._clients.values():
+            await client.aclose()
+        self._clients.clear()
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/adapters/omp/test_omp_pool.py -v
+```
+**Expected:** warm-hit, cold-start-resume, cold-start-new, LRU evict tests pass. No bare `time.sleep` (event-based waits only).
+
+**Agent instance:** backend-dev-2 | **Subject:** pool | **Spec trace:** N10, Success Criteria rows 7, 8 | **Difficulty:** 5/10 | deps: T2
+
+---
+
+#### T4 — Wire OmpPool into OmpWorker.handle()
+
+**Description:** Modify `src/factory/adapters/omp/omp_worker.py`. In `handle()` (~line 130), extract `pool_id` and `provider_session_id` from `envelope.payload` (absent = wire-compat defaults: `pool_id` fallback to `job_id`, `session_file = None`). Use `OmpPool.acquire(pool_id, session_file)`. Always write `session_file` into `JobResult.data` (obtain post-call via `client.get_state()` if not already known from cold-start; on warm hits the session_file is the already-known value from pool state). Replace the single shared `no_session=True` `RpcClient`. Unit tests: dumb-executor invariant (no config.db access, no backend branching), `session_file` in result, wire-compat with old envelope.
+
+**File paths:**
+- `src/factory/adapters/omp/omp_worker.py` (modify)
+- `tests/adapters/omp/test_omp_worker.py` (modify or new)
+
+**Code shape:**
+
+```python
+# omp_worker.py handle() — new extraction block
+pool_id = envelope.payload.get("pool_id", envelope.job_id)
+session_file = envelope.payload.get("provider_session_id") or None
+
+client = await self._pool.acquire(pool_id, session_file)
+# ... prompt_and_wait ...
+# after terminal result, obtain current session_file:
+state = await client.get_state()
+result_data = {**base_result_data, "session_file": state.session_file}
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/adapters/omp/test_omp_worker.py -v
+```
+**Expected:** dumb-executor test passes (no config.db import in omp_worker); session_file present in result.data; old-envelope compat test passes.
+
+**Agent instance:** backend-dev-2 | **Subject:** worker | **Spec trace:** N10, Success Criteria row 9 | **Difficulty:** 4/10 | deps: T3
+
+---
+
+#### T5 — Construct OmpPool in _bootstrap_omp_standalone, inject into OmpWorker
+
+**Description:** In `src/factory/bootstrap/standalone/worker_standalone.py` (~line 154), construct `OmpPool` (with the `RpcClient` factory from `_rpc_bridge`), inject into `OmpWorker`. Ensure `OmpPool.aclose()` is called on shutdown.
+
+**File paths:**
+- `src/factory/bootstrap/standalone/worker_standalone.py` (modify)
+
+**Code shape:**
+
+```python
+# worker_standalone.py _bootstrap_omp_standalone()
+from factory.adapters.omp.omp_pool import OmpPool
+
+omp_pool = OmpPool(rpc_client_factory=lambda: RpcClient(...))
+worker = OmpWorker(pool=omp_pool, ...)
+# register cleanup: omp_pool.aclose() on shutdown
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/bootstrap/ -k omp -v
+```
+**Expected:** bootstrap smoke test constructs OmpPool+OmpWorker without error; no bare sleeps.
+
+**Agent instance:** backend-dev-3 | **Subject:** bootstrap | **Spec trace:** N10 | **Difficulty:** 3/10 | deps: T3, T4
+
+---
+
+#### T6 — OmpRpcDriver real SessionAware: _turn_store, queue_resume, link_lyra_session, reset, complete backhaul
+
+**Description:** Modify `src/factory/llm/drivers/omp_rpc.py`. Add `_turn_store` (injected; same pattern as LlmClient:61-62), `_pending_resume: dict[str,str]`, `_lyra_sessions: dict[str,str]`. Implement:
+- `link_lyra_session(pool_id, session_id)`: store mapping.
+- `queue_resume(pool_id, session_id)`: `tok = await self._turn_store.get_cli_session(session_id)`; if tok: `self._pending_resume[pool_id] = tok`; return bool. EXACT LlmClient mirror.
+- `reset(pool_id)`: drop `_pending_resume[pool_id]` entry (hub-side cold-start next turn); document that the worker's `OmpPool` will cold-start because no session_file arrives on the next envelope.
+- `complete()`: pop `self._pending_resume.get(pool_id)` -> include as `provider_session_id` in `envelope.payload`; after terminal `JobResult`, read `session_file` from `result.data`; persist via `self._turn_store` set method keyed by linked `session_id` (first-turn mint -> backhaul -> persist -> next-turn resolve). Wire `_turn_store` at registration in `src/factory/llm/providers.py` (~line 70).
+
+**File paths:**
+- `src/factory/llm/drivers/omp_rpc.py` (modify)
+- `src/factory/llm/providers.py` (modify: inject _turn_store)
+- `tests/llm/drivers/test_omp_rpc_driver.py` (extend)
+
+**Code shape:**
+
+```python
+# omp_rpc.py additions
+class OmpRpcDriver(NatsDriverBase):
+    def __init__(self, ..., turn_store: TurnStoreSessionMixin) -> None:
+        ...
+        self._turn_store = turn_store
+        self._pending_resume: dict[str, str] = {}
+        self._lyra_sessions: dict[str, str] = {}
+
+    def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
+        self._lyra_sessions[pool_id] = lyra_session_id
+
+    async def reset(self, pool_id: str) -> None:
+        # Drop hub-side pending token; worker OmpPool will cold-start
+        # (no session_file in next envelope -> new_session() on worker side)
+        self._pending_resume.pop(pool_id, None)
+
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool:
+        tok = await self._turn_store.get_cli_session(session_id)
+        if tok:
+            self._pending_resume[pool_id] = tok
+        return bool(tok)
+
+    async def complete(self, pool_id: str, text: str, model_cfg, system_prompt: str, *, messages=None) -> LlmResult:
+        session_file = self._pending_resume.pop(pool_id, None)
+        envelope = JobEnvelope(
+            job_id=...,
+            payload={
+                "prompt": text,
+                "pool_id": pool_id,
+                "provider_session_id": session_file,
+                "model": model_cfg.model,
+                "system_prompt": system_prompt,
+            },
+        )
+        # ... publish + await JobResult ...
+        result_session_file = (result.data or {}).get("session_file")
+        if result_session_file:
+            session_id = self._lyra_sessions.get(pool_id)
+            if session_id:
+                await self._turn_store._set_cli_session(session_id, result_session_file)
+        return LlmResult(...)
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/llm/drivers/test_omp_rpc_driver.py -v
+```
+**Expected:** queue_resume/link/reset/backhaul tests pass; `isinstance(driver, SessionAware)` asserts True; `isinstance(driver, WorkspaceAware)` asserts False.
+
+**Agent instance:** backend-dev-3 | **Subject:** resume | **Spec trace:** N5, Success Criteria rows 6, 11 | **Difficulty:** 7/10 | deps: T1, T2
+
+---
+
+### Phase: REFACTOR
+
+#### T7 — simple_agent.py: unify 4 branch sites, update CLAUDE.md files
+
+**Description:** In `src/factory/agents/simple_agent.py`, resolve `_session_backend: SessionAware | None` and `_workspace_backend: WorkspaceAware | None` once in `__init__` (first that isinstance-matches among `cli_pool`, `cli_nats_driver`, `provider`). Replace four branch sites: `reset_backend()` (~106-109), `_maybe_register_reset()` (~160), `_maybe_register_resume()` (~182), `link_lyra_session` call in `process()` (~225-228). When `_workspace_backend is None`, pass `workspace_fn=None` to `pool.register_session_callbacks`. Keep `cli_pool=`/`cli_nats_driver=` kwargs for backward-compat construction. Greps scoped to attribute refs (`self._cli_pool`, `self._cli_nats_driver`), not bare names (kwargs survive). Update `src/factory/agents/CLAUDE.md` (two->three backend paths, new table). Update `src/factory/llm/CLAUDE.md` (OmpRpcDriver row: now session-aware).
+
+**File paths:**
+- `src/factory/agents/simple_agent.py` (modify)
+- `src/factory/agents/CLAUDE.md` (modify)
+- `src/factory/llm/CLAUDE.md` (modify)
+- `tests/agents/test_simple_agent.py` (modify)
+
+**Code shape:**
+
+```python
+# simple_agent.py __init__ additions
+from factory.core.ports.llm import SessionAware, WorkspaceAware
+
+self._session_backend: SessionAware | None = None
+self._workspace_backend: WorkspaceAware | None = None
+for candidate in [cli_pool, cli_nats_driver, provider]:
+    if candidate is None:
+        continue
+    if self._session_backend is None and isinstance(candidate, SessionAware):
+        self._session_backend = candidate
+    if self._workspace_backend is None and isinstance(candidate, WorkspaceAware):
+        self._workspace_backend = candidate
+
+# reset_backend() — unified, fixes latent cli_nats_driver silent-drop:
+async def reset_backend(self, pool_id: str) -> None:
+    if self._session_backend is not None:
+        await self._session_backend.reset(pool_id)
+```
+
+```python
+# tests/agents/test_simple_agent.py — new/updated tests:
+# test_reset_backend_delegates_to_session_backend_nats_driver
+# test_reset_backend_noop_when_no_session_backend (replaces prior "no cli_pool" test)
+# parametrize reset over 3 backend types: CliPool, LlmClient (nats), OmpRpcDriver
+# clipool no-regression: resume/reset/link/switch_cwd all called correctly
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/agents/test_simple_agent.py -v && uv run pyright src/factory/agents/simple_agent.py
+```
+**Expected:** All agent tests pass incl. 3-backend parametrized reset; pyright clean; clipool no-regression green.
+
+**Agent instance:** backend-dev-4 | **Subject:** dispatch | **Spec trace:** N5, N6, Success Criteria rows 6, 10 | **Difficulty:** 6/10 | deps: T1, T6
+
+---
+
+### Phase: GREEN (deploy)
+
+#### T8 — Deploy: named volume factory-omp-sessions + .volume unit + After= + quadlet.toml + DEPLOYMENT.md
+
+**Description:** Replace the ephemeral `Tmpfs` for `PI_CODING_AGENT_DIR` in `deploy/quadlet/factory-omp.container` (lines ~35-37) with a persistent named volume `factory-omp-sessions` mounted at the same path. Keep `$HOME/.omp` Tmpfs (~line 28, native modules) and `models.yml` `:ro` bind. Create `deploy/quadlet/factory-omp-sessions.volume` unit. Declare volume in `deploy/quadlet.toml`. Add `After=factory-omp-sessions.service` to `factory-omp.container`. Update `docs/DEPLOYMENT.md` Volumes table (required by `check_volumes_table.sh`).
+
+**File paths:**
+- `deploy/quadlet/factory-omp.container` (modify)
+- `deploy/quadlet/factory-omp-sessions.volume` (new)
+- `deploy/quadlet.toml` (modify)
+- `docs/DEPLOYMENT.md` (modify: Volumes table)
+
+**Code shape:**
+
+```ini
+# deploy/quadlet/factory-omp-sessions.volume
+[Volume]
+Label=app=factory
+```
+
+```ini
+# factory-omp.container — replace Tmpfs for PI_CODING_AGENT_DIR:
+# Before: Tmpfs=/home/agent/.omp-sessions:size=512m  (or equivalent)
+# After:
+Volume=factory-omp-sessions.volume:/home/agent/.omp-sessions:z
+# After= addition:
+After=factory-omp-sessions.service
+```
+
+```toml
+# deploy/quadlet.toml — add under volumes section:
+[[volumes]]
+name = "factory-omp-sessions"
+unit = "factory-omp-sessions.volume"
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run python tools/check_volumes_table.sh 2>&1 | tail -5
+```
+**Expected:** `check_volumes_table` passes (prose in DEPLOYMENT.md matches Volume= directives).
+
+**Agent instance:** devops-1 | **Subject:** deploy | **Spec trace:** NEEDS-CLARIFICATION #2 resolved: option (b) | **Difficulty:** 3/10 | [P] parallel with T1, T2
+
+---
+
+#### T9 — Manifest-install: Makefile + quadlet-install-verify.sh + converge.sh
+
+**Description:** Add `factory-omp.container` to `ADAPTER_TEMPLATES` in `Makefile` quadlet-install target. Add `factory-omp` to `UNITS` array in `deploy/quadlet-install-verify.sh`. Add `factory-omp` to the restart fan-out in `deploy/converge.sh`. All three are required by `check_quadlet_manifest_install.sh`.
+
+**File paths:**
+- `Makefile` (modify)
+- `deploy/quadlet-install-verify.sh` (modify)
+- `deploy/converge.sh` (modify)
+
+**Code shape:**
+
+```makefile
+# Makefile — ADAPTER_TEMPLATES addition:
+ADAPTER_TEMPLATES += factory-omp.container
+```
+
+```bash
+# quadlet-install-verify.sh — UNITS array:
+UNITS=( ... factory-omp ... )
+```
+
+```bash
+# converge.sh — restart fan-out:
+systemctl --user restart factory-omp.service
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && bash tools/check_quadlet_manifest_install.sh
+```
+**Expected:** `check_quadlet_manifest_install` passes — factory-omp present in all three files.
+
+**Agent instance:** devops-1 | **Subject:** manifest | **Spec trace:** quadlet-manifest-install gap memory | **Difficulty:** 2/10 | deps: T8
+
+---
+
+### Phase: RED-GATE
+
+#### T10 — Unit tests: cross-turn recall, cross-conversation isolation, conformance falsification, clipool no-regression
+
+**Description:** Implement the blocking tester tasks. Must use event-based waits only (no bare `time.sleep` — `test_sleep` gate).
+
+Tests required:
+
+1. **Conformance falsification** (`tests/core/test_llm_protocols.py`): run via subprocess stub — stash omp_rpc.py method body -> assert `isinstance(driver, SessionAware)` FAILS (or correct signature check fails) -> restore -> assert PASS. Document inline that `runtime_checkable` only checks name presence, not signatures.
+
+2. **test_omp_session_recall_across_turns** (`tests/llm/drivers/test_omp_rpc_driver.py`): call `driver.complete()` twice with same `pool_id`/`session_id`; assert the `provider_session_id` injected into the second envelope equals the `session_file` backhaul-persisted after the first. Token actually round-trips (not a no-op check).
+
+3. **test_omp_cross_conversation_isolation** (`tests/llm/drivers/test_omp_rpc_driver.py`): two distinct `pool_id`/`session_id` pairs -> assert distinct tokens, no bleed between `_pending_resume` entries.
+
+4. **clipool no-regression** (`tests/agents/test_simple_agent.py`): existing `CliPool` resume/reset/link/switch_cwd all still called correctly post-refactor. Parametrize reset over 3 backend types.
+
+5. **wire-compat** (`tests/llm/test_job_contracts.py`): JetStream replay of `{"prompt": "old"}` envelope consumed without KeyError on pool_id/provider_session_id absence.
+
+**File paths:**
+- `tests/core/test_llm_protocols.py` (extend from T1)
+- `tests/llm/drivers/test_omp_rpc_driver.py` (extend from T6)
+- `tests/agents/test_simple_agent.py` (extend from T7)
+- `tests/llm/test_job_contracts.py` (extend from T2)
+
+**Code shape:**
+
+```python
+# test_omp_session_recall_across_turns
+async def test_omp_session_recall_across_turns(driver, mock_turn_store, mock_nats):
+    pool_id, session_id = "p1", "s1"
+    driver.link_lyra_session(pool_id, session_id)
+    # Turn 1: cold start, no pending token
+    result1 = await driver.complete(pool_id, "tell me x", model_cfg, "sys")
+    # Simulate worker backhaul: JobResult.data has session_file
+    # (mock_nats returns JobResult with data={"session_file": "/tmp/s1.jsonl"})
+    persisted = await mock_turn_store.get_cli_session(session_id)
+    assert persisted == "/tmp/s1.jsonl"
+    # Turn 2: queue_resume then complete
+    resumed = await driver.queue_resume(pool_id, session_id)
+    assert resumed is True
+    result2 = await driver.complete(pool_id, "what was x?", model_cfg, "sys")
+    envelope2 = mock_nats.last_published_envelope
+    assert envelope2.payload["provider_session_id"] == "/tmp/s1.jsonl"
+```
+
+**Verify:**
+```bash
+cd /home/mickael/projects/roxabi-factory/.claude/worktrees/1813-runtime-selection-v2 && uv run pytest tests/core/test_llm_protocols.py tests/llm/drivers/test_omp_rpc_driver.py tests/agents/test_simple_agent.py tests/llm/test_job_contracts.py -v && bash tools/check_test_sleep.sh
+```
+**Expected:** All 5 test groups pass; `check_test_sleep` finds no bare sleeps in new test files.
+
+**Agent instance:** tester-1 | **Subject:** tests | **Spec trace:** N5, N10, tester BLOCKING findings | **Difficulty:** 7/10 | deps: T6, T7
+
+---
+
+#### T11 — Integration smoke (CI-skipped, M1-manual)
+
+**Description:** Integration tests gated by `INTEGRATION=1` env var (CI-skipped). Three scenarios against live `factory-omp` container on M1:
+
+1. **Cold-start mints + persists session_file**: send a job with no `provider_session_id`; assert `JobResult.data["session_file"]` is non-empty; assert `pool_sessions` row created for the session_id.
+2. **Resume calls switch_session**: send a second job with `provider_session_id` set; assert the warm client returned the same session context (check via a recall question or session_id in omp state).
+3. **Cap evict**: fill pool beyond `OMP_POOL_CAP`; assert oldest entry evicted, new entry accepted, no `PoolCapError`.
+
+**File paths:**
+- `tests/integration/test_omp_session_integration.py` (new)
+
+**Code shape:**
+
+```python
+# tests/integration/test_omp_session_integration.py
+import os, pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("INTEGRATION"), reason="INTEGRATION tests — run manually on M1"
+)
+
+async def test_cold_start_mints_session_file(): ...
+async def test_resume_calls_switch_session(): ...
+async def test_cap_evict_no_error(): ...
+```
+
+**Verify (M1-manual):**
+```bash
+INTEGRATION=1 uv run pytest tests/integration/test_omp_session_integration.py -v -s
+```
+**Expected:** All 3 scenarios pass on M1 against live factory-omp; CI skips cleanly.
+
+**Agent instance:** tester-1 | **Subject:** integration | **Spec trace:** N5, N10, Slice V2 demo | **Difficulty:** 5/10 | deps: T4, T5, T6, T7, T8, T9
+
+---
+
+### Phase: FOLLOW-UP
+
+#### T12 — File GitHub issue: cosmetic rename cli_session_id -> provider_session_id
+
+**Description:** File a GitHub issue to track the cosmetic rename of `cli_session_id` -> `provider_session_id` in `pool_sessions` table and `TurnStoreSessionMixin` methods (47 callsites). NOT a drift-undo. Explicitly scope: rename only, + per-backend token separation IF V5 per-job-override lands a second concurrent backend per agent. Include migration note: rename requires a DB migration for `pool_sessions` column.
+
+**File paths:** None (GitHub issue only)
+
+**Verify:**
+```bash
+gh issue view <filed-issue-number> --json title,body
+```
+**Expected:** Issue filed with scope, rationale (deferred from V2), and V5 trigger condition.
+
+**Agent instance:** backend-dev-4 | **Subject:** followup | **Spec trace:** Known constraints / session model | **Difficulty:** 1/10 | deps: T7
+
+---
+
+## Task Seeding Blueprint
+
+### Wave 1 (start)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-1 | — | protocol |
+| T2 | backend-dev-1 | — | contract |
+| T8 | devops-1 | — | deploy |
+
+### Wave 2 (T1 + T2 done)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-2 | T2 | pool |
+| T4 | backend-dev-2 | T3 | worker |
+| T5 | backend-dev-3 | T3, T4 | bootstrap |
+| T6 | backend-dev-3 | T1, T2 | resume |
+
+### Wave 3 (T3 + T4 + T5 + T6 done)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | backend-dev-4 | T1, T6 | dispatch |
+
+### Wave 4 (T8 done)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T9 | devops-1 | T8 | manifest |
+
+### Wave 5 (T6 + T7 done)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T10 | tester-1 | T6, T7 | tests |
+
+### Wave 6 (T4 + T5 + T6 + T7 + T8 + T9 done)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T11 | tester-1 | T4, T5, T6, T7, T8, T9 | integration |
+
+### Wave 7 (T7 done)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T12 | backend-dev-4 | T7 | followup |
+
+---
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 10 — protocol (backend-dev-1)
+- T2: 11 — contract (backend-dev-1)
+- T3: 12 — pool (backend-dev-2)
+- T4: 13 — worker (backend-dev-2)
+- T5: 14 — bootstrap (backend-dev-3)
+- T6: 15 — resume (backend-dev-3)
+- T7: 16 — dispatch (backend-dev-4)
+- T8: 17 — deploy (devops-1)
+- T9: 18 — manifest (devops-1)
+- T10: 19 — tests (tester-1)
+- T11: 20 — integration (tester-1)
+- T12: 21 — followup (backend-dev-4)

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -46,3 +46,7 @@ host_roles = ["factory-hub"]
 container = "factory-omp.container"
 host_roles = ["factory-hub"]
 required_secrets = ["factory-nats-omp", "factory-litellm-key"]
+
+[volume.omp-sessions]
+volume = "factory-omp-sessions.volume"
+host_roles = ["factory-hub"]

--- a/deploy/quadlet/factory-omp-sessions.volume
+++ b/deploy/quadlet/factory-omp-sessions.volume
@@ -1,0 +1,13 @@
+[Unit]
+Description=Factory OmpWorker session state — named volume for agent.db / models.db (#1813).
+# Named podman volume (podman-managed, no host bind) — persists omp SQLite session state
+# (agent.db, models.db) across container restarts. The repo's models.yml is layered :ro
+# on top at boot via a separate bind mount; this volume holds the compiled state only.
+# Replaces the ephemeral Tmpfs= used before #1813.
+
+[Volume]
+Label=app=factory
+VolumeName=factory-omp-sessions
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/factory-omp.container
+++ b/deploy/quadlet/factory-omp.container
@@ -1,6 +1,7 @@
 [Unit]
 Description=Factory OmpWorker — omp_rpc NATS runtime backend (#1812)
 After=factory-nats.service
+After=factory-omp-sessions-volume.service
 
 [Container]
 # Agent-runtime image — carries the factory CLI plus /opt/omp/omp baked from the
@@ -27,12 +28,11 @@ Tmpfs=/tmp
 # Ephemeral is correct: no_session=True, logs also go to journald (#1877/#1879).
 Tmpfs=/home/factory/.omp:mode=1777
 # omp's agent dir holds models.yml (config) AND agent.db/models.db (SQLite state), so it
-# MUST be writable — a :ro mount EACCESes the DB open, a root-owned tmpfs EACCESes uid
-# 1500, hence mode=1777. Ephemeral (tmpfs): agent.db is per-run state (no_session=True),
-# models.db recompiles from models.yml each boot — avoids secret-at-rest, stale model
-# cache, and unbounded growth (#1879). The repo's models.yml is layered :ro on top (SSoT);
-# podman orders mounts by destination depth, so the dir tmpfs lands before the file.
-Tmpfs=/home/factory/.config/omp-pi:mode=1777
+# MUST be writable. Persistent named volume (factory-omp-sessions) replaces the ephemeral
+# tmpfs used before #1813 — session state (agent.db, models.db) now survives container
+# restarts (clipool-parity). The repo's models.yml is layered :ro on top (SSoT); podman
+# orders mounts by destination depth, so the volume dir lands before the file bind.
+Volume=factory-omp-sessions.volume:/home/factory/.config/omp-pi:rw
 Volume=%h/projects/roxabi-factory/deploy/omp/models.yml:/home/factory/.config/omp-pi/models.yml:ro,Z
 Environment=PI_CODING_AGENT_DIR=/home/factory/.config/omp-pi
 # Workspace — mirrors host ~/projects so the git ownership probe finds its target

--- a/deploy/quadlet/factory-omp.container
+++ b/deploy/quadlet/factory-omp.container
@@ -2,6 +2,7 @@
 Description=Factory OmpWorker — omp_rpc NATS runtime backend (#1812)
 After=factory-nats.service
 After=factory-omp-sessions-volume.service
+Requires=factory-omp-sessions-volume.service
 
 [Container]
 # Agent-runtime image — carries the factory CLI plus /opt/omp/omp baked from the

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -145,6 +145,7 @@ resumes it rather than starting fresh.
 | `factory-jetstream.volume` | `~/.roxabi/factory/nats/jetstream` | NATS | rw | JetStream persistence |
 | `~/.claude/` (inline) | `~/.claude/` | CliPool | rw | Claude session `.jsonl` files (required for `--resume`) |
 | inline bind | `~/.roxabi/factory/nkeys/auth.conf` | NATS (factory-nats) | ro | Public ACL bundle (`U…` nkeys + permission blocks); inline bind mount for live SIGHUP reload (ADR-085) |
+| `factory-omp-sessions.volume` | `/home/factory/.config/omp-pi` | OmpWorker | rw | omp agent.db, models.db (SQLite session state — persists across restarts, #1813) |
 
 `factory-data.volume` is mounted **only** by `factory-hub` (#1721). Adapters use per-file inline binds for `config.toml` and the Discord-private `factory-discord-data.volume` for `discord.db`. `factory-discord-data.volume` is a named podman-managed volume (podman auto-creates it; no host bind required), mounted inside the Discord container at `/home/factory/.roxabi/factory/discord` — a separate mount point that keeps `discord.db` isolated from the hub's bind. Telegram mounts no data volume — last-session is resolved via `turns.db` (path-3, `get_last_session`). Discord resolves last-session the same way; `discord.db` is the thread-ownership store only.
 

--- a/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/jobs/models.py
@@ -22,6 +22,13 @@ class JobEnvelope(WorkEnvelope):
     """Job submission envelope. Canonical subject: factory.jobs.<job_name>.
 
     ``job_id`` and ``parent_job_id`` are inherited from ``WorkEnvelope`` (ADR-084).
+
+    ``payload`` is an untyped dict forwarded verbatim to the worker.  For omp
+    jobs the V2 convention adds two *optional* routing hints (both absent on
+    old senders — tolerated, treated as None):
+
+        pool_id            – str | absent  – clipool pool to resume a session
+        provider_session_id – str | absent  – opaque provider session handle
     """
 
     job_name: str
@@ -51,6 +58,11 @@ class JobResult(WorkEnvelope):
     """Job reply envelope. Sent to reply_to subject on completion.
 
     ``job_id`` inherited from ``WorkEnvelope`` (ADR-084).
+
+    ``data`` is an untyped dict returned by the worker.  For omp jobs the V2
+    convention adds one *optional* field (absent on old workers — tolerated):
+
+        session_file – str | absent  – path to the persisted omp session file
     """
 
     status: Literal["success", "error"]

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -174,8 +174,31 @@ class RpcBridge:
         self._client.on_agent_end(self._on_agent_end)
         await asyncio.to_thread(self._client.new_session)
 
-    async def run(self, prompt: str, job_id: str) -> None:
+    def _derive_assistant_text(self, turn: Any) -> str:
+        """Assistant text for the result: ``turn.assistant_text``, falling back to
+        the last message of the stored agent-end event (stdout-thread sentinel)."""
+        assistant_text = getattr(turn, "assistant_text", None)
+        if assistant_text is None:
+            end_event = self._last_agent_end_event
+            if end_event is not None:
+                messages = getattr(end_event, "messages", None)
+                if messages:
+                    assistant_text = getattr(messages[-1], "assistant_text", None)
+        return assistant_text if assistant_text is not None else ""
+
+    async def run(
+        self,
+        prompt: str,
+        job_id: str,
+        *,
+        client: Any | None = None,
+        session_file: str | None = None,
+    ) -> None:
         """Run a prompt through omp_rpc; publishes progress and result to NATS.
+
+        ``client``       – override self._client for this invocation (pool path).
+        ``session_file`` – omp session path to include in the JobResult data dict
+                           (backhaul — obtained from OmpPool after acquire).
 
         Stores job_id on self for callback access during prompt_and_wait.
         Subscribes factory.job.<job_id>.steer while prompt_and_wait is in flight;
@@ -196,34 +219,33 @@ class RpcBridge:
                 log.debug("rpc_bridge: steer message dropped — no active job")
                 return
             text = msg.data.decode("utf-8", errors="replace")
-            await asyncio.to_thread(self._client.steer, text)
+            await asyncio.to_thread(active_client.steer, text)
+
+        # Pool path: use the caller-supplied client; fall back to self._client
+        # for the legacy single-client path (e.g. tests without a pool).
+        active_client = client if client is not None else self._client
 
         steer_sub = None
         if nc is not None:
             steer_sub = await nc.subscribe(jobs_steer(job_id), cb=_handle_steer_msg)
         try:
-            turn = await asyncio.to_thread(self._client.prompt_and_wait, prompt)
+            turn = await asyncio.to_thread(active_client.prompt_and_wait, prompt)
             self._last_turn = turn
             # Publish success here — guaranteed to see the completed turn value.
             # _on_agent_end fires on the stdout thread BEFORE prompt_and_wait returns
             # so it cannot safely read _last_turn; this is the only safe publish site.
             if nc is not None and not self._result_sent:
                 self._result_sent = True
-                assistant_text = getattr(turn, "assistant_text", None)
-                if assistant_text is None:
-                    # Fallback: derive from stored agent-end event messages if available
-                    end_event = self._last_agent_end_event
-                    if end_event is not None:
-                        messages = getattr(end_event, "messages", None)
-                        if messages:
-                            last_msg = messages[-1]
-                            assistant_text = getattr(last_msg, "assistant_text", None)
-                text: str = assistant_text if assistant_text is not None else ""
+                text: str = self._derive_assistant_text(turn)
                 if not text:
                     log.warning(
                         "rpc_bridge: job %s produced an empty result text", job_id
                     )
-                payload = _make_result(job_id, status="success", data={"result": text})
+                data: dict[str, Any] = {"result": text}
+                # session_file backhaul (V2 pool path — None for legacy single-client).
+                if session_file is not None:
+                    data["session_file"] = session_file
+                payload = _make_result(job_id, status="success", data=data)
                 await nc.publish(jobs_result(job_id), payload)
         finally:
             self._in_prompt_await = False

--- a/src/factory/adapters/omp/omp_pool.py
+++ b/src/factory/adapters/omp/omp_pool.py
@@ -25,8 +25,8 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
-# Image-build constants — NEVER from env (mirrored from _rpc_bridge.py).
-_PINNED_SHA256 = "b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b"
+# omp binary path — image-build constant (NEVER from env). The sha256 pin + its
+# verification live in _rpc_bridge (_verify_digest) — reused, not duplicated.
 _OMP_BIN = Path("/opt/omp/omp")
 _DEFAULT_PROVIDER = "litellm"
 
@@ -80,6 +80,9 @@ class OmpPool:
         self._model = model
         self._entries: dict[str, _PoolEntry] = {}
         self._lru_counter: int = 0
+        # Serializes cold-starts so concurrent acquire() calls for the same
+        # pool_id never launch duplicate omp processes (check-then-act race).
+        self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Public API
@@ -103,33 +106,47 @@ class OmpPool:
             log.debug("[omp_pool:%s] warm hit", pool_id)
             return entry.client
 
-        # Cold start — evict the LRU entry if at cap.
-        await self._maybe_evict()
+        # Cold start — serialize under the lock so two coroutines racing on the
+        # same pool_id don't both launch a client (acquire has await points).
+        async with self._lock:
+            # Double-check: another coroutine may have cold-started while we waited.
+            entry = self._entries.get(pool_id)
+            if entry is not None:
+                self._lru_counter += 1
+                entry._lru_seq = self._lru_counter
+                log.debug("[omp_pool:%s] warm hit (post-lock)", pool_id)
+                return entry.client
 
-        client = await self._start_client()
-        minted_session: str | None = None
+            await self._maybe_evict()
 
-        if session_file is not None:
-            await asyncio.to_thread(client.switch_session, session_file)
-            minted_session = session_file
-            log.debug("[omp_pool:%s] cold start with session %s", pool_id, session_file)
-        else:
-            # new_session() returns a CancellationResult — NOT the path.
-            # Call get_state() to obtain the minted .jsonl session_file path.
-            await asyncio.to_thread(client.new_session)
-            state = await asyncio.to_thread(client.get_state)
-            minted_session = getattr(state, "session_file", None)
-            log.debug(
-                "[omp_pool:%s] cold start, minted session %s", pool_id, minted_session
+            client = await self._start_client()
+            minted_session: str | None = None
+
+            if session_file is not None:
+                await asyncio.to_thread(client.switch_session, session_file)
+                minted_session = session_file
+                log.debug(
+                    "[omp_pool:%s] cold start with session %s", pool_id, session_file
+                )
+            else:
+                # new_session() returns a CancellationResult — NOT the path.
+                # Call get_state() to obtain the minted .jsonl session_file path.
+                await asyncio.to_thread(client.new_session)
+                state = await asyncio.to_thread(client.get_state)
+                minted_session = getattr(state, "session_file", None)
+                log.debug(
+                    "[omp_pool:%s] cold start, minted session %s",
+                    pool_id,
+                    minted_session,
+                )
+
+            self._lru_counter += 1
+            self._entries[pool_id] = _PoolEntry(
+                client=client,
+                session_file=minted_session,
+                _lru_seq=self._lru_counter,
             )
-
-        self._lru_counter += 1
-        self._entries[pool_id] = _PoolEntry(
-            client=client,
-            session_file=minted_session,
-            _lru_seq=self._lru_counter,
-        )
-        return client
+            return client
 
     def release(self, pool_id: str) -> None:  # noqa: ARG002
         """Mark pool_id as released.
@@ -149,10 +166,15 @@ class OmpPool:
     # ------------------------------------------------------------------
 
     async def _start_client(self) -> Any:
-        """Construct and start a fresh omp_rpc.RpcClient."""
+        """Construct and start a fresh, digest-pinned omp_rpc.RpcClient."""
         # Import deferred: omp_rpc is a container image dep, absent from pyproject.toml.
         import omp_rpc  # type: ignore[import-not-found]
 
+        from factory.adapters.omp._rpc_bridge import _verify_digest
+
+        # Enforce the omp binary pin on every cold-start — same gate RpcBridge
+        # applies at construction; the sha256 lives only in _rpc_bridge.
+        _verify_digest(self._omp_bin)
         client: Any = omp_rpc.RpcClient(
             executable=str(self._omp_bin),
             provider=self._provider,
@@ -166,7 +188,7 @@ class OmpPool:
         """Stop a client, logging but swallowing errors (best-effort cleanup)."""
         try:
             await asyncio.to_thread(client.stop)
-        except Exception:  # noqa: BLE001  — DEBT:boundary-broad-catch# pool cleanup
+        except Exception:  # noqa: BLE001 — DEBT:boundary-broad-catch (pool cleanup)
             log.warning("[omp_pool:%s] client.stop raised", pool_id, exc_info=True)
 
     async def _maybe_evict(self) -> None:

--- a/src/factory/adapters/omp/omp_pool.py
+++ b/src/factory/adapters/omp/omp_pool.py
@@ -1,0 +1,181 @@
+"""OmpPool — worker-side pool of warm omp RpcClients keyed by pool_id.
+
+Manages a bounded set of warm omp_rpc.RpcClient instances so that repeated
+calls from the same conversation scope reuse the same running process.
+
+LRU eviction caps the pool at OMP_POOL_CAP (env, default 4); the least-recently
+used entry is stopped and removed to make room. The cap is never a hard error —
+forward progress is always guaranteed.
+
+Session lifecycle:
+  - Cold-start with a session_file  → client.switch_session(session_file)
+  - Cold-start without a session_file → client.new_session(), then client.get_state()
+    to obtain the minted .jsonl path (new_session returns a CancellationResult).
+  - Warm-hit → reuse the already-running client; session_file is ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Image-build constants — NEVER from env (mirrored from _rpc_bridge.py).
+_PINNED_SHA256 = "b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b"
+_OMP_BIN = Path("/opt/omp/omp")
+_DEFAULT_PROVIDER = "litellm"
+
+# Cap is a runtime config knob — read from env, never a bare literal.
+_ENV_CAP_KEY = "OMP_POOL_CAP"
+_DEFAULT_CAP = 4
+
+
+def _read_cap() -> int:
+    """Read OMP_POOL_CAP from env; fall back to _DEFAULT_CAP."""
+    raw = os.environ.get(_ENV_CAP_KEY, "")
+    if raw.strip().isdigit():
+        val = int(raw.strip())
+        return val if val > 0 else _DEFAULT_CAP
+    return _DEFAULT_CAP
+
+
+@dataclass
+class _PoolEntry:
+    """One live omp_rpc.RpcClient with its access-order index."""
+
+    client: Any  # omp_rpc.RpcClient
+    session_file: str | None  # path to the .jsonl session, None until first get_state
+    _lru_seq: int = field(default=0, compare=False)
+
+
+class OmpPool:
+    """Bounded LRU pool of warm omp_rpc.RpcClient instances.
+
+    Thread-safety: all methods are async and must be called from the event loop.
+    Blocking omp_rpc calls are dispatched via asyncio.to_thread.
+
+    Usage::
+
+        pool = OmpPool()
+        client = await pool.acquire(pool_id, session_file=None)
+        # ... use client ...
+        pool.release(pool_id)  # no-op today; reserved for future lock-based API
+        await pool.aclose()
+    """
+
+    def __init__(
+        self,
+        *,
+        omp_bin: Path = _OMP_BIN,
+        provider: str | None = _DEFAULT_PROVIDER,
+        model: str | None = None,
+    ) -> None:
+        self._omp_bin = omp_bin
+        self._provider = provider
+        self._model = model
+        self._entries: dict[str, _PoolEntry] = {}
+        self._lru_counter: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def acquire(self, pool_id: str, session_file: str | None) -> Any:
+        """Return a warm omp_rpc.RpcClient for *pool_id*.
+
+        Warm hit: existing client is returned immediately; session_file is ignored.
+        Cold start: a new RpcClient is constructed, started, and the session is
+        established (switch_session if session_file given, else new_session +
+        get_state to mint the .jsonl path).
+
+        LRU eviction fires when the pool is at cap before the cold start.
+        """
+        entry = self._entries.get(pool_id)
+        if entry is not None:
+            # Warm hit — bump LRU and return.
+            self._lru_counter += 1
+            entry._lru_seq = self._lru_counter
+            log.debug("[omp_pool:%s] warm hit", pool_id)
+            return entry.client
+
+        # Cold start — evict the LRU entry if at cap.
+        await self._maybe_evict()
+
+        client = await self._start_client()
+        minted_session: str | None = None
+
+        if session_file is not None:
+            await asyncio.to_thread(client.switch_session, session_file)
+            minted_session = session_file
+            log.debug("[omp_pool:%s] cold start with session %s", pool_id, session_file)
+        else:
+            # new_session() returns a CancellationResult — NOT the path.
+            # Call get_state() to obtain the minted .jsonl session_file path.
+            await asyncio.to_thread(client.new_session)
+            state = await asyncio.to_thread(client.get_state)
+            minted_session = getattr(state, "session_file", None)
+            log.debug(
+                "[omp_pool:%s] cold start, minted session %s", pool_id, minted_session
+            )
+
+        self._lru_counter += 1
+        self._entries[pool_id] = _PoolEntry(
+            client=client,
+            session_file=minted_session,
+            _lru_seq=self._lru_counter,
+        )
+        return client
+
+    def release(self, pool_id: str) -> None:  # noqa: ARG002
+        """Mark pool_id as released.
+
+        No-op in the current single-consumer-per-slot design; reserved for a
+        future lock-based acquire/release protocol.
+        """
+
+    async def aclose(self) -> None:
+        """Stop all running clients. Safe to call multiple times."""
+        for pool_id, entry in list(self._entries.items()):
+            await self._stop_client(pool_id, entry.client)
+        self._entries.clear()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _start_client(self) -> Any:
+        """Construct and start a fresh omp_rpc.RpcClient."""
+        # Import deferred: omp_rpc is a container image dep, absent from pyproject.toml.
+        import omp_rpc  # type: ignore[import-not-found]
+
+        client: Any = omp_rpc.RpcClient(
+            executable=str(self._omp_bin),
+            provider=self._provider,
+            model=self._model,
+            no_session=True,
+        )
+        await asyncio.to_thread(client.start)
+        return client
+
+    async def _stop_client(self, pool_id: str, client: Any) -> None:
+        """Stop a client, logging but swallowing errors (best-effort cleanup)."""
+        try:
+            await asyncio.to_thread(client.stop)
+        except Exception:  # noqa: BLE001  — DEBT:boundary-broad-catch# pool cleanup
+            log.warning("[omp_pool:%s] client.stop raised", pool_id, exc_info=True)
+
+    async def _maybe_evict(self) -> None:
+        """Evict the LRU entry if the pool is at or above cap."""
+        cap = _read_cap()
+        if len(self._entries) < cap:
+            return
+        # Find the entry with the smallest LRU sequence (least recently used).
+        lru_pool_id = min(self._entries, key=lambda k: self._entries[k]._lru_seq)
+        lru_entry = self._entries.pop(lru_pool_id)
+        log.info("[omp_pool] LRU evict pool_id=%s (cap=%d)", lru_pool_id, cap)
+        await self._stop_client(lru_pool_id, lru_entry.client)

--- a/src/factory/adapters/omp/omp_worker.py
+++ b/src/factory/adapters/omp/omp_worker.py
@@ -137,12 +137,10 @@ class OmpWorker(NatsAdapterBase):
             await self._bridge.publish_error(str(job_id), ValueError("empty prompt"))
             return
 
-        # pool_id is required (V2); reject jobs missing it.
-        pool_id: str = envelope.payload.get("pool_id", "")
-        if not pool_id:
-            log.warning("omp_worker: job_id=%s has no pool_id — rejecting", job_id)
-            await self._bridge.publish_error(str(job_id), ValueError("missing pool_id"))
-            return
+        # pool_id routes the job to its warm pool client. Pre-V2 envelopes omit
+        # it (wire-compat, incl. JetStream backlog replay) → fall back to job_id,
+        # a stable per-job key. Never hard-reject on absence (spec + contracts).
+        pool_id: str = envelope.payload.get("pool_id") or str(job_id)
 
         # provider_session_id: empty string → None (never pass empty string to pool).
         provider_session_id: str | None = (

--- a/src/factory/adapters/omp/omp_worker.py
+++ b/src/factory/adapters/omp/omp_worker.py
@@ -23,6 +23,7 @@ import time
 from typing import Any
 
 from factory.adapters.omp._rpc_bridge import RpcBridge
+from factory.adapters.omp.omp_pool import OmpPool
 from roxabi_contracts.jobs.models import JobEnvelope
 from roxabi_contracts.jobs.subjects import jobs_submit
 from roxabi_nats import nats_connect
@@ -56,6 +57,7 @@ class OmpWorker(NatsAdapterBase):
         self,
         bridge: RpcBridge | None = None,
         *,
+        pool: OmpPool | None = None,
         timeout: float = 300.0,
         identity_name: str | None = None,
     ) -> None:
@@ -70,8 +72,9 @@ class OmpWorker(NatsAdapterBase):
             identity_name=identity_name,
             wait_ready=False,  # worker semantics — hub readiness not required
         )
-        # Allow injection for testing; production always constructs real bridge.
+        # Allow injection for testing; production always constructs real bridge/pool.
         self._bridge: RpcBridge = bridge if bridge is not None else RpcBridge()
+        self._pool: OmpPool = pool if pool is not None else OmpPool()
 
     # ------------------------------------------------------------------
     # Lifecycle override — connect then register bridge before entering
@@ -102,8 +105,9 @@ class OmpWorker(NatsAdapterBase):
         try:
             await self.run_embedded(nc, stop)
         finally:
-            # Stop the omp_rpc subprocess on shutdown (idempotent).
+            # Stop the omp_rpc subprocess and pool clients on shutdown (idempotent).
             await self._bridge.aclose()
+            await self._pool.aclose()
 
     # ------------------------------------------------------------------
     # NatsAdapterBase overrides
@@ -132,6 +136,19 @@ class OmpWorker(NatsAdapterBase):
             log.warning("omp_worker: job_id=%s has empty prompt — rejecting", job_id)
             await self._bridge.publish_error(str(job_id), ValueError("empty prompt"))
             return
+
+        # pool_id is required (V2); reject jobs missing it.
+        pool_id: str = envelope.payload.get("pool_id", "")
+        if not pool_id:
+            log.warning("omp_worker: job_id=%s has no pool_id — rejecting", job_id)
+            await self._bridge.publish_error(str(job_id), ValueError("missing pool_id"))
+            return
+
+        # provider_session_id: empty string → None (never pass empty string to pool).
+        provider_session_id: str | None = (
+            envelope.payload.get("provider_session_id") or None
+        )
+
         model_cfg = envelope.payload.get("model_cfg", {})
         system_prompt = envelope.payload.get("system_prompt", "")
         _cfg_keys = (
@@ -142,18 +159,30 @@ class OmpWorker(NatsAdapterBase):
         _sp_len = len(system_prompt) if isinstance(system_prompt, str) else 0
         log.debug(
             "omp job %s: received model_cfg keys=%s"
-            " system_prompt_len=%d (V1: not applied)",
+            " system_prompt_len=%d (V1: not applied)"
+            " pool_id=%s provider_session_id=%s",
             job_id,
             _cfg_keys,
             _sp_len,
+            pool_id,
+            provider_session_id,
         )
         log.info("omp_worker: job_id=%s start", job_id)
         start = time.monotonic()
         try:
-            await self._bridge.run(prompt=str(prompt), job_id=str(job_id))
-        except (
-            Exception
-        ) as exc:  # propagated from prompt_and_wait; publish error  # noqa: BLE001
+            # Acquire a warm client from the pool — cold-start or reuse.
+            pool_client = await self._pool.acquire(
+                pool_id, session_file=provider_session_id
+            )
+            # Read the minted/provided session path back from the pool entry.
+            pool_session_file: str | None = self._pool._entries[pool_id].session_file
+            await self._bridge.run(
+                prompt=str(prompt),
+                job_id=str(job_id),
+                client=pool_client,
+                session_file=pool_session_file,
+            )
+        except Exception as exc:  # pool.acquire / prompt_and_wait  # noqa: BLE001
             log.exception("omp_worker: job_id=%s failed", job_id)
             await self._bridge.publish_error(str(job_id), exc)
         else:

--- a/src/factory/agents/CLAUDE.md
+++ b/src/factory/agents/CLAUDE.md
@@ -9,16 +9,24 @@ Store/lifecycle machinery (`AgentStore` lives in `infrastructure/stores/`, `Agen
 
 ## Backend wiring
 
-Two backend paths exist; exactly one is active per agent instance:
+Three backend paths are supported; the active one is resolved at construction time via
+`isinstance` checks against `SessionAware` / `WorkspaceAware` (both declared in
+`factory.core.ports.llm`):
 
-| Path | When | Key object |
-|------|------|------------|
-| Direct CLI | `backend = "claude-cli"`, single-process | `CliPool` |
-| NATS-relayed CLI | distributed / hub-spoke | `LlmClient` (composed via `CliNatsCodec` over `WorkerPoolClient`) |
+| Path | When | Key object | Protocols |
+|------|------|------------|-----------|
+| Direct CLI | `backend = "claude-cli"`, single-process | `CliPool` | `SessionAware` + `WorkspaceAware` |
+| NATS-relayed CLI | distributed / hub-spoke | `LlmClient` (composed via `CliNatsCodec` over `WorkerPoolClient`) | `SessionAware` + `WorkspaceAware` |
+| OmpRpc NATS job | `backend = "omp-rpc"`, hub-side job dispatch | `OmpRpcDriver` | `SessionAware` only (no `switch_cwd`) |
+
+`SimpleAgent.__init__` resolves `_session_backend` and `_workspace_backend` once from the
+`(cli_pool, cli_nats_driver)` candidate pair. All four dispatch sites (`reset_backend`,
+`_maybe_register_reset`, `_maybe_register_resume`, `link_lyra_session` in `process()`) route
+through these two attributes — no per-site if/elif fan-out.
 
 `configure_pool(pool)` wires `reset_fn / resume_fn / workspace_fn` callbacks before the first
-`process()` call. Both `cli_pool` and `cli_nats_driver` register the same callbacks; whichever is
-non-`None` at construction time is active.
+`process()` call. When `_workspace_backend` is `None` (e.g. `OmpRpcDriver`), `workspace_fn`
+is passed as `None` (existing no-op path in `Pool.register_session_callbacks`).
 
 ## Hot-reload
 

--- a/src/factory/agents/simple_agent.py
+++ b/src/factory/agents/simple_agent.py
@@ -22,6 +22,7 @@ from factory.core.messaging.message import (
 )
 from factory.core.messaging.messages import MessageManager
 from factory.core.pool import Pool
+from factory.core.ports.llm import SessionAware, WorkspaceAware
 from factory.core.ports.stt import STTNoiseError as STTNoiseError  # re-export (#1225)
 from factory.core.processors.stream_processor import StreamProcessor
 from factory.core.runtime_config import RuntimeConfig, RuntimeConfigHolder
@@ -88,6 +89,33 @@ class SimpleAgent(AgentBase):
         self._provider = provider
         self._cli_pool = cli_pool
         self._cli_nats_driver = cli_nats_driver
+        # Resolve capability-aware backends ONCE at construction — avoids
+        # repeated if/elif fan-out at every dispatch site (reset, register,
+        # link_lyra_session).  Candidates are the explicit CLI transports only;
+        # _provider is intentionally excluded so that MagicMock-based tests
+        # (which auto-create any attribute) do not accidentally match.
+        _candidates = (cli_pool, cli_nats_driver)
+
+        def _has_session_iface(x: object) -> bool:
+            # @runtime_checkable Protocol isinstance does NOT trigger MagicMock's
+            # __getattr__ in Python 3.12+; use getattr() which does.
+            return (
+                callable(getattr(x, "link_lyra_session", None))
+                and callable(getattr(x, "reset", None))
+                and callable(getattr(x, "queue_resume", None))
+            )
+
+        def _has_workspace_iface(x: object) -> bool:
+            return callable(getattr(x, "switch_cwd", None))
+
+        self._session_backend: SessionAware | None = next(
+            (x for x in _candidates if x is not None and _has_session_iface(x)),  # type: ignore[assignment]
+            None,
+        )
+        self._workspace_backend: WorkspaceAware | None = next(
+            (x for x in _candidates if x is not None and _has_workspace_iface(x)),  # type: ignore[assignment]
+            None,
+        )
         self._session_tools = session_tools
         super().__init__(
             config,
@@ -105,8 +133,8 @@ class SimpleAgent(AgentBase):
 
     async def reset_backend(self, pool_id: str) -> None:
         """Kill the backend process so the next turn gets a fresh one."""
-        if self._cli_pool is not None:
-            await self._cli_pool.reset(pool_id)
+        if self._session_backend is not None:
+            await self._session_backend.reset(pool_id)
 
     def _build_router_kwargs(self) -> dict[str, object]:
         return {
@@ -157,40 +185,34 @@ class SimpleAgent(AgentBase):
 
     def _maybe_register_reset(self, pool: Pool) -> None:
         """Register session reset/switch callbacks on the pool."""
-        _cli_pool = self._cli_pool  # narrow once; stable capture for lambdas
-        if _cli_pool is not None:
-            _pool_id = pool.pool_id
-            pool.register_session_callbacks(
-                reset_fn=lambda: _cli_pool.reset(_pool_id),
-                workspace_fn=lambda cwd: _cli_pool.switch_cwd(_pool_id, cwd),
-            )
-        elif self._cli_nats_driver is not None:
-            _driver = self._cli_nats_driver
-            _pool_id = pool.pool_id
-            pool.register_session_callbacks(
-                reset_fn=lambda: _driver.reset(_pool_id),
-                workspace_fn=lambda cwd: _driver.switch_cwd(_pool_id, cwd),
-            )
+        _session = self._session_backend
+        if _session is None:
+            return
+        _workspace = self._workspace_backend  # None when backend lacks switch_cwd
+        _pool_id = pool.pool_id
+        pool.register_session_callbacks(
+            reset_fn=lambda: _session.reset(_pool_id),
+            workspace_fn=(
+                (lambda cwd: _workspace.switch_cwd(_pool_id, cwd))
+                if _workspace is not None
+                else None
+            ),
+        )
 
     def _maybe_register_resume(self, pool: Pool) -> None:
         """Register session resume callback on the pool.
 
         Hub calls pool.resume_session(session_id) → delegates here →
-        CliPool.queue_resume(). Follows the same lazy-wiring pattern as
+        backend.queue_resume(). Follows the same lazy-wiring pattern as
         _maybe_register_reset.
         """
-        _cli_pool = self._cli_pool  # narrow once; stable capture for lambda
-        if _cli_pool is not None:
-            _pool_id = pool.pool_id
-            pool.register_session_callbacks(
-                resume_fn=lambda sid: _cli_pool.queue_resume(_pool_id, sid),
-            )
-        elif self._cli_nats_driver is not None:
-            _driver = self._cli_nats_driver
-            _pool_id = pool.pool_id
-            pool.register_session_callbacks(
-                resume_fn=lambda sid: _driver.queue_resume(_pool_id, sid),
-            )
+        _session = self._session_backend
+        if _session is None:
+            return
+        _pool_id = pool.pool_id
+        pool.register_session_callbacks(
+            resume_fn=lambda sid: _session.queue_resume(_pool_id, sid),
+        )
 
     def configure_pool(self, pool: Pool) -> None:
         """Wire provider callbacks onto *pool* before first message is processed.
@@ -221,11 +243,9 @@ class SimpleAgent(AgentBase):
 
         model_cfg = self.config.llm_config
 
-        # Link Lyra session → CLI session so reply-to-resume works.
-        if self._cli_pool is not None:
-            self._cli_pool.link_lyra_session(pool.pool_id, pool.session_id)
-        elif self._cli_nats_driver is not None:
-            self._cli_nats_driver.link_lyra_session(pool.pool_id, pool.session_id)
+        # Link Lyra session → backend session so reply-to-resume works.
+        if self._session_backend is not None:
+            self._session_backend.link_lyra_session(pool.pool_id, pool.session_id)
 
         log.debug(
             "[agent:%s][pool:%s] processing message (%d chars)",

--- a/src/factory/bootstrap/factory/providers.py
+++ b/src/factory/bootstrap/factory/providers.py
@@ -14,6 +14,7 @@ from factory.llm.drivers.cli import ClaudeCliDriver
 from factory.llm.registry import ProviderRegistry
 
 if TYPE_CHECKING:
+    from factory.llm.drivers.omp_rpc import _OmpSessionStore
     from factory.llm.llm_client import LlmClient
 
 log = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ def _build_shared_base_providers(  # noqa: PLR0913
     nats_llm_client: LlmClient | None = None,
     cli_nats_driver: LlmClient | None = None,
     omp_rpc_driver: LlmProvider | None = None,
+    omp_turn_store: _OmpSessionStore | None = None,
     cb_decorator_cls: type = CircuitBreakerDecorator,
     retry_decorator_cls: type = RetryDecorator,
 ) -> dict[str, LlmProvider]:
@@ -68,6 +70,8 @@ def _build_shared_base_providers(  # noqa: PLR0913
 
     if omp_rpc_driver is not None:
         providers["omp-rpc"] = omp_rpc_driver
+        if omp_turn_store is not None:
+            omp_rpc_driver.set_turn_store(omp_turn_store)  # type: ignore[attr-defined]
         log.info("Shared base: registered omp-rpc driver (bare, no decorator)")
 
     return providers

--- a/src/factory/bootstrap/factory/providers.py
+++ b/src/factory/bootstrap/factory/providers.py
@@ -71,7 +71,10 @@ def _build_shared_base_providers(  # noqa: PLR0913
     if omp_rpc_driver is not None:
         providers["omp-rpc"] = omp_rpc_driver
         if omp_turn_store is not None:
-            omp_rpc_driver.set_turn_store(omp_turn_store)  # type: ignore[attr-defined]
+            from factory.llm.drivers.omp_rpc import OmpRpcDriver
+
+            if isinstance(omp_rpc_driver, OmpRpcDriver):
+                omp_rpc_driver.set_turn_store(omp_turn_store)
         log.info("Shared base: registered omp-rpc driver (bare, no decorator)")
 
     return providers

--- a/src/factory/bootstrap/standalone/worker_standalone.py
+++ b/src/factory/bootstrap/standalone/worker_standalone.py
@@ -166,8 +166,12 @@ async def _bootstrap_omp_standalone(raw_config: dict) -> None:  # noqa: ARG001
 
     log_contracts_version()
 
+    # omp_rpc is a container image dep — deferred imports prevent ImportError
+    # in dev environments where the binary is absent from pyproject.toml.
+    from factory.adapters.omp.omp_pool import OmpPool
     from factory.adapters.omp.omp_worker import OmpWorker
 
-    worker = OmpWorker(identity_name="omp-worker")
+    pool = OmpPool()
+    worker = OmpWorker(pool=pool, identity_name="omp-worker")
     log.info("omp: starting OmpWorker on factory.jobs.omp")
     await worker.run(nats_url)

--- a/src/factory/core/ports/llm.py
+++ b/src/factory/core/ports/llm.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from factory.core.ports.llm_types import LlmEvent, ModelConfig
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from roxabi_contracts.errors import WorkerError
 
 
@@ -84,4 +86,39 @@ class LlmUnavailableError(Exception):
     """Raised when no LLM worker is reachable (timeout, no heartbeat, circuit open)."""
 
 
-__all__ = ["LlmProvider", "LlmResult", "LlmUnavailableError", "StreamingLlmProvider"]
+@runtime_checkable
+class SessionAware(Protocol):
+    """Capability protocol for providers that manage per-pool Lyra sessions.
+
+    Decoupled from ``LlmProvider`` so that drivers that do not support session
+    management are not forced to carry these methods.  Consumers should check
+    ``isinstance(provider, SessionAware)`` before calling.
+    """
+
+    def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None: ...
+
+    async def reset(self, pool_id: str) -> None: ...
+
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool: ...
+
+
+@runtime_checkable
+class WorkspaceAware(Protocol):
+    """Capability protocol for providers that support changing the working directory.
+
+    Decoupled from ``LlmProvider`` so that drivers without workspace control are
+    not polluted with this surface.  Consumers should check
+    ``isinstance(provider, WorkspaceAware)`` before calling.
+    """
+
+    async def switch_cwd(self, pool_id: str, cwd: "Path") -> None: ...
+
+
+__all__ = [
+    "LlmProvider",
+    "LlmResult",
+    "LlmUnavailableError",
+    "SessionAware",
+    "StreamingLlmProvider",
+    "WorkspaceAware",
+]

--- a/src/factory/llm/CLAUDE.md
+++ b/src/factory/llm/CLAUDE.md
@@ -21,7 +21,7 @@ SSoT: `factory.core.ports.llm`. `base.py` is a backward-compatibility shim — i
 |--------|-------------|-----------|-------------|
 | `ClaudeCliDriver` | `"claude-cli"` | in-process (`CliPool` subprocess) | single-process |
 | `LlmClient` | `"claude-cli"` / `"nats"` | NATS request-reply via `WorkerPoolClient` + `CliNatsCodec` | multi-process (hub side) |
-| `OmpRpcDriver` | `"omp-rpc"` | NATS `JobEnvelope` round-trip — publishes to `factory.jobs.omp`, subscribes `factory.job.<id>.result` (hub mints `job_id`); `model_dump_json` wire; `streaming=False` | multi-process (hub side); registered in `bootstrap/factory/providers.py` as the `"omp-rpc"` backend (bare driver — owns its own timeout, no CB/retry decorator) |
+| `OmpRpcDriver` | `"omp-rpc"` | NATS `JobEnvelope` round-trip — publishes to `factory.jobs.omp`, subscribes `factory.job.<id>.result` (hub mints `job_id`); `model_dump_json` wire; `streaming=False` | multi-process (hub side); registered in `bootstrap/factory/providers.py` as the `"omp-rpc"` backend (bare driver — owns its own timeout, no CB/retry decorator). Implements `SessionAware` (`link_lyra_session`, `reset`, `queue_resume`) — NOT `WorkspaceAware` (no `switch_cwd`). |
 
 `ClaudeCliDriver` and `LlmClient` may share the `"claude-cli"` registry key — selection between them is determined by wiring mode at bootstrap (single-process picks `ClaudeCliDriver`, multi-process picks `LlmClient(WorkerPoolClient, CliNatsCodec)`).
 

--- a/src/factory/llm/drivers/omp_rpc.py
+++ b/src/factory/llm/drivers/omp_rpc.py
@@ -101,6 +101,7 @@ class OmpRpcDriver:
         the JobEnvelope payload.
         """
         self._pending_resume.pop(pool_id, None)
+        self._lyra_sessions.pop(pool_id, None)
 
     async def queue_resume(self, pool_id: str, session_id: str) -> bool:
         """Resolve cli_session_id and stash it for the next complete() call.
@@ -168,6 +169,7 @@ class OmpRpcDriver:
                 "prompt": text,
                 "model_cfg": model_cfg.model_dump(),
                 "system_prompt": system_prompt,
+                "pool_id": pool_id,
             }
             if pending_resume is not None:
                 payload["provider_session_id"] = pending_resume

--- a/src/factory/llm/drivers/omp_rpc.py
+++ b/src/factory/llm/drivers/omp_rpc.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 from uuid import uuid4
 
 from pydantic import ValidationError
@@ -33,12 +33,34 @@ log = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT_S: float = 600.0
 
 
+class _OmpSessionStore(Protocol):
+    """Read+write session store protocol for OmpRpcDriver.
+
+    Extends the read-only _CliSessionStore shape (get_cli_session) with the
+    write path (_set_cli_session) so the driver can persist the omp session
+    file returned by a successful job result.
+    """
+
+    async def get_cli_session(self, session_id: str) -> str | None: ...
+
+    async def _set_cli_session(self, session_id: str, cli_session_id: str) -> None: ...
+
+
 class OmpRpcDriver:
     """LlmProvider adapter that dispatches work to the omp NATS worker.
 
     The hub mints the job_id (omp never mints its own).  The driver
     subscribes to the reply subject *before* publishing to avoid a
     race between the worker reply and the subscribe call.
+
+    SessionAware protocol (V2)
+    --------------------------
+    Mirrors LlmClient exactly for the session-management interface so the hub
+    can treat OmpRpcDriver and LlmClient uniformly:
+      - set_turn_store(store)        — wire the TurnStore read+write path
+      - link_lyra_session(p, s)      — local mapping pool_id → session_id
+      - queue_resume(p, s) -> bool   — resolve + stash cli_session_id
+      - reset(pool_id)               — drop pending resume (no NATS msg in V2)
     """
 
     capabilities: dict = {"streaming": False}
@@ -47,14 +69,72 @@ class OmpRpcDriver:
         # raw async NATS connection (nats-py), injected at bootstrap (T11)
         self._nc = nc
         self._timeout_s = timeout_s
+        # SessionAware state (mirrors LlmClient.__init__)
+        self._turn_store: _OmpSessionStore | None = None
+        self._pending_resume: dict[str, str] = {}
+        self._lyra_sessions: dict[str, str] = {}
 
     def is_alive(self, pool_id: str) -> bool:  # noqa: ARG002
         """V1: always reports alive — no heartbeat mechanism yet."""
         return True
 
+    # ── SessionAware protocol ──────────────────────────────────────────────
+
+    def set_turn_store(self, store: _OmpSessionStore) -> None:
+        """Wire the session store for cli_session_id lookups in queue_resume."""
+        self._turn_store = store
+
+    def link_lyra_session(self, pool_id: str, session_id: str) -> None:
+        """Store the pool_id → session_id mapping for session persistence.
+
+        Pure local mutation — no NATS message sent (mirrors LlmClient).
+        """
+        self._lyra_sessions[pool_id] = session_id
+        log.debug("omp_rpc: link pool_id=%s → lyra_session=%s", pool_id, session_id)
+
+    async def reset(self, pool_id: str) -> None:
+        """Drop any pending resume token for pool_id.
+
+        V2: no NATS control message is sent to the omp worker because there
+        is no per-worker control path in this version.  OmpPool cold-starts
+        the next turn automatically when no provider_session_id is present in
+        the JobEnvelope payload.
+        """
+        self._pending_resume.pop(pool_id, None)
+
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool:
+        """Resolve cli_session_id and stash it for the next complete() call.
+
+        Looks up cli_session_id from the hub TurnStore and stores it in
+        _pending_resume[pool_id].  The stashed token is injected into the next
+        JobEnvelope.payload as ``provider_session_id`` — no separate NATS
+        control message is sent.
+
+        Returns True iff a cli_session_id was resolved and stashed.  True does
+        NOT mean the resume has been applied — the omp worker applies it on
+        the next job it receives.
+
+        Mirrors LlmClient.queue_resume exactly.
+        """
+        cli_sid: str | None = None
+        if self._turn_store is not None:
+            cli_sid = await self._turn_store.get_cli_session(session_id)
+        if cli_sid is None:
+            log.debug(
+                "omp_rpc: no cli_session_id for lyra_session=%s, "
+                "skipping resume [pool:%s]",
+                session_id,
+                pool_id,
+            )
+            return False
+        self._pending_resume[pool_id] = cli_sid
+        return True
+
+    # ── LlmProvider protocol ───────────────────────────────────────────────
+
     async def complete(
         self,
-        pool_id: str,  # noqa: ARG002
+        pool_id: str,
         text: str,
         model_cfg: ModelConfig,
         system_prompt: str,
@@ -65,8 +145,18 @@ class OmpRpcDriver:
 
         ``messages`` is accepted for LlmProvider protocol compliance but
         ignored in V1: omp manages its own session history internally.
+
+        If a pending resume token exists for pool_id, it is injected into the
+        JobEnvelope payload as ``provider_session_id`` so the omp worker can
+        resume the previous session.  On success, if the worker returns a
+        ``session_file`` in JobResult.data and a lyra session_id is linked,
+        the file path is persisted via the TurnStore write path.
         """
         del messages  # omp uses its own session
+
+        # Pop pending resume before publish; do NOT re-stash on failure (omp
+        # is stateless per-job — a failed job does not consume the session).
+        pending_resume = self._pending_resume.pop(pool_id, None)
 
         job_id = uuid4().hex
         result_subject = jobs_result(job_id)
@@ -74,17 +164,21 @@ class OmpRpcDriver:
         # Subscribe BEFORE publish to avoid missing the reply.
         sub = await self._nc.subscribe(result_subject)
         try:
+            payload: dict[str, Any] = {
+                "prompt": text,
+                "model_cfg": model_cfg.model_dump(),
+                "system_prompt": system_prompt,
+            }
+            if pending_resume is not None:
+                payload["provider_session_id"] = pending_resume
+
             env = JobEnvelope(
                 contract_version=CONTRACT_VERSION,
                 trace_id=job_id,
                 issued_at=datetime.now(tz=timezone.utc),
                 job_id=job_id,
                 job_name="omp",
-                payload={
-                    "prompt": text,
-                    "model_cfg": model_cfg.model_dump(),
-                    "system_prompt": system_prompt,
-                },
+                payload=payload,
                 # reply_to satisfies the JobEnvelope contract validator (requires
                 # _INBOX.*/_R_.*) but is unused for routing: the omp worker publishes
                 # the JobResult to the deterministic jobs_result(job_id) subject we
@@ -106,6 +200,15 @@ class OmpRpcDriver:
                 )
 
             if result.status == "success":
+                # Persist the omp session file if the worker returned one and
+                # a lyra session_id is linked for this pool.
+                session_file = (result.data or {}).get("session_file")
+                if session_file and self._turn_store is not None:
+                    linked_session = self._lyra_sessions.get(pool_id)
+                    if linked_session is not None:
+                        await self._turn_store._set_cli_session(  # noqa: SLF001
+                            linked_session, session_file
+                        )
                 return LlmResult(result=(result.data or {}).get("result", ""))
 
             log.warning("omp worker returned error status for job %s", job_id)

--- a/tests/adapters/omp/test_omp_worker.py
+++ b/tests/adapters/omp/test_omp_worker.py
@@ -9,7 +9,7 @@ asyncio_mode = "auto" is configured project-wide in pyproject.toml.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -21,6 +21,7 @@ from factory.adapters.omp.omp_worker import OmpWorker
 
 _JOB_ID = "job-abc123"
 _JOB_NAME = "summarise"
+_POOL_ID = "test-pool"
 
 
 def _make_bridge() -> MagicMock:
@@ -32,8 +33,21 @@ def _make_bridge() -> MagicMock:
     return bridge
 
 
-def _make_worker(bridge: MagicMock | None = None) -> OmpWorker:
-    return OmpWorker(bridge=bridge or _make_bridge())
+def _make_pool() -> MagicMock:
+    mock_client = MagicMock()
+    pool = MagicMock()
+    pool.acquire = AsyncMock(return_value=mock_client)
+    pool.aclose = AsyncMock()
+    mock_entry = MagicMock()
+    mock_entry.session_file = None
+    pool._entries = {_POOL_ID: mock_entry}
+    return pool
+
+
+def _make_worker(
+    bridge: MagicMock | None = None, pool: MagicMock | None = None
+) -> OmpWorker:
+    return OmpWorker(bridge=bridge or _make_bridge(), pool=pool or _make_pool())
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +108,7 @@ class TestHandleHappyPath:
         payload = {
             "job_id": _JOB_ID,
             "job_name": _JOB_NAME,
-            "payload": {"prompt": "summarise this text"},
+            "payload": {"prompt": "summarise this text", "pool_id": _POOL_ID},
             "contract_version": "1",
             "reply_to": "_INBOX.test.reply",
             "trace_id": "trace-001",
@@ -104,6 +118,8 @@ class TestHandleHappyPath:
         bridge.run.assert_awaited_once_with(
             prompt="summarise this text",
             job_id=_JOB_ID,
+            client=ANY,
+            session_file=ANY,
         )
 
     async def test_handle_no_error_published_on_success(self) -> None:
@@ -112,7 +128,7 @@ class TestHandleHappyPath:
         payload = {
             "job_id": _JOB_ID,
             "job_name": _JOB_NAME,
-            "payload": {"prompt": "do something"},
+            "payload": {"prompt": "do something", "pool_id": _POOL_ID},
             "contract_version": "1",
             "reply_to": "_INBOX.test.reply",
             "trace_id": "trace-002",
@@ -214,7 +230,7 @@ class TestHandleBridgeRunError:
         payload = {
             "job_id": _JOB_ID,
             "job_name": _JOB_NAME,
-            "payload": {"prompt": "hi"},
+            "payload": {"prompt": "hi", "pool_id": _POOL_ID},
             "contract_version": "1",
             "reply_to": "_INBOX.test.reply",
             "trace_id": "trace-005",
@@ -361,7 +377,10 @@ class TestHandleBackwardCompat:
         payload = {
             "job_id": _JOB_ID,
             "job_name": _JOB_NAME,
-            "payload": {"prompt": "x"},  # old-style: no model_cfg, no system_prompt
+            "payload": {
+                "prompt": "x",
+                "pool_id": _POOL_ID,
+            },  # old-style: no model_cfg, no system_prompt
             "contract_version": "1",
             "reply_to": "_INBOX.test.reply",
             "trace_id": "trace-bc-001",
@@ -374,6 +393,8 @@ class TestHandleBackwardCompat:
         bridge.run.assert_awaited_once_with(
             prompt="x",
             job_id=_JOB_ID,
+            client=ANY,
+            session_file=ANY,
         )
         bridge.publish_error.assert_not_awaited()
 
@@ -390,6 +411,7 @@ class TestHandleBackwardCompat:
             "job_name": _JOB_NAME,
             "payload": {
                 "prompt": "x",
+                "pool_id": _POOL_ID,
                 "model_cfg": {"backend": "omp-rpc", "model": "grok-4-fast"},
                 "system_prompt": "be terse",
             },
@@ -403,5 +425,7 @@ class TestHandleBackwardCompat:
         bridge.run.assert_awaited_once_with(
             prompt="x",
             job_id=_JOB_ID,
+            client=ANY,
+            session_file=ANY,
         )
         bridge.publish_error.assert_not_awaited()

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -703,6 +703,24 @@ class TestSimpleAgentResetBackend:
 
         provider.reset.assert_not_called()
 
+    async def test_reset_backend_routes_through_nats_driver(self) -> None:
+        """reset_backend() delegates to nats_driver.reset(pool_id) when cli_pool=None.
+
+        Regression: before V2, reset_backend only checked _cli_pool and silently
+        dropped the call when cli_pool=None, even if a nats_driver was present.
+        This test locks the fixed behaviour where _session_backend is resolved from
+        the nats_driver candidate.
+        """
+        provider = MagicMock(spec=["complete", "stream", "is_alive"])
+        nats_driver = MagicMock()
+        nats_driver.reset = AsyncMock()
+
+        agent = make_agent_with_nats_driver(provider, nats_driver)
+
+        await agent.reset_backend("pool-nats-1")
+
+        nats_driver.reset.assert_awaited_once_with("pool-nats-1")
+
 
 # ---------------------------------------------------------------------------
 # TestSimpleAgentSessionToolsFailure

--- a/tests/bootstrap/test_omp_standalone.py
+++ b/tests/bootstrap/test_omp_standalone.py
@@ -1,0 +1,57 @@
+"""Bootstrap wiring tests for _bootstrap_omp_standalone (#1813)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+async def test_missing_nats_url_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NATS_URL unset → sys.exit before any OmpPool/OmpWorker is constructed."""
+    from factory.bootstrap.standalone.worker_standalone import (
+        _bootstrap_omp_standalone,
+    )
+
+    monkeypatch.delenv("NATS_URL", raising=False)
+
+    with (
+        patch("factory.bootstrap.standalone.worker_standalone._export_secret_file"),
+        patch("factory.bootstrap.standalone.worker_standalone.run_git_ownership_probe"),
+        pytest.raises(SystemExit),
+    ):
+        await _bootstrap_omp_standalone({})
+
+
+async def test_happy_path_wires_pool_into_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OmpPool() built with no args; injected into OmpWorker(pool=...)."""
+    from factory.bootstrap.standalone.worker_standalone import (
+        _bootstrap_omp_standalone,
+    )
+
+    monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+
+    mock_pool = MagicMock()
+    mock_worker = MagicMock()
+    mock_worker.run = AsyncMock()
+
+    mock_pool_cls = MagicMock(return_value=mock_pool)
+    mock_worker_cls = MagicMock(return_value=mock_worker)
+
+    with (
+        patch("factory.bootstrap.standalone.worker_standalone._export_secret_file"),
+        patch("factory.bootstrap.standalone.worker_standalone.run_git_ownership_probe"),
+        patch("factory.bootstrap.standalone.worker_standalone.log_contracts_version"),
+        patch("factory.adapters.omp.omp_pool.OmpPool", mock_pool_cls),
+        patch("factory.adapters.omp.omp_worker.OmpWorker", mock_worker_cls),
+    ):
+        await _bootstrap_omp_standalone({})
+
+    # Pool constructed with no positional or keyword args.
+    mock_pool_cls.assert_called_once_with()
+    # Worker injected with the constructed pool.
+    mock_worker_cls.assert_called_once_with(pool=mock_pool, identity_name="omp-worker")
+    # Worker.run called with the NATS URL.
+    mock_worker.run.assert_awaited_once_with("nats://localhost:4222")

--- a/tests/contracts/test_omp_payload_v2.py
+++ b/tests/contracts/test_omp_payload_v2.py
@@ -1,0 +1,96 @@
+"""Wire-compat tests for omp V2 payload convention.
+
+JobEnvelope.payload and JobResult.data are untyped dict[str, Any] — no Pydantic
+schema change is needed.  These tests assert that:
+
+  * Old senders (payload = {"prompt": "x"}, no new fields) still validate.
+  * New senders adding pool_id + provider_session_id also validate.
+  * Old workers (data has no session_file) still validate.
+  * New workers returning session_file also validate.
+
+All four cases are wire-compatible: absent fields are tolerated by both sides.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from roxabi_contracts.jobs import JobEnvelope, JobResult
+from roxabi_contracts.jobs.fixtures import ENV_BASE
+
+# ---------------------------------------------------------------------------
+# Shared base payloads (minimal valid envelopes)
+# ---------------------------------------------------------------------------
+
+_ENVELOPE_BASE: dict[str, Any] = {
+    **ENV_BASE,
+    "job_id": "job-omp-v2-test",
+    "job_name": "omp.run",
+    "reply_to": "_INBOX.omp-v2-test",
+}
+
+_RESULT_BASE: dict[str, Any] = {
+    **ENV_BASE,
+    "job_id": "job-omp-v2-test",
+    "status": "success",
+}
+
+# ---------------------------------------------------------------------------
+# JobEnvelope.payload wire-compat
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_payload_old_style_no_routing_hints() -> None:
+    """Old senders omitting pool_id/provider_session_id still validate (V1 compat)."""
+    inst = JobEnvelope.model_validate(
+        {**_ENVELOPE_BASE, "payload": {"prompt": "hello world"}}
+    )
+    assert inst.payload == {"prompt": "hello world"}
+    assert "pool_id" not in inst.payload
+    assert "provider_session_id" not in inst.payload
+
+
+def test_envelope_payload_v2_with_pool_id_and_session_id() -> None:
+    """New senders adding pool_id + provider_session_id validate without error."""
+    inst = JobEnvelope.model_validate(
+        {
+            **_ENVELOPE_BASE,
+            "payload": {
+                "prompt": "hello world",
+                "pool_id": "clipool-abc123",
+                "provider_session_id": "sess-xyz987",
+            },
+        }
+    )
+    assert inst.payload["pool_id"] == "clipool-abc123"
+    assert inst.payload["provider_session_id"] == "sess-xyz987"
+    assert inst.payload["prompt"] == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# JobResult.data wire-compat
+# ---------------------------------------------------------------------------
+
+
+def test_result_data_without_session_file() -> None:
+    """Old workers returning data without session_file still validate (V1 compat)."""
+    inst = JobResult.model_validate({**_RESULT_BASE, "data": {"output": "done"}})
+    assert inst.status == "success"
+    assert inst.data is not None
+    assert "session_file" not in inst.data
+
+
+def test_result_data_with_session_file() -> None:
+    """New workers returning session_file in data validate without error."""
+    inst = JobResult.model_validate(
+        {
+            **_RESULT_BASE,
+            "data": {
+                "output": "done",
+                "session_file": "/tmp/omp-sessions/sess-xyz987.json",
+            },
+        }
+    )
+    assert inst.status == "success"
+    assert inst.data is not None
+    assert inst.data["session_file"] == "/tmp/omp-sessions/sess-xyz987.json"

--- a/tests/integration/test_omp_session_resume_integration.py
+++ b/tests/integration/test_omp_session_resume_integration.py
@@ -1,0 +1,324 @@
+"""Integration RED-GATE: OmpPool + OmpRpcDriver session resume (#1813).
+
+These tests wire OmpPool (with _start_client patched to a fake RpcClient) together
+with OmpRpcDriver (against an AsyncMock NATS connection) and assert the full
+cold-start → persist → resume lifecycle without requiring a live omp binary.
+
+They are skipped in CI (INTEGRATION env var not set).  Run locally or on M1 with:
+
+    INTEGRATION=1 uv run --frozen pytest \\
+        tests/integration/test_omp_session_resume_integration.py -x
+
+M1 end-to-end validation checklist (requires the live container)
+---------------------------------------------------------------
+1.  Reproduce start::
+
+        podman run --rm --userns keep-id \\
+          --secret factory-nats-omp,type=env,target=NATS_CREDS \\
+          --secret factory-litellm-key,type=env,target=LITELLM_API_KEY \\
+          --tmpfs /home/factory/.config/omp-pi:mode=1777 \\
+          --tmpfs /home/factory/.omp:mode=1777 \\
+          ghcr.io/roxabi/factory:staging \\
+          factory adapter omp
+
+2.  Wait for "ready" log line (``omp_worker: ready``).
+
+3.  Submit a test job via NATS CLI and assert ``JobResult.data.session_file``
+    is present in the result payload.
+
+4.  Submit a second job with ``provider_session_id`` matching the persisted
+    ``session_file`` path and assert ``switch_session`` is reflected in the
+    progress events (no ``new_session`` call on the omp side).
+
+5.  On failure::
+
+        podman logs factory-omp
+        podman exec factory-omp env | grep -E 'NATS|LITELLM|OMP'
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.adapters.omp.omp_pool import OmpPool
+from factory.llm.drivers.omp_rpc import OmpRpcDriver
+from roxabi_contracts.jobs import JobResult
+from roxabi_contracts.jobs.fixtures import sample_job_result_ok
+
+# ---------------------------------------------------------------------------
+# Module-level skip guard — all tests in this file require INTEGRATION=1
+# ---------------------------------------------------------------------------
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("INTEGRATION"),
+        reason="set INTEGRATION=1 to run omp session-resume integration tests",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_rpc_client(
+    session_file: str = "/tmp/omp/.omp/sessions/sess-abc.jsonl",
+) -> MagicMock:
+    """Return a MagicMock shaped like omp_rpc.RpcClient."""
+    client = MagicMock()
+    client.start.return_value = None
+    client.new_session.return_value = MagicMock()  # CancellationResult, NOT a path
+    client.switch_session.return_value = None
+    client.get_state.return_value = SimpleNamespace(session_file=session_file)
+    client.stop.return_value = None
+    return client
+
+
+def _make_pool_with_fake_start(
+    session_file: str = "/tmp/omp/.omp/sessions/sess-abc.jsonl",
+) -> tuple[OmpPool, list[MagicMock]]:
+    """OmpPool whose _start_client returns a fake client without exec'ing omp."""
+    pool = OmpPool(omp_bin=Path("/fake/omp"), provider="litellm", model="grok-4-fast")
+    issued: list[MagicMock] = []
+
+    async def _fake_start(self: OmpPool) -> MagicMock:  # type: ignore[override]
+        client = _mock_rpc_client(session_file=session_file)
+        issued.append(client)
+        return client
+
+    pool._start_client = lambda: _fake_start(pool)  # type: ignore[method-assign]
+    return pool, issued
+
+
+def _make_store(*, cli_session: str | None = None) -> AsyncMock:
+    """Return a fake _OmpSessionStore."""
+    store = AsyncMock()
+    store.get_cli_session = AsyncMock(return_value=cli_session)
+    store._set_cli_session = AsyncMock()  # noqa: SLF001
+    return store
+
+
+def _make_nc_with_result(result: JobResult) -> tuple[AsyncMock, AsyncMock]:
+    """Return (nc, sub) NATS mocks whose next_msg yields the given JobResult."""
+    nc = AsyncMock()
+    sub = AsyncMock()
+    nc.subscribe.return_value = sub
+    sub.next_msg.return_value = SimpleNamespace(data=result.model_dump_json().encode())
+    return nc, sub
+
+
+def _model_cfg() -> MagicMock:
+    cfg = MagicMock()
+    cfg.model_dump.return_value = {"backend": "omp-rpc", "model": "grok-4-fast"}
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Scenario (a): cold-start — session_file present in result AND persisted
+# ---------------------------------------------------------------------------
+
+
+class TestColdStartPersistsSessionFile:
+    """Cold-start job: JobResult.data carries session_file and store is written."""
+
+    @pytest.mark.asyncio
+    async def test_session_file_in_result_data(self) -> None:
+        """complete() returns a result whose data dict contains session_file."""
+        _pool, _issued = _make_pool_with_fake_start()
+
+        session_path = "/tmp/omp/.omp/sessions/sess-abc.jsonl"
+        result = JobResult.model_validate(
+            {
+                **sample_job_result_ok,
+                "data": {"result": "done", "session_file": session_path},
+            }
+        )
+        nc, _sub = _make_nc_with_result(result)
+
+        driver = OmpRpcDriver(nc, timeout_s=5.0)
+        store = _make_store()
+        driver.set_turn_store(store)
+        driver.link_lyra_session("pool-cold", "lyra-sess-cold")
+
+        res = await driver.complete(
+            pool_id="pool-cold",
+            text="first task",
+            model_cfg=_model_cfg(),
+            system_prompt="sys",
+        )
+
+        assert res.ok is True
+        assert res.data.get("session_file") == session_path
+
+    @pytest.mark.asyncio
+    async def test_session_file_persisted_in_store(self) -> None:
+        """After complete(), store._set_cli_session is called with the session path."""
+        session_path = "/tmp/omp/.omp/sessions/sess-abc.jsonl"
+        result = JobResult.model_validate(
+            {
+                **sample_job_result_ok,
+                "data": {"result": "done", "session_file": session_path},
+            }
+        )
+        nc, _sub = _make_nc_with_result(result)
+
+        driver = OmpRpcDriver(nc, timeout_s=5.0)
+        store = _make_store()
+        driver.set_turn_store(store)
+        driver.link_lyra_session("pool-persist", "lyra-sess-persist")
+
+        await driver.complete(
+            pool_id="pool-persist",
+            text="task",
+            model_cfg=_model_cfg(),
+            system_prompt="sys",
+        )
+
+        store._set_cli_session.assert_awaited_once_with(  # noqa: SLF001
+            "lyra-sess-persist", session_path
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario (b): resume — switch_session called with the persisted session_file
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCallsSwitchSession:
+    """Resume path: queue_resume + complete → OmpPool.acquire uses persisted path."""
+
+    @pytest.mark.asyncio
+    async def test_switch_session_called_with_persisted_path(self) -> None:
+        """Resuming a known session causes OmpPool to call switch_session on the
+        RpcClient with the previously persisted session_file path.
+
+        Flow:
+          1. store pre-populated with cli_session token from a prior cold-start
+          2. queue_resume() looks up the token → True
+          3. OmpPool.acquire() called with that token → switch_session(token)
+        """
+        persisted_path = "/tmp/omp/.omp/sessions/persisted.jsonl"
+        pool, issued = _make_pool_with_fake_start(session_file=persisted_path)
+
+        # Simulate: store already has the persisted path from a prior job
+        store = _make_store(cli_session=persisted_path)
+
+        nc = AsyncMock()
+        sub = AsyncMock()
+        nc.subscribe.return_value = sub
+
+        driver = OmpRpcDriver(nc, timeout_s=5.0)
+        driver.set_turn_store(store)
+
+        # queue_resume() must find the token in the store
+        resumed = await driver.queue_resume(
+            pool_id="pool-resume", session_id="lyra-sess-resume"
+        )
+        assert resumed is True, "queue_resume must return True when store has a token"
+
+        # The pending token is stashed
+        assert driver._pending_resume.get("pool-resume") == persisted_path  # noqa: SLF001
+
+        # Now acquire the OmpPool slot with the stashed session_file
+        pending_token = driver._pending_resume.pop("pool-resume")  # noqa: SLF001
+        _client = await pool.acquire("pool-resume", session_file=pending_token)
+
+        # switch_session must have been called with the persisted path
+        assert len(issued) == 1
+        issued[0].switch_session.assert_called_once_with(persisted_path)
+        issued[0].new_session.assert_not_called()
+        issued[0].get_state.assert_not_called()
+
+        await pool.aclose()
+
+    @pytest.mark.asyncio
+    async def test_queue_resume_returns_false_when_no_stored_session(self) -> None:
+        """queue_resume returns False when the store has no prior session for the id."""
+        nc = AsyncMock()
+        nc.subscribe.return_value = AsyncMock()
+
+        driver = OmpRpcDriver(nc, timeout_s=5.0)
+        store = _make_store(cli_session=None)
+        driver.set_turn_store(store)
+
+        resumed = await driver.queue_resume(
+            pool_id="pool-new", session_id="lyra-sess-new"
+        )
+
+        assert resumed is False
+        assert "pool-new" not in driver._pending_resume  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Scenario (c): OmpPool cap=1 with two pool_ids — evicts without raising
+# ---------------------------------------------------------------------------
+
+
+class TestOmpPoolLruEviction:
+    """OmpPool at cap=1: acquiring a second pool_id evicts the first without error."""
+
+    @pytest.mark.asyncio
+    async def test_cap1_two_pool_ids_evicts_without_raising(self) -> None:
+        """With OMP_POOL_CAP=1, acquiring a second pool_id must:
+        - stop the first client (LRU evicted)
+        - not raise any exception
+        - leave only the new entry in the pool
+        """
+        import os
+        from unittest.mock import patch
+
+        pool, issued = _make_pool_with_fake_start()
+
+        with patch.dict(os.environ, {"OMP_POOL_CAP": "1"}):
+            client_a = await pool.acquire("pool-id-1", session_file=None)
+            assert len(issued) == 1
+
+            # Acquiring a second pool_id at cap=1 must evict pool-id-1 silently
+            client_b = await pool.acquire("pool-id-2", session_file=None)
+
+        assert len(issued) == 2
+
+        # pool-id-1 evicted; pool-id-2 present
+        assert "pool-id-1" not in pool._entries  # noqa: SLF001
+        assert "pool-id-2" in pool._entries  # noqa: SLF001
+        assert len(pool._entries) == 1  # noqa: SLF001
+
+        # LRU stop was called on the evicted client
+        client_a.stop.assert_called_once()
+        client_b.stop.assert_not_called()
+
+        await pool.aclose()
+
+    @pytest.mark.asyncio
+    async def test_cap1_stop_error_does_not_propagate(self) -> None:
+        """If client.stop() raises during LRU eviction, the error is swallowed
+        and the new acquire still succeeds (forward-progress guarantee)."""
+        import os
+        from unittest.mock import patch
+
+        pool, issued = _make_pool_with_fake_start()
+
+        with patch.dict(os.environ, {"OMP_POOL_CAP": "1"}):
+            await pool.acquire("pool-err-1", session_file=None)
+            assert len(issued) == 1
+
+            # Make stop() raise on the first client
+            issued[0].stop.side_effect = RuntimeError("omp died")
+
+            # Must NOT propagate — forward progress guaranteed by pool invariant
+            client_b = await pool.acquire("pool-err-2", session_file=None)
+
+        assert len(issued) == 2
+        assert "pool-err-2" in pool._entries  # noqa: SLF001
+        assert client_b is issued[1]
+
+        # Prevent stop() raising again during aclose
+        issued[1].stop.side_effect = None
+        await pool.aclose()

--- a/tests/integration/test_omp_session_resume_integration.py
+++ b/tests/integration/test_omp_session_resume_integration.py
@@ -129,8 +129,11 @@ class TestColdStartPersistsSessionFile:
     """Cold-start job: JobResult.data carries session_file and store is written."""
 
     @pytest.mark.asyncio
-    async def test_session_file_in_result_data(self) -> None:
-        """complete() returns a result whose data dict contains session_file."""
+    async def test_cold_start_complete_returns_text(self) -> None:
+        """Cold-start: complete() returns an ok LlmResult carrying the assistant text.
+
+        The session_file rides JobResult.data and is persisted to the store — it is
+        NOT surfaced on LlmResult (see test_session_file_persisted_in_store)."""
         _pool, _issued = _make_pool_with_fake_start()
 
         session_path = "/tmp/omp/.omp/sessions/sess-abc.jsonl"
@@ -155,7 +158,7 @@ class TestColdStartPersistsSessionFile:
         )
 
         assert res.ok is True
-        assert res.data.get("session_file") == session_path
+        assert res.result == "done"
 
     @pytest.mark.asyncio
     async def test_session_file_persisted_in_store(self) -> None:

--- a/tests/llm/drivers/test_omp_pool.py
+++ b/tests/llm/drivers/test_omp_pool.py
@@ -1,0 +1,194 @@
+"""Tests for OmpPool — worker-side LRU pool of warm omp_rpc.RpcClients.
+
+Four scenarios:
+  1. warm-hit reuse — second acquire returns the same client, no re-start/new_session
+  2. cold-start-with-token — switch_session() called with the provided session_file
+  3. cold-start-no-token — new_session() + get_state() called; minted path stored
+  4. LRU evict at cap — oldest entry is stopped when cap is reached
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from factory.adapters.omp.omp_pool import _DEFAULT_CAP, OmpPool, _read_cap
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_rpc_client(session_file: str = "/tmp/session.jsonl") -> MagicMock:
+    """Return a MagicMock whose blocking RpcClient methods record calls."""
+    client = MagicMock()
+    client.start.return_value = None
+    client.new_session.return_value = MagicMock()  # CancellationResult, NOT a path
+    client.switch_session.return_value = None
+    # get_state returns an object with a session_file attribute
+    client.get_state.return_value = SimpleNamespace(session_file=session_file)
+    client.stop.return_value = None
+    return client
+
+
+def _make_pool_with_fake_start(
+    clients: list[MagicMock] | None = None,
+) -> tuple[OmpPool, list[MagicMock]]:
+    """Return an OmpPool whose _start_client is patched to hand out fake clients."""
+    pool = OmpPool(omp_bin=Path("/fake/omp"), provider="litellm", model="grok-4-fast")
+    issued: list[MagicMock] = clients if clients is not None else []
+
+    async def _fake_start(self: OmpPool) -> MagicMock:  # type: ignore[override]
+        client = _mock_rpc_client()
+        client.start()  # mirror real _start_client (constructs + starts the client)
+        issued.append(client)
+        return client
+
+    pool._start_client = lambda: _fake_start(pool)  # type: ignore[method-assign]
+    return pool, issued
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOmpPool:
+    # -- 1. warm-hit reuse ---------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_warm_hit_reuses_same_client(self) -> None:
+        """Second acquire for the same pool_id returns the exact same client
+        without calling start(), new_session(), or switch_session() again."""
+        pool, issued = _make_pool_with_fake_start()
+
+        first = await pool.acquire("user:1", session_file=None)
+        second = await pool.acquire("user:1", session_file=None)
+
+        assert first is second, "warm hit must return the same client object"
+        assert len(issued) == 1, "only one client should have been constructed"
+        # start() called exactly once (during cold start)
+        issued[0].start.assert_called_once()
+        # new_session called once (cold start), NOT on the warm hit
+        assert issued[0].new_session.call_count == 1
+
+        await pool.aclose()
+
+    # -- 2. cold-start with session_file (switch_session) --------------------
+
+    @pytest.mark.asyncio
+    async def test_cold_start_with_token_calls_switch_session(self) -> None:
+        """Cold start with a non-None session_file calls switch_session with
+        that path and does NOT call new_session or get_state."""
+        pool, issued = _make_pool_with_fake_start()
+        token = "/home/.omp/sessions/abc123.jsonl"
+
+        client = await pool.acquire("user:2", session_file=token)
+
+        assert len(issued) == 1
+        issued[0].switch_session.assert_called_once_with(token)
+        issued[0].new_session.assert_not_called()
+        issued[0].get_state.assert_not_called()
+
+        # The returned client is the one we handed out
+        assert client is issued[0]
+
+        await pool.aclose()
+
+    # -- 3. cold-start without token (new_session + get_state) ---------------
+
+    @pytest.mark.asyncio
+    async def test_cold_start_no_token_calls_new_session_and_get_state(
+        self,
+    ) -> None:
+        """Cold start with session_file=None calls new_session() then get_state()
+        to obtain the minted .jsonl path.  switch_session must NOT be called."""
+        pool, issued = _make_pool_with_fake_start()
+
+        client = await pool.acquire("user:3", session_file=None)
+
+        assert len(issued) == 1
+        issued[0].new_session.assert_called_once()
+        issued[0].get_state.assert_called_once()
+        issued[0].switch_session.assert_not_called()
+
+        # The minted session path is stored on the pool entry
+        entry = pool._entries["user:3"]
+        assert entry.session_file == "/tmp/session.jsonl"
+
+        assert client is issued[0]
+
+        await pool.aclose()
+
+    # -- 4. LRU evict at cap -------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_lru_evict_at_cap_stops_oldest_entry(self) -> None:
+        """When the pool is at cap (OMP_POOL_CAP=2 for this test), acquiring a
+        new pool_id evicts the least-recently-used entry and calls stop() on it."""
+        pool, issued = _make_pool_with_fake_start()
+
+        # Patch cap to 2 so the test is deterministic and fast
+        with patch.dict(os.environ, {"OMP_POOL_CAP": "2"}):
+            # Fill pool to cap
+            client_a = await pool.acquire("user:A", session_file=None)
+            client_b = await pool.acquire("user:B", session_file=None)
+
+            assert len(issued) == 2
+            assert len(pool._entries) == 2
+
+            # Touch B again to make A the LRU
+            await pool.acquire("user:B", session_file=None)
+
+            # Acquire C — should evict A (LRU)
+            client_c = await pool.acquire("user:C", session_file=None)
+
+        assert len(issued) == 3
+        # Pool should have B and C; A is evicted
+        assert "user:A" not in pool._entries
+        assert "user:B" in pool._entries
+        assert "user:C" in pool._entries
+        assert len(pool._entries) == 2
+
+        # stop() must have been called on A's client
+        client_a.stop.assert_called_once()
+        # B and C are still alive (stop not called yet)
+        client_b.stop.assert_not_called()
+        client_c.stop.assert_not_called()
+
+        await pool.aclose()
+
+    # -- 5. aclose stops all clients -----------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_aclose_stops_all_clients(self) -> None:
+        """aclose() calls stop() on every live client and clears _entries."""
+        pool, issued = _make_pool_with_fake_start()
+
+        await pool.acquire("user:X", session_file=None)
+        await pool.acquire("user:Y", session_file="/tmp/y.jsonl")
+        assert len(issued) == 2
+
+        await pool.aclose()
+
+        for client in issued:
+            client.stop.assert_called_once()
+        assert len(pool._entries) == 0
+
+    # -- 6. _read_cap falls back to default ----------------------------------
+
+    def test_read_cap_defaults_to_four(self) -> None:
+        """_read_cap() returns _DEFAULT_CAP when OMP_POOL_CAP is unset."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("OMP_POOL_CAP", None)
+            assert _read_cap() == _DEFAULT_CAP
+            assert _DEFAULT_CAP == 4
+
+    def test_read_cap_honours_env_var(self) -> None:
+        """_read_cap() returns the integer value of OMP_POOL_CAP when set."""
+        with patch.dict(os.environ, {"OMP_POOL_CAP": "7"}):
+            assert _read_cap() == 7

--- a/tests/llm/drivers/test_omp_rpc_session.py
+++ b/tests/llm/drivers/test_omp_rpc_session.py
@@ -150,6 +150,8 @@ class TestOmpRpcDriverSession:
         envelope = json.loads(published_bytes)
         payload = envelope["payload"]
         assert payload.get("provider_session_id") == "cli-tok-xyz"
+        # B1 regression-lock: pool_id MUST ride the wire — the worker routes on it.
+        assert payload.get("pool_id") == "pool-1"
 
         # Token consumed — second call must NOT re-inject
         sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))

--- a/tests/llm/drivers/test_omp_rpc_session.py
+++ b/tests/llm/drivers/test_omp_rpc_session.py
@@ -1,0 +1,308 @@
+"""Tests for OmpRpcDriver SessionAware protocol (T6).
+
+Falsification: run `git stash -- src/factory/llm/drivers/omp_rpc.py` (before
+T6 changes) then `pytest tests/llm/drivers/test_omp_rpc_session.py -x`.
+
+Expected result:
+  - test_queue_resume_resolves_and_stashes   → FAIL (AttributeError: no queue_resume)
+  - test_complete_injects_provider_session_id → FAIL (provider_session_id absent)
+  - test_complete_persists_session_file       → FAIL (no queue_resume / no persist)
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.llm.drivers.omp_rpc import OmpRpcDriver
+from roxabi_contracts.jobs import JobResult
+from roxabi_contracts.jobs.fixtures import sample_job_result_ok
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode_result(result: JobResult) -> bytes:
+    return result.model_dump_json().encode()
+
+
+def _make_store(
+    *,
+    cli_session: str | None = "cli-tok-abc",
+) -> AsyncMock:
+    """Return a fake _OmpSessionStore."""
+    store = AsyncMock()
+    store.get_cli_session = AsyncMock(return_value=cli_session)
+    store._set_cli_session = AsyncMock()  # noqa: SLF001
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def nc() -> AsyncMock:
+    mock_nc = AsyncMock()
+    sub = AsyncMock()
+    mock_nc.subscribe.return_value = sub
+    return mock_nc
+
+
+@pytest.fixture()
+def sub(nc: AsyncMock) -> AsyncMock:
+    return nc.subscribe.return_value
+
+
+@pytest.fixture()
+def model_cfg() -> MagicMock:
+    cfg = MagicMock()
+    cfg.model_dump.return_value = {"backend": "omp-rpc", "model": "grok-4-fast"}
+    return cfg
+
+
+@pytest.fixture()
+def driver(nc: AsyncMock) -> OmpRpcDriver:
+    return OmpRpcDriver(nc, timeout_s=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOmpRpcDriverSession:
+    # -- (1) queue_resume resolves and stashes --
+
+    @pytest.mark.asyncio
+    async def test_queue_resume_resolves_and_stashes(
+        self, driver: OmpRpcDriver
+    ) -> None:
+        """queue_resume() looks up cli_session_id from the store and stashes it.
+
+        Contract:
+          - returns True when cli_session_id is found
+          - _pending_resume[pool_id] is set to the resolved token
+        """
+        store = _make_store(cli_session="cli-tok-abc")
+        driver.set_turn_store(store)
+
+        result = await driver.queue_resume(pool_id="pool-1", session_id="lyra-sess-1")
+
+        assert result is True
+        store.get_cli_session.assert_awaited_once_with("lyra-sess-1")
+        assert driver._pending_resume.get("pool-1") == "cli-tok-abc"  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_queue_resume_returns_false_when_no_session(
+        self, driver: OmpRpcDriver
+    ) -> None:
+        """queue_resume() returns False and leaves _pending_resume empty when
+        no cli_session_id exists for the given session_id."""
+        store = _make_store(cli_session=None)
+        driver.set_turn_store(store)
+
+        result = await driver.queue_resume(pool_id="pool-x", session_id="no-such")
+
+        assert result is False
+        assert "pool-x" not in driver._pending_resume  # noqa: SLF001
+
+    # -- (2) complete() injects provider_session_id --
+
+    @pytest.mark.asyncio
+    async def test_complete_injects_provider_session_id(
+        self,
+        driver: OmpRpcDriver,
+        nc: AsyncMock,
+        sub: AsyncMock,
+        model_cfg: MagicMock,
+    ) -> None:
+        """After queue_resume(), complete() injects provider_session_id into payload.
+
+        Contract:
+          - published envelope payload contains provider_session_id == resolved token
+          - _pending_resume is cleared after the call (token consumed exactly once)
+        """
+        store = _make_store(cli_session="cli-tok-xyz")
+        driver.set_turn_store(store)
+        await driver.queue_resume(pool_id="pool-1", session_id="lyra-sess-1")
+
+        success_result = JobResult.model_validate(
+            {**sample_job_result_ok, "data": {"result": "ok"}}
+        )
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+
+        res = await driver.complete(
+            pool_id="pool-1",
+            text="hello",
+            model_cfg=model_cfg,
+            system_prompt="sys",
+        )
+
+        assert res.ok is True
+
+        published_bytes = nc.publish.await_args.args[1]
+        envelope = json.loads(published_bytes)
+        payload = envelope["payload"]
+        assert payload.get("provider_session_id") == "cli-tok-xyz"
+
+        # Token consumed — second call must NOT re-inject
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+        await driver.complete(
+            pool_id="pool-1", text="again", model_cfg=model_cfg, system_prompt="sys"
+        )
+        second_payload = json.loads(nc.publish.await_args.args[1])["payload"]
+        assert "provider_session_id" not in second_payload
+
+    @pytest.mark.asyncio
+    async def test_complete_no_injection_without_queue_resume(
+        self,
+        driver: OmpRpcDriver,
+        sub: AsyncMock,
+        nc: AsyncMock,
+        model_cfg: MagicMock,
+    ) -> None:
+        """complete() must NOT inject provider_session_id.
+
+        Precondition: queue_resume was NOT called before this complete().
+        """
+        success_result = JobResult.model_validate(
+            {**sample_job_result_ok, "data": {"result": "ok"}}
+        )
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+
+        await driver.complete(
+            pool_id="pool-2", text="hi", model_cfg=model_cfg, system_prompt="s"
+        )
+
+        published_bytes = nc.publish.await_args.args[1]
+        payload = json.loads(published_bytes)["payload"]
+        assert "provider_session_id" not in payload
+
+    # -- (3) complete() persists session_file --
+
+    @pytest.mark.asyncio
+    async def test_complete_persists_session_file(
+        self,
+        driver: OmpRpcDriver,
+        sub: AsyncMock,
+        model_cfg: MagicMock,
+    ) -> None:
+        """On success with session_file in JobResult.data, _set_cli_session is called.
+
+        Contract:
+          - driver must have link_lyra_session() set for the pool_id
+          - _set_cli_session(session_id, session_file_path) is awaited exactly once
+          - session_id is the lyra session_id linked via link_lyra_session()
+        """
+        store = _make_store()
+        driver.set_turn_store(store)
+        driver.link_lyra_session("pool-3", "lyra-sess-99")
+
+        success_result = JobResult.model_validate(
+            {
+                **sample_job_result_ok,
+                "data": {
+                    "result": "done",
+                    "session_file": "/tmp/omp/.omp/sessions/sess-abc.json",
+                },
+            }
+        )
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+
+        res = await driver.complete(
+            pool_id="pool-3", text="q", model_cfg=model_cfg, system_prompt="s"
+        )
+
+        assert res.ok is True
+        store._set_cli_session.assert_awaited_once_with(  # noqa: SLF001
+            "lyra-sess-99", "/tmp/omp/.omp/sessions/sess-abc.json"
+        )
+
+    @pytest.mark.asyncio
+    async def test_complete_skips_persist_when_no_session_file(
+        self,
+        driver: OmpRpcDriver,
+        sub: AsyncMock,
+        model_cfg: MagicMock,
+    ) -> None:
+        """When JobResult.data has no session_file, _set_cli_session is NOT called."""
+        store = _make_store()
+        driver.set_turn_store(store)
+        driver.link_lyra_session("pool-4", "lyra-sess-42")
+
+        success_result = JobResult.model_validate(
+            {**sample_job_result_ok, "data": {"result": "done"}}
+        )
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+
+        await driver.complete(
+            pool_id="pool-4", text="q", model_cfg=model_cfg, system_prompt="s"
+        )
+
+        store._set_cli_session.assert_not_awaited()  # noqa: SLF001
+
+    # -- (4) cross-conversation isolation --
+
+    @pytest.mark.asyncio
+    async def test_cross_conversation_isolation(
+        self,
+        driver: OmpRpcDriver,
+        nc: AsyncMock,
+        sub: AsyncMock,
+        model_cfg: MagicMock,
+    ) -> None:
+        """Tokens from distinct sessions never bleed across pools.
+
+        Contract:
+          - Each pool_id stashes the token belonging to its own session_id
+          - complete() for poolA injects tokA (not tokB), and vice-versa
+          - _pending_resume is consumed independently per pool
+        """
+        # Arrange — store returns a different token per session_id
+        session_tokens: dict[str, str] = {"sessA": "tokA", "sessB": "tokB"}
+
+        store = AsyncMock()
+        store.get_cli_session = AsyncMock(
+            side_effect=lambda sid: session_tokens.get(sid)
+        )
+        store._set_cli_session = AsyncMock()  # noqa: SLF001
+        driver.set_turn_store(store)
+
+        driver.link_lyra_session("poolA", "sessA")
+        driver.link_lyra_session("poolB", "sessB")
+
+        await driver.queue_resume(pool_id="poolA", session_id="sessA")
+        await driver.queue_resume(pool_id="poolB", session_id="sessB")
+
+        # Assert stash contains correct tokens for both pools, no bleed
+        assert driver._pending_resume == {"poolA": "tokA", "poolB": "tokB"}  # noqa: SLF001
+
+        success_result = JobResult.model_validate(
+            {**sample_job_result_ok, "data": {"result": "ok"}}
+        )
+
+        # Act + Assert — poolA injects tokA
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+        await driver.complete(
+            pool_id="poolA", text="hello", model_cfg=model_cfg, system_prompt="sys"
+        )
+        published_bytes_a = nc.publish.await_args.args[1]
+        payload_a = json.loads(published_bytes_a)["payload"]
+        assert payload_a.get("provider_session_id") == "tokA"
+        assert "poolA" not in driver._pending_resume  # noqa: SLF001
+
+        # Act + Assert — poolB injects tokB (not tokA)
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success_result))
+        await driver.complete(
+            pool_id="poolB", text="world", model_cfg=model_cfg, system_prompt="sys"
+        )
+        published_bytes_b = nc.publish.await_args.args[1]
+        payload_b = json.loads(published_bytes_b)["payload"]
+        assert payload_b.get("provider_session_id") == "tokB"
+        assert "poolB" not in driver._pending_resume  # noqa: SLF001

--- a/tests/llm/drivers/test_omp_worker_pool.py
+++ b/tests/llm/drivers/test_omp_worker_pool.py
@@ -1,0 +1,234 @@
+"""Tests for OmpWorker pool wiring (T4 — runtime-selection V2).
+
+Three scenarios:
+  1. handle() extracts pool_id + provider_session_id and calls pool.acquire
+     with the correct arguments.
+  2. bridge.run() receives client= and session_file= matching the pool entry
+     (i.e. JobResult.data would carry session_file).
+  3. OmpWorker does not import sqlite3 or access config.db (dumb executor
+     invariant — ADR-073).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.adapters.omp.omp_pool import OmpPool
+from factory.adapters.omp.omp_worker import OmpWorker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXED_NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+_JOB_ID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"  # 32 hex chars
+_POOL_ID = "user:conv-42"
+_SESSION_FILE = "/home/factory/.omp/sessions/abc123.jsonl"
+_REPLY_TO = "factory.reply.test"
+
+
+def _base_payload(
+    *,
+    pool_id: str = _POOL_ID,
+    provider_session_id: str | None = _SESSION_FILE,
+    prompt: str = "hello omp",
+) -> dict:
+    """Minimal valid JobEnvelope dict for a V2 omp job."""
+    payload: dict = {
+        "contract_version": "1",
+        "trace_id": "trace-test-001",
+        "issued_at": _FIXED_NOW.isoformat(),
+        "job_id": _JOB_ID,
+        "job_name": "omp",
+        "reply_to": _REPLY_TO,
+        "payload": {
+            "prompt": prompt,
+            "pool_id": pool_id,
+        },
+    }
+    if provider_session_id is not None:
+        payload["payload"]["provider_session_id"] = provider_session_id
+    return payload
+
+
+def _mock_pool(session_file: str = _SESSION_FILE) -> MagicMock:
+    """Return a MagicMock OmpPool whose acquire() succeeds and entries readable.
+
+    The ``session_file`` argument is the path that the pool entry will report
+    back after acquire() — mimicking what OmpPool stores in _entries[pool_id].
+    When the caller passes ``provider_session_id=None`` (no-token cold start),
+    the pool mints a new session path; ``session_file`` is that minted path.
+    When the caller passes a non-None ``session_file`` kwarg to acquire(), the
+    pool stores that exact path on the entry.
+    """
+    fake_client = MagicMock()
+    pool = MagicMock(spec=OmpPool)
+    pool.aclose = AsyncMock()
+    pool._entries = {}  # start empty; populated below
+
+    # Capture the pool-level default so the closure sees the right value.
+    _default_sf = session_file
+
+    async def _side_effect_acquire(pid: str, *, session_file: str | None) -> MagicMock:
+        # Mimic OmpPool: if a session_file was provided use it; otherwise use
+        # the minted default (the value passed to _mock_pool()).
+        stored = session_file if session_file is not None else _default_sf
+        pool._entries[pid] = SimpleNamespace(session_file=stored)
+        return fake_client
+
+    pool.acquire = AsyncMock(side_effect=_side_effect_acquire)
+    return pool
+
+
+def _mock_bridge() -> MagicMock:
+    """Return a MagicMock RpcBridge whose async methods are AsyncMocks."""
+    bridge = MagicMock()
+    bridge.register = AsyncMock()
+    bridge.run = AsyncMock()
+    bridge.publish_error = AsyncMock()
+    bridge.aclose = AsyncMock()
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOmpWorkerPool:
+    # -- 1. handle() routes to pool.acquire with correct args ------------------
+
+    @pytest.mark.asyncio
+    async def test_handle_routes_to_pool_acquire(self) -> None:
+        """handle() extracts pool_id and provider_session_id from the envelope
+        payload and calls pool.acquire(pool_id, session_file=provider_session_id)."""
+        pool = _mock_pool()
+        bridge = _mock_bridge()
+        worker = OmpWorker(bridge=bridge, pool=pool)
+
+        payload = _base_payload(
+            pool_id=_POOL_ID,
+            provider_session_id=_SESSION_FILE,
+        )
+        await worker.handle(msg=None, payload=payload)
+
+        pool.acquire.assert_called_once_with(_POOL_ID, session_file=_SESSION_FILE)
+
+    @pytest.mark.asyncio
+    async def test_handle_passes_none_when_provider_session_id_absent(self) -> None:
+        """When provider_session_id is absent from the payload, pool.acquire
+        is called with session_file=None (never an empty string)."""
+        pool = _mock_pool()
+        bridge = _mock_bridge()
+        worker = OmpWorker(bridge=bridge, pool=pool)
+
+        payload = _base_payload(pool_id=_POOL_ID, provider_session_id=None)
+        await worker.handle(msg=None, payload=payload)
+
+        pool.acquire.assert_called_once_with(_POOL_ID, session_file=None)
+
+    @pytest.mark.asyncio
+    async def test_handle_passes_none_when_provider_session_id_empty_string(
+        self,
+    ) -> None:
+        """Empty-string provider_session_id is normalised to None before
+        being passed to pool.acquire (never pass empty string)."""
+        pool = _mock_pool()
+        bridge = _mock_bridge()
+        worker = OmpWorker(bridge=bridge, pool=pool)
+
+        # Inject empty string directly into payload
+        payload = _base_payload(pool_id=_POOL_ID, provider_session_id=None)
+        payload["payload"]["provider_session_id"] = ""  # explicit empty string
+        await worker.handle(msg=None, payload=payload)
+
+        pool.acquire.assert_called_once_with(_POOL_ID, session_file=None)
+
+    @pytest.mark.asyncio
+    async def test_handle_rejects_missing_pool_id(self) -> None:
+        """handle() publishes an error and returns when pool_id is absent."""
+        pool = _mock_pool()
+        bridge = _mock_bridge()
+        worker = OmpWorker(bridge=bridge, pool=pool)
+
+        payload = _base_payload(pool_id="", provider_session_id=None)
+        # Remove pool_id key entirely
+        del payload["payload"]["pool_id"]
+        await worker.handle(msg=None, payload=payload)
+
+        pool.acquire.assert_not_called()
+        bridge.publish_error.assert_called_once()
+
+    # -- 2. bridge.run receives session_file from pool entry -------------------
+
+    @pytest.mark.asyncio
+    async def test_bridge_run_receives_session_file_from_pool(self) -> None:
+        """bridge.run() is called with session_file= matching the pool entry's
+        session_file (which backs the session_file key in JobResult.data)."""
+        minted = "/home/factory/.omp/sessions/minted-xyz.jsonl"
+        pool = _mock_pool(session_file=minted)
+        bridge = _mock_bridge()
+        worker = OmpWorker(bridge=bridge, pool=pool)
+
+        payload = _base_payload(pool_id=_POOL_ID, provider_session_id=None)
+        await worker.handle(msg=None, payload=payload)
+
+        # bridge.run must have been called with the minted session file
+        bridge.run.assert_called_once()
+        _call_kwargs = bridge.run.call_args.kwargs
+        got = _call_kwargs.get("session_file")
+        assert got == minted, (
+            f"Expected session_file={minted!r} in bridge.run kwargs, got {got!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bridge_run_receives_client_from_pool(self) -> None:
+        """bridge.run() is called with the client object returned by pool.acquire."""
+        pool = _mock_pool()
+        bridge = _mock_bridge()
+        worker = OmpWorker(bridge=bridge, pool=pool)
+
+        payload = _base_payload(pool_id=_POOL_ID, provider_session_id=_SESSION_FILE)
+        await worker.handle(msg=None, payload=payload)
+
+        bridge.run.assert_called_once()
+        _call_kwargs = bridge.run.call_args.kwargs
+        # Verify bridge.run received a non-None client object from pool.acquire.
+        assert "client" in _call_kwargs, "bridge.run must receive client= kwarg"
+        assert _call_kwargs["client"] is not None
+
+    # -- 3. dumb-executor invariant: no config.db / sqlite3 access -----------
+
+    def test_omp_worker_does_not_import_sqlite3(self) -> None:
+        """OmpWorker module must not import sqlite3 — dumb executor invariant.
+
+        Workers must NOT read config.db; sqlite3 in the module-level import
+        graph would violate the 'worker stays dumb' constraint (ADR-073).
+        """
+        import factory.adapters.omp.omp_worker as worker_mod
+
+        # Direct module-level import check
+        assert "sqlite3" not in dir(worker_mod), (
+            "sqlite3 must not be imported at module level in omp_worker"
+        )
+        # Also check the module's __dict__ for the sqlite3 module object
+        assert "sqlite3" not in worker_mod.__dict__, (
+            "sqlite3 must not be a name in omp_worker module namespace"
+        )
+
+    def test_omp_worker_source_has_no_config_db_reference(self) -> None:
+        """OmpWorker source file must not reference 'config.db' — dumb executor
+        invariant.  A worker reading from config.db couples it to the hub's
+        database, which breaks horizontal scaling and ADR-073 isolation."""
+        import factory.adapters.omp.omp_worker as worker_mod
+
+        source_file = Path(worker_mod.__file__)  # type: ignore[arg-type]
+        source_text = source_file.read_text(encoding="utf-8")
+        assert "config.db" not in source_text, (
+            "omp_worker.py must not reference 'config.db'"
+        )

--- a/tests/llm/drivers/test_omp_worker_pool.py
+++ b/tests/llm/drivers/test_omp_worker_pool.py
@@ -150,19 +150,21 @@ class TestOmpWorkerPool:
         pool.acquire.assert_called_once_with(_POOL_ID, session_file=None)
 
     @pytest.mark.asyncio
-    async def test_handle_rejects_missing_pool_id(self) -> None:
-        """handle() publishes an error and returns when pool_id is absent."""
+    async def test_handle_falls_back_to_job_id_when_pool_id_absent(self) -> None:
+        """B3 wire-compat: a pre-V2 envelope without pool_id is NOT rejected —
+        handle() falls back to job_id as the routing key and proceeds."""
         pool = _mock_pool()
         bridge = _mock_bridge()
         worker = OmpWorker(bridge=bridge, pool=pool)
 
         payload = _base_payload(pool_id="", provider_session_id=None)
-        # Remove pool_id key entirely
+        # Remove pool_id key entirely → simulate an old (pre-V2) sender.
         del payload["payload"]["pool_id"]
         await worker.handle(msg=None, payload=payload)
 
-        pool.acquire.assert_not_called()
-        bridge.publish_error.assert_called_once()
+        # Falls back to job_id, routes to the pool, does NOT publish an error.
+        pool.acquire.assert_called_once_with(_JOB_ID, session_file=None)
+        bridge.publish_error.assert_not_called()
 
     # -- 2. bridge.run receives session_file from pool entry -------------------
 

--- a/tests/llm/test_session_protocols.py
+++ b/tests/llm/test_session_protocols.py
@@ -1,0 +1,66 @@
+"""Tests for SessionAware and WorkspaceAware capability protocols (llm.py)."""
+
+from pathlib import Path
+
+from factory.core.ports.llm import SessionAware, WorkspaceAware
+
+# ---------------------------------------------------------------------------
+# SessionAware
+# ---------------------------------------------------------------------------
+
+
+class _FullSessionAware:
+    """Dummy that satisfies all three SessionAware methods."""
+
+    def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
+        pass
+
+    async def reset(self, pool_id: str) -> None:
+        pass
+
+    async def queue_resume(self, pool_id: str, session_id: str) -> bool:
+        return True
+
+
+class _MissingQueueResume:
+    """Dummy missing ``queue_resume`` — must NOT satisfy SessionAware."""
+
+    def link_lyra_session(self, pool_id: str, lyra_session_id: str) -> None:
+        pass
+
+    async def reset(self, pool_id: str) -> None:
+        pass
+
+
+def test_session_aware_is_runtime_checkable() -> None:
+    assert isinstance(_FullSessionAware(), SessionAware)
+
+
+def test_session_aware_missing_method_fails() -> None:
+    assert not isinstance(_MissingQueueResume(), SessionAware)
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceAware
+# ---------------------------------------------------------------------------
+
+
+class _FullWorkspaceAware:
+    """Dummy that satisfies the single WorkspaceAware method."""
+
+    async def switch_cwd(self, pool_id: str, cwd: Path) -> None:
+        pass
+
+
+class _MissingSwitchCwd:
+    """Dummy missing ``switch_cwd`` — must NOT satisfy WorkspaceAware."""
+
+    pass
+
+
+def test_workspace_aware_is_runtime_checkable() -> None:
+    assert isinstance(_FullWorkspaceAware(), WorkspaceAware)
+
+
+def test_workspace_aware_missing_method_fails() -> None:
+    assert not isinstance(_MissingSwitchCwd(), WorkspaceAware)


### PR DESCRIPTION
## Summary
Slice **V2** of the runtime-selection epic (#1813).

- **Native-session memory:** omp agents now remember context across turns via a **hub-driven** session token (mirror of clipool's `cli_session_id`). `OmpRpcDriver` gains real `SessionAware` methods (`_turn_store`/`_pending_resume`): `queue_resume` resolves the token, `complete()` injects `provider_session_id` into the `JobEnvelope` and persists the backhauled `session_file`.
- **`OmpPool`** (worker-side, CliPool mirror): warm `RpcClient` per `pool_id`, LRU evict at `OMP_POOL_CAP` (env, default 4), cold-start `switch_session(session_file)` or `new_session()`+`get_state()`. Worker stays a dumb executor.
- **Dispatch unified (Axis A):** standalone `SessionAware` / `WorkspaceAware` protocols replace the four `_cli_pool`/`_cli_nats_driver` branch sites in `SimpleAgent` with `isinstance` resolution — collapses the pre-existing 2-branch duplication, absorbs omp polymorphically, and fixes a latent `reset_backend()` asymmetry (the nats path was silently dropped). omp is excluded from `WorkspaceAware` (no `switch_cwd` faking).
- **Token reuse (Axis B):** omp reuses the existing `pool_sessions.cli_session_id` column — **no migration**. Cosmetic rename deferred to **#1893**.
- **Deploy:** session dir persisted on a named volume `factory-omp-sessions` (clipool-parity → cold-start resume survives a worker restart).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1813: runtime selection — clipool ⟷ omp_rpc | OPEN (epic, slice V2) |
| Analysis | [1813-runtime-selection-analysis.mdx](artifacts/analyses/1813-runtime-selection-analysis.mdx) | Present |
| Spec | [1813-runtime-selection-spec.mdx](artifacts/specs/1813-runtime-selection-spec.mdx) | Present |
| Plan | [1813-runtime-selection-v2-plan.mdx](artifacts/plans/1813-runtime-selection-v2-plan.mdx) | Present |
| Implementation | 6 commits on `feat/1813-runtime-selection-v2` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (5861 passed; 9 new test files) | Passed |

## Test Plan
- [ ] omp agent recalls a prior-turn fact via its warm pool client
- [ ] a 2nd conversation (distinct `session_id`) does NOT see the 1st's history
- [ ] clipool + nats backends unchanged (no regression — existing suite green)
- [ ] M₁: `INTEGRATION=1` omp session-resume smoke (manual — needs live binary)

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| omp remembers context across turns | `test_omp_rpc_session :: queue_resume/complete inject+persist` | ✓ proven |
| no cross-conversation bleed | `test_omp_rpc_session :: test_cross_conversation_isolation` | ✓ proven |
| OmpPool warm/cold-start + LRU | `test_omp_pool` (5 cases) | ✓ proven |
| SessionAware/WorkspaceAware conformance | `test_session_protocols` | ✓ proven |
| reset_backend nats asymmetry fixed | `test_simple_agent :: test_reset_backend_routes_through_nats_driver` | ✓ proven |
| worker stays dumb executor | `test_omp_worker_pool` | ✓ ran green |
| clipool/nats no-regression | `test_simple_agent` (t8n/t9an/t9bn + existing) | ✓ ran green |
| wire-compat (old envelope validates) | `test_omp_payload_v2` | ✓ ran green |
| integration cold-start/resume/evict | `test_omp_session_resume_integration` | ⚠ INTEGRATION=1 (M₁-manual) |
| streaming / concurrency-wallclock / per-job override / parity runbook | — | deferred → V4 / V3 / V5 / V6 |

"✓ proven" = test runs green AND fails when the implementation is stashed (falsification gate executed).

## Notes
- **Multi-slice epic** — this is **slice V2**. V3 (OmpPool concurrency), V4 (streaming), V5 (per-job override), V6 (parity runbook) remain. Uses `Refs` (not `Fixes`) so the epic stays open.

Refs #1813 (slice V2) · follow-up #1893

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
