### PR TITLE
chore(deps): sync uv.lock — roxabi-contracts 0.11.0 (unjams M₁ ff-only deploy)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1362,7 +1362,7 @@ provides-extras = ["testing"]
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.7.0"
+version = "0.11.0"
 source = { editable = "packages/roxabi-contracts" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Incident
`factory-quadlet-sync` on M₁ has been **failing every cycle since the #1900 merge** — `factory-deploy-failure` firing, M₁ stuck at `60e4d94e` (wave-1 not deployed). Root cause:

- `2a702f57` bumped `packages/roxabi-contracts` → `0.11.0` but **did not regenerate `uv.lock`** (left stale at `0.7.0`).
- Every `uv run` (e.g. `factory bot init` inside `make quadlet-install`) re-resolves the editable package → `uv.lock` becomes dirty (`0.11.0`).
- The #1899 ff-only **dirty-checkout guard** then refuses the prod `git pull` → auto-deploy jammed.
- Condition is repo-wide (`M uv.lock` present on M₁ **and** the dev box).

## Fix
Commit the resolved lock (1 line, `0.7.0`→`0.11.0`) so the committed lock matches reality → `uv run` no longer churns it → the guard stops tripping. Verified **byte-identical** to the `uv`-resolved lock (hash `d412e0f0`).

## Follow-up (separate)
Belt-and-suspenders: switch converge/quadlet-install `uv run` calls to `uv run --frozen` so a future stale lock can never re-jam the deploy. Filing as an issue.

## Post-merge
One-time `git checkout uv.lock` on M₁ to clear its current dirty state; the next `factory-quadlet-sync` then pulls this fix + wave-1 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)