### PR TITLE
chore(roxabi-nats): remove stale _serialize.py file-length exemption

### DIFF
--- a/packages/roxabi-nats/tools/file_exemptions.txt
+++ b/packages/roxabi-nats/tools/file_exemptions.txt
@@ -1,4 +1,3 @@
 # File size exemptions (≤300 lines per file)
 # Each entry must have a tracking issue.
 # Format: <path>  # <lines> lines — <issue> <description>
-packages/roxabi-nats/src/roxabi_nats/_serialize.py  # 318 lines — #977 needs split, tracked for follow-up


### PR DESCRIPTION
## Summary
- Remove the obsolete `_serialize.py` entry from `packages/roxabi-nats/tools/file_exemptions.txt`
- File is now 199 SLOC (Radon), well under the 300-line cap — exemption no longer needed

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1957: chore(roxabi-nats): remove stale _serialize.py file-length exemption | OPEN |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 1 commit on `feat/1957-remove-stale-serialize-py-file-length-exemption` | Complete |
| Verification | File-length gate | Passed |

## Test Plan
- [x] `QG_FILE_ROOT=packages/roxabi-nats/src/ QG_FILE_EXEMPTIONS=packages/roxabi-nats/tools/file_exemptions.txt tools/check_file_length.sh` passes
- [x] Exemption entry removed; header comments retained

Fixes #1957