### PR TITLE
fix(ci): wire orphan quality gates and drop false-green integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Check duplicate test basenames
         run: bash tools/check_duplicate_test_basenames.sh
 
+      - name: Check folder size
+        run: bash tools/check_folder_size.sh
+
+      - name: Check no runtime TOML bots
+        run: bash tools/check_no_runtime_toml_bots.sh
+
       - name: Check ACL matrix lifecycle fields
         run: uv run factory-check-acl-retired
 
@@ -124,6 +130,9 @@ jobs:
       - name: Check quadlet manifest install wiring (quadlet.toml → Makefile/verify/converge)
         run: bash tools/check_quadlet_manifest_install.sh
 
+      - name: Check deployment.md Volumes table matches quadlet Volume= directives
+        run: bash tools/check_volumes_table.sh
+
       - name: Check architecture snapshot freshness
         run: bash tools/check_architecture_snapshot.sh
 
@@ -141,6 +150,9 @@ jobs:
 
       - name: Typecheck
         run: uv run pyright
+
+      - name: License check
+        run: uv run tools/license_check.py
 
       - name: Verify error codes registry sync
         run: |
@@ -185,12 +197,3 @@ jobs:
       - name: Tear down Docker environment
         if: always()
         run: docker compose -f docker/docker-compose.test.yml down -v
-
-  integration-report:
-    name: integration
-    needs: [integration]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report success
-        run: echo "Integration tests passed"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
     files: ^packages/roxabi-contracts/(src/roxabi_contracts/errors\.py|docs/error-codes\.md|scripts/check_codes_sync\.py)$
   - id: trufflehog
     name: trufflehog secret scan
-    entry: bash -c "[ -d .git ] && trufflehog git file://. --fail || true"
+    entry: bash -c 'command -v trufflehog >/dev/null || { echo "trufflehog not installed — https://github.com/trufflesecurity/trufflehog/releases" >&2; exit 2; }; trufflehog git file://. --only-verified --fail'
     language: system
     pass_filenames: false
     stages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ uv sync
 cp .env.example .env
 # Fill in TELEGRAM_TOKEN, DISCORD_TOKEN, ANTHROPIC_API_KEY (see README Configuration)
 
-# 3. Install pre-commit hooks (runs ruff on every commit)
-uv run pre-commit install
+# 3. Install git hooks (commit + pre-push quality gates)
+make hooks-install
 
 # 4. Run the test suite to verify your setup
 uv run pytest
@@ -68,11 +68,25 @@ uv run pyright           # type check — must pass
 uv run pytest            # tests — must pass
 ```
 
-Pre-commit hooks run `ruff check` and `ruff format` automatically on `git commit`. Install them once:
+Git hooks run quality gates locally:
+
+- **commit** — ruff, pyright, file/folder size, import layers, …
+- **pre-push** — trufflehog, ACL drift, debt expiry, architecture snapshot, …
+
+Install both hook types once:
+
+```bash
+make hooks-install
+```
+
+Equivalent:
 
 ```bash
 uv run pre-commit install
+uv run pre-commit install --hook-type pre-push
 ```
+
+Pre-push hooks require [trufflehog](https://github.com/trufflesecurity/trufflehog/releases) on your `PATH`.
 
 ## Adding a channel adapter
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ define require_machine1
 	@case "$(DEPLOY_DIR)" in *[\'\"\$$\\\;\&\|\`]*) echo "Error: DEPLOY_DIR contains shell metacharacters"; exit 1 ;; esac
 endef
 
-.PHONY: build push factory telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy converge remote nats-setup nats-regen-authconf nats-add-identity test test-integration voice-smoke lint typecheck format quality-debt-report quality-debt-classify
+.PHONY: build push factory telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy converge remote nats-setup nats-regen-authconf nats-add-identity test test-integration voice-smoke lint typecheck format hooks-install quality-debt-report quality-debt-classify
 
 # ── Container image build + transfer ─────────────────────────────────────────
 
@@ -388,6 +388,10 @@ typecheck:
 
 format:
 	uv run ruff format .
+
+hooks-install:  ## install pre-commit + pre-push git hooks (see CONTRIBUTING.md)
+	uv run pre-commit install
+	uv run pre-commit install --hook-type pre-push
 
 # dep-graph and corpus migrated to roxabi-dashboard (2026-04-22).
 # Run via dashboard: `uv run --project ../roxabi-dashboard roxabi-corpus sync`


### PR DESCRIPTION
## Summary

Closes the wiring gaps identified in the quality-gates audit (PR 1 — Fix):

- **CI** now runs `folder_size`, `no_runtime_toml_bots`, `volumes_table`, and `license_check` (declared in `stack.yml` but previously local-only or unwired).
- **Removed** `integration-report` job — it always printed success even when the integration matrix failed.
- **Local hooks**: `make hooks-install` installs both commit and pre-push hooks; CONTRIBUTING updated.
- **TruffleHog pre-push**: removed `|| true`; uses `--only-verified --fail` (aligned with `secret-scan.yml`).

## Test plan

- [x] `bash tools/check_folder_size.sh`
- [x] `bash tools/check_no_runtime_toml_bots.sh`
- [x] `bash tools/check_volumes_table.sh`
- [x] `uv run tools/license_check.py`
- [ ] CI green on this PR