### PR TITLE
refactor(typing): collapse typing_publisher_shim to WorkScope

### DIFF
--- a/artifacts/quality-debt-report.json
+++ b/artifacts/quality-debt-report.json
@@ -100,7 +100,6 @@
     "PLR0913": {
       "DEBT": {
         "complexity-residual": 2,
-        "typing-publisher-shim-args": 1,
         "wiring-bootstrap-deps": 24
       },
       "UNTAGGED": {
@@ -254,11 +253,6 @@
         "__none__": 5
       }
     },
-    "src/factory/adapters/shared": {
-      "DEBT": {
-        "folder-exemptions": 1
-      }
-    },
     "type-arg": {
       "UNTAGGED": {
         "__none__": 3
@@ -273,7 +267,7 @@
       }
     }
   },
-  "generated_at": "2026-06-20T17:18:12.778961+00:00",
+  "generated_at": "2026-06-20T20:44:59.889055+00:00",
   "rows": [
     {
       "bucket": "UNTAGGED",
@@ -620,7 +614,7 @@
     },
     {
       "bucket": "DEBT",
-      "line": 169,
+      "line": 168,
       "path": "src/factory/adapters/clipool/clipool_worker.py",
       "rule": "BLE001",
       "slug": "boundary-broad-catch",
@@ -628,7 +622,7 @@
     },
     {
       "bucket": "DEBT",
-      "line": 259,
+      "line": 258,
       "path": "src/factory/adapters/clipool/clipool_worker.py",
       "rule": "BLE001",
       "slug": "boundary-broad-catch",
@@ -636,7 +630,7 @@
     },
     {
       "bucket": "DEBT",
-      "line": 306,
+      "line": 305,
       "path": "src/factory/adapters/clipool/clipool_worker.py",
       "rule": "BLE001",
       "slug": "boundary-broad-catch",
@@ -652,14 +646,14 @@
     },
     {
       "bucket": "UNTAGGED",
-      "line": 63,
+      "line": 66,
       "path": "src/factory/adapters/discord/adapter.py",
       "rule": "E402",
       "source": "noqa"
     },
     {
       "bucket": "DEBT",
-      "line": 86,
+      "line": 89,
       "path": "src/factory/adapters/discord/adapter.py",
       "rule": "PLR0913",
       "slug": "wiring-bootstrap-deps",
@@ -847,7 +841,7 @@
     },
     {
       "bucket": "UNTAGGED",
-      "line": 106,
+      "line": 102,
       "path": "src/factory/adapters/omp/_rpc_bridge.py",
       "rule": "import-not-found",
       "source": "type-ignore"
@@ -962,14 +956,14 @@
     {
       "bucket": "UNTAGGED",
       "line": 80,
-      "path": "src/factory/adapters/shared/inbound_pipeline.py",
+      "path": "src/factory/adapters/shared/inbound/pipeline.py",
       "rule": "PLR0913",
       "source": "noqa"
     },
     {
       "bucket": "UNTAGGED",
-      "line": 14,
-      "path": "src/factory/adapters/shared/typing_shim.py",
+      "line": 24,
+      "path": "src/factory/adapters/shared/inbound/typing_shim.py",
       "rule": "PLR0913",
       "source": "noqa"
     },
@@ -3169,16 +3163,8 @@
       "source": "noqa"
     },
     {
-      "bucket": "DEBT",
-      "line": 48,
-      "path": "src/factory/typing/listener.py",
-      "rule": "PLR0913",
-      "slug": "typing-publisher-shim-args",
-      "source": "noqa"
-    },
-    {
       "bucket": "UNTAGGED",
-      "line": 85,
+      "line": 75,
       "path": "src/factory/typing/listener.py",
       "rule": "PLR0913",
       "source": "noqa"
@@ -3301,13 +3287,6 @@
       "path": "factory.core.processors.processor_registry -> factory.integrations.base",
       "slug": "importlinter-shared-modules-transitive",
       "source": "importlinter"
-    },
-    {
-      "bucket": "DEBT",
-      "line": 11,
-      "path": "src/factory/adapters/shared",
-      "slug": "folder-exemptions",
-      "source": "folder-exemptions"
     }
   ],
   "sources": [
@@ -3318,12 +3297,5 @@
     "file-exemptions",
     "folder-exemptions"
   ],
-  "stale_references": [
-    {
-      "line": 48,
-      "path": "src/factory/typing/listener.py",
-      "reason": "missing",
-      "slug": "typing-publisher-shim-args"
-    }
-  ]
+  "stale_references": []
 }

--- a/src/factory/adapters/shared/inbound/typing_shim.py
+++ b/src/factory/adapters/shared/inbound/typing_shim.py
@@ -7,11 +7,21 @@ from uuid import uuid4
 
 from factory.core.trace import TraceContext
 from factory.transport.typing_publisher import is_typing_enabled
+from factory.transport.work_scope import WorkScope
 from factory.typing.listener import typing_publisher_shim
 from factory.typing.types import FactoryBuilder
 
 
-def start_typing_shim(  # noqa: PLR0913 — mirrors typing_publisher_shim arity (#1377)
+def _typing_work_scope(platform: str, bot_id: str, scope_id: int) -> WorkScope:
+    return WorkScope(
+        platform=platform,
+        bot_id=bot_id,
+        scope_id=scope_id,
+        trace_id=TraceContext.get_trace_id() or uuid4().hex,
+    )
+
+
+def start_typing_shim(  # noqa: PLR0913 — adapter glue: platform identity + legacy fallback (#1377)
     *,
     platform: str,
     bot_id: str,
@@ -22,12 +32,9 @@ def start_typing_shim(  # noqa: PLR0913 — mirrors typing_publisher_shim arity 
 ) -> None:
     """Start typing — pub/sub path when enabled, else legacy TypingTaskManager."""
     if typing_publisher is not None and typing_publisher_shim(
-        platform,
-        bot_id,
-        scope_id,
+        _typing_work_scope(platform, bot_id, scope_id),
         typing_publisher,
         typing_publisher.publish_started,
-        trace_id=TraceContext.get_trace_id() or uuid4().hex,
     ):
         return
     if is_typing_enabled():
@@ -45,12 +52,9 @@ def cancel_typing_shim(
 ) -> None:
     """Cancel typing — pub/sub path when enabled, else legacy TypingTaskManager."""
     if typing_publisher is not None and typing_publisher_shim(
-        platform,
-        bot_id,
-        scope_id,
+        _typing_work_scope(platform, bot_id, scope_id),
         typing_publisher,
         typing_publisher.publish_ended,
-        trace_id=TraceContext.get_trace_id() or uuid4().hex,
     ):
         return
     if is_typing_enabled():

--- a/src/factory/typing/listener.py
+++ b/src/factory/typing/listener.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
 
 from factory.transport.typing_event import TypingEvent
 from factory.transport.typing_publisher import is_typing_enabled
@@ -45,13 +44,10 @@ def make_typing_factory(
     return factory_builder
 
 
-def typing_publisher_shim(  # noqa: PLR0913 — DEBT:typing-publisher-shim-args — 6 params for platform+bot+scope+publisher+method+trace_id; no reasonable grouping exists
-    platform: str,
-    bot_id: str,
-    scope_id: int,
+def typing_publisher_shim(
+    scope: WorkScope,
     publisher: "TypingPublisher | None",
     method: Callable[[WorkScope], Coroutine[Any, Any, None]],
-    trace_id: str | None = None,
 ) -> bool:
     """Stage-axis helper for pub/sub typing path (ADR-073, #1377).
 
@@ -62,13 +58,7 @@ def typing_publisher_shim(  # noqa: PLR0913 — DEBT:typing-publisher-shim-args 
     """
     if not is_typing_enabled() or publisher is None:
         return False
-    work_scope = WorkScope(
-        platform=platform,
-        bot_id=bot_id,
-        scope_id=scope_id,
-        trace_id=trace_id or uuid4().hex,
-    )
-    task = asyncio.create_task(method(work_scope))
+    task = asyncio.create_task(method(scope))
 
     def _on_done(t: asyncio.Task) -> None:
         if t.cancelled():

--- a/tests/adapters/test_adapter_glue_kit.py
+++ b/tests/adapters/test_adapter_glue_kit.py
@@ -16,6 +16,7 @@ from factory.adapters.shared.inbound import (
     run_inbound_guarded,
     start_typing_shim,
 )
+from factory.adapters.shared.inbound.typing_shim import _typing_work_scope
 from factory.core.auth.trust import TrustLevel
 from factory.core.messaging.message import DiscordMeta, InboundMessage, TelegramMeta
 from factory.inbound.attachment_ingest import AttachmentIngestError
@@ -69,6 +70,36 @@ def test_start_typing_shim_legacy_path(monkeypatch: pytest.MonkeyPatch) -> None:
             typing_publisher=None,
         )
     typing_manager.start.assert_called_once_with(42, factory_builder.return_value)
+
+
+@pytest.mark.parametrize("trace_id", [None, ""])
+def test_typing_work_scope_trace_id_falls_back_to_uuid4(
+    trace_id: str | None,
+) -> None:
+    with patch(
+        "factory.adapters.shared.inbound.typing_shim.TraceContext.get_trace_id",
+        return_value=trace_id,
+    ):
+        with patch(
+            "factory.adapters.shared.inbound.typing_shim.uuid4"
+        ) as mock_uuid:
+            mock_uuid.return_value.hex = "deadbeef1234567890abcdef12345678"
+            scope = _typing_work_scope("telegram", "main", 42)
+
+    assert scope.platform == "telegram"
+    assert scope.bot_id == "main"
+    assert scope.scope_id == 42
+    assert scope.trace_id == "deadbeef1234567890abcdef12345678"
+
+
+def test_typing_work_scope_trace_id_from_context() -> None:
+    with patch(
+        "factory.adapters.shared.inbound.typing_shim.TraceContext.get_trace_id",
+        return_value="trace-from-context",
+    ):
+        scope = _typing_work_scope("discord", "main", 7)
+
+    assert scope.trace_id == "trace-from-context"
 
 
 def test_cancel_typing_for_discord_meta() -> None:

--- a/tests/typing/test_typing_publisher_shim.py
+++ b/tests/typing/test_typing_publisher_shim.py
@@ -98,7 +98,7 @@ class TestOnDoneCallback:
         publisher: TypingPublisher | None,
     ) -> None:
         async def _method(_scope: WorkScope) -> None:
-            await asyncio.sleep(0)
+            await asyncio.sleep(0)  # event-based
 
         with patch(
             "factory.typing.listener.is_typing_enabled",

--- a/tests/typing/test_typing_publisher_shim.py
+++ b/tests/typing/test_typing_publisher_shim.py
@@ -11,6 +11,13 @@ from factory.transport.typing_publisher import TypingPublisher
 from factory.transport.work_scope import WorkScope
 from factory.typing.listener import typing_publisher_shim
 
+_SCOPE = WorkScope(
+    platform="telegram",
+    bot_id="main",
+    scope_id=1,
+    trace_id="trace-abc",
+)
+
 
 class TestOnDoneCallback:
     @pytest.mark.asyncio
@@ -24,12 +31,9 @@ class TestOnDoneCallback:
         with patch("factory.typing.listener.is_typing_enabled", return_value=True):
             with patch("factory.typing.listener.log.warning") as mock_warning:
                 result = typing_publisher_shim(
-                    platform="telegram",
-                    bot_id="main",
-                    scope_id=1,
-                    publisher=publisher,
-                    method=_failing_method,
-                    trace_id="trace-abc",
+                    _SCOPE,
+                    publisher,
+                    _failing_method,
                 )
                 assert result is True
                 # Wait for the task to complete and the done callback to fire
@@ -51,12 +55,9 @@ class TestOnDoneCallback:
         with patch("factory.typing.listener.is_typing_enabled", return_value=True):
             with patch("factory.typing.listener.log.warning") as mock_warning:
                 result = typing_publisher_shim(
-                    platform="telegram",
-                    bot_id="main",
-                    scope_id=1,
-                    publisher=publisher,
-                    method=_slow_method,
-                    trace_id="trace-abc",
+                    _SCOPE,
+                    publisher,
+                    _slow_method,
                 )
                 assert result is True
                 # Cancel the pending task(s) excluding the current test task.
@@ -69,30 +70,19 @@ class TestOnDoneCallback:
         mock_warning.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_trace_id_none_falls_back_to_uuid4(self):
-        """trace_id=None → WorkScope constructed with a uuid4().hex fallback."""
+    async def test_passes_work_scope_to_method(self):
+        """WorkScope is forwarded unchanged to the publish method."""
         publisher = MagicMock(spec=TypingPublisher)
         seen_scope: WorkScope | None = None
 
-        async def _capture_method(scope):
+        async def _capture_method(scope: WorkScope) -> None:
             nonlocal seen_scope
             seen_scope = scope
             await asyncio.sleep(0)  # event-based
 
         with patch("factory.typing.listener.is_typing_enabled", return_value=True):
-            with patch("factory.typing.listener.uuid4") as mock_uuid:
-                mock_uuid.return_value.hex = "deadbeef1234"
-                result = typing_publisher_shim(
-                    platform="telegram",
-                    bot_id="main",
-                    scope_id=1,
-                    publisher=publisher,
-                    method=_capture_method,
-                    trace_id=None,
-                )
+            result = typing_publisher_shim(_SCOPE, publisher, _capture_method)
 
         assert result is True
-        # Wait for the task to complete so _capture_method runs
         await asyncio.sleep(0)  # event-based
-        assert seen_scope is not None
-        assert seen_scope.trace_id == "deadbeef1234"  # pyright: ignore[reportUnreachable]
+        assert seen_scope is _SCOPE

--- a/tests/typing/test_typing_publisher_shim.py
+++ b/tests/typing/test_typing_publisher_shim.py
@@ -86,3 +86,26 @@ class TestOnDoneCallback:
         assert result is True
         await asyncio.sleep(0)  # event-based
         assert seen_scope is _SCOPE
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("typing_enabled", "publisher"),
+        [(False, MagicMock(spec=TypingPublisher)), (True, None)],
+    )
+    async def test_returns_false_without_scheduling_task(
+        self,
+        typing_enabled: bool,
+        publisher: TypingPublisher | None,
+    ) -> None:
+        async def _method(_scope: WorkScope) -> None:
+            await asyncio.sleep(0)
+
+        with patch(
+            "factory.typing.listener.is_typing_enabled",
+            return_value=typing_enabled,
+        ):
+            with patch("factory.typing.listener.asyncio.create_task") as mock_create:
+                result = typing_publisher_shim(_SCOPE, publisher, _method)
+
+        assert result is False
+        mock_create.assert_not_called()


### PR DESCRIPTION
## Summary
- Drain stale `DEBT:typing-publisher-shim-args` by refactoring `typing_publisher_shim` to take `WorkScope` at the stage boundary (3 params, no PLR0913 suppression).
- Move identity composition (`platform`, `bot_id`, `scope_id`, `trace_id`) into adapter glue via `_typing_work_scope()` in `typing_shim.py`.
- Regenerate `quality-debt-report.json` — stale refs now 0.

Related: #1377 (typing pub/sub), follow-up from epic #1956 quality-gate drain.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | Post-#1956 stale debt cleanup | Ad-hoc |
| Analysis | architect + axial-adr-review panel | Present (conversation) |
| Spec | — | Absent (S-tier hygiene) |
| Implementation | 1 commit on `fix/typing-publisher-shim-workscope` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (17 typing shim tests) | Passed |

## Test Plan
- [x] `pytest tests/typing/test_typing_publisher_shim.py tests/adapters/discord/test_typing_shims.py tests/adapters/telegram/test_typing_shims.py`
- [x] `make quality-debt-report` — `typing-publisher-shim-args` absent, stale refs 0
- [x] `make lint && make typecheck`

---
Generated with Claude Code via `/pr`