### PR TITLE
feat(core): complete ADR-089 LLM user-error display

### DIFF
--- a/docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx
+++ b/docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx
@@ -146,7 +146,8 @@ Resolution order:
    `messages.toml` key; if no template, check `_PASSTHROUGH_CODES` and return
    `worker_error.message` (already scrubbed by worker validator / CLI parser).
 2. **`worker_error` absent, `error_text` present** → legacy shim: timeout pattern →
-   `timeout` template; else passthrough if printable and bounded.
+   `timeout` template; else → `generic` (no flat-string passthrough without a
+   structured `WorkerError` code).
 3. **Fallback** → `generic` template / `GENERIC_ERROR_REPLY`.
 
 Security invariants (non-negotiable):

--- a/docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx
+++ b/docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx
@@ -225,6 +225,11 @@ user_msg = resolve_user_error(
 
 ### Negative
 
+- Clipool timeout classification differs by failure shape: `asyncio.TimeoutError`
+  at the worker exception boundary maps to `cli.session_lost`; flat
+  `CliResult.error` strings containing ``timeout`` / ``timed out`` map to
+  `transport.timeout` via `_resolve_cli_worker_error()`. Resolver behavior
+  differs (passthrough vs timeout template) until a future unification pass.
 - `StreamProcessor` gains an optional `msg_manager` dependency (or receives a
   `resolve_fn` callable) — small wiring change in hub bootstrap.
 - Passthrough allowlist requires review when `KNOWN_CODES` grows; mitigated by CI test

--- a/docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx
+++ b/docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx
@@ -1,0 +1,245 @@
+---
+title: "ADR-089: Centralized LLM user-error resolution (WorkerError → user text)"
+description: Single hub-side resolver maps WorkerError codes from all LLM backends (clipool, omp-rpc, in-process CliPool) to i18n templates or safe passthrough text — consumed by SimpleAgent (blocking) and StreamProcessor (streaming).
+status: accepted
+---
+
+> **Current truth** → [`docs/architecture/architecture-patterns.md`](../architecture-patterns.md){#typed-error-boundary}
+> Complements ADR-066 (WorkerError envelope), ADR-009 (GENERIC_ERROR_REPLY placement), ADR-058 (typed error boundary for inbound/audio). This ADR covers **LLM backend soft errors** only.
+
+## Status
+
+Accepted
+
+## Context
+
+Phase 1 (#1941) stopped silent empty replies by routing them through `GENERIC_ERROR_REPLY`.
+Users now see a message, but it is often wrong: quota limits, auth failures, and other
+curated CLI errors are classified correctly at the worker boundary (`CliStreamingParser`
+→ `WorkerError`) yet discarded before display.
+
+Investigation (2026-06-18) identified fragmented consumption:
+
+| Site | Problem |
+|------|---------|
+| `agents/simple_agent.py` | Blocking path: only `"Timeout"` in `result.error` gets a specific template; ignores `LlmResult.worker_error` |
+| `adapters/clipool/clipool_worker.py` | Blocking path: forwards `is_error` but not `worker_error` or error text on the NATS chunk |
+| `llm/drivers/omp_rpc.py` | Drops `JobResult.error: WorkerError`; returns opaque `"omp worker returned an error"` |
+| `outbound/_emitter_run.py` | Streaming path: sets `is_error_pending` from `RunErrorRenderEvent` but does not store `.message`; soft errors with no `text_delta` fall through to `GENERIC_ERROR_REPLY` |
+| `outbound/error_handler.py` | Correctly scoped to **infra** stream exceptions only — must not absorb LLM soft errors |
+
+Lyra runs multiple LLM backends behind the same `LlmProvider` port:
+
+- **clipool** (NATS worker) — `LlmClient` + `CliPoolCodec`
+- **claude-cli** (in-process) — `ClaudeCliDriver` over `CliPool`
+- **omp-rpc** — `OmpRpcDriver` over `JobResult`
+
+ADR-066 established `WorkerError` + `KNOWN_CODES` on NATS reply envelopes and planned a
+hub-side helper at `core/messaging/error_extractor.py`. That module extracts
+`worker_error` from envelopes but does **not** resolve user-facing text. ADR-066 also
+deferred adapter i18n via `code` lookup to a follow-up epic — this ADR is that follow-up
+for the LLM path.
+
+## Options Considered
+
+### Option A: Per-backend user messages in workers (clipool, omp)
+
+Each worker maps errors to final user-facing strings before publishing on NATS.
+
+- **Pros:** Hub stays thin; workers know their protocol best.
+- **Cons:** i18n duplicated per worker and per platform locale; Telegram/Discord would
+  need locale passed down the NATS wire; violates hexagonal layering (presentation in
+  adapters); OMP and clipool would diverge on wording for the same `llm.rate_limit` code.
+
+### Option B: Per-consumption-site ad hoc mapping (status quo extended)
+
+Add `if "weekly limit" in error` in `SimpleAgent`, similar checks in `StreamProcessor`,
+and OMP-specific strings in `OmpRpcDriver`.
+
+- **Pros:** Fast local fixes.
+- **Cons:** N backends × 2 consumption paths (blocking + streaming) = combinatorial
+  drift; security risk (raw upstream text leaked without central scrub policy); already
+  proven insufficient.
+
+### Option C: Single domain resolver + worker classification only (chosen)
+
+Workers and codecs **classify** into `WorkerError` (code + scrubbed message). A single
+`resolve_user_error()` in `core/messaging/utils/` **presents** the error using
+`MessageManager` templates and a passthrough allowlist. All `LlmProvider` implementations
+converge on `LlmResult.worker_error` before the resolver runs.
+
+- **Pros:** One policy for clipool, omp-rpc, and in-process CliPool; i18n in
+  `messages.toml`; security rules enforced once; aligns with ADR-066 hub-side plan and
+  ADR-059 domain layer; `OutboundErrorHandler` keeps infra-only scope.
+- **Cons:** Requires wiring in multiple files (resolver is small; integration is the
+  work); passthrough allowlist must be reviewed when new codes are added to `KNOWN_CODES`.
+
+## Decision
+
+Adopt **Option C**.
+
+### Layer responsibilities
+
+```mermaid
+flowchart TB
+    subgraph classify ["Classify (worker / parser — origin-specific)"]
+        CSP[CliStreamingParser]
+        OMPW[OmpWorker classifier]
+        WPC[WorkerPoolClient transport synthesis]
+    end
+
+    subgraph transport ["Transport (codec / driver — backend-agnostic)"]
+        CPC[CliPoolCodec]
+        CNC[CliNatsCodec]
+        OJC[OmpJobCodec — new]
+        CCD[ClaudeCliDriver]
+    end
+
+    subgraph present ["Present (domain — backend-agnostic)"]
+        R[resolve_user_error]
+        MM[MessageManager / messages.toml]
+    end
+
+    subgraph consume ["Consume (application)"]
+        SA[SimpleAgent.complete]
+        SP[StreamProcessor → RunErrorRenderEvent]
+        OB[OutboundEmitter — display only]
+    end
+
+    CSP --> CPC
+    OMPW --> OJC
+    WPC --> CPC
+    CPC --> R
+    CNC --> R
+    OJC --> R
+    CCD --> R
+    R --> MM
+    R --> SA
+    R --> SP
+    SP --> OB
+```
+
+| Layer | Module(s) | Owns |
+|-------|-----------|------|
+| **Contracts** | `roxabi_contracts.errors` | `WorkerError`, `KNOWN_CODES`, credential scrub on wire fields |
+| **Worker** | `adapters/clipool/`, `adapters/omp/` | Origin-specific classification → `WorkerError.code` |
+| **Infrastructure** | `llm/*_codec.py`, `llm/drivers/omp_rpc.py` | Wire decode → `LlmResult { worker_error, error, retryable }` — no i18n |
+| **Domain** | `core/messaging/utils/user_error_resolver.py` | `resolve_user_error()` — template map + passthrough policy |
+| **Application** | `agents/simple_agent.py`, `core/processors/stream_processor.py` | Call resolver; emit `Response` or `RunErrorRenderEvent.message` |
+| **Outbound** | `outbound/error_handler.py`, `_streaming_state.py` | Infra stream exceptions only; display `RunErrorRenderEvent.message` when `final_text` is absent |
+
+### `resolve_user_error()` contract
+
+```python
+def resolve_user_error(
+    *,
+    worker_error: WorkerError | None,
+    error_text: str | None = None,
+    msg_manager: MessageManager | None = None,
+) -> str:
+    """Map a structured LLM error to a user-safe display string."""
+```
+
+Resolution order:
+
+1. **`worker_error` present** → look up `code` in `_CODE_TO_TEMPLATE` for a
+   `messages.toml` key; if no template, check `_PASSTHROUGH_CODES` and return
+   `worker_error.message` (already scrubbed by worker validator / CLI parser).
+2. **`worker_error` absent, `error_text` present** → legacy shim: timeout pattern →
+   `timeout` template; else passthrough if printable and bounded.
+3. **Fallback** → `generic` template / `GENERIC_ERROR_REPLY`.
+
+Security invariants (non-negotiable):
+
+- **Never** use `str(exc)` or raw transport diagnostics as user text.
+- **Passthrough** only for codes in `_PASSTHROUGH_CODES` where upstream message was
+  scrubbed before landing in `WorkerError.message` (`CliStreamingParser._scrub_cli_error_text`,
+  Pydantic validators on `WorkerError`).
+- **Infra codes** (`worker.crash`, `worker.internal`, `stream.error`, `transport.error`,
+  …) → always `generic` — never forward `message` (it may be `type(exc).__name__`).
+
+### Consumption paths
+
+**Blocking** (`SimpleAgent.process` when `ModelConfig.streaming` is false):
+
+```python
+if not result.ok:
+    user_msg = resolve_user_error(
+        worker_error=result.worker_error,
+        error_text=result.error or None,
+        msg_manager=self._msg_manager,
+    )
+    return Response(content=user_msg, metadata={"error": True})
+```
+
+**Streaming** (`StreamProcessor.process` soft-error branch):
+
+```python
+user_msg = resolve_user_error(
+    worker_error=self._result_worker_error,
+    error_text=self._result_error_text,
+    msg_manager=self._msg_manager,  # injected at construction
+)
+# emit RunErrorRenderEvent(message=user_msg, code=_we.code)
+```
+
+**Outbound** (`_emitter_run.py` + `_streaming_state.py`):
+
+- Store `RunErrorRenderEvent.message` on `StreamingState.run_error_message`.
+- `build_display_text()`: when `final_text is None` and `run_error_message` is set,
+  return it (optionally with `❌` prefix) — do **not** re-resolve.
+
+`OutboundErrorHandler.classify_stream_error` is unchanged — it handles
+`StreamChunkTimeout` and adapter exceptions, not `WorkerError`.
+
+### Backend convergence checklist (implementation slices)
+
+| Slice | Scope |
+|-------|-------|
+| **S1** | `user_error_resolver.py` + `messages.toml` keys + unit tests |
+| **S2** | `SimpleAgent` + `StreamProcessor` call resolver; outbound stores `RunErrorRenderEvent.message` |
+| **S3** | `clipool_worker` blocking forward `worker_error`; `CliPoolCodec` populate `LlmResult.worker_error` on success path errors |
+| **S4** | `OmpJobCodec` + `OmpRpcDriver` propagate `JobResult.error`; OMP worker classifier for LLM quota/auth |
+| **S5** | `ClaudeCliDriver` reuse `CliStreamingParser` classification for in-process `CliResult` |
+| **S6** | `CliStreamingParser`: map `subtype=rate_limit_error` → `llm.rate_limit` (not `cli.parse`) |
+
+### Relationship to other error systems
+
+| System | Scope | Interaction |
+|--------|-------|-------------|
+| ADR-058 `LyraUserError` / `ErrorBoundaryMiddleware` | Inbound pipeline + adapter pre-hub failures | Orthogonal — not replaced |
+| `OutboundErrorHandler` | Adapter infra / stream chunk timeout | Orthogonal — infra only |
+| `SttMiddleware` | STT failures | Parallel pattern (template keys in `messages.toml`) |
+| `safe_error_response()` | Plugin command handlers | Parallel pattern — plugins keep generic; LLM uses resolver |
+
+## Consequences
+
+### Positive
+
+- One presentation policy for clipool, omp-rpc, and in-process CliPool; new backends only
+  need to populate `LlmResult.worker_error`.
+- i18n lives in `messages.toml`; locale follows existing `MessageManager` wiring on the hub.
+- Security scrub/passthrough rules are auditable in one module.
+- Completes the ADR-066 hub-side plan without duplicating `KNOWN_CODES` in `core/`.
+
+### Negative
+
+- `StreamProcessor` gains an optional `msg_manager` dependency (or receives a
+  `resolve_fn` callable) — small wiring change in hub bootstrap.
+- Passthrough allowlist requires review when `KNOWN_CODES` grows; mitigated by CI test
+  that asserts every `llm.*` and `cli.parse` code is either mapped or allowlisted.
+
+### Neutral
+
+- `LlmResult.user_message` remains a convenience field; resolver output may be copied
+  there by drivers for backward compatibility but is not the primary API.
+- Voice/image/STT/TTS workers keep their own template keys until a future ADR unifies
+  non-LLM worker errors under the same resolver pattern.
+
+## See also
+
+- ADR-066 (archive) — WorkerError envelope on NATS replies
+- ADR-009 — `GENERIC_ERROR_REPLY` in `core/messaging/message.py`
+- ADR-058 — typed error boundary for inbound/audio
+- ADR-073 — outbound `OutboundErrorHandler` infra scope
+- `packages/roxabi-contracts/docs/error-codes.md` — `KNOWN_CODES` registry

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -61,6 +61,7 @@
     "009-generic-error-reply-placement-and-simple-agent-hub-coupling",
     "058-typed-error-boundary-and-user-visible-error-contract",
     "059-hexagonal-clean-architecture-canonical-model",
+    "089-centralized-llm-user-error-resolution",
     "---Workers & Tooling---",
     "004-cli-pool-cwd-resolution-and-agent-type-annotation",
     "005-wildcard-binding-concurrency-and-per-user-pools",

--- a/src/factory/adapters/clipool/_worker_helpers.py
+++ b/src/factory/adapters/clipool/_worker_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from factory.core.cli.cli_error_classify import worker_error_from_cli_error
 from roxabi_contracts.cli.models import CliChunkEvent, CliControlAck
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.errors import WorkerError
@@ -42,6 +43,11 @@ def _classify_exception(exc: BaseException) -> WorkerError:
         message=f"Unhandled worker exception: {type(exc).__name__}",
         retryable=True,
     )
+
+
+def _worker_error_from_cli_result(error: str) -> WorkerError:
+    """Synthesise a WorkerError for blocking CliPool.send() failures."""
+    return worker_error_from_cli_error(error)
 
 
 def _make_chunk(pool_id: str, **kwargs: Any) -> bytes:

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -21,6 +21,7 @@ from factory.adapters.clipool._worker_helpers import (
     _classify_exception,
     _make_ack,
     _make_chunk,
+    _worker_error_from_cli_result,
 )
 from factory.core.agent.agent_config import ModelConfig
 from factory.core.cli.cli_pool import CliPool
@@ -271,13 +272,20 @@ class CliPoolNatsWorker(NatsAdapterBase):
             )
             return
 
+        worker_error = (
+            _worker_error_from_cli_result(result.error) if result.error else None
+        )
+        if worker_error is not None:
+            emit_populated_total(domain="cli")
         chunk = _make_chunk(
             cmd.pool_id,
             event_type="result",
             is_error=bool(result.error),
+            text=result.result or None,
             session_id=result.session_id or None,
             done=True,
             resumed=resumed,
+            worker_error=worker_error,
         )
         await self.reply(msg, chunk)
 

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -277,11 +277,12 @@ class CliPoolNatsWorker(NatsAdapterBase):
         )
         if worker_error is not None:
             emit_populated_total(domain="cli")
+        result_text = result.result if isinstance(result.result, str) else None
         chunk = _make_chunk(
             cmd.pool_id,
             event_type="result",
             is_error=bool(result.error),
-            text=result.result or None,
+            text=result_text or None,
             session_id=result.session_id or None,
             done=True,
             resumed=resumed,

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -277,12 +277,11 @@ class CliPoolNatsWorker(NatsAdapterBase):
         )
         if worker_error is not None:
             emit_populated_total(domain="cli")
-        result_text = result.result if isinstance(result.result, str) else None
         chunk = _make_chunk(
             cmd.pool_id,
             event_type="result",
             is_error=bool(result.error),
-            text=result_text or None,
+            text=result.result or None,
             session_id=result.session_id or None,
             done=True,
             resumed=resumed,

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -75,12 +75,14 @@ def _classify_exception(exc: BaseException) -> WorkerError:
     """
     name = type(exc).__name__
     if name == "DigestMismatchError":
-        return WorkerError(code="digest_mismatch", message=name, retryable=False)
+        return WorkerError(
+            code="transport.contract_mismatch", message=name, retryable=False
+        )
     if isinstance(exc, asyncio.TimeoutError):
-        return WorkerError(code="timeout", message=name, retryable=True)
+        return WorkerError(code="transport.timeout", message=name, retryable=True)
     if name in ("ConnectionRefusedError", "BrokenPipeError"):
-        return WorkerError(code="connection_error", message=name, retryable=True)
-    return WorkerError(code="internal_error", message=name, retryable=False)
+        return WorkerError(code="transport.error", message=name, retryable=True)
+    return WorkerError(code="worker.internal", message=name, retryable=False)
 
 
 def _make_progress(job_id: str, **kwargs: Any) -> bytes:

--- a/src/factory/core/cli/cli_error_classify.py
+++ b/src/factory/core/cli/cli_error_classify.py
@@ -1,0 +1,30 @@
+"""CLI flat-error classification for blocking/in-process paths (ADR-089 S5).
+
+Streaming errors are classified in ``CliStreamingParser._classify_cli_error``.
+Blocking ``CliPool.send()`` returns only a flat ``CliResult.error`` string;
+this helper synthesises the equivalent ``WorkerError`` envelope.
+"""
+
+from __future__ import annotations
+
+from roxabi_contracts.errors import WorkerError
+
+from .cli_streaming_parser import _scrub_cli_error_text
+
+__all__ = ["worker_error_from_cli_error"]
+
+
+def worker_error_from_cli_error(error: str) -> WorkerError:
+    """Map a blocking CliResult.error string to a structured WorkerError."""
+    scrubbed = _scrub_cli_error_text(error) or error
+    if "Timeout" in error:
+        return WorkerError(
+            code="transport.timeout",
+            message=scrubbed,
+            retryable=True,
+        )
+    return WorkerError(
+        code="cli.parse",
+        message=scrubbed,
+        retryable=False,
+    )

--- a/src/factory/core/cli/cli_error_classify.py
+++ b/src/factory/core/cli/cli_error_classify.py
@@ -9,22 +9,24 @@ from __future__ import annotations
 
 from roxabi_contracts.errors import WorkerError
 
-from .cli_streaming_parser import _scrub_cli_error_text
+from .cli_streaming_parser import (
+    _classify_cli_error,
+    _infer_subtype_from_flat_error,
+    _scrub_cli_error_text,
+)
 
 __all__ = ["worker_error_from_cli_error"]
 
 
 def worker_error_from_cli_error(error: str) -> WorkerError:
     """Map a blocking CliResult.error string to a structured WorkerError."""
-    scrubbed = _scrub_cli_error_text(error) or error
-    if "Timeout" in error:
+    lower = error.lower()
+    if "timeout" in lower or "timed out" in lower:
+        scrubbed = _scrub_cli_error_text(error) or error
         return WorkerError(
             code="transport.timeout",
             message=scrubbed,
             retryable=True,
         )
-    return WorkerError(
-        code="cli.parse",
-        message=scrubbed,
-        retryable=False,
-    )
+    subtype = _infer_subtype_from_flat_error(error)
+    return _classify_cli_error(subtype, error)

--- a/src/factory/core/cli/cli_error_classify.py
+++ b/src/factory/core/cli/cli_error_classify.py
@@ -1,17 +1,134 @@
-"""CLI flat-error classification for blocking/in-process paths (ADR-089 S5).
+"""CLI error classification for blocking and streaming paths (ADR-089).
 
-Streaming errors are classified in ``CliStreamingParser._classify_cli_error``.
-Blocking ``CliPool.send()`` returns only a flat ``CliResult.error`` string;
-this helper synthesises the equivalent ``WorkerError`` envelope.
+``CliStreamingParser`` and blocking ``CliPool.send()`` converge on
+``_resolve_cli_worker_error()`` for structured ``WorkerError`` envelopes.
 """
 
 from __future__ import annotations
 
-from roxabi_contracts.errors import WorkerError
+import re
 
-from .cli_streaming_parser import _resolve_cli_worker_error
+from roxabi_contracts.errors import KNOWN_CODES, WorkerError
 
-__all__ = ["worker_error_from_cli_error"]
+__all__ = ["worker_error_from_cli_error", "_scrub_cli_error_text"]
+
+# Subtypes that indicate an auth failure from the upstream CLI.
+_AUTH_SUBTYPES = frozenset({"auth_error", "auth", "login_required"})
+# Subtypes that suggest a lost / unresumable session.
+_SESSION_LOST_SUBTYPES = frozenset({"session_expired", "session_lost", "resume_failed"})
+# Provider quota / rate-limit failures (ADR-089 S6).
+_RATE_LIMIT_SUBTYPES = frozenset(
+    {"rate_limit_error", "rate_limit", "quota_exceeded", "usage_limit"}
+)
+
+# Max length of bus-bound CLI error messages. Upstream wire content is
+# unbounded; trim before publishing to keep the NATS payload predictable.
+_BUS_BOUND_MESSAGE_MAX_LEN = 200  # const-ok: bus-bound error message length cap
+
+# Flat blocking CliResult.error strings carry no subtype; infer from message text.
+_AUTH_FLAT_HINTS = (
+    "not logged in",
+    "login required",
+    "auth error",
+    "authentication required",
+    "oauth",
+)
+_RATE_LIMIT_FLAT_HINTS = (
+    "weekly limit",
+    "rate limit",
+    "quota exceeded",
+    "usage limit",
+    "hit your limit",
+)
+_SESSION_LOST_FLAT_HINTS = (
+    "session expired",
+    "session lost",
+    "resume failed",
+)
+
+
+def _scrub_cli_error_text(text: str) -> str:
+    """Bound length + strip control chars from bus-bound CLI error text.
+
+    #1252 (sibling of #1212/#1215/#1219): path (a) — when the CLI reports
+    ``is_error=True`` — sources error text verbatim from upstream wire
+    fields (``result.errors[0]`` / ``result.result``). Without scrubbing,
+    arbitrary bytes propagate to ``WorkerError.message`` and
+    ``ResultLlmEvent.error_text`` (both bus-bound). Full diagnostic stays
+    in ``log.warning`` at the call site.
+    """
+    if not text:
+        return text
+    scrubbed = "".join(c if c.isprintable() else " " for c in text)
+    if len(scrubbed) > _BUS_BOUND_MESSAGE_MAX_LEN:
+        scrubbed = scrubbed[: _BUS_BOUND_MESSAGE_MAX_LEN - 1] + "…"
+    return scrubbed
+
+
+def _hint_matches(lower: str, hint: str) -> bool:
+    """Match a flat-error hint; single-token hints use word boundaries."""
+    if " " in hint:
+        return hint in lower
+    return bool(re.search(rf"\b{re.escape(hint)}\b", lower))
+
+
+def _infer_subtype_from_flat_error(error: str) -> str:
+    """Infer a CLI result subtype from a flat blocking error string (ADR-089 S5)."""
+    lower = error.lower()
+    if any(_hint_matches(lower, hint) for hint in _AUTH_FLAT_HINTS):
+        return "auth_error"
+    if any(hint in lower for hint in _RATE_LIMIT_FLAT_HINTS):
+        return "rate_limit_error"
+    if any(hint in lower for hint in _SESSION_LOST_FLAT_HINTS):
+        return "session_expired"
+    return ""
+
+
+def _subtype_is_specific(subtype: str) -> bool:
+    return (
+        subtype in _AUTH_SUBTYPES
+        or subtype in _SESSION_LOST_SUBTYPES
+        or subtype in _RATE_LIMIT_SUBTYPES
+        or bool(subtype and "rate_limit" in subtype)
+    )
+
+
+def _classify_cli_error(subtype: str, error_text: str) -> WorkerError:
+    """Map a CLI result subtype + message to a structured WorkerError."""
+    if subtype in _AUTH_SUBTYPES:
+        code = "cli.auth"
+    elif subtype in _SESSION_LOST_SUBTYPES:
+        code = "cli.session_lost"
+    elif subtype in _RATE_LIMIT_SUBTYPES or "rate_limit" in subtype:
+        code = "llm.rate_limit"
+    else:
+        code = "cli.parse"
+
+    meta = KNOWN_CODES[code]
+    return WorkerError(
+        code=code,
+        message=_scrub_cli_error_text(error_text) or meta.description,
+        retryable=meta.default_retryable,
+    )
+
+
+def _resolve_cli_worker_error(subtype: str, error_text: str) -> WorkerError:
+    """Classify CLI errors for blocking and streaming paths (ADR-089)."""
+    lower = error_text.lower()
+    if "timeout" in lower or "timed out" in lower:
+        scrubbed = _scrub_cli_error_text(error_text)
+        fallback = KNOWN_CODES["transport.timeout"].description
+        return WorkerError(
+            code="transport.timeout",
+            message=scrubbed or fallback,
+            retryable=True,
+        )
+    effective = subtype
+    if not _subtype_is_specific(subtype):
+        inferred = _infer_subtype_from_flat_error(error_text)
+        if inferred:
+            effective = inferred
+    return _classify_cli_error(effective, error_text)
 
 
 def worker_error_from_cli_error(error: str) -> WorkerError:

--- a/src/factory/core/cli/cli_error_classify.py
+++ b/src/factory/core/cli/cli_error_classify.py
@@ -9,24 +9,11 @@ from __future__ import annotations
 
 from roxabi_contracts.errors import WorkerError
 
-from .cli_streaming_parser import (
-    _classify_cli_error,
-    _infer_subtype_from_flat_error,
-    _scrub_cli_error_text,
-)
+from .cli_streaming_parser import _resolve_cli_worker_error
 
 __all__ = ["worker_error_from_cli_error"]
 
 
 def worker_error_from_cli_error(error: str) -> WorkerError:
     """Map a blocking CliResult.error string to a structured WorkerError."""
-    lower = error.lower()
-    if "timeout" in lower or "timed out" in lower:
-        scrubbed = _scrub_cli_error_text(error) or error
-        return WorkerError(
-            code="transport.timeout",
-            message=scrubbed,
-            retryable=True,
-        )
-    subtype = _infer_subtype_from_flat_error(error)
-    return _classify_cli_error(subtype, error)
+    return _resolve_cli_worker_error("", error)

--- a/src/factory/core/cli/cli_streaming_parser.py
+++ b/src/factory/core/cli/cli_streaming_parser.py
@@ -43,6 +43,10 @@ log = logging.getLogger(__name__)
 _AUTH_SUBTYPES = frozenset({"auth_error", "auth", "login_required"})
 # Subtypes that suggest a lost / unresumable session.
 _SESSION_LOST_SUBTYPES = frozenset({"session_expired", "session_lost", "resume_failed"})
+# Provider quota / rate-limit failures (ADR-089 S6).
+_RATE_LIMIT_SUBTYPES = frozenset(
+    {"rate_limit_error", "rate_limit", "quota_exceeded", "usage_limit"}
+)
 
 # Max length of bus-bound CLI error messages. Upstream wire content is
 # unbounded; trim before publishing to keep the NATS payload predictable.
@@ -73,6 +77,7 @@ def _classify_cli_error(subtype: str, error_text: str) -> WorkerError:
     Mapping rules (path a — upstream CLI reports is_error):
       * auth-related subtype  → cli.auth   (not retryable)
       * session-related       → cli.session_lost (retryable)
+      * rate-limit subtype    → llm.rate_limit (retryable)
       * anything else         → cli.parse  (not retryable)
 
     ``worker.parse`` is NOT present in KNOWN_CODES (registry only has
@@ -86,6 +91,8 @@ def _classify_cli_error(subtype: str, error_text: str) -> WorkerError:
         code = "cli.auth"
     elif subtype in _SESSION_LOST_SUBTYPES:
         code = "cli.session_lost"
+    elif subtype in _RATE_LIMIT_SUBTYPES or "rate_limit" in subtype:
+        code = "llm.rate_limit"
     else:
         code = "cli.parse"
 

--- a/src/factory/core/cli/cli_streaming_parser.py
+++ b/src/factory/core/cli/cli_streaming_parser.py
@@ -11,7 +11,7 @@ import logging
 from collections import deque
 from typing import Iterable
 
-from roxabi_contracts.errors import WorkerError
+from roxabi_contracts.errors import KNOWN_CODES, WorkerError
 
 from ...streaming.event_emitter import EventEmitter
 from ...streaming.state_machine import StateMachine

--- a/src/factory/core/cli/cli_streaming_parser.py
+++ b/src/factory/core/cli/cli_streaming_parser.py
@@ -8,11 +8,10 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections import deque
 from typing import Iterable
 
-from roxabi_contracts.errors import KNOWN_CODES, WorkerError
+from roxabi_contracts.errors import WorkerError
 
 from ...streaming.event_emitter import EventEmitter
 from ...streaming.state_machine import StateMachine
@@ -28,6 +27,7 @@ from ..messaging.events import (
     ToolUseLlmEvent,
 )
 from ..messaging.utils.metrics import emit_populated_total
+from .cli_error_classify import _resolve_cli_worker_error
 
 # Anthropic CLI NDJSON wire constants — kept here so the parser is the single
 # source of truth on what shapes upstream emits.
@@ -39,139 +39,6 @@ _DELTA_THINKING = "thinking_delta"
 _DELTA_SIGNATURE = "signature_delta"
 
 log = logging.getLogger(__name__)
-
-# Subtypes that indicate an auth failure from the upstream CLI.
-_AUTH_SUBTYPES = frozenset({"auth_error", "auth", "login_required"})
-# Subtypes that suggest a lost / unresumable session.
-_SESSION_LOST_SUBTYPES = frozenset({"session_expired", "session_lost", "resume_failed"})
-# Provider quota / rate-limit failures (ADR-089 S6).
-_RATE_LIMIT_SUBTYPES = frozenset(
-    {"rate_limit_error", "rate_limit", "quota_exceeded", "usage_limit"}
-)
-
-# Max length of bus-bound CLI error messages. Upstream wire content is
-# unbounded; trim before publishing to keep the NATS payload predictable.
-_BUS_BOUND_MESSAGE_MAX_LEN = 200  # const-ok: bus-bound error message length cap
-
-
-def _scrub_cli_error_text(text: str) -> str:
-    """Bound length + strip control chars from bus-bound CLI error text.
-
-    #1252 (sibling of #1212/#1215/#1219): path (a) — when the CLI reports
-    ``is_error=True`` — sources error text verbatim from upstream wire
-    fields (``result.errors[0]`` / ``result.result``). Without scrubbing,
-    arbitrary bytes propagate to ``WorkerError.message`` and
-    ``ResultLlmEvent.error_text`` (both bus-bound). Full diagnostic stays
-    in ``log.warning`` at the call site.
-    """
-    if not text:
-        return text
-    scrubbed = "".join(c if c.isprintable() else " " for c in text)
-    if len(scrubbed) > _BUS_BOUND_MESSAGE_MAX_LEN:
-        scrubbed = scrubbed[: _BUS_BOUND_MESSAGE_MAX_LEN - 1] + "…"
-    return scrubbed
-
-
-# Flat blocking CliResult.error strings carry no subtype; infer from message text.
-_AUTH_FLAT_HINTS = (
-    "not logged in",
-    "login required",
-    "auth error",
-    "authentication required",
-    "oauth",
-)
-_RATE_LIMIT_FLAT_HINTS = (
-    "weekly limit",
-    "rate limit",
-    "quota exceeded",
-    "usage limit",
-    "hit your limit",
-)
-_SESSION_LOST_FLAT_HINTS = (
-    "session expired",
-    "session lost",
-    "resume failed",
-)
-
-
-def _hint_matches(lower: str, hint: str) -> bool:
-    """Match a flat-error hint; single-token hints use word boundaries."""
-    if " " in hint:
-        return hint in lower
-    return bool(re.search(rf"\b{re.escape(hint)}\b", lower))
-
-
-def _infer_subtype_from_flat_error(error: str) -> str:
-    """Infer a CLI result subtype from a flat blocking error string (ADR-089 S5)."""
-    lower = error.lower()
-    if any(_hint_matches(lower, hint) for hint in _AUTH_FLAT_HINTS):
-        return "auth_error"
-    if any(hint in lower for hint in _RATE_LIMIT_FLAT_HINTS):
-        return "rate_limit_error"
-    if any(hint in lower for hint in _SESSION_LOST_FLAT_HINTS):
-        return "session_expired"
-    return ""
-
-
-def _subtype_is_specific(subtype: str) -> bool:
-    return (
-        subtype in _AUTH_SUBTYPES
-        or subtype in _SESSION_LOST_SUBTYPES
-        or subtype in _RATE_LIMIT_SUBTYPES
-        or bool(subtype and "rate_limit" in subtype)
-    )
-
-
-def _resolve_cli_worker_error(subtype: str, error_text: str) -> WorkerError:
-    """Classify CLI errors for blocking and streaming paths (ADR-089)."""
-    lower = error_text.lower()
-    if "timeout" in lower or "timed out" in lower:
-        scrubbed = _scrub_cli_error_text(error_text)
-        fallback = KNOWN_CODES["transport.timeout"].description
-        return WorkerError(
-            code="transport.timeout",
-            message=scrubbed or fallback,
-            retryable=True,
-        )
-    effective = subtype
-    if not _subtype_is_specific(subtype):
-        inferred = _infer_subtype_from_flat_error(error_text)
-        if inferred:
-            effective = inferred
-    return _classify_cli_error(effective, error_text)
-
-
-def _classify_cli_error(subtype: str, error_text: str) -> WorkerError:
-    """Map a CLI result subtype + message to a structured WorkerError.
-
-    Mapping rules (path a — upstream CLI reports is_error):
-      * auth-related subtype  → cli.auth   (not retryable)
-      * session-related       → cli.session_lost (retryable)
-      * rate-limit subtype    → llm.rate_limit (retryable)
-      * anything else         → cli.parse  (not retryable)
-
-    ``worker.parse`` is NOT present in KNOWN_CODES (registry only has
-    ``cli.parse`` and ``transport.parse``), so parser failures use
-    ``cli.parse`` per ADR-066 (absorbed into ADR-049) fallback policy.
-
-    ``error_text`` is scrubbed via :func:`_scrub_cli_error_text` before
-    landing in ``WorkerError.message`` — see #1252.
-    """
-    if subtype in _AUTH_SUBTYPES:
-        code = "cli.auth"
-    elif subtype in _SESSION_LOST_SUBTYPES:
-        code = "cli.session_lost"
-    elif subtype in _RATE_LIMIT_SUBTYPES or "rate_limit" in subtype:
-        code = "llm.rate_limit"
-    else:
-        code = "cli.parse"
-
-    meta = KNOWN_CODES[code]
-    return WorkerError(
-        code=code,
-        message=_scrub_cli_error_text(error_text) or meta.description,
-        retryable=meta.default_retryable,
-    )
 
 
 class CliStreamingParser:

--- a/src/factory/core/cli/cli_streaming_parser.py
+++ b/src/factory/core/cli/cli_streaming_parser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections import deque
 from typing import Iterable
 
@@ -77,7 +78,6 @@ _AUTH_FLAT_HINTS = (
     "login required",
     "auth error",
     "authentication required",
-    "authenticate",
     "oauth",
 )
 _RATE_LIMIT_FLAT_HINTS = (
@@ -94,16 +94,51 @@ _SESSION_LOST_FLAT_HINTS = (
 )
 
 
+def _hint_matches(lower: str, hint: str) -> bool:
+    """Match a flat-error hint; single-token hints use word boundaries."""
+    if " " in hint:
+        return hint in lower
+    return bool(re.search(rf"\b{re.escape(hint)}\b", lower))
+
+
 def _infer_subtype_from_flat_error(error: str) -> str:
     """Infer a CLI result subtype from a flat blocking error string (ADR-089 S5)."""
     lower = error.lower()
-    if any(hint in lower for hint in _AUTH_FLAT_HINTS):
+    if any(_hint_matches(lower, hint) for hint in _AUTH_FLAT_HINTS):
         return "auth_error"
     if any(hint in lower for hint in _RATE_LIMIT_FLAT_HINTS):
         return "rate_limit_error"
     if any(hint in lower for hint in _SESSION_LOST_FLAT_HINTS):
         return "session_expired"
     return ""
+
+
+def _subtype_is_specific(subtype: str) -> bool:
+    return (
+        subtype in _AUTH_SUBTYPES
+        or subtype in _SESSION_LOST_SUBTYPES
+        or subtype in _RATE_LIMIT_SUBTYPES
+        or bool(subtype and "rate_limit" in subtype)
+    )
+
+
+def _resolve_cli_worker_error(subtype: str, error_text: str) -> WorkerError:
+    """Classify CLI errors for blocking and streaming paths (ADR-089)."""
+    lower = error_text.lower()
+    if "timeout" in lower or "timed out" in lower:
+        scrubbed = _scrub_cli_error_text(error_text)
+        fallback = KNOWN_CODES["transport.timeout"].description
+        return WorkerError(
+            code="transport.timeout",
+            message=scrubbed or fallback,
+            retryable=True,
+        )
+    effective = subtype
+    if not _subtype_is_specific(subtype):
+        inferred = _infer_subtype_from_flat_error(error_text)
+        if inferred:
+            effective = inferred
+    return _classify_cli_error(effective, error_text)
 
 
 def _classify_cli_error(subtype: str, error_text: str) -> WorkerError:
@@ -495,7 +530,7 @@ class CliStreamingParser:
         # Path (a): upstream CLI emits is_error=True — classify to cli.* code.
         worker_error: WorkerError | None = None
         if is_error:
-            worker_error = _classify_cli_error(subtype, self.error or "")
+            worker_error = _resolve_cli_worker_error(subtype, self.error or "")
             emit_populated_total(domain="cli")
         return [
             ResultLlmEvent(

--- a/src/factory/core/cli/cli_streaming_parser.py
+++ b/src/factory/core/cli/cli_streaming_parser.py
@@ -71,6 +71,41 @@ def _scrub_cli_error_text(text: str) -> str:
     return scrubbed
 
 
+# Flat blocking CliResult.error strings carry no subtype; infer from message text.
+_AUTH_FLAT_HINTS = (
+    "not logged in",
+    "login required",
+    "auth error",
+    "authentication required",
+    "authenticate",
+    "oauth",
+)
+_RATE_LIMIT_FLAT_HINTS = (
+    "weekly limit",
+    "rate limit",
+    "quota exceeded",
+    "usage limit",
+    "hit your limit",
+)
+_SESSION_LOST_FLAT_HINTS = (
+    "session expired",
+    "session lost",
+    "resume failed",
+)
+
+
+def _infer_subtype_from_flat_error(error: str) -> str:
+    """Infer a CLI result subtype from a flat blocking error string (ADR-089 S5)."""
+    lower = error.lower()
+    if any(hint in lower for hint in _AUTH_FLAT_HINTS):
+        return "auth_error"
+    if any(hint in lower for hint in _RATE_LIMIT_FLAT_HINTS):
+        return "rate_limit_error"
+    if any(hint in lower for hint in _SESSION_LOST_FLAT_HINTS):
+        return "session_expired"
+    return ""
+
+
 def _classify_cli_error(subtype: str, error_text: str) -> WorkerError:
     """Map a CLI result subtype + message to a structured WorkerError.
 

--- a/src/factory/core/messaging/utils/user_error_resolver.py
+++ b/src/factory/core/messaging/utils/user_error_resolver.py
@@ -140,7 +140,7 @@ def resolve_user_error(
             )
 
         if code in _PASSTHROUGH_CODES and worker_error.message:
-            from factory.core.cli.cli_streaming_parser import _scrub_cli_error_text
+            from factory.core.cli.cli_error_classify import _scrub_cli_error_text
 
             scrubbed = _scrub_cli_error_text(worker_error.message)
             return scrub_credentials(scrubbed) if scrubbed else _generic(msg_manager)

--- a/src/factory/core/messaging/utils/user_error_resolver.py
+++ b/src/factory/core/messaging/utils/user_error_resolver.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from factory.core.messaging.message import GENERIC_ERROR_REPLY
-from roxabi_contracts.errors import KNOWN_CODES, WorkerError
+from roxabi_contracts.errors import KNOWN_CODES, WorkerError, scrub_credentials
 
 if TYPE_CHECKING:
     from factory.core.messaging.messages import MessageManager
@@ -142,12 +142,14 @@ def resolve_user_error(
         if code in _PASSTHROUGH_CODES and worker_error.message:
             from factory.core.cli.cli_streaming_parser import _scrub_cli_error_text
 
-            return _scrub_cli_error_text(worker_error.message)
+            scrubbed = _scrub_cli_error_text(worker_error.message)
+            return scrub_credentials(scrubbed) if scrubbed else _generic(msg_manager)
 
         return _generic(msg_manager)
 
     if error_text:
-        if "Timeout" in error_text or "timed out" in error_text.lower():
+        lower = error_text.lower()
+        if "timeout" in lower or "timed out" in lower:
             return _from_template(
                 "timeout",
                 msg_manager,

--- a/src/factory/llm/drivers/cli.py
+++ b/src/factory/llm/drivers/cli.py
@@ -71,7 +71,7 @@ class ClaudeCliDriver:
         return LlmResult(
             result=cli_result.result,
             session_id=cli_result.session_id,
-            error=cli_result.error,
+            error=worker_error.message if worker_error else cli_result.error,
             warning=cli_result.warning,
             worker_error=worker_error,
             retryable=worker_error.retryable if worker_error else True,

--- a/src/factory/llm/drivers/cli.py
+++ b/src/factory/llm/drivers/cli.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 from factory.core.agent.agent_config import ModelConfig
+from factory.core.cli.cli_error_classify import worker_error_from_cli_error
 from factory.core.cli.cli_pool import CliPool
 from factory.core.messaging.events import LlmEvent
 from factory.llm.base import LlmResult
@@ -62,11 +63,18 @@ class ClaudeCliDriver:
         messages: list[dict] | None = None,  # ignored — CliPool manages history
     ) -> LlmResult:
         cli_result = await self._pool.send(pool_id, text, model_cfg, system_prompt)
+        worker_error = (
+            worker_error_from_cli_error(cli_result.error)
+            if cli_result.error
+            else None
+        )
         return LlmResult(
             result=cli_result.result,
             session_id=cli_result.session_id,
             error=cli_result.error,
             warning=cli_result.warning,
+            worker_error=worker_error,
+            retryable=worker_error.retryable if worker_error else True,
         )
 
     async def stream(

--- a/src/factory/llm/drivers/omp_rpc.py
+++ b/src/factory/llm/drivers/omp_rpc.py
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 
 from factory.core.agent.agent_config import ModelConfig
 from factory.core.ports.llm import LlmResult
+from factory.llm.omp_job_codec import OmpJobCodec
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.jobs import JobEnvelope, JobResult
 from roxabi_contracts.jobs.subjects import jobs_result, jobs_submit
@@ -65,10 +66,17 @@ class OmpRpcDriver:
 
     capabilities: dict = {"streaming": False}
 
-    def __init__(self, nc: Any, *, timeout_s: float = _DEFAULT_TIMEOUT_S) -> None:
+    def __init__(
+        self,
+        nc: Any,
+        *,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        codec: OmpJobCodec | None = None,
+    ) -> None:
         # raw async NATS connection (nats-py), injected at bootstrap (T11)
         self._nc = nc
         self._timeout_s = timeout_s
+        self._codec = codec or OmpJobCodec()
         # SessionAware state (mirrors LlmClient.__init__)
         self._turn_store: _OmpSessionStore | None = None
         self._pending_resume: dict[str, str] = {}
@@ -197,13 +205,10 @@ class OmpRpcDriver:
                 result = JobResult.model_validate_json(msg.data)
             except ValidationError:
                 log.warning("omp job %s returned a malformed result", job_id)
-                return LlmResult(
-                    error="omp returned a malformed result", retryable=False
-                )
+                return self._codec.decode_malformed()
 
+            decoded = self._codec.decode(result)
             if result.status == "success":
-                # Persist the omp session file if the worker returned one and
-                # a lyra session_id is linked for this pool.
                 session_file = (result.data or {}).get("session_file")
                 if session_file and self._turn_store is not None:
                     linked_session = self._lyra_sessions.get(pool_id)
@@ -211,14 +216,14 @@ class OmpRpcDriver:
                         await self._turn_store._set_cli_session(  # noqa: SLF001
                             linked_session, session_file
                         )
-                return LlmResult(result=(result.data or {}).get("result", ""))
+                return decoded
 
             log.warning("omp worker returned error status for job %s", job_id)
-            return LlmResult(error="omp worker returned an error", retryable=True)
+            return decoded
 
         except (TimeoutError, asyncio.TimeoutError):
             log.warning("omp job %s timed out after %.1fs", job_id, self._timeout_s)
-            return LlmResult(error="omp request timed out", retryable=True)
+            return self._codec.decode_timeout()
 
         finally:
             await sub.unsubscribe()

--- a/src/factory/llm/omp_job_codec.py
+++ b/src/factory/llm/omp_job_codec.py
@@ -1,0 +1,62 @@
+"""OmpJobCodec — decode JobResult → LlmResult (ADR-089 S4)."""
+
+from __future__ import annotations
+
+import logging
+
+from factory.core.ports.llm import LlmResult
+from roxabi_contracts.errors import KNOWN_CODES, WorkerError
+from roxabi_contracts.jobs import JobResult
+
+log = logging.getLogger(__name__)
+
+_FALLBACK_CODE = "worker.internal"
+_MALFORMED_ERROR = "omp returned a malformed result"
+_TIMEOUT_ERROR = "omp request timed out"
+
+
+def _validate_worker_error(we: WorkerError | None) -> WorkerError | None:
+    if we is None or we.code in KNOWN_CODES:
+        return we
+    log.warning(
+        "OmpJobCodec: unregistered WorkerError code %r — mapping to %r",
+        we.code,
+        _FALLBACK_CODE,
+    )
+    return WorkerError(
+        code=_FALLBACK_CODE,
+        message=we.message,
+        retryable=we.retryable,
+        detail=we.detail,
+    )
+
+
+class OmpJobCodec:
+    """Decode omp worker JobResult envelopes into hub-side LlmResult."""
+
+    def decode(self, result: JobResult) -> LlmResult:
+        if result.status == "success":
+            return LlmResult(result=(result.data or {}).get("result", ""))
+
+        validated = _validate_worker_error(result.error)
+        error_msg = validated.message if validated else _MALFORMED_ERROR
+        return LlmResult(
+            error=error_msg,
+            retryable=validated.retryable if validated else True,
+            worker_error=validated,
+        )
+
+    def decode_malformed(self) -> LlmResult:
+        return LlmResult(error=_MALFORMED_ERROR, retryable=False)
+
+    def decode_timeout(self) -> LlmResult:
+        worker_error = WorkerError(
+            code="transport.timeout",
+            message=_TIMEOUT_ERROR,
+            retryable=True,
+        )
+        return LlmResult(
+            error=_TIMEOUT_ERROR,
+            retryable=True,
+            worker_error=worker_error,
+        )

--- a/src/factory/llm/omp_job_codec.py
+++ b/src/factory/llm/omp_job_codec.py
@@ -47,7 +47,16 @@ class OmpJobCodec:
         )
 
     def decode_malformed(self) -> LlmResult:
-        return LlmResult(error=_MALFORMED_ERROR, retryable=False)
+        worker_error = WorkerError(
+            code="transport.parse",
+            message=_MALFORMED_ERROR,
+            retryable=False,
+        )
+        return LlmResult(
+            error=_MALFORMED_ERROR,
+            retryable=False,
+            worker_error=worker_error,
+        )
 
     def decode_timeout(self) -> LlmResult:
         worker_error = WorkerError(

--- a/src/factory/outbound/_emitter_run.py
+++ b/src/factory/outbound/_emitter_run.py
@@ -69,6 +69,7 @@ async def _run_event_loop(  # noqa: C901
                 # producing the ``❌`` prefix on the final rendered text.
                 if isinstance(event, RunErrorRenderEvent):
                     emitter._st.is_error_pending = True
+                    emitter._st.run_error_message = event.message
                 continue
             if isinstance(
                 event,

--- a/src/factory/outbound/_streaming_state.py
+++ b/src/factory/outbound/_streaming_state.py
@@ -107,6 +107,9 @@ class StreamState:
     # → RunErrorRenderEvent (post-finally, for soft errors). Reading at
     # delivery time means the order of TextEnd vs RunError does not matter.
     is_error_pending: bool = False
+    # Curated user message from RunErrorRenderEvent (ADR-089). Used when the
+    # stream ends with no text_delta (soft error only in the terminal event).
+    run_error_message: str | None = None
     stream_error: Exception | None = None
 
     def set_final_text(self, text: str, *, is_error: bool = False) -> None:
@@ -123,6 +126,9 @@ class StreamState:
         turns so the user always sees a meaningful message.
         """
         if self.final_text is None:
+            if self.run_error_message:
+                prefix = "❌ " if self.is_error_pending else ""
+                return prefix + self.run_error_message
             # Deferred import — avoids circular load: emitter.py imports this
             # module at the bottom, and error_handler is part of factory.outbound.
             from factory.outbound.error_handler import (

--- a/tests/adapters/clipool/test_clipool_worker_resume.py
+++ b/tests/adapters/clipool/test_clipool_worker_resume.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from factory.core.agent.agent_config import ModelConfig
-from factory.core.cli.cli_pool import CliPool, CliPoolDeps
+from factory.core.cli.cli_pool import CliPool, CliPoolDeps, CliResult
 from factory.core.cli.cli_pool_worker import _ProcessEntry
 
 # ---------------------------------------------------------------------------
@@ -417,9 +417,7 @@ class TestHandleCmdEmbeddedResume:
 
         pool = MagicMock(spec=CliPool)
         pool.resume_direct = AsyncMock(return_value=True)
-        fake_result = MagicMock()
-        fake_result.error = None
-        fake_result.session_id = _VALID_CLI_SID
+        fake_result = CliResult(result="", session_id=_VALID_CLI_SID, error="")
         pool.send = AsyncMock(return_value=fake_result)
 
         worker = CliPoolNatsWorker(pool)

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -99,26 +99,26 @@ def _remove_omp_rpc_stub() -> None:
 class TestClassifyException:
     def test_timeout_retryable(self) -> None:
         err = _classify_exception(asyncio.TimeoutError())
-        assert err.code == "timeout"
+        assert err.code == "transport.timeout"
         assert err.retryable is True
         assert err.message == "TimeoutError"
 
     def test_connection_refused_retryable(self) -> None:
         err = _classify_exception(ConnectionRefusedError())
-        assert err.code == "connection_error"
+        assert err.code == "transport.error"
         assert err.retryable is True
         assert err.message == "ConnectionRefusedError"
 
     def test_digest_mismatch_not_retryable(self) -> None:
         exc = DigestMismatchError(actual="aaa", expected="bbb")
         err = _classify_exception(exc)
-        assert err.code == "digest_mismatch"
+        assert err.code == "transport.contract_mismatch"
         assert err.retryable is False
         assert err.message == "DigestMismatchError"
 
     def test_generic_exception_maps_internal_error(self) -> None:
         err = _classify_exception(RuntimeError("oops"))
-        assert err.code == "internal_error"
+        assert err.code == "worker.internal"
         assert err.retryable is False
         # ADR-073: message must be the type name, not the exception string
         assert err.message == "RuntimeError"

--- a/tests/adapters/test_clipool_worker.py
+++ b/tests/adapters/test_clipool_worker.py
@@ -190,6 +190,32 @@ async def test_handle_cmd_nonstream_calls_pool_send() -> None:
     assert publish_subject == "_INBOX.reply"
 
 
+async def test_handle_cmd_nonstream_error_forwards_worker_error() -> None:
+    """stream=False error: blocking chunk carries worker_error for hub resolver."""
+    from factory.adapters.clipool.clipool_worker import CliPoolNatsWorker
+
+    pool = _make_pool()
+    pool.send.return_value = CliResult(
+        result="",
+        session_id="sid",
+        error="You've hit your weekly limit",
+    )
+
+    worker = CliPoolNatsWorker(pool)
+    nc = AsyncMock()
+    worker._nc = nc
+
+    msg = _make_nats_msg(subject="factory.clipool.cmd", reply="_INBOX.reply")
+    payload = _cmd_payload(stream=False)
+
+    await worker._handle_cmd(msg, payload)
+
+    published = json.loads(nc.publish.call_args.args[1].decode())
+    assert published["is_error"] is True
+    assert published["worker_error"]["code"] == "cli.parse"
+    assert "weekly limit" in published["worker_error"]["message"]
+
+
 async def test_handle_cmd_send_streaming_exception_publishes_error() -> None:
     """When pool.send_streaming raises, worker publishes error chunk via _nc.publish."""
     from factory.adapters.clipool.clipool_worker import CliPoolNatsWorker

--- a/tests/adapters/test_clipool_worker.py
+++ b/tests/adapters/test_clipool_worker.py
@@ -212,7 +212,7 @@ async def test_handle_cmd_nonstream_error_forwards_worker_error() -> None:
 
     published = json.loads(nc.publish.call_args.args[1].decode())
     assert published["is_error"] is True
-    assert published["worker_error"]["code"] == "cli.parse"
+    assert published["worker_error"]["code"] == "llm.rate_limit"
     assert "weekly limit" in published["worker_error"]["message"]
 
 

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -53,7 +53,9 @@ def make_pool(pool_id: str = "telegram:main:alice") -> Pool:
     return Pool(pool_id=pool_id, agent_name="lyra", ctx=MagicMock())
 
 
-_MESSAGES = Path(__file__).resolve().parents[2] / "src" / "factory" / "data" / "messages.toml"
+_MESSAGES = (
+    Path(__file__).resolve().parents[2] / "src" / "factory" / "data" / "messages.toml"
+)
 
 
 def make_agent(

--- a/tests/agents/test_simple_agent.py
+++ b/tests/agents/test_simple_agent.py
@@ -22,6 +22,7 @@ from factory.core.messaging.message import (
     Response,
     TelegramMeta,
 )
+from factory.core.messaging.messages import MessageManager
 from factory.core.pool import Pool
 from factory.llm.base import LlmResult
 from roxabi_contracts.errors import WorkerError
@@ -52,14 +53,25 @@ def make_pool(pool_id: str = "telegram:main:alice") -> Pool:
     return Pool(pool_id=pool_id, agent_name="lyra", ctx=MagicMock())
 
 
-def make_agent(provider: object) -> SimpleAgent:
+_MESSAGES = Path(__file__).resolve().parents[2] / "src" / "factory" / "data" / "messages.toml"
+
+
+def make_agent(
+    provider: object,
+    *,
+    msg_manager: MessageManager | None = None,
+) -> SimpleAgent:
     config = Agent(
         name="lyra",
         system_prompt="You are Lyra.",
         memory_namespace="lyra",
         llm_config=ModelConfig(),
     )
-    return SimpleAgent(config, cast("LlmProvider", provider))
+    return SimpleAgent(
+        config,
+        cast("LlmProvider", provider),
+        msg_manager=msg_manager,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +131,29 @@ class TestSimpleAgentProcess:
 
         assert isinstance(response, Response)
         assert response.content == "You've hit your weekly limit"
+        assert response.metadata.get("error") is True
+
+    async def test_llm_rate_limit_uses_template_response(self) -> None:
+        mm = MessageManager(_MESSAGES, language="en")
+        provider = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=LlmResult(
+                error="You've hit your weekly limit",
+                worker_error=WorkerError(
+                    code="llm.rate_limit",
+                    message="You've hit your weekly limit",
+                    retryable=True,
+                ),
+            )
+        )
+        agent = make_agent(provider, msg_manager=mm)
+        msg = make_inbound_message("hi")
+        pool = make_pool()
+
+        response = await agent.process(msg, pool)
+
+        assert isinstance(response, Response)
+        assert response.content == mm.get("rate_limit")
         assert response.metadata.get("error") is True
 
     async def test_timeout_error_response(self) -> None:

--- a/tests/core/test_cli_error_classify.py
+++ b/tests/core/test_cli_error_classify.py
@@ -24,6 +24,10 @@ class TestWorkerErrorFromCliError:
         assert we.code == "cli.auth"
         assert we.retryable is False
 
+    def test_authenticated_does_not_map_to_cli_auth(self) -> None:
+        we = worker_error_from_cli_error("User authenticated but request failed")
+        assert we.code == "cli.parse"
+
     def test_unclassified_message_maps_to_cli_parse(self) -> None:
         we = worker_error_from_cli_error("unexpected CLI failure")
         assert we.code == "cli.parse"

--- a/tests/core/test_cli_error_classify.py
+++ b/tests/core/test_cli_error_classify.py
@@ -1,0 +1,19 @@
+"""Tests for cli_error_classify.worker_error_from_cli_error."""
+
+from __future__ import annotations
+
+from factory.core.cli.cli_error_classify import worker_error_from_cli_error
+
+
+class TestWorkerErrorFromCliError:
+    def test_timeout_maps_to_transport_timeout(self) -> None:
+        we = worker_error_from_cli_error("Timeout: no output for 120s")
+        assert we.code == "transport.timeout"
+        assert we.retryable is True
+
+    def test_quota_message_maps_to_cli_parse(self) -> None:
+        we = worker_error_from_cli_error(
+            "You've hit your weekly limit · resets 6pm (UTC)"
+        )
+        assert we.code == "cli.parse"
+        assert "weekly limit" in we.message

--- a/tests/core/test_cli_error_classify.py
+++ b/tests/core/test_cli_error_classify.py
@@ -11,9 +11,20 @@ class TestWorkerErrorFromCliError:
         assert we.code == "transport.timeout"
         assert we.retryable is True
 
-    def test_quota_message_maps_to_cli_parse(self) -> None:
+    def test_quota_message_maps_to_llm_rate_limit(self) -> None:
         we = worker_error_from_cli_error(
             "You've hit your weekly limit · resets 6pm (UTC)"
         )
-        assert we.code == "cli.parse"
+        assert we.code == "llm.rate_limit"
+        assert we.retryable is True
         assert "weekly limit" in we.message
+
+    def test_auth_message_maps_to_cli_auth(self) -> None:
+        we = worker_error_from_cli_error("Not logged in — run /login")
+        assert we.code == "cli.auth"
+        assert we.retryable is False
+
+    def test_unclassified_message_maps_to_cli_parse(self) -> None:
+        we = worker_error_from_cli_error("unexpected CLI failure")
+        assert we.code == "cli.parse"
+        assert we.retryable is False

--- a/tests/core/test_cli_streaming_parse.py
+++ b/tests/core/test_cli_streaming_parse.py
@@ -482,6 +482,25 @@ class TestStreamingIteratorNonJson:
         assert result.worker_error.code == "llm.rate_limit"
         assert "weekly limit" in (result.worker_error.message or "")
 
+    def test_timeout_text_with_generic_subtype_maps_to_transport_timeout(self) -> None:
+        line = json.dumps(
+            {
+                "type": "result",
+                "session_id": "sess-to",
+                "is_error": True,
+                "subtype": "execute_error",
+                "result": "Timeout: no output for 120s",
+                "duration_ms": 10,
+            }
+        )
+        parser = CliStreamingParser(pool_id=DEFAULT_POOL_ID)
+        events = _collect_all(parser, line)
+
+        result = events[0]
+        assert isinstance(result, ResultLlmEvent)
+        assert result.worker_error is not None
+        assert result.worker_error.code == "transport.timeout"
+
 
 # ---------------------------------------------------------------------------
 # TestStreamingIteratorAssistant

--- a/tests/core/test_cli_streaming_parse.py
+++ b/tests/core/test_cli_streaming_parse.py
@@ -461,6 +461,27 @@ class TestStreamingIteratorNonJson:
         # surfaces are scrubbed.
         assert parser.error == leaky
 
+    def test_rate_limit_subtype_maps_to_llm_rate_limit(self) -> None:
+        line = json.dumps(
+            {
+                "type": "result",
+                "session_id": "sess-rl",
+                "is_error": True,
+                "subtype": "rate_limit_error",
+                "result": "You've hit your weekly limit · resets 6pm (UTC)",
+                "duration_ms": 10,
+            }
+        )
+        parser = CliStreamingParser(pool_id=DEFAULT_POOL_ID)
+        events = _collect_all(parser, line)
+
+        assert len(events) == 1
+        result = events[0]
+        assert isinstance(result, ResultLlmEvent)
+        assert result.worker_error is not None
+        assert result.worker_error.code == "llm.rate_limit"
+        assert "weekly limit" in (result.worker_error.message or "")
+
 
 # ---------------------------------------------------------------------------
 # TestStreamingIteratorAssistant

--- a/tests/core/test_user_error_resolver_coverage.py
+++ b/tests/core/test_user_error_resolver_coverage.py
@@ -1,0 +1,28 @@
+"""ADR-089 CI gate — every llm.* and cli.parse KNOWN_CODE is resolver-covered."""
+
+from __future__ import annotations
+
+from factory.core.messaging.utils import user_error_resolver as resolver
+from roxabi_contracts.errors import KNOWN_CODES
+
+
+def _is_covered(code: str) -> bool:
+    if code in resolver._CODE_TO_TEMPLATE:
+        return True
+    if code in resolver._PASSTHROUGH_CODES:
+        return True
+    if code in resolver._GENERIC_ONLY_CODES:
+        return True
+    return resolver._is_generic_code(code)
+
+
+class TestUserErrorResolverKnownCodesCoverage:
+    def test_llm_and_cli_parse_codes_are_resolver_covered(self) -> None:
+        targets = sorted(
+            code
+            for code in KNOWN_CODES
+            if code.startswith("llm.") or code == "cli.parse"
+        )
+        assert targets, "expected at least one llm.* / cli.parse code in KNOWN_CODES"
+        uncovered = [code for code in targets if not _is_covered(code)]
+        assert uncovered == [], f"uncovered codes: {uncovered}"

--- a/tests/llm/drivers/test_omp_rpc.py
+++ b/tests/llm/drivers/test_omp_rpc.py
@@ -201,9 +201,10 @@ class TestOmpRpcDriver:
             system_prompt="sys",
         )
 
-        # Assert
         assert res.ok is False
-        assert res.error  # non-empty string
+        assert res.error
+        assert res.worker_error is not None
+        assert res.worker_error.code == "transport.timeout"
 
     # -- (c) worker error --
 
@@ -229,9 +230,10 @@ class TestOmpRpcDriver:
             system_prompt="sys",
         )
 
-        # Assert
         assert res.ok is False
-        assert res.error  # non-empty static error string (ADR-073: no str(exc) on bus)
+        assert res.error == "scraper failed"
+        assert res.worker_error is not None
+        assert res.worker_error.code == "worker.crash"
 
     # -- unsubscribe cleanup --
 

--- a/tests/llm/drivers/test_omp_rpc.py
+++ b/tests/llm/drivers/test_omp_rpc.py
@@ -301,9 +301,10 @@ class TestOmpRpcDriver:
             pool_id="p", text="hi", model_cfg=model_cfg, system_prompt="sys"
         )
 
-        # Assert — error result, NOT retryable (malformed ≠ transient)
         assert res.ok is False
         assert res.retryable is False
+        assert res.worker_error is not None
+        assert res.worker_error.code == "transport.parse"
 
         # Assert — cleanup runs even on malformed path (finally block)
         sub.unsubscribe.assert_awaited_once()

--- a/tests/llm/test_cli_driver.py
+++ b/tests/llm/test_cli_driver.py
@@ -112,11 +112,11 @@ class TestClaudeCliDriverComplete:
         )
 
         assert result.ok is False
-        assert result.worker_error == WorkerError(
-            code="cli.parse",
-            message="You've hit your weekly limit · resets 6pm (UTC)",
-            retryable=False,
-        )
+        assert result.worker_error is not None
+        assert result.worker_error.code == "llm.rate_limit"
+        assert result.worker_error.retryable is True
+        assert "weekly limit" in result.worker_error.message
+        assert result.error == result.worker_error.message
 
     async def test_complete_translates_warning(self) -> None:
         """CliResult(result='r', warning='truncated') → LlmResult with warning."""

--- a/tests/llm/test_cli_driver.py
+++ b/tests/llm/test_cli_driver.py
@@ -17,7 +17,6 @@ from factory.core.agent.agent_config import ModelConfig
 from factory.core.cli.cli_pool import CliResult
 from factory.llm.base import LlmResult
 from factory.llm.drivers.cli import ClaudeCliDriver
-from roxabi_contracts.errors import WorkerError
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/llm/test_cli_driver.py
+++ b/tests/llm/test_cli_driver.py
@@ -17,6 +17,7 @@ from factory.core.agent.agent_config import ModelConfig
 from factory.core.cli.cli_pool import CliResult
 from factory.llm.base import LlmResult
 from factory.llm.drivers.cli import ClaudeCliDriver
+from roxabi_contracts.errors import WorkerError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -82,11 +83,9 @@ class TestClaudeCliDriverComplete:
         assert result.error == ""
 
     async def test_complete_translates_error(self) -> None:
-        """CliResult(error='timeout') → LlmResult(ok=False, error='timeout')."""
-        # Arrange
-        driver, _ = make_driver(CliResult(error="timeout"))
+        """CliResult(error='timeout') → LlmResult with worker_error envelope."""
+        driver, _ = make_driver(CliResult(error="Timeout: no output for 120s"))
 
-        # Act
         result = await driver.complete(
             pool_id="p1",
             text="hi",
@@ -94,10 +93,30 @@ class TestClaudeCliDriverComplete:
             system_prompt="",
         )
 
-        # Assert
         assert result.ok is False
-        assert result.error == "timeout"
+        assert "Timeout" in result.error
         assert result.result == ""
+        assert result.worker_error is not None
+        assert result.worker_error.code == "transport.timeout"
+
+    async def test_complete_translates_cli_error_with_worker_error(self) -> None:
+        driver, _ = make_driver(
+            CliResult(error="You've hit your weekly limit · resets 6pm (UTC)")
+        )
+
+        result = await driver.complete(
+            pool_id="p1",
+            text="hi",
+            model_cfg=make_model_cfg(),
+            system_prompt="",
+        )
+
+        assert result.ok is False
+        assert result.worker_error == WorkerError(
+            code="cli.parse",
+            message="You've hit your weekly limit · resets 6pm (UTC)",
+            retryable=False,
+        )
 
     async def test_complete_translates_warning(self) -> None:
         """CliResult(result='r', warning='truncated') → LlmResult with warning."""

--- a/tests/llm/test_omp_job_codec.py
+++ b/tests/llm/test_omp_job_codec.py
@@ -1,0 +1,40 @@
+"""OmpJobCodec — JobResult → LlmResult (ADR-089 S4)."""
+
+from __future__ import annotations
+
+from factory.llm.omp_job_codec import OmpJobCodec
+from roxabi_contracts.jobs import JobResult
+from roxabi_contracts.jobs.fixtures import sample_job_result_err, sample_job_result_ok
+
+_codec = OmpJobCodec()
+
+
+class TestOmpJobCodecDecode:
+    def test_success_extracts_result_text(self) -> None:
+        result = JobResult.model_validate(
+            {**sample_job_result_ok, "data": {"result": "pong"}}
+        )
+        llm = _codec.decode(result)
+        assert llm.ok is True
+        assert llm.result == "pong"
+        assert llm.worker_error is None
+
+    def test_error_populates_worker_error(self) -> None:
+        result = JobResult.model_validate(sample_job_result_err)
+        llm = _codec.decode(result)
+        assert llm.ok is False
+        assert llm.worker_error is not None
+        assert llm.worker_error.code == "worker.crash"
+        assert llm.error == "scraper failed"
+        assert llm.retryable is True
+
+    def test_decode_timeout_carries_transport_code(self) -> None:
+        llm = _codec.decode_timeout()
+        assert llm.ok is False
+        assert llm.worker_error is not None
+        assert llm.worker_error.code == "transport.timeout"
+
+    def test_decode_malformed_is_non_retryable(self) -> None:
+        llm = _codec.decode_malformed()
+        assert llm.ok is False
+        assert llm.retryable is False

--- a/tests/llm/test_omp_job_codec.py
+++ b/tests/llm/test_omp_job_codec.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from factory.llm.omp_job_codec import OmpJobCodec
-from roxabi_contracts.errors import WorkerError
 from roxabi_contracts.jobs import JobResult
 from roxabi_contracts.jobs.fixtures import sample_job_result_err, sample_job_result_ok
 

--- a/tests/llm/test_omp_job_codec.py
+++ b/tests/llm/test_omp_job_codec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from factory.llm.omp_job_codec import OmpJobCodec
+from roxabi_contracts.errors import WorkerError
 from roxabi_contracts.jobs import JobResult
 from roxabi_contracts.jobs.fixtures import sample_job_result_err, sample_job_result_ok
 
@@ -38,3 +39,23 @@ class TestOmpJobCodecDecode:
         llm = _codec.decode_malformed()
         assert llm.ok is False
         assert llm.retryable is False
+        assert llm.worker_error is not None
+        assert llm.worker_error.code == "transport.parse"
+        assert llm.error == "omp returned a malformed result"
+
+    def test_unregistered_error_code_maps_to_worker_internal(self) -> None:
+        result = JobResult.model_validate(
+            {
+                **sample_job_result_err,
+                "error": {
+                    "code": "worker.bogus_future",
+                    "message": "future error",
+                    "retryable": True,
+                },
+            }
+        )
+        llm = _codec.decode(result)
+        assert llm.worker_error is not None
+        assert llm.worker_error.code == "worker.internal"
+        assert llm.worker_error.message == "future error"
+        assert llm.error == "future error"

--- a/tests/outbound/test_emitter_run.py
+++ b/tests/outbound/test_emitter_run.py
@@ -191,8 +191,8 @@ class TestRunEventLoop:
             placeholder_obj=object(),
         )
 
-        # RunError sets the flag
         assert session._st.is_error_pending is True
+        assert session._st.run_error_message == "boom"
 
     async def test_routes_reasoning_events_to_edit_reasoning(self) -> None:
         """Reasoning* events are routed through fmt.edit_reasoning."""

--- a/tests/outbound/test_streaming_state_errors.py
+++ b/tests/outbound/test_streaming_state_errors.py
@@ -14,3 +14,12 @@ class TestStreamStateRunErrorMessage:
         display = state.build_display_text(lambda _key, fallback: fallback)
 
         assert display == "❌ You've hit your weekly limit"
+
+    def test_build_display_text_run_error_without_pending_omits_prefix(self) -> None:
+        state = StreamState()
+        state.is_error_pending = False
+        state.run_error_message = "You've hit your weekly limit"
+
+        display = state.build_display_text(lambda _key, fallback: fallback)
+
+        assert display == "You've hit your weekly limit"

--- a/tests/outbound/test_streaming_state_errors.py
+++ b/tests/outbound/test_streaming_state_errors.py
@@ -1,0 +1,16 @@
+"""StreamState soft-error display (ADR-089)."""
+
+from __future__ import annotations
+
+from factory.outbound._streaming_state import StreamState
+
+
+class TestStreamStateRunErrorMessage:
+    def test_build_display_text_uses_run_error_when_no_final_text(self) -> None:
+        state = StreamState()
+        state.is_error_pending = True
+        state.run_error_message = "You've hit your weekly limit"
+
+        display = state.build_display_text(lambda _key, fallback: fallback)
+
+        assert display == "❌ You've hit your weekly limit"


### PR DESCRIPTION
## Summary

Completes [ADR-089](docs/architecture/adr/089-centralized-llm-user-error-resolution.mdx) slices S4–S6 on top of the hub-side `resolve_user_error()` work already merged via #1942.

Users now see curated error messages (quota limits, auth, timeouts) instead of a generic fallback when the LLM backend returns a structured `WorkerError`.

## Changes

- **ADR-089** — documents the three-layer model (classify → transport → present)
- **Outbound** — store `RunErrorRenderEvent.message` for soft streaming errors without `text_delta`
- **Clipool blocking** — forward `worker_error` on NATS chunks; shared `cli_error_classify` helper
- **OMP** — `OmpJobCodec` decodes `JobResult.error` → `LlmResult.worker_error`
- **ClaudeCliDriver** — populate `worker_error` for in-process `CliPool` errors
- **Parser** — map `rate_limit_error` subtype → `llm.rate_limit`

## Test plan

- [x] `tests/core/test_cli_error_classify.py`
- [x] `tests/llm/test_omp_job_codec.py`
- [x] `tests/llm/drivers/test_omp_rpc.py`
- [x] `tests/llm/test_cli_driver.py`
- [x] `tests/outbound/test_streaming_state_errors.py`
- [x] `tests/adapters/test_clipool_worker.py` (blocking worker_error)
- [x] `tests/core/test_cli_streaming_parse.py` (rate_limit subtype)

## Post-merge

Validate on M1: Lyra weekly-limit message and Aryl error paths after auto-deploy.