### PR TITLE
fix(telegram): rich thinking + tool recap safety

### DIFF
--- a/src/factory/adapters/telegram/telegram_formatter.py
+++ b/src/factory/adapters/telegram/telegram_formatter.py
@@ -26,7 +26,7 @@ from factory.core.messaging.render_events import (
     ReasoningEndRenderEvent,
     ReasoningStartRenderEvent,
 )
-from factory.outbound._reasoning_accum import ReasoningAccumulator
+from factory.outbound._reasoning_accum import REASONING_MAX_LEN, ReasoningAccumulator
 from factory.outbound.formatter import BaseFormatter
 
 if TYPE_CHECKING:
@@ -67,7 +67,9 @@ class TelegramFormatter(BaseFormatter):
         self._placeholder_text = placeholder_text
         self._reply_to = reply_to
         self._topic_id = topic_id
-        self._reasoning = ReasoningAccumulator()
+        self._reasoning = ReasoningAccumulator(
+            max_len=None if rich_messages_enabled() else REASONING_MAX_LEN,
+        )
 
     def placeholder_text(self) -> str:
         return self._placeholder_text
@@ -290,7 +292,9 @@ class TelegramFormatter(BaseFormatter):
             return
         text, should_edit = self._reasoning.process(event)
         if should_edit and text is not None:
-            await self._edit_trace_with_text(trace_obj, self.dim_italic(text))
+            # Rich <tg-thinking> is HTML — no markdown italic wrapper (#1949).
+            display = text if rich_messages_enabled() else self.dim_italic(text)
+            await self._edit_trace_with_text(trace_obj, display)
 
     async def edit_tool_recap(
         self,

--- a/src/factory/outbound/_reasoning_accum.py
+++ b/src/factory/outbound/_reasoning_accum.py
@@ -22,11 +22,12 @@ REASONING_MAX_LEN: int = 120
 REASONING_TRUNC_LEN: int = 117
 
 
-def _truncate_reasoning(text: str) -> str:
-    """Truncate reasoning text to REASONING_MAX_LEN chars with '…' suffix."""
-    if len(text) > REASONING_MAX_LEN:
-        return text[:REASONING_TRUNC_LEN] + "…"
-    return text
+def _truncate_reasoning(text: str, *, max_len: int | None) -> str:
+    """Truncate reasoning text when *max_len* is set; ``None`` disables truncation."""
+    if max_len is None or len(text) <= max_len:
+        return text
+    trunc_len = max_len - (REASONING_MAX_LEN - REASONING_TRUNC_LEN)
+    return text[:trunc_len] + "…"
 
 
 @dataclass
@@ -38,6 +39,10 @@ class ReasoningAccumulator:
 
     ``clock`` is injectable for unit-test control (default: ``time.monotonic``).
 
+    ``max_len`` controls truncation (default ``REASONING_MAX_LEN``). Pass
+    ``None`` to stream the full accumulated text (e.g. Telegram rich
+    ``<tg-thinking>`` blocks).
+
     Usage::
 
         self._reasoning = ReasoningAccumulator()
@@ -48,6 +53,7 @@ class ReasoningAccumulator:
     """
 
     clock: Callable[[], float] = field(default_factory=lambda: time.monotonic)
+    max_len: int | None = REASONING_MAX_LEN
 
     _accum: str = field(default="", init=False)
     _last_edit: float | None = field(default=None, init=False)
@@ -73,7 +79,7 @@ class ReasoningAccumulator:
 
         if isinstance(event, ReasoningDeltaRenderEvent):
             self._accum += event.delta
-            truncated = _truncate_reasoning(self._accum)
+            truncated = _truncate_reasoning(self._accum, max_len=self.max_len)
             now = self.clock()
             elapsed = None if self._last_edit is None else (now - self._last_edit)
             if elapsed is None or elapsed >= STREAMING_EDIT_INTERVAL:
@@ -83,7 +89,7 @@ class ReasoningAccumulator:
 
         # ReasoningEndRenderEvent — flush unconditionally if non-empty
         if self._accum:
-            truncated = _truncate_reasoning(self._accum)
+            truncated = _truncate_reasoning(self._accum, max_len=self.max_len)
             return truncated, True
         return None, False
 

--- a/src/factory/outbound/_tool_recap.py
+++ b/src/factory/outbound/_tool_recap.py
@@ -53,6 +53,11 @@ def _sanitize(text: str) -> str:
     return text.replace("`", "")
 
 
+def _wrap_inline_code(text: str) -> str:
+    """Wrap sanitized text in backticks for MarkdownV2 and rich-markdown code spans."""
+    return f"`{_sanitize(text)}`"
+
+
 def _accumulate_file_edit(
     accum: "ToolRecapAccumulator", call_id: str, tool_name: str, args: dict
 ) -> None:
@@ -206,7 +211,8 @@ def _format_files(accum: ToolRecapAccumulator) -> list[str]:
     for summary in accum.files.values():
         label = ", ".join(summary.edits) if summary.edits else f"×{summary.count}"
         path = _sanitize(summary.path)
-        lines.append(f"✏️ `{path}` ({label})")
+        # Label outside backticks was a rich-markdown injection surface (#1950).
+        lines.append(f"✏️ `{path}` ({_wrap_inline_code(label)})")
     return lines
 
 

--- a/tests/adapters/test_telegram_reasoning.py
+++ b/tests/adapters/test_telegram_reasoning.py
@@ -171,13 +171,11 @@ class TestTelegramReasoningRendering:
         )
 
     @pytest.mark.asyncio
-    async def test_reasoning_truncation(self) -> None:
-        """Delta text > 120 chars is truncated to 117 chars + ellipsis (118 total).
-
-        Arrange: adapter with show_intermediate=True; session pre-supplies trace_obj.
-        Act: Start → Delta(200 'x' chars) → End.
-        Assert: the edit call receives text of length 118 ending with '…'.
-        """
+    async def test_reasoning_truncation_legacy_markdownv2(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """MarkdownV2 fallback truncates reasoning >120 chars (#1951 legacy)."""
+        monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "0")
         # Arrange
         adapter = _make_telegram_adapter()
         trace_mock = _make_trace_send_mock(message_id=503)
@@ -222,6 +220,38 @@ class TestTelegramReasoningRendering:
         assert "…" in last_text, (
             f"Expected truncation ellipsis in edit text, got: {last_text!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_reasoning_rich_mode_no_truncation_no_literal_asterisks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rich <tg-thinking>: full text, no * markdown wrapper (#1949, #1951)."""
+        monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "1")
+        adapter = _make_telegram_adapter()
+        trace_mock = _make_trace_send_mock(message_id=504)
+        adapter.bot = MagicMock()
+        adapter.bot.edit_message_text = AsyncMock()
+
+        formatter = _make_formatter(adapter)
+        long_reasoning = "Thinking deeply about " + ("x" * 200)
+
+        await formatter.edit_reasoning(
+            trace_mock, ReasoningStartRenderEvent(message_id=_MSG_ID)
+        )
+        await formatter.edit_reasoning(
+            trace_mock,
+            ReasoningDeltaRenderEvent(message_id=_MSG_ID, delta=long_reasoning),
+        )
+        await formatter.edit_reasoning(
+            trace_mock, ReasoningEndRenderEvent(message_id=_MSG_ID)
+        )
+
+        assert adapter.bot.edit_message_text.await_count >= 1
+        rich = adapter.bot.edit_message_text.call_args.kwargs["rich_message"]
+        html = rich.html
+        assert "<tg-thinking>" in html
+        assert long_reasoning in html
+        assert "*" not in html
 
     # NOTE: show_intermediate=False adapter no-op test removed. The gate now
     # lives upstream on StreamProcessor (SC-6) — when disabled, no Reasoning*

--- a/tests/outbound/test_reasoning_accum.py
+++ b/tests/outbound/test_reasoning_accum.py
@@ -178,6 +178,16 @@ class TestReasoningAccumulatorEnd:
         assert text.endswith("…")
         assert len(text) == REASONING_TRUNC_LEN + 1
 
+    def test_max_len_none_disables_truncation(self) -> None:
+        clock_val = 0.0
+        accum = ReasoningAccumulator(max_len=None, clock=lambda: clock_val)
+        accum.process(_start())
+        long_text = "z" * 500
+        text, should_edit = accum.process(_delta(long_text))
+        assert should_edit is True
+        assert text == long_text
+        assert "…" not in (text or "")
+
     def test_end_not_throttle_gated(self) -> None:
         """End fires even if the last edit was very recent (no throttle gate on End)."""
         clock_val = 0.0

--- a/tests/outbound/test_tool_recap.py
+++ b/tests/outbound/test_tool_recap.py
@@ -79,6 +79,21 @@ def test_default_config_bash_max_len_is_80() -> None:
     assert ToolDisplayConfig().bash_max_len == 80
 
 
+def test_file_edit_label_wrapped_in_inline_code_for_rich_markdown() -> None:
+    """Tool names with markdown metacharacters stay inside code spans (#1950)."""
+    accum = ToolRecapAccumulator()
+    _feed_tool(
+        accum,
+        "e1",
+        "Edit",
+        json.dumps({"path": "src/foo_bar.py", "old_string": "a", "new_string": "b"}),
+    )
+    lines = format_recap_lines(accum, done=True)
+    file_lines = [ln for ln in lines if ln.startswith("✏️")]
+    assert len(file_lines) == 1
+    assert file_lines[0] == "✏️ `src/foo_bar.py` (`Edit`)"
+
+
 def test_default_config_names_threshold_is_5() -> None:
     """ToolDisplayConfig() default names_threshold must match live constant (5)."""
     assert ToolDisplayConfig().names_threshold == 5


### PR DESCRIPTION
## Summary
- **#1949** — Rich `<tg-thinking>`: pass plain text (no `*…*` markdown wrapper that renders literally in HTML)
- **#1950** — Tool recap: wrap edit labels in inline code at **outbound** stage (`_tool_recap.py`), not adapter
- **#1951** — `ReasoningAccumulator(max_len=None)` in rich mode → full thinking stream; legacy MarkdownV2 keeps 120-char cap

## Architecture note (tables / content vs structure)
| Path | Role |
|------|------|
| `outbound/_tool_recap.py` | **Content** — sanitize, wrap, truncate |
| `outbound/_reasoning_accum.py` | **Content** — truncation policy |
| `telegram_rich.py` | **Structure** — `InputRichMessage`, HTML escape, chunk split (identity `escape_fn` — no table rewrite) |
| `telegram_formatting.py` | **Legacy only** — `telegramify_markdown` for MarkdownV2 (pre-existing; candidate for outbound move) |

Rich mode does **not** transform tables in the adapter (`chunk_markdown` passes markdown through). Legacy MarkdownV2 still converts via `telegramify_markdown` in the adapter — separate follow-up if we want zero content mutation there.

Fixes #1949
Fixes #1950
Fixes #1951