### PR TITLE
refactor(deploy): manifest-driven quadlet-install — glob the unit dir, complete quadlet.toml inventory (#1900)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,16 +151,12 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 	@uv run factory bot init
 	@rm -f "$(QUADLET_DIR)"/factory*.{network,volume,container,pod} "$(QUADLET_DIR)"/factory*.{network,volume,container,pod} "$(QUADLET_DIR)/nats.container" \
 	       "$(QUADLET_DIR)/roxabi.network" "$(QUADLET_DIR)/factory-nats.container"
-	@cp deploy/quadlet/roxabi.network                  "$(QUADLET_DIR)/roxabi.network"
-	@cp deploy/quadlet/factory-data.volume                "$(QUADLET_DIR)/factory-data.volume"
-	@cp deploy/quadlet/factory-jetstream.volume           "$(QUADLET_DIR)/factory-jetstream.volume"
-	@cp deploy/quadlet/factory-gh-token.volume            "$(QUADLET_DIR)/factory-gh-token.volume"
-	@cp deploy/quadlet/factory-discord-data.volume        "$(QUADLET_DIR)/factory-discord-data.volume"
+	@for f in deploy/quadlet/*.network deploy/quadlet/*.volume deploy/quadlet/*.pod deploy/quadlet/*.container; do \
+		cp "$$f" "$(QUADLET_DIR)/"; \
+	done
 	@install -d -m 0700 "$(HOME)/.roxabi/factory/nats/jetstream"
 	@chmod 0700 "$(HOME)/.roxabi/factory/nats"
 	@chmod 0700 "$(HOME)/.roxabi/factory/nats/jetstream"
-	@cp deploy/quadlet/factory-nats.container             "$(QUADLET_DIR)/factory-nats.container"
-	@cp deploy/quadlet/factory-hub.container              "$(QUADLET_DIR)/factory-hub.container"
 	@uv run python tools/render_quadlet.py \
 		--platform telegram \
 		--db "$(HOME)/.roxabi/factory/config.db" \
@@ -171,13 +167,6 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 		--db "$(HOME)/.roxabi/factory/config.db" \
 		--tmpl deploy/quadlet/factory-discord.container.tmpl \
 		--dest "$(QUADLET_DIR)/factory-discord.container"
-	@cp deploy/quadlet/factory-gh.pod                     "$(QUADLET_DIR)/factory-gh.pod"
-	@cp deploy/quadlet/factory-gh-helper.container        "$(QUADLET_DIR)/factory-gh-helper.container"
-	@cp deploy/quadlet/factory-clipool.container          "$(QUADLET_DIR)/factory-clipool.container"
-	@cp deploy/quadlet/factory-blobstore.container        "$(QUADLET_DIR)/factory-blobstore.container"
-	@cp deploy/quadlet/factory-turn-writer.container      "$(QUADLET_DIR)/factory-turn-writer.container"
-	@cp deploy/quadlet/factory-omp.container              "$(QUADLET_DIR)/factory-omp.container"
-	@cp deploy/quadlet/factory-omp-sessions.volume        "$(QUADLET_DIR)/factory-omp-sessions.volume"
 	@echo "Quadlet units copied."
 	@if [ "$(NO_RESTART)" = "1" ]; then \
 		echo "NO_RESTART=1 — skipping daemon-reload, restart, and verification."; \
@@ -325,7 +314,7 @@ remote:
 # Shared list of services that hold NATS subject auth and must restart
 # whenever `auth.conf` is regenerated or a new identity is added. The bare
 # `factory-nats` is restarted separately by the target itself before this list.
-FACTORY_NATS_CLIENTS := factory-hub factory-telegram factory-discord factory-clipool factory-turn-writer factory-gh-helper factory-blobstore
+FACTORY_NATS_CLIENTS := factory-hub factory-telegram factory-discord factory-clipool factory-turn-writer factory-gh-helper factory-blobstore factory-omp
 
 nats-setup:
 	@bash deploy/nats/setup.sh

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -47,6 +47,30 @@ container = "factory-omp.container"
 host_roles = ["factory-hub"]
 required_secrets = ["factory-nats-omp", "factory-litellm-key"]
 
+[volume.data]
+volume = "factory-data.volume"
+host_roles = ["factory-hub"]
+
+[volume.jetstream]
+volume = "factory-jetstream.volume"
+host_roles = ["factory-hub"]
+
+[volume.gh-token]
+volume = "factory-gh-token.volume"
+host_roles = ["factory-hub"]
+
+[volume.discord-data]
+volume = "factory-discord-data.volume"
+host_roles = ["factory-hub"]
+
 [volume.omp-sessions]
 volume = "factory-omp-sessions.volume"
+host_roles = ["factory-hub"]
+
+[network.roxabi]
+network = "roxabi.network"
+host_roles = ["factory-hub"]
+
+[pod.gh]
+pod = "factory-gh.pod"
 host_roles = ["factory-hub"]

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -31,9 +31,12 @@ while IFS= read -r container; do
 
     # Template-rendered units (telegram/discord) hit the first arm via the
     # .container.tmpl source-path substring; the QUADLET_DIR arm matches the
-    # rendered --dest line. Either is acceptable evidence of install wiring.
+    # rendered --dest line. A glob loop in the Makefile covering the file's
+    # extension + the file existing on disk is also acceptable evidence.
+    ext="${container##*.}"
     if ! grep -qF "deploy/quadlet/${container}" Makefile \
-       && ! grep -qF "QUADLET_DIR)/${container}" Makefile; then
+       && ! grep -qF "QUADLET_DIR)/${container}" Makefile \
+       && ! { grep -qF "deploy/quadlet/*.${ext}" Makefile && [[ -f "deploy/quadlet/${container}" ]]; }; then
         echo "FAIL: ${container} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
         fail=1
     fi
@@ -59,7 +62,9 @@ done < <(grep -oE '^container = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 # factory-omp.service → 5-min NATS+clients bounce loop).
 while IFS= read -r volume; do
     count=$((count + 1))
-    if ! grep -qF "deploy/quadlet/${volume}" Makefile; then
+    ext="${volume##*.}"
+    if ! grep -qF "deploy/quadlet/${volume}" Makefile \
+       && ! { grep -qF "deploy/quadlet/*.${ext}" Makefile && [[ -f "deploy/quadlet/${volume}" ]]; }; then
         echo "FAIL: ${volume} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
         fail=1
     fi


### PR DESCRIPTION
Closes #1900. Wave 1 of the manifest↔install hygiene program (#1900 → #1901).

## Why
`make quadlet-install` hand-enumerated `cp deploy/quadlet/<unit>` lines, decoupled from the dir. A unit added to `deploy/quadlet/` but not wired into the Makefile was silently **not installed** — root cause of #1867 (factory-omp shipped, never installed) and #1897 (omp-sessions volume → 5-min NATS bounce loop). The pre-copy `rm -f factory*.{…}` wipe made any omission **fatal**.

## What
| File | Change |
|---|---|
| `Makefile` | 13 hand-enumerated `cp` lines → one glob loop `for f in deploy/quadlet/*.{network,volume,pod,container}`. The two `*.container.tmpl` (telegram/discord) stay explicit `render_quadlet.py` renders (a `*.container` glob does **not** match `.tmpl` — copying install.sh's glob would silently drop them). `FACTORY_NATS_CLIENTS += factory-omp` (was missing → omp creds skipped on `nats-regen-authconf`). |
| `deploy/quadlet.toml` | Declare the 6 units the glob installs but the manifest omitted: `[volume.{data,jetstream,gh-token,discord-data}]`, `[network.roxabi]`, `[pod.gh]` → manifest is now the **complete install inventory** (enables the wave-2 bidirectional gate). `discord-data` flagged unreferenced (follow-up prune). |
| `tools/check_quadlet_manifest_install.sh` | Forward checks gain a third OR arm (`glob-loop-in-Makefile ∧ source-file-exists`) so the gate stays green against the glob instead of the removed literal `cp` lines. |

## Verify (independently re-run on this branch)
- `check_quadlet_manifest_install.sh` → pass · `check_secrets_drift.sh` → 3/3 OK · `check_volumes_table.sh` → OK
- `make -n quadlet-install` → glob loop + 2 renders + bot-init + jetstream prep + verify tail; **no unit dropped** (16 static + 2 rendered, `.env.example` excluded)
- `python3 tomllib` parse OK; `bash -n` clean
- pre-push date-sensitive gates (debt_expiry, file_exemptions, architecture_snapshot, test_sleep) → all pass

## M1 risk
Install **mechanism** change only — the resulting installed fileset is **identical** to the old hand-list (same 16+2 units). Post-merge `factory-quadlet-sync` re-runs `make quadlet-install` on M₁ with the `factory-deploy-failure` notification safety net.

## Scope guard
Forward gate only. Reverse direction (install→manifest), `[network.*]`/`[pod.*]` gating, and secret-source↔podman-secret checks are **wave 2 (#1901)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)