### PR TITLE
fix(ci): repair dependabot auto-merge labelling

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   reviewed-label:
     name: Label dependabot patch/minor reviewed
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -45,7 +45,8 @@ jobs:
       - name: Add reviewed label (patch/minor only)
         if: >-
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor'
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          startsWith(github.event.pull_request.head.ref, 'dependabot/pip/minor-and-patch')
         run: gh pr edit "$PR_URL" --add-label reviewed
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}


### PR DESCRIPTION
Two compounding bugs left every grouped pip Dependabot PR unlabelled (so auto-merge never armed; ~26 stale PRs org-wide). (1) job if: used github.actor, which flips to roxabi-ci[bot] when update-behind-prs rebases the PR -> job skipped on every sync; now keys on the PR author (github.event.pull_request.user.login), the GitHub-recommended pattern. (2) grouped pip PRs return an empty update-type from fetch-metadata so the patch/minor label step never ran; the minor-and-patch group is config-restricted to update-types [minor,patch] in dependabot.yml, so a 'dependabot/pip/minor-and-patch*' head branch is provably safe to label. Major bumps still arrive as individual PRs and remain gated on explicit semver-minor/patch. Ref: ops audit GATE-4 / D-27.