### PR TITLE
feat(telegram): Rich Messages phase 1+2 — sendRichMessage and draft streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "cryptography>=48.0.0",
     "pydantic>=2.13.4",
     # Adapters
-    "aiogram>=3.28.2",       # Telegram — asyncio-native, tracks Bot API same-day
+    "aiogram>=3.29.0",       # Telegram — Bot API 10.1 Rich Messages (sendRichMessage)
     "discord.py[voice]>=2.7.1",  # Discord — gateway WebSocket + voice support (voice extra pulls pynacl + davey for crypto; keep updated)
     # TODO(#271): CVE-2025-69277 — pynacl 1.5.0 needs upgrade to >=1.6.2 once discord.py
     # relaxes its pynacl<1.6 Windows constraint.

--- a/src/factory/adapters/discord/discord_formatter.py
+++ b/src/factory/adapters/discord/discord_formatter.py
@@ -107,7 +107,10 @@ class DiscordFormatter(BaseFormatter):
             placeholder = await messageable.send(self._placeholder_text)
         return placeholder, placeholder.id
 
-    async def edit_placeholder_text(self, ph: Any, text: str) -> None:
+    async def edit_placeholder_text(
+        self, ph: Any, text: str, *, finalize: bool = False
+    ) -> None:
+        del finalize
         display = text[-DISCORD_MAX_LENGTH:]
         await send_with_retry(
             lambda d=display: ph.edit(content=d, embed=None),

--- a/src/factory/adapters/telegram/telegram.py
+++ b/src/factory/adapters/telegram/telegram.py
@@ -303,6 +303,7 @@ class TelegramAdapter(OutboundAdapterBase):
             formatter_cls=TelegramFormatter,
             formatter_kwargs_fn=lambda m: {
                 "chat_id": m[0],
+                "topic_id": m[1],
                 "reply_to": _pm.message_id if isinstance(_pm, TelegramMeta) else None,
             },
             typing_cls=TelegramTypingIndicator,

--- a/src/factory/adapters/telegram/telegram_formatter.py
+++ b/src/factory/adapters/telegram/telegram_formatter.py
@@ -8,6 +8,19 @@ from typing import TYPE_CHECKING, Any
 from aiogram.exceptions import TelegramAPIError
 
 from factory.adapters.telegram.telegram_formatting import _render_buttons, _render_text
+from factory.adapters.telegram.telegram_rich import (
+    TelegramPlaceholder,
+    build_rich_message,
+    build_thinking_message,
+    chunk_markdown,
+    edit_text_with_fallback,
+    resolve_draft_id,
+    rich_messages_enabled,
+    send_markdownv2_text,
+    send_rich_draft,
+    send_text_with_fallback,
+    use_rich_draft,
+)
 from factory.core.messaging.render_events import (
     ReasoningDeltaRenderEvent,
     ReasoningEndRenderEvent,
@@ -24,35 +37,44 @@ if TYPE_CHECKING:
 log = logging.getLogger("factory.adapters.telegram")
 
 
+def _message_id(ph: Any) -> int:
+    if isinstance(ph, TelegramPlaceholder):
+        if ph.message_id is None:
+            raise ValueError("placeholder has no message_id")
+        return ph.message_id
+    return ph.message_id
+
+
 class TelegramFormatter(BaseFormatter):
-    """OutboundFormatter impl for Telegram (MarkdownV2 escape, 4096 chunk).
+    """OutboundFormatter impl for Telegram (Rich Messages + MarkdownV2 fallback).
 
-    Encapsulates chunking, escaping, button rendering, trace rendering
-    (reasoning + tool recap), and send-mechanics for the Telegram platform.
-
-    Per-formatter (per-turn) state: reasoning accumulator + last-edit timestamp.
-    Both reset on ReasoningStartRenderEvent so each turn starts clean.
+    Private chats may stream via sendRichMessageDraft (phase 2); groups use
+    edit-in-place with rich_message. Reasoning trace uses <tg-thinking> HTML.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 — formatter wiring arity from _make_emitter
         self,
         adapter: "TelegramAdapter",
         chat_id: int,
         get_msg: "Callable[[str, str], str]",
         placeholder_text: str,
         reply_to: int | None = None,
+        topic_id: int | None = None,
     ) -> None:
         self._adapter = adapter
         self._chat_id = chat_id
         self._get_msg = get_msg
         self._placeholder_text = placeholder_text
         self._reply_to = reply_to
+        self._topic_id = topic_id
         self._reasoning = ReasoningAccumulator()
 
     def placeholder_text(self) -> str:
         return self._placeholder_text
 
     def chunk(self, text: str) -> list[str]:
+        if rich_messages_enabled():
+            return chunk_markdown(text) or [text]
         return _render_text(text) or [text]
 
     def render_text(self, text: str) -> list[str]:
@@ -67,49 +89,132 @@ class TelegramFormatter(BaseFormatter):
     def get_msg(self, key: str, fallback: str) -> str:
         return self._get_msg(key, fallback)
 
-    async def send_placeholder(self) -> tuple[Any, int]:
-        kw: dict = {}
-        if self._reply_to is not None:
-            kw["reply_to_message_id"] = self._reply_to
-        msg = await self._adapter.bot.send_message(
-            chat_id=self._chat_id,
-            text=self._placeholder_text,
-            **kw,
+    async def send_placeholder(self) -> tuple[Any, int | None]:
+        if use_rich_draft(self._chat_id):
+            draft_id = resolve_draft_id(self._reply_to, self._chat_id)
+            await send_rich_draft(
+                self._adapter.bot,
+                self._chat_id,
+                draft_id,
+                build_thinking_message(self._placeholder_text),
+                topic_id=self._topic_id,
+            )
+            ph = TelegramPlaceholder(
+                chat_id=self._chat_id,
+                topic_id=self._topic_id,
+                draft_id=draft_id,
+                use_draft=True,
+            )
+            return ph, None
+        if rich_messages_enabled():
+            sent = await send_text_with_fallback(
+                self._adapter.bot,
+                self._chat_id,
+                self._placeholder_text,
+                reply_to=self._reply_to,
+                topic_id=self._topic_id,
+            )
+            ph = TelegramPlaceholder(
+                chat_id=self._chat_id,
+                topic_id=self._topic_id,
+                message_id=sent.message_id,
+            )
+            return ph, sent.message_id
+        sent = await send_markdownv2_text(
+            self._adapter.bot,
+            self._chat_id,
+            self._placeholder_text,
+            reply_to=self._reply_to,
+            topic_id=self._topic_id,
         )
-        return msg, msg.message_id
+        return sent, sent.message_id
 
-    async def edit_placeholder_text(self, ph: Any, text: str) -> None:
-        rendered = _render_text(text)
-        if rendered:
-            try:
-                await self._adapter.bot.edit_message_text(
-                    chat_id=self._chat_id,
-                    message_id=ph.message_id,
-                    text=rendered[0],
-                    parse_mode="MarkdownV2",
+    async def edit_placeholder_text(
+        self, ph: Any, text: str, *, finalize: bool = False
+    ) -> None:
+        if not text:
+            return
+        if (
+            isinstance(ph, TelegramPlaceholder)
+            and ph.use_draft
+            and ph.draft_id is not None
+        ):
+            if finalize:
+                sent = await send_text_with_fallback(
+                    self._adapter.bot,
+                    ph.chat_id,
+                    text,
+                    reply_to=self._reply_to,
+                    topic_id=ph.topic_id,
                 )
-            except TelegramAPIError as exc:
-                log.debug("Placeholder text edit skipped: type=%s", type(exc).__name__)
+                ph.message_id = sent.message_id
+                return
+            ok = await send_rich_draft(
+                self._adapter.bot,
+                ph.chat_id,
+                ph.draft_id,
+                build_rich_message(text),
+                topic_id=ph.topic_id,
+            )
+            if not ok:
+                await edit_text_with_fallback(
+                    self._adapter.bot,
+                    ph.chat_id,
+                    _message_id(ph),
+                    text,
+                )
+            return
+        try:
+            await edit_text_with_fallback(
+                self._adapter.bot,
+                self._chat_id,
+                _message_id(ph),
+                text,
+            )
+        except (TelegramAPIError, ValueError) as exc:
+            log.debug("Placeholder text edit skipped: type=%s", type(exc).__name__)
 
     async def send_trace_placeholder(self) -> tuple[Any, int | None]:
-        kw: dict = {}
-        if self._reply_to is not None:
-            kw["reply_to_message_id"] = self._reply_to
-        msg = await self._adapter.bot.send_message(
-            chat_id=self._chat_id,
-            text="🔧 …",
-            **kw,
+        if rich_messages_enabled():
+            sent = await send_text_with_fallback(
+                self._adapter.bot,
+                self._chat_id,
+                "🔧 …",
+                reply_to=self._reply_to,
+                topic_id=self._topic_id,
+            )
+            return sent, sent.message_id
+        sent = await send_markdownv2_text(
+            self._adapter.bot,
+            self._chat_id,
+            "🔧 …",
+            reply_to=self._reply_to,
+            topic_id=self._topic_id,
         )
-        return msg, msg.message_id
+        return sent, sent.message_id
 
     async def send_message(self, text: str) -> int | None:
-        rendered = _render_text(text)
+        if rich_messages_enabled():
+            chunks = self.chunk(text)
+        else:
+            chunks = _render_text(text) or [text]
         last = None
-        for chunk in rendered:
+        for chunk in chunks:
             try:
-                last = await self._adapter.bot.send_message(
-                    chat_id=self._chat_id, text=chunk, parse_mode="MarkdownV2"
-                )
+                if rich_messages_enabled():
+                    last = await send_text_with_fallback(
+                        self._adapter.bot,
+                        self._chat_id,
+                        chunk,
+                        topic_id=self._topic_id,
+                    )
+                else:
+                    last = await send_markdownv2_text(
+                        self._adapter.bot,
+                        self._chat_id,
+                        chunk,
+                        topic_id=self._topic_id,
+                    )
             except Exception as exc:  # noqa: BLE001 — terminal final-chunk send; type sanitized
                 log.warning(
                     "Failed to send final text chunk: type=%s", type(exc).__name__
@@ -117,29 +222,48 @@ class TelegramFormatter(BaseFormatter):
         return last.message_id if last else None
 
     async def send_fallback(self, text: str) -> int | None:
-        rendered = _render_text(text) if text else []
-        if not rendered:
-            rendered = [text or self._placeholder_text]
+        payload = text or self._placeholder_text
+        if rich_messages_enabled():
+            chunks = self.chunk(payload)
+        else:
+            chunks = _render_text(payload) or [payload]
         last = None
-        for chunk in rendered:
-            last = await self._adapter.bot.send_message(
-                chat_id=self._chat_id, text=chunk, parse_mode="MarkdownV2"
-            )
+        for chunk in chunks:
+            if rich_messages_enabled():
+                last = await send_text_with_fallback(
+                    self._adapter.bot,
+                    self._chat_id,
+                    chunk,
+                    topic_id=self._topic_id,
+                )
+            else:
+                last = await send_markdownv2_text(
+                    self._adapter.bot,
+                    self._chat_id,
+                    chunk,
+                    topic_id=self._topic_id,
+                )
         return last.message_id if last else None
 
     async def _edit_trace_with_text(self, trace_obj: Any, text: str) -> None:
-        """Edit the trace placeholder with formatted text."""
-        rendered = _render_text(text)
-        if rendered:
-            try:
+        if not text:
+            return
+        try:
+            if rich_messages_enabled():
                 await self._adapter.bot.edit_message_text(
                     chat_id=self._chat_id,
                     message_id=trace_obj.message_id,
-                    text=rendered[0],
-                    parse_mode="MarkdownV2",
+                    rich_message=build_thinking_message(text),
                 )
-            except TelegramAPIError as exc:
-                log.debug("Reasoning trace edit skipped: type=%s", type(exc).__name__)
+            else:
+                await edit_text_with_fallback(
+                    self._adapter.bot,
+                    self._chat_id,
+                    trace_obj.message_id,
+                    text,
+                )
+        except TelegramAPIError as exc:
+            log.debug("Reasoning trace edit skipped: type=%s", type(exc).__name__)
 
     async def edit_reasoning(
         self,
@@ -148,15 +272,6 @@ class TelegramFormatter(BaseFormatter):
         | ReasoningDeltaRenderEvent
         | ReasoningEndRenderEvent,
     ) -> None:
-        """Render reasoning events as dim italic text in the trace placeholder.
-
-        Slice 4 (#1101): the show_intermediate=False gate lives upstream on
-        StreamProcessor — no Reasoning* events reach here when disabled.
-        Delta edits are throttled by STREAMING_EDIT_INTERVAL. Accumulated
-        text is truncated to 120 chars with '…' suffix.
-
-        trace_obj=None means placeholder send failed — bail silently.
-        """
         if trace_obj is None:
             return
         text, should_edit = self._reasoning.process(event)
@@ -169,20 +284,16 @@ class TelegramFormatter(BaseFormatter):
         lines: list[str],
         done: bool,
     ) -> None:
-        """Render tool recap card lines into the trace placeholder."""
-        del done  # header is already part of lines (per format_recap_lines)
+        del done
         if not lines:
             return
         text = "\n".join(lines)
-        rendered = _render_text(text)
-        if not rendered:
-            return
         try:
-            await self._adapter.bot.edit_message_text(
-                chat_id=self._chat_id,
-                message_id=trace_obj.message_id,
-                text=rendered[0],
-                parse_mode="MarkdownV2",
+            await edit_text_with_fallback(
+                self._adapter.bot,
+                self._chat_id,
+                trace_obj.message_id,
+                text,
             )
         except TelegramAPIError as exc:
             log.debug("Tool recap edit skipped: type=%s", type(exc).__name__)

--- a/src/factory/adapters/telegram/telegram_formatter.py
+++ b/src/factory/adapters/telegram/telegram_formatter.py
@@ -92,13 +92,27 @@ class TelegramFormatter(BaseFormatter):
     async def send_placeholder(self) -> tuple[Any, int | None]:
         if use_rich_draft(self._chat_id):
             draft_id = resolve_draft_id(self._reply_to, self._chat_id)
-            await send_rich_draft(
+            ok = await send_rich_draft(
                 self._adapter.bot,
                 self._chat_id,
                 draft_id,
                 build_thinking_message(self._placeholder_text),
                 topic_id=self._topic_id,
             )
+            if not ok:
+                sent = await send_text_with_fallback(
+                    self._adapter.bot,
+                    self._chat_id,
+                    self._placeholder_text,
+                    reply_to=self._reply_to,
+                    topic_id=self._topic_id,
+                )
+                ph = TelegramPlaceholder(
+                    chat_id=self._chat_id,
+                    topic_id=self._topic_id,
+                    message_id=sent.message_id,
+                )
+                return ph, sent.message_id
             ph = TelegramPlaceholder(
                 chat_id=self._chat_id,
                 topic_id=self._topic_id,
@@ -156,11 +170,11 @@ class TelegramFormatter(BaseFormatter):
                 build_rich_message(text),
                 topic_id=ph.topic_id,
             )
-            if not ok:
+            if not ok and ph.message_id is not None:
                 await edit_text_with_fallback(
                     self._adapter.bot,
                     ph.chat_id,
-                    _message_id(ph),
+                    ph.message_id,
                     text,
                 )
             return

--- a/src/factory/adapters/telegram/telegram_outbound.py
+++ b/src/factory/adapters/telegram/telegram_outbound.py
@@ -16,6 +16,12 @@ from factory.adapters.telegram.telegram_formatting import (
     _render_text,
     _validate_inbound,
 )
+from factory.adapters.telegram.telegram_rich import (
+    chunk_markdown,
+    rich_messages_enabled,
+    send_markdownv2_text,
+    send_text_with_fallback,
+)
 from factory.core.messaging.message import (
     InboundMessage,
     OutboundMessage,
@@ -140,10 +146,10 @@ async def send(
     meta = _validate_inbound(original_msg, "send")
     if meta is None:
         return
-    chat_id, _, _ = meta
+    chat_id, topic_id, _ = meta
 
     text = outbound.to_text()
-    chunks = _render_text(text)
+    chunks = chunk_markdown(text) if rich_messages_enabled() else _render_text(text)
     keyboard = _render_buttons(outbound.buttons)
 
     _pm = original_msg.platform_meta
@@ -152,16 +158,26 @@ async def send(
     async def send_chunk(
         chunk: str, is_first: bool, is_last: bool, buttons: Any
     ) -> int:
-        kwargs: dict = {
-            "chat_id": chat_id,
-            "text": chunk,
-            "parse_mode": "MarkdownV2",
-        }
-        if is_first and reply_to is not None:
-            kwargs["reply_to_message_id"] = reply_to
-        if buttons is not None:
-            kwargs["reply_markup"] = buttons
-        sent = await adapter.bot.send_message(**kwargs)
+        reply = reply_to if is_first else None
+        chunk_buttons = buttons if is_last else None
+        if rich_messages_enabled():
+            sent = await send_text_with_fallback(
+                adapter.bot,
+                chat_id,
+                chunk,
+                reply_to=reply,
+                topic_id=topic_id,
+                reply_markup=chunk_buttons,
+            )
+        else:
+            sent = await send_markdownv2_text(
+                adapter.bot,
+                chat_id,
+                chunk,
+                reply_to=reply,
+                topic_id=topic_id,
+                reply_markup=chunk_buttons,
+            )
         return sent.message_id
 
     ctx = SendContext(

--- a/src/factory/adapters/telegram/telegram_rich.py
+++ b/src/factory/adapters/telegram/telegram_rich.py
@@ -1,0 +1,254 @@
+"""Telegram Rich Messages (Bot API 10.1+) — send helpers with MarkdownV2 fallback."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from aiogram.types import InputRichMessage
+
+from factory.adapters.shared._shared import chunk_text
+from factory.adapters.telegram.telegram_formatting import (
+    TELEGRAM_MAX_LENGTH,
+    _render_text,
+)
+
+log = logging.getLogger("factory.adapters.telegram")
+
+_THINKING_TAG = "tg-thinking"
+
+
+def rich_messages_enabled() -> bool:
+    """Rich Messages on by default; set FACTORY_TELEGRAM_RICH_MESSAGES=0 to disable."""
+    return os.environ.get("FACTORY_TELEGRAM_RICH_MESSAGES", "1").lower() not in (
+        "0",
+        "false",
+        "no",
+    )
+
+
+def rich_drafts_enabled() -> bool:
+    """Draft streaming on by default; set FACTORY_TELEGRAM_RICH_DRAFTS=0 to disable."""
+    return os.environ.get("FACTORY_TELEGRAM_RICH_DRAFTS", "1").lower() not in (
+        "0",
+        "false",
+        "no",
+    )
+
+
+def is_private_chat(chat_id: int) -> bool:
+    return chat_id > 0
+
+
+def use_rich_draft(chat_id: int) -> bool:
+    return (
+        rich_messages_enabled()
+        and rich_drafts_enabled()
+        and is_private_chat(chat_id)
+    )
+
+
+def build_rich_message(text: str) -> InputRichMessage:
+    return InputRichMessage(markdown=text)
+
+
+def build_thinking_message(text: str) -> InputRichMessage:
+    """RichMessage thinking block — HTML <tg-thinking> (draft-only block type)."""
+    return InputRichMessage(html=f"<{_THINKING_TAG}>{text}</{_THINKING_TAG}>")
+
+
+def chunk_markdown(text: str) -> list[str]:
+    """Split markdown without MarkdownV2 escaping (for sendRichMessage)."""
+    return chunk_text(text, TELEGRAM_MAX_LENGTH, escape_fn=lambda s: s)
+
+
+@dataclass
+class TelegramPlaceholder:
+    """Streaming placeholder — persisted message or private-chat draft."""
+
+    chat_id: int
+    topic_id: int | None
+    message_id: int | None = None
+    draft_id: int | None = None
+    use_draft: bool = False
+
+
+def _thread_kwargs(
+    reply_to: int | None, topic_id: int | None
+) -> dict[str, Any]:
+    kw: dict[str, Any] = {}
+    if reply_to is not None:
+        kw["reply_to_message_id"] = reply_to
+    if topic_id is not None:
+        kw["message_thread_id"] = topic_id
+    return kw
+
+
+def resolve_draft_id(reply_to: int | None, chat_id: int) -> int:
+    """Non-zero draft id required by sendRichMessageDraft."""
+    if reply_to is not None:
+        return reply_to
+    return (chat_id % 2_147_483_000) or 1
+
+
+async def send_rich_text(  # noqa: PLR0913 — mirrors Telegram send kwargs surface
+    bot: Any,
+    chat_id: int,
+    text: str,
+    *,
+    reply_to: int | None = None,
+    topic_id: int | None = None,
+    reply_markup: Any = None,
+) -> Any | None:
+    """Send via sendRichMessage; return Message on success, None to signal fallback."""
+    if not rich_messages_enabled() or not text:
+        return None
+    try:
+        kwargs: dict[str, Any] = {
+            "chat_id": chat_id,
+            "rich_message": build_rich_message(text),
+            **_thread_kwargs(reply_to, topic_id),
+        }
+        if reply_markup is not None:
+            kwargs["reply_markup"] = reply_markup
+        return await bot.send_rich_message(**kwargs)
+    except Exception as exc:  # noqa: BLE001 — rich path is best-effort; MarkdownV2 fallback follows
+        log.debug("sendRichMessage failed, will fallback: type=%s", type(exc).__name__)
+        return None
+
+
+async def edit_rich_text(
+    bot: Any,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    *,
+    reply_markup: Any = None,
+) -> bool:
+    """Edit via editMessageText(rich_message=...); return True on success."""
+    if not rich_messages_enabled() or not text:
+        return False
+    try:
+        kwargs: dict[str, Any] = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "rich_message": build_rich_message(text),
+        }
+        if reply_markup is not None:
+            kwargs["reply_markup"] = reply_markup
+        await bot.edit_message_text(**kwargs)
+        return True
+    except Exception as exc:  # noqa: BLE001 — rich edit is best-effort; MarkdownV2 fallback follows
+        log.debug("editMessageText(rich_message) failed: type=%s", type(exc).__name__)
+        return False
+
+
+async def send_rich_draft(
+    bot: Any,
+    chat_id: int,
+    draft_id: int,
+    rich_message: InputRichMessage,
+    *,
+    topic_id: int | None = None,
+) -> bool:
+    """Stream a partial rich message in private chats (sendRichMessageDraft)."""
+    if not use_rich_draft(chat_id):
+        return False
+    try:
+        kwargs: dict[str, Any] = {
+            "chat_id": chat_id,
+            "draft_id": draft_id,
+            "rich_message": rich_message,
+        }
+        if topic_id is not None:
+            kwargs["message_thread_id"] = topic_id
+        await bot.send_rich_message_draft(**kwargs)
+        return True
+    except Exception as exc:  # noqa: BLE001 — draft API optional; caller may fall back
+        log.debug("sendRichMessageDraft failed: type=%s", type(exc).__name__)
+        return False
+
+
+async def send_markdownv2_text(  # noqa: PLR0913 — mirrors Telegram send kwargs surface
+    bot: Any,
+    chat_id: int,
+    text: str,
+    *,
+    reply_to: int | None = None,
+    topic_id: int | None = None,
+    reply_markup: Any = None,
+) -> Any:
+    """Legacy sendMessage path with MarkdownV2 escaping."""
+    rendered = _render_text(text)
+    if not rendered:
+        rendered = [text]
+    kwargs: dict[str, Any] = {
+        "chat_id": chat_id,
+        "text": rendered[0],
+        "parse_mode": "MarkdownV2",
+        **_thread_kwargs(reply_to, topic_id),
+    }
+    if reply_markup is not None:
+        kwargs["reply_markup"] = reply_markup
+    return await bot.send_message(**kwargs)
+
+
+async def edit_markdownv2_text(
+    bot: Any,
+    chat_id: int,
+    message_id: int,
+    text: str,
+) -> None:
+    rendered = _render_text(text)
+    if not rendered:
+        return
+    await bot.edit_message_text(
+        chat_id=chat_id,
+        message_id=message_id,
+        text=rendered[0],
+        parse_mode="MarkdownV2",
+    )
+
+
+async def send_text_with_fallback(  # noqa: PLR0913 — mirrors Telegram send kwargs surface
+    bot: Any,
+    chat_id: int,
+    text: str,
+    *,
+    reply_to: int | None = None,
+    topic_id: int | None = None,
+    reply_markup: Any = None,
+) -> Any:
+    """Prefer sendRichMessage; fall back to sendMessage MarkdownV2."""
+    sent = await send_rich_text(
+        bot,
+        chat_id,
+        text,
+        reply_to=reply_to,
+        topic_id=topic_id,
+        reply_markup=reply_markup,
+    )
+    if sent is not None:
+        return sent
+    return await send_markdownv2_text(
+        bot,
+        chat_id,
+        text,
+        reply_to=reply_to,
+        topic_id=topic_id,
+        reply_markup=reply_markup,
+    )
+
+
+async def edit_text_with_fallback(
+    bot: Any,
+    chat_id: int,
+    message_id: int,
+    text: str,
+) -> None:
+    """Prefer editMessageText(rich_message); fall back to MarkdownV2."""
+    if await edit_rich_text(bot, chat_id, message_id, text):
+        return
+    await edit_markdownv2_text(bot, chat_id, message_id, text)

--- a/src/factory/adapters/telegram/telegram_rich.py
+++ b/src/factory/adapters/telegram/telegram_rich.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import logging
 import os
 from dataclasses import dataclass
@@ -56,7 +57,8 @@ def build_rich_message(text: str) -> InputRichMessage:
 
 def build_thinking_message(text: str) -> InputRichMessage:
     """RichMessage thinking block — HTML <tg-thinking> (draft-only block type)."""
-    return InputRichMessage(html=f"<{_THINKING_TAG}>{text}</{_THINKING_TAG}>")
+    safe = html.escape(text, quote=True)
+    return InputRichMessage(html=f"<{_THINKING_TAG}>{safe}</{_THINKING_TAG}>")
 
 
 def chunk_markdown(text: str) -> list[str]:

--- a/src/factory/outbound/_placeholder_lifecycle.py
+++ b/src/factory/outbound/_placeholder_lifecycle.py
@@ -72,7 +72,9 @@ async def _deliver_text_chunks(
         pass  # guard already logged; non-fatal
     if len(final_chunks) == 1:
         mid = getattr(placeholder_obj, "message_id", None)
-        if mid is not None and emitter._outbound is not None:
+        # Draft finalize sets a real int on TelegramPlaceholder; AsyncMock.message_id
+        # and Discord .id must not overwrite reply_message_id from send_placeholder.
+        if isinstance(mid, int) and emitter._outbound is not None:
             emitter._outbound.metadata["reply_message_id"] = mid
     for extra_chunk in final_chunks[1:]:
         result = await emitter._handler.guard(

--- a/src/factory/outbound/_placeholder_lifecycle.py
+++ b/src/factory/outbound/_placeholder_lifecycle.py
@@ -33,7 +33,7 @@ async def _send_placeholder(
         await emitter._cancel_typing()
         return None
     placeholder_obj, reply_message_id = result.value
-    if emitter._outbound is not None:
+    if reply_message_id is not None and emitter._outbound is not None:
         emitter._outbound.metadata["reply_message_id"] = reply_message_id
     return placeholder_obj, reply_message_id
 
@@ -64,12 +64,16 @@ async def _deliver_text_chunks(
     """Edit placeholder with first chunk, send overflow."""
     result = await emitter._handler.guard(
         lambda p=placeholder_obj, c=final_chunks[0]: emitter._fmt.edit_placeholder_text(
-            p, c
+            p, c, finalize=True
         ),
         context="deliver_final_edit",
     )
     if isinstance(result, Err):
         pass  # guard already logged; non-fatal
+    if len(final_chunks) == 1:
+        mid = getattr(placeholder_obj, "message_id", None)
+        if mid is not None and emitter._outbound is not None:
+            emitter._outbound.metadata["reply_message_id"] = mid
     for extra_chunk in final_chunks[1:]:
         result = await emitter._handler.guard(
             lambda c=extra_chunk: emitter._fmt.send_message(c),
@@ -125,7 +129,7 @@ async def _deliver_final(emitter: "OutboundEmitter", placeholder_obj: Any) -> No
     )
     result = await emitter._handler.guard(
         lambda p=placeholder_obj, t=error_text: emitter._fmt.edit_placeholder_text(
-            p, t
+            p, t, finalize=True
         ),
         context="error_edit",
     )

--- a/src/factory/outbound/formatter.py
+++ b/src/factory/outbound/formatter.py
@@ -86,7 +86,9 @@ class OutboundFormatter(Protocol):
     def get_msg(self, key: str, fallback: str) -> str: ...
 
     async def send_placeholder(self) -> tuple[Any, int | None]: ...
-    async def edit_placeholder_text(self, ph: Any, text: str) -> None: ...
+    async def edit_placeholder_text(
+        self, ph: Any, text: str, *, finalize: bool = False
+    ) -> None: ...
     async def send_trace_placeholder(self) -> tuple[Any, int | None]: ...
     async def send_message(self, text: str) -> int | None: ...
     async def send_fallback(self, text: str) -> int | None: ...
@@ -140,8 +142,10 @@ class BadFormatter:
     async def send_placeholder(self) -> tuple[Any, int | None]:
         raise ValueError(self._error_msg)
 
-    async def edit_placeholder_text(self, ph: Any, text: str) -> None:
-        pass
+    async def edit_placeholder_text(
+        self, ph: Any, text: str, *, finalize: bool = False
+    ) -> None:
+        del ph, text, finalize
 
     async def send_trace_placeholder(self) -> tuple[Any, int | None]:
         raise ValueError(self._error_msg)
@@ -215,8 +219,11 @@ class BaseFormatter(ABC):
         """Send the initial placeholder; returns (message_object, message_id)."""
 
     @abstractmethod
-    async def edit_placeholder_text(self, ph: Any, text: str) -> None:
+    async def edit_placeholder_text(
+        self, ph: Any, text: str, *, finalize: bool = False
+    ) -> None:
         """Edit the placeholder message *ph* to display *text*."""
+        del finalize
 
     @abstractmethod
     async def send_trace_placeholder(self) -> tuple[Any, int | None]:

--- a/src/factory/outbound/formatter.py
+++ b/src/factory/outbound/formatter.py
@@ -215,7 +215,7 @@ class BaseFormatter(ABC):
     # ------------------------------------------------------------------
 
     @abstractmethod
-    async def send_placeholder(self) -> tuple[Any, int]:
+    async def send_placeholder(self) -> tuple[Any, int | None]:
         """Send the initial placeholder; returns (message_object, message_id)."""
 
     @abstractmethod

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -9,6 +9,7 @@ functionality, we skip extraction when the request URL is relative.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -84,6 +85,21 @@ def _make_telegram_adapter() -> TelegramAdapter:
         inbound_bus=MagicMock(),
     )
     return adapter
+
+
+def wire_telegram_rich_bot(bot: AsyncMock, *, message_id: int = 42) -> SimpleNamespace:
+    """Attach Bot API 10.1 rich-message mocks (happy path for outbound tests)."""
+    sent = SimpleNamespace(message_id=message_id)
+    bot.send_rich_message = AsyncMock(return_value=sent)
+    bot.send_rich_message_draft = AsyncMock(return_value=True)
+    bot.edit_message_text = AsyncMock(return_value=sent)
+    return sent
+
+
+@pytest.fixture(autouse=True)
+def _disable_telegram_rich_drafts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing tests target persisted-message path; draft tests opt in explicitly."""
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_DRAFTS", "0")
 
 
 def _make_telegram_message() -> InboundMessage:

--- a/tests/adapters/test_streaming.py
+++ b/tests/adapters/test_streaming.py
@@ -19,6 +19,7 @@ from factory.core.messaging.render_events import (
     TextEndRenderEvent,
     ToolCallStartRenderEvent,
 )
+from tests.adapters.conftest import wire_telegram_rich_bot
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -98,10 +99,7 @@ class TestTelegramStreaming:
             webhook_secret="secret",
         )
         mock_bot = AsyncMock()
-        placeholder = MagicMock()
-        placeholder.message_id = 999
-        mock_bot.send_message = AsyncMock(return_value=placeholder)
-        mock_bot.edit_message_text = AsyncMock()
+        wire_telegram_rich_bot(mock_bot, message_id=999)
         adapter.bot = mock_bot
         return adapter, mock_bot
 
@@ -112,11 +110,14 @@ class TestTelegramStreaming:
         await adapter.send_streaming(msg, quick_events())
 
         # Placeholder sent
-        bot.send_message.assert_awaited_once()
-        # Final edit called with full text (MarkdownV2-escaped)
+        bot.send_rich_message.assert_awaited_once()
+        # Final edit called with full text (rich markdown, unescaped)
         last_edit = bot.edit_message_text.call_args
-        assert last_edit.kwargs["text"] == "Hello world\\!"
-        assert last_edit.kwargs.get("parse_mode") == "MarkdownV2"
+        assert last_edit.kwargs["rich_message"].markdown == "Hello world!"
+
+    def _rich_markdown(self, call) -> str:
+        rich = call.kwargs.get("rich_message")
+        return rich.markdown if rich is not None else call.kwargs.get("text", "")
 
     async def test_debounce_limits_edits(self) -> None:
         adapter, bot = self._make_adapter()
@@ -131,15 +132,18 @@ class TestTelegramStreaming:
 
     async def test_placeholder_failure_falls_back(self) -> None:
         adapter, bot = self._make_adapter()
-        # First call (placeholder) fails, second call (fallback send) succeeds
-        bot.send_message = AsyncMock(side_effect=[RuntimeError("network"), MagicMock()])
+        fallback_msg = MagicMock(message_id=1002)
+        bot.send_rich_message = AsyncMock(side_effect=RuntimeError("network"))
+        bot.send_message = AsyncMock(
+            side_effect=[RuntimeError("network"), fallback_msg, fallback_msg]
+        )
         msg = make_tg_message()
 
         await adapter.send_streaming(msg, quick_events())
 
-        # Should fall back to regular send with full accumulated text
-        assert bot.send_message.await_count == 2
-        fallback_call = bot.send_message.call_args_list[1]
+        # Placeholder rich+markdown fail, then drain_fallback sends via MarkdownV2
+        assert bot.send_message.await_count >= 1
+        fallback_call = bot.send_message.call_args_list[-1]
         assert fallback_call.kwargs["text"] == "Hello world\\!"
         assert fallback_call.kwargs.get("parse_mode") == "MarkdownV2"
 
@@ -158,7 +162,7 @@ class TestTelegramStreaming:
 
         await adapter.send_streaming(msg, quick_events())
 
-        bot.send_message.assert_awaited_once()
+        bot.send_rich_message.assert_awaited_once()
 
     async def test_mid_stream_error_stores_reply_message_id(self) -> None:
         adapter, _ = self._make_adapter()
@@ -186,8 +190,8 @@ class TestTelegramStreaming:
 
     async def test_placeholder_failure_writes_fallback_id_to_outbound(self) -> None:
         adapter, bot = self._make_adapter()
-        fallback_msg = MagicMock()
-        fallback_msg.message_id = 1001
+        fallback_msg = MagicMock(message_id=1001)
+        bot.send_rich_message = AsyncMock(side_effect=RuntimeError("network"))
         bot.send_message = AsyncMock(
             side_effect=[RuntimeError("network"), fallback_msg]
         )
@@ -243,11 +247,11 @@ class TestTelegramStreaming:
         await adapter.send_streaming(msg, long_events())
 
         # Placeholder was created
-        assert bot.send_message.call_count >= 1
+        assert bot.send_rich_message.call_count >= 1
         # First chunk edits placeholder (text-only path)
         assert bot.edit_message_text.call_count >= 1
-        # Overflow chunk sent as new message: send_message = placeholder + overflow
-        assert bot.send_message.call_count >= 2
+        # Overflow chunk sent as new message: placeholder + overflow rich sends
+        assert bot.send_rich_message.call_count >= 2
 
 
 # ---------------------------------------------------------------------------
@@ -372,10 +376,7 @@ class TestTelegramIntermediateText:
             webhook_secret="secret",
         )
         mock_bot = AsyncMock()
-        placeholder = MagicMock()
-        placeholder.message_id = 999
-        mock_bot.send_message = AsyncMock(return_value=placeholder)
-        mock_bot.edit_message_text = AsyncMock()
+        wire_telegram_rich_bot(mock_bot, message_id=999)
         adapter.bot = mock_bot
         return adapter, mock_bot
 
@@ -426,7 +427,9 @@ class TestTelegramIntermediateText:
         last_edit = bot.edit_message_text.call_args
         assert last_edit is not None
         # Final edit contains the accumulated text
-        assert "Final answer" in last_edit.kwargs.get("text", "")
+        rich = last_edit.kwargs.get("rich_message")
+        final_text = rich.markdown if rich is not None else last_edit.kwargs.get("text", "")
+        assert "Final answer" in final_text
 
 
 class TestDiscordIntermediateText:
@@ -511,7 +514,8 @@ async def test_telegram_streaming_fallback_sends_all_chunks() -> None:
     )
     fallback_msgs = [MagicMock(message_id=i) for i in range(1, 4)]
     bot = AsyncMock()
-    # First send_message raises (placeholder) → triggers fallback path
+    bot.send_rich_message = AsyncMock(side_effect=RuntimeError("rich fail"))
+    # Placeholder markdown attempt fails, then 3 fallback chunks via send_message
     bot.send_message = AsyncMock(
         side_effect=[RuntimeError("placeholder fail")] + fallback_msgs
     )
@@ -530,7 +534,7 @@ async def test_telegram_streaming_fallback_sends_all_chunks() -> None:
     outbound.metadata = {}
     await adapter.send_streaming(msg, long_events(), outbound)
 
-    # Placeholder attempt + 3 fallback chunks = 4 total send_message calls
+    # Placeholder markdown attempt + 3 fallback chunks = 4 total send_message calls
     assert bot.send_message.await_count == 4
     # reply_message_id set to the LAST chunk's message_id
     assert outbound.metadata["reply_message_id"] == 3

--- a/tests/adapters/test_streaming.py
+++ b/tests/adapters/test_streaming.py
@@ -115,10 +115,6 @@ class TestTelegramStreaming:
         last_edit = bot.edit_message_text.call_args
         assert last_edit.kwargs["rich_message"].markdown == "Hello world!"
 
-    def _rich_markdown(self, call) -> str:
-        rich = call.kwargs.get("rich_message")
-        return rich.markdown if rich is not None else call.kwargs.get("text", "")
-
     async def test_debounce_limits_edits(self) -> None:
         adapter, bot = self._make_adapter()
         msg = make_tg_message()
@@ -428,7 +424,10 @@ class TestTelegramIntermediateText:
         assert last_edit is not None
         # Final edit contains the accumulated text
         rich = last_edit.kwargs.get("rich_message")
-        final_text = rich.markdown if rich is not None else last_edit.kwargs.get("text", "")
+        if rich is not None:
+            final_text = rich.markdown
+        else:
+            final_text = last_edit.kwargs.get("text", "")
         assert "Final answer" in final_text
 
 

--- a/tests/adapters/test_streaming_session.py
+++ b/tests/adapters/test_streaming_session.py
@@ -92,7 +92,9 @@ async def test_text_only_turn():
         )
     )
 
-    assert fmt.edit_placeholder_text.call_args == ((placeholder_obj, "hello"),)
+    fmt.edit_placeholder_text.assert_called_with(
+        placeholder_obj, "hello", finalize=True
+    )
     fmt.send_message.assert_not_called()
 
 
@@ -149,6 +151,7 @@ async def test_empty_stream_surfaces_generic_error():
     fmt.edit_placeholder_text.assert_called_once_with(
         placeholder_obj,
         GENERIC_ERROR_REPLY,
+        finalize=True,
     )
 
 
@@ -392,7 +395,9 @@ async def test_overflow_chunks():
         )
     )
 
-    fmt.edit_placeholder_text.assert_called_with(placeholder_obj, "chunk1")
+    fmt.edit_placeholder_text.assert_called_with(
+        placeholder_obj, "chunk1", finalize=True
+    )
     fmt.send_message.assert_called_once_with("chunk2")
 
 
@@ -428,6 +433,7 @@ async def test_get_msg_used_for_display_text():
     fmt.edit_placeholder_text.assert_called_with(
         placeholder_obj,
         "partial answer [interrompu]",
+        finalize=True,
     )
 
 
@@ -449,7 +455,9 @@ async def test_get_msg_default_fallback():
     # but the callback is still wired correctly). v2 streaming may emit an
     # intermediate edit before the final one; check that the final call delivered
     # the clean text without the "⏳ " live-feedback prefix.
-    assert fmt.edit_placeholder_text.call_args == ((placeholder_obj, "hello"),)
+    fmt.edit_placeholder_text.assert_called_with(
+        placeholder_obj, "hello", finalize=True
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_telegram_outbound_render.py
+++ b/tests/adapters/test_telegram_outbound_render.py
@@ -16,11 +16,16 @@ from factory.adapters.telegram.telegram_formatting import (
 from factory.adapters.telegram.telegram_formatting import (
     _render_text as render_text,
 )
+from factory.adapters.telegram.telegram_rich import build_rich_message
 from factory.core.messaging.message import (  # noqa: F401
     Button,
     OutboundMessage,
 )
-from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_message
+from tests.adapters.conftest import (
+    _make_telegram_adapter,
+    _make_telegram_message,
+    wire_telegram_rich_bot,
+)
 
 # ---------------------------------------------------------------------------
 # Slice 3 RED tests — TelegramAdapter rendering of OutboundMessage
@@ -36,10 +41,8 @@ class TestTelegramOutboundMessage:
         bot.send_message once with chat_id and text="hello"."""
         # Arrange
         adapter = _make_telegram_adapter()
-        sent_mock = MagicMock()
-        sent_mock.message_id = 42
         adapter.bot = AsyncMock()
-        adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+        wire_telegram_rich_bot(adapter.bot, message_id=42)
 
         outbound = OutboundMessage.from_text("hello")
         original_msg = _make_telegram_message()
@@ -48,14 +51,12 @@ class TestTelegramOutboundMessage:
         await adapter.send(original_msg, outbound)
 
         # Assert
-        adapter.bot.send_message.assert_awaited_once()
-        call_kwargs = adapter.bot.send_message.call_args
+        adapter.bot.send_rich_message.assert_awaited_once()
+        call_kwargs = adapter.bot.send_rich_message.call_args
         assert call_kwargs.kwargs.get("chat_id") == 123 or (
             len(call_kwargs.args) > 0 and call_kwargs.args[0] == 123
         )
-        assert call_kwargs.kwargs.get("text") == "hello" or (
-            len(call_kwargs.args) > 1 and call_kwargs.args[1] == "hello"
-        )
+        assert call_kwargs.kwargs["rich_message"] == build_rich_message("hello")
 
     def test_render_text_empty_returns_no_chunks(self) -> None:
         """_render_text("") returns [] — no empty-string chunk to send to the API."""
@@ -124,7 +125,7 @@ class TestTelegramOutboundMessage:
             return m
 
         adapter.bot = AsyncMock()
-        adapter.bot.send_message = capture_send
+        adapter.bot.send_rich_message = capture_send
 
         outbound = OutboundMessage(
             content=["x" * 5000],
@@ -136,7 +137,7 @@ class TestTelegramOutboundMessage:
         await adapter.send(original_msg, outbound)
 
         # Assert — two send calls were made (5000 chars -> 2 chunks of <= 4096)
-        assert len(calls) == 2, f"Expected 2 send_message calls, got {len(calls)}"
+        assert len(calls) == 2, f"Expected 2 send_rich_message calls, got {len(calls)}"
         # First chunk: no reply_markup key, or reply_markup is None/falsy
         assert calls[0].get("reply_markup") is None or "reply_markup" not in calls[0]
         # Last chunk: reply_markup is set (truthy)
@@ -147,10 +148,8 @@ class TestTelegramOutboundMessage:
         """send() stores the reply message_id in outbound.metadata."""
         # Arrange
         adapter = _make_telegram_adapter()
-        sent_mock = MagicMock()
-        sent_mock.message_id = 999
         adapter.bot = AsyncMock()
-        adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+        wire_telegram_rich_bot(adapter.bot, message_id=999)
 
         outbound = OutboundMessage.from_text("hi")
         original_msg = _make_telegram_message()
@@ -169,13 +168,13 @@ async def test_telegram_fallback_sets_reply_message_id() -> None:
     from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_message
 
     adapter = _make_telegram_adapter()
-    sent_mock = MagicMock()
-    sent_mock.message_id = 77
     adapter.bot = AsyncMock()
-    # Make send_message raise to trigger fallback
-    adapter.bot.send_message = AsyncMock(
-        side_effect=[Exception("placeholder failed"), sent_mock]
-    )  # noqa: E501
+    fallback_sent = wire_telegram_rich_bot(adapter.bot, message_id=77)
+    # Rich + MarkdownV2 placeholder attempts fail → drain_fallback path
+    adapter.bot.send_rich_message = AsyncMock(
+        side_effect=[Exception("placeholder failed"), fallback_sent, fallback_sent]
+    )
+    adapter.bot.send_message = AsyncMock(side_effect=Exception("placeholder failed"))
 
     original_msg = _make_telegram_message()
     outbound = OutboundMessage.from_text("")

--- a/tests/adapters/test_telegram_outbound_send.py
+++ b/tests/adapters/test_telegram_outbound_send.py
@@ -8,22 +8,21 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiogram.exceptions import TelegramAPIError
 
+from factory.adapters.telegram.telegram_rich import (
+    TelegramPlaceholder,
+    build_rich_message,
+)
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import (  # noqa: F401
     DiscordMeta,
     InboundMessage,
     OutboundMessage,
     TelegramMeta,
-)
-from factory.adapters.telegram.telegram_rich import (
-    TelegramPlaceholder,
-    build_rich_message,
 )
 from tests.adapters.conftest import (
     _make_telegram_adapter,

--- a/tests/adapters/test_telegram_outbound_send.py
+++ b/tests/adapters/test_telegram_outbound_send.py
@@ -21,7 +21,15 @@ from factory.core.messaging.message import (  # noqa: F401
     OutboundMessage,
     TelegramMeta,
 )
-from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_message
+from factory.adapters.telegram.telegram_rich import (
+    TelegramPlaceholder,
+    build_rich_message,
+)
+from tests.adapters.conftest import (
+    _make_telegram_adapter,
+    _make_telegram_message,
+    wire_telegram_rich_bot,
+)
 
 # ---------------------------------------------------------------------------
 # T7 — send() calls bot.send_message(chat_id, text)
@@ -37,6 +45,7 @@ async def test_send_calls_bot_send_message() -> None:
     from factory.adapters.telegram import TelegramAdapter  # ImportError expected in RED
 
     bot = AsyncMock()
+    wire_telegram_rich_bot(bot)
 
     adapter = TelegramAdapter(
         bot_id="main",
@@ -68,10 +77,9 @@ async def test_send_calls_bot_send_message() -> None:
 
     await adapter.send(original_msg, outbound)
 
-    bot.send_message.assert_awaited_once_with(
+    bot.send_rich_message.assert_awaited_once_with(
         chat_id=123,
-        text="reply",
-        parse_mode="MarkdownV2",
+        rich_message=build_rich_message("reply"),
         reply_to_message_id=99,
     )
 
@@ -122,6 +130,7 @@ async def test_send_skips_when_platform_context_is_not_telegram(
     with caplog.at_level(logging.WARNING, logger="factory.adapters.telegram"):
         await adapter.send(original_msg, OutboundMessage.from_text("hi"))
 
+    bot.send_rich_message.assert_not_awaited()
     bot.send_message.assert_not_awaited()
     assert any("non-telegram" in r.message for r in caplog.records)
 
@@ -138,8 +147,7 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
 
     # Arrange
     bot = AsyncMock()
-    sent_msg = SimpleNamespace(message_id=888)
-    bot.send_message.return_value = sent_msg
+    sent_msg = wire_telegram_rich_bot(bot, message_id=888)
 
     adapter = TelegramAdapter(
         bot_id="main",
@@ -173,13 +181,12 @@ async def test_send_stores_reply_message_id_in_metadata() -> None:
     await adapter.send(original_msg, outbound)
 
     # Assert
-    bot.send_message.assert_awaited_once_with(
+    bot.send_rich_message.assert_awaited_once_with(
         chat_id=123,
-        text="reply",
-        parse_mode="MarkdownV2",
+        rich_message=build_rich_message("reply"),
         reply_to_message_id=777,
     )
-    assert outbound.metadata["reply_message_id"] == 888
+    assert outbound.metadata["reply_message_id"] == sent_msg.message_id
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +211,7 @@ async def test_send_always_delivers_regardless_of_circuit_state() -> None:
         registry.register(cb)
 
     bot = AsyncMock()
-    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
+    wire_telegram_rich_bot(bot, message_id=99)
 
     adapter = TelegramAdapter(
         bot_id="main",
@@ -238,7 +245,7 @@ async def test_send_always_delivers_regardless_of_circuit_state() -> None:
     await adapter.send(original_msg, OutboundMessage.from_text("reply"))
 
     # Assert — CB is open but adapter still sends (CB check owned by dispatcher)
-    bot.send_message.assert_awaited_once()
+    bot.send_rich_message.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -303,9 +310,8 @@ async def test_streaming_send_placeholder_with_reply() -> None:
     from factory.adapters.telegram.telegram_formatter import TelegramFormatter
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=42)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=42)
 
     formatter = TelegramFormatter(
         adapter,
@@ -319,8 +325,8 @@ async def test_streaming_send_placeholder_with_reply() -> None:
     await formatter.send_placeholder()
 
     # Assert
-    adapter.bot.send_message.assert_awaited_once()
-    call_kwargs = adapter.bot.send_message.call_args.kwargs
+    adapter.bot.send_rich_message.assert_awaited_once()
+    call_kwargs = adapter.bot.send_rich_message.call_args.kwargs
     assert call_kwargs.get("reply_to_message_id") == 77
 
 
@@ -332,9 +338,8 @@ async def test_streaming_send_placeholder_no_reply() -> None:
     from factory.adapters.telegram.telegram_formatter import TelegramFormatter
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=10)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=10)
 
     formatter = TelegramFormatter(
         adapter,
@@ -348,7 +353,7 @@ async def test_streaming_send_placeholder_no_reply() -> None:
     await formatter.send_placeholder()
 
     # Assert — no reply_to_message_id kwarg
-    call_kwargs = adapter.bot.send_message.call_args.kwargs
+    call_kwargs = adapter.bot.send_rich_message.call_args.kwargs
     assert "reply_to_message_id" not in call_kwargs
 
 
@@ -367,7 +372,7 @@ async def test_streaming_edit_placeholder_text() -> None:
         get_msg=lambda k, fb: fb,
         placeholder_text="…",
     )
-    ph = SimpleNamespace(message_id=5)
+    ph = TelegramPlaceholder(chat_id=123, topic_id=None, message_id=5)
 
     # Act
     await formatter.edit_placeholder_text(ph, "hello")
@@ -376,6 +381,7 @@ async def test_streaming_edit_placeholder_text() -> None:
     adapter.bot.edit_message_text.assert_awaited_once()
     call_kwargs = adapter.bot.edit_message_text.call_args.kwargs
     assert call_kwargs.get("message_id") == 5
+    assert call_kwargs["rich_message"].markdown == "hello"
 
 
 @pytest.mark.asyncio
@@ -395,13 +401,13 @@ async def test_streaming_edit_placeholder_text_failure() -> None:
         get_msg=lambda k, fb: fb,
         placeholder_text="…",
     )
-    ph = SimpleNamespace(message_id=5)
+    ph = TelegramPlaceholder(chat_id=123, topic_id=None, message_id=5)
 
     # Act — should not raise
     await formatter.edit_placeholder_text(ph, "hello")
 
-    # Assert — exception swallowed
-    adapter.bot.edit_message_text.assert_awaited_once()
+    # Assert — rich edit fails, MarkdownV2 fallback also fails; both swallowed
+    assert adapter.bot.edit_message_text.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -410,9 +416,8 @@ async def test_streaming_send_message() -> None:
     from factory.adapters.telegram.telegram_formatter import TelegramFormatter
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=99)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=99)
 
     formatter = TelegramFormatter(
         adapter,
@@ -425,7 +430,7 @@ async def test_streaming_send_message() -> None:
     result = await formatter.send_message("hello world")
 
     # Assert
-    adapter.bot.send_message.assert_awaited()
+    adapter.bot.send_rich_message.assert_awaited()
     assert result == 99
 
 
@@ -435,9 +440,8 @@ async def test_streaming_send_fallback_with_text() -> None:
     from factory.adapters.telegram.telegram_formatter import TelegramFormatter
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=88)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=88)
 
     formatter = TelegramFormatter(
         adapter,
@@ -450,7 +454,7 @@ async def test_streaming_send_fallback_with_text() -> None:
     result = await formatter.send_fallback("fallback text")
 
     # Assert
-    adapter.bot.send_message.assert_awaited()
+    adapter.bot.send_rich_message.assert_awaited()
     assert result == 88
 
 
@@ -460,9 +464,8 @@ async def test_streaming_send_fallback_empty_text() -> None:
     from factory.adapters.telegram.telegram_formatter import TelegramFormatter
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=77)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=77)
 
     formatter = TelegramFormatter(
         adapter,
@@ -474,8 +477,8 @@ async def test_streaming_send_fallback_empty_text() -> None:
     # Act — empty string triggers fallback to placeholder_text
     result = await formatter.send_fallback("")
 
-    # Assert — send_message was called (with placeholder text as fallback)
-    adapter.bot.send_message.assert_awaited()
+    # Assert — send_rich_message was called (with placeholder text as fallback)
+    adapter.bot.send_rich_message.assert_awaited()
     assert result == 77
 
 
@@ -493,9 +496,8 @@ async def test_send_intermediate_starts_typing() -> None:
     from factory.adapters.telegram.telegram_outbound import send
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=1)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=1)
     adapter._start_typing = MagicMock()
     adapter._cancel_typing = MagicMock()
 
@@ -519,9 +521,8 @@ async def test_send_no_reply_to() -> None:
     from factory.adapters.telegram.telegram_outbound import send
 
     adapter = _make_telegram_adapter()
-    sent_mock = SimpleNamespace(message_id=1)
     adapter.bot = AsyncMock()
-    adapter.bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(adapter.bot, message_id=1)
 
     original_msg = InboundMessage(
         id="msg-no-reply",
@@ -548,7 +549,7 @@ async def test_send_no_reply_to() -> None:
     await send(adapter, original_msg, outbound)
 
     # Assert — no reply_to_message_id kwarg
-    call_kwargs = adapter.bot.send_message.call_args.kwargs
+    call_kwargs = adapter.bot.send_rich_message.call_args.kwargs
     assert "reply_to_message_id" not in call_kwargs
 
 

--- a/tests/adapters/test_telegram_reasoning.py
+++ b/tests/adapters/test_telegram_reasoning.py
@@ -76,10 +76,11 @@ class TestTelegramReasoningRendering:
         # Arrange
         adapter = _make_telegram_adapter()
         trace_mock = _make_trace_send_mock(message_id=501)
-        send_message_mock = AsyncMock(return_value=trace_mock)
+        send_rich_mock = AsyncMock(return_value=trace_mock)
         edit_message_mock = AsyncMock()
         adapter.bot = MagicMock()
-        adapter.bot.send_message = send_message_mock
+        adapter.bot.send_rich_message = send_rich_mock
+        adapter.bot.send_message = AsyncMock(return_value=trace_mock)
         adapter.bot.edit_message_text = edit_message_mock
 
         formatter = _make_formatter(adapter)
@@ -97,10 +98,10 @@ class TestTelegramReasoningRendering:
                 trace_mock, ReasoningEndRenderEvent(message_id=block_id)
             )
 
-        # Assert — formatter never calls send_message (session owns placeholder)
-        assert send_message_mock.await_count == 0, (
+        # Assert — formatter never calls send APIs (session owns placeholder)
+        assert send_rich_mock.await_count == 0, (
             f"Formatter must not create its own placeholder; "
-            f"got {send_message_mock.await_count} send_message calls"
+            f"got {send_rich_mock.await_count} send_rich_message calls"
         )
         # At least 2 edit calls (one End flush per block)
         assert edit_message_mock.await_count >= 2, (
@@ -122,6 +123,7 @@ class TestTelegramReasoningRendering:
         adapter = _make_telegram_adapter()
         trace_mock = _make_trace_send_mock(message_id=502)
         adapter.bot = MagicMock()
+        adapter.bot.send_rich_message = AsyncMock(return_value=trace_mock)
         adapter.bot.send_message = AsyncMock(return_value=trace_mock)
         adapter.bot.edit_message_text = AsyncMock()
 
@@ -180,13 +182,18 @@ class TestTelegramReasoningRendering:
         adapter = _make_telegram_adapter()
         trace_mock = _make_trace_send_mock(message_id=503)
         adapter.bot = MagicMock()
+        adapter.bot.send_rich_message = AsyncMock(return_value=trace_mock)
         adapter.bot.send_message = AsyncMock(return_value=trace_mock)
         edit_calls: list[str] = []
 
         async def capture_edit(**kwargs: object) -> None:
-            text = kwargs.get("text", "")
-            assert isinstance(text, str)
-            edit_calls.append(text)
+            rich = kwargs.get("rich_message")
+            if rich is not None and rich.html is not None:
+                edit_calls.append(rich.html)
+            else:
+                text = kwargs.get("text", "")
+                assert isinstance(text, str)
+                edit_calls.append(text)
 
         adapter.bot.edit_message_text = capture_edit
 

--- a/tests/adapters/test_telegram_reasoning.py
+++ b/tests/adapters/test_telegram_reasoning.py
@@ -188,8 +188,9 @@ class TestTelegramReasoningRendering:
 
         async def capture_edit(**kwargs: object) -> None:
             rich = kwargs.get("rich_message")
-            if rich is not None and rich.html is not None:
-                edit_calls.append(rich.html)
+            html = getattr(rich, "html", None) if rich is not None else None
+            if html is not None:
+                edit_calls.append(html)
             else:
                 text = kwargs.get("text", "")
                 assert isinstance(text, str)

--- a/tests/adapters/test_telegram_rich.py
+++ b/tests/adapters/test_telegram_rich.py
@@ -92,7 +92,10 @@ def test_build_rich_message_wraps_markdown() -> None:
 
 def test_build_thinking_message_escapes_html() -> None:
     rich = build_thinking_message('</tg-thinking><b>x</b>')
-    assert rich.html == "<tg-thinking>&lt;/tg-thinking&gt;&lt;b&gt;x&lt;/b&gt;</tg-thinking>"
+    expected = (
+        "<tg-thinking>&lt;/tg-thinking&gt;&lt;b&gt;x&lt;/b&gt;</tg-thinking>"
+    )
+    assert rich.html == expected
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_telegram_rich.py
+++ b/tests/adapters/test_telegram_rich.py
@@ -1,0 +1,134 @@
+"""Unit tests for telegram_rich helpers and private-chat draft streaming."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.adapters.telegram.telegram_formatter import TelegramFormatter
+from factory.adapters.telegram.telegram_rich import (
+    TelegramPlaceholder,
+    build_rich_message,
+    chunk_markdown,
+    edit_text_with_fallback,
+    send_text_with_fallback,
+)
+from tests.adapters.conftest import _make_telegram_adapter, wire_telegram_rich_bot
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_fallback_uses_rich_message() -> None:
+    bot = AsyncMock()
+    wire_telegram_rich_bot(bot, message_id=7)
+
+    await send_text_with_fallback(bot, 123, "hello_world")
+
+    bot.send_rich_message.assert_awaited_once_with(
+        chat_id=123,
+        rich_message=build_rich_message("hello_world"),
+    )
+    bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_fallback_falls_back_to_markdownv2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "0")
+    bot = AsyncMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+
+    await send_text_with_fallback(bot, 123, "hello_world")
+
+    bot.send_rich_message.assert_not_awaited()
+    bot.send_message.assert_awaited_once()
+    call_kwargs = bot.send_message.call_args.kwargs
+    assert call_kwargs["parse_mode"] == "MarkdownV2"
+    assert call_kwargs["text"] == r"hello\_world"
+
+
+@pytest.mark.asyncio
+async def test_send_text_with_fallback_on_rich_api_error() -> None:
+    bot = AsyncMock()
+    bot.send_rich_message = AsyncMock(side_effect=RuntimeError("rich API down"))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=2))
+
+    await send_text_with_fallback(bot, 123, "plain text")
+
+    bot.send_rich_message.assert_awaited_once()
+    bot.send_message.assert_awaited_once_with(
+        chat_id=123,
+        text="plain text",
+        parse_mode="MarkdownV2",
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_text_with_fallback_uses_rich_message() -> None:
+    bot = AsyncMock()
+    bot.edit_message_text = AsyncMock(return_value=None)
+
+    await edit_text_with_fallback(bot, 123, 55, "updated")
+
+    bot.edit_message_text.assert_awaited_once_with(
+        chat_id=123,
+        message_id=55,
+        rich_message=build_rich_message("updated"),
+    )
+
+
+def test_chunk_markdown_does_not_escape_underscores() -> None:
+    chunks = chunk_markdown("hello_world")
+    assert chunks == ["hello_world"]
+
+
+def test_build_rich_message_wraps_markdown() -> None:
+    rich = build_rich_message("**bold**")
+    assert rich.markdown == "**bold**"
+    assert rich.html is None
+
+
+@pytest.mark.asyncio
+async def test_private_streaming_uses_draft_then_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Private chat + drafts enabled: draft placeholder, then persist on finalize."""
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_DRAFTS", "1")
+
+    adapter = _make_telegram_adapter()
+    bot = AsyncMock()
+    sent = wire_telegram_rich_bot(bot, message_id=901)
+    adapter.bot = bot
+
+    formatter = TelegramFormatter(
+        adapter,
+        chat_id=123,
+        get_msg=lambda k, fb: fb,
+        placeholder_text="…",
+        reply_to=77,
+    )
+
+    ph, reply_id = await formatter.send_placeholder()
+    assert reply_id is None
+    assert isinstance(ph, TelegramPlaceholder)
+    assert ph.use_draft is True
+    assert ph.draft_id == 77
+    bot.send_rich_message_draft.assert_awaited_once()
+    draft_kwargs = bot.send_rich_message_draft.call_args.kwargs
+    assert draft_kwargs["chat_id"] == 123
+    assert draft_kwargs["draft_id"] == 77
+    assert draft_kwargs["rich_message"].html == "<tg-thinking>…</tg-thinking>"
+
+    await formatter.edit_placeholder_text(ph, "partial", finalize=False)
+    bot.send_rich_message_draft.assert_awaited()
+    partial_kwargs = bot.send_rich_message_draft.call_args.kwargs
+    assert partial_kwargs["rich_message"].markdown == "partial"
+
+    await formatter.edit_placeholder_text(ph, "final answer", finalize=True)
+    bot.send_rich_message.assert_awaited_once_with(
+        chat_id=123,
+        rich_message=build_rich_message("final answer"),
+        reply_to_message_id=77,
+    )
+    assert ph.message_id == sent.message_id

--- a/tests/adapters/test_telegram_rich.py
+++ b/tests/adapters/test_telegram_rich.py
@@ -10,6 +10,7 @@ from factory.adapters.telegram.telegram_formatter import TelegramFormatter
 from factory.adapters.telegram.telegram_rich import (
     TelegramPlaceholder,
     build_rich_message,
+    build_thinking_message,
     chunk_markdown,
     edit_text_with_fallback,
     send_text_with_fallback,
@@ -87,6 +88,37 @@ def test_build_rich_message_wraps_markdown() -> None:
     rich = build_rich_message("**bold**")
     assert rich.markdown == "**bold**"
     assert rich.html is None
+
+
+def test_build_thinking_message_escapes_html() -> None:
+    rich = build_thinking_message('</tg-thinking><b>x</b>')
+    assert rich.html == "<tg-thinking>&lt;/tg-thinking&gt;&lt;b&gt;x&lt;/b&gt;</tg-thinking>"
+
+
+@pytest.mark.asyncio
+async def test_send_placeholder_draft_failure_falls_back_to_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_DRAFTS", "1")
+
+    adapter = _make_telegram_adapter()
+    bot = AsyncMock()
+    sent = wire_telegram_rich_bot(bot, message_id=55)
+    bot.send_rich_message_draft = AsyncMock(side_effect=RuntimeError("draft down"))
+    adapter.bot = bot
+
+    formatter = TelegramFormatter(
+        adapter,
+        chat_id=123,
+        get_msg=lambda k, fb: fb,
+        placeholder_text="…",
+    )
+
+    ph, reply_id = await formatter.send_placeholder()
+
+    assert reply_id == sent.message_id
+    assert ph.use_draft is False
+    bot.send_rich_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_telegram_snapshots.py
+++ b/tests/adapters/test_telegram_snapshots.py
@@ -28,7 +28,11 @@ from factory.core.messaging.render_events import (
     ToolCallEndRenderEvent,
     ToolCallStartRenderEvent,
 )
-from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_message
+from tests.adapters.conftest import (
+    _make_telegram_adapter,
+    _make_telegram_message,
+    wire_telegram_rich_bot,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,21 +40,21 @@ from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_messa
 
 
 def _make_adapter_with_bot():
-    """Return (adapter, bot_mock) with send_message + edit_message_text mocked."""
+    """Return (adapter, bot_mock) with rich-message mocks."""
     adapter = _make_telegram_adapter()
-    placeholder = MagicMock()
-    placeholder.message_id = 999
     bot = AsyncMock()
-    bot.send_message = AsyncMock(return_value=placeholder)
-    bot.edit_message_text = AsyncMock()
+    wire_telegram_rich_bot(bot, message_id=999)
     adapter.bot = bot
     return adapter, bot
 
 
 def _last_edit_text(bot: AsyncMock) -> str:
-    """Return the `text` kwarg from the last edit_message_text call."""
+    """Return rich_message.markdown from the last edit_message_text call."""
     call = bot.edit_message_text.call_args
     assert call is not None, "edit_message_text was never called"
+    rich = call.kwargs.get("rich_message")
+    if rich is not None:
+        return rich.markdown or ""
     return call.kwargs.get("text", "") or (call.args[0] if call.args else "")
 
 
@@ -72,7 +76,7 @@ class TestTelegramSnapshots:
 
         Input stream (v2): RunStarted, TextStart, TextDelta("Hello world!"),
                            TextEnd, RunFinished
-        Expected rendered text: MarkdownV2-escaped "Hello world\\!"
+        Expected rendered text: unescaped "Hello world!"
         """
         adapter, bot = _make_adapter_with_bot()
         msg = _make_telegram_message()
@@ -86,10 +90,9 @@ class TestTelegramSnapshots:
 
         await adapter.send_streaming(msg, _events())
 
-        # Exact-match (B5 fix #1205): pinned to catch MarkdownV2 escape
-        # regressions. `!` must be escaped → `\!` in Telegram MarkdownV2.
+        # Exact-match (B5 fix #1205): rich messages keep punctuation unescaped.
         final_text = _last_edit_text(bot)
-        assert final_text == "Hello world\\!", f"Snapshot mismatch: {final_text!r}"
+        assert final_text == "Hello world!", f"Snapshot mismatch: {final_text!r}"
 
     @pytest.mark.asyncio
     async def test_multi_block_snapshot(self) -> None:
@@ -158,8 +161,7 @@ class TestTelegramSnapshots:
         await adapter.send_streaming(msg, _events())
 
         final_text = _last_edit_text(bot)
-        # Exact-match: ❌ prefix prepended, then MarkdownV2-escaped content.
-        # Telegram escapes `.` as `\.`.
-        assert final_text == "❌ Something went wrong\\.", (
+        # Exact-match: ❌ prefix prepended; rich markdown keeps `.` unescaped.
+        assert final_text == "❌ Something went wrong.", (
             f"Expected ❌-prefixed error text, got: {final_text!r}"
         )

--- a/tests/adapters/test_telegram_snapshots.py
+++ b/tests/adapters/test_telegram_snapshots.py
@@ -15,7 +15,7 @@ receives as its final call.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/adapters/test_telegram_tool_recap.py
+++ b/tests/adapters/test_telegram_tool_recap.py
@@ -27,13 +27,24 @@ from factory.core.messaging.render_events import (
     ToolCallEndRenderEvent,
     ToolCallStartRenderEvent,
 )
-from tests.adapters.conftest import _make_telegram_adapter, _make_telegram_message
+from tests.adapters.conftest import (
+    _make_telegram_adapter,
+    _make_telegram_message,
+    wire_telegram_rich_bot,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 _TRACE_MSG_ID = 999
+
+
+def _rich_markdown(call) -> str:
+    rich = call.kwargs.get("rich_message")
+    if rich is None:
+        return ""
+    return rich.markdown or ""
 
 
 def _make_bot_mocks() -> tuple[MagicMock, MagicMock, MagicMock]:
@@ -52,8 +63,8 @@ def _make_bot_mocks() -> tuple[MagicMock, MagicMock, MagicMock]:
     trace_msg.message_id = _TRACE_MSG_ID
 
     bot = MagicMock()
-    # Response placeholder first, trace placeholder second
-    bot.send_message = AsyncMock(side_effect=[placeholder_msg, trace_msg])
+    bot.send_rich_message = AsyncMock(side_effect=[placeholder_msg, trace_msg])
+    bot.send_rich_message_draft = AsyncMock(return_value=True)
     bot.edit_message_text = AsyncMock(return_value=None)
     return bot, trace_msg, placeholder_msg
 
@@ -75,9 +86,8 @@ async def test_multi_tool_turn_renders_recap_card_via_edit_message_text() -> Non
     Asserts:
     - bot.edit_message_text was called at least once.
     - At least one call targets the trace placeholder message_id.
-    - At least one such call's ``text`` contains the recap header '🔧 Done ✅'.
+    - At least one such call's ``rich_message.markdown`` contains the recap header '🔧 Done ✅'.
     - At least one call contains '✏️' (edit tool icon) AND '💻' (bash icon).
-    - parse_mode is 'MarkdownV2' on those calls.
 
     This test FAILS on the unmodified codebase because ``edit_tool_recap`` is the
     default no-op, so bot.edit_message_text is never called with recap content.
@@ -142,20 +152,14 @@ async def test_multi_tool_turn_renders_recap_card_via_edit_message_text() -> Non
     matching = [
         c
         for c in recap_calls
-        if done_header in (c.kwargs.get("text") or "")
-        and edit_icon in (c.kwargs.get("text") or "")
-        and bash_icon in (c.kwargs.get("text") or "")
+        if done_header in _rich_markdown(c)
+        and edit_icon in _rich_markdown(c)
+        and bash_icon in _rich_markdown(c)
     ]
     assert len(matching) >= 1, (
         f"No edit_message_text call contained recap header + icons. "
-        f"Recap calls texts: {[c.kwargs.get('text') for c in recap_calls]}"
+        f"Recap calls texts: {[_rich_markdown(c) for c in recap_calls]}"
     )
-
-    # parse_mode must be MarkdownV2 on those calls
-    for c in matching:
-        assert c.kwargs.get("parse_mode") == "MarkdownV2", (
-            f"Expected parse_mode='MarkdownV2', got {c.kwargs.get('parse_mode')!r}"
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +171,7 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
     """SC9: a pure text turn must never trigger a trace placeholder or recap edit.
 
     Asserts:
-    - No bot.send_message call has text='🔧 …' (the trace placeholder text).
+    - No bot.send_rich_message call has trace placeholder text.
     - bot.edit_message_text is never called with text containing recap header.
 
     This test is expected to PASS even at RED state — it is a regression guard.
@@ -178,7 +182,8 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
     placeholder_msg.message_id = 42
 
     bot = MagicMock()
-    bot.send_message = AsyncMock(return_value=placeholder_msg)
+    bot.send_rich_message = AsyncMock(return_value=placeholder_msg)
+    bot.send_rich_message_draft = AsyncMock(return_value=True)
     bot.edit_message_text = AsyncMock(return_value=None)
     adapter.bot = bot
     original_msg = _make_telegram_message()
@@ -197,12 +202,11 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
 
     # Assert — no trace placeholder send (text="\U0001f527 …")
     _TRACE_PLACEHOLDER_TEXT = "\U0001f527 …"  # "🔧 …"
-    send_calls = bot.send_message.call_args_list
+    send_calls = bot.send_rich_message.call_args_list
     trace_sends = [
         c
         for c in send_calls
-        if c.kwargs.get("text") == _TRACE_PLACEHOLDER_TEXT
-        or (c.args and c.args[0] == _TRACE_PLACEHOLDER_TEXT)
+        if _rich_markdown(c) == _TRACE_PLACEHOLDER_TEXT
     ]
     assert len(trace_sends) == 0, (
         f"Expected no trace placeholder send, but found: {trace_sends}"
@@ -215,8 +219,8 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
     recap_edits = [
         c
         for c in edit_calls
-        if recap_header in (c.kwargs.get("text") or "")
-        or recap_working in (c.kwargs.get("text") or "")
+        if recap_header in _rich_markdown(c)
+        or recap_working in _rich_markdown(c)
     ]
     assert len(recap_edits) == 0, (
         f"Expected no recap card edit_message_text calls, found: {recap_edits}"
@@ -224,22 +228,20 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
 
 
 # ---------------------------------------------------------------------------
-# Test smoke — recap text is MarkdownV2 escaped via _render_text
+# Test smoke — recap text uses rich_message (no MarkdownV2 escaping)
 # ---------------------------------------------------------------------------
 
 
 async def test_recap_text_is_markdownv2_escaped() -> None:
-    """Smoke: when a bash command is in the recap, the edit_message_text call
-    uses parse_mode='MarkdownV2' and the text has been run through _render_text.
+    """Smoke: bash recap content is sent via rich_message.markdown (unescaped).
 
     Drive a single bash tool call with command 'echo *hi*' (contains MarkdownV2-
-    special '*'). The rendered recap line wraps the command in a code span, so
-    backtick escaping applies. The key assertion is parse_mode='MarkdownV2'.
+    special '*'). Rich messages preserve the raw command in markdown.
 
     This test FAILS on the unmodified codebase because edit_tool_recap is a no-op
     and bot.edit_message_text is never called.
     """
-    # Arrange — response placeholder is the FIRST send_message call; trace is second
+    # Arrange — response placeholder is the FIRST send_rich_message call; trace is second
     adapter = _make_telegram_adapter()
 
     placeholder_msg = MagicMock()
@@ -248,7 +250,8 @@ async def test_recap_text_is_markdownv2_escaped() -> None:
     trace_msg.message_id = _TRACE_MSG_ID
 
     bot = MagicMock()
-    bot.send_message = AsyncMock(side_effect=[placeholder_msg, trace_msg])
+    bot.send_rich_message = AsyncMock(side_effect=[placeholder_msg, trace_msg])
+    bot.send_rich_message_draft = AsyncMock(return_value=True)
     bot.edit_message_text = AsyncMock(return_value=None)
     adapter.bot = bot
     original_msg = _make_telegram_message()
@@ -285,19 +288,21 @@ async def test_recap_text_is_markdownv2_escaped() -> None:
         f"No edit_message_text call targeted trace message_id={_TRACE_MSG_ID}"
     )
 
-    # parse_mode must be 'MarkdownV2' — this confirms _render_text was used
+    # Rich path: no parse_mode; markdown carries unescaped special chars
     for c in recap_calls:
-        assert c.kwargs.get("parse_mode") == "MarkdownV2", (
-            f"Expected parse_mode='MarkdownV2', got {c.kwargs.get('parse_mode')!r}"
-        )
+        assert c.kwargs.get("parse_mode") is None
+        assert c.kwargs.get("rich_message") is not None
 
     # The text must contain the bash icon (proof it is recap content, not some
     # other edit — e.g. the response placeholder edit)
     bash_icon = "\U0001f4bb"  # 💻
     recap_with_bash = [
-        c for c in recap_calls if bash_icon in (c.kwargs.get("text") or "")
+        c for c in recap_calls if bash_icon in _rich_markdown(c)
     ]
-    texts = [c.kwargs.get("text") for c in recap_calls]
+    texts = [_rich_markdown(c) for c in recap_calls]
     assert len(recap_with_bash) >= 1, (
         f"No recap call contained bash icon. Texts: {texts}"
+    )
+    assert any("*hi*" in t for t in texts), (
+        f"Expected unescaped '*hi*' in recap markdown, got: {texts}"
     )

--- a/tests/adapters/test_telegram_tool_recap.py
+++ b/tests/adapters/test_telegram_tool_recap.py
@@ -30,7 +30,6 @@ from factory.core.messaging.render_events import (
 from tests.adapters.conftest import (
     _make_telegram_adapter,
     _make_telegram_message,
-    wire_telegram_rich_bot,
 )
 
 # ---------------------------------------------------------------------------
@@ -86,7 +85,7 @@ async def test_multi_tool_turn_renders_recap_card_via_edit_message_text() -> Non
     Asserts:
     - bot.edit_message_text was called at least once.
     - At least one call targets the trace placeholder message_id.
-    - At least one such call's ``rich_message.markdown`` contains the recap header '🔧 Done ✅'.
+    - At least one call's ``rich_message.markdown`` contains recap header '🔧 Done ✅'.
     - At least one call contains '✏️' (edit tool icon) AND '💻' (bash icon).
 
     This test FAILS on the unmodified codebase because ``edit_tool_recap`` is the
@@ -241,7 +240,7 @@ async def test_recap_text_is_markdownv2_escaped() -> None:
     This test FAILS on the unmodified codebase because edit_tool_recap is a no-op
     and bot.edit_message_text is never called.
     """
-    # Arrange — response placeholder is the FIRST send_rich_message call; trace is second
+    # Arrange — response placeholder is first send_rich_message; trace is second
     adapter = _make_telegram_adapter()
 
     placeholder_msg = MagicMock()

--- a/tests/adapters/test_telegram_typing.py
+++ b/tests/adapters/test_telegram_typing.py
@@ -17,6 +17,7 @@ from factory.core.messaging.render_events import (
     TextDeltaRenderEvent,
     TextEndRenderEvent,
 )
+from tests.adapters.conftest import wire_telegram_rich_bot
 
 # ---------------------------------------------------------------------------
 # T1.4 — Unit tests for _typing_loop
@@ -141,9 +142,7 @@ async def test_send_cancels_typing_task(monkeypatch: pytest.MonkeyPatch) -> None
 
     # Arrange
     bot = AsyncMock()
-    sent_mock = MagicMock()
-    sent_mock.message_id = 1
-    bot.send_message = AsyncMock(return_value=sent_mock)
+    wire_telegram_rich_bot(bot, message_id=1)
 
     adapter = TelegramAdapter(
         bot_id="main",
@@ -186,7 +185,7 @@ async def test_send_cancels_typing_task(monkeypatch: pytest.MonkeyPatch) -> None
     assert 123 not in adapter._typing_tasks
 
     # Assert — reply was sent
-    bot.send_message.assert_awaited_once()
+    bot.send_rich_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -210,9 +209,7 @@ async def test_send_streaming_cancels_typing_task_after_placeholder(
 
     # Arrange
     bot = AsyncMock()
-    placeholder_mock = MagicMock()
-    placeholder_mock.message_id = 10
-    bot.send_message = AsyncMock(return_value=placeholder_mock)
+    wire_telegram_rich_bot(bot, message_id=10)
 
     adapter = TelegramAdapter(
         bot_id="main",

--- a/tests/bootstrap/test_adapter_standalone.py
+++ b/tests/bootstrap/test_adapter_standalone.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from tests.conftest import _LOAD_BOT_TOKEN_PATH
-from tests.helpers.standalone_bot_store import patch_discord_roster, patch_telegram_roster
+from tests.helpers.standalone_bot_store import (
+    patch_discord_roster,
+    patch_telegram_roster,
+)
 
 # Patch target for helpers that moved into the shared common module.
 _COMMON = "factory.bootstrap.wiring._standalone_wiring_common"

--- a/tests/outbound/test_emitter_telegram_smoke.py
+++ b/tests/outbound/test_emitter_telegram_smoke.py
@@ -2,13 +2,13 @@
 
 Verifies that TelegramAdapter._make_emitter() constructs a real OutboundEmitter
 composed with TelegramFormatter and that send_streaming() runs it end-to-end with
-platform-correct bot.send_message kwargs at each call site.
+platform-correct rich-message kwargs at each call site.
 
 SC-10 smoke acceptance criteria:
   - send_streaming() completes without raising
-  - bot.send_message called at least once (placeholder send)
-  - First placeholder call includes parse_mode="MarkdownV2" and reply_to_message_id
-  - Final edit call (edit_message_text) includes parse_mode="MarkdownV2"
+  - bot.send_rich_message called at least once (placeholder send)
+  - First placeholder call includes reply_to_message_id
+  - Final edit call (edit_message_text) includes rich_message
   - OutboundMessage.metadata["reply_message_id"] is populated
 """
 
@@ -18,7 +18,10 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from factory.adapters.telegram import TelegramAdapter
+from tests.adapters.conftest import wire_telegram_rich_bot
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import InboundMessage, OutboundMessage, TelegramMeta
 from factory.core.messaging.render_events import (
@@ -33,6 +36,12 @@ from factory.core.messaging.render_events import (
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _disable_telegram_rich_drafts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Smoke tests target persisted rich messages, not private-chat drafts."""
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_DRAFTS", "0")
+
+
 def _make_tg_adapter_with_bot() -> tuple[TelegramAdapter, AsyncMock]:
     """Build a TelegramAdapter with a fully mocked aiogram bot."""
     adapter = TelegramAdapter(
@@ -41,11 +50,7 @@ def _make_tg_adapter_with_bot() -> tuple[TelegramAdapter, AsyncMock]:
         inbound_bus=MagicMock(),
     )
     bot = AsyncMock()
-    # send_message returns a Telegram Message-like object with .message_id
-    placeholder_msg = SimpleNamespace(message_id=100)
-    bot.send_message = AsyncMock(return_value=placeholder_msg)
-    # edit_message_text is called during streaming and final delivery
-    bot.edit_message_text = AsyncMock()
+    wire_telegram_rich_bot(bot, message_id=100)
     adapter.bot = bot
     return adapter, bot
 
@@ -157,7 +162,7 @@ class TestTelegramMakeEmitter:
 
 class TestTelegramSendStreamingSmoke:
     async def test_send_streaming_calls_bot_send_message(self) -> None:
-        """send_streaming() must call bot.send_message at least once (placeholder)."""
+        """send_streaming() must call bot.send_rich_message at least once (placeholder)."""
         # Arrange
         adapter, bot = _make_tg_adapter_with_bot()
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
@@ -169,15 +174,11 @@ class TestTelegramSendStreamingSmoke:
         )
 
         # Assert — placeholder was sent
-        bot.send_message.assert_awaited()
-        assert bot.send_message.await_count >= 1
+        bot.send_rich_message.assert_awaited()
+        assert bot.send_rich_message.await_count >= 1
 
     async def test_send_streaming_edit_has_parse_mode_markdownv2(self) -> None:
-        """Streaming edit_message_text calls must include parse_mode='MarkdownV2'.
-
-        The placeholder send_message itself has no parse_mode (plain '…' text);
-        parse_mode is applied on edit_message_text and final delivery calls only.
-        """
+        """Streaming edit_message_text calls must include rich_message payload."""
         # Arrange
         adapter, bot = _make_tg_adapter_with_bot()
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
@@ -188,18 +189,16 @@ class TestTelegramSendStreamingSmoke:
             original_msg, _three_chunk_events(), outbound=outbound
         )
 
-        # Assert — at least one edit_message_text call has parse_mode=MarkdownV2
+        # Assert — at least one edit uses rich_message
         bot.edit_message_text.assert_awaited()
-        found_markdownv2 = any(
-            call.kwargs.get("parse_mode") == "MarkdownV2"
+        found_rich = any(
+            call.kwargs.get("rich_message") is not None
             for call in bot.edit_message_text.call_args_list
         )
-        assert found_markdownv2, (
-            "Expected at least one edit_message_text call with parse_mode='MarkdownV2'"
-        )
+        assert found_rich, "Expected at least one edit_message_text with rich_message"
 
     async def test_send_streaming_placeholder_has_reply_to_message_id(self) -> None:
-        """Placeholder send_message call must include reply_to_message_id=message_id."""
+        """Placeholder send_rich_message must include reply_to_message_id=message_id."""
         # Arrange
         adapter, bot = _make_tg_adapter_with_bot()
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
@@ -211,18 +210,14 @@ class TestTelegramSendStreamingSmoke:
         )
 
         # Assert — reply_to_message_id in first call
-        first_call = bot.send_message.call_args_list[0]
+        first_call = bot.send_rich_message.call_args_list[0]
         kwargs = first_call.kwargs
         assert kwargs.get("reply_to_message_id") == 10, (
             f"Expected reply_to_message_id=10, got: {kwargs}"
         )
 
     async def test_send_streaming_final_edit_uses_markdownv2(self) -> None:
-        """Final delivery edit_message_text (last call) must use parse_mode=MarkdownV2.
-
-        Distinct from the intermediate-edit assertion: this pins the *last*
-        edit_message_text call (the final delivery) to MarkdownV2 specifically.
-        """  # noqa: E501
+        """Final delivery edit_message_text (last call) must use rich_message."""
         # Arrange
         adapter, bot = _make_tg_adapter_with_bot()
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
@@ -233,11 +228,11 @@ class TestTelegramSendStreamingSmoke:
             original_msg, _three_chunk_events(), outbound=outbound
         )
 
-        # Assert — the final (last) edit_message_text call carries MarkdownV2
+        # Assert — the final (last) edit_message_text call carries rich_message
         bot.edit_message_text.assert_awaited()
         last_call = bot.edit_message_text.call_args_list[-1]
-        assert last_call.kwargs.get("parse_mode") == "MarkdownV2", (
-            "Expected final edit_message_text to use parse_mode='MarkdownV2', "
+        assert last_call.kwargs.get("rich_message") is not None, (
+            "Expected final edit_message_text to use rich_message, "
             f"got kwargs: {last_call.kwargs}"
         )
 
@@ -262,7 +257,7 @@ class TestTelegramSendStreamingSmoke:
         assert outbound.metadata["reply_message_id"] == 100
 
     async def test_send_streaming_placeholder_before_edit(self) -> None:
-        """Placeholder send_message must happen before any edit_message_text call."""
+        """Placeholder send_rich_message must happen before any edit_message_text call."""
         # Arrange
         call_order: list[str] = []
 
@@ -275,7 +270,7 @@ class TestTelegramSendStreamingSmoke:
         async def record_edit(*args, **kwargs):
             call_order.append("edit")
 
-        bot.send_message = AsyncMock(side_effect=record_send)
+        bot.send_rich_message = AsyncMock(side_effect=record_send)
         bot.edit_message_text = AsyncMock(side_effect=record_edit)
 
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
@@ -287,7 +282,7 @@ class TestTelegramSendStreamingSmoke:
         )
 
         # Assert — send happened before any edit
-        assert "send" in call_order, "bot.send_message must be called"
+        assert "send" in call_order, "bot.send_rich_message must be called"
         if "edit" in call_order:
             first_send = call_order.index("send")
             first_edit = call_order.index("edit")
@@ -329,12 +324,10 @@ class TestTelegramSendStreamingSmoke:
         # Assert — last edit_message_text call has the accumulated content
         bot.edit_message_text.assert_awaited()
         last_call = bot.edit_message_text.call_args_list[-1]
-        text_arg = last_call.kwargs.get("text") or (
-            last_call.args[0] if last_call.args else ""
-        )
-        # MarkdownV2 escapes spaces and characters, but "Hello" and "world" must be
-        # present after escaping (content check at character level).
-        assert text_arg is not None, "edit_message_text must receive a text argument"
+        rich = last_call.kwargs.get("rich_message")
+        text_arg = rich.markdown if rich is not None else last_call.kwargs.get("text")
+        assert text_arg is not None, "edit_message_text must receive content"
+        assert "Hello" in text_arg and "world" in text_arg
 
     async def test_send_streaming_soft_error_displays_run_error_message(self) -> None:
         """ADR-089: soft error only shows curated message on Telegram."""
@@ -348,8 +341,7 @@ class TestTelegramSendStreamingSmoke:
 
         bot.edit_message_text.assert_awaited()
         last_call = bot.edit_message_text.call_args_list[-1]
-        text_arg = last_call.kwargs.get("text") or (
-            last_call.args[0] if last_call.args else ""
-        )
+        rich = last_call.kwargs.get("rich_message")
+        text_arg = rich.markdown if rich is not None else last_call.kwargs.get("text")
         assert text_arg is not None
         assert "weekly limit" in text_arg

--- a/tests/outbound/test_emitter_telegram_smoke.py
+++ b/tests/outbound/test_emitter_telegram_smoke.py
@@ -21,7 +21,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from factory.adapters.telegram import TelegramAdapter
-from tests.adapters.conftest import wire_telegram_rich_bot
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import InboundMessage, OutboundMessage, TelegramMeta
 from factory.core.messaging.render_events import (
@@ -30,6 +29,7 @@ from factory.core.messaging.render_events import (
     TextEndRenderEvent,
     TextStartRenderEvent,
 )
+from tests.adapters.conftest import wire_telegram_rich_bot
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -162,7 +162,7 @@ class TestTelegramMakeEmitter:
 
 class TestTelegramSendStreamingSmoke:
     async def test_send_streaming_calls_bot_send_message(self) -> None:
-        """send_streaming() must call bot.send_rich_message at least once (placeholder)."""
+        """send_streaming() calls bot.send_rich_message at least once (placeholder)."""
         # Arrange
         adapter, bot = _make_tg_adapter_with_bot()
         original_msg = _make_tg_inbound(chat_id=42, message_id=10)
@@ -257,7 +257,7 @@ class TestTelegramSendStreamingSmoke:
         assert outbound.metadata["reply_message_id"] == 100
 
     async def test_send_streaming_placeholder_before_edit(self) -> None:
-        """Placeholder send_rich_message must happen before any edit_message_text call."""
+        """Placeholder send_rich_message happens before edit_message_text."""
         # Arrange
         call_order: list[str] = []
 

--- a/tests/outbound/test_placeholder_lifecycle.py
+++ b/tests/outbound/test_placeholder_lifecycle.py
@@ -148,7 +148,9 @@ class TestDeliverTextChunks:
 
         await _deliver_text_chunks(session, placeholder_obj, ["hello"])
 
-        fmt.edit_placeholder_text.assert_awaited_once_with(placeholder_obj, "hello")
+        fmt.edit_placeholder_text.assert_awaited_once_with(
+            placeholder_obj, "hello", finalize=True
+        )
         fmt.send_message.assert_not_awaited()
 
     async def test_multiple_chunks_edit_then_send_overflow(self) -> None:
@@ -162,7 +164,9 @@ class TestDeliverTextChunks:
             session, placeholder_obj, ["chunk1", "chunk2", "chunk3"]
         )
 
-        fmt.edit_placeholder_text.assert_awaited_once_with(placeholder_obj, "chunk1")
+        fmt.edit_placeholder_text.assert_awaited_once_with(
+            placeholder_obj, "chunk1", finalize=True
+        )
         assert fmt.send_message.await_count == 2
         fmt.send_message.assert_any_await("chunk2")
         fmt.send_message.assert_any_await("chunk3")
@@ -205,7 +209,7 @@ class TestDeliverFinal:
         await _deliver_final(session, placeholder_obj)
 
         fmt.edit_placeholder_text.assert_awaited_once_with(
-            placeholder_obj, "final hello"
+            placeholder_obj, "final hello", finalize=True
         )
         fmt.send_message.assert_not_awaited()
 

--- a/tests/test_bootstrap_credential_resolution.py
+++ b/tests/test_bootstrap_credential_resolution.py
@@ -14,7 +14,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.helpers.standalone_bot_store import patch_discord_roster, patch_telegram_roster
+from tests.helpers.standalone_bot_store import (
+    patch_discord_roster,
+    patch_telegram_roster,
+)
 
 
 async def test_adapter_reads_token_from_run_secrets(

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "aiogram"
-version = "3.28.2"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -51,9 +51,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/3c/72e62c25a7fffedd7dd869e193797b0ed5207041ca90de16bf56fd99e41a/aiogram-3.28.2.tar.gz", hash = "sha256:140913a569516811c4ce576a292491024c8d8a739c47150d64a05aa4adc35310", size = 1855159, upload-time = "2026-05-10T14:20:40.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/e0/fe516e9c424858e44d190636563e0b9a8c0cc940032d43212d4def861f01/aiogram-3.29.0.tar.gz", hash = "sha256:17be0061174fd5b3aa494537f166c2f147b983ebef60d9ede2a3e8837af9c01e", size = 1895315, upload-time = "2026-06-14T17:25:24.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/7b/8bc61691b1fc9d1653e12697436b2742dd1408f14c479d15f46d1ab34be1/aiogram-3.28.2-py3-none-any.whl", hash = "sha256:8a90cdf75a64ba629468f73b6e999662943fff39db213bb406afe114a3e8c0f2", size = 751693, upload-time = "2026-05-10T14:20:38.265Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1a/c56efc85cee9aca96de596253936590df163d2dfb0f8993e1db50f0c4a70/aiogram-3.29.0-py3-none-any.whl", hash = "sha256:f4b2c39d89c44e37998b4b4a8510d6914fc24f3d31125d6b3f6ea9589e67ec85", size = 803438, upload-time = "2026-06-14T17:25:23.064Z" },
 ]
 
 [[package]]
@@ -467,7 +467,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiogram", specifier = ">=3.28.2" },
+    { name = "aiogram", specifier = ">=3.29.0" },
     { name = "cryptography", specifier = ">=48.0.0" },
     { name = "discord-py", extras = ["voice"], specifier = ">=2.7.1" },
     { name = "fastapi", specifier = ">=0.136.3" },


### PR DESCRIPTION
## Summary
- Upgrade aiogram to 3.29+ (Bot API 10.1) and add `telegram_rich.py` for `sendRichMessage` / `editMessageText(rich_message=...)` with MarkdownV2 fallback
- Wire rich sends through `telegram_formatter` and `telegram_outbound`; private chats stream via `sendRichMessageDraft` with `<tg-thinking>` blocks
- Minimal core change: `edit_placeholder_text(..., finalize=False)` so Telegram can distinguish stream edits from final delivery; Discord ignores the flag

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | — (Telegram Rich Messages upgrade) | Ad-hoc |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/telegram-rich-draft` | Complete |
| Verification | Lint ❌ Typecheck ❌ Tests ⚠️ | Partial |

## Test Plan
- [x] `uv run pytest tests/adapters/test_telegram_rich.py` — rich send/edit/draft unit tests
- [x] `uv run pytest tests/adapters/test_streaming.py::TestTelegramStreaming` — streaming path migrated to rich mocks
- [ ] Manual: private chat draft streaming with reasoning blocks
- [ ] Manual: group chat rich edit-in-place (no draft)

## Notes
- Feature flags: `FACTORY_TELEGRAM_RICH_MESSAGES` (default on), `FACTORY_TELEGRAM_RICH_DRAFTS` (default on)
- Existing adapter tests autouse `FACTORY_TELEGRAM_RICH_DRAFTS=0` to keep persisted-message path; drafts tested explicitly in `test_telegram_rich.py`

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`