### PR TITLE
refactor(adapters): extract adapter glue kit (#1931)

### DIFF
--- a/src/factory/adapters/discord/adapter.py
+++ b/src/factory/adapters/discord/adapter.py
@@ -7,11 +7,8 @@ import re
 from collections.abc import AsyncIterator
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
-from uuid import uuid4
 
 import discord
-
-from factory.core.trace import TraceContext
 
 if TYPE_CHECKING:
     from factory.adapters.shared.outbound_listener import OutboundListener
@@ -24,6 +21,8 @@ if TYPE_CHECKING:
 from factory.adapters.discord import discord_audio  # noqa: I001 — DEBT:module-level-patch-fixtures
 from factory.adapters.discord import discord_audio_outbound
 from factory.adapters.shared._shared import TypingTaskManager, resolve_msg
+from factory.adapters.shared.platform_meta import cancel_typing_for_inbound
+from factory.adapters.shared.typing_shim import cancel_typing_shim, start_typing_shim
 from factory.typing import make_typing_factory
 from factory.adapters.discord.discord_inbound import handle_message
 from factory.adapters.discord.discord_normalize import (
@@ -49,7 +48,6 @@ from factory.core.lifecycle.circuit_breaker import CircuitRegistry
 from factory.core.auth.guard import BlockedGuard, GuardChain
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import (
-    DiscordMeta,
     InboundMessage,
     OutboundAttachment,
     OutboundAudio,
@@ -62,9 +60,7 @@ log = logging.getLogger(__name__)
 
 
 # ── Typing plane (#1376) — module-level resolver for AC8 ─────────────────
-from factory.transport.typing_publisher import is_typing_enabled  # noqa: E402
 from factory.transport.work_scope import WorkScope  # noqa: E402
-from factory.typing.listener import typing_publisher_shim  # noqa: E402
 
 
 def _discord_scope_resolver(scope: WorkScope) -> int:
@@ -147,39 +143,26 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         return self._typing._tasks
 
     def _start_typing(self, scope_id: int) -> None:
-        publisher = getattr(self, "_typing_publisher", None)
-        if publisher is not None and typing_publisher_shim(
-            "discord",
-            self._bot_id,
-            scope_id,
-            publisher,
-            publisher.publish_started,
-            trace_id=TraceContext.get_trace_id() or uuid4().hex,
-        ):
-            return
-        if is_typing_enabled():
-            return  # pub/sub active but publisher absent → intentional no-op
-        self._typing.start(scope_id, self._factory_builder(scope_id))
+        start_typing_shim(
+            platform="discord",
+            bot_id=self._bot_id,
+            scope_id=scope_id,
+            typing_manager=self._typing,
+            factory_builder=self._factory_builder,
+            typing_publisher=getattr(self, "_typing_publisher", None),
+        )
 
     def _cancel_typing(self, scope_id: int) -> None:
-        publisher = getattr(self, "_typing_publisher", None)
-        if publisher is not None and typing_publisher_shim(
-            "discord",
-            self._bot_id,
-            scope_id,
-            publisher,
-            publisher.publish_ended,
-            trace_id=TraceContext.get_trace_id() or uuid4().hex,
-        ):
-            return
-        if is_typing_enabled():
-            return  # pub/sub active but publisher absent → intentional no-op
-        self._typing.cancel(scope_id)
+        cancel_typing_shim(
+            platform="discord",
+            bot_id=self._bot_id,
+            scope_id=scope_id,
+            typing_manager=self._typing,
+            typing_publisher=getattr(self, "_typing_publisher", None),
+        )
 
     def _cancel_typing_for(self, inbound: InboundMessage) -> None:
-        pm = inbound.platform_meta
-        if isinstance(pm, DiscordMeta):
-            self._cancel_typing(pm.thread_id or pm.channel_id)
+        cancel_typing_for_inbound(self, inbound)
 
     async def astart(self) -> None:
         if self._outbound_listener is not None:

--- a/src/factory/adapters/discord/discord_audio.py
+++ b/src/factory/adapters/discord/discord_audio.py
@@ -120,7 +120,7 @@ def normalize_audio(  # noqa: PLR0913 — additive signature (audio_bytes, mime_
     )
 
 
-async def handle_audio(  # noqa: C901 — DEBT:wiring-bootstrap-deps
+async def handle_audio(  # noqa: C901, PLR0915 — DEBT:wiring-bootstrap-deps
     adapter: "DiscordAdapter",
     message: Any,
     audio_attachment: Any,
@@ -255,10 +255,13 @@ async def handle_audio(  # noqa: C901 — DEBT:wiring-bootstrap-deps
     from factory.adapters.discord import (
         discord_inbound,  # noqa: PLC0415 — local import avoids module-level circular dep
     )
-
-    inbound_ctx = discord_inbound.build_discord_inbound_ctx(
-        adapter, ingest=adapter._ingest_ctx
+    from factory.adapters.shared.inbound_context import build_discord_inbound_ctx
+    from factory.adapters.shared.inbound_pipeline import (
+        get_inbound_pipeline_kit,
+        run_inbound_guarded,
     )
+
+    inbound_ctx = build_discord_inbound_ctx(adapter, ingest=adapter._ingest_ctx)
 
     pre_route = functools.partial(
         discord_inbound._discord_pre_route_hook, adapter=adapter
@@ -272,13 +275,20 @@ async def handle_audio(  # noqa: C901 — DEBT:wiring-bootstrap-deps
     async def _send_bp(text: str) -> None:
         await message.reply(text)
 
+    async def _noop_ingest_error(_exc: object) -> None:
+        return
+
     adapter._start_typing(message.channel.id)
-    await discord_inbound._pipeline.run(
-        adapter.normalize_audio(
+    kit = get_inbound_pipeline_kit()
+    await run_inbound_guarded(
+        pipeline=kit.pipeline,
+        raw_message=adapter.normalize_audio(
             message, audio_bytes, mime_type, trust_level=trust, pending=pending
         ),
-        inbound_ctx,
-        PrebuiltParser(),
+        inbound_ctx=inbound_ctx,
+        parser=PrebuiltParser(),
+        log_context=f"discord audio message id={message.id}",
+        on_attachment_ingest_error=_noop_ingest_error,
         pre_route_hook=pre_route,
         pre_session_hook=pre_session,
         send_backpressure=_send_bp,

--- a/src/factory/adapters/discord/discord_inbound.py
+++ b/src/factory/adapters/discord/discord_inbound.py
@@ -15,64 +15,25 @@ from factory.adapters.discord.discord_audio import handle_audio as _handle_audio
 from factory.adapters.discord.discord_formatting import make_thread_name
 from factory.adapters.discord.discord_threads import persist_thread_claim
 from factory.adapters.shared._shared import AUDIO_MIME_TYPES
+from factory.adapters.shared.inbound_context import build_discord_inbound_ctx
+from factory.adapters.shared.inbound_pipeline import (
+    get_inbound_pipeline_kit,
+    get_or_create_parser,
+    run_inbound_guarded,
+)
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import DiscordMeta, InboundMessage
 from factory.inbound.attachment_ingest import (
     MAX_ATTACHMENT_INGEST_BYTES,
     AttachmentIngestError,
-    AttachmentIngestStage,
 )
-from factory.inbound.context import DispatchCtx, InboundContext, RouterCtx, SessionCtx
-from factory.inbound.dispatcher import Dispatcher
-from factory.inbound.pipeline import InboundPipeline
-from factory.inbound.router import Router
-from factory.inbound.session_builder import SessionBuilder
+from factory.inbound.context import InboundContext
 from factory.inbound.wire_parser_discord import DiscordWireParser
 
 if TYPE_CHECKING:
     from factory.adapters.discord import DiscordAdapter
 
 log = logging.getLogger("factory.adapters.discord")
-
-_dispatcher = Dispatcher()
-_router = Router()
-_session_builder = SessionBuilder()
-_pipeline = InboundPipeline(
-    router=_router,
-    session_builder=_session_builder,
-    dispatcher=_dispatcher,
-    ingest_stage=AttachmentIngestStage(),
-)
-# Adapters are process-singletons created at bootstrap; id-keying is safe for
-# this lifecycle (no GC + id-reuse window). Revisit when bootstrap DI lands (#1283).
-_parser_cache: dict[int, DiscordWireParser] = {}  # one parser per adapter instance
-
-
-def build_discord_inbound_ctx(
-    adapter: "DiscordAdapter",
-    *,
-    ingest: Any = None,
-) -> InboundContext:
-    """Shared InboundContext builder for text path (ingest=None) and audio path."""
-    return InboundContext(
-        router=RouterCtx(
-            bot_id=adapter._bot_id,
-            owned_threads=adapter._owned_threads,
-            watch_channels=adapter._watch_channels if adapter._watch_channels else None,
-        ),
-        session=SessionCtx(
-            turn_store=None,
-            thread_store=adapter._thread_store,
-        ),
-        dispatch=DispatchCtx(
-            inbound_bus=adapter._inbound_bus,
-            circuit_registry=adapter._circuit_registry,
-            outbound_listener=adapter._outbound_listener,
-            typing=adapter._typing,
-            msg_catalog=adapter._msg_manager,
-        ),
-        ingest=ingest,
-    )
 
 
 async def _discord_pre_route_hook(
@@ -256,10 +217,14 @@ async def _discord_pre_session_hook(
     return msg
 
 
-async def _warn_oversize_reply(message: Any) -> None:
-    """Send oversize warning reply, swallowing HTTP errors."""
+async def _warn_oversize_reply(adapter: "DiscordAdapter", message: Any) -> None:
+    """Send oversize warning reply via i18n catalog, swallowing HTTP errors."""
+    text = adapter._msg(
+        "attachment_too_large",
+        "That file is too large to process.",
+    )
     try:
-        await message.reply("That file is too large to process.")
+        await message.reply(text)
     except discord.HTTPException:
         log.warning(
             "Failed to send oversize reply for message id=%s",
@@ -273,17 +238,9 @@ async def _run_pipeline_guarded(
     message: Any,
     send_to_id: int,
 ) -> None:
-    """Run InboundPipeline with the always-return boundary (#5).
-
-    Extracted to keep handle_message below C901 complexity=10.
-    The broad except must NOT be removed — any unhandled error must NOT
-    propagate to discord.py or it crashes the gateway connection,
-    triggering a reconnect loop.  (#5)
-    """
-    parser = _parser_cache.get(id(adapter))
-    if parser is None:
-        parser = DiscordWireParser(adapter)
-        _parser_cache[id(adapter)] = parser
+    """Run InboundPipeline with the always-return boundary (#5)."""
+    kit = get_inbound_pipeline_kit()
+    parser = get_or_create_parser(kit.parser_cache, adapter, DiscordWireParser)
 
     _ingest = getattr(adapter, "_ingest_ctx", None)
     inbound_ctx = build_discord_inbound_ctx(adapter, ingest=_ingest)
@@ -296,24 +253,21 @@ async def _run_pipeline_guarded(
     async def _dc_backpressure(text: str) -> None:
         await message.reply(text)
 
-    try:
-        await _pipeline.run(
-            message,
-            inbound_ctx,
-            parser,
-            pre_route_hook=pre_route,
-            pre_session_hook=pre_session,
-            send_backpressure=_dc_backpressure,
-            on_drop=lambda: adapter._cancel_typing(send_to_id),
-        )
-    except AttachmentIngestError as e:
-        await message.reply(e.user_message)
-    except Exception:  # always-return boundary (#5): unhandled errors must not
-        # reach discord.py — that would crash the gateway → reconnect loop.
-        log.exception(
-            "Unhandled exception in handle_message for message id=%s",
-            message.id,
-        )
+    async def _on_ingest_error(exc: AttachmentIngestError) -> None:
+        await message.reply(exc.user_message)
+
+    await run_inbound_guarded(
+        pipeline=kit.pipeline,
+        raw_message=message,
+        inbound_ctx=inbound_ctx,
+        parser=parser,
+        log_context=f"discord message id={message.id}",
+        on_attachment_ingest_error=_on_ingest_error,
+        pre_route_hook=pre_route,
+        pre_session_hook=pre_session,
+        send_backpressure=_dc_backpressure,
+        on_drop=lambda: adapter._cancel_typing(send_to_id),
+    )
 
 
 async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:
@@ -351,7 +305,7 @@ async def handle_message(adapter: "DiscordAdapter", message: Any) -> None:
         if (getattr(a, "size", None) or 0) > MAX_ATTACHMENT_INGEST_BYTES
     )
     if oversize_count:
-        await _warn_oversize_reply(message)
+        await _warn_oversize_reply(adapter, message)
     if (
         oversize_count
         and oversize_count == len(raw_atts)

--- a/src/factory/adapters/nats/_constants.py
+++ b/src/factory/adapters/nats/_constants.py
@@ -1,0 +1,8 @@
+"""Shared NATS adapter constants (#1931)."""
+
+from __future__ import annotations
+
+MAX_STREAMS = 100
+MAX_QUEUE_SIZE = 256
+MAX_TERMINATED_STREAMS = 500
+SUBSCRIBE_SUBJECT_MINT_FAILURE = "factory.gh.mint_failure.>"

--- a/src/factory/adapters/nats/mint_failure_subscriber.py
+++ b/src/factory/adapters/nats/mint_failure_subscriber.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from factory.adapters.nats._constants import SUBSCRIBE_SUBJECT_MINT_FAILURE
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import (
     InboundMessage,
@@ -27,8 +28,6 @@ from roxabi_contracts.gh.models import MintFailureEvent
 from roxabi_nats._serialize import serialize
 
 log = logging.getLogger(__name__)
-
-_SUBSCRIBE_SUBJECT = "factory.gh.mint_failure.>"
 
 
 class MintFailureSubscriber:
@@ -54,10 +53,12 @@ class MintFailureSubscriber:
 
     async def start(self) -> None:
         """Subscribe to factory.gh.mint_failure.> on the hub NATS connection."""
-        self._sub = await self._nc.subscribe(_SUBSCRIBE_SUBJECT, cb=self._handle)
+        self._sub = await self._nc.subscribe(
+            SUBSCRIBE_SUBJECT_MINT_FAILURE, cb=self._handle
+        )
         log.info(
             "MintFailureSubscriber started — subject=%r ops_chat=%d bot=%r",
-            _SUBSCRIBE_SUBJECT,
+            SUBSCRIBE_SUBJECT_MINT_FAILURE,
             self._ops_telegram_chat_id,
             self._ops_telegram_bot_id,
         )

--- a/src/factory/adapters/nats/nats_envelope_handlers.py
+++ b/src/factory/adapters/nats/nats_envelope_handlers.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from nats.aio.msg import Msg
 
+from factory.adapters.nats._constants import MAX_QUEUE_SIZE, MAX_STREAMS
 from factory.core.messaging.message import (
     SCHEMA_VERSION_OUTBOUND_MESSAGE,
     OutboundAttachment,
@@ -28,9 +29,6 @@ if TYPE_CHECKING:
     from factory.adapters.nats.nats_outbound_listener import NatsOutboundListener
 
 log = logging.getLogger(__name__)
-
-_MAX_STREAMS = 100
-_MAX_QUEUE_SIZE = 256
 
 
 async def handle_send(
@@ -124,11 +122,11 @@ def handle_stream_start(
         return
     if not _check_outbound_version(listener, outbound_data, "OutboundMessage"):
         return
-    if len(listener._stream_outbound) >= _MAX_STREAMS:
+    if len(listener._stream_outbound) >= MAX_STREAMS:
         log.warning(
             "NatsOutboundListener: _stream_outbound full"
             " (%d entries), dropping stream_id=%r",
-            _MAX_STREAMS,
+            MAX_STREAMS,
             stream_id,
         )
         return
@@ -136,7 +134,7 @@ def handle_stream_start(
         listener._stream_outbound[stream_id] = _deserialize_dict(
             outbound_data, OutboundMessage, resolver=resolver
         )
-        raw_orig = data.get("original_msg")  # bounded by _MAX_STREAMS guard above
+        raw_orig = data.get("original_msg")  # bounded by MAX_STREAMS guard above
         if raw_orig is not None:
             listener._stream_original_msgs[stream_id] = raw_orig
     except (ValueError, TypeError):
@@ -155,18 +153,18 @@ async def handle_chunk(listener: "NatsOutboundListener", data: dict) -> None:
             stream_id,
         )
         return
-    at_limit = len(listener._stream_tasks) >= _MAX_STREAMS
+    at_limit = len(listener._stream_tasks) >= MAX_STREAMS
     if stream_id not in listener._stream_tasks and at_limit:
         log.warning(
             "NatsOutboundListener: _stream_tasks full"
             " (%d streams), dropping stream_id=%r",
-            _MAX_STREAMS,
+            MAX_STREAMS,
             stream_id,
         )
         return
     q = listener._stream_queues.setdefault(
         stream_id,
-        asyncio.Queue(maxsize=_MAX_QUEUE_SIZE),
+        asyncio.Queue(maxsize=MAX_QUEUE_SIZE),
     )
     if stream_id in listener._cache:
         listener._cache.touch(stream_id)

--- a/src/factory/adapters/nats/nats_outbound_listener.py
+++ b/src/factory/adapters/nats/nats_outbound_listener.py
@@ -33,9 +33,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_MAX_STREAMS = 100
-_MAX_QUEUE_SIZE = 256
-
 
 @dataclass(frozen=True)
 class ListenerDeps:

--- a/src/factory/adapters/nats/nats_stream_decoder.py
+++ b/src/factory/adapters/nats/nats_stream_decoder.py
@@ -19,6 +19,7 @@ import time
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
+from factory.adapters.nats._constants import MAX_TERMINATED_STREAMS
 from factory.core.exceptions import HubUnavailableError, StreamChunkTimeout
 
 if TYPE_CHECKING:
@@ -29,7 +30,6 @@ log = logging.getLogger(__name__)
 
 _CHUNK_TIMEOUT_SECONDS = 120.0
 _LIVENESS_POLL_SECONDS = 5.0
-_MAX_TERMINATED_STREAMS = 500
 
 
 async def _wait_for_chunk(
@@ -164,7 +164,7 @@ def remember_terminated(listener: Any, stream_id: str) -> None:
     timestamp *and* the insertion order so FIFO eviction reflects recency.
     """
     listener._terminated_streams.pop(stream_id, None)
-    if len(listener._terminated_streams) >= _MAX_TERMINATED_STREAMS:
+    if len(listener._terminated_streams) >= MAX_TERMINATED_STREAMS:
         listener._terminated_streams.popitem(last=False)
     listener._terminated_streams[stream_id] = time.monotonic()
 

--- a/src/factory/adapters/shared/inbound_context.py
+++ b/src/factory/adapters/shared/inbound_context.py
@@ -1,0 +1,65 @@
+"""Shared InboundContext builders for platform adapters (#1931)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from factory.inbound.context import DispatchCtx, InboundContext, RouterCtx, SessionCtx
+
+if TYPE_CHECKING:
+    from factory.adapters.discord import DiscordAdapter
+    from factory.adapters.telegram import TelegramAdapter
+
+
+def build_telegram_inbound_ctx(
+    adapter: "TelegramAdapter",
+    *,
+    ingest: Any = None,
+) -> InboundContext:
+    """InboundContext for Telegram text and voice paths."""
+    return InboundContext(
+        router=RouterCtx(
+            bot_id=adapter._bot_id,
+            owned_threads=set(),  # Telegram has no thread model; Router only reads
+            watch_channels=None,
+        ),
+        session=SessionCtx(
+            turn_store=None,
+            thread_store=None,  # Telegram has no thread model
+        ),
+        dispatch=DispatchCtx(
+            inbound_bus=adapter._inbound_bus,
+            circuit_registry=adapter._circuit_registry,
+            outbound_listener=adapter._outbound_listener,
+            typing=adapter._typing,
+            msg_catalog=adapter._msg_manager,
+        ),
+        ingest=ingest,
+    )
+
+
+def build_discord_inbound_ctx(
+    adapter: "DiscordAdapter",
+    *,
+    ingest: Any = None,
+) -> InboundContext:
+    """InboundContext for Discord text and audio paths."""
+    return InboundContext(
+        router=RouterCtx(
+            bot_id=adapter._bot_id,
+            owned_threads=adapter._owned_threads,
+            watch_channels=adapter._watch_channels if adapter._watch_channels else None,
+        ),
+        session=SessionCtx(
+            turn_store=None,
+            thread_store=adapter._thread_store,
+        ),
+        dispatch=DispatchCtx(
+            inbound_bus=adapter._inbound_bus,
+            circuit_registry=adapter._circuit_registry,
+            outbound_listener=adapter._outbound_listener,
+            typing=adapter._typing,
+            msg_catalog=adapter._msg_manager,
+        ),
+        ingest=ingest,
+    )

--- a/src/factory/adapters/shared/inbound_pipeline.py
+++ b/src/factory/adapters/shared/inbound_pipeline.py
@@ -1,0 +1,111 @@
+"""Shared inbound pipeline kit — resettable singleton + guarded runner (#1931)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+from factory.inbound.attachment_ingest import (
+    AttachmentIngestError,
+    AttachmentIngestStage,
+)
+from factory.inbound.context import InboundContext
+from factory.inbound.dispatcher import Dispatcher
+from factory.inbound.pipeline import InboundPipeline
+from factory.inbound.router import Router
+from factory.inbound.session_builder import SessionBuilder
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass
+class InboundPipelineKit:
+    """Process-singleton inbound stages + per-adapter parser cache."""
+
+    pipeline: InboundPipeline
+    parser_cache: dict[int, Any] = field(default_factory=dict)
+
+    def reset(self) -> None:
+        """Clear parser cache — for tests; pipeline stages are reused."""
+        self.parser_cache.clear()
+
+
+_kit: InboundPipelineKit | None = None
+
+
+def _build_default_pipeline() -> InboundPipeline:
+    dispatcher = Dispatcher()
+    router = Router()
+    session_builder = SessionBuilder()
+    return InboundPipeline(
+        router=router,
+        session_builder=session_builder,
+        dispatcher=dispatcher,
+        ingest_stage=AttachmentIngestStage(),
+    )
+
+
+def get_inbound_pipeline_kit() -> InboundPipelineKit:
+    """Return the process-singleton kit, creating it on first access."""
+    global _kit
+    if _kit is None:
+        _kit = InboundPipelineKit(pipeline=_build_default_pipeline())
+    return _kit
+
+
+def reset_inbound_pipeline_kit() -> None:
+    """Drop the singleton — for tests that need a fresh parser cache."""
+    global _kit
+    _kit = None
+
+
+def get_or_create_parser(
+    cache: dict[int, T],
+    adapter: Any,
+    factory: Callable[[Any], T],
+) -> T:
+    """Per-adapter wire parser cache keyed by adapter object id."""
+    key = id(adapter)
+    parser = cache.get(key)
+    if parser is None:
+        parser = factory(adapter)
+        cache[key] = parser
+    return parser
+
+
+async def run_inbound_guarded(  # noqa: PLR0913 — pipeline.run kwargs surface as explicit params
+    *,
+    pipeline: InboundPipeline,
+    raw_message: Any,
+    inbound_ctx: InboundContext,
+    parser: Any,
+    log_context: str,
+    on_attachment_ingest_error: Callable[[AttachmentIngestError], Awaitable[None]],
+    pre_route_hook: Callable[..., Awaitable[None]] | None = None,
+    pre_session_hook: Callable[..., Awaitable[Any]] | None = None,
+    send_backpressure: Callable[[str], Awaitable[None]],
+    on_drop: Callable[[], None] | None = None,
+) -> None:
+    """Run InboundPipeline with the always-return boundary.
+
+    The broad except must NOT be removed — unhandled errors must NOT propagate
+    to platform SDK event loops (discord.py gateway, aiogram webhook retries).
+    """
+    try:
+        await pipeline.run(
+            raw_message,
+            inbound_ctx,
+            parser,
+            pre_route_hook=pre_route_hook,
+            pre_session_hook=pre_session_hook,
+            send_backpressure=send_backpressure,
+            on_drop=on_drop,
+        )
+    except AttachmentIngestError as exc:
+        await on_attachment_ingest_error(exc)
+    except Exception:
+        log.exception("Unhandled exception in inbound pipeline (%s)", log_context)

--- a/src/factory/adapters/shared/platform_meta.py
+++ b/src/factory/adapters/shared/platform_meta.py
@@ -1,0 +1,19 @@
+"""Platform-meta helpers for adapter typing scope resolution (#1931)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from factory.core.messaging.message import DiscordMeta, InboundMessage, TelegramMeta
+
+if TYPE_CHECKING:
+    pass
+
+
+def cancel_typing_for_inbound(adapter: Any, inbound: InboundMessage) -> None:
+    """Cancel typing indicator using platform_meta routing fields."""
+    pm = inbound.platform_meta
+    if isinstance(pm, DiscordMeta):
+        adapter._cancel_typing(pm.thread_id or pm.channel_id)
+    elif isinstance(pm, TelegramMeta):
+        adapter._cancel_typing(pm.chat_id)

--- a/src/factory/adapters/shared/typing_shim.py
+++ b/src/factory/adapters/shared/typing_shim.py
@@ -1,0 +1,58 @@
+"""Adapter-side typing shim — pub/sub vs legacy TypingTaskManager (#1931)."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from factory.core.trace import TraceContext
+from factory.transport.typing_publisher import is_typing_enabled
+from factory.typing.listener import typing_publisher_shim
+from factory.typing.types import FactoryBuilder
+
+
+def start_typing_shim(  # noqa: PLR0913 — mirrors typing_publisher_shim arity (#1377)
+    *,
+    platform: str,
+    bot_id: str,
+    scope_id: int,
+    typing_manager: Any,
+    factory_builder: FactoryBuilder,
+    typing_publisher: Any | None,
+) -> None:
+    """Start typing — pub/sub path when enabled, else legacy TypingTaskManager."""
+    if typing_publisher is not None and typing_publisher_shim(
+        platform,
+        bot_id,
+        scope_id,
+        typing_publisher,
+        typing_publisher.publish_started,
+        trace_id=TraceContext.get_trace_id() or uuid4().hex,
+    ):
+        return
+    if is_typing_enabled():
+        return  # pub/sub active but publisher absent → intentional no-op
+    typing_manager.start(scope_id, factory_builder(scope_id))
+
+
+def cancel_typing_shim(
+    *,
+    platform: str,
+    bot_id: str,
+    scope_id: int,
+    typing_manager: Any,
+    typing_publisher: Any | None,
+) -> None:
+    """Cancel typing — pub/sub path when enabled, else legacy TypingTaskManager."""
+    if typing_publisher is not None and typing_publisher_shim(
+        platform,
+        bot_id,
+        scope_id,
+        typing_publisher,
+        typing_publisher.publish_ended,
+        trace_id=TraceContext.get_trace_id() or uuid4().hex,
+    ):
+        return
+    if is_typing_enabled():
+        return  # pub/sub active but publisher absent → intentional no-op
+    typing_manager.cancel(scope_id)

--- a/src/factory/adapters/telegram/telegram.py
+++ b/src/factory/adapters/telegram/telegram.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 from factory.adapters.telegram import telegram_audio  # noqa: I001 — DEBT:lint-residual
 from factory.adapters.shared._base_outbound import OutboundAdapterBase
 from factory.adapters.shared._shared import TypingTaskManager, resolve_msg
+from factory.adapters.shared.typing_shim import cancel_typing_shim, start_typing_shim
 from factory.typing import make_typing_factory
 from factory.adapters.telegram.telegram_guard import _make_verifier
 from factory.adapters.telegram.telegram_inbound import (
@@ -49,16 +50,12 @@ from factory.core.messaging.message import (
     OutboundMessage,
 )
 from factory.core.messaging.messages import MessageManager
-from factory.core.trace import TraceContext
-from uuid import uuid4
 
 log = logging.getLogger(__name__)
 
 
 # ── Typing plane (#1376) — module-level resolver for AC8 ─────────────────
-from factory.transport.typing_publisher import is_typing_enabled  # noqa: E402
 from factory.transport.work_scope import WorkScope  # noqa: E402
-from factory.typing.listener import typing_publisher_shim  # noqa: E402
 
 
 def _telegram_scope_resolver(scope: WorkScope) -> int:
@@ -203,34 +200,23 @@ class TelegramAdapter(OutboundAdapterBase):
         return _typing_worker(self.bot, chat_id)
 
     def _start_typing(self, scope_id: int) -> None:
-        publisher = getattr(self, "_typing_publisher", None)
-        if publisher is not None and typing_publisher_shim(
-            "telegram",
-            self._bot_id,
-            scope_id,
-            publisher,
-            publisher.publish_started,
-            trace_id=TraceContext.get_trace_id() or uuid4().hex,
-        ):
-            return
-        if is_typing_enabled():
-            return  # pub/sub active but publisher absent → intentional no-op
-        self._typing.start(scope_id, self._factory_builder(scope_id))
+        start_typing_shim(
+            platform="telegram",
+            bot_id=self._bot_id,
+            scope_id=scope_id,
+            typing_manager=self._typing,
+            factory_builder=self._factory_builder,
+            typing_publisher=getattr(self, "_typing_publisher", None),
+        )
 
     def _cancel_typing(self, scope_id: int) -> None:
-        publisher = getattr(self, "_typing_publisher", None)
-        if publisher is not None and typing_publisher_shim(
-            "telegram",
-            self._bot_id,
-            scope_id,
-            publisher,
-            publisher.publish_ended,
-            trace_id=TraceContext.get_trace_id() or uuid4().hex,
-        ):
-            return
-        if is_typing_enabled():
-            return  # pub/sub active but publisher absent → intentional no-op
-        self._typing.cancel(scope_id)
+        cancel_typing_shim(
+            platform="telegram",
+            bot_id=self._bot_id,
+            scope_id=scope_id,
+            typing_manager=self._typing,
+            typing_publisher=getattr(self, "_typing_publisher", None),
+        )
 
     async def astart(self) -> None:
         if self._outbound_listener is not None:

--- a/src/factory/adapters/telegram/telegram_inbound.py
+++ b/src/factory/adapters/telegram/telegram_inbound.py
@@ -7,40 +7,24 @@ from typing import TYPE_CHECKING, Any
 
 from aiogram.exceptions import TelegramAPIError
 
+from factory.adapters.shared.inbound_context import build_telegram_inbound_ctx
+from factory.adapters.shared.inbound_pipeline import (
+    get_inbound_pipeline_kit,
+    get_or_create_parser,
+    run_inbound_guarded,
+)
 from factory.adapters.telegram.telegram_audio import _download_audio
 from factory.adapters.telegram.telegram_formatting import _make_send_kwargs
 from factory.adapters.telegram.telegram_normalize import _make_scope_id, normalize_audio
 from factory.core.auth.trust import TrustLevel
-from factory.inbound.attachment_ingest import (
-    AttachmentIngestError,
-    AttachmentIngestStage,
-    PendingAttachment,
-)
-from factory.inbound.context import DispatchCtx, InboundContext, RouterCtx, SessionCtx
-from factory.inbound.dispatcher import Dispatcher
-from factory.inbound.pipeline import InboundPipeline
+from factory.inbound.attachment_ingest import AttachmentIngestError, PendingAttachment
 from factory.inbound.prebuilt_parser import PrebuiltParser
-from factory.inbound.router import Router
-from factory.inbound.session_builder import SessionBuilder
 from factory.inbound.wire_parser_telegram import TelegramWireParser
 
 if TYPE_CHECKING:
     from factory.adapters.telegram import TelegramAdapter
 
 log = logging.getLogger("factory.adapters.telegram")
-
-_dispatcher = Dispatcher()
-_router = Router()
-_session_builder = SessionBuilder()
-_pipeline = InboundPipeline(
-    router=_router,
-    session_builder=_session_builder,
-    dispatcher=_dispatcher,
-    ingest_stage=AttachmentIngestStage(),
-)
-# Adapters are process-singletons created at bootstrap; id-keying is safe for
-# this lifecycle (no GC + id-reuse window). Revisit when bootstrap DI lands (#1283).
-_parser_cache: dict[int, TelegramWireParser] = {}  # one parser per adapter instance
 
 
 def _expected_media_count(msg: Any) -> int:
@@ -96,31 +80,9 @@ async def handle_message(adapter: "TelegramAdapter", msg: Any) -> None:
     # the update indefinitely.
     adapter._start_typing(msg.chat.id)
 
-    # Per-adapter parser — avoid recreating each message.
-    parser = _parser_cache.get(id(adapter))
-    if parser is None:
-        parser = TelegramWireParser(adapter)
-        _parser_cache[id(adapter)] = parser
-
-    inbound_ctx = InboundContext(
-        router=RouterCtx(
-            bot_id=adapter._bot_id,
-            owned_threads=set(),  # Telegram has no thread model; Router only reads
-            watch_channels=None,
-        ),
-        session=SessionCtx(
-            turn_store=None,
-            thread_store=None,  # Telegram has no thread model
-        ),
-        dispatch=DispatchCtx(
-            inbound_bus=adapter._inbound_bus,
-            circuit_registry=adapter._circuit_registry,
-            outbound_listener=adapter._outbound_listener,
-            typing=adapter._typing,
-            msg_catalog=adapter._msg_manager,
-        ),
-        ingest=adapter._ingest_ctx,
-    )
+    kit = get_inbound_pipeline_kit()
+    parser = get_or_create_parser(kit.parser_cache, adapter, TelegramWireParser)
+    inbound_ctx = build_telegram_inbound_ctx(adapter, ingest=adapter._ingest_ctx)
 
     # Pre-parse to detect oversize-attachment filtering (T6/T7, #1561).
     parsed = parser.parse(msg, inbound_ctx)
@@ -137,31 +99,27 @@ async def handle_message(adapter: "TelegramAdapter", msg: Any) -> None:
     async def _tg_backpressure(text: str) -> None:
         await adapter.bot.send_message(msg.chat.id, text)
 
-    try:
-        await _pipeline.run(
-            msg,
-            inbound_ctx,
-            parser,
-            send_backpressure=_tg_backpressure,
-            on_drop=lambda: adapter._cancel_typing(msg.chat.id),
-        )
-    except AttachmentIngestError as e:
+    async def _on_ingest_error(exc: AttachmentIngestError) -> None:
         try:
             await adapter.bot.send_message(
-                **_make_send_kwargs(msg.chat.id, e.user_message, msg.message_id)
+                **_make_send_kwargs(msg.chat.id, exc.user_message, msg.message_id)
             )
         except TelegramAPIError:
             log.warning(
                 "Failed to send attachment-too-large reply for chat_id=%s",
                 msg.chat.id,
             )
-        return
-    except Exception:  # always-return boundary (#4): unhandled errors must not
-        # reach aiogram — Telegram would retry the update indefinitely.
-        log.exception(
-            "Unhandled exception in handle_message for chat_id=%s",
-            msg.chat.id,
-        )
+
+    await run_inbound_guarded(
+        pipeline=kit.pipeline,
+        raw_message=msg,
+        inbound_ctx=inbound_ctx,
+        parser=parser,
+        log_context=f"telegram chat_id={msg.chat.id}",
+        on_attachment_ingest_error=_on_ingest_error,
+        send_backpressure=_tg_backpressure,
+        on_drop=lambda: adapter._cancel_typing(msg.chat.id),
+    )
 
 
 async def handle_voice_message(adapter: "TelegramAdapter", msg: Any) -> None:  # noqa: C901
@@ -274,41 +232,23 @@ async def handle_voice_message(adapter: "TelegramAdapter", msg: Any) -> None:  #
 
     adapter._start_typing(chat_id)
 
-    inbound_ctx = InboundContext(
-        router=RouterCtx(
-            bot_id=adapter._bot_id,
-            owned_threads=set(),  # Telegram has no thread model
-            watch_channels=None,
-        ),
-        session=SessionCtx(
-            turn_store=None,
-            thread_store=None,  # Telegram has no thread model
-        ),
-        dispatch=DispatchCtx(
-            inbound_bus=adapter._inbound_bus,
-            circuit_registry=adapter._circuit_registry,
-            outbound_listener=adapter._outbound_listener,
-            typing=adapter._typing,
-            msg_catalog=adapter._msg_manager,
-        ),
-        ingest=adapter._ingest_ctx,
-    )
+    inbound_ctx = build_telegram_inbound_ctx(adapter, ingest=adapter._ingest_ctx)
+    kit = get_inbound_pipeline_kit()
 
     async def _send_bp(text: str) -> None:
         await adapter.bot.send_message(**_make_send_kwargs(chat_id, text, message_id))
 
-    try:
-        await _pipeline.run(
-            hub_audio,
-            inbound_ctx,
-            PrebuiltParser(),
-            send_backpressure=_send_bp,
-            on_drop=lambda: adapter._cancel_typing(chat_id),
-        )
-    except Exception:  # always-return boundary (#4): unhandled errors must not
-        # reach aiogram — Telegram would retry the update indefinitely.
-        log.exception(
-            "Unhandled exception in handle_voice_message for chat_id=%s user_id=%s",
-            chat_id,
-            user_id,
-        )
+    await run_inbound_guarded(
+        pipeline=kit.pipeline,
+        raw_message=hub_audio,
+        inbound_ctx=inbound_ctx,
+        parser=PrebuiltParser(),
+        log_context=f"telegram voice chat_id={chat_id} user_id={user_id}",
+        on_attachment_ingest_error=_noop_ingest_error,
+        send_backpressure=_send_bp,
+        on_drop=lambda: adapter._cancel_typing(chat_id),
+    )
+
+
+async def _noop_ingest_error(_exc: AttachmentIngestError) -> None:
+    """Voice path uses pre-built hub_audio — ingest errors are not expected."""

--- a/tests/adapters/discord/test_discord_nonaudio_ingest.py
+++ b/tests/adapters/discord/test_discord_nonaudio_ingest.py
@@ -208,7 +208,9 @@ async def test_dc_multi_attachment_pipeline_stamps_all_blob_refs() -> None:
     mock_dispatcher = MagicMock()
     mock_dispatcher.dispatch = _capture_dispatch
 
-    with patch("factory.adapters.discord.discord_inbound._pipeline") as mock_pipeline:
+    with patch(
+        "factory.adapters.discord.discord_inbound.get_inbound_pipeline_kit"
+    ) as mock_get_kit:
         from factory.inbound.attachment_ingest import AttachmentIngestStage
         from factory.inbound.pipeline import InboundPipeline
         from factory.inbound.router import Router
@@ -220,7 +222,10 @@ async def test_dc_multi_attachment_pipeline_stamps_all_blob_refs() -> None:
             dispatcher=mock_dispatcher,  # type: ignore[arg-type]
             ingest_stage=AttachmentIngestStage(),
         )
-        mock_pipeline.run = real_pipeline.run
+        mock_kit = MagicMock()
+        mock_kit.parser_cache = {}
+        mock_kit.pipeline = real_pipeline
+        mock_get_kit.return_value = mock_kit
 
         await handle_message(adapter, raw)
 
@@ -279,7 +284,9 @@ async def test_dc_oversize_attachment_reply_no_hub_push() -> None:
     mock_dispatcher = MagicMock()
     mock_dispatcher.dispatch = _capture_dispatch
 
-    with patch("factory.adapters.discord.discord_inbound._pipeline") as mock_pipeline:
+    with patch(
+        "factory.adapters.discord.discord_inbound.get_inbound_pipeline_kit"
+    ) as mock_get_kit:
         from factory.inbound.attachment_ingest import AttachmentIngestStage
         from factory.inbound.pipeline import InboundPipeline
         from factory.inbound.router import Router
@@ -291,7 +298,10 @@ async def test_dc_oversize_attachment_reply_no_hub_push() -> None:
             dispatcher=mock_dispatcher,  # type: ignore[arg-type]
             ingest_stage=AttachmentIngestStage(),
         )
-        mock_pipeline.run = real_pipeline.run
+        mock_kit = MagicMock()
+        mock_kit.parser_cache = {}
+        mock_kit.pipeline = real_pipeline
+        mock_get_kit.return_value = mock_kit
 
         await handle_message(adapter, raw)
 

--- a/tests/adapters/discord/test_discord_voice_ingest.py
+++ b/tests/adapters/discord/test_discord_voice_ingest.py
@@ -75,15 +75,14 @@ async def test_dc_voice_routes_via_pipeline_not_direct_push() -> None:
     message = _make_discord_message()
     audio_attachment = _make_audio_attachment()
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
-
-    # handle_audio shares discord_inbound._pipeline (single pipeline per adapter)
-    with patch("factory.adapters.discord.discord_inbound._pipeline", mock_pipeline):
+    mock_guarded = AsyncMock(return_value=None)
+    with patch(
+        "factory.adapters.shared.inbound_pipeline.run_inbound_guarded",
+        mock_guarded,
+    ):
         await handle_audio(adapter, message, audio_attachment, TrustLevel.PUBLIC)
 
-    # Assert: pipeline.run was called exactly once
-    mock_pipeline.run.assert_awaited_once()
+    mock_guarded.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -105,27 +104,21 @@ async def test_dc_eager_read_and_pending_attachment_routed() -> None:
     message = _make_discord_message()
     audio_attachment = _make_audio_attachment()
 
-    # Capture the InboundMessage that _pipeline.run receives.
     captured_msg: list = []
 
-    async def _capture_run(raw, ctx, parser, **kwargs):  # noqa: ARG001
-        msg = parser.parse(raw, ctx)
-        captured_msg.append(msg)
+    async def _capture_guarded(*, raw_message, **kwargs):  # noqa: ARG001
+        captured_msg.append(raw_message)
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(side_effect=_capture_run)
-
-    # handle_audio shares discord_inbound._pipeline (single pipeline per adapter)
-    with patch("factory.adapters.discord.discord_inbound._pipeline", mock_pipeline):
+    with patch(
+        "factory.adapters.shared.inbound_pipeline.run_inbound_guarded",
+        side_effect=_capture_guarded,
+    ):
         await handle_audio(adapter, message, audio_attachment, TrustLevel.PUBLIC)
 
     # Attachment was read eagerly (synchronously in the handler).
     audio_attachment.read.assert_awaited_once()
 
-    # pipeline.run was called once.
-    mock_pipeline.run.assert_awaited_once()
-
-    # The routed message carries a non-None pending_attachment (FetchFn closure).
+    # run_inbound_guarded was called once with normalized hub audio.
     assert len(captured_msg) == 1
     routed = captured_msg[0]
     assert routed.pending_attachment is not None
@@ -150,10 +143,11 @@ async def test_dc_too_large_reply_no_pipeline() -> None:
     # Size exactly one byte over the limit
     oversized = _make_audio_attachment(size=adapter._max_audio_bytes + 1)
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
-
-    with patch("factory.adapters.discord.discord_inbound._pipeline", mock_pipeline):
+    mock_guarded = AsyncMock(return_value=None)
+    with patch(
+        "factory.adapters.shared.inbound_pipeline.run_inbound_guarded",
+        mock_guarded,
+    ):
         await handle_audio(adapter, message, oversized, TrustLevel.PUBLIC)
 
     # (a) Reply was sent
@@ -162,7 +156,7 @@ async def test_dc_too_large_reply_no_pipeline() -> None:
     assert "large" in reply_text.lower()
 
     # (b) Pipeline was NOT reached — load-bearing assertion
-    mock_pipeline.run.assert_not_awaited()
+    mock_guarded.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -188,10 +182,11 @@ async def test_dc_download_failed_reply_no_pipeline() -> None:
         side_effect=discord.HTTPException(resp_mock, "service unavailable")
     )
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
-
-    with patch("factory.adapters.discord.discord_inbound._pipeline", mock_pipeline):
+    mock_guarded = AsyncMock(return_value=None)
+    with patch(
+        "factory.adapters.shared.inbound_pipeline.run_inbound_guarded",
+        mock_guarded,
+    ):
         await handle_audio(adapter, message, attachment, TrustLevel.PUBLIC)
 
     # (a) Reply was sent
@@ -204,7 +199,7 @@ async def test_dc_download_failed_reply_no_pipeline() -> None:
     )
 
     # (b) Pipeline was NOT reached — load-bearing assertion
-    mock_pipeline.run.assert_not_awaited()
+    mock_guarded.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -227,10 +222,11 @@ async def test_dc_invalid_magic_reply_no_pipeline() -> None:
     # Return bytes that look like plain text — fails every magic signature
     attachment.read = AsyncMock(return_value=b"NOTAUDIO" + b"\x00" * 20)
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
-
-    with patch("factory.adapters.discord.discord_inbound._pipeline", mock_pipeline):
+    mock_guarded = AsyncMock(return_value=None)
+    with patch(
+        "factory.adapters.shared.inbound_pipeline.run_inbound_guarded",
+        mock_guarded,
+    ):
         await handle_audio(adapter, message, attachment, TrustLevel.PUBLIC)
 
     # (a) Reply was sent
@@ -243,4 +239,4 @@ async def test_dc_invalid_magic_reply_no_pipeline() -> None:
     )
 
     # (b) Pipeline was NOT reached — load-bearing assertion
-    mock_pipeline.run.assert_not_awaited()
+    mock_guarded.assert_not_awaited()

--- a/tests/adapters/discord/test_typing_shims.py
+++ b/tests/adapters/discord/test_typing_shims.py
@@ -46,7 +46,7 @@ def test_dc_start_typing_enabled_delegates_to_publisher(monkeypatch: Any) -> Non
 
     with patch.object(adapter._typing, "start") as mock_start:
         with patch(
-            "factory.adapters.discord.adapter.TraceContext.get_trace_id",
+            "factory.adapters.shared.typing_shim.TraceContext.get_trace_id",
             return_value="trace_dc_123",
         ):
             with patch("asyncio.create_task") as mock_create_task:
@@ -77,7 +77,7 @@ def test_dc_cancel_typing_enabled_delegates_to_publisher(monkeypatch: Any) -> No
 
     with patch.object(adapter._typing, "cancel") as mock_cancel:
         with patch(
-            "factory.adapters.discord.adapter.TraceContext.get_trace_id",
+            "factory.adapters.shared.typing_shim.TraceContext.get_trace_id",
             return_value="trace_dc_456",
         ):
             with patch("asyncio.create_task") as mock_create_task:

--- a/tests/adapters/nats/test_mint_failure_subscriber.py
+++ b/tests/adapters/nats/test_mint_failure_subscriber.py
@@ -48,10 +48,8 @@ def _make_nats_msg(
 
 async def test_subscribes_to_correct_subject_on_start() -> None:
     """start() subscribes to factory.gh.mint_failure.> wildcard."""
-    from factory.adapters.nats.mint_failure_subscriber import (
-        _SUBSCRIBE_SUBJECT,
-        MintFailureSubscriber,
-    )
+    from factory.adapters.nats._constants import SUBSCRIBE_SUBJECT_MINT_FAILURE
+    from factory.adapters.nats.mint_failure_subscriber import MintFailureSubscriber
 
     nc = AsyncMock()
     subscriber = MintFailureSubscriber(
@@ -63,7 +61,7 @@ async def test_subscribes_to_correct_subject_on_start() -> None:
 
     nc.subscribe.assert_called_once()
     call_args = nc.subscribe.call_args
-    assert call_args[0][0] == _SUBSCRIBE_SUBJECT
+    assert call_args[0][0] == SUBSCRIBE_SUBJECT_MINT_FAILURE
     assert call_args[0][0] == "factory.gh.mint_failure.>"
 
 

--- a/tests/adapters/telegram/test_telegram_nonaudio_ingest.py
+++ b/tests/adapters/telegram/test_telegram_nonaudio_ingest.py
@@ -211,8 +211,9 @@ async def test_tg_photo_pipeline_stamps_blob_ref() -> None:
     mock_dispatcher = MagicMock()
     mock_dispatcher.dispatch = _capture_dispatch
 
-    with patch("factory.adapters.telegram.telegram_inbound._pipeline") as mock_pipeline:
-        # Build a real InboundPipeline but intercept dispatcher
+    with patch(
+        "factory.adapters.telegram.telegram_inbound.get_inbound_pipeline_kit"
+    ) as mock_get_kit:
         from factory.inbound.attachment_ingest import AttachmentIngestStage
         from factory.inbound.pipeline import InboundPipeline
         from factory.inbound.router import Router
@@ -224,7 +225,10 @@ async def test_tg_photo_pipeline_stamps_blob_ref() -> None:
             dispatcher=mock_dispatcher,  # type: ignore[arg-type]
             ingest_stage=AttachmentIngestStage(),
         )
-        mock_pipeline.run = real_pipeline.run
+        mock_kit = MagicMock()
+        mock_kit.parser_cache = {}
+        mock_kit.pipeline = real_pipeline
+        mock_get_kit.return_value = mock_kit
 
         await handle_message(adapter, raw)
 
@@ -273,7 +277,9 @@ async def test_tg_oversize_photo_reply_no_hub_push() -> None:
     mock_dispatcher = MagicMock()
     mock_dispatcher.dispatch = _capture_dispatch
 
-    with patch("factory.adapters.telegram.telegram_inbound._pipeline") as mock_pipeline:
+    with patch(
+        "factory.adapters.telegram.telegram_inbound.get_inbound_pipeline_kit"
+    ) as mock_get_kit:
         from factory.inbound.attachment_ingest import AttachmentIngestStage
         from factory.inbound.pipeline import InboundPipeline
         from factory.inbound.router import Router
@@ -285,7 +291,10 @@ async def test_tg_oversize_photo_reply_no_hub_push() -> None:
             dispatcher=mock_dispatcher,  # type: ignore[arg-type]
             ingest_stage=AttachmentIngestStage(),
         )
-        mock_pipeline.run = real_pipeline.run
+        mock_kit = MagicMock()
+        mock_kit.parser_cache = {}
+        mock_kit.pipeline = real_pipeline
+        mock_get_kit.return_value = mock_kit
 
         await handle_message(adapter, raw)
 

--- a/tests/adapters/telegram/test_telegram_voice_ingest.py
+++ b/tests/adapters/telegram/test_telegram_voice_ingest.py
@@ -73,11 +73,13 @@ async def test_tg_voice_routes_via_pipeline_not_direct_push(
     audio_file = tmp_path / "voice.ogg"
     audio_file.write_bytes(b"fake_ogg")
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
+    mock_guarded = AsyncMock(return_value=None)
 
     with (
-        patch("factory.adapters.telegram.telegram_inbound._pipeline", mock_pipeline),
+        patch(
+            "factory.adapters.telegram.telegram_inbound.run_inbound_guarded",
+            mock_guarded,
+        ),
         patch(
             "factory.adapters.telegram.telegram_inbound._download_audio",
             new_callable=AsyncMock,
@@ -86,8 +88,7 @@ async def test_tg_voice_routes_via_pipeline_not_direct_push(
     ):
         await handle_voice_message(adapter, msg)
 
-    # Assert: pipeline.run was called exactly once (routing contract)
-    mock_pipeline.run.assert_awaited_once()
+    mock_guarded.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -112,17 +113,16 @@ async def test_tg_eager_download_and_pending_attachment_set(
     audio_file = tmp_path / "voice.ogg"
     audio_file.write_bytes(b"audio_bytes")
 
-    mock_pipeline = MagicMock()
-
     captured_msgs: list = []
 
-    async def _capture_run(raw, ctx, parser, **kwargs):  # type: ignore[no-untyped-def]
-        captured_msgs.append(raw)
-
-    mock_pipeline.run = _capture_run
+    async def _capture_guarded(*, raw_message, **kwargs):  # type: ignore[no-untyped-def]
+        captured_msgs.append(raw_message)
 
     with (
-        patch("factory.adapters.telegram.telegram_inbound._pipeline", mock_pipeline),
+        patch(
+            "factory.adapters.telegram.telegram_inbound.run_inbound_guarded",
+            side_effect=_capture_guarded,
+        ),
         patch(
             "factory.adapters.telegram.telegram_inbound._download_audio",
             new_callable=AsyncMock,
@@ -159,11 +159,13 @@ async def test_tg_too_large_reply_no_pipeline(
     adapter = _make_adapter()
     msg = _make_voice_msg()
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
+    mock_guarded = AsyncMock(return_value=None)
 
     with (
-        patch("factory.adapters.telegram.telegram_inbound._pipeline", mock_pipeline),
+        patch(
+            "factory.adapters.telegram.telegram_inbound.run_inbound_guarded",
+            mock_guarded,
+        ),
         patch(
             "factory.adapters.telegram.telegram_inbound._download_audio",
             new_callable=AsyncMock,
@@ -179,8 +181,7 @@ async def test_tg_too_large_reply_no_pipeline(
     text_sent: str = call_kwargs.kwargs["text"]
     assert "large" in text_sent.lower()
 
-    # (b) Pipeline was NOT reached — load-bearing assertion
-    mock_pipeline.run.assert_not_awaited()
+    mock_guarded.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -202,11 +203,13 @@ async def test_tg_download_failed_reply_no_pipeline(
     adapter = _make_adapter()
     msg = _make_voice_msg()
 
-    mock_pipeline = MagicMock()
-    mock_pipeline.run = AsyncMock(return_value=None)
+    mock_guarded = AsyncMock(return_value=None)
 
     with (
-        patch("factory.adapters.telegram.telegram_inbound._pipeline", mock_pipeline),
+        patch(
+            "factory.adapters.telegram.telegram_inbound.run_inbound_guarded",
+            mock_guarded,
+        ),
         patch(
             "factory.adapters.telegram.telegram_inbound._download_audio",
             new_callable=AsyncMock,
@@ -227,5 +230,4 @@ async def test_tg_download_failed_reply_no_pipeline(
         or "try again" in text_sent.lower()
     )
 
-    # (b) Pipeline was NOT reached — load-bearing assertion
-    mock_pipeline.run.assert_not_awaited()
+    mock_guarded.assert_not_awaited()

--- a/tests/adapters/telegram/test_typing_shims.py
+++ b/tests/adapters/telegram/test_typing_shims.py
@@ -44,7 +44,7 @@ def test_tg_start_typing_enabled_delegates_to_publisher(monkeypatch: Any) -> Non
 
     with patch.object(adapter._typing, "start") as mock_start:
         with patch(
-            "factory.adapters.telegram.telegram.TraceContext.get_trace_id",
+            "factory.adapters.shared.typing_shim.TraceContext.get_trace_id",
             return_value="trace_tg_123",
         ):
             with patch("asyncio.create_task") as mock_create_task:
@@ -75,7 +75,7 @@ def test_tg_cancel_typing_enabled_delegates_to_publisher(monkeypatch: Any) -> No
 
     with patch.object(adapter._typing, "cancel") as mock_cancel:
         with patch(
-            "factory.adapters.telegram.telegram.TraceContext.get_trace_id",
+            "factory.adapters.shared.typing_shim.TraceContext.get_trace_id",
             return_value="trace_tg_456",
         ):
             with patch("asyncio.create_task") as mock_create_task:

--- a/tests/adapters/test_adapter_glue_kit.py
+++ b/tests/adapters/test_adapter_glue_kit.py
@@ -1,0 +1,143 @@
+"""Tests for adapter glue kit shared modules (#1931)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.adapters.shared.inbound_pipeline import (
+    get_inbound_pipeline_kit,
+    reset_inbound_pipeline_kit,
+    run_inbound_guarded,
+)
+from factory.adapters.shared.platform_meta import cancel_typing_for_inbound
+from factory.adapters.shared.typing_shim import cancel_typing_shim, start_typing_shim
+from factory.core.auth.trust import TrustLevel
+from factory.core.messaging.message import DiscordMeta, InboundMessage, TelegramMeta
+from factory.inbound.attachment_ingest import AttachmentIngestError
+
+
+def _minimal_inbound(**kwargs: object) -> InboundMessage:
+    defaults = {
+        "id": "m1",
+        "platform": "telegram",
+        "bot_id": "main",
+        "scope_id": "chat:1",
+        "user_id": "u1",
+        "user_name": "user",
+        "is_mention": False,
+        "text": "hi",
+        "text_raw": "hi",
+        "trust_level": TrustLevel.PUBLIC,
+        "platform_meta": TelegramMeta(chat_id=1, message_id=1),
+    }
+    defaults.update(kwargs)
+    return InboundMessage(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _reset_pipeline_kit() -> None:
+    reset_inbound_pipeline_kit()
+    yield
+    reset_inbound_pipeline_kit()
+
+
+def test_pipeline_kit_reset_clears_parser_cache() -> None:
+    kit = get_inbound_pipeline_kit()
+    kit.parser_cache[1] = object()
+    kit.reset()
+    assert kit.parser_cache == {}
+
+
+def test_start_typing_shim_legacy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    typing_manager = MagicMock()
+    factory_builder = MagicMock(return_value=lambda: None)
+    with patch(
+        "factory.adapters.shared.typing_shim.is_typing_enabled", return_value=False
+    ):
+        start_typing_shim(
+            platform="telegram",
+            bot_id="main",
+            scope_id=42,
+            typing_manager=typing_manager,
+            factory_builder=factory_builder,
+            typing_publisher=None,
+        )
+    typing_manager.start.assert_called_once_with(42, factory_builder.return_value)
+
+
+def test_cancel_typing_for_discord_meta() -> None:
+    adapter = MagicMock()
+    inbound = _minimal_inbound(
+        platform="discord",
+        scope_id="thread:9",
+        platform_meta=DiscordMeta(guild_id=1, channel_id=2, message_id=3, thread_id=9),
+    )
+    cancel_typing_for_inbound(adapter, inbound)
+    adapter._cancel_typing.assert_called_once_with(9)
+
+
+def test_cancel_typing_for_telegram_meta() -> None:
+    adapter = MagicMock()
+    inbound = _minimal_inbound(
+        scope_id="chat:55",
+        platform_meta=TelegramMeta(chat_id=55, message_id=1),
+    )
+    cancel_typing_for_inbound(adapter, inbound)
+    adapter._cancel_typing.assert_called_once_with(55)
+
+
+@pytest.mark.asyncio
+async def test_run_inbound_guarded_swallows_unhandled_errors() -> None:
+    pipeline = AsyncMock()
+    pipeline.run.side_effect = RuntimeError("boom")
+
+    await run_inbound_guarded(
+        pipeline=pipeline,
+        raw_message=object(),
+        inbound_ctx=MagicMock(),
+        parser=MagicMock(),
+        log_context="test",
+        on_attachment_ingest_error=AsyncMock(),
+        send_backpressure=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_inbound_guarded_handles_attachment_ingest_error() -> None:
+    pipeline = AsyncMock()
+    pipeline.run.side_effect = AttachmentIngestError(
+        user_message="nope", reason="oversize"
+    )
+    on_error = AsyncMock()
+
+    await run_inbound_guarded(
+        pipeline=pipeline,
+        raw_message=object(),
+        inbound_ctx=MagicMock(),
+        parser=MagicMock(),
+        log_context="test",
+        on_attachment_ingest_error=on_error,
+        send_backpressure=AsyncMock(),
+    )
+
+    on_error.assert_awaited_once()
+    assert on_error.await_args.args[0].user_message == "nope"
+
+
+def test_cancel_typing_shim_pubsub_noop_when_enabled_without_publisher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_manager = MagicMock()
+    with patch(
+        "factory.adapters.shared.typing_shim.is_typing_enabled", return_value=True
+    ):
+        cancel_typing_shim(
+            platform="discord",
+            bot_id="main",
+            scope_id=1,
+            typing_manager=typing_manager,
+            typing_publisher=None,
+        )
+    typing_manager.cancel.assert_not_called()

--- a/tests/adapters/test_adapter_glue_kit.py
+++ b/tests/adapters/test_adapter_glue_kit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,26 +20,26 @@ from factory.core.messaging.message import DiscordMeta, InboundMessage, Telegram
 from factory.inbound.attachment_ingest import AttachmentIngestError
 
 
-def _minimal_inbound(**kwargs: object) -> InboundMessage:
-    defaults = {
-        "id": "m1",
-        "platform": "telegram",
-        "bot_id": "main",
-        "scope_id": "chat:1",
-        "user_id": "u1",
-        "user_name": "user",
-        "is_mention": False,
-        "text": "hi",
-        "text_raw": "hi",
-        "trust_level": TrustLevel.PUBLIC,
-        "platform_meta": TelegramMeta(chat_id=1, message_id=1),
-    }
-    defaults.update(kwargs)
-    return InboundMessage(**defaults)  # type: ignore[arg-type]
+def _minimal_inbound(**kwargs: Any) -> InboundMessage:
+    return InboundMessage(
+        id=kwargs.get("id", "m1"),
+        platform=kwargs.get("platform", "telegram"),
+        bot_id=kwargs.get("bot_id", "main"),
+        scope_id=kwargs.get("scope_id", "chat:1"),
+        user_id=kwargs.get("user_id", "u1"),
+        user_name=kwargs.get("user_name", "user"),
+        is_mention=kwargs.get("is_mention", False),
+        text=kwargs.get("text", "hi"),
+        text_raw=kwargs.get("text_raw", "hi"),
+        trust_level=kwargs.get("trust_level", TrustLevel.PUBLIC),
+        platform_meta=kwargs.get(
+            "platform_meta", TelegramMeta(chat_id=1, message_id=1)
+        ),
+    )
 
 
 @pytest.fixture(autouse=True)
-def _reset_pipeline_kit() -> None:
+def _reset_pipeline_kit() -> Iterator[None]:
     reset_inbound_pipeline_kit()
     yield
     reset_inbound_pipeline_kit()
@@ -123,7 +125,9 @@ async def test_run_inbound_guarded_handles_attachment_ingest_error() -> None:
     )
 
     on_error.assert_awaited_once()
-    assert on_error.await_args.args[0].user_message == "nope"
+    exc = on_error.call_args.args[0]
+    assert isinstance(exc, AttachmentIngestError)
+    assert exc.user_message == "nope"
 
 
 def test_cancel_typing_shim_pubsub_noop_when_enabled_without_publisher(

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -1138,7 +1138,7 @@ def test_remember_terminated_evicts_oldest_first(monkeypatch) -> None:
     from factory.adapters.nats.nats_stream_decoder import remember_terminated
 
     # Shrink the cap so the FIFO property is verified against a tiny sequence.
-    monkeypatch.setattr(nsd, "_MAX_TERMINATED_STREAMS", 3)
+    monkeypatch.setattr(nsd, "MAX_TERMINATED_STREAMS", 3)
 
     nc = AsyncMock()
     adapter = AsyncMock()

--- a/tests/adapters/test_nats_outbound_listener.py
+++ b/tests/adapters/test_nats_outbound_listener.py
@@ -302,8 +302,8 @@ async def test_stream_drops_when_at_max_streams(caplog) -> None:
     import asyncio
     import logging
 
+    from factory.adapters.nats._constants import MAX_STREAMS
     from factory.adapters.nats.nats_outbound_listener import (
-        _MAX_STREAMS,
         ListenerDeps,
         NatsOutboundListener,
     )
@@ -320,7 +320,7 @@ async def test_stream_drops_when_at_max_streams(caplog) -> None:
     )
 
     # Fill stream_tasks to the limit with mock tasks
-    for i in range(_MAX_STREAMS):
+    for i in range(MAX_STREAMS):
         mock_task = MagicMock(spec=asyncio.Task)
         listener._stream_tasks[f"stream-{i}"] = mock_task
 
@@ -347,8 +347,8 @@ async def test_existing_stream_receives_chunks_at_capacity(caplog) -> None:
     import asyncio
     import logging
 
+    from factory.adapters.nats._constants import MAX_STREAMS
     from factory.adapters.nats.nats_outbound_listener import (
-        _MAX_STREAMS,
         ListenerDeps,
         NatsOutboundListener,
     )
@@ -369,11 +369,11 @@ async def test_existing_stream_receives_chunks_at_capacity(caplog) -> None:
     existing_task = MagicMock(spec=asyncio.Task)
     listener._stream_tasks[existing_id] = existing_task
 
-    # Fill _stream_tasks to _MAX_STREAMS (existing_id already occupies one slot)
-    for i in range(_MAX_STREAMS - 1):
+    # Fill _stream_tasks to MAX_STREAMS (existing_id already occupies one slot)
+    for i in range(MAX_STREAMS - 1):
         listener._stream_tasks[f"other-{i}"] = MagicMock(spec=asyncio.Task)
 
-    assert len(listener._stream_tasks) == _MAX_STREAMS
+    assert len(listener._stream_tasks) == MAX_STREAMS
 
     chunk = {
         "stream_id": existing_id,

--- a/tests/adapters/test_telegram_auth.py
+++ b/tests/adapters/test_telegram_auth.py
@@ -223,8 +223,7 @@ class TestTelegramAdapterInbound:
         audio_file.write_bytes(b"audio")
 
         _fake_dl = AsyncMock(return_value=(audio_file, 5.0))
-        mock_pipeline = MagicMock()
-        mock_pipeline.run = AsyncMock(return_value=None)
+        mock_guarded = AsyncMock(return_value=None)
         with (
             patch(
                 "factory.adapters.telegram.telegram_inbound._download_audio",
@@ -234,8 +233,8 @@ class TestTelegramAdapterInbound:
                 "factory.adapters.telegram.telegram_inbound.normalize_audio"
             ) as mock_norm_audio,
             patch(
-                "factory.adapters.telegram.telegram_inbound._pipeline",
-                mock_pipeline,
+                "factory.adapters.telegram.telegram_inbound.run_inbound_guarded",
+                mock_guarded,
             ),
         ):
             _stub_msg = MagicMock()
@@ -248,4 +247,4 @@ class TestTelegramAdapterInbound:
         call_kwargs = mock_norm_audio.call_args
         assert call_kwargs.kwargs.get("trust_level") == TrustLevel.PUBLIC
         # Voice now routes via the pipeline, not push_to_hub_guarded
-        mock_pipeline.run.assert_awaited_once()
+        mock_guarded.assert_awaited_once()

--- a/tools/folder_exemptions.txt
+++ b/tools/folder_exemptions.txt
@@ -10,5 +10,5 @@
 # factory_data_dir → $ROXABI_FACTORY_DIR). Top-level is correct for a
 # broadly-imported zero-dep resolver; cli_* decomposition (the real bloat)
 # is the follow-up. Plan: artifacts/plans/lyra-to-roxabi-factory-rename.md
-src / factory  # 15 files — +cli_secrets.py, secrets_reset.py (#1945 disaster recovery); cli_* split = follow-up
-src / factory / adapters / shared  # 16 files — glue kit extraction (#1931 typing_shim, inbound_context, inbound_pipeline, platform_meta)
+src/factory  # 15 files — +cli_secrets.py, secrets_reset.py (#1945 disaster recovery); cli_* split = follow-up
+src/factory/adapters/shared  # 16 files — glue kit extraction (#1931)

--- a/tools/folder_exemptions.txt
+++ b/tools/folder_exemptions.txt
@@ -10,4 +10,5 @@
 # factory_data_dir → $ROXABI_FACTORY_DIR). Top-level is correct for a
 # broadly-imported zero-dep resolver; cli_* decomposition (the real bloat)
 # is the follow-up. Plan: artifacts/plans/lyra-to-roxabi-factory-rename.md
-src/factory  # 15 files — +cli_secrets.py, secrets_reset.py (#1945 disaster recovery); cli_* split = follow-up
+src / factory  # 15 files — +cli_secrets.py, secrets_reset.py (#1945 disaster recovery); cli_* split = follow-up
+src / factory / adapters / shared  # 16 files — glue kit extraction (#1931 typing_shim, inbound_context, inbound_pipeline, platform_meta)


### PR DESCRIPTION
## Summary

Extract shared adapter glue into `adapters/shared/` for N+1 platform readiness (E7 / #1931):

- **typing_shim** — pub/sub vs legacy `TypingTaskManager` path for TG/DC adapters
- **inbound_context** — `build_telegram_inbound_ctx` / `build_discord_inbound_ctx`
- **inbound_pipeline** — resettable process-singleton kit + `run_inbound_guarded` always-return boundary
- **platform_meta** — `cancel_typing_for_inbound` scope resolver
- **nats/_constants** — consolidated `MAX_STREAMS`, queue sizes, mint-failure subject
- **Discord oversize i18n** — oversize replies use `attachment_too_large` msg catalog key

## Guards

- No new `factory.inbound` imports from shared glue modules
- `run_inbound_guarded` consolidates TG/DC `except Exception` boundaries (net reduction vs duplicated handlers)

## Test plan

- [x] `tests/adapters/test_adapter_glue_kit.py` (new)
- [x] Updated discord voice/nonaudio ingest + typing shim tests
- [x] `uv run ruff check` on touched adapter paths
- [x] `uv run pyright` on new shared modules

Closes #1931