### PR TITLE
fix(omp): propagate turn errors and model fallback (#1954)

### DIFF
--- a/src/factory/adapters/omp/_model_catalogue.py
+++ b/src/factory/adapters/omp/_model_catalogue.py
@@ -1,0 +1,93 @@
+"""LiteLLM catalogue helpers for omp model fallback (#1923)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+_ENV_AGENT_DIR = "PI_CODING_AGENT_DIR"
+_DEFAULT_AGENT_DIR = Path("/home/factory/.config/omp-pi")
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_REPO_MODELS_YML = _REPO_ROOT / "deploy" / "omp" / "models.yml"
+
+
+def _models_yml_path() -> Path:
+    agent_dir = os.environ.get(_ENV_AGENT_DIR, "").strip()
+    if agent_dir:
+        candidate = Path(agent_dir) / "models.yml"
+        if candidate.is_file():
+            return candidate
+    default_candidate = _DEFAULT_AGENT_DIR / "models.yml"
+    if default_candidate.is_file():
+        return default_candidate
+    return _REPO_MODELS_YML
+
+
+def _litellm_api_key() -> str:
+    key = os.environ.get("LITELLM_API_KEY", "").strip()
+    if key:
+        return key
+    key_file = os.environ.get("LITELLM_API_KEY_FILE", "").strip()
+    if key_file:
+        return Path(key_file).read_text(encoding="utf-8").strip()
+    return ""
+
+
+@lru_cache(maxsize=1)
+def _load_litellm_provider() -> dict[str, Any] | None:
+    path = _models_yml_path()
+    if not path.is_file():
+        log.warning("omp model catalogue: models.yml not found at %s", path)
+        return None
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        log.warning("omp model catalogue: failed to read %s: %s", path, exc)
+        return None
+    provider = (doc or {}).get("providers", {}).get("litellm")
+    return provider if isinstance(provider, dict) else None
+
+
+def fetch_catalogue_model_ids() -> list[str]:
+    """Return model ids from the LiteLLM OpenAI-compatible catalogue."""
+    provider = _load_litellm_provider()
+    if provider is None:
+        return []
+    base_url = str(provider.get("baseUrl", "")).rstrip("/")
+    if not base_url:
+        return []
+    api_key = _litellm_api_key()
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    req = Request(f"{base_url}/models", headers=headers)
+    try:
+        with urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode())
+    except (URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError) as exc:
+        log.warning("omp model catalogue: fetch failed for %s: %s", base_url, exc)
+        return []
+    data = payload.get("data", [])
+    if not isinstance(data, list):
+        return []
+    ids: list[str] = []
+    for entry in data:
+        if isinstance(entry, dict):
+            model_id = entry.get("id")
+            if isinstance(model_id, str) and model_id:
+                ids.append(model_id)
+    return ids
+
+
+def first_registry_model() -> str | None:
+    """First model id from the discovered LiteLLM catalogue, if any."""
+    ids = fetch_catalogue_model_ids()
+    return ids[0] if ids else None

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -13,18 +13,30 @@ ADR: ADR-073 (SanitizedError discipline) — all bus-bound error message fields 
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
-import os
-import uuid
-from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from roxabi_contracts.envelope import CONTRACT_VERSION
+from factory.adapters.omp._rpc_digest import (
+    DigestMismatchError,
+    _DEFAULT_REQUEST_TIMEOUT,
+    _ENV_REQUEST_TIMEOUT_KEY,
+    _OMP_BIN,
+    _PINNED_SHA256,
+    read_request_timeout,
+    verify_digest,
+)
+from factory.adapters.omp._rpc_envelope import (
+    classify_exception,
+    make_progress,
+    make_result,
+    publish_job_error,
+)
+from factory.adapters.omp._rpc_turn import (
+    TurnPublishContext,
+    worker_error_from_omp_turn,
+)
 from roxabi_contracts.errors import WorkerError
-from roxabi_contracts.jobs.models import JobProgress, JobResult
 from roxabi_contracts.jobs.subjects import jobs_progress, jobs_result, jobs_steer
 
 if TYPE_CHECKING:
@@ -32,8 +44,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_PINNED_SHA256 = "b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b"
-_OMP_BIN = Path("/opt/omp/omp")  # image-build constant — NEVER from env
 _DEFAULT_PROVIDER = (
     "litellm"  # routes through factory LiteLLM proxy (deploy/omp/models.yml)
 )
@@ -41,169 +51,18 @@ _DEFAULT_PROVIDER = (
 # (grok-4 full) and risks RpcClient(request_timeout=30s) timeouts (#1910).
 # Alias must exist in the LiteLLM xAI pass-through catalogue (#1923).
 _DEFAULT_MODEL = "grok-4.20-non-reasoning"
-_ENV_REQUEST_TIMEOUT_KEY = "OMP_REQUEST_TIMEOUT"
-_DEFAULT_REQUEST_TIMEOUT = 30.0
-
-
-def _read_request_timeout() -> float:
-    """Read OMP_REQUEST_TIMEOUT from env; fall back to _DEFAULT_REQUEST_TIMEOUT."""
-    raw = os.environ.get(_ENV_REQUEST_TIMEOUT_KEY)
-    if raw is None:
-        return _DEFAULT_REQUEST_TIMEOUT
-    try:
-        val = float(raw)
-        return val if val > 0 else _DEFAULT_REQUEST_TIMEOUT
-    except ValueError:
-        return _DEFAULT_REQUEST_TIMEOUT
-
-
-class DigestMismatchError(Exception):
-    """Raised when the omp binary sha256 does not match the pinned value."""
-
-    def __init__(self, actual: str, expected: str) -> None:
-        super().__init__(f"digest mismatch: actual={actual} expected={expected}")
-        self.actual = actual
-        self.expected = expected
+_read_request_timeout = read_request_timeout
+_verify_digest = verify_digest
 
 
 class SteerViolationError(Exception):
     """Raised when steer() is attempted while prompt_and_wait is in flight."""
 
 
-@dataclass(frozen=True)
-class _TurnPublishContext:
-    turn: Any
-    turn_error: WorkerError | None
-    model_fallback: dict[str, str] | None
-    session_file: str | None
-
-
-def _classify_exception(exc: BaseException) -> WorkerError:
-    """Map an exception to a WorkerError.
-
-    SanitizedError discipline (ADR-073): message field = type(exc).__name__ only.
-    """
-    name = type(exc).__name__
-    if name == "DigestMismatchError":
-        return WorkerError(
-            code="transport.contract_mismatch", message=name, retryable=False
-        )
-    if isinstance(exc, asyncio.TimeoutError):
-        return WorkerError(code="transport.timeout", message=name, retryable=True)
-    if name in ("ConnectionRefusedError", "BrokenPipeError"):
-        return WorkerError(code="transport.error", message=name, retryable=True)
-    return WorkerError(code="worker.internal", message=name, retryable=False)
-
-
-def _make_progress(job_id: str, **kwargs: Any) -> bytes:
-    """Serialise a JobProgress to JSON bytes."""
-    event = JobProgress(
-        contract_version=CONTRACT_VERSION,
-        trace_id=str(uuid.uuid4()),
-        issued_at=datetime.now(timezone.utc),
-        job_id=job_id,
-        **kwargs,
-    )
-    return event.model_dump_json().encode()
-
-
-def _make_result(job_id: str, **kwargs: Any) -> bytes:
-    """Serialise a JobResult to JSON bytes."""
-    event = JobResult(
-        contract_version=CONTRACT_VERSION,
-        trace_id=str(uuid.uuid4()),
-        issued_at=datetime.now(timezone.utc),
-        job_id=job_id,
-        **kwargs,
-    )
-    return event.model_dump_json().encode()
-
-
-def _field(obj: Any, *names: str) -> Any:
-    """Read the first present attribute/key from a TypedDict or dataclass."""
-    if obj is None:
-        return None
-    if isinstance(obj, dict):
-        for name in names:
-            if name in obj:
-                return obj[name]
-        return None
-    for name in names:
-        value = getattr(obj, name, None)
-        if value is not None:
-            return value
-    return None
-
-
-def _assistant_message_from_turn(turn: Any, end_event: Any | None) -> Any | None:
-    """Best-effort assistant message from PromptTurn or stored AgentEndEvent."""
-    assistant = getattr(turn, "assistant_message", None)
-    if assistant is not None:
-        return assistant
-    if end_event is None:
-        return None
-    messages = getattr(end_event, "messages", None)
-    if not messages:
-        return None
-    for candidate in reversed(messages):
-        role = _field(candidate, "role")
-        if role == "assistant":
-            return candidate
-    return None
-
-
-def _worker_error_from_omp_turn(turn: Any, end_event: Any | None) -> WorkerError | None:
-    """Map an OMP PromptTurn provider failure to a structured WorkerError.
-
-    ADR-073: returned ``WorkerError.message`` is a stable type label only —
-    never the provider's ``errorMessage`` string.
-    """
-    assistant = _assistant_message_from_turn(turn, end_event)
-    stop_reason = _field(assistant, "stopReason", "stop_reason")
-    if stop_reason == "aborted":
-        return WorkerError(code="worker.internal", message="Aborted", retryable=True)
-    if stop_reason != "error":
-        return None
-
-    error_message = _field(assistant, "errorMessage", "error_message")
-    if error_message:
-        lower = str(error_message).lower()
-        if "invalid model" in lower:
-            return WorkerError(
-                code="llm.model_unavailable",
-                message="ModelUnavailable",
-                retryable=False,
-            )
-        if "rate limit" in lower or "429" in lower:
-            return WorkerError(
-                code="llm.rate_limit",
-                message="RateLimitError",
-                retryable=True,
-            )
-        if "context" in lower and (
-            "too long" in lower or "length" in lower or "window" in lower
-        ):
-            return WorkerError(
-                code="llm.context_too_long",
-                message="ContextTooLong",
-                retryable=False,
-            )
-    return WorkerError(
-        code="worker.internal",
-        message="OmpProviderError",
-        retryable=False,
-    )
-
-
-def _verify_digest(omp_bin: Path) -> None:
-    """Hash the omp binary and raise DigestMismatchError on mismatch."""
-    hasher = hashlib.sha256()
-    with omp_bin.open("rb") as fh:
-        for chunk in iter(lambda: fh.read(65536), b""):
-            hasher.update(chunk)
-    actual = hasher.hexdigest()
-    if actual != _PINNED_SHA256:
-        raise DigestMismatchError(actual=actual, expected=_PINNED_SHA256)
+_classify_exception = classify_exception
+_make_progress = make_progress
+_make_result = make_result
+_worker_error_from_omp_turn = worker_error_from_omp_turn
 
 
 def _log_publish_result(task: asyncio.Task[Any]) -> None:
@@ -219,22 +78,6 @@ def _log_publish_result(task: asyncio.Task[Any]) -> None:
         return
     if exc is not None:
         log.warning("rpc_bridge: scheduled NATS publish failed", exc_info=exc)
-
-
-async def publish_job_error(nc: Any, job_id: str, exc: BaseException) -> None:
-    """Publish a JobResult(status=error) for a failed job without requiring a bridge.
-
-    Used by the worker to publish parse/acquire errors before any bridge exists.
-    No-op if nc is None.
-
-    SanitizedError discipline (ADR-073): uses type(exc).__name__ only via
-    _classify_exception — never str(exc), f"{exc}", or repr(exc).
-    """
-    if nc is None:
-        return
-    worker_error = _classify_exception(exc)
-    payload = _make_result(job_id, status="error", error=worker_error)
-    await nc.publish(jobs_result(job_id), payload)
 
 
 class RpcBridge:
@@ -364,7 +207,7 @@ class RpcBridge:
         """Retry with the first catalogue model when the requested model is invalid."""
         from factory.adapters.omp._model_catalogue import first_registry_model
 
-        turn_error = _worker_error_from_omp_turn(turn, self._last_agent_end_event)
+        turn_error = worker_error_from_omp_turn(turn, self._last_agent_end_event)
         if turn_error is None or turn_error.code != "llm.model_unavailable":
             return turn, turn_error, None
 
@@ -382,7 +225,7 @@ class RpcBridge:
         await self._switch_model(fallback)
         retry_turn = await self._execute_prompt(prompt)
         self._last_turn = retry_turn
-        retry_error = _worker_error_from_omp_turn(
+        retry_error = worker_error_from_omp_turn(
             retry_turn, self._last_agent_end_event
         )
         if retry_error is not None:
@@ -393,7 +236,7 @@ class RpcBridge:
         self,
         nc: NatsClient,
         job_id: str,
-        ctx: _TurnPublishContext,
+        ctx: TurnPublishContext,
     ) -> None:
         if ctx.turn_error is not None:
             log.warning(
@@ -401,7 +244,7 @@ class RpcBridge:
                 job_id,
                 ctx.turn_error.code,
             )
-            payload = _make_result(job_id, status="error", error=ctx.turn_error)
+            payload = make_result(job_id, status="error", error=ctx.turn_error)
             await nc.publish(jobs_result(job_id), payload)
             return
 
@@ -413,7 +256,7 @@ class RpcBridge:
                 message="EmptyResponse",
                 retryable=False,
             )
-            payload = _make_result(job_id, status="error", error=empty_error)
+            payload = make_result(job_id, status="error", error=empty_error)
             await nc.publish(jobs_result(job_id), payload)
             return
 
@@ -422,7 +265,7 @@ class RpcBridge:
             data["model_fallback"] = ctx.model_fallback
         if ctx.session_file is not None:
             data["session_file"] = ctx.session_file
-        payload = _make_result(job_id, status="success", data=data)
+        payload = make_result(job_id, status="success", data=data)
         await nc.publish(jobs_result(job_id), payload)
 
     async def run(
@@ -491,7 +334,7 @@ class RpcBridge:
                 await self._publish_turn_outcome(
                     nc,
                     job_id,
-                    _TurnPublishContext(
+                    TurnPublishContext(
                         turn=turn,
                         turn_error=turn_error,
                         model_fallback=model_fallback,
@@ -547,7 +390,7 @@ class RpcBridge:
         if job_id is None:
             return
         partial_text = getattr(event, "text", None)
-        payload = _make_progress(
+        payload = make_progress(
             job_id,
             step="message_update",
             event_type="message_update",
@@ -564,7 +407,7 @@ class RpcBridge:
         tool_name = getattr(event, "tool_name", None)
         tool_id = getattr(event, "tool_id", None)
         # tool_input NOT published — may contain credentials/file fragments (ADR-073)
-        payload = _make_progress(
+        payload = make_progress(
             job_id,
             step="tool_start",
             event_type="tool_start",

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -17,15 +17,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from factory.adapters.omp._rpc_digest import (
-    DigestMismatchError,
-    _DEFAULT_REQUEST_TIMEOUT,
-    _ENV_REQUEST_TIMEOUT_KEY,
-    _OMP_BIN,
-    _PINNED_SHA256,
-    read_request_timeout,
-    verify_digest,
-)
+from factory.adapters.omp import _rpc_digest
+from factory.adapters.omp._rpc_digest import read_request_timeout, verify_digest
 from factory.adapters.omp._rpc_envelope import (
     classify_exception,
     make_progress,
@@ -51,6 +44,11 @@ _DEFAULT_PROVIDER = (
 # (grok-4 full) and risks RpcClient(request_timeout=30s) timeouts (#1910).
 # Alias must exist in the LiteLLM xAI pass-through catalogue (#1923).
 _DEFAULT_MODEL = "grok-4.20-non-reasoning"
+_OMP_BIN = _rpc_digest._OMP_BIN
+_PINNED_SHA256 = _rpc_digest._PINNED_SHA256
+_DEFAULT_REQUEST_TIMEOUT = _rpc_digest._DEFAULT_REQUEST_TIMEOUT
+_ENV_REQUEST_TIMEOUT_KEY = _rpc_digest._ENV_REQUEST_TIMEOUT_KEY
+DigestMismatchError = _rpc_digest.DigestMismatchError
 _read_request_timeout = read_request_timeout
 _verify_digest = verify_digest
 

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -255,6 +255,8 @@ class RpcBridge:
         # Import deferred: omp_rpc is a container image dep, absent from pyproject.toml.
         import omp_rpc  # type: ignore[import-not-found]
 
+        resolved_provider = provider or _DEFAULT_PROVIDER
+        resolved_model = model if model is not None else _DEFAULT_MODEL
         if _client is not None:
             # Pool path: adopt the already-started client; skip the digest gate.
             self._client: omp_rpc.RpcClient = _client
@@ -264,7 +266,6 @@ class RpcBridge:
             # provider/model are constructor kwargs only — no env axis. The runtime
             # model list comes from deploy/omp/models.yml (via PI_CODING_AGENT_DIR),
             # not from OMP_PROVIDER/OMP_MODEL env vars (#1876).
-            resolved_model = model if model is not None else _DEFAULT_MODEL
             resolved_timeout = (
                 request_timeout
                 if request_timeout is not None
@@ -272,11 +273,13 @@ class RpcBridge:
             )
             self._client = omp_rpc.RpcClient(
                 executable=str(omp_bin),
-                provider=provider,
+                provider=resolved_provider,
                 model=resolved_model,
                 no_session=False,
                 request_timeout=resolved_timeout,
             )
+        self._provider = resolved_provider
+        self._startup_model = resolved_model
         self._nc: NatsClient | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._started: bool = False
@@ -336,12 +339,54 @@ class RpcBridge:
                     assistant_text = getattr(messages[-1], "assistant_text", None)
         return assistant_text if assistant_text is not None else ""
 
+    async def _switch_model(self, model_id: str) -> None:
+        await asyncio.to_thread(self._client.set_model, self._provider, model_id)
+
+    async def _execute_prompt(self, prompt: str) -> Any:
+        return await asyncio.to_thread(self._client.prompt_and_wait, prompt)
+
+    async def _maybe_retry_with_registry_fallback(
+        self,
+        prompt: str,
+        *,
+        requested_model: str | None,
+        turn: Any,
+    ) -> tuple[Any, WorkerError | None, dict[str, str] | None]:
+        """Retry once with the first discovered catalogue model on invalid-model errors."""
+        from factory.adapters.omp._model_catalogue import first_registry_model
+
+        turn_error = _worker_error_from_omp_turn(turn, self._last_agent_end_event)
+        if turn_error is None or turn_error.code != "llm.model_unavailable":
+            return turn, turn_error, None
+
+        attempted = requested_model or self._startup_model
+        fallback = await asyncio.to_thread(first_registry_model)
+        if not fallback or fallback == attempted:
+            return turn, turn_error, None
+
+        log.warning(
+            "rpc_bridge: model %s unavailable — retrying with registry default %s",
+            attempted,
+            fallback,
+        )
+        self._last_agent_end_event = None
+        await self._switch_model(fallback)
+        retry_turn = await self._execute_prompt(prompt)
+        self._last_turn = retry_turn
+        retry_error = _worker_error_from_omp_turn(
+            retry_turn, self._last_agent_end_event
+        )
+        if retry_error is not None:
+            return retry_turn, retry_error, None
+        return retry_turn, None, {"requested": attempted, "fallback": fallback}
+
     async def run(
         self,
         prompt: str,
         job_id: str,
         *,
         session_file: str | None = None,
+        model: str | None = None,
     ) -> None:
         """Run a prompt through omp_rpc; publishes progress and result to NATS.
 
@@ -380,16 +425,24 @@ class RpcBridge:
             steer_sub = await nc.subscribe(jobs_steer(job_id), cb=_handle_steer_msg)
         assert self._client is not None, "no client (register/attach missing)"
         try:
-            turn = await asyncio.to_thread(self._client.prompt_and_wait, prompt)
+            requested_model = (model or "").strip() or None
+            if requested_model:
+                await self._switch_model(requested_model)
+
+            turn = await self._execute_prompt(prompt)
             self._last_turn = turn
+            turn, turn_error, model_fallback = (
+                await self._maybe_retry_with_registry_fallback(
+                    prompt,
+                    requested_model=requested_model,
+                    turn=turn,
+                )
+            )
             # Publish success here — guaranteed to see the completed turn value.
             # _on_agent_end fires on the stdout thread BEFORE prompt_and_wait returns
             # so it cannot safely read _last_turn; this is the only safe publish site.
             if nc is not None and not self._result_sent:
                 self._result_sent = True
-                turn_error = _worker_error_from_omp_turn(
-                    turn, self._last_agent_end_event
-                )
                 if turn_error is not None:
                     log.warning(
                         "rpc_bridge: job %s OMP turn failed (code=%s)",
@@ -419,6 +472,8 @@ class RpcBridge:
                     return
 
                 data: dict[str, Any] = {"result": text}
+                if model_fallback is not None:
+                    data["model_fallback"] = model_fallback
                 # session_file backhaul (V2 pool path — None for legacy single-client).
                 if session_file is not None:
                     data["session_file"] = session_file

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -17,6 +17,7 @@ import hashlib
 import logging
 import os
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -67,6 +68,14 @@ class DigestMismatchError(Exception):
 
 class SteerViolationError(Exception):
     """Raised when steer() is attempted while prompt_and_wait is in flight."""
+
+
+@dataclass(frozen=True)
+class _TurnPublishContext:
+    turn: Any
+    turn_error: WorkerError | None
+    model_fallback: dict[str, str] | None
+    session_file: str | None
 
 
 def _classify_exception(exc: BaseException) -> WorkerError:
@@ -352,7 +361,7 @@ class RpcBridge:
         requested_model: str | None,
         turn: Any,
     ) -> tuple[Any, WorkerError | None, dict[str, str] | None]:
-        """Retry once with the first discovered catalogue model on invalid-model errors."""
+        """Retry with the first catalogue model when the requested model is invalid."""
         from factory.adapters.omp._model_catalogue import first_registry_model
 
         turn_error = _worker_error_from_omp_turn(turn, self._last_agent_end_event)
@@ -379,6 +388,42 @@ class RpcBridge:
         if retry_error is not None:
             return retry_turn, retry_error, None
         return retry_turn, None, {"requested": attempted, "fallback": fallback}
+
+    async def _publish_turn_outcome(
+        self,
+        nc: NatsClient,
+        job_id: str,
+        ctx: _TurnPublishContext,
+    ) -> None:
+        if ctx.turn_error is not None:
+            log.warning(
+                "rpc_bridge: job %s OMP turn failed (code=%s)",
+                job_id,
+                ctx.turn_error.code,
+            )
+            payload = _make_result(job_id, status="error", error=ctx.turn_error)
+            await nc.publish(jobs_result(job_id), payload)
+            return
+
+        text: str = self._derive_assistant_text(ctx.turn)
+        if not text:
+            log.warning("rpc_bridge: job %s produced an empty result text", job_id)
+            empty_error = WorkerError(
+                code="worker.validation",
+                message="EmptyResponse",
+                retryable=False,
+            )
+            payload = _make_result(job_id, status="error", error=empty_error)
+            await nc.publish(jobs_result(job_id), payload)
+            return
+
+        data: dict[str, Any] = {"result": text}
+        if ctx.model_fallback is not None:
+            data["model_fallback"] = ctx.model_fallback
+        if ctx.session_file is not None:
+            data["session_file"] = ctx.session_file
+        payload = _make_result(job_id, status="success", data=data)
+        await nc.publish(jobs_result(job_id), payload)
 
     async def run(
         self,
@@ -438,47 +483,21 @@ class RpcBridge:
                     turn=turn,
                 )
             )
-            # Publish success here — guaranteed to see the completed turn value.
+            # Publish here — guaranteed to see the completed turn value.
             # _on_agent_end fires on the stdout thread BEFORE prompt_and_wait returns
             # so it cannot safely read _last_turn; this is the only safe publish site.
             if nc is not None and not self._result_sent:
                 self._result_sent = True
-                if turn_error is not None:
-                    log.warning(
-                        "rpc_bridge: job %s OMP turn failed (code=%s)",
-                        job_id,
-                        turn_error.code,
-                    )
-                    payload = _make_result(
-                        job_id, status="error", error=turn_error
-                    )
-                    await nc.publish(jobs_result(job_id), payload)
-                    return
-
-                text: str = self._derive_assistant_text(turn)
-                if not text:
-                    log.warning(
-                        "rpc_bridge: job %s produced an empty result text", job_id
-                    )
-                    empty_error = WorkerError(
-                        code="worker.validation",
-                        message="EmptyResponse",
-                        retryable=False,
-                    )
-                    payload = _make_result(
-                        job_id, status="error", error=empty_error
-                    )
-                    await nc.publish(jobs_result(job_id), payload)
-                    return
-
-                data: dict[str, Any] = {"result": text}
-                if model_fallback is not None:
-                    data["model_fallback"] = model_fallback
-                # session_file backhaul (V2 pool path — None for legacy single-client).
-                if session_file is not None:
-                    data["session_file"] = session_file
-                payload = _make_result(job_id, status="success", data=data)
-                await nc.publish(jobs_result(job_id), payload)
+                await self._publish_turn_outcome(
+                    nc,
+                    job_id,
+                    _TurnPublishContext(
+                        turn=turn,
+                        turn_error=turn_error,
+                        model_fallback=model_fallback,
+                        session_file=session_file,
+                    ),
+                )
         finally:
             self._in_prompt_await = False
             if steer_sub is not None:

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -36,9 +36,10 @@ _OMP_BIN = Path("/opt/omp/omp")  # image-build constant — NEVER from env
 _DEFAULT_PROVIDER = (
     "litellm"  # routes through factory LiteLLM proxy (deploy/omp/models.yml)
 )
-# Pin a fast default — model=None falls through to models.yml[0] (grok-4) and
-# risks RpcClient(request_timeout=30s) timeouts (#1910).
-_DEFAULT_MODEL = "grok-4-fast"
+# Pin a fast non-reasoning default — model=None falls through to models.yml[0]
+# (grok-4 full) and risks RpcClient(request_timeout=30s) timeouts (#1910).
+# Alias must exist in the LiteLLM xAI pass-through catalogue (#1923).
+_DEFAULT_MODEL = "grok-4.20-non-reasoning"
 _ENV_REQUEST_TIMEOUT_KEY = "OMP_REQUEST_TIMEOUT"
 _DEFAULT_REQUEST_TIMEOUT = 30.0
 
@@ -107,6 +108,82 @@ def _make_result(job_id: str, **kwargs: Any) -> bytes:
         **kwargs,
     )
     return event.model_dump_json().encode()
+
+
+def _field(obj: Any, *names: str) -> Any:
+    """Read the first present attribute/key from a TypedDict or dataclass."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        for name in names:
+            if name in obj:
+                return obj[name]
+        return None
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _assistant_message_from_turn(turn: Any, end_event: Any | None) -> Any | None:
+    """Best-effort assistant message from PromptTurn or stored AgentEndEvent."""
+    assistant = getattr(turn, "assistant_message", None)
+    if assistant is not None:
+        return assistant
+    if end_event is None:
+        return None
+    messages = getattr(end_event, "messages", None)
+    if not messages:
+        return None
+    for candidate in reversed(messages):
+        role = _field(candidate, "role")
+        if role == "assistant":
+            return candidate
+    return None
+
+
+def _worker_error_from_omp_turn(turn: Any, end_event: Any | None) -> WorkerError | None:
+    """Map an OMP PromptTurn provider failure to a structured WorkerError.
+
+    ADR-073: returned ``WorkerError.message`` is a stable type label only —
+    never the provider's ``errorMessage`` string.
+    """
+    assistant = _assistant_message_from_turn(turn, end_event)
+    stop_reason = _field(assistant, "stopReason", "stop_reason")
+    if stop_reason == "aborted":
+        return WorkerError(code="worker.internal", message="Aborted", retryable=True)
+    if stop_reason != "error":
+        return None
+
+    error_message = _field(assistant, "errorMessage", "error_message")
+    if error_message:
+        lower = str(error_message).lower()
+        if "invalid model" in lower:
+            return WorkerError(
+                code="llm.model_unavailable",
+                message="ModelUnavailable",
+                retryable=False,
+            )
+        if "rate limit" in lower or "429" in lower:
+            return WorkerError(
+                code="llm.rate_limit",
+                message="RateLimitError",
+                retryable=True,
+            )
+        if "context" in lower and (
+            "too long" in lower or "length" in lower or "window" in lower
+        ):
+            return WorkerError(
+                code="llm.context_too_long",
+                message="ContextTooLong",
+                retryable=False,
+            )
+    return WorkerError(
+        code="worker.internal",
+        message="OmpProviderError",
+        retryable=False,
+    )
 
 
 def _verify_digest(omp_bin: Path) -> None:
@@ -310,11 +387,37 @@ class RpcBridge:
             # so it cannot safely read _last_turn; this is the only safe publish site.
             if nc is not None and not self._result_sent:
                 self._result_sent = True
+                turn_error = _worker_error_from_omp_turn(
+                    turn, self._last_agent_end_event
+                )
+                if turn_error is not None:
+                    log.warning(
+                        "rpc_bridge: job %s OMP turn failed (code=%s)",
+                        job_id,
+                        turn_error.code,
+                    )
+                    payload = _make_result(
+                        job_id, status="error", error=turn_error
+                    )
+                    await nc.publish(jobs_result(job_id), payload)
+                    return
+
                 text: str = self._derive_assistant_text(turn)
                 if not text:
                     log.warning(
                         "rpc_bridge: job %s produced an empty result text", job_id
                     )
+                    empty_error = WorkerError(
+                        code="worker.validation",
+                        message="EmptyResponse",
+                        retryable=False,
+                    )
+                    payload = _make_result(
+                        job_id, status="error", error=empty_error
+                    )
+                    await nc.publish(jobs_result(job_id), payload)
+                    return
+
                 data: dict[str, Any] = {"result": text}
                 # session_file backhaul (V2 pool path — None for legacy single-client).
                 if session_file is not None:

--- a/src/factory/adapters/omp/_rpc_digest.py
+++ b/src/factory/adapters/omp/_rpc_digest.py
@@ -1,0 +1,44 @@
+"""omp binary digest gate for RpcBridge."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+_PINNED_SHA256 = "b877091c91ebdc8c8d907c4b62681895cd3ae049815858aea7b69ac1d53b7c7b"
+_OMP_BIN = Path("/opt/omp/omp")
+_ENV_REQUEST_TIMEOUT_KEY = "OMP_REQUEST_TIMEOUT"
+_DEFAULT_REQUEST_TIMEOUT = 30.0
+
+
+class DigestMismatchError(Exception):
+    """Raised when the omp binary sha256 does not match the pinned value."""
+
+    def __init__(self, actual: str, expected: str) -> None:
+        super().__init__(f"digest mismatch: actual={actual} expected={expected}")
+        self.actual = actual
+        self.expected = expected
+
+
+def read_request_timeout() -> float:
+    """Read OMP_REQUEST_TIMEOUT from env; fall back to _DEFAULT_REQUEST_TIMEOUT."""
+    raw = os.environ.get(_ENV_REQUEST_TIMEOUT_KEY)
+    if raw is None:
+        return _DEFAULT_REQUEST_TIMEOUT
+    try:
+        val = float(raw)
+        return val if val > 0 else _DEFAULT_REQUEST_TIMEOUT
+    except ValueError:
+        return _DEFAULT_REQUEST_TIMEOUT
+
+
+def verify_digest(omp_bin: Path) -> None:
+    """Hash the omp binary and raise DigestMismatchError on mismatch."""
+    hasher = hashlib.sha256()
+    with omp_bin.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            hasher.update(chunk)
+    actual = hasher.hexdigest()
+    if actual != _PINNED_SHA256:
+        raise DigestMismatchError(actual=actual, expected=_PINNED_SHA256)

--- a/src/factory/adapters/omp/_rpc_envelope.py
+++ b/src/factory/adapters/omp/_rpc_envelope.py
@@ -1,0 +1,63 @@
+"""Job envelope serialization and exception classification for omp RpcBridge."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.errors import WorkerError
+from roxabi_contracts.jobs.models import JobProgress, JobResult
+from roxabi_contracts.jobs.subjects import jobs_result
+
+
+def classify_exception(exc: BaseException) -> WorkerError:
+    """Map an exception to a WorkerError.
+
+    SanitizedError discipline (ADR-073): message field = type(exc).__name__ only.
+    """
+    name = type(exc).__name__
+    if name == "DigestMismatchError":
+        return WorkerError(
+            code="transport.contract_mismatch", message=name, retryable=False
+        )
+    if isinstance(exc, asyncio.TimeoutError):
+        return WorkerError(code="transport.timeout", message=name, retryable=True)
+    if name in ("ConnectionRefusedError", "BrokenPipeError"):
+        return WorkerError(code="transport.error", message=name, retryable=True)
+    return WorkerError(code="worker.internal", message=name, retryable=False)
+
+
+def make_progress(job_id: str, **kwargs: Any) -> bytes:
+    """Serialise a JobProgress to JSON bytes."""
+    event = JobProgress(
+        contract_version=CONTRACT_VERSION,
+        trace_id=str(uuid.uuid4()),
+        issued_at=datetime.now(timezone.utc),
+        job_id=job_id,
+        **kwargs,
+    )
+    return event.model_dump_json().encode()
+
+
+def make_result(job_id: str, **kwargs: Any) -> bytes:
+    """Serialise a JobResult to JSON bytes."""
+    event = JobResult(
+        contract_version=CONTRACT_VERSION,
+        trace_id=str(uuid.uuid4()),
+        issued_at=datetime.now(timezone.utc),
+        job_id=job_id,
+        **kwargs,
+    )
+    return event.model_dump_json().encode()
+
+
+async def publish_job_error(nc: Any, job_id: str, exc: BaseException) -> None:
+    """Publish a JobResult(status=error) for a failed job without requiring a bridge."""
+    if nc is None:
+        return
+    worker_error = classify_exception(exc)
+    payload = make_result(job_id, status="error", error=worker_error)
+    await nc.publish(jobs_result(job_id), payload)

--- a/src/factory/adapters/omp/_rpc_turn.py
+++ b/src/factory/adapters/omp/_rpc_turn.py
@@ -1,0 +1,92 @@
+"""OMP PromptTurn → WorkerError mapping for RpcBridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from roxabi_contracts.errors import WorkerError
+
+
+@dataclass(frozen=True)
+class TurnPublishContext:
+    turn: Any
+    turn_error: WorkerError | None
+    model_fallback: dict[str, str] | None
+    session_file: str | None
+
+
+def _field(obj: Any, *names: str) -> Any:
+    """Read the first present attribute/key from a TypedDict or dataclass."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        for name in names:
+            if name in obj:
+                return obj[name]
+        return None
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _assistant_message_from_turn(turn: Any, end_event: Any | None) -> Any | None:
+    """Best-effort assistant message from PromptTurn or stored AgentEndEvent."""
+    assistant = getattr(turn, "assistant_message", None)
+    if assistant is not None:
+        return assistant
+    if end_event is None:
+        return None
+    messages = getattr(end_event, "messages", None)
+    if not messages:
+        return None
+    for candidate in reversed(messages):
+        role = _field(candidate, "role")
+        if role == "assistant":
+            return candidate
+    return None
+
+
+def worker_error_from_omp_turn(turn: Any, end_event: Any | None) -> WorkerError | None:
+    """Map an OMP PromptTurn provider failure to a structured WorkerError.
+
+    ADR-073: returned ``WorkerError.message`` is a stable type label only —
+    never the provider's ``errorMessage`` string.
+    """
+    assistant = _assistant_message_from_turn(turn, end_event)
+    stop_reason = _field(assistant, "stopReason", "stop_reason")
+    if stop_reason == "aborted":
+        return WorkerError(code="worker.internal", message="Aborted", retryable=True)
+    if stop_reason != "error":
+        return None
+
+    error_message = _field(assistant, "errorMessage", "error_message")
+    if error_message:
+        lower = str(error_message).lower()
+        if "invalid model" in lower:
+            return WorkerError(
+                code="llm.model_unavailable",
+                message="ModelUnavailable",
+                retryable=False,
+            )
+        if "rate limit" in lower or "429" in lower:
+            return WorkerError(
+                code="llm.rate_limit",
+                message="RateLimitError",
+                retryable=True,
+            )
+        if "context" in lower and (
+            "too long" in lower or "length" in lower or "window" in lower
+        ):
+            return WorkerError(
+                code="llm.context_too_long",
+                message="ContextTooLong",
+                retryable=False,
+            )
+    return WorkerError(
+        code="worker.internal",
+        message="OmpProviderError",
+        retryable=False,
+    )

--- a/src/factory/adapters/omp/omp_worker.py
+++ b/src/factory/adapters/omp/omp_worker.py
@@ -180,6 +180,11 @@ class OmpWorker(NatsAdapterBase):
 
         model_cfg = envelope.payload.get("model_cfg", {})
         system_prompt = envelope.payload.get("system_prompt", "")
+        requested_model: str | None = None
+        if isinstance(model_cfg, dict):
+            raw_model = model_cfg.get("model")
+            if isinstance(raw_model, str) and raw_model.strip():
+                requested_model = raw_model.strip()
         _cfg_keys = (
             sorted(model_cfg)
             if isinstance(model_cfg, dict)
@@ -187,24 +192,35 @@ class OmpWorker(NatsAdapterBase):
         )
         _sp_len = len(system_prompt) if isinstance(system_prompt, str) else 0
         log.debug(
-            "omp job %s: received model_cfg keys=%s"
-            " system_prompt_len=%d (V1: not applied)"
+            "omp job %s: received model_cfg keys=%s model=%s"
+            " system_prompt_len=%d (system_prompt V1: not applied)"
             " pool_id=%s provider_session_id=%s",
             job_id,
             _cfg_keys,
+            requested_model,
             _sp_len,
             pool_id,
             provider_session_id,
         )
 
         task = asyncio.create_task(
-            self._run_job(str(job_id), str(prompt), provider_session_id)
+            self._run_job(
+                str(job_id),
+                str(prompt),
+                provider_session_id,
+                model=requested_model,
+            )
         )
         self._jobs.add(task)
         task.add_done_callback(self._jobs.discard)
 
     async def _run_job(
-        self, job_id: str, prompt: str, session_file: str | None
+        self,
+        job_id: str,
+        prompt: str,
+        session_file: str | None,
+        *,
+        model: str | None = None,
     ) -> None:
         """Acquire a pool worker, run the job, release on completion."""
         log.info("omp_worker: job_id=%s start", job_id)
@@ -212,7 +228,12 @@ class OmpWorker(NatsAdapterBase):
         worker = None
         try:
             worker = await self._pool.acquire(session_file)
-            await worker.bridge.run(prompt, job_id, session_file=worker.session_file)
+            await worker.bridge.run(
+                prompt,
+                job_id,
+                session_file=worker.session_file,
+                model=model,
+            )
         except Exception as exc:  # pool.acquire / bridge.run  # noqa: BLE001
             # _run_job is create_task-spawned (non-blocking, frees core-NATS dispatch
             # for Model B). Runs *outside* _dispatch guard in adapter_base; must

--- a/src/factory/agents/simple_agent.py
+++ b/src/factory/agents/simple_agent.py
@@ -277,9 +277,10 @@ class SimpleAgent(AgentBase):
 
         if not result.ok:
             log.warning(
-                "[agent:%s][pool:%s] CLI error: %s",
+                "[agent:%s][pool:%s] backend error (%s): %s",
                 self.name,
                 pool.pool_id,
+                model_cfg.backend,
                 result.error,
             )
             pool._last_turn_had_backend_error = True
@@ -301,9 +302,10 @@ class SimpleAgent(AgentBase):
 
         if not reply:
             log.warning(
-                "[agent:%s][pool:%s] empty reply from CLI",
+                "[agent:%s][pool:%s] empty reply from backend (%s)",
                 self.name,
                 pool.pool_id,
+                model_cfg.backend,
             )
             pool._last_turn_had_backend_error = True
             user_msg = resolve_user_error(

--- a/src/factory/agents/simple_agent.py
+++ b/src/factory/agents/simple_agent.py
@@ -299,6 +299,14 @@ class SimpleAgent(AgentBase):
         meta: dict[str, Any] = {"session_id": result.session_id}
         if result.warning:
             meta["warning"] = result.warning
+        if result.model_fallback and self._msg_manager is not None:
+            notice = self._msg_manager.get(
+                "model_fallback",
+                requested_model=result.model_fallback["requested"],
+                fallback_model=result.model_fallback["fallback"],
+            )
+            if notice:
+                reply = f"{notice}\n\n{reply}" if reply else notice
 
         if not reply:
             log.warning(

--- a/src/factory/core/messaging/messages.py
+++ b/src/factory/core/messaging/messages.py
@@ -31,6 +31,9 @@ _FALLBACKS: dict[str, str] = {
     "stt_unsupported": "Voice messages are not supported — STT is not configured.",
     "stt_failed": "Sorry, I couldn't transcribe your voice message.",
     "audio_download_failed": "Couldn't retrieve your audio file. Please try again.",
+    "model_fallback": (
+        "⚠️ {requested_model} is unavailable — replying with {fallback_model}."
+    ),
 }
 
 
@@ -60,6 +63,8 @@ class MessageManager:
         fmt.setdefault("bot_name", "factory")
         try:
             raw = self._resolve(key, platform)
+            if not raw:
+                raw = self._resolve_notification(key)
             return raw.format_map(fmt)
         except (KeyError, ValueError) as exc:
             log.debug(
@@ -79,6 +84,15 @@ class MessageManager:
                 return raw.format_map(safe)
             except ValueError:
                 return raw
+
+    def _resolve_notification(self, key: str) -> str:
+        lang = self.language
+        notifications = self._templates.get("notifications", {})
+        if key in notifications.get(lang, {}):
+            return notifications[lang][key]
+        if key in notifications.get("en", {}):
+            return notifications["en"][key]
+        return _FALLBACKS.get(key, "")
 
     def _resolve(self, key: str, platform: str | None) -> str:
         lang = self.language

--- a/src/factory/core/ports/llm.py
+++ b/src/factory/core/ports/llm.py
@@ -37,6 +37,7 @@ class LlmResult:
     retryable: bool = True
     warning: str = ""
     user_message: str = ""
+    model_fallback: dict[str, str] | None = None
     worker_error: "WorkerError | None" = field(default=None)
 
     @property

--- a/src/factory/data/messages.toml
+++ b/src/factory/data/messages.toml
@@ -55,6 +55,8 @@ stream_interrupted  = " [réponse interrompue]"
 
 [notifications.en]
 idle_eviction       = "Session timed out after inactivity."
+model_fallback      = "⚠️ {requested_model} is unavailable — replying with {fallback_model}."
 
 [notifications.fr]
 idle_eviction       = "Session expirée après inactivité."
+model_fallback      = "⚠️ {requested_model} est indisponible — réponse avec {fallback_model}."

--- a/src/factory/llm/omp_job_codec.py
+++ b/src/factory/llm/omp_job_codec.py
@@ -36,7 +36,29 @@ class OmpJobCodec:
 
     def decode(self, result: JobResult) -> LlmResult:
         if result.status == "success":
-            return LlmResult(result=(result.data or {}).get("result", ""))
+            data = result.data or {}
+            model_fallback = data.get("model_fallback")
+            if not isinstance(model_fallback, dict):
+                model_fallback = None
+            else:
+                requested = model_fallback.get("requested")
+                fallback = model_fallback.get("fallback")
+                if not (
+                    isinstance(requested, str)
+                    and isinstance(fallback, str)
+                    and requested
+                    and fallback
+                ):
+                    model_fallback = None
+                else:
+                    model_fallback = {
+                        "requested": requested,
+                        "fallback": fallback,
+                    }
+            return LlmResult(
+                result=data.get("result", ""),
+                model_fallback=model_fallback,
+            )
 
         validated = _validate_worker_error(result.error)
         error_msg = validated.message if validated else _MALFORMED_ERROR

--- a/tests/adapters/omp/test_model_catalogue.py
+++ b/tests/adapters/omp/test_model_catalogue.py
@@ -1,0 +1,77 @@
+"""Tests for omp LiteLLM catalogue helpers."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from factory.adapters.omp import _model_catalogue as catalogue
+
+
+class _ModelsListHandler(BaseHTTPRequestHandler):
+    catalogue: dict[str, Any] = {
+        "object": "list",
+        "data": [
+            {"id": "grok-4.20-non-reasoning", "object": "model"},
+            {"id": "grok-4.20-reasoning", "object": "model"},
+        ],
+    }
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") != "/xai/v1/models":
+            self.send_error(404)
+            return
+        body = json.dumps(self.catalogue).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture
+def mock_gateway(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ModelsListHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    base_url = f"http://{host}:{port}/xai/v1"
+    models_yml = tmp_path / "models.yml"
+    models_yml.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "litellm": {
+                        "baseUrl": base_url,
+                        "api": "openai-completions",
+                        "apiKey": "LITELLM_API_KEY",
+                        "discovery": {"type": "openai-models-list"},
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv("LITELLM_API_KEY", "test-key")
+    catalogue._load_litellm_provider.cache_clear()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        catalogue._load_litellm_provider.cache_clear()
+
+
+def test_first_registry_model_returns_catalogue_head(mock_gateway: None) -> None:
+    assert catalogue.first_registry_model() == "grok-4.20-non-reasoning"

--- a/tests/adapters/omp/test_omp_worker.py
+++ b/tests/adapters/omp/test_omp_worker.py
@@ -132,6 +132,7 @@ class TestHandleHappyPath:
             "summarise this text",
             _JOB_ID,
             session_file=fake_pw.session_file,
+            model=None,
         )
 
     async def test_handle_releases_pool_worker_on_success(self) -> None:
@@ -199,7 +200,9 @@ class TestHandleSpawnSemantics:
         def _fresh_pool_worker() -> MagicMock:
             pw = _make_fake_pool_worker()
 
-            async def run_until_released(prompt, job_id, *, session_file=None):  # noqa: ARG001
+            async def run_until_released(  # noqa: ARG001
+                prompt, job_id, *, session_file=None, model=None
+            ):
                 nonlocal call_count
                 call_count += 1
                 started.release()  # this job has entered bridge.run
@@ -503,6 +506,7 @@ class TestHandleBackwardCompat:
             "x",
             _JOB_ID,
             session_file=ANY,
+            model=None,
         )
 
     async def test_handle_reads_model_cfg_and_system_prompt(self) -> None:
@@ -532,4 +536,5 @@ class TestHandleBackwardCompat:
             "x",
             _JOB_ID,
             session_file=ANY,
+            model="grok-4-fast",
         )

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -76,6 +76,7 @@ def _stub_omp_rpc_module() -> tuple[ModuleType, MagicMock]:
     client_instance.stop = MagicMock()
     client_instance.new_session = MagicMock()
     client_instance.prompt_and_wait = MagicMock()
+    client_instance.set_model = MagicMock()
     client_instance.steer = MagicMock()
     client_instance.on_message_update = MagicMock()
     client_instance.on_tool_execution_start = MagicMock()
@@ -861,6 +862,46 @@ class TestTurnFailurePublishing:
         assert payload["error"]["code"] == "llm.model_unavailable"
         assert payload["error"]["message"] == "ModelUnavailable"
         assert "grok-4-fast" not in json.dumps(payload)
+
+    async def test_invalid_model_falls_back_to_registry_first(
+        self, bridge_and_nc
+    ) -> None:
+        bridge, nc, client = bridge_and_nc
+        nc.subscribe = AsyncMock(return_value=AsyncMock(unsubscribe=AsyncMock()))
+        await bridge.register(nc)
+
+        failed_turn = SimpleNamespace(
+            assistant_text=None,
+            assistant_message={
+                "role": "assistant",
+                "stopReason": "error",
+                "errorMessage": "400 Invalid model name passed in model=grok-4-fast",
+            },
+        )
+        success_turn = SimpleNamespace(
+            assistant_text="fallback reply",
+            assistant_message={"role": "assistant", "stopReason": "end_turn"},
+        )
+        client.prompt_and_wait.side_effect = [failed_turn, success_turn]
+
+        with patch(
+            "factory.adapters.omp._model_catalogue.first_registry_model",
+            return_value="grok-4.20-non-reasoning",
+        ):
+            await bridge.run(
+                prompt="hello",
+                job_id=_JOB_ID,
+                model="grok-4-fast",
+            )
+
+        client.set_model.assert_called()
+        payload = json.loads(nc.publish.await_args.args[1])
+        assert payload["status"] == "success"
+        assert payload["data"]["result"] == "fallback reply"
+        assert payload["data"]["model_fallback"] == {
+            "requested": "grok-4-fast",
+            "fallback": "grok-4.20-non-reasoning",
+        }
 
     async def test_stop_reason_error_does_not_leak_provider_message(
         self, bridge_and_nc

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -160,7 +160,7 @@ class TestDigestGate:
         actual_sha = hashlib.sha256(content).hexdigest()
         _stub_omp_rpc_module()
         try:
-            with patch("factory.adapters.omp._rpc_bridge._PINNED_SHA256", actual_sha):
+            with patch("factory.adapters.omp._rpc_digest._PINNED_SHA256", actual_sha):
                 bridge = RpcBridge(omp_bin=omp_bin)
             assert bridge is not None
         finally:
@@ -190,7 +190,7 @@ def bridge_and_nc(tmp_path: Path):
     actual_sha = hashlib.sha256(content).hexdigest()
     _, client_instance = _stub_omp_rpc_module()
     try:
-        with patch("factory.adapters.omp._rpc_bridge._PINNED_SHA256", actual_sha):
+        with patch("factory.adapters.omp._rpc_digest._PINNED_SHA256", actual_sha):
             bridge = RpcBridge(omp_bin=omp_bin)
         nc = AsyncMock()
         nc.publish = AsyncMock()
@@ -694,7 +694,7 @@ class TestStartLifecycle:
         sys.modules["omp_rpc"] = module
 
         with patch(
-            "factory.adapters.omp._rpc_bridge._PINNED_SHA256",
+            "factory.adapters.omp._rpc_digest._PINNED_SHA256",
             actual_sha,
         ):
             bridge = RpcBridge(omp_bin=omp_bin)
@@ -761,7 +761,7 @@ class TestStartLifecycle:
         sys.modules["omp_rpc"] = module
 
         with patch(
-            "factory.adapters.omp._rpc_bridge._PINNED_SHA256",
+            "factory.adapters.omp._rpc_digest._PINNED_SHA256",
             actual_sha,
         ):
             RpcBridge(omp_bin=omp_bin)

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -290,8 +290,9 @@ class TestRun:
         nc.publish.assert_awaited_once()
         payload_bytes = nc.publish.await_args.args[1]
         payload = json.loads(payload_bytes)
-        assert payload.get("data") == {"result": ""}, (
-            f"reset should clear stale event; got {payload.get('data')!r}"
+        assert payload["status"] == "error"
+        assert payload["error"]["code"] == "worker.validation", (
+            "empty text without OMP stopReason=error is a validation failure"
         )
 
 
@@ -831,6 +832,60 @@ class TestStartLifecycle:
 # T2 — _on_agent_end must publish data={"result": <assistant_text>}
 # T3 — run() must store the PromptTurn return value as _last_turn
 # ---------------------------------------------------------------------------
+
+
+class TestTurnFailurePublishing:
+    async def test_stop_reason_error_publishes_model_unavailable(
+        self, bridge_and_nc
+    ) -> None:
+        bridge, nc, client = bridge_and_nc
+        nc.subscribe = AsyncMock(return_value=AsyncMock(unsubscribe=AsyncMock()))
+        await bridge.register(nc)
+
+        client.prompt_and_wait.return_value = SimpleNamespace(
+            assistant_text=None,
+            assistant_message={
+                "role": "assistant",
+                "stopReason": "error",
+                "errorMessage": (
+                    "400 /chat/completions: Invalid model name passed in "
+                    "model=grok-4-fast"
+                ),
+            },
+        )
+
+        await bridge.run(prompt="hello", job_id=_JOB_ID)
+
+        payload = json.loads(nc.publish.await_args.args[1])
+        assert payload["status"] == "error"
+        assert payload["error"]["code"] == "llm.model_unavailable"
+        assert payload["error"]["message"] == "ModelUnavailable"
+        assert "grok-4-fast" not in json.dumps(payload)
+
+    async def test_stop_reason_error_does_not_leak_provider_message(
+        self, bridge_and_nc
+    ) -> None:
+        bridge, nc, client = bridge_and_nc
+        nc.subscribe = AsyncMock(return_value=AsyncMock(unsubscribe=AsyncMock()))
+        await bridge.register(nc)
+
+        secret = "super-secret-provider-detail"
+        client.prompt_and_wait.return_value = SimpleNamespace(
+            assistant_text="",
+            assistant_message={
+                "role": "assistant",
+                "stopReason": "error",
+                "errorMessage": secret,
+            },
+        )
+
+        await bridge.run(prompt="hello", job_id=_JOB_ID)
+
+        payload_bytes = nc.publish.await_args.args[1]
+        assert secret not in payload_bytes.decode()
+        payload = json.loads(payload_bytes)
+        assert payload["status"] == "error"
+        assert payload["error"]["code"] == "worker.internal"
 
 
 class TestAgentEndResultData:

--- a/tests/integration/test_adr089_omp_error_e2e.py
+++ b/tests/integration/test_adr089_omp_error_e2e.py
@@ -130,6 +130,38 @@ class TestAdr089OmpBlockingErrorE2E:
             "unavailable", bot_name="main", retry_secs="0"
         )
 
+    async def test_model_fallback_notice_prepended_to_reply(self) -> None:
+        """Successful JobResult with model_fallback metadata → user notice prefix."""
+        mm = message_manager()
+        result = JobResult.model_validate(
+            {
+                **ENV_BASE,
+                "job_id": "job-omp-fallback",
+                "status": "success",
+                "data": {
+                    "result": "Hello there.",
+                    "model_fallback": {
+                        "requested": "grok-4-fast",
+                        "fallback": "grok-4.20-non-reasoning",
+                    },
+                },
+            }
+        )
+        nc = _make_omp_nc(result)
+        hub = hub_with_agent(_make_omp_agent(nc))
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await run_hub_until_processed(hub)
+
+        notice = mm.get(
+            "model_fallback",
+            requested_model="grok-4-fast",
+            fallback_model="grok-4.20-non-reasoning",
+        )
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0].to_text() == f"{notice}\n\nHello there."
+
     async def test_nats_timeout_shows_timeout_template(self) -> None:
         """NATS reply timeout → transport.timeout template."""
         mm = message_manager()

--- a/tests/integration/test_adr089_omp_error_e2e.py
+++ b/tests/integration/test_adr089_omp_error_e2e.py
@@ -103,6 +103,33 @@ class TestAdr089OmpBlockingErrorE2E:
         assert len(adapter.sent) == 1
         assert adapter.sent[0].to_text() == mm.get("rate_limit")
 
+    async def test_model_unavailable_job_result_shows_template(self) -> None:
+        """JobResult llm.model_unavailable → messages.toml unavailable template."""
+        mm = message_manager()
+        result = JobResult.model_validate(
+            {
+                **ENV_BASE,
+                "job_id": "job-omp-model",
+                "status": "error",
+                "error": {
+                    "code": "llm.model_unavailable",
+                    "message": "ModelUnavailable",
+                    "retryable": False,
+                },
+            }
+        )
+        nc = _make_omp_nc(result)
+        hub = hub_with_agent(_make_omp_agent(nc))
+        adapter = hub.adapter_registry[(Platform.TELEGRAM, "main")]
+        assert isinstance(adapter, _RecordingAdapter)
+
+        await run_hub_until_processed(hub)
+
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0].to_text() == mm.get(
+            "unavailable", bot_name="main", retry_secs="0"
+        )
+
     async def test_nats_timeout_shows_timeout_template(self) -> None:
         """NATS reply timeout → transport.timeout template."""
         mm = message_manager()

--- a/tests/llm/drivers/test_omp_pool.py
+++ b/tests/llm/drivers/test_omp_pool.py
@@ -234,7 +234,7 @@ class TestOmpPool:
         import sys
 
         pool = OmpPool(
-            omp_bin=Path("/fake/omp"), provider="litellm", model="grok-4-fast"
+            omp_bin=Path("/fake/omp"), provider="litellm", model=None
         )
         await pool.register(_NC)
 
@@ -272,7 +272,7 @@ class TestOmpPool:
 
     @pytest.mark.asyncio
     async def test_start_worker_defaults_model_when_unset(self) -> None:
-        """OmpPool() with model=None must pin grok-4-fast on RpcClient (#1910)."""
+        """OmpPool() with model=None must pin the RpcBridge default on RpcClient (#1910)."""
         import sys
 
         pool = OmpPool(omp_bin=Path("/fake/omp"))

--- a/tests/llm/drivers/test_omp_pool.py
+++ b/tests/llm/drivers/test_omp_pool.py
@@ -272,7 +272,7 @@ class TestOmpPool:
 
     @pytest.mark.asyncio
     async def test_start_worker_defaults_model_when_unset(self) -> None:
-        """OmpPool() with model=None must pin the RpcBridge default on RpcClient (#1910)."""
+        """OmpPool(model=None) pins the RpcBridge default on RpcClient (#1910)."""
         import sys
 
         pool = OmpPool(omp_bin=Path("/fake/omp"))

--- a/tests/llm/test_omp_job_codec.py
+++ b/tests/llm/test_omp_job_codec.py
@@ -23,6 +23,25 @@ class TestOmpJobCodecDecode:
         assert llm.result == "pong"
         assert llm.worker_error is None
 
+    def test_success_extracts_model_fallback(self) -> None:
+        result = JobResult.model_validate(
+            {
+                **sample_job_result_ok,
+                "data": {
+                    "result": "pong",
+                    "model_fallback": {
+                        "requested": "grok-4-fast",
+                        "fallback": "grok-4.20-non-reasoning",
+                    },
+                },
+            }
+        )
+        llm = _codec.decode(result)
+        assert llm.model_fallback == {
+            "requested": "grok-4-fast",
+            "fallback": "grok-4.20-non-reasoning",
+        }
+
     def test_error_populates_worker_error(self) -> None:
         result = JobResult.model_validate(sample_job_result_err)
         llm = _codec.decode(result)


### PR DESCRIPTION
## Summary

- Map OMP `stopReason=error` turns to structured `JobResult(status=error)` instead of success with empty text, so the hub surfaces ADR-089 user-facing error templates
- Apply per-job `model_cfg.model` via `set_model()`; on `llm.model_unavailable`, retry with the first LiteLLM catalogue id and prepend a `model_fallback` notice to the reply
- Pin default OMP model to `grok-4.20-non-reasoning` (replaces removed `grok-4-fast` alias)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1954: propagate turn failures and model fallback | Open |
| Analysis | — | Absent (S-tier hotfix) |
| Spec | — | Absent (S-tier hotfix) |
| Implementation | 3 commits on `fix/omp-turn-error-propagation` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (117 OMP-related) | Passed |

## Test Plan

- [x] `pytest tests/adapters/omp/ tests/llm/test_omp_job_codec.py tests/integration/test_adr089_omp_error_e2e.py`
- [x] Turn failure publishes `llm.model_unavailable` without leaking provider message
- [x] Registry fallback retries and sets `model_fallback` metadata
- [x] Hub e2e prepends `notifications.model_fallback` template

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1: OMP provider error → structured JobResult | `test_rpc_bridge.py :: test_stop_reason_error_publishes_model_unavailable` | ✅ |
| SC2: Empty text → worker.validation | `test_rpc_bridge.py :: TestRun empty-text test` | ✅ |
| SC3: model_unavailable → user template | `test_adr089_omp_error_e2e.py :: test_model_unavailable_job_result_shows_template` | ✅ |
| SC4: Invalid model → registry fallback + notice | `test_rpc_bridge.py :: test_invalid_model_falls_back_to_registry_first` + `test_model_fallback_notice_prepended_to_reply` | ✅ |

Fixes #1954

Related #1924 (partial per-job model apply slice)

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`