### PR TITLE
feat(omp): dynamic model catalog via LiteLLM discovery (#1923)

### DIFF
--- a/artifacts/frames/1923-omp-dynamic-model-discovery-frame.mdx
+++ b/artifacts/frames/1923-omp-dynamic-model-discovery-frame.mdx
@@ -1,0 +1,81 @@
+---
+title: "feat(omp): dynamic model catalog — discovery mode from LiteLLM gateway"
+issue: 1923
+status: approved
+tier: F-lite
+date: 2026-06-17
+---
+
+## Problem
+
+`deploy/omp/models.yml` ships a **static** explicit model list (`grok-4`,
+`grok-4-fast`) — deliberate #1811 Option D to dodge omp's discovery
+chicken-and-egg (override-only entries still discover against
+`localhost:4000`). That trade-off now creates ops toil: new xAI models (e.g.
+`grok-4.3`) appear on the factory LiteLLM proxy but stay invisible to omp
+until someone edits `models.yml` and restarts `factory-omp`.
+
+The omp worker logs `model_cfg` from the hub but does not apply it yet (V1 gap;
+#1924). Even with hub `model=grok-4-fast`, `RpcClient(model=None)` defaults to
+the **first** `models.yml` entry → `grok-4` (#1910). A dynamic catalog from
+the gateway removes the manual sync step and lets the proxy catalogue be the
+source of truth.
+
+## Who
+
+- **Primary:** operators running `factory-omp` on M₁ — no image rebuild or
+  `models.yml` edit when xAI ships a new Grok variant on the proxy.
+- **Secondary:** hub/job dispatch (#1924) — a discovered catalogue is
+  prerequisite for per-job model selection to mean anything beyond the static
+  default.
+
+## Constraints
+
+- Discovery shape verified in #1811 against oh-my-pi `model-registry.ts` —
+  `discovery: {type: openai-models-list}` under the `litellm` provider override.
+- **Interim phase** (unblocked): Roxabi/llmCLI#129 (`pass_through /xai`) must
+  ship first; omp `baseUrl` targets `:18091/xai/v1` for Grok catalogue fetch.
+- **Target phase** (blocked on llmCLI#130): unified `:18091/v1` + merged
+  catalogue; full AC including `grok-4.3` boot discovery without rebuild.
+- Single-domain scope: `deploy/omp/` config + README + smoke/integration test —
+  no Quadlet unit changes (#1812), no hub model-apply logic (#1924).
+- Keep deterministic fallback if discovery fails (document behaviour; optional
+  static list as last resort).
+
+## Out of Scope
+
+- **Hub per-job model apply** → #1924 (`model_cfg` → `RpcClient(model=…)`).
+- **Quadlet secret mount / volume wiring** → #1812 (OmpWorker).
+- **Target-phase `baseUrl` switch to `:18091/v1`** → waits on llmCLI#130; this
+  slice delivers interim discovery only unless #130 lands during implementation.
+- **Non-Grok providers** on the merged catalogue — interim slice is xAI pass-through.
+
+## Premise Validity
+
+**Success in 6 months:** by 2026-12, adding a Grok model to the factory LiteLLM
+proxy makes it available to `factory-omp` after container restart with **zero**
+`models.yml` edits; operators have not filed a manual-catalog-sync incident in
+≥90 days.
+
+**Failure in 6 months:** by 2026-12, ≥3 production incidents where a proxy-new
+Grok model was unreachable by omp because `models.yml` still required a manual
+id entry (same failure mode as today), OR discovery boot adds >30s to omp worker
+cold-start p95 → revert to static list.
+
+**Simplest alternative:** keep the static list and document a runbook step
+("edit `models.yml`, restart `factory-omp`") whenever the proxy catalogue changes.
+**Why not simplest:** ops toil scales with model churn; the chicken-and-egg is
+solved now that llmCLI#129 provides a stable `/xai/v1/models` endpoint — the
+static list was a temporary dodge, not the steady-state.
+
+## Complexity
+
+**Tier: F-lite** — clear scope in one domain (`deploy/omp/`), config + docs +
+smoke test; discovery shape already verified in #1811; no new architectural
+patterns.
+
+Signals observed:
+- Issue label `size:F-lite`
+- Touches ≤3 files (`models.yml`, `README.md`, test/smoke)
+- Single domain (omp deploy config)
+- No cross-layer boundary changes (inbound/core/infrastructure)

--- a/artifacts/plans/1923-omp-dynamic-model-discovery-plan.mdx
+++ b/artifacts/plans/1923-omp-dynamic-model-discovery-plan.mdx
@@ -1,0 +1,266 @@
+---
+title: "Plan: feat(omp) dynamic model catalog — discovery mode"
+issue: 1923
+spec: artifacts/specs/1923-omp-dynamic-model-discovery-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: "2026-06-17T20:00:00Z"
+---
+
+## Summary
+
+Replace the static `models:` list in `deploy/omp/models.yml` with
+`discovery: {type: openai-models-list}` against the interim xAI pass-through
+URL (`:18091/xai/v1`), update operator docs, and add CI tests under
+`tests/deploy/` — static YAML invariants plus a mock-gateway catalogue fetch.
+
+## Architecture
+
+### Data Flow
+
+```mermaid
+flowchart TD
+    subgraph "Repo SSoT"
+        MY["deploy/omp/models.yml"]
+        RD["deploy/omp/README.md"]
+    end
+
+    subgraph "Quadlet (unchanged)"
+        FC["factory-omp.container bind mount"]
+    end
+
+    subgraph "Runtime"
+        OMP["omp agent dir via PI_CODING_AGENT_DIR"]
+        DISC["openai-models-list fetcher"]
+        REG["omp model registry / models.db"]
+    end
+
+    subgraph "External"
+        GW["LiteLLM :18091/xai/v1/models"]
+        MOCK["tests: ThreadingHTTPServer stub"]
+    end
+
+    subgraph "CI"
+        T1["test_models_yml_invariants"]
+        T2["test_mock_gateway_discovery"]
+    end
+
+    MY --> FC --> OMP
+    MY --> DISC
+    DISC --> GW
+    DISC --> REG
+    MY -.-> T1
+    MOCK -.-> T2
+    DISC -.-> T2
+```
+
+### File × Function Map
+
+```mermaid
+flowchart LR
+    subgraph "deploy/omp/"
+        MY["models.yml — provider override"]
+        RD["README.md — operator docs"]
+    end
+
+    subgraph "tests/deploy/"
+        TD["test_omp_models_discovery.py"]
+        TI["test_load_models_yml()"]
+        TM["test_mock_gateway_catalogue()"]
+        TL["test_live_gateway_catalogue() optional"]
+    end
+
+    MY --> TI
+    MY --> TM
+    TD --> TI
+    TD --> TM
+    TD --> TL
+    RD -.->|"documents"| MY
+```
+
+## Bootstrap Context
+
+No analysis artifact — frame + spec only. Discovery shape verified in #1811
+against oh-my-pi `model-registry.ts:1395-1408`. Chicken-and-egg rationale and
+Quadlet mount pattern documented in `deploy/omp/README.md` (#1811). `factory-omp`
+bind mount is stable — this plan does not touch `deploy/quadlet/`.
+
+## Agents
+
+| Agent | Task count | Files |
+|-------|-----------|-------|
+| devops-A | 1 | `deploy/omp/models.yml` |
+| doc-writer-A | 1 | `deploy/omp/README.md` |
+| tester-A | 4 | `tests/deploy/test_omp_models_discovery.py` |
+
+## Wave Structure
+
+3 waves, max 3 parallel agents. Elapsed ~1 session vs ~2 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | devops-A: T1 · doc-writer-A: T2 · tester-A: T3 |
+| 2 | Wave 1 done | 1 | tester-A: T4→T5 |
+| 3 | Wave 2 done | 1 | tester-A: T6 RED-GATE |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 models.yml discovery switch | 1 | bounded | 3 | — |
+| T2 README phase docs | 1 | judgmental | 5 | — |
+| T3 static YAML invariants (RED) | 1 | bounded | 4 | — |
+| T4 mock-gateway discovery test | 1 | judgmental | 8 | — |
+| T5 pytest gate | 1 | trivial | 2 | — |
+| T6 RED-GATE V2 | 1 | trivial | 1 | — |
+
+**Total estimated ops: 23**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1 | 3 | deploy | — |
+| doc-writer-A | T2 | 5 | docs | — |
+| tester-A | T3, T4, T5, T6 | 15 | yaml, discovery | — |
+
+## Consistency Report
+
+- Criteria covered: 5/5 interim success criteria
+- Uncovered criteria: target-phase items (deferred per spec)
+- Tasks without spec backing: none
+- Gold plating exemptions applied: 0
+
+## Micro-Tasks
+
+### Slice V1: Discovery config + docs
+
+#### Task 1: Switch models.yml to discovery mode [P] → devops-A
+- **File:** `deploy/omp/models.yml`
+- **Snippet:**
+  ```yaml
+  providers:
+    litellm:
+      baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/xai/v1
+      api: openai-completions
+      apiKey: LITELLM_API_KEY
+      discovery:
+        type: openai-models-list
+  ```
+- **Verify:** `grep -q 'openai-models-list' deploy/omp/models.yml && ! grep -q '^    models:' deploy/omp/models.yml` (ready)
+- **Expected:** exit 0
+- **Time:** 3 min
+- **Difficulty:** 2
+- **Traces:** SC-1
+- **Phase:** GREEN
+
+#### Task 2: Document discovery mode + phase table [P] → doc-writer-A
+- **File:** `deploy/omp/README.md`
+- **Snippet:** Replace "Why an explicit models: list" section with discovery-mode docs; add interim/target phase table; operator restart procedure; pointers to #1924, llmCLI#129, llmCLI#130.
+- **Verify:** `grep -q 'openai-models-list' deploy/omp/README.md && grep -q 'xai/v1' deploy/omp/README.md` (ready)
+- **Expected:** exit 0
+- **Time:** 5 min
+- **Difficulty:** 2
+- **Traces:** SC-2
+- **Phase:** GREEN
+
+### Slice V2: CI discovery smoke
+
+#### Task 3: Add static YAML invariant tests [P] → tester-A
+- **File:** `tests/deploy/test_omp_models_discovery.py`
+- **Snippet:**
+  ```python
+  MODELS_YML = REPO_ROOT / "deploy" / "omp" / "models.yml"
+
+  def test_models_yml_has_discovery_block():
+      doc = yaml.safe_load(MODELS_YML.read_text())
+      litellm = doc["providers"]["litellm"]
+      assert litellm["discovery"]["type"] == "openai-models-list"
+      assert "models" not in litellm
+      assert litellm["baseUrl"].endswith("/xai/v1")
+  ```
+- **Verify:** `uv run --frozen pytest tests/deploy/test_omp_models_discovery.py::test_models_yml_has_discovery_block -x` (deferred until T1)
+- **Expected:** PASS after T1
+- **Time:** 4 min
+- **Difficulty:** 2
+- **Traces:** SC-3, T1
+- **Phase:** RED
+
+#### Task 4: Add mock-gateway catalogue test → tester-A
+- **File:** `tests/deploy/test_omp_models_discovery.py`
+- **Snippet:**
+  ```python
+  @pytest.fixture
+  def mock_gateway():
+      # ThreadingHTTPServer on 127.0.0.1:0 serving GET /xai/v1/models
+      # {"data": [{"id": "grok-4-fast", "object": "model"}]}
+      ...
+
+  def test_discovery_fetch_returns_grok_model(mock_gateway, tmp_path):
+      # Write temp models.yml pointing baseUrl at mock_gateway
+      # GET {baseUrl}/models with Authorization: Bearer test-key
+      # assert any m["id"].startswith("grok") for m in body["data"]
+  ```
+- **Verify:** `uv run --frozen pytest tests/deploy/test_omp_models_discovery.py::test_discovery_fetch_returns_grok_model -x` (ready)
+- **Expected:** PASS
+- **Time:** 8 min
+- **Difficulty:** 3
+- **Traces:** SC-3, C3, C4, T2
+- **Phase:** GREEN
+
+#### Task 5: Run full deploy discovery test module → tester-A
+- **File:** `tests/deploy/test_omp_models_discovery.py`
+- **Snippet:** _(no file change — verify only)_
+- **Verify:** `uv run --frozen pytest tests/deploy/test_omp_models_discovery.py -x` (ready)
+- **Expected:** all tests PASS
+- **Time:** 2 min
+- **Difficulty:** 1
+- **Traces:** SC-3
+- **Phase:** GREEN
+
+#### RED-GATE: RED complete V2 → tester-A
+- **Verify:** T3–T5 complete; `git diff` excludes `deploy/quadlet*`
+- **Phase:** RED-GATE
+
+#### Task 6 (optional manual): Live gateway smoke note → doc-writer-A
+- **File:** PR description or README footnote
+- **Snippet:** Document live validation command for M₁ post-llmCLI#129 deploy.
+- **Verify:** manual — recorded in PR body (manual)
+- **Expected:** operator checklist present
+- **Time:** 3 min
+- **Difficulty:** 1
+- **Traces:** SC-5
+- **Phase:** REFACTOR
+
+## Task Seeding Blueprint
+
+### Wave 1 — no deps, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | deploy |
+| T2 | doc-writer-A | — | docs |
+| T3 | tester-A | — | yaml |
+
+### Wave 2 — after Wave 1, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | tester-A | T1, T3 | discovery |
+| T5 | tester-A | T4 | discovery |
+
+### Wave 3 — after Wave 2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | tester-A | T5 | gate |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: plan-t1-deploy — deploy
+- T2: plan-t2-docs — docs
+- T3: plan-t3-yaml — yaml
+- T4: plan-t4-discovery — discovery
+- T5: plan-t5-pytest — discovery
+- T6: plan-t6-redgate — gate

--- a/artifacts/specs/1923-omp-dynamic-model-discovery-spec.mdx
+++ b/artifacts/specs/1923-omp-dynamic-model-discovery-spec.mdx
@@ -1,0 +1,148 @@
+---
+title: "feat(omp): dynamic model catalog — discovery mode from LiteLLM gateway"
+issue: 1923
+status: approved
+tier: F-lite
+date: 2026-06-17
+promoted-from: artifacts/frames/1923-omp-dynamic-model-discovery-frame.mdx
+---
+
+## Context
+
+Promoted from [frame](../frames/1923-omp-dynamic-model-discovery-frame.mdx)
+(approved 2026-06-17). Parent epic #1490 (pluggable harness runtime). #1811
+(closed) landed the static `models:` list as Option D to dodge omp's discovery
+chicken-and-egg. #1812 shipped `factory-omp` with `PI_CODING_AGENT_DIR` +
+repo-mounted `deploy/omp/models.yml`. #1910 fixed default-model selection when
+hub omits `model`. This issue reverses the #1811 trade-off now that
+Roxabi/llmCLI#129 (`pass_through /xai`) provides a stable Grok catalogue
+endpoint.
+
+**External dependency (interim):** Roxabi/llmCLI#129 must be deployed on M₁
+before live discovery works. Target-phase switch to `:18091/v1` waits on
+llmCLI#130 — out of scope unless it lands during implementation.
+
+## Goal
+
+`deploy/omp/models.yml` uses omp's built-in `openai-models-list` discovery
+against the factory LiteLLM xAI pass-through (`:18091/xai/v1`), eliminating
+manual Grok id maintenance while preserving the #1811 provider-override pattern.
+
+## Users
+
+- **Operators on M₁:** restart `factory-omp` after a proxy catalogue change —
+  no `models.yml` edit, no image rebuild.
+- **#1924 (hub model apply):** discovered catalogue is prerequisite for
+  per-job `model_cfg` to select a non-default Grok variant.
+
+## Expected Behavior
+
+1. `deploy/omp/models.yml` keeps the `litellm` provider override shape from
+   #1811 (`api: openai-completions`, `apiKey: LITELLM_API_KEY`) but:
+   - sets `baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/xai/v1`
+     (interim — xAI pass-through path per issue phases table)
+   - adds `discovery: {type: openai-models-list}`
+   - **removes** the explicit `models:` list (no static Grok ids)
+2. On `factory-omp` boot, omp fetches the gateway catalogue from
+   `{baseUrl}/models` (OpenAI-compatible list) and registers discovered Grok
+   models. A proxy-new id (e.g. `grok-4.3`) becomes selectable after container
+   restart without repo changes.
+3. If discovery fails (gateway unreachable, auth failure, empty catalogue):
+   worker startup logs the error clearly; behaviour matches omp upstream
+   (session init fails or falls back per omp defaults — document in README,
+   do not invent custom retry logic in this slice).
+4. `deploy/omp/README.md` documents:
+   - reversal of #1811 static-list trade-off and why discovery is safe now
+   - interim (`/xai/v1`) vs target (`/v1`) phases and llmCLI blockers
+   - operator restart procedure when proxy catalogue changes
+   - relationship to #1924 (hub model apply) and #1910 (default model)
+5. CI gains a deterministic test proving discovery wiring without requiring
+   live M₁ network (mock gateway); optional live marker for manual/M₁ smoke.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+  class ModelsYml {
+    <<frozen, repo SSoT>>
+    +providers.litellm.baseUrl: string
+    +providers.litellm.api: openai-completions
+    +providers.litellm.apiKey: LITELLM_API_KEY
+    +providers.litellm.discovery.type: openai-models-list
+    -models: list REMOVED
+  }
+  class GatewayCatalogue {
+    <<mutable, external>>
+    +GET /xai/v1/models
+    +data[]: {id, object, created, owned_by}
+    source = LiteLLM pass-through (#129)
+  }
+  class OmpModelRegistry {
+    <<mutable, runtime>>
+    +discovered_models: ModelRef[]
+    persisted in models.db (factory-omp-sessions volume)
+  }
+  class RpcClient {
+    <<runtime>>
+    +model: string | null
+    default = first discovered model (#1910)
+  }
+  ModelsYml --> GatewayCatalogue : discovery fetch at boot
+  GatewayCatalogue --> OmpModelRegistry : register ids
+  OmpModelRegistry --> RpcClient : model selection
+```
+
+```mermaid
+flowchart LR
+  MY[deploy/omp/models.yml] -->|ro bind :ro| FC[factory-omp container]
+  FC -->|PI_CODING_AGENT_DIR| OMP[omp agent dir]
+  OMP -->|discovery GET| GW[LiteLLM :18091/xai/v1]
+  GW -->|models list JSON| REG[omp model registry]
+  REG -->|default / explicit model| RPC[RpcClient session]
+  HUB[hub job dispatch] -.->|model_cfg #1924| RPC
+```
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `factory-omp` Quadlet unit | full `models.yml` via bind mount | container start | existing (#1812) |
+| omp discovery subsystem | `baseUrl`, `discovery.type`, `apiKey` | agent dir init | this issue |
+| omp `RpcClient` | discovered model ids | session `new_session()` | existing; #1924 adds hub override |
+| operators | README phase table + restart runbook | catalogue changes | this issue |
+| CI mock-gateway test | `discovery` block + resolved catalogue | PR gate | this issue |
+
+## Breadboard
+
+| ID | Affordance | Handler / mechanism | Data |
+|---|---|---|---|
+| C1 | `deploy/omp/models.yml` | omp provider override YAML | `baseUrl`, `discovery`, no `models:` |
+| C2 | Quadlet bind mount | `factory-omp.container` Volume line (unchanged) | repo SSoT → `/home/factory/.config/omp-pi/models.yml` |
+| C3 | Gateway catalogue | LiteLLM `GET /xai/v1/models` (llmCLI#129) | OpenAI models-list JSON |
+| C4 | omp discovery | oh-my-pi `openai-models-list` fetcher | registered model refs |
+| C5 | `deploy/omp/README.md` | operator docs | phase table, trade-off reversal |
+| T1 | Static YAML gate | pytest asserts schema invariants on `models.yml` | no `models:` key, `discovery.type` present |
+| T2 | Mock discovery smoke | pytest + local HTTP stub serving `{"data":[{"id":"grok-4-fast"}]}` | omp discovers ≥1 id without live tailnet |
+
+Wiring: C1→C2 (mount) · C1+C3→C4 (discovery) · C4→RpcClient (existing) ·
+C5 documents C1+C3 · T1 guards C1 · T2 proves C1+C4 end-to-end offline.
+
+## Slices
+
+| # | Slice | Demo | Contains |
+|---|---|---|---|
+| 1 | Discovery config + docs | `models.yml` has `discovery` block, no static list; README explains interim/target phases | C1, C5 |
+| 2 | CI discovery smoke | `pytest tests/deploy/test_omp_models_discovery.py` green in PR CI without M₁ network | T1, T2 |
+
+## Success Criteria
+
+### Interim (this PR — after llmCLI#129 deployed on M₁ for live validation)
+
+- [ ] `deploy/omp/models.yml` sets `baseUrl` to `http://roxabituwer.goose-logarithm.ts.net:18091/xai/v1` and includes `discovery: {type: openai-models-list}` with **no** `models:` key
+- [ ] `deploy/omp/README.md` documents discovery mode, #1811 trade-off reversal, interim vs target `baseUrl`, operator restart procedure, and pointers to #1924 / llmCLI#129 / llmCLI#130
+- [ ] `tests/deploy/test_omp_models_discovery.py` passes in CI: (a) static YAML invariants, (b) mock-gateway test proving omp discovers ≥1 model id from a local stub catalogue
+- [ ] `git diff` touches no `deploy/quadlet*` files, no `deploy/quadlet.toml` changes, no secrets surface — existing `secrets_drift` / `volumes_table` gates pass unchanged
+- [ ] Live smoke (manual or `@pytest.mark.gateway`): with `LITELLM_API_KEY` set and llmCLI#129 deployed, `factory-omp` restart discovers ≥1 Grok model from the real `:18091/xai/v1` catalogue — recorded in PR description or runbook note
+
+### Target (deferred — llmCLI#130)
+
+- [ ] `baseUrl` switched to `:18091/v1` — tracked as follow-up issue or phase-2 PR, not this slice
+- [ ] `grok-4.3` (or successor) discovered on boot without image rebuild — validated when #130 lands

--- a/deploy/omp/README.md
+++ b/deploy/omp/README.md
@@ -1,13 +1,14 @@
 # deploy/omp/ — omp (oh-my-pi) runtime config for the factory LiteLLM route
 
 Origin: #1811 (Option D, decided 2026-06-10). Parent: #1490 (pluggable harness
-runtime — omp alongside clipool).
+runtime — omp alongside clipool). Discovery mode: #1923 (reverses #1811 static
+list trade-off).
 
 ## What lives here
 
 | File | Role |
 |---|---|
-| `models.yml` | omp provider override — points the built-in `litellm` provider at the factory LiteLLM proxy (`:18091`, tailnet) with an explicit model catalog |
+| `models.yml` | omp provider override — points the built-in `litellm` provider at the factory LiteLLM xAI pass-through (`:18091/xai/v1`, tailnet) with dynamic catalogue discovery |
 
 ## How omp picks this up
 
@@ -29,24 +30,60 @@ default `http://localhost:4000/v1` is a `config?.baseUrl ?? …` fallback in
 | `PI_CODING_AGENT_DIR` | omp (`packages/utils/src/dirs.ts`) | Absolute path of the config dir containing `models.yml`. Mount target for this file in the worker unit. |
 | `LITELLM_API_KEY` | omp `litellm` provider | The proxy bearer key. `models.yml` references it **by name** (`apiKey: LITELLM_API_KEY` = env-name-or-literal semantics) — the value enters the container via the #1812 secret mount, never via this repo. ⚠ Fallback: if the env var is **unset**, omp sends the literal string `LITELLM_API_KEY` as the bearer (`resolveApiKeyConfig` — passes omp's non-empty check, rejected by the proxy) → auth failures with a config that looks correct. #1812 must verify injection before relying on proxy auth. |
 
-## Why an explicit `models:` list
+## Discovery mode (#1923)
 
-omp's built-in catalog discovery resolves the fetch URL from models it already
-knows, not from the overrides map — so an override-only entry would still
-discover against `localhost:4000` (chicken-and-egg). The explicit list both
-dodges that and makes the worker deterministic (no discovery round-trip at
-session start, no behaviour change when the proxy catalog moves).
+`models.yml` uses omp's built-in `openai-models-list` discovery:
 
-Trade-off: the list **replaces** discovery. Adding a model to the LiteLLM proxy
-requires adding its id here. Current catalog = the four models served by the
-factory proxy (`/v1/models`, 2026-06-10).
+```yaml
+discovery:
+  type: openai-models-list
+```
 
-## Validation (gate for #1811)
+At boot, omp fetches `GET {baseUrl}/models` (OpenAI-compatible list) and
+registers discovered Grok ids. A model added to the LiteLLM proxy becomes
+available after **`factory-omp` restart** — no `models.yml` edit, no image
+rebuild.
 
-One-shot re-run of the spike PoC (`artifacts/spikes/1807/omp_rpc_poc.py`) with
-`PI_CODING_AGENT_DIR` pointing at a directory containing this `models.yml` —
-all 4 probes (text/tool/steer/abort) must PASS against the factory proxy
-`:18091` with **no TCP forward**. Result recorded on #1811.
+### Why discovery replaces the #1811 static list
+
+#1811 used an explicit `models:` list to dodge a chicken-and-egg: omp's
+discovery URL was derived from already-known models, so an override-only entry
+still fetched against `localhost:4000`. That trade-off is reversed now that
+Roxabi/llmCLI#129 ships a stable xAI pass-through catalogue at `/xai/v1/models`.
+
+### Phases (gateway prerequisites)
+
+| Phase | Gateway prerequisite | omp `baseUrl` | Scope |
+|-------|---------------------|---------------|-------|
+| **Interim** (current) | Roxabi/llmCLI#129 (`pass_through /xai`) | `:18091/xai/v1` | Discovery + Grok catalogue via xAI route |
+| **Target** (deferred) | Roxabi/llmCLI#130 (unified `/v1/models`) | `:18091/v1` | Single canonical base URL; merged catalogue |
+
+**Operator procedure when the proxy catalogue changes:** restart `factory-omp`
+(`systemctl --user restart factory-omp`). No repo change required for new Grok
+variants on the interim route.
+
+**Related issues:** #1924 (hub `model_cfg` → `RpcClient(model=…)`), #1910
+(default model when hub omits `model`).
+
+### Discovery failure behaviour
+
+If the gateway is unreachable, auth fails, or the catalogue is empty, omp logs
+the error at boot and session init fails per upstream defaults. This repo does
+not add custom retry logic — fix gateway availability or credentials on M₁.
+
+## Validation
+
+- CI: `tests/deploy/test_omp_models_discovery.py` — static YAML invariants +
+  mock-gateway catalogue fetch (no M₁ network).
+- Live smoke (manual, post-llmCLI#129 deploy on M₁):
+
+  ```bash
+  INTEGRATION=1 LITELLM_API_KEY=<key> uv run --frozen pytest \
+    tests/deploy/test_omp_models_discovery.py::test_live_gateway_catalogue_has_grok_model -x
+  ```
+
+- Historical gate (#1811): spike PoC `artifacts/spikes/1807/omp_rpc_poc.py` with
+  `PI_CODING_AGENT_DIR` — superseded for catalogue sync by discovery (#1923).
 
 ## Boundary
 

--- a/deploy/omp/models.yml
+++ b/deploy/omp/models.yml
@@ -1,30 +1,25 @@
-# deploy/omp/models.yml — omp (oh-my-pi) provider override → factory LiteLLM proxy (#1811, Option D)
+# deploy/omp/models.yml — omp (oh-my-pi) provider override → factory LiteLLM proxy
 #
 # Mounted into the omp config dir (relocated via PI_CODING_AGENT_DIR) so the
 # built-in `litellm` provider targets the factory proxy on :18091 instead of
 # its default http://localhost:4000/v1. Pure config — no TCP forward, no
 # upstream patch (options A/B/C superseded; see issue #1811).
 #
+# #1923: dynamic discovery against the LiteLLM xAI pass-through catalogue
+# (interim baseUrl until llmCLI#130 unifies on :18091/v1).
+#
 # Invariants:
 # - `apiKey` holds an ENV VAR NAME, not a secret value. omp resolves
 #   `LITELLM_API_KEY` from the environment at runtime — safe to commit.
-# - The explicit `models:` list is REQUIRED, not cosmetic: omp's built-in
-#   discovery resolves the catalog URL from already-known models, not from
-#   this override, so an override-only entry would still discover against
-#   localhost:4000 (chicken-and-egg). Listed models inherit the provider
-#   baseUrl/api; missing capability metadata (context window, cost) backfills
-#   from omp's bundled references on id match.
-# - This list REPLACES discovery: a model added to the proxy is invisible to
-#   omp until it is added here.
+# - `discovery.type: openai-models-list` fetches GET {baseUrl}/models at boot.
+#   Proxy-new Grok ids appear after container restart — no manual edit here.
 # - Quadlet wiring (secret mount, env injection, volume mount into the worker
 #   unit) is #1812's scope — this file only proves the config pattern.
-# - dead upstreams pruned (kimi-k2.6 = Fireworks sub terminated llmCLI#116; deepseek-v4-pro = NVIDIA NIM PoC dropped 2026-06-13, #1881)
 
 providers:
   litellm:
-    baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/v1
+    baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/xai/v1
     api: openai-completions
     apiKey: LITELLM_API_KEY
-    models:
-      - id: grok-4
-      - id: grok-4-fast
+    discovery:
+      type: openai-models-list

--- a/tests/deploy/test_omp_models_discovery.py
+++ b/tests/deploy/test_omp_models_discovery.py
@@ -1,0 +1,119 @@
+"""deploy/omp/models.yml discovery invariants + mock-gateway catalogue (#1923)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODELS_YML = REPO_ROOT / "deploy" / "omp" / "models.yml"
+
+
+def _load_litellm_provider(path: Path = MODELS_YML) -> dict[str, Any]:
+    doc = yaml.safe_load(path.read_text())
+    return doc["providers"]["litellm"]
+
+
+def test_models_yml_has_discovery_block() -> None:
+    litellm = _load_litellm_provider()
+    assert litellm["discovery"]["type"] == "openai-models-list"
+    assert "models" not in litellm
+    assert litellm["baseUrl"].endswith("/xai/v1")
+
+
+def test_models_yml_preserves_litellm_provider_shape() -> None:
+    litellm = _load_litellm_provider()
+    assert litellm["api"] == "openai-completions"
+    assert litellm["apiKey"] == "LITELLM_API_KEY"
+
+
+class _ModelsListHandler(BaseHTTPRequestHandler):
+    catalogue: dict[str, Any] = {
+        "object": "list",
+        "data": [{"id": "grok-4-fast", "object": "model"}],
+    }
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") != "/xai/v1/models":
+            self.send_error(404)
+            return
+        body = json.dumps(self.catalogue).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture
+def mock_gateway() -> Generator[str, None, None]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ModelsListHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address[:2]
+        yield f"http://{host}:{port}/xai/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _fetch_catalogue(base_url: str, *, api_key: str = "test-key") -> list[str]:
+    req = Request(
+        f"{base_url.rstrip('/')}/models",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    with urlopen(req, timeout=5) as resp:
+        payload = json.loads(resp.read().decode())
+    return [entry["id"] for entry in payload.get("data", [])]
+
+
+def test_discovery_fetch_returns_grok_model(mock_gateway: str, tmp_path: Path) -> None:
+    models_yml = tmp_path / "models.yml"
+    models_yml.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "litellm": {
+                        "baseUrl": mock_gateway,
+                        "api": "openai-completions",
+                        "apiKey": "LITELLM_API_KEY",
+                        "discovery": {"type": "openai-models-list"},
+                    }
+                }
+            },
+            sort_keys=False,
+        )
+    )
+    litellm = _load_litellm_provider(models_yml)
+    model_ids = _fetch_catalogue(litellm["baseUrl"])
+    assert any(model_id.startswith("grok") for model_id in model_ids)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not __import__("os").environ.get("INTEGRATION"),
+    reason="set INTEGRATION=1 to run live LiteLLM gateway catalogue smoke",
+)
+def test_live_gateway_catalogue_has_grok_model() -> None:
+    litellm = _load_litellm_provider()
+    api_key = __import__("os").environ.get("LITELLM_API_KEY", "")
+    if not api_key:
+        pytest.skip("LITELLM_API_KEY unset — live gateway smoke requires proxy auth")
+    try:
+        model_ids = _fetch_catalogue(litellm["baseUrl"], api_key=api_key)
+    except HTTPError as exc:
+        pytest.skip(f"live gateway unreachable or rejected auth: {exc}")
+    assert any(model_id.startswith("grok") for model_id in model_ids)


### PR DESCRIPTION
## Summary

Switch `deploy/omp/models.yml` from a static Grok model list to dynamic
`openai-models-list` discovery against the interim LiteLLM xAI pass-through
(`:18091/xai/v1`). Operators get new proxy catalogue entries after
`factory-omp` restart — no manual `models.yml` edits.

## Changes

- **`deploy/omp/models.yml`**: add `discovery: {type: openai-models-list}`,
  point `baseUrl` at `/xai/v1`, remove static `models:` list
- **`deploy/omp/README.md`**: document discovery mode, interim vs target
  phases (llmCLI#129 / #130), operator restart procedure
- **`tests/deploy/test_omp_models_discovery.py`**: static YAML invariants +
  mock-gateway catalogue fetch; optional live smoke behind `INTEGRATION=1`

## Test plan

- [x] `uv run --frozen pytest tests/deploy/test_omp_models_discovery.py`
- [ ] Live smoke on M₁ post-llmCLI#129 deploy:
  `INTEGRATION=1 LITELLM_API_KEY=<key> uv run --frozen pytest tests/deploy/test_omp_models_discovery.py::test_live_gateway_catalogue_has_grok_model -x`

## Lifecycle artifacts

- Frame: `artifacts/frames/1923-omp-dynamic-model-discovery-frame.mdx`
- Spec: `artifacts/specs/1923-omp-dynamic-model-discovery-spec.mdx`
- Plan: `artifacts/plans/1923-omp-dynamic-model-discovery-plan.mdx`

Closes #1923