### PR TITLE
chore(ci): slim build cache (mode=min), pin pr-title action, fix uv label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           nk -v
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
         run: |
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
         run: uv sync --frozen --group dev

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6
         with:
           types: |
             feat

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ target "agent-runtime" {
   context    = "."
   target     = "agent-runtime"
   cache-from = ["type=gha,scope=factory-agent"]
-  cache-to   = ["type=gha,mode=max,scope=factory-agent"]
+  cache-to   = ["type=gha,mode=min,scope=factory-agent"]
 }
 
 target "svc-runtime" {
@@ -15,5 +15,5 @@ target "svc-runtime" {
   context    = "."
   target     = "svc-runtime"
   cache-from = ["type=gha,scope=factory-svc"]
-  cache-to   = ["type=gha,mode=max,scope=factory-svc"]
+  cache-to   = ["type=gha,mode=min,scope=factory-svc"]
 }


### PR DESCRIPTION
D-29: docker-bake used cache-to mode=max (writes every intermediate layer); the GHA cache is at ~8.6/10 GB and about to LRU-evict -> full 21-min Docker rebuilds. mode=min caches only the final image layer. NOTE: after merge, purge the stale backlog: gh api -X DELETE per entry in /repos/Roxabi/roxabi-factory/actions/caches. D-31: pin amannn/action-semantic-pull-request from floating @v6 to its commit SHA (matches the 5 already-pinned repos). D-30: setup-uv comment said v7 but the pinned SHA is v8.2.0.