### PR TITLE
fix(omp): pin grok-4-fast default and configurable RpcClient timeout

### DIFF
--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +36,23 @@ _OMP_BIN = Path("/opt/omp/omp")  # image-build constant — NEVER from env
 _DEFAULT_PROVIDER = (
     "litellm"  # routes through factory LiteLLM proxy (deploy/omp/models.yml)
 )
+# Pin a fast default — model=None falls through to models.yml[0] (grok-4) and
+# risks RpcClient(request_timeout=30s) timeouts (#1910).
+_DEFAULT_MODEL = "grok-4-fast"
+_ENV_REQUEST_TIMEOUT_KEY = "OMP_REQUEST_TIMEOUT"
+_DEFAULT_REQUEST_TIMEOUT = 30.0
+
+
+def _read_request_timeout() -> float:
+    """Read OMP_REQUEST_TIMEOUT from env; fall back to _DEFAULT_REQUEST_TIMEOUT."""
+    raw = os.environ.get(_ENV_REQUEST_TIMEOUT_KEY)
+    if raw is None:
+        return _DEFAULT_REQUEST_TIMEOUT
+    try:
+        val = float(raw)
+        return val if val > 0 else _DEFAULT_REQUEST_TIMEOUT
+    except ValueError:
+        return _DEFAULT_REQUEST_TIMEOUT
 
 
 class DigestMismatchError(Exception):
@@ -152,6 +170,7 @@ class RpcBridge:
         *,
         provider: str | None = _DEFAULT_PROVIDER,
         model: str | None = None,
+        request_timeout: float | None = None,
         _client: Any | None = None,
     ) -> None:
         # Import deferred: omp_rpc is a container image dep, absent from pyproject.toml.
@@ -166,11 +185,18 @@ class RpcBridge:
             # provider/model are constructor kwargs only — no env axis. The runtime
             # model list comes from deploy/omp/models.yml (via PI_CODING_AGENT_DIR),
             # not from OMP_PROVIDER/OMP_MODEL env vars (#1876).
+            resolved_model = model if model is not None else _DEFAULT_MODEL
+            resolved_timeout = (
+                request_timeout
+                if request_timeout is not None
+                else _read_request_timeout()
+            )
             self._client = omp_rpc.RpcClient(
                 executable=str(omp_bin),
                 provider=provider,
-                model=model,
+                model=resolved_model,
                 no_session=False,
+                request_timeout=resolved_timeout,
             )
         self._nc: NatsClient | None = None
         self._loop: asyncio.AbstractEventLoop | None = None

--- a/src/factory/adapters/omp/omp_pool.py
+++ b/src/factory/adapters/omp/omp_pool.py
@@ -86,10 +86,12 @@ class OmpPool:
         omp_bin: Path = _OMP_BIN,
         provider: str | None = _DEFAULT_PROVIDER,
         model: str | None = None,
+        request_timeout: float | None = None,
     ) -> None:
         self._omp_bin = omp_bin
         self._provider = provider
         self._model = model
+        self._request_timeout = request_timeout
         self._free: list[_PoolWorker] = []
         self._all: list[_PoolWorker] = []
         self._checked_out: set[int] = set()  # ids (workers not hashable)
@@ -135,7 +137,9 @@ class OmpPool:
                 await asyncio.to_thread(worker.client.new_session)
                 state = await asyncio.to_thread(worker.client.get_state)
                 worker.session_file = getattr(state, "session_file", None)
-                log.debug("[omp_pool] acquire new session, minted %s", worker.session_file)  # noqa: E501
+                log.debug(
+                    "[omp_pool] acquire new session, minted %s", worker.session_file
+                )  # noqa: E501
             return worker
         except BaseException:
             self._checked_out.discard(id(worker))
@@ -174,17 +178,29 @@ class OmpPool:
         # Deferred import — omp_rpc is a container image dep (absent from pyproject).
         import omp_rpc  # type: ignore[import-not-found]
 
-        from factory.adapters.omp._rpc_bridge import RpcBridge, _verify_digest
+        from factory.adapters.omp._rpc_bridge import (
+            _DEFAULT_MODEL,
+            RpcBridge,
+            _read_request_timeout,
+            _verify_digest,
+        )
 
         # gate before client (non-blocking via to_thread)
         await asyncio.to_thread(_verify_digest, self._omp_bin)
+        resolved_model = self._model if self._model is not None else _DEFAULT_MODEL
+        resolved_timeout = (
+            self._request_timeout
+            if self._request_timeout is not None
+            else _read_request_timeout()
+        )
         client: Any = None
         try:
             client = omp_rpc.RpcClient(
                 executable=str(self._omp_bin),
                 provider=self._provider,
-                model=self._model,
+                model=resolved_model,
                 no_session=False,
+                request_timeout=resolved_timeout,
             )
             await asyncio.to_thread(client.start)
             # RpcBridge(_client=): skips digest (done) + no own ctor.

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import sys
 import threading
 from pathlib import Path
@@ -24,11 +25,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from factory.adapters.omp._rpc_bridge import (
+    _DEFAULT_MODEL,
+    _DEFAULT_REQUEST_TIMEOUT,
+    _ENV_REQUEST_TIMEOUT_KEY,
     _PINNED_SHA256,
     DigestMismatchError,
     RpcBridge,
     SteerViolationError,
     _classify_exception,
+    _read_request_timeout,
 )
 
 # ---------------------------------------------------------------------------
@@ -767,6 +772,12 @@ class TestStartLifecycle:
         assert received_kwargs.get("provider") == "litellm", (
             f"expected provider='litellm', got: {received_kwargs.get('provider')}"
         )
+        assert received_kwargs.get("model") == _DEFAULT_MODEL, (
+            f"expected model={_DEFAULT_MODEL!r}, got: {received_kwargs.get('model')}"
+        )
+        assert received_kwargs.get("request_timeout") == _DEFAULT_REQUEST_TIMEOUT, (
+            "expected default request_timeout when unset"
+        )
 
     async def test_injected_client_is_adopted_without_constructing(
         self, tmp_path: Path
@@ -876,3 +887,20 @@ class TestRunCapturesLastTurn:
         assert bridge._last_turn is sentinel_turn, (
             f"_last_turn should be the sentinel turn, got {bridge._last_turn!r}"
         )
+
+
+class TestRequestTimeoutConfig:
+    def test_read_request_timeout_defaults(self) -> None:
+        env_without = {
+            k: v for k, v in os.environ.items() if k != _ENV_REQUEST_TIMEOUT_KEY
+        }
+        with patch.dict(os.environ, env_without, clear=True):
+            assert _read_request_timeout() == _DEFAULT_REQUEST_TIMEOUT
+
+    def test_read_request_timeout_honours_env(self) -> None:
+        with patch.dict(os.environ, {_ENV_REQUEST_TIMEOUT_KEY: "120"}):
+            assert _read_request_timeout() == 120.0
+
+    def test_read_request_timeout_rejects_invalid(self) -> None:
+        with patch.dict(os.environ, {_ENV_REQUEST_TIMEOUT_KEY: "not-a-float"}):
+            assert _read_request_timeout() == _DEFAULT_REQUEST_TIMEOUT

--- a/tests/llm/drivers/test_omp_pool.py
+++ b/tests/llm/drivers/test_omp_pool.py
@@ -14,6 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from factory.adapters.omp._rpc_bridge import (
+    _DEFAULT_MODEL,
+    _DEFAULT_REQUEST_TIMEOUT,
+    _ENV_REQUEST_TIMEOUT_KEY,
+    _read_request_timeout,
+)
 from factory.adapters.omp.omp_pool import (
     _DEFAULT_CAP,
     OmpPool,
@@ -259,7 +265,44 @@ class TestOmpPool:
         assert captured_kwargs.get("no_session") is False, (
             f"Expected no_session=False, got kwargs={captured_kwargs}"
         )
+        assert captured_kwargs.get("model") == _DEFAULT_MODEL
+        assert captured_kwargs.get("request_timeout") == _DEFAULT_REQUEST_TIMEOUT
 
+        await pool.aclose()
+
+    @pytest.mark.asyncio
+    async def test_start_worker_defaults_model_when_unset(self) -> None:
+        """OmpPool() with model=None must pin grok-4-fast on RpcClient (#1910)."""
+        import sys
+
+        pool = OmpPool(omp_bin=Path("/fake/omp"))
+        await pool.register(_NC)
+
+        captured_kwargs: dict = {}
+        fake_bridge = _mock_bridge()
+
+        class _CapturingFakeOmpRpc:
+            def RpcClient(self, **kwargs: object) -> MagicMock:  # noqa: N802
+                captured_kwargs.update(kwargs)
+                return _mock_rpc_client()
+
+        sys.modules["omp_rpc"] = _CapturingFakeOmpRpc()  # type: ignore[assignment]
+        try:
+            with (
+                patch(
+                    "factory.adapters.omp._rpc_bridge._verify_digest",
+                    return_value=None,
+                ),
+                patch(
+                    "factory.adapters.omp._rpc_bridge.RpcBridge",
+                    return_value=fake_bridge,
+                ),
+            ):
+                await pool.acquire(None)
+        finally:
+            sys.modules.pop("omp_rpc", None)
+
+        assert captured_kwargs.get("model") == _DEFAULT_MODEL
         await pool.aclose()
 
     # -- Bonus: _read_cap falls back to default -----------------------------
@@ -275,3 +318,7 @@ class TestOmpPool:
         """_read_cap() returns the integer value of OMP_POOL_CAP when set."""
         with patch.dict(os.environ, {"OMP_POOL_CAP": "7"}):
             assert _read_cap() == 7
+
+    def test_read_request_timeout_honours_env_var(self) -> None:
+        with patch.dict(os.environ, {_ENV_REQUEST_TIMEOUT_KEY: "90"}):
+            assert _read_request_timeout() == 90.0


### PR DESCRIPTION
## Summary
- Pin `grok-4-fast` as the default omp RpcClient model when `model=None`, preventing fallback to `models.yml[0]` (`grok-4`) and 30s `RpcTimeoutError` under prod load (#1910).
- Expose `OMP_REQUEST_TIMEOUT` env var (constructor override also supported) so operators can raise the timeout for reasoning models without changing code.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1910: fix(omp) worker model=None → grok-4 timeout risk | OPEN |
| Implementation | 1 commit on `feat/1910-fix-omp-rpcclient-model-timeout` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (58 omp tests) | Passed |

## Test Plan
- [x] `RpcBridge` passes `model=grok-4-fast` and `request_timeout=30.0` by default
- [x] `OmpPool()` with unset model pins `grok-4-fast` on worker RpcClient construction
- [x] `OMP_REQUEST_TIMEOUT` env honoured; invalid values fall back to 30s

Fixes #1910

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`