### PR TITLE
feat(cli): add factory secrets reset for lost NATS nkeys

### DIFF
--- a/artifacts/analyses/agent-secret-broker.md
+++ b/artifacts/analyses/agent-secret-broker.md
@@ -1,0 +1,255 @@
+---
+title: Isolation des secrets pour agents — Broker, Facade & Setup
+description: Analyse + recommandation pour donner aux agents l'usage des API keys (Telegram, CF, GitHub, Vercel, Brevo, X…) sans qu'ils puissent jamais les lire. Command facade > broker MITM ; validée web/xAI.
+---
+
+# Isolation des secrets pour agents — Broker, Facade & Setup
+
+> Status: ANALYSIS — décision technique posée, implémentation à acter (ADR).
+> Last updated: 2026-06-15.
+> Guide visuel: `~/.roxabi/forge/roxabi-factory/visuals/agent-secret-broker.html` (8 onglets, diagrammes).
+> Verdict externe: **confirmé avec caveats** (8 recherches web + xAI/Grok, 23 claims vérifiées sur source).
+
+## TL;DR — la décision
+
+Le bon design = une **command facade** en **user séparé** que l'agent pilote par **intent** — le secret ne
+traverse jamais l'agent. Mais isoler la **lecture** de la clé ne suffit pas : l'agent peut toujours **mal
+utiliser** une capacité qu'il ne peut pas lire → **ACL par-action + egress allowlist obligatoires**.
+
+- **Facade (B)** retenue **plutôt que** broker egress TLS-MITM (A).
+- Conteneurs agents `--network=none` = le **vrai** gate (l'agent ne peut pas contourner la facade).
+- Identité = **UDS** (socket inode, même hôte) ou **NATS + ACL factory** (cross-host). Jamais un token bearer.
+- Creds dans **Vaultwarden** (déjà en place), fetch **JIT par-requête**.
+- `gh` garde son **dispenser éphémère** (cas où la facade « suffit ») ; les tokens **statiques** passent en facade.
+
+## 1. Problème & invariant
+
+Si un script peut lire la variable, l'agent peut la lire — donc la **leaker** (echo, logs, contexte LLM,
+commit public). Vrai pour `.env` **et** pour un vault qui *délivre* le secret au process. Déclencheur réel :
+un agent a déjà écrit un token Telegram en clair dans un fichier de test.
+
+L'invariant « l'agent ne doit JAMAIS pouvoir lire la clé » élimine toute la colonne **Injection**.
+
+| Modèle | Livraison du secret | Dans le process agent ? | Exemples |
+|---|---|---|---|
+| **Broker** | requête sans cred → le broker l'attache | **Jamais** | Secretless Broker, Envoy credential_injector, Infisical agent-vault |
+| **Injection** | daemon écrit le secret en fichier/env → l'agent le lit | **Oui** | Vault Agent, Doppler `run`, 1Password `op run`, Akeyless |
+
+> Vault = excellent **store** derrière un broker, mais Vault Agent = injection. Seul le modèle broker satisfait l'invariant.
+
+## 2. Deux patterns — verdict : facade (B)
+
+| | A. Egress broker MITM | B. Command facade (retenu) |
+|---|---|---|
+| L'agent lance la CLI | oui, dans son conteneur | non |
+| Ce qui sort du conteneur | HTTPS sans creds, intercepté MITM | **intent / params** |
+| Mécanisme | TLS-MITM + injection header | RPC/socket → la CLI tourne côté trusted |
+| Surface ajoutée | **CA broker = SPF crown-jewel** | aucune CA, aucun MITM |
+| Signing (Twitter v1.1) | **impossible** (HMAC pré-calculé) | **oui** (signe côté trusted) |
+| Token-refresh (Reddit/IG) | bricolage | naturel |
+| Coût | shims par CLI + distribution CA + fragile | curation de la surface d'opérations |
+
+La curation redoutée (« wrapper chaque CLI ») **EST la feature** : surface d'opérations whitelistée =
+scope par-agent + traçabilité, par construction.
+
+## 3. Routage CLI (fact-checké sur source)
+
+En MITM, l'identité = la **source transport** (la CLI ne signe rien). Mais le « no-wrap » n'est vrai que pour
+un sous-ensemble, et le transparent-redirect rootless est **impossible** (`CAP_NET_ADMIN` absent sous pasta).
+
+| CLI / lib | HTTPS_PROXY auto ? | CA custom | Verdict |
+|---|---|---|---|
+| `gh` (Go) | oui (`ProxyFromEnvironment`) | `SSL_CERT_FILE` | marche |
+| `git` HTTPS | oui | `GIT_SSL_CAINFO` | marche |
+| `vercel` | oui (PR #9880, 2023) | proxy-agent | marche |
+| `wrangler` (undici) | **non** (bug #4515) | `NODE_EXTRA_CA_CERTS`¹ | shim requis |
+| Python bots | `requests`=oui / `httpx`,`aiohttp`=non | per-SDK | vérif par bot |
+| `git` SSH | **non** — bypasse le proxy | — | hors-bande (force HTTPS) |
+| **X/Twitter v1.1** | n/a — OAuth1 HMAC-SHA1 signé | — | **MITM impossible** |
+
+¹ `NODE_EXTRA_CA_CERTS` ne couvre pas les libs qui passent un `ca` explicite (carve-out Node).
+
+**Identité de l'agent** (sans bearer-token leakable) :
+
+| Primitive | Falsifiable ? | Supply-chain | Rootless Podman | Coût |
+|---|---|---|---|---|
+| **UDS bind-mount** (socket inode = identité) | Non | Haute | Excellent | Bas |
+| mTLS / SPIFFE SVID | Faible (TTL) | Haute | Moyen | Haut |
+| Source IP / netns | Moyen | Faible | Moyen | Moyen |
+| Token par-boot (bearer) | **Oui (leak)** | Nulle | Trivial | Minimal |
+
+> Même hôte → **UDS**. Cross-host M₁↔M₂ → **NATS request-reply** (`factory.tool.<service>.<action>`) :
+> l'**ACL NATS de factory EST** la couche d'autorisation par-agent.
+
+## 4. Taxonomie auth par service
+
+| Service | Mode facade | Note |
+|---|---|---|
+| Telegram | exec/proxy — token dans l'URL **path** | rewrite path, pas header |
+| Discord | header `Authorization: Bot` statique | trivial |
+| Cloudflare | header `Bearer` statique | trivial |
+| GitHub API + git-HTTPS | header `Bearer` / Basic | gh-helper couvre déjà (éphémère) |
+| GitHub SSH | hors-bande | force HTTPS (`url.insteadOf`) |
+| Vercel | header `Bearer` statique | trivial |
+| Brevo | header **`api-key:`** (¬ `Authorization`) | nom de header custom |
+| **X/Twitter v1.1** | **SIGNING** (OAuth1 HMAC) | la facade signe — impossible autrement |
+| X v2 write / Reddit / Instagram | **OAUTH-REFRESH** | Reddit=1h ¬refresh-token ; IG=60j refresh |
+
+## 5. gh-helper aujourd'hui = dispenser, pas facade
+
+`factory-gh-helper` isole la **clé RSA** de la GitHub App (PEM, uid 1501) mais **vend le token `ghs_…` en clair**
+à l'agent (uid 1500) via socket — git (credential helper) **et** gh (`GH_TOKEN` dans le child). L'agent **peut
+lire/leaker** ce token. Acceptable **uniquement** car éphémère (1h) + révocable. **Non généralisable** aux tokens
+statiques.
+
+| | Idéal facade | gh-helper dispenser |
+|---|---|---|
+| L'agent voit le credential | jamais | oui (token court) |
+| Ce qui est protégé | la capacité | la clé de minting (PEM) |
+| Mitigation du leak | n/a | TTL 1h + révocable + scopé |
+| Autorisation par-opération | oui | non (tout process group-1502 obtient le token) |
+
+> La littérature (arXiv 2506.08837) nomme exactement quand la facade **suffit** : apps à actions fixes étroites
+> → c'est la description de gh-helper. **Le garder tel quel** ; basculer les tokens statiques en facade.
+
+## 6. Red-team — ce que la facade ne résout PAS
+
+La facade empêche l'agent de **lire** le secret, pas de **mal utiliser** la capacité. La panne initiale ressurgit :
+« envoie ce fichier-contenant-le-token via Telegram » → la facade le délivre.
+
+| Risque | Sév. | Mitigation |
+|---|---|---|
+| Abus de capacité via canal légitime (push public, spam, delete zone) | Haut | ACL verbe+path par scope, rate-limit, human-in-loop destructif |
+| Confused-deputy / SSRF via la facade | Haut | egress allowlist + DNS-pin + reject IP privées + schéma d'entrée strict |
+| Facade = cible #1 (crown-jewel amplifier) | Haut | image pinnée/lockfile, creds JIT (zéro long-lived), 1 facade/type de cred, backup off-site |
+| Résurgence en réponse (« list tokens ») | Moyen | filtrer/redacter les réponses, bloquer management-plane |
+| Exfil via canal légitime (Discord → /home) | Moyen | inspection payload + allowlist chat_id/webhook |
+| TLS-MITM (modèle A) | Bas | n/a — la facade évite tout MITM |
+
+**3 risques les plus sous-estimés** : 1) abus via canal légitime ; 2) le MITM casse les CLI de façon
+non-évidente ; 3) le store de la facade devient la cible la plus précieuse de l'infra.
+
+## 7. Validation externe (8 recherches — web ×6 + xAI ×2)
+
+**Verdict : confirmed-with-caveats.** Consensus industrie, pas un design idiosyncratique.
+
+**Validations**
+- **V1** — pattern = consensus : CyberArk Secretless, GitHub Agentic Workflows MCP gateway, AWS Bedrock AgentCore,
+  Arcade.dev, Infisical Agent Vault, SANS CB4A, **Anthropic Zero-Trust for AI Agents** (tool-firewall + tokens courts),
+  **OWASP Top 10 Agentic 2026 ASI03**.
+- **V2** — `--network=none` = le vrai gate : Red Hat confirme **AF_UNIX survit à `--network=none`** (egress IP éliminé) ;
+  **SO_PEERCRED = identité noyau inforgeable** → « socket inode = identité » est sain, sans token bearer.
+- **V3** — rejeter le MITM pour une facade signing-aware = correct : SigV4 / OAuth1 HMAC cassent sous un proxy qui
+  modifie les headers.
+
+**Réfutations (caveats)**
+- **R1** — facade = amplificateur crown-jewel : attaque supply-chain **LiteLLM (mars 2026)**, fenêtre PyPI 40 min →
+  AWS/GCP/Azure/SSH/K8s creds de toute la base ; fuites OpenRouter ×48 YoY.
+- **R2** — le prompt-injection détourne l'**intent**, pas la clé : *lethal trifecta* (Willison) ; la facade exécute
+  fidèlement la requête compromise (M365 Copilot, GitHub MCP, GitLab Duo). Pièce manquante = **Dual LLM** (arXiv 2506.08837).
+- **R3** — SSRF inhérent à toute facade HTTP-sortante (sinks LiteLLM, bypass DNS-rebinding / IPv6 `fd00:ec2::254`).
+
+**Ajustements justifiés**
+- **A1 (R1)** — durcir la facade : image pinnée + lockfile, creds **JIT par-requête** (zéro long-lived au repos),
+  **1 facade par type de cred**, audit append-only obligatoire.
+- **A2 (R2)** — intent en contrôle **primaire** : human-in-loop par défaut (Rule of Two), **Dual LLM**
+  (LLM quarantaine sans accès facade traite l'input ; LLM privilégié appelle la facade), ACL **deny-all** par défaut.
+- **A3 (R3)** — egress durci : DNS résolu une fois (pin, refus rebinding), reject IP privées/link-local, refus URL
+  avec creds, **schéma d'entrée strict** par endpoint.
+
+## 8. Architecture recommandée & rollout
+
+```
+agents (--network=none, aucun secret)
+   │  intent via UDS (même hôte) | NATS+ACL factory (cross-host)
+   ▼
+facade (user dédié)  ── policy ──▶ ACL / egress allowlist (deny-all)
+   │  signe · refresh   ── log ───▶ audit append-only (autre uid)
+   ├── fetch cred JIT ─▶ Vaultwarden (creds réels, backup off-site)
+   └── appel authentifié ─▶ Upstream APIs (Telegram·CF·GitHub·Vercel·Brevo·X)
+```
+
+| Phase | Objet | Détail |
+|---|---|---|
+| **P1** | Contrat & identité | surface d'opérations facade ; schéma NATS subjects/ACL aligné factory ; UDS vs NATS |
+| **P2** | 1er service bout-en-bout | PoC Telegram ou Cloudflare (token statique) ; `--network=none` ; creds JIT Vaultwarden |
+| **P3** | Migration tokens statiques | Discord, Brevo, Vercel, CF en facade ; gh garde son dispenser ; Twitter v1.1 → facade signe |
+| **P4** | Durcissement | ACL deny-all + egress allowlist + DNS-pin ; audit append-only + rate-limit ; human-in-loop + Dual LLM |
+
+## 9. Décisions / ADR à acter
+
+- Facade-vs-dispenser + découpage par-service (gh = dispenser éphémère ; statiques = facade).
+- Creds = Vaultwarden (déjà en place), fetch JIT.
+- Réutiliser **NATS + ACL factory** comme couche d'autorisation cross-host.
+- Facade durcie en cible supply-chain (image pinnée, 1 facade par type de cred).
+- **Recovery destructive obligatoire** : si la clé maîtresse / le store est perdu, l'opérateur doit pouvoir **wipe les data locales** et **tout regénérer** sans état zombie (voir §10).
+
+## 10. Recovery — clé perdue → wipe + regen
+
+**Invariant ops :** perte de la clé maîtresse ≠ état indéterminé. L'opérateur doit avoir un chemin
+documenté : *backup si possible → wipe data dépendantes → regen from scratch → re-seed depuis les
+fournisseurs upstream*.
+
+### Précédent factory (NATS nkeys — déjà en place)
+
+Rotation **destructive mais réversible** via backup horodaté :
+
+```bash
+# Backup ~/.roxabi/factory/nkeys/ → nkeys.bak.{epoch}/ puis wipe + regen complète
+factory-acl genkeys --regenerate          # TTY : confirmation interactive
+factory-acl genkeys --regenerate --yes    # scripts / CI
+
+# Identités external (M₂ llmCLI, voiceCLI…) : fan-out manuel obligatoire
+factory-acl genkeys --regenerate --yes --ack-external-distribution
+
+# Recharger secrets Podman + redémarrer la stack
+./deploy/install.sh --force --secrets-only
+make converge
+```
+
+Chemins touchés : `~/.roxabi/factory/nkeys/*.seed`, `auth.conf`, secrets Podman `factory-nats-*`.
+Les **clients NATS** (hub, adapters, workers) doivent redémarrer — anciennes seeds = auth rejetée.
+
+> `factory-acl genkeys --regen-authconf` **ne wipe pas** : re-render `auth.conf` depuis seeds
+> existants. Insuffisant si les `.seed` sont perdus — il faut `--regenerate`.
+
+### Broker / Vaultwarden (à acter — gap actuel)
+
+Si le **mot de passe maître Vaultwarden** ou le **chiffrement du vault** est perdu :
+
+| Étape | Action |
+|-------|--------|
+| 1. Wipe | Supprimer les data Vaultwarden **factory** (DB SQLite + attachments) — pas de « déchiffrer sans clé » |
+| 2. Regen store | Réinitialiser l'org/collection factory (nouveau master password) |
+| 3. Re-seed | Re-saisir chaque API key depuis les consoles fournisseurs (Telegram BotFather, GitHub, CF, Brevo…) |
+| 4. Redémarrer | `systemctl --user restart` sur les facades ; agents `--network=none` inchangés (aucun secret local) |
+
+**Ce qu'on ne peut pas regénérer automatiquement :** les tokens upstream — il faut les **révoquer +
+recréer** côté fournisseur si fuite suspectée, puis re-importer dans le vault neuf.
+
+**Data à wipe explicitement** (pas de demi-mesure) :
+
+- Vaultwarden : DB + fichiers attachés du vault factory
+- Facade : cache JIT éventuel, audit log local (optionnel — append-only peut être archivé avant wipe)
+- **Pas** les agents : ils n'ont jamais stocké la clé
+
+**Garde-fous ADR :**
+
+- Commande unique documentée (`factory secrets reset --i-know-what-im-doing` ou runbook dédié)
+- Confirmation interactive + `--yes` pour automation
+- Backup automatique avant wipe (comme `nkeys.bak.{epoch}`)
+- Checklist post-regen : smoke par service (Telegram send, gh api, …)
+
+### Lien avec l'architecture §8
+
+Les facades ne gardent **aucun cred long-lived au repos** (JIT Vaultwarden) → le blast radius d'une
+perte de clé maîtresse se limite au store central, pas aux conteneurs agents. Le prix : **obligation**
+d'un runbook wipe+regen clair — sinon l'opérateur reste bloqué sans chemin de sortie.
+
+## Sources
+
+- À lire en 1er — **arXiv 2506.08837**, *Design Patterns for Securing LLM Agents against Prompt Injections* (IBM/ETH/Google/MS) — Dual LLM + condition d'adéquation de la Command Facade.
+- CyberArk Secretless Broker · GitHub Agentic Workflows security architecture · Anthropic « Zero Trust for AI Agents » (2026-05) · OWASP Top 10 for Agentic Applications 2026 (ASI03, Excessive Agency).
+- Red Hat socket-activation Podman (AF_UNIX + `--network=none`) · SPIFFE/SPIRE (SO_PEERCRED).
+- Simon Willison « the lethal trifecta » · HeroDevs / Escape.tech (attaque & SSRF LiteLLM).
+- Fact-checks CLI : code go-gh, code git `http.c`, workers-sdk #4515, vercel #9880, RFC 5849.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,6 +7,7 @@ Step-by-step procedures for running factory in production (Podman Quadlet). Thes
 | [quadlet-install.md](quadlet-install.md) | First install, re-deploy, quadlet auto-sync |
 | [bot-onboarding.md](bot-onboarding.md) | Add a bot, render adapter secrets, multi-host caveat |
 | [secrets-rotation.md](secrets-rotation.md) | Rotate nkeys, GH PEM, OAuth, blobstore token |
+| [secrets-disaster-recovery.md](secrets-disaster-recovery.md) | Lost NATS nkeys — wipe, regen, M₂ fan-out |
 | [blobstore-backup-restore.md](blobstore-backup-restore.md) | Snapshot and restore the blob index + shards |
 | [quadlet-diagnostic.md](quadlet-diagnostic.md) | Status checks, common failures, auto-update fix |
 | [discord-db-migration.md](discord-db-migration.md) | One-time #1721 — move discord.db to named volume |

--- a/docs/runbooks/secrets-disaster-recovery.md
+++ b/docs/runbooks/secrets-disaster-recovery.md
@@ -100,7 +100,7 @@ Smoke: send a test message through Telegram/Discord; confirm clipool/OMP health 
 
 When the secret broker lands, master-password loss is a **separate** recovery path: wipe the factory Vaultwarden data, re-create the org/collection, re-import API keys from upstream consoles. Agents (`--network=none`) hold no long-lived creds.
 
-Design and checklist → [agent-secret-broker.md §10](../../artifacts/analyses/agent-secret-broker.md#10-recovery--clé-perdue--wipe--regen) (analysis not yet promoted).
+Design and checklist → [agent-secret-broker.md §10](../../artifacts/analyses/agent-secret-broker.md#10-recovery--clé-perdue--wipe--regen).
 
 `factory secrets reset` today covers **NATS nkeys only**; broker wipe will get its own runbook step when implemented.
 

--- a/docs/runbooks/secrets-disaster-recovery.md
+++ b/docs/runbooks/secrets-disaster-recovery.md
@@ -1,0 +1,119 @@
+# Runbook — Secrets disaster recovery (lost NATS nkeys)
+
+Use when **`~/.roxabi/factory/nkeys/*.seed` are lost or compromised** and you must wipe and regenerate all NATS identities from `deploy/nats/acl-matrix.json`.
+
+For rotating a single nkey without wiping the directory, see [secrets-rotation.md](secrets-rotation.md). For suspected compromise of one identity, see [nkey-rotation.md](../ops/nkey-rotation.md).
+
+## What this resets
+
+| Touched | Untouched |
+|---------|-----------|
+| `~/.roxabi/factory/nkeys/*.seed` (backup → `nkeys.bak.{epoch}/` first) | Bot tokens (`factory-telegram-*`, Discord, …) |
+| `~/.roxabi/factory/nkeys/auth.conf` | `gh-app.pem`, `claude-oauth.tok`, `litellm-key.tok`, `blobstore.tok` |
+| Podman secrets `factory-nats-*` (via `install.sh --secrets-only`) | `config.db`, `auth.db`, `turns.db`, JetStream streams |
+| `/etc/nats/nkeys/auth.conf` only if `FACTORY_ACL_WRITE_ETC_NATS=1` | Vaultwarden / future broker store (see below) |
+
+`factory-acl genkeys --regen-authconf` **does not wipe** — it re-renders `auth.conf` from existing seeds. If `.seed` files are gone, you need full regeneration (`--regenerate` or `factory secrets reset`).
+
+## One-command recovery (M₁)
+
+Run from the `roxabi-factory` checkout on the hub host (e.g. `roxabituwer`):
+
+```bash
+factory secrets reset --yes --converge
+```
+
+Steps executed:
+
+1. Backup then wipe `~/.roxabi/factory/nkeys/`
+2. `factory-acl genkeys --regenerate` — provision all active identities + render `auth.conf`
+3. `./deploy/install.sh --force --secrets-only` — refresh Podman nkey secrets
+4. `make converge` — remount `auth.conf`, restart stack (when `--converge` is set)
+
+Without `--converge`, restart manually after step 3:
+
+```bash
+systemctl --user restart factory-nats factory-hub factory-telegram factory-discord factory-clipool factory-omp factory-turn-writer
+```
+
+### Flags
+
+| Flag | When |
+|------|------|
+| `--yes` | Non-interactive / no TTY — required for scripts |
+| `--converge` | Full stack restart via `make converge` (recommended on M₁) |
+| `--ack-external-distribution` | After manual fan-out to M₂ (see below) — without it, regen exits 2 when externals exist |
+| `--dry-run` | Print planned steps only |
+
+Preview:
+
+```bash
+factory secrets reset --dry-run
+```
+
+Equivalent manual sequence (same as the CLI):
+
+```bash
+factory-acl genkeys --regenerate --yes
+./deploy/install.sh --force --secrets-only
+make converge
+```
+
+## External identities (M₂ fan-out)
+
+`acl-matrix.json` declares identities with `"deploy": { "type": "external", … }`. After regen on M₁, copy new seeds to the remote host **before** restarting clients that use them.
+
+Current externals (check matrix for live list):
+
+| Identity | Remote host | Target path |
+|----------|-------------|-------------|
+| `llm-worker` | `roxabitower` | `~/.roxabi/llmcli/nkeys/llm-worker.seed` |
+| `llm-operator` | `roxabitower` | `~/.roxabi/llmcli/nkeys/operator.creds` |
+| `image-worker` | `roxabitower` | `~/.roxabi/imagecli/nkeys/image-worker.seed` |
+| `voice-client` | `roxabitower` | `~/.voicecli/nkeys/voice-client.seed` |
+
+Workflow:
+
+```bash
+# On M₁ — regen stops with manifest unless acknowledged
+factory secrets reset --yes --ack-external-distribution --converge
+
+# Regen prints scp lines, e.g.:
+#   scp ~/.roxabi/factory/nkeys/llm-worker.seed user@roxabitower:~/.roxabi/llmcli/nkeys/llm-worker.seed
+
+# On M₂ — install creds, restart affected units (llmCLI, voiceCLI, imageCLI)
+```
+
+Only pass `--ack-external-distribution` after seeds are copied to every external target.
+
+## Post-recovery verification
+
+```bash
+factory ops verify
+systemctl --user status 'factory-*.service'
+journalctl --user -u factory-hub -u factory-nats --since "5 min ago" --no-pager
+```
+
+Smoke: send a test message through Telegram/Discord; confirm clipool/OMP health if in use.
+
+## Future: Vaultwarden / agent-secret broker
+
+When the secret broker lands, master-password loss is a **separate** recovery path: wipe the factory Vaultwarden data, re-create the org/collection, re-import API keys from upstream consoles. Agents (`--network=none`) hold no long-lived creds.
+
+Design and checklist → [agent-secret-broker.md §10](../../artifacts/analyses/agent-secret-broker.md#10-recovery--clé-perdue--wipe--regen) (analysis not yet promoted).
+
+`factory secrets reset` today covers **NATS nkeys only**; broker wipe will get its own runbook step when implemented.
+
+## Rollback
+
+If regen fails mid-flight, `_mode_regenerate` restores from `nkeys.bak.{epoch}/`. If regen succeeded but the stack is unhealthy:
+
+```bash
+# Restore backup (replace {epoch} with timestamp from nkeys.bak.*)
+rm -rf ~/.roxabi/factory/nkeys
+cp -a ~/.roxabi/factory/nkeys.bak.{epoch} ~/.roxabi/factory/nkeys
+./deploy/install.sh --force --secrets-only
+make converge
+```
+
+Rollback is only viable if the backup predates the incident and seeds were not compromised.

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -1,5 +1,7 @@
 # Runbook — Secret layout & rotation
 
+> **Lost all nkey seeds?** Use [secrets-disaster-recovery.md](secrets-disaster-recovery.md) (`factory secrets reset`) — this runbook is for routine rotation of individual secrets.
+
 ## Secret layout
 
 | Podman secret | Source file | Mounted at |

--- a/src/factory/cli.py
+++ b/src/factory/cli.py
@@ -29,6 +29,7 @@ from factory.cli_agent import (
 )
 from factory.cli_bot import bot_app
 from factory.cli_ops import ops_app
+from factory.cli_secrets import secrets_app
 from factory.cli_setup import setup_app
 from factory.cli_voice_smoke import voice_smoke_app
 
@@ -70,6 +71,7 @@ factory_app.add_typer(bot_app, name="bot")
 factory_app.add_typer(setup_app, name="setup")
 factory_app.add_typer(voice_smoke_app, name="voice-smoke")
 factory_app.add_typer(ops_app, name="ops")
+factory_app.add_typer(secrets_app, name="secrets")
 factory_app.add_typer(blobstore_app, name="blobstore")
 
 hub_app = typer.Typer(name="hub", help="Run standalone Hub process (requires NATS).")

--- a/src/factory/cli_secrets.py
+++ b/src/factory/cli_secrets.py
@@ -1,0 +1,63 @@
+"""factory secrets — disaster recovery for lost NATS nkeys."""
+
+from __future__ import annotations
+
+import subprocess
+
+import typer
+
+from factory.secrets_reset import run_secrets_reset
+
+secrets_app = typer.Typer(
+    name="secrets",
+    help="Manage factory secrets and disaster recovery.",
+)
+
+
+@secrets_app.command("reset")
+def secrets_reset(
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Skip confirmation prompt (required when stdin is not a TTY).",
+    ),
+    ack_external_distribution: bool = typer.Option(
+        False,
+        "--ack-external-distribution",
+        help=(
+            "Acknowledge manual fan-out of external seeds (M₂ llmCLI, voiceCLI, …) "
+            "after regen. Without this flag, genkeys exits 2 when externals exist."
+        ),
+    ),
+    converge: bool = typer.Option(
+        False,
+        "--converge",
+        help="Run make converge after refreshing Podman secrets (full stack restart).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print planned steps without executing.",
+    ),
+) -> None:
+    """Wipe lost NATS nkeys, regenerate from acl-matrix, refresh Podman secrets.
+
+    Use when ~/.roxabi/factory/nkeys/*.seed are lost or compromised.
+    Creates a timestamped backup (nkeys.bak.{epoch}/) before wiping.
+
+    Does NOT rotate bot tokens, OAuth, or LiteLLM keys — see
+    docs/runbooks/secrets-disaster-recovery.md for the full matrix.
+    """
+    try:
+        run_secrets_reset(
+            yes=yes,
+            ack_external_distribution=ack_external_distribution,
+            converge=converge,
+            dry_run=dry_run,
+        )
+    except FileNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
+    except subprocess.CalledProcessError as exc:
+        typer.echo(f"Command failed (exit {exc.returncode}): {exc.cmd}", err=True)
+        raise typer.Exit(exc.returncode) from exc

--- a/src/factory/secrets_reset.py
+++ b/src/factory/secrets_reset.py
@@ -1,0 +1,164 @@
+"""Destructive NATS nkey recovery — wipe seeds, regenerate, refresh Podman secrets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from factory.paths import factory_data_dir
+
+RunStep = Callable[[], None]
+SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class ResetPlan:
+    """Ordered recovery steps for operator visibility."""
+
+    steps: tuple[str, ...]
+
+
+def factory_repo_root() -> Path:
+    """Resolve the roxabi-factory checkout (deploy/install.sh must exist)."""
+    env = os.environ.get("ROXABI_FACTORY_REPO")
+    if env:
+        root = Path(env).expanduser().resolve()
+        if (root / "deploy" / "install.sh").is_file():
+            return root
+        raise FileNotFoundError(f"ROXABI_FACTORY_REPO invalid: {root}")
+
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "deploy" / "install.sh").is_file():
+            return parent
+    raise FileNotFoundError(
+        "factory repo root not found — run from checkout or set ROXABI_FACTORY_REPO"
+    )
+
+
+def build_reset_plan(*, converge: bool) -> ResetPlan:
+    steps = (
+        "factory-acl genkeys --regenerate (backup + wipe nkeys + regen auth.conf)",
+        "./deploy/install.sh --force --secrets-only (refresh Podman secrets)",
+    )
+    if converge:
+        steps = (*steps, "make converge (regen auth.conf mount + restart stack)")
+    else:
+        steps = (
+            *steps,
+            "manual: systemctl --user restart factory-nats + clients "
+            "(or make converge)",
+        )
+    return ResetPlan(steps=steps)
+
+
+def confirm_reset(*, assume_yes: bool) -> None:
+    if assume_yes:
+        return
+    if not sys.stdin.isatty():
+        raise SystemExit(
+            "Refusing destructive reset without a TTY — pass --yes to confirm."
+        )
+    reply = input(
+        "This will BACKUP then WIPE ~/.roxabi/factory/nkeys and regenerate all "
+        "NATS identities. Continue? [y/N] "
+    )
+    if not reply.strip().lower().startswith("y"):
+        raise SystemExit("Aborted.")
+
+
+def run_nkeys_regenerate(
+    repo_root: Path,
+    *,
+    yes: bool,
+    ack_external_distribution: bool,
+    run_regenerate: RunStep | None = None,
+) -> None:
+    matrix = repo_root / "deploy" / "nats" / "acl-matrix.json"
+    args = argparse.Namespace(
+        yes=yes,
+        ack_external_distribution=ack_external_distribution,
+        matrix=matrix,
+    )
+
+    def _default() -> None:
+        from scripts._modes import _mode_regenerate
+
+        _mode_regenerate(args)
+
+    (run_regenerate or _default)()
+
+
+def run_install_secrets(
+    repo_root: Path,
+    *,
+    runner: SubprocessRunner = subprocess.run,
+) -> None:
+    install = repo_root / "deploy" / "install.sh"
+    runner(
+        [str(install), "--force", "--secrets-only"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+    )
+
+
+def run_converge(
+    repo_root: Path,
+    *,
+    runner: SubprocessRunner = subprocess.run,
+) -> None:
+    runner(["make", "converge"], cwd=repo_root, check=True, text=True)
+
+
+def run_secrets_reset(  # noqa: PLR0913 — injectable orchestration for tests
+    *,
+    yes: bool = False,
+    ack_external_distribution: bool = False,
+    converge: bool = False,
+    dry_run: bool = False,
+    repo_root: Path | None = None,
+    run_regenerate: RunStep | None = None,
+    runner: SubprocessRunner = subprocess.run,
+) -> ResetPlan:
+    """Execute wipe + regen + secrets refresh. Returns the plan for logging."""
+    root = repo_root or factory_repo_root()
+    plan = build_reset_plan(converge=converge)
+
+    if dry_run:
+        print(f"Repo: {root}")
+        print(f"Nkeys dir: {factory_data_dir() / 'nkeys'}")
+        for i, step in enumerate(plan.steps, start=1):
+            print(f"  {i}. {step}")
+        if ack_external_distribution:
+            print("  (with --ack-external-distribution)")
+        return plan
+
+    confirm_reset(assume_yes=yes)
+
+    print("==> Regenerating NATS nkeys (backup + wipe + provision)...")
+    run_nkeys_regenerate(
+        root,
+        yes=True,
+        ack_external_distribution=ack_external_distribution,
+        run_regenerate=run_regenerate,
+    )
+
+    print("==> Refreshing Podman secrets from new seeds...")
+    run_install_secrets(root, runner=runner)
+
+    if converge:
+        print("==> Running make converge...")
+        run_converge(root, runner=runner)
+    else:
+        print(
+            "==> Next: restart NATS + clients "
+            "(see docs/runbooks/secrets-disaster-recovery.md)"
+        )
+
+    return plan

--- a/tests/cli/test_cli_secrets_reset.py
+++ b/tests/cli/test_cli_secrets_reset.py
@@ -1,0 +1,151 @@
+"""Tests for `factory secrets reset` disaster recovery CLI."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from factory.cli import factory_app
+from factory.secrets_reset import (
+    build_reset_plan,
+    confirm_reset,
+    factory_repo_root,
+    run_secrets_reset,
+)
+
+runner = CliRunner()
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    (deploy / "install.sh").write_text("#!/bin/sh\n")
+    (deploy / "nats").mkdir()
+    (deploy / "nats" / "acl-matrix.json").write_text('{"version":"1","identities":{}}')
+    return tmp_path
+
+
+class TestResetPlan:
+    def test_build_plan_without_converge(self) -> None:
+        plan = build_reset_plan(converge=False)
+        assert "genkeys --regenerate" in plan.steps[0]
+        assert "install.sh" in plan.steps[1]
+        assert "manual" in plan.steps[2]
+
+    def test_build_plan_with_converge(self) -> None:
+        plan = build_reset_plan(converge=True)
+        assert plan.steps[-1].startswith("make converge")
+
+
+class TestConfirmReset:
+    def test_assume_yes_skips_prompt(self) -> None:
+        confirm_reset(assume_yes=True)
+
+    def test_non_tty_without_yes_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        with pytest.raises(SystemExit, match="Refusing destructive reset"):
+            confirm_reset(assume_yes=False)
+
+    def test_tty_decline_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        with pytest.raises(SystemExit, match="Aborted"):
+            confirm_reset(assume_yes=False)
+
+
+class TestFactoryRepoRoot:
+    def test_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        root = _fake_repo(tmp_path)
+        monkeypatch.setenv("ROXABI_FACTORY_REPO", str(root))
+        assert factory_repo_root() == root.resolve()
+
+    def test_invalid_env_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ROXABI_FACTORY_REPO", str(tmp_path))
+        with pytest.raises(FileNotFoundError, match="ROXABI_FACTORY_REPO invalid"):
+            factory_repo_root()
+
+
+class TestRunSecretsReset:
+    def test_dry_run_prints_steps(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = _fake_repo(tmp_path)
+        plan = run_secrets_reset(dry_run=True, repo_root=root, converge=True)
+        out = capsys.readouterr().out
+        assert str(root) in out
+        assert len(plan.steps) == 3
+        for step in plan.steps:
+            assert step.split(" ", 1)[-1] in out or step in out
+
+    def test_executes_regenerate_install_converge(self, tmp_path: Path) -> None:
+        root = _fake_repo(tmp_path)
+        calls: list[list[str]] = []
+
+        def fake_runner(cmd: list[str], **kwargs: object) -> MagicMock:
+            calls.append(cmd)
+            proc = MagicMock(spec=subprocess.CompletedProcess)
+            proc.returncode = 0
+            return proc
+
+        regen_called: list[bool] = []
+
+        def fake_regen() -> None:
+            regen_called.append(True)
+
+        with patch("factory.secrets_reset.confirm_reset"):
+            run_secrets_reset(
+                yes=True,
+                converge=True,
+                repo_root=root,
+                run_regenerate=fake_regen,
+                runner=fake_runner,
+            )
+
+        assert regen_called == [True]
+        assert calls[0][0].endswith("install.sh")
+        assert calls[0][1:] == ["--force", "--secrets-only"]
+        assert calls[1] == ["make", "converge"]
+
+
+class TestSecretsResetCli:
+    def test_dry_run_exit_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = _fake_repo(tmp_path)
+        monkeypatch.setenv("ROXABI_FACTORY_REPO", str(root))
+        result = runner.invoke(factory_app, ["secrets", "reset", "--dry-run"])
+        assert result.exit_code == 0
+        assert "genkeys --regenerate" in result.output
+
+    def test_subprocess_failure_propagates_exit_code(self, tmp_path: Path) -> None:
+        root = _fake_repo(tmp_path)
+
+        def boom(cmd: list[str], **kwargs: object) -> None:
+            raise subprocess.CalledProcessError(7, cmd)
+
+        with (
+            patch("factory.secrets_reset.factory_repo_root", return_value=root),
+            patch("factory.secrets_reset.confirm_reset"),
+            patch("factory.secrets_reset.run_nkeys_regenerate"),
+            patch("factory.secrets_reset.run_install_secrets", side_effect=boom),
+        ):
+            result = runner.invoke(factory_app, ["secrets", "reset", "--yes"])
+
+        assert result.exit_code == 7
+        assert "Command failed" in result.output
+
+    def test_missing_repo_exit_two(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ROXABI_FACTORY_REPO", raising=False)
+        with patch(
+            "factory.secrets_reset.factory_repo_root",
+            side_effect=FileNotFoundError("no repo"),
+        ):
+            result = runner.invoke(factory_app, ["secrets", "reset", "--dry-run"])
+        assert result.exit_code == 2
+        assert "no repo" in result.output

--- a/tools/folder_exemptions.txt
+++ b/tools/folder_exemptions.txt
@@ -10,4 +10,4 @@
 # factory_data_dir → $ROXABI_FACTORY_DIR). Top-level is correct for a
 # broadly-imported zero-dep resolver; cli_* decomposition (the real bloat)
 # is the follow-up. Plan: artifacts/plans/lyra-to-roxabi-factory-rename.md
-src/factory  # 13 files — roxabi-factory rename (paths.py SSoT); cli_* split = follow-up
+src/factory  # 15 files — +cli_secrets.py, secrets_reset.py (#1945 disaster recovery); cli_* split = follow-up


### PR DESCRIPTION
## Summary
- Add `factory secrets reset` — orchestrates NATS nkey disaster recovery: backup+wipe regen via `factory-acl genkeys --regenerate`, refresh Podman secrets (`deploy/install.sh --force --secrets-only`), optional `make converge`
- Add `docs/runbooks/secrets-disaster-recovery.md` with touch/untouch matrix, M₂ external fan-out, verification, and rollback
- Cross-link from runbook index and `secrets-rotation.md`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | — | Standalone ops improvement |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/secrets-disaster-recovery` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (12 new) | Passed |

## Test Plan
- [ ] `factory secrets reset --dry-run` from checkout prints 3-step plan
- [ ] On M₁ (non-prod): confirm `--yes` path stops before regen if externals lack `--ack-external-distribution`
- [ ] `factory ops verify` green after full reset + converge

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| Dry-run shows plan | `test_cli_secrets_reset.py :: TestSecretsResetCli::test_dry_run_exit_zero` | ✅ |
| Orchestration calls regen/install/converge | `test_cli_secrets_reset.py :: TestRunSecretsReset::test_executes_regenerate_install_converge` | ✅ |
| Subprocess failure surfaces exit code | `test_cli_secrets_reset.py :: TestSecretsResetCli::test_subprocess_failure_propagates_exit_code` | ✅ |
| Non-TTY requires --yes | `test_cli_secrets_reset.py :: TestConfirmReset::test_non_tty_without_yes_exits` | ✅ |

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`