### PR TITLE
feat(omp): switch models.yml baseUrl to :18091/v1 (#1974)

### DIFF
--- a/deploy/omp/README.md
+++ b/deploy/omp/README.md
@@ -8,7 +8,7 @@ list trade-off).
 
 | File | Role |
 |---|---|
-| `models.yml` | omp provider override — points the built-in `litellm` provider at the factory LiteLLM xAI pass-through (`:18091/xai/v1`, tailnet) with dynamic catalogue discovery |
+| `models.yml` | omp provider override — points the built-in `litellm` provider at the factory LiteLLM canonical route (`:18091/v1`, tailnet) with dynamic merged-catalogue discovery |
 
 ## How omp picks this up
 
@@ -49,18 +49,19 @@ rebuild.
 #1811 used an explicit `models:` list to dodge a chicken-and-egg: omp's
 discovery URL was derived from already-known models, so an override-only entry
 still fetched against `localhost:4000`. That trade-off is reversed now that
-Roxabi/llmCLI#129 ships a stable xAI pass-through catalogue at `/xai/v1/models`.
+Roxabi/llmCLI#130 ships a unified merged catalogue at `/v1/models` (TOML
+remotes + xAI forwarder + supplements).
 
 ### Phases (gateway prerequisites)
 
 | Phase | Gateway prerequisite | omp `baseUrl` | Scope |
 |-------|---------------------|---------------|-------|
-| **Interim** (current) | Roxabi/llmCLI#129 (`pass_through /xai`) | `:18091/xai/v1` | Discovery + Grok catalogue via xAI route |
-| **Target** (deferred) | Roxabi/llmCLI#130 (unified `/v1/models`) | `:18091/v1` | Single canonical base URL; merged catalogue |
+| **Interim** (done) | Roxabi/llmCLI#129 (`pass_through /xai`) | `:18091/xai/v1` | Discovery + Grok catalogue via xAI route (#1923) |
+| **Target** (current) | Roxabi/llmCLI#130 (unified `/v1/models`) | `:18091/v1` | Single canonical base URL; merged catalogue (#1974) |
 
 **Operator procedure when the proxy catalogue changes:** restart `factory-omp`
-(`systemctl --user restart factory-omp`). No repo change required for new Grok
-variants on the interim route.
+(`systemctl --user restart factory-omp`). No repo change required for new models
+in the merged catalogue.
 
 **Related issues:** #1924 (hub `model_cfg` → `RpcClient(model=…)`), #1910
 (default model when hub omits `model`).
@@ -75,7 +76,7 @@ not add custom retry logic — fix gateway availability or credentials on M₁.
 
 - CI: `tests/deploy/test_omp_models_discovery.py` — static YAML invariants +
   mock-gateway catalogue fetch (no M₁ network).
-- Live smoke (manual, post-llmCLI#129 deploy on M₁):
+- Live smoke (manual, post-llmCLI#130 deploy on M₁):
 
   ```bash
   INTEGRATION=1 LITELLM_API_KEY=<key> uv run --frozen pytest \

--- a/deploy/omp/models.yml
+++ b/deploy/omp/models.yml
@@ -5,8 +5,8 @@
 # its default http://localhost:4000/v1. Pure config — no TCP forward, no
 # upstream patch (options A/B/C superseded; see issue #1811).
 #
-# #1923: dynamic discovery against the LiteLLM xAI pass-through catalogue
-# (interim baseUrl until llmCLI#130 unifies on :18091/v1).
+# #1923: dynamic discovery against the factory LiteLLM merged catalogue.
+# #1974: target-phase baseUrl on canonical :18091/v1 (llmCLI#130 unified route).
 #
 # Invariants:
 # - `apiKey` holds an ENV VAR NAME, not a secret value. omp resolves
@@ -18,7 +18,7 @@
 
 providers:
   litellm:
-    baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/xai/v1
+    baseUrl: http://roxabituwer.goose-logarithm.ts.net:18091/v1
     api: openai-completions
     apiKey: LITELLM_API_KEY
     discovery:

--- a/tests/deploy/test_omp_models_discovery.py
+++ b/tests/deploy/test_omp_models_discovery.py
@@ -27,7 +27,7 @@ def test_models_yml_has_discovery_block() -> None:
     litellm = _load_litellm_provider()
     assert litellm["discovery"]["type"] == "openai-models-list"
     assert "models" not in litellm
-    assert litellm["baseUrl"].endswith("/xai/v1")
+    assert litellm["baseUrl"].endswith("/v1")
 
 
 def test_models_yml_preserves_litellm_provider_shape() -> None:
@@ -46,7 +46,7 @@ class _ModelsListHandler(BaseHTTPRequestHandler):
         return
 
     def do_GET(self) -> None:  # noqa: N802
-        if self.path.rstrip("/") != "/xai/v1/models":
+        if self.path.rstrip("/") != "/v1/models":
             self.send_error(404)
             return
         body = json.dumps(self.catalogue).encode()
@@ -64,7 +64,7 @@ def mock_gateway() -> Generator[str, None, None]:
     thread.start()
     try:
         host, port = server.server_address[:2]
-        yield f"http://{host}:{port}/xai/v1"
+        yield f"http://{host}:{port}/v1"
     finally:
         server.shutdown()
         thread.join(timeout=5)


### PR DESCRIPTION
## Summary
- Switch omp `litellm` provider `baseUrl` from `:18091/xai/v1` → `:18091/v1` so discovery hits the unified merged catalogue (llmCLI#130).
- Update `deploy/omp/README.md` phases table: interim → done, target → current.
- Align CI mock-gateway tests with the canonical `/v1/models` route.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1974: feat(omp): switch models.yml baseUrl to :18091/v1 — #1923 target phase | OPEN |
| Implementation | 1 commit on `feat/1974-feat-omp-switch-models-yml-baseurl-to-18091-v1-1923-target-phase` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (3 passed, 1 skipped) | Passed |

## Test Plan
- [x] `uv run pytest tests/deploy/test_omp_models_discovery.py` — mock + static YAML invariants green
- [ ] Post-deploy smoke on M₁: `factory-omp` restart discovers `grok-4.3` (or current xAI id) without repo edit
- [ ] Durable sessions (`no_session=False`, Model B pool) still work

Fixes #1974

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`