### PR TITLE
feat(tools): gate wiring audit and quality-gates index

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -1,6 +1,9 @@
 # .claude/stack.yml — dev-core stack configuration
 schema_version: "1.0"
 
+hooks:
+  tool: pre-commit
+
 runtime: python
 package_manager: uv
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Check qg.conf drift (stack.yml is source of truth)
         run: bash scripts/check-qg-conf-drift.sh
 
+      - name: Audit quality_gates wiring (stack.yml vs pre-commit vs CI)
+        run: uv run python tools/audit_gate_wiring.py
+
       - name: Check duplicate test basenames
         run: bash tools/check_duplicate_test_basenames.sh
 
@@ -126,6 +129,9 @@ jobs:
 
       - name: Check secrets drift (unit Secret= / quadlet.toml / manifest / acl-matrix)
         run: bash tools/check_secrets_drift.sh
+
+      - name: Check secrets source files (skips when factory data dir absent)
+        run: bash tools/check_secrets_source.sh
 
       - name: Check quadlet manifest install wiring (quadlet.toml → Makefile/verify/converge)
         run: bash tools/check_quadlet_manifest_install.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,13 @@ repos:
     pass_filenames: false
     stages:
     - pre-push
+  - id: check-secrets-source
+    name: check-secrets-source (host data dir; skips when absent)
+    entry: tools/check_secrets_source.sh
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push
   - id: license
     name: license check
     entry: uv run tools/license_check.py

--- a/docs/ops/quality-gates.md
+++ b/docs/ops/quality-gates.md
@@ -1,0 +1,126 @@
+# Quality Gates — Index
+
+Every automated check that can block a commit, push, or merge — and where it runs.
+
+Gate definitions: `.claude/stack.yml` → `quality_gates`. Wiring is verified by `tools/audit_gate_wiring.py` (CI).
+
+Script behaviour: [`tools/CLAUDE.md`](../../tools/CLAUDE.md).
+
+---
+
+## Four layers (not one file)
+
+| Layer | Config | When | Blocks merge? |
+|---|---|---|---|
+| **CI** | `.github/workflows/ci.yml` + path workflows | Every PR | Yes |
+| **Git commit** | `.pre-commit-config.yaml` (default stage) | `git commit` | Local |
+| **Git pre-push** | `.pre-commit-config.yaml` (`stages: [pre-push]`) | `git push` | Local |
+| **Claude session** | `dev-core` plugin `hooks/hooks.json` | Agent Edit/Write | No |
+
+`hooks.tool: pre-commit` in `stack.yml` declares the git hook runner. Install: `make hooks-install`.
+
+**Claude hooks are separate.** They run during an agent session (format + security patterns on file edits). They do not replace git hooks or CI. Source: `roxabi-plugins/plugins/dev-core/hooks/` — see [Claude session hooks](#claude-session-hooks).
+
+---
+
+## Stages
+
+| Stage | Invoke locally |
+|---|---|
+| commit | `pre-commit run --all-files` |
+| pre-push | `pre-commit run --hook-stage pre-push --all-files` |
+| CI | Push branch; or run step commands from `ci.yml` |
+| wiring audit | `uv run python tools/audit_gate_wiring.py` |
+
+---
+
+## Gates in `stack.yml`
+
+| Gate | Script / mechanism | stack stage | pre-commit | pre-push | CI |
+|---|---|:---:|:---:|:---:|:---:|
+| `file_length` | `check_file_length.sh` (SLOC) | commit | ✓ (+ package variants) | — | ✓ |
+| `folder_size` | `check_folder_size.sh` | commit | ✓ | — | ✓ |
+| `duplicate_test_basenames` | `check_duplicate_test_basenames.sh` | commit | ✓ | — | ✓ |
+| `import_layers` | `lint-imports` | pre-push* | ✓ (commit stage) | — | ✓ |
+| `doc_drift` | `check_doc_drift.py` | commit | — | — | ✓ |
+| `no_runtime_toml_bots` | `check_no_runtime_toml_bots.sh` | commit | — | ✓ | ✓ |
+| `architecture_snapshot` | `check_architecture_snapshot.sh` | pre-push | — | ✓ | ✓ |
+| `debt_expiry` | `check_debt_expiry.sh` | pre-push | — | ✓ | ✓ |
+| `hardcoded_constants` | `check_hardcoded_constants.sh` | commit | ✓ | — | ✓ |
+| `file_exemptions` | `check_file_exemptions.sh` | commit | ✓ | — | ✓ |
+| `test_sleep` | `check_test_sleep.sh` | pre-push | — | ✓ | ✓ |
+| `secrets_drift` | `check_secrets_drift.sh` | pre-push | — | — | ✓ |
+| `secrets_source` | `check_secrets_source.sh` | pre-push | — | ✓ | ✓† |
+| `volumes_table` | `check_volumes_table.sh` | pre-push | — | — | ✓ |
+| `quadlet_manifest_install` | `check_quadlet_manifest_install.sh` | pre-push | — | — | ✓ |
+| `str_exc_bus_bound` | `check_str_exc_bus_bound.sh` | commit | — | — | ✓ |
+
+\* `import_layers` runs at commit stage in `.pre-commit-config.yaml` despite `stage: pre-push` in `stack.yml`.
+
+† `secrets_source` exits 0 on CI runners when `~/.roxabi/factory` is absent; enforces on hosts with data dir.
+
+**Wiring audit** — `tools/audit_gate_wiring.py` fails CI if any enabled gate above is missing from both pre-commit and `ci.yml`.
+
+---
+
+## pre-commit hooks (not in `stack.yml`)
+
+| Hook | Stage |
+|---|---|
+| `lint` / `typecheck` | commit |
+| `codes-sync` | commit (path-filtered) |
+| `trufflehog` | pre-push (`--only-verified --fail`) |
+| `license` | pre-push |
+| `qg-conf-drift` / ACL drift scripts | pre-push |
+| `check-single-write-tool-display-config` | pre-push |
+
+`license_check` also runs in CI (not a `stack.yml` gate).
+
+---
+
+## CI-only checks (not in `stack.yml`)
+
+| Check | Purpose |
+|---|---|
+| `audit_gate_wiring.py` | stack.yml gates ⊆ pre-commit ∪ CI |
+| ACL retired / flows / grants | NATS matrix enforcement |
+| `check_inbox_prefix.py` / `check_subject_literals.py` | Subject discipline |
+| `check_codes_sync.py` | Error codes registry |
+| Coverage floors (50 / 70 / 80 %) | factory / nats / contracts |
+| Integration matrix | Docker NATS (`typing_enabled` true/false) |
+
+Path-triggered: `quadlet-lint.yml`, `renderer-roundtrip.yml`, `secret-scan.yml`, `pr-title.yml`, `omp-base.yml`.
+
+---
+
+## Claude session hooks
+
+From plugin `dev-core@roxabi-marketplace` (not git, not CI):
+
+| Hook | Trigger | Blocking? | Action |
+|---|---|:---:|---|
+| `format.js` | PostToolUse Edit/Write | No | Runs `build.formatter_fix_cmd` from `stack.yml` (`ruff format` + `ruff check --fix`) |
+| `security-check.js` | PreToolUse Edit/Write | Yes | Blocks naive hardcoded secrets / injection patterns |
+| bun test blocker | PreToolUse Bash | Yes | N/A for this Python repo |
+
+Override per project: `.claude/hooks/hooks.json`. Full reference: `roxabi-plugins/plugins/dev-core/hooks/README.md`.
+
+---
+
+## Run locally
+
+```bash
+make hooks-install
+pre-commit run --all-files
+pre-commit run --hook-stage pre-push --all-files
+uv run python tools/audit_gate_wiring.py
+```
+
+---
+
+## Adding a gate
+
+1. Add under `quality_gates` in `.claude/stack.yml`.
+2. Wire to `.pre-commit-config.yaml` and/or `.github/workflows/ci.yml`.
+3. `uv run python tools/audit_gate_wiring.py` must pass.
+4. Update this file if the gate is non-obvious.

--- a/tests/tools/test_audit_gate_wiring.py
+++ b/tests/tools/test_audit_gate_wiring.py
@@ -1,0 +1,92 @@
+"""Tests for tools/audit_gate_wiring.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from tools.audit_gate_wiring import audit, main
+
+
+def _write_stack(root: Path, gates: dict) -> None:
+    stack_dir = root / ".claude"
+    stack_dir.mkdir(parents=True, exist_ok=True)
+    (stack_dir / "stack.yml").write_text(
+        yaml.safe_dump({"quality_gates": gates}),
+        encoding="utf-8",
+    )
+
+
+def _write_pre_commit(root: Path, content: str) -> None:
+    (root / ".pre-commit-config.yaml").write_text(content, encoding="utf-8")
+
+
+def _write_ci(root: Path, content: str) -> None:
+    ci_dir = root / ".github" / "workflows"
+    ci_dir.mkdir(parents=True)
+    (ci_dir / "ci.yml").write_text(content, encoding="utf-8")
+
+
+def test_all_wired_passes(tmp_path: Path) -> None:
+    _write_stack(
+        tmp_path,
+        {
+            "folder_size": {"enabled": True, "script": "tools/check_folder_size.sh"},
+            "secrets_source": {"enabled": True, "script": "tools/check_secrets_source.sh"},
+        },
+    )
+    _write_pre_commit(tmp_path, "entry: tools/check_secrets_source.sh\n")
+    _write_ci(tmp_path, "run: bash tools/check_folder_size.sh\n")
+
+    assert audit(tmp_path) == []
+
+
+def test_orphan_reported(tmp_path: Path) -> None:
+    _write_stack(
+        tmp_path,
+        {"volumes_table": {"enabled": True, "script": "tools/check_volumes_table.sh"}},
+    )
+    _write_pre_commit(tmp_path, "repos: []\n")
+    _write_ci(tmp_path, "jobs: {}\n")
+
+    orphans = audit(tmp_path)
+    assert len(orphans) == 1
+    assert "volumes_table" in orphans[0]
+
+
+def test_disabled_gate_skipped(tmp_path: Path) -> None:
+    _write_stack(
+        tmp_path,
+        {"volumes_table": {"enabled": False, "script": "tools/check_volumes_table.sh"}},
+    )
+    _write_pre_commit(tmp_path, "repos: []\n")
+    _write_ci(tmp_path, "jobs: {}\n")
+
+    assert audit(tmp_path) == []
+
+
+def test_main_exit_codes(tmp_path: Path) -> None:
+    _write_stack(tmp_path, {})
+    _write_pre_commit(tmp_path, "repos: []\n")
+    _write_ci(tmp_path, "jobs: {}\n")
+    assert main(["--root", str(tmp_path)]) == 0
+
+    _write_stack(
+        tmp_path,
+        {"no_runtime_toml_bots": {"enabled": True, "script": "tools/check_no_runtime_toml_bots.sh"}},
+    )
+    assert main(["--root", str(tmp_path)]) == 1
+
+
+def test_repo_root_audit_passes() -> None:
+    root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, str(root / "tools" / "audit_gate_wiring.py"), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -7,7 +7,7 @@ Canonical source: `roxabi-plugins/plugins/dev-core/tools/` — ¬edit project-si
 
 ## Wiring
 
-Scripts are driven by `.claude/stack.yml` `quality_gates` block — that block is the SSoT for which gates exist and their stage (pre-commit, pre-push, CI). Most gates run pre-commit; `import_layers` and `architecture_snapshot` run pre-push; `doc_drift` runs CI.
+Scripts are driven by `.claude/stack.yml` `quality_gates` block — that block is the SSoT for which gates exist and their stage (pre-commit, pre-push, CI). Wiring index: `docs/ops/quality-gates.md`. Drift guard: `tools/audit_gate_wiring.py` (CI). Git hooks: `hooks.tool: pre-commit` + `make hooks-install`. Claude session hooks (format/security on agent edits) are a separate layer — see quality-gates.md § Claude session hooks.
 
 ### `check_doc_drift.py` — scanned scope (allowlist, #1538)
 

--- a/tools/audit_gate_wiring.py
+++ b/tools/audit_gate_wiring.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Verify enabled stack.yml quality_gates are wired in pre-commit and/or CI.
+
+Reads .claude/stack.yml (registry), .pre-commit-config.yaml, and
+.github/workflows/ci.yml. Each enabled gate must appear in at least one
+wiring file unless listed in CI_EXEMPT (host-dependent gates).
+
+Exit 0 = wired. Exit 1 = orphan(s). Exit 2 = script error.
+
+Usage:
+    uv run python tools/audit_gate_wiring.py [--root ROOT]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# Gates that may skip on CI runners but must still appear in wiring files.
+# (Empty — add gate IDs here only when host-only and intentionally unwired in CI.)
+CI_EXEMPT: frozenset[str] = frozenset()
+
+# Gates without a script: key in stack.yml → substring(s) to find in wiring files.
+_EXTRA_MARKERS: dict[str, tuple[str, ...]] = {
+    "import_layers": ("lint-imports",),
+    "file_length": ("check_file_length",),
+    "folder_size": ("check_folder_size",),
+}
+
+
+def _markers(gate_id: str, cfg: dict) -> tuple[str, ...]:
+    script = cfg.get("script")
+    if script:
+        stem = Path(str(script)).stem
+        return (stem,)
+    extra = _EXTRA_MARKERS.get(gate_id)
+    if extra:
+        return extra
+    return (gate_id.replace("_", "-"), gate_id)
+
+
+def _load_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_gates(stack_path: Path) -> dict[str, dict]:
+    data = yaml.safe_load(stack_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{stack_path}: expected mapping at root")
+    qg = data.get("quality_gates")
+    if not isinstance(qg, dict):
+        raise ValueError(f"{stack_path}: quality_gates block missing or invalid")
+    return qg
+
+
+def audit(root: Path) -> list[str]:
+    stack_path = root / ".claude" / "stack.yml"
+    pre_commit_path = root / ".pre-commit-config.yaml"
+    ci_path = root / ".github" / "workflows" / "ci.yml"
+
+    for p in (stack_path, pre_commit_path, ci_path):
+        if not p.is_file():
+            raise FileNotFoundError(p)
+
+    gates = _parse_gates(stack_path)
+    pre_commit = _load_text(pre_commit_path)
+    ci = _load_text(ci_path)
+
+    orphans: list[str] = []
+    for gate_id, cfg in sorted(gates.items()):
+        if not isinstance(cfg, dict):
+            continue
+        if cfg.get("enabled") is False:
+            continue
+
+        markers = _markers(gate_id, cfg)
+        in_pre_commit = any(m in pre_commit for m in markers)
+        in_ci = any(m in ci for m in markers)
+
+        if gate_id in CI_EXEMPT:
+            if not (in_pre_commit or in_ci):
+                orphans.append(
+                    f"{gate_id}: CI_EXEMPT but not wired locally — "
+                    f"add pre-push hook or document manual run"
+                )
+            continue
+
+        if not (in_pre_commit or in_ci):
+            want = ", ".join(markers)
+            orphans.append(
+                f"{gate_id}: not found in .pre-commit-config.yaml or ci.yml "
+                f"(markers: {want})"
+            )
+
+    return orphans
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+
+    try:
+        orphans = audit(root)
+    except (FileNotFoundError, ValueError, yaml.YAMLError) as exc:
+        print(f"audit_gate_wiring: error: {exc}", file=sys.stderr)
+        return 2
+
+    if orphans:
+        print("audit_gate_wiring: FAILED — orphan quality_gates:", file=sys.stderr)
+        for line in orphans:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+
+    print("audit_gate_wiring: OK — all enabled stack.yml gates are wired")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Lands #1919 on `staging` (was merged into `fix/quality-gates-wiring` only).

- `tools/audit_gate_wiring.py` — CI fails when enabled `stack.yml` gates lack pre-commit/CI wiring
- `docs/ops/quality-gates.md` — four-layer index (CI, git hooks, Claude session hooks)
- `hooks.tool: pre-commit` in `stack.yml`
- `secrets_source` wired to pre-push + CI (graceful skip on runners)

Depends on #1918 (already on staging).

## Test plan

- [x] `uv run pytest tests/tools/test_audit_gate_wiring.py`
- [x] `uv run python tools/audit_gate_wiring.py`
- [ ] CI green