### PR TITLE
feat(deploy): bidirectional manifest↔install gate + secret-source integrity (#1901)

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -111,7 +111,7 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_secrets_drift.sh
-    description: assert unit Secret= names ⊆ quadlet.toml required_secrets, quadlet.toml == manifest, factory-nats-* seeds have acl-matrix factory+container identities (changes under deploy/)
+    description: assert unit Secret= names ⊆ quadlet.toml required_secrets, quadlet.toml == manifest, factory-nats-* seeds have acl-matrix factory+container identities, and required_secrets ↔ secrets-policy.toml [secret.*] (check d, #1901) (changes under deploy/)
 
   volumes_table:
     enabled: true
@@ -123,7 +123,13 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_quadlet_manifest_install.sh
-    description: every container declared in deploy/quadlet.toml must be wired into Makefile quadlet-install, quadlet-install-verify.sh UNITS, and converge.sh restart fan-out (#1867 — factory-omp shipped but never installed)
+    description: bidirectional manifest↔install — every container/volume/network/pod declared in deploy/quadlet.toml is wired into Makefile quadlet-install + verify UNITS + converge fan-out (forward, #1867), AND every on-disk unit file in deploy/quadlet/ is declared in quadlet.toml (reverse — orphan-install guard, #1901)
+
+  secrets_source:
+    enabled: true
+    stage: pre-push
+    script: tools/check_secrets_source.sh
+    description: assert every nats-seed/required secret in secrets-policy.toml has its source file under the factory data dir; skip gracefully when the data dir is absent (CI/dev). optional secrets WARN, not fail (#1901)
 
   str_exc_bus_bound:
     enabled: true

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -11,6 +11,17 @@
 #
 # Gap class (#1867): PR #1858 shipped factory-omp.container + its manifest entry,
 # converge kept reporting "Converge complete" while the unit was never installed.
+#
+# BIDIRECTIONAL CHECK (#1901):
+#   Reverse direction: every unit FILE in deploy/quadlet/ (*.container,
+#   *.volume, *.network, *.pod — excluding *.example, *.env) MUST be declared
+#   in deploy/quadlet.toml.  For *.container.tmpl, strip .tmpl and check the
+#   resulting name.  Any on-disk file with no matching declaration → FAIL.
+#
+# NETWORK / POD FORWARD CHECK (#1901):
+#   [network.*] and [pod.*] entries in quadlet.toml are also install-evidenced
+#   by the Makefile quadlet-install glob (*.network / *.pod) — same 2-arm check
+#   as volumes.  These are not services, so no verify.sh / converge.sh arms.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -70,6 +81,110 @@ while IFS= read -r volume; do
     fi
 done < <(grep -oE '^volume = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 
+# Network units: a [network.*] declared in the manifest must be install-evidenced
+# by the Makefile quadlet-install recipe (same 2-arm check as volumes).
+while IFS= read -r network; do
+    count=$((count + 1))
+    ext="${network##*.}"
+    if ! grep -qF "deploy/quadlet/${network}" Makefile \
+       && ! { grep -qF "deploy/quadlet/*.${ext}" Makefile && [[ -f "deploy/quadlet/${network}" ]]; }; then
+        echo "FAIL: ${network} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
+        fail=1
+    fi
+done < <(grep -oE '^network = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+
+# Pod units: a [pod.*] declared in the manifest must be install-evidenced by
+# the Makefile quadlet-install recipe.
+while IFS= read -r pod; do
+    count=$((count + 1))
+    ext="${pod##*.}"
+    if ! grep -qF "deploy/quadlet/${pod}" Makefile \
+       && ! { grep -qF "deploy/quadlet/*.${ext}" Makefile && [[ -f "deploy/quadlet/${pod}" ]]; }; then
+        echo "FAIL: ${pod} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
+        fail=1
+    fi
+done < <(grep -oE '^pod = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+
+# ── REVERSE DIRECTION: every on-disk unit file must be declared in quadlet.toml ─
+# A single python3 heredoc reads quadlet.toml via tomllib, iterates deploy/quadlet/,
+# and prints one FAIL line per undeclared file.  Using the heredoc-stdin pattern
+# (python3 - FILE <<'PYEOF') keeps this safe under set -euo pipefail — unlike
+# `read -r -d '' VAR << 'PYEOF'` which exits 1 at EOF and aborts the script.
+#
+# Excluded: *.example, *.env files.
+# *.container.tmpl → strip .tmpl → checked as *.container.
+_reverse_fails=$(python3 - deploy/quadlet.toml <<'PYEOF'
+import sys, tomllib, pathlib
+
+toml_path = pathlib.Path(sys.argv[1])
+with toml_path.open("rb") as f:
+    data = tomllib.load(f)
+
+containers: set[str] = set()
+volumes: set[str] = set()
+networks: set[str] = set()
+pods: set[str] = set()
+
+# TOML nests sub-tables: [component.nats] → data["component"]["nats"].
+# Iterate the sub-table VALUES (mirrors load_quadlet_required_secrets).
+for sub in data.get("component", {}).values():
+    if "container" in sub:
+        containers.add(sub["container"])
+for sub in data.get("volume", {}).values():
+    if "volume" in sub:
+        volumes.add(sub["volume"])
+for sub in data.get("network", {}).values():
+    if "network" in sub:
+        networks.add(sub["network"])
+for sub in data.get("pod", {}).values():
+    if "pod" in sub:
+        pods.add(sub["pod"])
+
+quadlet_dir = pathlib.Path("deploy/quadlet")
+for fpath in sorted(quadlet_dir.iterdir()):
+    if not fpath.is_file():
+        continue
+    fname = fpath.name
+    # Skip non-unit files
+    if fname.endswith(".example") or fname.endswith(".env"):
+        continue
+    # Determine effective name and which set to check
+    if fname.endswith(".container.tmpl"):
+        effective = fname[:-len(".tmpl")]  # strip .tmpl → *.container
+        declared = containers
+    elif fname.endswith(".container"):
+        effective = fname
+        declared = containers
+    elif fname.endswith(".volume"):
+        effective = fname
+        declared = volumes
+    elif fname.endswith(".network"):
+        effective = fname
+        declared = networks
+    elif fname.endswith(".pod"):
+        effective = fname
+        declared = pods
+    else:
+        # Unknown extension — not a Quadlet unit file, skip
+        continue
+    if effective not in declared:
+        print(
+            f"::error file=deploy/quadlet/{fname}::"
+            f"FAIL (reverse): deploy/quadlet/{fname} has no matching declaration"
+            f" in deploy/quadlet.toml"
+        )
+PYEOF
+)
+if [[ -n "${_reverse_fails}" ]]; then
+    echo "" >&2
+    echo "FAIL (reverse): on-disk unit files in deploy/quadlet/ not declared in deploy/quadlet.toml:" >&2
+    while IFS= read -r line; do
+        echo "  ${line}" >&2
+        echo "${line}"
+    done <<< "${_reverse_fails}"
+    fail=1
+fi
+
 if [ "${count}" -eq 0 ]; then
     echo "FAIL: no containers parsed from deploy/quadlet.toml — gate validated nothing"
     exit 1
@@ -81,6 +196,7 @@ if [ "${fail}" -ne 0 ]; then
     echo "Makefile quadlet-install recipe, the quadlet-install-verify.sh UNITS array,"
     echo "and the converge.sh restart fan-out — see #1867."
     echo "Every [volume.*] volume must be cp'd by the quadlet-install recipe — see #1813."
+    echo "Every unit FILE in deploy/quadlet/ must be declared in deploy/quadlet.toml — see #1901."
     exit 1
 fi
 

--- a/tools/check_secrets_drift.sh
+++ b/tools/check_secrets_drift.sh
@@ -40,6 +40,12 @@
 #   The auth bundle secret (factory-nats-auth) is excluded from both directions:
 #   it is the NATS server auth.conf, not an NKey identity seed.
 #
+# CHECK (d) — quadlet.toml required_secrets ↔ secrets-policy.toml [secret.*]
+#   Bidirectional: every required_secret must have a [secret.<name>] policy
+#   entry (catches a required secret with no declared source), and every
+#   policy entry must be referenced by some component (catches an orphan
+#   policy entry with no consumer).
+#
 # OPTIONAL SECRETS
 #   Secrets with policy=optional (factory-gh-pem, factory-claude-oauth) are
 #   logged as SKIP and never cause a failure.  The optional set is derived by
@@ -156,6 +162,20 @@ for name, attrs in data.get("secret", {}).items():
 PYEOF
 }
 
+# load_policy_secret_names
+# Emit every secret name with a [secret.<name>] entry in secrets-policy.toml,
+# one per line, sorted.
+load_policy_secret_names() {
+    python3 - "$POLICY_TOML" <<'PYEOF'
+import sys, tomllib, pathlib
+path = pathlib.Path(sys.argv[1])
+with path.open("rb") as f:
+    data = tomllib.load(f)
+for name in sorted(data.get("secret", {}).keys()):
+    print(name)
+PYEOF
+}
+
 # load_manifest_secret_names
 # Emit secret names declared in secrets-manifest.sh (lines of the form
 #     [name]="..."
@@ -199,6 +219,12 @@ declare -A OPTIONAL_SET=()
 while IFS= read -r name; do
     OPTIONAL_SET["$name"]=1
 done < <(load_optional_secrets)
+
+# Policy-declared secret names (associative set for fast lookup)
+declare -A POLICY_SET=()
+while IFS= read -r name; do
+    POLICY_SET["$name"]=1
+done < <(load_policy_secret_names)
 
 # Manifest secret names (sorted array)
 mapfile -t MANIFEST_SECRETS < <(load_manifest_secret_names)
@@ -361,6 +387,44 @@ if [[ ${#nats_seed_violations[@]} -gt 0 || ${#nats_reverse_violations[@]} -gt 0 
     fail=1
 else
     echo "check_secrets_drift (c): factory-nats-* seeds ↔ acl-matrix factory+container identities — OK (bidirectional)"
+fi
+
+# ── CHECK (d) — quadlet.toml required_secrets ↔ secrets-policy.toml [secret.*] ─
+# Bidirectional set-membership:
+#   Forward:  every required_secret in quadlet.toml MUST have a [secret.<name>]
+#             entry in secrets-policy.toml (catches a required secret with no
+#             declared policy/source — the litellm-key-lost class).
+#   Reverse:  every [secret.<name>] in secrets-policy.toml MUST appear in some
+#             component required_secrets (catches an orphan policy entry with
+#             no consumer — the factory-nats-auth class).
+in_quadlet_not_policy=()
+for s in "${QUADLET_SECRETS[@]}"; do
+    if [[ -z "${POLICY_SET[$s]+_}" ]]; then
+        in_quadlet_not_policy+=("$s")
+    fi
+done
+
+in_policy_not_quadlet=()
+for s in "${!POLICY_SET[@]}"; do
+    if [[ -z "${QUADLET_SET[$s]+_}" ]]; then
+        in_policy_not_quadlet+=("$s")
+    fi
+done
+
+if [[ ${#in_quadlet_not_policy[@]} -gt 0 || ${#in_policy_not_quadlet[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "FAIL (d): quadlet.toml required_secrets / secrets-policy.toml [secret.*] out of sync:" >&2
+    for s in "${in_quadlet_not_policy[@]}"; do
+        echo "  required_secret with no secrets-policy.toml entry: $s" >&2
+        echo "::error file=deploy/secrets-policy.toml::required secret $s has no [secret.$s] policy entry — add it (policy + source)"
+    done
+    for s in "${in_policy_not_quadlet[@]}"; do
+        echo "  orphan policy entry not referenced by any required_secrets: $s" >&2
+        echo "::error file=deploy/secrets-policy.toml::policy entry $s is referenced by no component required_secrets — remove it or wire the secret"
+    done
+    fail=1
+else
+    echo "check_secrets_drift (d): required_secrets ↔ secrets-policy.toml [secret.*] — OK (bidirectional)"
 fi
 
 # ── SUMMARY ───────────────────────────────────────────────────────────────────

--- a/tools/check_secrets_source.sh
+++ b/tools/check_secrets_source.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check_secrets_source.sh — secret-source ↔ on-disk integrity gate (host-dependent).
+#
+# For every secret in deploy/secrets-policy.toml with a file-based source,
+# verify the source file exists under the factory data dir. Catches the class
+# of incident where a Podman secret survives but its source file is lost
+# (e.g. litellm-key.tok during the 2026-06-11/12 overhaul) — leaving the secret
+# unrecoverable on the next rotation (#1901).
+#
+# HOST-DEPENDENT — SKIP-IN-CI:
+#   The factory data dir (~/.roxabi/factory/) is not present on CI runners or
+#   dev machines without a deploy. When it is absent this gate SKIPS (exit 0):
+#   it is an operator-host pre-push integrity check, not a CI gate.
+#
+# Policy semantics (deploy/secrets-policy.toml `policy =`):
+#   nats-seed / required  → source file MUST exist (HARD FAIL if missing)
+#   optional              → WARN if missing (unrecoverable after rotation), no fail
+#   generated             → source "n/a", skipped (generated at install time)
+#
+# ENVIRONMENT OVERRIDES
+#   POLICY_TOML        — default: deploy/secrets-policy.toml
+#   FACTORY_DATA_DIR   — default: $HOME/.roxabi/factory
+#
+# EXIT-CODE CONTRACT (tools/CLAUDE.md): 0 = clean, 1 = violations, 2 = setup error.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || { echo "ERROR: not a git repository" >&2; exit 2; }
+cd "$REPO_ROOT"
+
+POLICY_TOML="${POLICY_TOML:-deploy/secrets-policy.toml}"
+DATA_DIR="${FACTORY_DATA_DIR:-$HOME/.roxabi/factory}"
+
+if [[ ! -f "$POLICY_TOML" ]]; then
+    echo "ERROR: policy file not found: $POLICY_TOML" >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import tomllib' >/dev/null 2>&1; then
+    echo "ERROR: python3 with tomllib (Python 3.11+) required" >&2
+    exit 2
+fi
+
+# Skip gracefully when the operator data dir is absent (CI runner / dev box).
+if [[ ! -d "$DATA_DIR" ]]; then
+    echo "check_secrets_source: SKIP — factory data dir ($DATA_DIR) not present (CI/dev runner); source-existence not checked"
+    exit 0
+fi
+
+fail=0
+
+# Emit one "<name>\t<policy>\t<source>" line per secret with a file-based source.
+while IFS=$'\t' read -r name policy source; do
+    if [[ -z "$name" ]]; then
+        continue
+    fi
+    src_path="$DATA_DIR/$source"
+    if [[ -f "$src_path" ]]; then
+        continue
+    fi
+    case "$policy" in
+        nats-seed|required)
+            echo "FAIL: $name (policy=$policy) source missing: $src_path" >&2
+            echo "::error file=deploy/secrets-policy.toml::secret $name source file missing on host: $src_path"
+            fail=1
+            ;;
+        optional)
+            echo "WARN: optional secret $name source missing: $src_path — unrecoverable after next rotation" >&2
+            ;;
+        *)
+            echo "WARN: $name has unrecognized policy '$policy' — source-missing treated as non-fatal" >&2
+            ;;
+    esac
+done < <(python3 - "$POLICY_TOML" <<'PYEOF'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+
+for name, attrs in data.get("secret", {}).items():
+    source = attrs.get("source", "n/a")
+    if source == "n/a":
+        continue
+    print(f"{name}\t{attrs.get('policy', '')}\t{source}")
+PYEOF
+)
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "" >&2
+    echo "check_secrets_source: required secret source files missing on host (see above)." >&2
+    echo "Restore the source file under $DATA_DIR, or flip the secret to policy=optional if non-vital." >&2
+    exit 1
+fi
+
+echo "check_secrets_source: all required secret sources present — OK"
+exit 0


### PR DESCRIPTION
Refs #1901 (factory half — wave 2 of the manifest↔install hygiene program; #1901 stays open for the llmCLI/voiceCLI/baseline waves).

Builds on #1900 (wave 1): now that quadlet.toml is the complete install inventory, add the reverse checks.

## What
| File | Change |
|---|---|
| `tools/check_quadlet_manifest_install.sh` | **Reverse direction** — every on-disk unit in `deploy/quadlet/` (`*.container/.volume/.network/.pod`, `*.container.tmpl`→`.container`; excl. `*.example/.env`) must be declared in `quadlet.toml` (orphan-install guard). Plus **forward gating for `[network.*]`/`[pod.*]`**. |
| `tools/check_secrets_drift.sh` | **check (d)** — `required_secrets ↔ secrets-policy.toml [secret.*]`, bidirectional (missing policy entry / orphan policy entry). |
| `tools/check_secrets_source.sh` *(new, pre-push)* | Every `nats-seed`/`required` secret has its source file under the factory data dir; **skip-in-CI** when the dir is absent; `optional` secrets WARN (litellm-key-lost recurrence signal), don't fail. |
| `.claude/stack.yml` | Wire `secrets_source` (pre-push) + refresh `secrets_drift`/`quadlet_manifest_install` descriptions. |

## Verify (lead-run, positive + negative — a gate that can't fail is not a gate)
- `check_quadlet_manifest_install.sh` → **0** (bidirectional green on real tree); orphan `*.container` → **1**, recovers to **0** on removal.
- `check_secrets_drift.sh` → **0** (a/b/c/d all OK); orphan policy entry → **1**.
- `check_secrets_source.sh` `FACTORY_DATA_DIR=/nonexistent` → **0** SKIP; empty data dir → **1** (8 nats-seed hard-fails, optional→WARN).
- `bash -n` clean on all 3; `stack.yml` valid YAML.

## Note (caught in review)
The first-draft reverse logic iterated `data.items()` and read `"container" in vals` — but TOML nests `[component.nats]` under `data["component"]["nats"]`, so all declared-sets came up empty → every real unit false-flagged as orphan. Fixed to iterate `data.get("component", {}).values()` (mirrors `load_quadlet_required_secrets`); positive test now green.

## Scope
Factory only. llmCLI/voiceCLI gate ports + baseline Control-11 source↔secret audit are waves 4/6/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)