### PR TITLE
test(adr-089): add error resolution E2E, smoke, and OMP contract gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ markers = [
     "integration: cross-host integration tests requiring M1 Tailnet",
     "audio_consumer_live: test exercises audio consumer directly; skip the autouse no-op neutralizer",
     "smoke: fast in-process smoke tests for critical user-facing paths",
+    "omp_contract: OMP wire + driver + codec + E2E contract regression gate",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ markers = [
     "nats_integration: NATS integration tests requiring Docker Compose",
     "integration: cross-host integration tests requiring M1 Tailnet",
     "audio_consumer_live: test exercises audio consumer directly; skip the autouse no-op neutralizer",
+    "smoke: fast in-process smoke tests for critical user-facing paths",
 ]
 
 [tool.coverage.run]

--- a/tests/adapters/omp/test_omp_v1_slice_gate.py
+++ b/tests/adapters/omp/test_omp_v1_slice_gate.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+pytestmark = pytest.mark.omp_contract
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/adapters/omp/test_omp_worker.py
+++ b/tests/adapters/omp/test_omp_worker.py
@@ -17,6 +17,8 @@ import pytest
 
 from factory.adapters.omp.omp_worker import OmpWorker
 
+pytestmark = pytest.mark.omp_contract
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -24,6 +24,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.omp_contract
+
 from factory.adapters.omp._rpc_bridge import (
     _DEFAULT_MODEL,
     _DEFAULT_REQUEST_TIMEOUT,

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -24,8 +24,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-pytestmark = pytest.mark.omp_contract
-
 from factory.adapters.omp._rpc_bridge import (
     _DEFAULT_MODEL,
     _DEFAULT_REQUEST_TIMEOUT,
@@ -37,6 +35,8 @@ from factory.adapters.omp._rpc_bridge import (
     _classify_exception,
     _read_request_timeout,
 )
+
+pytestmark = pytest.mark.omp_contract
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/contracts/omp_invariants.py
+++ b/tests/contracts/omp_invariants.py
@@ -27,7 +27,7 @@ def llm_result_shape(result: LlmResult) -> dict[str, Any]:
 
 
 def assert_llm_result_invariant(result: LlmResult) -> None:
-    """ADR-089 P2 shim: ok/error paths must keep worker_error, error, retryable coherent."""
+    """ADR-089 P2 shim: keep worker_error, error, and retryable coherent."""
     if result.ok:
         assert result.error == ""
         assert result.worker_error is None

--- a/tests/contracts/omp_invariants.py
+++ b/tests/contracts/omp_invariants.py
@@ -1,0 +1,39 @@
+"""Shared OMP contract helpers — LlmResult shape invariants (ADR-089 P2 shim)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from factory.core.ports.llm import LlmResult
+
+
+def llm_result_shape(result: LlmResult) -> dict[str, Any]:
+    """Serialize LlmResult to a stable dict for golden comparisons."""
+    we = result.worker_error
+    return {
+        "result": result.result,
+        "error": result.error,
+        "retryable": result.retryable,
+        "worker_error": (
+            None
+            if we is None
+            else {
+                "code": we.code,
+                "message": we.message,
+                "retryable": we.retryable,
+            }
+        ),
+    }
+
+
+def assert_llm_result_invariant(result: LlmResult) -> None:
+    """ADR-089 P2 shim: ok/error paths must keep worker_error, error, retryable coherent."""
+    if result.ok:
+        assert result.error == ""
+        assert result.worker_error is None
+        return
+
+    assert result.error
+    assert result.worker_error is not None
+    assert result.worker_error.message == result.error
+    assert result.retryable == result.worker_error.retryable

--- a/tests/contracts/test_omp_contract.py
+++ b/tests/contracts/test_omp_contract.py
@@ -1,0 +1,239 @@
+"""OMP contract gate — golden wire shapes + LlmResult invariants.
+
+Run the full OMP contract suite:
+
+    pytest -m omp_contract
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.llm.drivers.omp_rpc import OmpRpcDriver
+from factory.llm.omp_job_codec import OmpJobCodec
+from roxabi_contracts.jobs import JobResult
+from roxabi_contracts.jobs.fixtures import sample_job_result_err, sample_job_result_ok
+from roxabi_contracts.jobs.subjects import jobs_result, jobs_submit
+from tests.contracts.omp_invariants import (
+    assert_llm_result_invariant,
+    llm_result_shape,
+)
+
+pytestmark = pytest.mark.omp_contract
+
+_FIXED_JOB_ID = "deadbeefcafebabe0123456789abcdef"
+_FIXED_ISSUED_AT = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+_GOLDEN_JOB_ENVELOPE: dict[str, object] = {
+    "contract_version": "1",
+    "trace_id": _FIXED_JOB_ID,
+    "issued_at": "2026-06-18T12:00:00Z",
+    "job_id": _FIXED_JOB_ID,
+    "job_name": "omp",
+    "payload": {
+        "prompt": "ping",
+        "model_cfg": {"backend": "omp-rpc", "model": "grok-4-fast"},
+        "system_prompt": "sys",
+        "pool_id": "pool-golden",
+    },
+    "reply_to": f"_INBOX.{_FIXED_JOB_ID}",
+    "composite_depth": 0,
+    "parent_job_id": None,
+}
+
+_GOLDEN_LLM_OK: dict[str, object] = {
+    "result": "pong",
+    "error": "",
+    "retryable": True,
+    "worker_error": None,
+}
+
+_GOLDEN_LLM_WORKER_CRASH: dict[str, object] = {
+    "result": "",
+    "error": "scraper failed",
+    "retryable": True,
+    "worker_error": {
+        "code": "worker.crash",
+        "message": "scraper failed",
+        "retryable": True,
+    },
+}
+
+_GOLDEN_LLM_TIMEOUT: dict[str, object] = {
+    "result": "",
+    "error": "omp request timed out",
+    "retryable": True,
+    "worker_error": {
+        "code": "transport.timeout",
+        "message": "omp request timed out",
+        "retryable": True,
+    },
+}
+
+_GOLDEN_LLM_MALFORMED: dict[str, object] = {
+    "result": "",
+    "error": "omp returned a malformed result",
+    "retryable": False,
+    "worker_error": {
+        "code": "transport.parse",
+        "message": "omp returned a malformed result",
+        "retryable": False,
+    },
+}
+
+
+def _model_cfg() -> MagicMock:
+    cfg = MagicMock()
+    cfg.model_dump.return_value = {"backend": "omp-rpc", "model": "grok-4-fast"}
+    return cfg
+
+
+def _encode_result(result: JobResult) -> bytes:
+    return result.model_dump_json().encode()
+
+
+class TestOmpRpcDriverGoldenEnvelope:
+    @pytest.mark.asyncio
+    async def test_complete_publishes_golden_job_envelope(self) -> None:
+        """Pinned JobEnvelope JSON from OmpRpcDriver.complete() (frozen uuid + issued_at)."""
+        nc = AsyncMock()
+        sub = AsyncMock()
+        nc.subscribe.return_value = sub
+        success = JobResult.model_validate(
+            {**sample_job_result_ok, "job_id": _FIXED_JOB_ID, "data": {"result": "pong"}}
+        )
+        sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success))
+        driver = OmpRpcDriver(nc, timeout_s=5.0)
+
+        fixed_uuid = MagicMock()
+        fixed_uuid.hex = _FIXED_JOB_ID
+
+        with (
+            patch("factory.llm.drivers.omp_rpc.uuid4", return_value=fixed_uuid),
+            patch(
+                "factory.llm.drivers.omp_rpc.datetime",
+                wraps=datetime,
+            ) as dt_mock,
+        ):
+            dt_mock.now.return_value = _FIXED_ISSUED_AT
+            await driver.complete(
+                pool_id="pool-golden",
+                text="ping",
+                model_cfg=_model_cfg(),
+                system_prompt="sys",
+            )
+
+        publish_call = nc.publish.await_args
+        assert publish_call is not None
+        assert publish_call.args[0] == jobs_submit("omp")
+        assert publish_call.args[0] == "factory.jobs.omp"
+
+        envelope = json.loads(publish_call.args[1])
+        assert envelope == _GOLDEN_JOB_ENVELOPE
+
+        subscribe_subject = nc.subscribe.call_args.args[0]
+        assert subscribe_subject == jobs_result(_FIXED_JOB_ID)
+
+
+class TestOmpCodecGoldenLlmResult:
+    @pytest.mark.parametrize(
+        ("fixture", "golden"),
+        [
+            pytest.param(
+                {**sample_job_result_ok, "data": {"result": "pong"}},
+                _GOLDEN_LLM_OK,
+                id="success",
+            ),
+            pytest.param(sample_job_result_err, _GOLDEN_LLM_WORKER_CRASH, id="worker.crash"),
+        ],
+    )
+    def test_decode_matches_golden_shape(
+        self,
+        fixture: dict[str, object],
+        golden: dict[str, object],
+    ) -> None:
+        codec = OmpJobCodec()
+        result = JobResult.model_validate(fixture)
+        llm = codec.decode(result)
+        assert_llm_result_invariant(llm)
+        assert llm_result_shape(llm) == golden
+
+    def test_decode_timeout_matches_golden_shape(self) -> None:
+        llm = OmpJobCodec().decode_timeout()
+        assert_llm_result_invariant(llm)
+        assert llm_result_shape(llm) == _GOLDEN_LLM_TIMEOUT
+
+    def test_decode_malformed_matches_golden_shape(self) -> None:
+        llm = OmpJobCodec().decode_malformed()
+        assert_llm_result_invariant(llm)
+        assert llm_result_shape(llm) == _GOLDEN_LLM_MALFORMED
+
+
+class TestLlmResultShapeInvariant:
+    @pytest.mark.parametrize(
+        "fixture",
+        [
+            pytest.param(
+                {**sample_job_result_ok, "data": {"result": "x"}},
+                id="success",
+            ),
+            pytest.param(sample_job_result_err, id="worker.crash"),
+            pytest.param(
+                {
+                    **sample_job_result_err,
+                    "error": {
+                        "code": "llm.rate_limit",
+                        "message": "quota",
+                        "retryable": True,
+                    },
+                },
+                id="llm.rate_limit",
+            ),
+        ],
+    )
+    def test_codec_decode_satisfies_invariant(self, fixture: dict[str, object]) -> None:
+        llm = OmpJobCodec().decode(JobResult.model_validate(fixture))
+        assert_llm_result_invariant(llm)
+
+    @pytest.mark.asyncio
+    async def test_driver_paths_satisfy_invariant(self) -> None:
+        nc = AsyncMock()
+        sub = AsyncMock()
+        nc.subscribe.return_value = sub
+        driver = OmpRpcDriver(nc, timeout_s=5.0)
+        model_cfg = _model_cfg()
+
+        sub.next_msg.return_value = SimpleNamespace(
+            data=_encode_result(
+                JobResult.model_validate(
+                    {**sample_job_result_ok, "data": {"result": "ok"}}
+                )
+            )
+        )
+        assert_llm_result_invariant(
+            await driver.complete("p", "t", model_cfg, "s")
+        )
+
+        sub.next_msg.return_value = SimpleNamespace(
+            data=_encode_result(JobResult.model_validate(sample_job_result_err))
+        )
+        assert_llm_result_invariant(
+            await driver.complete("p", "t", model_cfg, "s")
+        )
+
+        sub.next_msg.side_effect = asyncio.TimeoutError
+        assert_llm_result_invariant(
+            await driver.complete("p", "t", model_cfg, "s")
+        )
+
+        sub.next_msg.side_effect = None
+        sub.next_msg.return_value = SimpleNamespace(data=b"not-json")
+        assert_llm_result_invariant(
+            await driver.complete("p", "t", model_cfg, "s")
+        )

--- a/tests/contracts/test_omp_contract.py
+++ b/tests/contracts/test_omp_contract.py
@@ -101,12 +101,16 @@ def _encode_result(result: JobResult) -> bytes:
 class TestOmpRpcDriverGoldenEnvelope:
     @pytest.mark.asyncio
     async def test_complete_publishes_golden_job_envelope(self) -> None:
-        """Pinned JobEnvelope JSON from OmpRpcDriver.complete() (frozen uuid + issued_at)."""
+        """Pinned JobEnvelope JSON from OmpRpcDriver.complete() (frozen ids)."""
         nc = AsyncMock()
         sub = AsyncMock()
         nc.subscribe.return_value = sub
         success = JobResult.model_validate(
-            {**sample_job_result_ok, "job_id": _FIXED_JOB_ID, "data": {"result": "pong"}}
+            {
+                **sample_job_result_ok,
+                "job_id": _FIXED_JOB_ID,
+                "data": {"result": "pong"},
+            }
         )
         sub.next_msg.return_value = SimpleNamespace(data=_encode_result(success))
         driver = OmpRpcDriver(nc, timeout_s=5.0)
@@ -150,7 +154,11 @@ class TestOmpCodecGoldenLlmResult:
                 _GOLDEN_LLM_OK,
                 id="success",
             ),
-            pytest.param(sample_job_result_err, _GOLDEN_LLM_WORKER_CRASH, id="worker.crash"),
+            pytest.param(
+                sample_job_result_err,
+                _GOLDEN_LLM_WORKER_CRASH,
+                id="worker.crash",
+            ),
         ],
     )
     def test_decode_matches_golden_shape(

--- a/tests/contracts/test_omp_payload_v2.py
+++ b/tests/contracts/test_omp_payload_v2.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from roxabi_contracts.jobs import JobEnvelope, JobResult
 from roxabi_contracts.jobs.fixtures import ENV_BASE
+
+pytestmark = pytest.mark.omp_contract
 
 # ---------------------------------------------------------------------------
 # Shared base payloads (minimal valid envelopes)

--- a/tests/integration/adr089_helpers.py
+++ b/tests/integration/adr089_helpers.py
@@ -1,0 +1,70 @@
+"""Shared helpers for ADR-089 Hub/OMP error-resolution E2E tests."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from factory.agents.simple_agent import SimpleAgent
+from factory.core.hub import Hub
+from factory.core.lifecycle.circuit_breaker import CircuitBreaker, CircuitRegistry
+from factory.core.messaging.message import Platform
+from factory.core.messaging.messages import MessageManager
+from factory.core.messaging.render_events import (
+    RunErrorRenderEvent,
+    TextDeltaRenderEvent,
+)
+from tests.core.conftest import push_to_hub
+from tests.integration.test_e2e_telegram_to_agent import (
+    _make_telegram_message,
+    _RecordingAdapter,
+)
+
+_MESSAGES = (
+    Path(__file__).resolve().parents[2] / "src" / "factory" / "data" / "messages.toml"
+)
+
+
+def message_manager() -> MessageManager:
+    return MessageManager(_MESSAGES, language="en")
+
+
+class DrainingStreamingAdapter(_RecordingAdapter):
+    """Records outbound payloads and drains render-event streams."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_error_messages: list[str] = []
+        self.streamed_deltas: list[str] = []
+
+    async def send_streaming(self, original_msg, events, outbound=None) -> None:
+        del original_msg
+        async for event in events:
+            if isinstance(event, RunErrorRenderEvent):
+                self.run_error_messages.append(event.message)
+            elif isinstance(event, TextDeltaRenderEvent):
+                self.streamed_deltas.append(event.delta)
+        if outbound is not None:
+            self.streamed.append(outbound)
+
+
+def hub_with_agent(agent: SimpleAgent) -> Hub:
+    mm = message_manager()
+    registry = CircuitRegistry()
+    registry.register(CircuitBreaker("claude-cli"))
+    hub = Hub(circuit_registry=registry, msg_manager=mm)
+    hub.register_agent(agent)
+    adapter = DrainingStreamingAdapter()
+    hub.register_adapter(Platform.TELEGRAM, "main", adapter)
+    hub.register_binding(
+        Platform.TELEGRAM, "main", "*", agent.config.name, "telegram:main:*"
+    )
+    return hub
+
+
+async def run_hub_until_processed(hub: Hub) -> None:
+    await push_to_hub(hub, _make_telegram_message("hi"))
+    try:
+        await asyncio.wait_for(hub.run(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pass

--- a/tests/integration/test_adr089_error_resolution_e2e.py
+++ b/tests/integration/test_adr089_error_resolution_e2e.py
@@ -20,14 +20,17 @@ from factory.core.hub import Hub
 from factory.core.lifecycle.circuit_breaker import CircuitBreaker, CircuitRegistry
 from factory.core.messaging.events import ResultLlmEvent
 from factory.core.messaging.message import Platform
-from factory.core.messaging.render_events import RunErrorRenderEvent, TextDeltaRenderEvent
 from factory.core.messaging.messages import MessageManager
+from factory.core.messaging.render_events import (
+    RunErrorRenderEvent,
+    TextDeltaRenderEvent,
+)
 from factory.llm.base import LlmResult
 from roxabi_contracts.errors import WorkerError
 from tests.core.conftest import push_to_hub
 from tests.integration.test_e2e_telegram_to_agent import (
-    _RecordingAdapter,
     _make_telegram_message,
+    _RecordingAdapter,
 )
 
 _MESSAGES = (

--- a/tests/integration/test_adr089_error_resolution_e2e.py
+++ b/tests/integration/test_adr089_error_resolution_e2e.py
@@ -6,9 +6,7 @@ and resolve_user_error() wiring. No NATS / no live CLI.
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterator
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,77 +14,23 @@ import pytest
 from factory.agents.simple_agent import SimpleAgent
 from factory.core.agent import Agent
 from factory.core.agent.agent_config import ModelConfig
-from factory.core.hub import Hub
-from factory.core.lifecycle.circuit_breaker import CircuitBreaker, CircuitRegistry
 from factory.core.messaging.events import ResultLlmEvent
 from factory.core.messaging.message import Platform
-from factory.core.messaging.messages import MessageManager
-from factory.core.messaging.render_events import (
-    RunErrorRenderEvent,
-    TextDeltaRenderEvent,
-)
 from factory.llm.base import LlmResult
 from roxabi_contracts.errors import WorkerError
-from tests.core.conftest import push_to_hub
-from tests.integration.test_e2e_telegram_to_agent import (
-    _make_telegram_message,
-    _RecordingAdapter,
+from tests.integration.adr089_helpers import (
+    DrainingStreamingAdapter,
+    hub_with_agent,
+    message_manager,
+    run_hub_until_processed,
 )
-
-_MESSAGES = (
-    Path(__file__).resolve().parents[2] / "src" / "factory" / "data" / "messages.toml"
-)
-
-
-def _message_manager() -> MessageManager:
-    return MessageManager(_MESSAGES, language="en")
-
-
-class _DrainingStreamingAdapter(_RecordingAdapter):
-    """Records outbound payloads and drains render-event streams."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.run_error_messages: list[str] = []
-        self.streamed_deltas: list[str] = []
-
-    async def send_streaming(self, original_msg, events, outbound=None) -> None:
-        del original_msg
-        async for event in events:
-            if isinstance(event, RunErrorRenderEvent):
-                self.run_error_messages.append(event.message)
-            elif isinstance(event, TextDeltaRenderEvent):
-                self.streamed_deltas.append(event.delta)
-        if outbound is not None:
-            self.streamed.append(outbound)
-
-
-def _hub_with_agent(agent: SimpleAgent) -> Hub:
-    mm = _message_manager()
-    registry = CircuitRegistry()
-    registry.register(CircuitBreaker("claude-cli"))
-    hub = Hub(circuit_registry=registry, msg_manager=mm)
-    hub.register_agent(agent)
-    adapter = _DrainingStreamingAdapter()
-    hub.register_adapter(Platform.TELEGRAM, "main", adapter)
-    hub.register_binding(
-        Platform.TELEGRAM, "main", "*", agent.config.name, "telegram:main:*"
-    )
-    return hub
-
-
-async def _run_hub_until_processed(hub: Hub) -> None:
-    await push_to_hub(hub, _make_telegram_message("hi"))
-    try:
-        await asyncio.wait_for(hub.run(), timeout=2.0)
-    except asyncio.TimeoutError:
-        pass
+from tests.integration.test_e2e_telegram_to_agent import _RecordingAdapter
 
 
 @pytest.mark.smoke
 class TestAdr089BlockingErrorE2E:
     async def test_rate_limit_template_reaches_telegram_adapter(self) -> None:
-        mm = _message_manager()
+        mm = message_manager()
         provider = MagicMock()
         provider.complete = AsyncMock(
             return_value=LlmResult(
@@ -109,11 +53,11 @@ class TestAdr089BlockingErrorE2E:
             provider,
             msg_manager=mm,
         )
-        hub = _hub_with_agent(agent)
+        hub = hub_with_agent(agent)
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
         assert isinstance(adapter, _RecordingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.sent) == 1
         assert adapter.sent[0].to_text() == mm.get("rate_limit")
@@ -140,13 +84,13 @@ class TestAdr089BlockingErrorE2E:
                 llm_config=ModelConfig(streaming=False),
             ),
             provider,
-            msg_manager=_message_manager(),
+            msg_manager=message_manager(),
         )
-        hub = _hub_with_agent(agent)
+        hub = hub_with_agent(agent)
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
         assert isinstance(adapter, _RecordingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.sent) == 1
         assert "weekly limit" in adapter.sent[0].to_text()
@@ -165,13 +109,13 @@ class TestAdr089BlockingErrorE2E:
                 llm_config=ModelConfig(streaming=False),
             ),
             provider,
-            msg_manager=_message_manager(),
+            msg_manager=message_manager(),
         )
-        hub = _hub_with_agent(agent)
+        hub = hub_with_agent(agent)
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
         assert isinstance(adapter, _RecordingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.sent) == 1
         text = adapter.sent[0].to_text()
@@ -183,7 +127,7 @@ class TestAdr089BlockingErrorE2E:
 @pytest.mark.smoke
 class TestAdr089StreamingSoftErrorE2E:
     async def test_rate_limit_soft_error_reaches_streaming_adapter(self) -> None:
-        mm = _message_manager()
+        mm = message_manager()
         expected = mm.get("rate_limit")
 
         async def _error_stream() -> AsyncIterator[ResultLlmEvent]:
@@ -212,11 +156,11 @@ class TestAdr089StreamingSoftErrorE2E:
             provider,
             msg_manager=mm,
         )
-        hub = _hub_with_agent(agent)
+        hub = hub_with_agent(agent)
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
-        assert isinstance(adapter, _DrainingStreamingAdapter)
+        assert isinstance(adapter, DrainingStreamingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.streamed) == 1
         assert adapter.run_error_messages == [expected]

--- a/tests/integration/test_adr089_error_resolution_e2e.py
+++ b/tests/integration/test_adr089_error_resolution_e2e.py
@@ -1,0 +1,219 @@
+"""ADR-089 E2E — Telegram → Hub → SimpleAgent → resolved user error text.
+
+In-process smoke: mocked LlmProvider, real Hub routing, real MessageManager
+and resolve_user_error() wiring. No NATS / no live CLI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.agents.simple_agent import SimpleAgent
+from factory.core.agent import Agent
+from factory.core.agent.agent_config import ModelConfig
+from factory.core.hub import Hub
+from factory.core.lifecycle.circuit_breaker import CircuitBreaker, CircuitRegistry
+from factory.core.messaging.events import ResultLlmEvent
+from factory.core.messaging.message import Platform
+from factory.core.messaging.render_events import RunErrorRenderEvent, TextDeltaRenderEvent
+from factory.core.messaging.messages import MessageManager
+from factory.llm.base import LlmResult
+from roxabi_contracts.errors import WorkerError
+from tests.core.conftest import push_to_hub
+from tests.integration.test_e2e_telegram_to_agent import (
+    _RecordingAdapter,
+    _make_telegram_message,
+)
+
+_MESSAGES = (
+    Path(__file__).resolve().parents[2] / "src" / "factory" / "data" / "messages.toml"
+)
+
+
+def _message_manager() -> MessageManager:
+    return MessageManager(_MESSAGES, language="en")
+
+
+class _DrainingStreamingAdapter(_RecordingAdapter):
+    """Records outbound payloads and drains render-event streams."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_error_messages: list[str] = []
+        self.streamed_deltas: list[str] = []
+
+    async def send_streaming(self, original_msg, events, outbound=None) -> None:
+        del original_msg
+        async for event in events:
+            if isinstance(event, RunErrorRenderEvent):
+                self.run_error_messages.append(event.message)
+            elif isinstance(event, TextDeltaRenderEvent):
+                self.streamed_deltas.append(event.delta)
+        if outbound is not None:
+            self.streamed.append(outbound)
+
+
+def _hub_with_agent(agent: SimpleAgent) -> Hub:
+    mm = _message_manager()
+    registry = CircuitRegistry()
+    registry.register(CircuitBreaker("claude-cli"))
+    hub = Hub(circuit_registry=registry, msg_manager=mm)
+    hub.register_agent(agent)
+    adapter = _DrainingStreamingAdapter()
+    hub.register_adapter(Platform.TELEGRAM, "main", adapter)
+    hub.register_binding(
+        Platform.TELEGRAM, "main", "*", agent.config.name, "telegram:main:*"
+    )
+    return hub
+
+
+async def _run_hub_until_processed(hub: Hub) -> None:
+    await push_to_hub(hub, _make_telegram_message("hi"))
+    try:
+        await asyncio.wait_for(hub.run(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pass
+
+
+@pytest.mark.smoke
+class TestAdr089BlockingErrorE2E:
+    async def test_rate_limit_template_reaches_telegram_adapter(self) -> None:
+        mm = _message_manager()
+        provider = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=LlmResult(
+                error="You've hit your weekly limit",
+                worker_error=WorkerError(
+                    code="llm.rate_limit",
+                    message="You've hit your weekly limit",
+                    retryable=True,
+                ),
+            )
+        )
+        provider.is_alive = MagicMock(return_value=True)
+        agent = SimpleAgent(
+            Agent(
+                name="lyra",
+                system_prompt="You are Lyra.",
+                memory_namespace="lyra",
+                llm_config=ModelConfig(streaming=False),
+            ),
+            provider,
+            msg_manager=mm,
+        )
+        hub = _hub_with_agent(agent)
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0].to_text() == mm.get("rate_limit")
+
+    async def test_cli_parse_passthrough_reaches_telegram_adapter(self) -> None:
+        curated = "You've hit your weekly limit · resets 6pm (UTC)"
+        provider = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=LlmResult(
+                error=curated,
+                worker_error=WorkerError(
+                    code="cli.parse",
+                    message=curated,
+                    retryable=False,
+                ),
+            )
+        )
+        provider.is_alive = MagicMock(return_value=True)
+        agent = SimpleAgent(
+            Agent(
+                name="lyra",
+                system_prompt="You are Lyra.",
+                memory_namespace="lyra",
+                llm_config=ModelConfig(streaming=False),
+            ),
+            provider,
+            msg_manager=_message_manager(),
+        )
+        hub = _hub_with_agent(agent)
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        assert "weekly limit" in adapter.sent[0].to_text()
+
+    async def test_flat_error_without_worker_error_is_generic(self) -> None:
+        provider = MagicMock()
+        provider.complete = AsyncMock(
+            return_value=LlmResult(error="internal scraper stack trace")
+        )
+        provider.is_alive = MagicMock(return_value=True)
+        agent = SimpleAgent(
+            Agent(
+                name="lyra",
+                system_prompt="You are Lyra.",
+                memory_namespace="lyra",
+                llm_config=ModelConfig(streaming=False),
+            ),
+            provider,
+            msg_manager=_message_manager(),
+        )
+        hub = _hub_with_agent(agent)
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        text = adapter.sent[0].to_text()
+        assert "scraper" not in text
+        assert "stack trace" not in text
+        assert text == "Something went wrong. Please try again."
+
+
+@pytest.mark.smoke
+class TestAdr089StreamingSoftErrorE2E:
+    async def test_rate_limit_soft_error_reaches_streaming_adapter(self) -> None:
+        mm = _message_manager()
+        expected = mm.get("rate_limit")
+
+        async def _error_stream() -> AsyncIterator[ResultLlmEvent]:
+            yield ResultLlmEvent(
+                is_error=True,
+                duration_ms=10,
+                error_text="You've hit your weekly limit",
+                worker_error=WorkerError(
+                    code="llm.rate_limit",
+                    message="You've hit your weekly limit",
+                    retryable=True,
+                ),
+            )
+
+        provider = MagicMock()
+        provider.stream = MagicMock(return_value=_error_stream())
+        provider.is_alive = MagicMock(return_value=True)
+
+        agent = SimpleAgent(
+            Agent(
+                name="lyra",
+                system_prompt="You are Lyra.",
+                memory_namespace="lyra",
+                llm_config=ModelConfig(streaming=True),
+            ),
+            provider,
+            msg_manager=mm,
+        )
+        hub = _hub_with_agent(agent)
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _DrainingStreamingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.streamed) == 1
+        assert adapter.run_error_messages == [expected]

--- a/tests/integration/test_adr089_omp_error_e2e.py
+++ b/tests/integration/test_adr089_omp_error_e2e.py
@@ -26,6 +26,8 @@ from tests.integration.test_adr089_error_resolution_e2e import (
 )
 from tests.integration.test_e2e_telegram_to_agent import _RecordingAdapter
 
+pytestmark = [pytest.mark.omp_contract, pytest.mark.smoke]
+
 _OMP_MODEL = ModelConfig(backend="omp-rpc", model="grok-4-fast")
 
 
@@ -60,7 +62,6 @@ def _make_omp_agent(nc: AsyncMock) -> SimpleAgent:
     )
 
 
-@pytest.mark.smoke
 class TestAdr089OmpBlockingErrorE2E:
     async def test_worker_crash_job_result_shows_generic(self) -> None:
         """JobResult worker.crash → generic (infra code, no message leak)."""

--- a/tests/integration/test_adr089_omp_error_e2e.py
+++ b/tests/integration/test_adr089_omp_error_e2e.py
@@ -19,10 +19,10 @@ from factory.core.messaging.message import Platform
 from factory.llm.drivers.omp_rpc import OmpRpcDriver
 from roxabi_contracts.jobs import JobResult
 from roxabi_contracts.jobs.fixtures import ENV_BASE, sample_job_result_err
-from tests.integration.test_adr089_error_resolution_e2e import (
-    _hub_with_agent,
-    _message_manager,
-    _run_hub_until_processed,
+from tests.integration.adr089_helpers import (
+    hub_with_agent,
+    message_manager,
+    run_hub_until_processed,
 )
 from tests.integration.test_e2e_telegram_to_agent import _RecordingAdapter
 
@@ -58,7 +58,7 @@ def _make_omp_agent(nc: AsyncMock) -> SimpleAgent:
             llm_config=_OMP_MODEL,
         ),
         driver,
-        msg_manager=_message_manager(),
+        msg_manager=message_manager(),
     )
 
 
@@ -67,11 +67,11 @@ class TestAdr089OmpBlockingErrorE2E:
         """JobResult worker.crash → generic (infra code, no message leak)."""
         result = JobResult.model_validate(sample_job_result_err)
         nc = _make_omp_nc(result)
-        hub = _hub_with_agent(_make_omp_agent(nc))
+        hub = hub_with_agent(_make_omp_agent(nc))
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
         assert isinstance(adapter, _RecordingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.sent) == 1
         text = adapter.sent[0].to_text()
@@ -80,7 +80,7 @@ class TestAdr089OmpBlockingErrorE2E:
 
     async def test_llm_rate_limit_job_result_shows_template(self) -> None:
         """JobResult llm.rate_limit → messages.toml rate_limit template."""
-        mm = _message_manager()
+        mm = message_manager()
         result = JobResult.model_validate(
             {
                 **ENV_BASE,
@@ -94,24 +94,24 @@ class TestAdr089OmpBlockingErrorE2E:
             }
         )
         nc = _make_omp_nc(result)
-        hub = _hub_with_agent(_make_omp_agent(nc))
+        hub = hub_with_agent(_make_omp_agent(nc))
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
         assert isinstance(adapter, _RecordingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.sent) == 1
         assert adapter.sent[0].to_text() == mm.get("rate_limit")
 
     async def test_nats_timeout_shows_timeout_template(self) -> None:
         """NATS reply timeout → transport.timeout template."""
-        mm = _message_manager()
+        mm = message_manager()
         nc = _make_omp_nc(timeout=True)
-        hub = _hub_with_agent(_make_omp_agent(nc))
+        hub = hub_with_agent(_make_omp_agent(nc))
         adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
         assert isinstance(adapter, _RecordingAdapter)
 
-        await _run_hub_until_processed(hub)
+        await run_hub_until_processed(hub)
 
         assert len(adapter.sent) == 1
         assert adapter.sent[0].to_text() == mm.get("timeout")

--- a/tests/integration/test_adr089_omp_error_e2e.py
+++ b/tests/integration/test_adr089_omp_error_e2e.py
@@ -1,0 +1,116 @@
+"""ADR-089 E2E — OMP backend via OmpRpcDriver + mock NATS → Hub user error text.
+
+Exercises the real OmpRpcDriver → OmpJobCodec → SimpleAgent → resolve_user_error()
+chain. NATS is mocked (no omp worker container).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from factory.agents.simple_agent import SimpleAgent
+from factory.core.agent import Agent
+from factory.core.agent.agent_config import ModelConfig
+from factory.core.messaging.message import Platform
+from factory.llm.drivers.omp_rpc import OmpRpcDriver
+from roxabi_contracts.jobs import JobResult
+from roxabi_contracts.jobs.fixtures import ENV_BASE, sample_job_result_err
+from tests.integration.test_adr089_error_resolution_e2e import (
+    _hub_with_agent,
+    _message_manager,
+    _run_hub_until_processed,
+)
+from tests.integration.test_e2e_telegram_to_agent import _RecordingAdapter
+
+_OMP_MODEL = ModelConfig(backend="omp-rpc", model="grok-4-fast")
+
+
+def _make_omp_nc(
+    job_result: JobResult | None = None,
+    *,
+    timeout: bool = False,
+) -> AsyncMock:
+    nc = AsyncMock()
+    sub = AsyncMock()
+    nc.subscribe.return_value = sub
+    if timeout:
+        sub.next_msg.side_effect = asyncio.TimeoutError
+    elif job_result is not None:
+        sub.next_msg.return_value = SimpleNamespace(
+            data=job_result.model_dump_json().encode()
+        )
+    return nc
+
+
+def _make_omp_agent(nc: AsyncMock) -> SimpleAgent:
+    driver = OmpRpcDriver(nc, timeout_s=5.0)
+    return SimpleAgent(
+        Agent(
+            name="lyra",
+            system_prompt="You are Lyra.",
+            memory_namespace="lyra",
+            llm_config=_OMP_MODEL,
+        ),
+        driver,
+        msg_manager=_message_manager(),
+    )
+
+
+@pytest.mark.smoke
+class TestAdr089OmpBlockingErrorE2E:
+    async def test_worker_crash_job_result_shows_generic(self) -> None:
+        """JobResult worker.crash → generic (infra code, no message leak)."""
+        result = JobResult.model_validate(sample_job_result_err)
+        nc = _make_omp_nc(result)
+        hub = _hub_with_agent(_make_omp_agent(nc))
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        text = adapter.sent[0].to_text()
+        assert "scraper" not in text
+        assert text == "Something went wrong. Please try again."
+
+    async def test_llm_rate_limit_job_result_shows_template(self) -> None:
+        """JobResult llm.rate_limit → messages.toml rate_limit template."""
+        mm = _message_manager()
+        result = JobResult.model_validate(
+            {
+                **ENV_BASE,
+                "job_id": "job-omp-rl",
+                "status": "error",
+                "error": {
+                    "code": "llm.rate_limit",
+                    "message": "You've hit your weekly limit",
+                    "retryable": True,
+                },
+            }
+        )
+        nc = _make_omp_nc(result)
+        hub = _hub_with_agent(_make_omp_agent(nc))
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0].to_text() == mm.get("rate_limit")
+
+    async def test_nats_timeout_shows_timeout_template(self) -> None:
+        """NATS reply timeout → transport.timeout template."""
+        mm = _message_manager()
+        nc = _make_omp_nc(timeout=True)
+        hub = _hub_with_agent(_make_omp_agent(nc))
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await _run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0].to_text() == mm.get("timeout")

--- a/tests/integration/test_omp_session_resume_integration.py
+++ b/tests/integration/test_omp_session_resume_integration.py
@@ -55,6 +55,7 @@ from roxabi_contracts.jobs.fixtures import sample_job_result_ok
 # ---------------------------------------------------------------------------
 
 pytestmark = [
+    pytest.mark.omp_contract,
     pytest.mark.integration,
     pytest.mark.skipif(
         not os.environ.get("INTEGRATION"),

--- a/tests/llm/drivers/test_omp_rpc.py
+++ b/tests/llm/drivers/test_omp_rpc.py
@@ -21,6 +21,8 @@ from roxabi_contracts.jobs import JobResult
 from roxabi_contracts.jobs.fixtures import sample_job_result_ok
 from roxabi_contracts.jobs.subjects import jobs_result, jobs_submit
 
+pytestmark = pytest.mark.omp_contract
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/llm/drivers/test_omp_rpc_session.py
+++ b/tests/llm/drivers/test_omp_rpc_session.py
@@ -21,6 +21,8 @@ from factory.llm.drivers.omp_rpc import OmpRpcDriver
 from roxabi_contracts.jobs import JobResult
 from roxabi_contracts.jobs.fixtures import sample_job_result_ok
 
+pytestmark = pytest.mark.omp_contract
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/llm/test_omp_job_codec.py
+++ b/tests/llm/test_omp_job_codec.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
 from factory.llm.omp_job_codec import OmpJobCodec
 from roxabi_contracts.jobs import JobResult
 from roxabi_contracts.jobs.fixtures import sample_job_result_err, sample_job_result_ok
+
+pytestmark = pytest.mark.omp_contract
 
 _codec = OmpJobCodec()
 

--- a/tests/outbound/test_emitter_telegram_smoke.py
+++ b/tests/outbound/test_emitter_telegram_smoke.py
@@ -22,6 +22,7 @@ from factory.adapters.telegram import TelegramAdapter
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import InboundMessage, OutboundMessage, TelegramMeta
 from factory.core.messaging.render_events import (
+    RunErrorRenderEvent,
     TextDeltaRenderEvent,
     TextEndRenderEvent,
     TextStartRenderEvent,
@@ -77,6 +78,11 @@ async def _three_chunk_events():
     yield TextDeltaRenderEvent(delta="Hello", message_id="m1")
     yield TextDeltaRenderEvent(delta=" world", message_id="m1")
     yield TextEndRenderEvent(message_id="m1")
+
+
+async def _soft_error_only_events():
+    """Soft LLM error with no text deltas (ADR-089 streaming path)."""
+    yield RunErrorRenderEvent(run_id="r1", message="You've hit your weekly limit")
 
 
 # ---------------------------------------------------------------------------
@@ -329,3 +335,21 @@ class TestTelegramSendStreamingSmoke:
         # MarkdownV2 escapes spaces and characters, but "Hello" and "world" must be
         # present after escaping (content check at character level).
         assert text_arg is not None, "edit_message_text must receive a text argument"
+
+    async def test_send_streaming_soft_error_displays_run_error_message(self) -> None:
+        """ADR-089: soft error only (no text_delta) shows curated message on Telegram."""
+        adapter, bot = _make_tg_adapter_with_bot()
+        original_msg = _make_tg_inbound(chat_id=42, message_id=10)
+        outbound = OutboundMessage.from_text("")
+
+        await adapter.send_streaming(
+            original_msg, _soft_error_only_events(), outbound=outbound
+        )
+
+        bot.edit_message_text.assert_awaited()
+        last_call = bot.edit_message_text.call_args_list[-1]
+        text_arg = last_call.kwargs.get("text") or (
+            last_call.args[0] if last_call.args else ""
+        )
+        assert text_arg is not None
+        assert "weekly limit" in text_arg

--- a/tests/outbound/test_emitter_telegram_smoke.py
+++ b/tests/outbound/test_emitter_telegram_smoke.py
@@ -337,7 +337,7 @@ class TestTelegramSendStreamingSmoke:
         assert text_arg is not None, "edit_message_text must receive a text argument"
 
     async def test_send_streaming_soft_error_displays_run_error_message(self) -> None:
-        """ADR-089: soft error only (no text_delta) shows curated message on Telegram."""
+        """ADR-089: soft error only shows curated message on Telegram."""
         adapter, bot = _make_tg_adapter_with_bot()
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
         outbound = OutboundMessage.from_text("")


### PR DESCRIPTION
## Summary
- Add Hub-level E2E tests for ADR-089 user error resolution (blocking quota template, cli.parse passthrough, generic fallback, streaming soft errors)
- Add OMP E2E via real `OmpRpcDriver` + mock NATS (worker.crash, llm.rate_limit, timeout)
- Introduce `@pytest.mark.omp_contract` regression gate with golden `JobEnvelope`/`LlmResult` shapes and `LlmResult` shape invariants

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | ADR-089 user error resolution (merged #1943) | Complete |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 6 commits on `test/adr-089-error-e2e` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (17 new) | Passed |

## Test Plan
- [x] `pytest -m smoke` — Hub E2E + OMP E2E + Telegram emitter smoke
- [x] `pytest -m omp_contract` — 112 passed (wire + driver + codec + bridge + worker + E2E)
- [x] `pytest tests/contracts/test_omp_contract.py` — golden envelope + LlmResult invariants

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| Blocking quota → rate_limit template | `test_adr089_error_resolution_e2e.py :: TestAdr089BlockingErrorE2E::test_rate_limit_template_reaches_telegram_adapter` | ✅ |
| cli.parse passthrough (scrubbed) | `test_adr089_error_resolution_e2e.py :: TestAdr089BlockingErrorE2E::test_cli_parse_passthrough_reaches_telegram_adapter` | ✅ |
| Flat error without worker_error → generic | `test_adr089_error_resolution_e2e.py :: TestAdr089BlockingErrorE2E::test_flat_error_without_worker_error_is_generic` | ✅ |
| Streaming soft error → curated text (Hub) | `test_adr089_error_resolution_e2e.py :: TestAdr089StreamingSoftErrorE2E::test_rate_limit_soft_error_reaches_streaming_adapter` | ✅ |
| Streaming soft error → curated text (Telegram) | `test_emitter_telegram_smoke.py :: test_send_streaming_soft_error_displays_run_error_message` | ✅ |
| OMP worker.crash → generic | `test_adr089_omp_error_e2e.py :: TestAdr089OmpBlockingErrorE2E::test_worker_crash_job_result_shows_generic` | ✅ |
| OMP llm.rate_limit → template | `test_adr089_omp_error_e2e.py :: TestAdr089OmpBlockingErrorE2E::test_llm_rate_limit_job_result_shows_template` | ✅ |
| OMP NATS timeout → template | `test_adr089_omp_error_e2e.py :: TestAdr089OmpBlockingErrorE2E::test_nats_timeout_shows_timeout_template` | ✅ |
| OMP golden JobEnvelope wire shape | `test_omp_contract.py :: TestOmpRpcDriverGoldenEnvelope::test_complete_publishes_golden_job_envelope` | ✅ |
| LlmResult P2 shim invariant | `test_omp_contract.py :: TestLlmResultShapeInvariant` | ✅ |

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`