### PR TITLE
chore(deploy): --frozen on host-side uv invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ quadlet-lint:  ## lint Quadlet unit files: dryrun parse check + inline-comment g
 
 quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify (NO_RESTART=1 skips restart/verify)
 	@mkdir -p "$(QUADLET_DIR)"
-	@uv run factory bot init
+	@uv run --frozen factory bot init
 	@rm -f "$(QUADLET_DIR)"/factory*.{network,volume,container,pod} "$(QUADLET_DIR)"/factory*.{network,volume,container,pod} "$(QUADLET_DIR)/nats.container" \
 	       "$(QUADLET_DIR)/roxabi.network" "$(QUADLET_DIR)/factory-nats.container"
 	@for f in deploy/quadlet/*.network deploy/quadlet/*.volume deploy/quadlet/*.pod deploy/quadlet/*.container; do \
@@ -157,12 +157,12 @@ quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify
 	@install -d -m 0700 "$(HOME)/.roxabi/factory/nats/jetstream"
 	@chmod 0700 "$(HOME)/.roxabi/factory/nats"
 	@chmod 0700 "$(HOME)/.roxabi/factory/nats/jetstream"
-	@uv run python tools/render_quadlet.py \
+	@uv run --frozen python tools/render_quadlet.py \
 		--platform telegram \
 		--db "$(HOME)/.roxabi/factory/config.db" \
 		--tmpl deploy/quadlet/factory-telegram.container.tmpl \
 		--dest "$(QUADLET_DIR)/factory-telegram.container"
-	@uv run python tools/render_quadlet.py \
+	@uv run --frozen python tools/render_quadlet.py \
 		--platform discord \
 		--db "$(HOME)/.roxabi/factory/config.db" \
 		--tmpl deploy/quadlet/factory-discord.container.tmpl \
@@ -320,8 +320,8 @@ nats-setup:
 	@bash deploy/nats/setup.sh
 
 nats-regen-specs:             ## re-render ACL spec table + parity fixture from acl-matrix.json
-	@uv run python scripts/render_acl_spec.py
-	@uv run python scripts/render_acl_parity.py
+	@uv run --frozen python scripts/render_acl_spec.py
+	@uv run --frozen python scripts/render_acl_parity.py
 	@echo "[ok] ACL spec + parity fixture regenerated"
 
 nats-regen-authconf:          ## re-render auth.conf from acl-matrix.json, restart factory-nats + all NATS clients (#1390)
@@ -346,7 +346,7 @@ nats-add-identity:  ## add a single NATS identity rootless; idempotent after ful
 	@test -n "$(NAME)" || { echo "usage: make nats-add-identity NAME=<x>"; exit 2; }
 	@echo "$(NAME)" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9_-]*$$' \
 	  || { echo "error: NAME must match [a-zA-Z0-9][a-zA-Z0-9_-]* — got '$(NAME)'"; exit 1; }
-	@out=$$(uv run --project . factory-acl genkeys --add-identity "$(NAME)"); \
+	@out=$$(uv run --frozen --project . factory-acl genkeys --add-identity "$(NAME)"); \
 	rc=$$?; \
 	if [ $$rc -ne 0 ]; then echo "$$out" >&2; echo "factory-acl failed (exit $$rc) — aborting"; exit $$rc; fi; \
 	state=$$(echo "$$out" | grep -oE 'STATE=(noop|repaired|added)'); \

--- a/tests/cli/test_bot_secret.py
+++ b/tests/cli/test_bot_secret.py
@@ -575,9 +575,11 @@ class TestE2EV1RedGate:
             "Makefile quadlet-install missing tools/render_quadlet.py invocation"
         )
         # Makefile uses backslash line continuation; match across newlines.
-        # Both invocations must use the actual Makefile shape (uv run python …).
+        # Both invocations must use the actual Makefile shape (uv run [--frozen] python …).
+        # `--frozen` is optional: host-side render targets carry it (#1905) so a stale
+        # uv.lock fails loudly instead of being rewritten in the working tree.
         assert re.search(
-            r"uv run python tools/render_quadlet\.py.*?--platform telegram",
+            r"uv run (?:--frozen )?python tools/render_quadlet\.py.*?--platform telegram",
             makefile_contents,
             re.DOTALL,
         ), (
@@ -585,7 +587,7 @@ class TestE2EV1RedGate:
             "`uv run python tools/render_quadlet.py --platform telegram` invocation"
         )
         assert re.search(
-            r"uv run python tools/render_quadlet\.py.*?--platform discord",
+            r"uv run (?:--frozen )?python tools/render_quadlet\.py.*?--platform discord",
             makefile_contents,
             re.DOTALL,
         ), (

--- a/tests/cli/test_bot_secret.py
+++ b/tests/cli/test_bot_secret.py
@@ -575,20 +575,21 @@ class TestE2EV1RedGate:
             "Makefile quadlet-install missing tools/render_quadlet.py invocation"
         )
         # Makefile uses backslash line continuation; match across newlines.
-        # Both invocations must use the actual Makefile shape (uv run [--frozen] python …).
-        # `--frozen` is optional: host-side render targets carry it (#1905) so a stale
-        # uv.lock fails loudly instead of being rewritten in the working tree.
+        # Both invocations must use the actual Makefile shape (uv run python …).
+        # Host-side render targets carry an optional `--frozen` (#1905) so a stale
+        # uv.lock fails loudly; normalize it out before the shape assertion.
+        normalized = makefile_contents.replace("--frozen ", "")
         assert re.search(
-            r"uv run (?:--frozen )?python tools/render_quadlet\.py.*?--platform telegram",
-            makefile_contents,
+            r"uv run python tools/render_quadlet\.py.*?--platform telegram",
+            normalized,
             re.DOTALL,
         ), (
             "Makefile quadlet-install missing "
             "`uv run python tools/render_quadlet.py --platform telegram` invocation"
         )
         assert re.search(
-            r"uv run (?:--frozen )?python tools/render_quadlet\.py.*?--platform discord",
-            makefile_contents,
+            r"uv run python tools/render_quadlet\.py.*?--platform discord",
+            normalized,
             re.DOTALL,
         ), (
             "Makefile quadlet-install missing "


### PR DESCRIPTION
## Summary

- Adds `--frozen` to all host-side `uv run` invocations in deploy/install targets (`quadlet-install`, `nats-regen-specs`, `nats-add-identity`)
- Without `--frozen`, a pyproject.toml drift silently rewrites `uv.lock` on M₁, dirtying the checkout and blocking the factory-quadlet-sync ff-only pull (#1899 dirty-guard)
- Fix makes a stale lock FAIL LOUDLY (non-zero exit) instead of mutating the tree

## Targets changed

| Line | Before | After |
|---|---|---|
| 151 | `uv run factory bot init` | `uv run --frozen factory bot init` |
| 160 | `uv run python tools/render_quadlet.py` | `uv run --frozen python tools/render_quadlet.py` |
| 165 | `uv run python tools/render_quadlet.py` | `uv run --frozen python tools/render_quadlet.py` |
| 323 | `uv run python scripts/render_acl_spec.py` | `uv run --frozen python scripts/render_acl_spec.py` |
| 324 | `uv run python scripts/render_acl_parity.py` | `uv run --frozen python scripts/render_acl_parity.py` |
| 349 | `uv run --project . factory-acl genkeys` | `uv run --frozen --project . factory-acl genkeys` |

**Line 151 (`factory bot init`) and 349 (`factory-acl genkeys`):** added `--frozen`. These are idempotent provisioning commands in the install path — they have no legitimate need to re-resolve dependencies. Consistent with all other install-path targets.

**Dev-workflow targets** (pytest/ruff/pyright/format, lines 367+): untouched, out of scope.

## Acceptance

Lock-drift failure demonstrated via `uv lock --check` with `fake-drift-package>=999.0.0` injected into `pyproject.toml`:
```
× No solution found when resolving dependencies...
  ╰─▶ Because fake-drift-package was not found in the package registry...
lock-check exit=1
```
`pyproject.toml` restored. `git status --short` after demonstration: `M Makefile` only (already committed on this branch); `uv.lock` byte-identical to HEAD.

Closes #1905