### PR TITLE
fix(nats): wire-rename robustness for docker stub subjects

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -23,8 +23,8 @@ services:
   stt-stub:
     <<: [*logging]
     build:
-      context: ./stubs
-      dockerfile: Dockerfile.stub
+      context: ..
+      dockerfile: docker/stubs/Dockerfile.stub
     command: ["python", "stt_stub.py"]
     environment:
       NATS_URL: nats://nats:4222
@@ -40,8 +40,8 @@ services:
   tts-stub:
     <<: [*logging]
     build:
-      context: ./stubs
-      dockerfile: Dockerfile.stub
+      context: ..
+      dockerfile: docker/stubs/Dockerfile.stub
     command: ["python", "tts_stub.py"]
     environment:
       NATS_URL: nats://nats:4222

--- a/docker/stubs/Dockerfile.stub
+++ b/docker/stubs/Dockerfile.stub
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY docker/stubs/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY *.py .
+COPY packages/roxabi-contracts /tmp/roxabi-contracts
+RUN pip install --no-cache-dir /tmp/roxabi-contracts
+COPY docker/stubs/*.py .

--- a/docker/stubs/stt_stub.py
+++ b/docker/stubs/stt_stub.py
@@ -24,6 +24,7 @@ import time
 from datetime import datetime, timezone
 
 import nats
+from roxabi_contracts.voice import SUBJECTS, per_worker_stt
 
 NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
 WORKER_ID = os.getenv("STT_STUB_WORKER_ID", "stt-stub-01")
@@ -75,7 +76,7 @@ async def heartbeat_loop(nc: nats.aio.client.Client) -> None:
             "uptime_s": int(time.monotonic() - _start),
             "ts": int(time.time()),
         }
-        await nc.publish("factory.voice.stt.heartbeat", json.dumps(payload).encode())
+        await nc.publish(SUBJECTS.stt_heartbeat, json.dumps(payload).encode())
         await asyncio.sleep(HB_INTERVAL)
 
 
@@ -84,9 +85,9 @@ async def main() -> None:
     nc = await nats.connect(NATS_URL)
 
     await nc.subscribe(
-        "factory.voice.stt.request", queue="stt-workers", cb=handle_request
+        SUBJECTS.stt_request, queue="stt-workers", cb=handle_request
     )
-    await nc.subscribe(f"factory.voice.stt.request.{WORKER_ID}", cb=handle_request)
+    await nc.subscribe(per_worker_stt(WORKER_ID), cb=handle_request)
     print(f"[stt-stub] ready — queue=stt-workers worker={WORKER_ID}", flush=True)
 
     loop = asyncio.get_running_loop()

--- a/docker/stubs/tts_stub.py
+++ b/docker/stubs/tts_stub.py
@@ -24,6 +24,7 @@ import time
 from datetime import datetime, timezone
 
 import nats
+from roxabi_contracts.voice import SUBJECTS, per_worker_tts
 
 NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
 WORKER_ID = os.getenv("TTS_STUB_WORKER_ID", "tts-stub-01")
@@ -83,7 +84,7 @@ async def heartbeat_loop(nc: nats.aio.client.Client) -> None:
             "uptime_s": int(time.monotonic() - _start),
             "ts": int(time.time()),
         }
-        await nc.publish("factory.voice.tts.heartbeat", json.dumps(payload).encode())
+        await nc.publish(SUBJECTS.tts_heartbeat, json.dumps(payload).encode())
         await asyncio.sleep(HB_INTERVAL)
 
 
@@ -92,9 +93,9 @@ async def main() -> None:
     nc = await nats.connect(NATS_URL)
 
     await nc.subscribe(
-        "factory.voice.tts.request", queue="tts-workers", cb=handle_request
+        SUBJECTS.tts_request, queue="tts-workers", cb=handle_request
     )
-    await nc.subscribe(f"factory.voice.tts.request.{WORKER_ID}", cb=handle_request)
+    await nc.subscribe(per_worker_tts(WORKER_ID), cb=handle_request)
     print(f"[tts-stub] ready — queue=tts-workers worker={WORKER_ID}", flush=True)
 
     loop = asyncio.get_running_loop()

--- a/scripts/check_subject_literals.py
+++ b/scripts/check_subject_literals.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""check_subject_literals.py — every raw lyra.* subject literal in src/ resolves.
+"""check_subject_literals.py — every raw subject literal in src/ + docker/stubs/ resolves.
 
-Scans src/ for raw ``lyra.*`` NATS subject string literals and verifies each one
+Scans src/ and docker/stubs/ for raw ``lyra.*`` / ``factory.*`` NATS subject string literals and verifies each one
 against the semantic CodeInventory oracle (tools/code_inventory.py), whose
 ``subjects`` set is sourced from deploy/nats/acl-matrix.json + roxabi-contracts
 SUBJECTS. A literal that the oracle classifies as a subject but cannot resolve
@@ -226,18 +226,25 @@ def _scan(
     return orphans
 
 
+_DEFAULT_SCAN_DIRS = (
+    _REPO_ROOT / "src",
+    _REPO_ROOT / "docker" / "stubs",
+)
+
+
 def _resolve_src_dirs(src_dirs: list[Path] | None) -> list[Path]:
     """Return the effective source directories to scan."""
     if src_dirs:
         return src_dirs
-    return [d for d in [_REPO_ROOT / "src"] if d.is_dir()]
+    return [d for d in _DEFAULT_SCAN_DIRS if d.is_dir()]
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
-            "Check that every raw lyra.* subject literal in src/ resolves to the "
-            "CodeInventory oracle (acl-matrix.json + roxabi-contracts SUBJECTS)."
+            "Check that every raw lyra.*/factory.* subject literal in src/ and "
+            "docker/stubs/ resolves to the CodeInventory oracle "
+            "(acl-matrix.json + roxabi-contracts SUBJECTS)."
         )
     )
     parser.add_argument(
@@ -246,7 +253,7 @@ def main() -> None:
         action="append",
         dest="src_dirs",
         metavar="DIR",
-        help="Source directory to scan (repeatable). Defaults to src/.",
+        help="Source directory to scan (repeatable). Defaults to src/ and docker/stubs/.",
     )
     parser.add_argument(
         "--root",
@@ -295,7 +302,7 @@ def main() -> None:
 
     if orphans:
         print(
-            f"FAIL: {len(orphans)} orphan subject literal(s) in src/ "
+            f"FAIL: {len(orphans)} orphan subject literal(s) in scanned dirs "
             "not declared in acl-matrix.json or roxabi-contracts SUBJECTS:"
         )
         for subject in sorted(orphans):
@@ -308,7 +315,9 @@ def main() -> None:
         )
         sys.exit(1)
 
-    print("check-subject-literals: OK (all lyra.* literals in src/ resolve)")
+    print(
+        "check-subject-literals: OK (all lyra.*/factory.* literals in src/ + docker/stubs/ resolve)"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/check_subject_literals.py
+++ b/scripts/check_subject_literals.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""check_subject_literals.py — every raw subject literal in src/ + docker/stubs/ resolves.
+"""check_subject_literals.py — raw subject literals in src/ + docker/stubs/ resolve.
 
-Scans src/ and docker/stubs/ for raw ``lyra.*`` / ``factory.*`` NATS subject string literals and verifies each one
+Scans src/ and docker/stubs/ for raw ``lyra.*`` / ``factory.*`` NATS subject
+string literals and verifies each one
 against the semantic CodeInventory oracle (tools/code_inventory.py), whose
 ``subjects`` set is sourced from deploy/nats/acl-matrix.json + roxabi-contracts
 SUBJECTS. A literal that the oracle classifies as a subject but cannot resolve
@@ -253,7 +254,10 @@ def main() -> None:
         action="append",
         dest="src_dirs",
         metavar="DIR",
-        help="Source directory to scan (repeatable). Defaults to src/ and docker/stubs/.",
+        help=(
+            "Source directory to scan (repeatable). "
+            "Defaults to src/ and docker/stubs/."
+        ),
     )
     parser.add_argument(
         "--root",
@@ -316,7 +320,8 @@ def main() -> None:
         sys.exit(1)
 
     print(
-        "check-subject-literals: OK (all lyra.*/factory.* literals in src/ + docker/stubs/ resolve)"
+        "check-subject-literals: OK "
+        "(all lyra.*/factory.* literals in src/ + docker/stubs/ resolve)"
     )
 
 

--- a/tests/scripts/test_check_subject_literals.py
+++ b/tests/scripts/test_check_subject_literals.py
@@ -96,6 +96,11 @@ class TestHappyPath:
         result = _run()
         assert result.returncode == 0, result.stdout + result.stderr
 
+    def test_docker_stubs_pass_with_default_scan(self) -> None:
+        """docker/stubs/ is scanned by default and has no raw subject literals (#1892)."""
+        result = _run([REPO_ROOT / "docker" / "stubs"])
+        assert result.returncode == 0, result.stdout + result.stderr
+
 
 # ---------------------------------------------------------------------------
 # Orphan detection + falsification pair

--- a/tests/scripts/test_check_subject_literals.py
+++ b/tests/scripts/test_check_subject_literals.py
@@ -97,7 +97,7 @@ class TestHappyPath:
         assert result.returncode == 0, result.stdout + result.stderr
 
     def test_docker_stubs_pass_with_default_scan(self) -> None:
-        """docker/stubs/ is scanned by default and has no raw subject literals (#1892)."""
+        """docker/stubs/ is scanned by default; no raw subject literals (#1892)."""
         result = _run([REPO_ROOT / "docker" / "stubs"])
         assert result.returncode == 0, result.stdout + result.stderr
 


### PR DESCRIPTION
## Summary
- `docker/stubs/stt_stub.py` and `tts_stub.py` import voice subjects from `roxabi_contracts.voice` (`SUBJECTS`, `per_worker_*`) instead of hardcoded string literals
- `check_subject_literals.py` now scans `docker/stubs/` by default alongside `src/` — a rename miss fails pre-merge, not only in CI integration
- Stub Docker image installs `roxabi-contracts` (build context widened to repo root)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1892: wire-rename robustness docker/stubs | Open |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `fix/1892-wire-rename-stub-subjects` | Complete |
| Verification | Gate ✅ Tests ✅ (22/22) Docker build ✅ | Passed |

## Test Plan
- [x] `uv run python scripts/check_subject_literals.py`
- [x] `uv run pytest tests/scripts/test_check_subject_literals.py -q` — 22 passed
- [x] `docker build -f docker/stubs/Dockerfile.stub .` — roxabi-contracts installs cleanly

Fixes #1892

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`