### PR TITLE
fix(deploy): install factory-omp-sessions.volume to stop omp converge loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 	@cp deploy/quadlet/factory-blobstore.container        "$(QUADLET_DIR)/factory-blobstore.container"
 	@cp deploy/quadlet/factory-turn-writer.container      "$(QUADLET_DIR)/factory-turn-writer.container"
 	@cp deploy/quadlet/factory-omp.container              "$(QUADLET_DIR)/factory-omp.container"
+	@cp deploy/quadlet/factory-omp-sessions.volume        "$(QUADLET_DIR)/factory-omp-sessions.volume"
 	@echo "Quadlet units copied."
 	@if [ "$(NO_RESTART)" = "1" ]; then \
 		echo "NO_RESTART=1 — skipping daemon-reload, restart, and verification."; \

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -51,6 +51,20 @@ while IFS= read -r container; do
     fi
 done < <(grep -oE '^container = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 
+# Volume units: a [volume.*] declared in the manifest must also be cp'd by the
+# Makefile quadlet-install recipe. If it is not, the Quadlet generator drops
+# every .container that references it via Volume=/Requires= — the unit silently
+# fails to generate and converge's restart fan-out errors every cycle (#1813:
+# factory-omp-sessions.volume shipped + referenced but never installed → no
+# factory-omp.service → 5-min NATS+clients bounce loop).
+while IFS= read -r volume; do
+    count=$((count + 1))
+    if ! grep -qF "deploy/quadlet/${volume}" Makefile; then
+        echo "FAIL: ${volume} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
+        fail=1
+    fi
+done < <(grep -oE '^volume = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+
 if [ "${count}" -eq 0 ]; then
     echo "FAIL: no containers parsed from deploy/quadlet.toml — gate validated nothing"
     exit 1
@@ -61,6 +75,7 @@ if [ "${fail}" -ne 0 ]; then
     echo "Every [component.*] container in deploy/quadlet.toml must be wired into the"
     echo "Makefile quadlet-install recipe, the quadlet-install-verify.sh UNITS array,"
     echo "and the converge.sh restart fan-out — see #1867."
+    echo "Every [volume.*] volume must be cp'd by the quadlet-install recipe — see #1813."
     exit 1
 fi
 


### PR DESCRIPTION
## Incident
`factory-nats` + all NATS clients (hub, telegram, discord, clipool, turn-writer, gh-helper, blobstore, omp, voicecli-stt/tts) restarted **every ~5 min for ~15h** (since the #1813 deploy). `podman-auto-update.service` exited **125** every cycle; `factory-post-autoupdate.service` exited **2** every cycle.

## Root cause (single)
`quadlet-install` does `rm -f .../factory*.{network,volume,container,pod}` then copies back a **hardcoded list that omitted `factory-omp-sessions.volume`**. #1813 added the volume unit + the `factory-omp.container` `Volume=`/`Requires=` references, but never the install line.

Consequence chain:
1. Quadlet generator drops `factory-omp.service` → `converting "factory-omp.container": requested Quadlet source factory-omp-sessions.volume was not found`.
2. `converge.sh` structural fan-out hits `systemctl --user restart factory-omp` → *Unit not found* → `exit 1` **before** `write_convergence_state` → stamp never written → every cycle re-detects structural drift → restarts NATS + all clients.
3. `podman-auto-update` chokes on the same missing unit during rollback → `exit 125`, leaving `:staging` half-pulled → `factory-post-autoupdate` saw perpetual `:staging` digest drift → forced a structural converge each cycle. (No independent bug — symptom of the same gap.)

## Fix
- **Makefile** `quadlet-install`: `cp factory-omp-sessions.volume` into `QUADLET_DIR`.
- **`check_quadlet_manifest_install.sh`**: extend the #1867 gate to require every `[volume.*]` in `quadlet.toml` be wired into `quadlet-install`. The gate only checked `[component.*]` containers — exactly why this shipped. Verified it now fails on the pre-fix Makefile and passes post-fix.

## Validation on M1 (applied manually pending this merge)
- `converge` → `Converge complete.` (exit 0); 2nd run → `Already converged — nothing to do.` (idempotent)
- `factory-omp` adopted as managed unit (`UnitFileState=generated`, NRestarts=0), connected to NATS (`OmpWorker on factory.jobs.omp`)
- `podman-auto-update` → exit **0** (no omp rollback error)
- `factory-post-autoupdate` → `All tracked image digests unchanged — nothing to do.`
- Full factory + voicecli stack healthy; NATS bounce loop stopped.

## Deploy note
M1 currently runs the fix via a local Makefile edit (dirty working tree). At merge, reconcile M1: stop `factory-quadlet-sync.timer`, `git checkout -- Makefile`, `git pull --ff-only`, re-enable timer (the pull→converge will redeploy cleanly with the committed fix).

Refs #1813 #1867