### PR TITLE
refactor(deploy): derive unit lists from quadlet.toml SSoT

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -127,7 +127,7 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_quadlet_manifest_install.sh
-    description: bidirectional manifest↔install — every container/volume/network/pod declared in deploy/quadlet.toml is wired into Makefile quadlet-install + verify UNITS + converge fan-out (forward, #1867), AND every on-disk unit file in deploy/quadlet/ is declared in quadlet.toml (reverse — orphan-install guard, #1901)
+    description: bidirectional manifest↔install — every container/volume/network/pod declared in deploy/quadlet.toml is wired into Makefile quadlet-install (forward, #1867), AND every on-disk unit file in deploy/quadlet/ is declared in quadlet.toml (reverse — orphan-install guard, #1901)
 
   secrets_source:
     enabled: true

--- a/artifacts/frames/1979-quadlet-toml-ssot-codegen-frame.mdx
+++ b/artifacts/frames/1979-quadlet-toml-ssot-codegen-frame.mdx
@@ -1,0 +1,54 @@
+---
+title: make quadlet.toml the single source of truth (codegen)
+issue: 1979
+status: approved
+tier: F-lite
+date: 2026-06-21
+---
+
+## Problem
+
+The factory container inventory is duplicated across **5 hand-maintained sources**: `deploy/quadlet.toml` (manifest), the Makefile `quadlet-install` `UNITS` array, `deploy/quadlet-install-verify.sh` `UNITS` list, the `deploy/converge.sh` restart fan-out, and the docs Volumes table. Adding/renaming a container or volume means editing all five by hand. To catch the inevitable drift, two CI gates exist whose only job is to police that the copies agree: `tools/check_quadlet_manifest_install.sh` (203 lines) and `tools/check_volumes_table.sh` (162 lines).
+
+Root cause: Quadlet/systemd has no native reconciliation, so the inventory got copy-pasted and the gates are the duct tape. This is a governance problem (multi-SSoT), not an orchestrator problem — decided against a k8s/k3s/Nomad migration, which would break rootless + 6 behavioral primitives and create mixed-runtime hell on M₁.
+
+Observable impact: container-add is a 5-file edit; drift has already caused real incidents (#1858 — factory-omp declared in the manifest but never installed; the "component ≠ deployed" gap).
+
+## Who
+
+- **Primary:** the maintainer (Mickael) editing `deploy/` to add/rename/remove factory containers and volumes.
+- **Secondary:** the M₁ converge path (`make converge`, `factory-quadlet-sync`) that consumes the derived artifacts; CI that runs the gates.
+
+## Constraints
+
+- Generated output must be **byte-identical** to the current hand-maintained lists — zero deploy-behavior change at merge.
+- `make converge` must still work end-to-end (dry-run / `NO_RESTART=1`) — no regression on the M₁ deploy path.
+- Do not touch `tools/check_secrets_drift.sh`, `deploy/provision.sh`, `deploy/nats/{gen-certs.sh,bootstrap_streams.py}`, or the 15 app-quality gates.
+- `tools/` scripts are canonically sourced from `roxabi-plugins/dev-core/tools/` — the **new** generator is project-local (factory-specific), so it lives in factory `tools/` without the upstream-sync constraint.
+- Generator should be Python stdlib (the repo already parses TOML; matches the `uv`/Python stack).
+
+## Out of Scope
+
+- Any orchestrator migration (k8s / k3s / Nomad / podman kube play) — explicitly rejected.
+- Touching the secrets-drift gate or NATS/cert/provision infra (orthogonal — survives any orchestrator).
+- Refactoring the 15 app-quality gates.
+- Changing the runtime behavior of converge/install beyond consuming generated lists.
+
+## Premise Validity
+
+**Success in 6 months:** Adding or renaming a container/volume is a **1-file edit** (`deploy/quadlet.toml`) + `make generate`. The 4 derived artifacts (Makefile UNITS, verify UNITS, converge fan-out, docs Volumes table) are generated and never hand-edited. The 2 consistency gates are deleted and their `stack.yml` entries removed. No manifest-drift CI failure or "declared-but-not-installed" incident (the #1858 class) recurs.
+
+**Failure in 6 months (falsifiable):** Any of — (a) the `quadlet manifest_install` + `volumes_table` gate count is **> 0** (gates weren't actually removed); (b) ≥1 PR hand-edits a generated artifact (drift returned — measurable via a generated-file drift check or git blame); (c) net deploy-tooling line count did **not** drop by ≥300 lines; (d) a "component in quadlet.toml but never installed/restarted" incident recurs.
+
+**Simplest alternative:** Just delete the 2 gates and stop checking consistency — no generator.
+**Why not simplest:** That removes the safety net while keeping the 5-copy duplication, so silent drift returns immediately — precisely the #1858 failure mode (component declared, never installed, "Converge complete" lies). The gates must be **replaced by generation**, not merely deleted.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (deploy/devops tooling), one mild unknown (wiring strategy).
+
+Signals observed:
+- ~6–9 files touched: new generator, Makefile, `quadlet-install-verify.sh`, `converge.sh`, docs Volumes section, 2 gate deletions, `.claude/stack.yml`.
+- Single domain (deploy tooling) — no cross-layer/app code.
+- One open question for spec: committed-generated artifacts + drift check vs generate-at-build-time (mirrors existing `qg.conf` generated-but-committed pattern).
+- Known pattern (codegen from a manifest), low technical risk; the risk is byte-identical output + converge non-regression, both verifiable.

--- a/artifacts/plans/1979-quadlet-toml-ssot-codegen-plan.mdx
+++ b/artifacts/plans/1979-quadlet-toml-ssot-codegen-plan.mdx
@@ -1,0 +1,172 @@
+---
+title: "Plan: make quadlet.toml the single source of truth for the unit list"
+issue: 1979
+spec: artifacts/specs/1979-quadlet-toml-ssot-codegen-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-06-21
+---
+
+## Summary
+
+Introduce a grep-based helper `deploy/lib/quadlet-units.sh::quadlet_containers()` that derives the container list from `deploy/quadlet.toml` at run time; rewire `quadlet-install-verify.sh` and `converge.sh` to consume it (fail-closed, pipefail-safe); slim the two forward arms out of `check_quadlet_manifest_install.sh`. Option B (runtime derivation) per the approved spec.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph manifest
+      TOML["deploy/quadlet.toml<br/>[component.*] ×9 (SSoT)"]
+    end
+    subgraph lib
+      HELPER["deploy/lib/quadlet-units.sh<br/>quadlet_containers()<br/>BASH_SOURCE path · fail-closed"]
+    end
+    subgraph consumers
+      VERIFY["quadlet-install-verify.sh<br/>mapfile UNITS · floor ≥9"]
+      CONVERGE["converge.sh<br/>array fan-out · ¬nats · floor ≥9"]
+    end
+    subgraph gate
+      GATE["check_quadlet_manifest_install.sh<br/>drop verify/converge arms<br/>keep Makefile+volume+reverse"]
+      STACK[".claude/stack.yml<br/>description fix"]
+    end
+    TOML --> HELPER --> VERIFY & CONVERGE
+    TOML --> GATE --> STACK
+    HELPER -.unit test.-> TEST["tests: 9-in-order + fail-closed"]
+```
+
+```mermaid
+flowchart LR
+    QU["quadlet-units.sh<br/>quadlet_containers()"]
+    QU --> V["quadlet-install-verify.sh<br/>UNITS=()"]
+    QU --> C["converge.sh<br/>_all/_clients"]
+    T["test_quadlet_units.*"] -.calls.-> QU
+    E["e2e: gates + dry-run"] -.exercises.-> V & C & G2["check_quadlet_manifest_install.sh"]
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| devops-A | T1, T3, T4 | `deploy/lib/quadlet-units.sh`, `deploy/quadlet-install-verify.sh`, `deploy/converge.sh` |
+| devops-B | T5, T6 | `tools/check_quadlet_manifest_install.sh`, `.claude/stack.yml` |
+| tester-A | T2, T7 | `tests/…/test_quadlet_units` (new), e2e gate run |
+
+## Wave Structure
+
+4 waves, max 3 parallel agents. Elapsed ~1 short session vs ~sequential same (tiny F-lite; parallelism is marginal — kept for clean instance separation).
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | devops-A: T1 |
+| 2 | T1 done | 2 ∥ | devops-A: T3→T4 · tester-A: T2 |
+| 3 | T3,T4 done | 1 | devops-B: T5→T6 |
+| 4 | T2,T4,T6 done | 1 | tester-A: T7 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 helper | 1 | judgmental | 5 | — |
+| T2 unit test | 1 | bounded | 4 | — |
+| T3 verify rewire | 1 | bounded | 4 | — |
+| T4 converge rewire | 1 | judgmental | 5 | — |
+| T5 gate slim | 1 | judgmental | 6 | — |
+| T6 stack.yml | 1 | trivial | 2 | — |
+| T7 e2e verify | 1 | judgmental | 8 | — |
+
+**Total estimated ops: ~34**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| devops-A | T1, T3, T4 | 14 | unit-list | — |
+| devops-B | T5, T6 | 8 | gate | — |
+| tester-A | T2, T7 | 12 | test | — |
+
+All instances ≤3 tasks, 1 subject, Σ ops < 50 — no splits required.
+
+## Consistency Report
+
+Spec success criteria → tasks: 10/10 covered. Mapping: SC1→T1/T2 · SC2→T3 · SC3→T4 · SC4→T7 · SC5(gate fail-cases)→T5/T7 · SC6(stack desc)→T6 · SC7(fail-closed)→T1/T3/T4 · SC8(pipefail-safe)→T4 · SC9(gates pass+converge no-op)→T7 · SC10(net lines drop)→T7. No untraced tasks. No exemptions.
+
+## Micro-Tasks
+
+### Slice S1 — derivation helper
+
+**T1 — create `deploy/lib/quadlet-units.sh`** · devops-A · subject: unit-list · diff 3 · trace SC1/SC7
+- Implement `quadlet_containers()` exactly per spec N1 hardened contract: `${BASH_SOURCE[0]}`-relative toml path; `[[ -f ]]` guard; regex `^container[[:space:]]*=[[:space:]]*"[^"]+"`; `cut -d'"' -f2 | sed 's/\.container$//' | tr -d '[:space:]'`; hard-fail `return 1` on empty.
+- Verify: `bash -c 'source deploy/lib/quadlet-units.sh; quadlet_containers'` from repo root AND from `/tmp` → both print the 9 names; `cd /tmp && bash -c 'source <abs>/quadlet-units.sh; quadlet_containers'` still works.
+- Expected: `factory-nats factory-hub factory-telegram factory-discord factory-clipool factory-gh-helper factory-turn-writer factory-blobstore factory-omp` (declaration order, newline-separated).
+
+**T2 — unit test for the helper** · tester-A · subject: test · diff 2 · trace SC1 · blockedBy T1
+- Add a test (bats-style `.sh` under `tests/scripts/` matching repo convention, or pytest invoking bash — match existing `tests/scripts/` pattern) asserting: (a) exactly 9 names; (b) declaration order; (c) `.container` stripped; (d) a temp toml with 0 components → function returns non-zero (fail-closed); (e) missing toml path → non-zero.
+- Verify: run the test → green. Expected: pass.
+
+### Slice S2 — rewire consumers
+
+**T3 — rewire `quadlet-install-verify.sh`** · devops-A · subject: unit-list · diff 2 · trace SC2/SC7 · blockedBy T1
+- Replace the literal `UNITS=(…)` (lines 17–27) with `source "$(dirname "${BASH_SOURCE[0]}")/lib/quadlet-units.sh"` + `mapfile -t UNITS < <(quadlet_containers)` + floor guard `[[ ${#UNITS[@]} -ge 9 ]] || { echo "ERROR: quadlet_containers returned ${#UNITS[@]} (<9)"; exit 1; }`. Note the file sources `lib/env.sh` already — keep ordering.
+- Verify: `bash -n deploy/quadlet-install-verify.sh`; print `${UNITS[@]}` via a dry harness → equals prior 9.
+
+**T4 — rewire `converge.sh` fan-out** · devops-A · subject: unit-list · diff 3 · trace SC3/SC8 · blockedBy T1
+- Source the helper. Replace `for svc in factory-hub … factory-omp` with: `mapfile -t _all_svcs < <(quadlet_containers)`; floor `[[ ${#_all_svcs[@]} -ge 9 ]] || { echo ERROR…; exit 1; }`; `mapfile -t _client_svcs < <(printf '%s\n' "${_all_svcs[@]}" | grep -v '^factory-nats$' || true)`; `for svc in "${_client_svcs[@]}"`. Keep the existing `failed=…` error accumulation. factory-nats stays excluded.
+- Verify: `bash -n deploy/converge.sh`; assert `_client_svcs` = prior 8 and excludes `factory-nats`; confirm `set -euo pipefail` not tripped when grep matches (it always matches here, but `|| true` guards the degenerate case).
+
+### Slice S3 — slim the gate
+
+**T5 — slim `check_quadlet_manifest_install.sh`** · devops-B · subject: gate · diff 3 · trace SC5 · blockedBy T3,T4
+- Delete ONLY the two grep `if` arms: lines 55–58 (verify-array) + 60–65 (converge-fan-out). Keep the `while` loop + `count++`, the Makefile arm (48–53), volume/network/pod arms, reverse orphan-guard, zero-guard. Update the stale header comment (7–24: drop refs to verify UNITS array + converge fan-out) and the footer message (196–200). Patch the line-66 feed regex to the whitespace-tolerant form `^container[[:space:]]*=[[:space:]]*"[^"]+"` for parity with the helper.
+- Verify: `bash tools/check_quadlet_manifest_install.sh` passes on the current tree; temporarily add `[component.fake]` with no file → FAILs (Makefile/reverse arm); revert.
+
+**T6 — fix `.claude/stack.yml` description** · devops-B · subject: gate · diff 1 · trace SC6 · blockedBy T5
+- Edit the `quadlet_manifest_install` `description:` to drop "+ verify UNITS + converge fan-out"; keep the Makefile-install + reverse-orphan claims.
+- Verify: `grep -A1 'quadlet_manifest_install' .claude/stack.yml` no longer mentions verify/converge fan-out.
+
+### Slice S4 — verification (RED-GATE)
+
+**T7 — end-to-end verification** · tester-A · subject: test · diff 3 · trace SC4/SC9/SC10 · blockedBy T2,T3,T4,T5,T6
+- Assert derived verify UNITS == old 9 and derived converge `_client_svcs` == old 8. Run ALL pre-push gates (`check_quadlet_manifest_install.sh`, `check_volumes_table.sh`, `check_secrets_drift.sh`, plus `bash -n` on the 3 shell files). Add-a-10th dry test: append a throwaway `[component.zzz]`+file, confirm it appears in both derived lists with zero edits to the scripts, then revert. Confirm net line delta is negative (lists+arms removed > helper added).
+- Verify: all gates exit 0; throwaway add reflected; `git diff --stat` shows net negative on deploy/ + tools/.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls. T{n} | agent-instance | blockedBy | subject -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | devops-A | — | unit-list |
+
+### Wave 2 — after T1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | tester-A | T1 | test |
+| T3 | devops-A | T1 | unit-list |
+| T4 | devops-A | T3 | unit-list |
+
+### Wave 3 — after T3,T4, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | devops-B | T3,T4 | gate |
+| T6 | devops-B | T5 | gate |
+
+### Wave 4 — after T2,T4,T6, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | tester-A | T2,T4,T6 | test |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 10 — unit-list (devops-A)
+- T2: 11 — test (tester-A)
+- T3: 12 — unit-list (devops-A)
+- T4: 13 — unit-list (devops-A)
+- T5: 14 — gate (devops-B)
+- T6: 15 — gate (devops-B)
+- T7: 16 — test (tester-A)

--- a/artifacts/specs/1979-quadlet-toml-ssot-codegen-spec.mdx
+++ b/artifacts/specs/1979-quadlet-toml-ssot-codegen-spec.mdx
@@ -1,0 +1,157 @@
+---
+title: make quadlet.toml the single source of truth for the unit list
+issue: 1979
+status: approved
+tier: F-lite
+date: 2026-06-21
+promoted_from: artifacts/frames/1979-quadlet-toml-ssot-codegen-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1979-quadlet-toml-ssot-codegen-frame.mdx` (approved).
+
+**The frame's scope was corrected by reading the code.** Two frame assumptions did not survive:
+
+1. **The Makefile does not enumerate units.** `quadlet-install` (Makefile:149) *globs* `deploy/quadlet/*.{network,volume,pod,container}` and copies all of them. There is no "Makefile UNITS array" to generate. Install-by-glob is already SSoT-free.
+2. **The docs Volumes table is semantic, not derivable.** `docs/architecture/deployment.md` `## Volumes` has columns `Volume | File | Container(s) | Access | Contents` — the File/Access/Contents cells are hand-authored knowledge (what each volume holds), not a projection of `quadlet.toml`. It cannot be codegen'd from the manifest.
+
+The **actual** hand-maintained duplication of the container list is exactly two places, both shell:
+
+| Source | Lines | Holds |
+|---|---|---|
+| `deploy/quadlet-install-verify.sh` | 17–27 | `UNITS=(…)` — **9** containers incl. `factory-nats` |
+| `deploy/converge.sh` | ~98 | `for svc in …` structural restart fan-out — **8** containers, **excludes** `factory-nats` (own `_restart_nats` path) |
+
+Their orderings even differ from each other and from `quadlet.toml`, confirming they drifted independently. `deploy/quadlet.toml` `[component.*]` (9 entries) is the natural source of truth.
+
+## Goal
+
+`deploy/quadlet.toml` becomes the **only** hand-edited place the container list lives; `verify.sh` and `converge.sh` derive their lists from it, so adding/renaming a container no longer touches them.
+
+## Users
+
+- **Primary:** maintainer editing `deploy/` to add/rename/remove a factory container.
+- **Secondary:** the M₁ converge path (`make converge`, `factory-quadlet-sync.timer`) that runs `verify.sh` + `converge.sh`; CI running the pre-push gates.
+
+## Expected Behavior
+
+**Adding a container — before:** edit `quadlet.toml` + create the `.container` file + add to `verify.sh` UNITS + add to `converge.sh` fan-out (remembering nats is exempt) → if you miss one, `check_quadlet_manifest_install.sh` fails the push (or, pre-#1867, it shipped broken — #1858).
+
+**Adding a container — after:** edit `quadlet.toml` + create the `.container` file. `verify.sh` and `converge.sh` read the list from `quadlet.toml` at run time. Nothing else to touch; the forward-drift gate arms become unfalsifiable by construction.
+
+### Core design decision (surfaced for the gate)
+
+> ── Decision: how does the list get from quadlet.toml into the two scripts ──
+>
+> **Option A — Codegen + commit.** A `make generate` writes the `UNITS=()` block and the `for svc in` line into the scripts as generated-but-committed content; a new drift-check gate re-runs the generator and diffs. Matches the repo's existing `qg.conf` generated-but-committed pattern (auditable in-file), but adds a generator *and* a drift gate (more machinery, the opposite of the goal).
+>
+> **Option B — Runtime derivation.** A ~10-line shared helper `deploy/lib/quadlet-units.sh` extracts the container list from `quadlet.toml` (grep, the same `grep -oE '^container = "[^"]+"'` the gate already uses — no python dep). `verify.sh` and `converge.sh` source it and `mapfile` the list live. No generated files, no codegen step, no drift gate. The forward arms of `check_quadlet_manifest_install.sh` become structurally impossible to violate.   ← **recommended**
+>
+> Recommended: **Option B** — the issue says "codegen", but runtime-derivation is strictly less machinery and better serves the goal (reduce scripts). It eliminates the lists *and* a gate instead of trading two hand-lists for a generator + a drift gate.
+
+The spec below assumes **Option B**. (Option A is a drop-in alternative for slices S2–S3 if the gate prefers committed/auditable artifacts.)
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class QuadletManifest {
+        +component[name].container : str  «9»
+        +volume[name].volume : str  «5»
+        +network[name].network : str  «1»
+        +pod[name].pod : str  «1»
+    }
+    class QuadletUnitsHelper {
+        +quadlet_containers() list~str~  «strips .container»
+    }
+    QuadletManifest <.. QuadletUnitsHelper : grep extract
+```
+
+```mermaid
+flowchart TD
+    TOML["deploy/quadlet.toml<br/>[component.*] (SSoT)"]
+    HELPER["deploy/lib/quadlet-units.sh<br/>quadlet_containers()"]
+    VERIFY["quadlet-install-verify.sh<br/>UNITS (all 9)"]
+    CONVERGE["converge.sh<br/>fan-out (8, ¬nats)"]
+    MAKE["Makefile quadlet-install<br/>glob *.container (unchanged)"]
+    GATE["check_quadlet_manifest_install.sh<br/>reverse orphan-guard (kept)"]
+    DOCS["deployment.md Volumes table<br/>semantic (kept, untouched)"]
+
+    TOML --> HELPER
+    HELPER --> VERIFY
+    HELPER --> CONVERGE
+    TOML -.glob covers files.-> MAKE
+    TOML --> GATE
+    TOML -.semantic, not derived.-> DOCS
+```
+
+| Consumer | Reads from quadlet.toml | When | Status (this issue) |
+|---|---|---|---|
+| `quadlet-install-verify.sh` UNITS | all `[component.*]` containers | every `make quadlet-install` | **this issue** — derive via helper |
+| `converge.sh` fan-out | `[component.*]` minus `factory-nats` | structural-drift converge | **this issue** — derive via helper |
+| Makefile `quadlet-install` | glob of `deploy/quadlet/*` | install | unchanged (already glob) |
+| `check_quadlet_manifest_install.sh` | toml ↔ on-disk + verify/converge | pre-push + CI | **this issue** — drop forward verify/converge arms, keep reverse orphan-guard + makefile arm |
+| `check_volumes_table.sh` | Volume= ↔ docs table | pre-push + CI | unchanged (semantic) |
+| `deployment.md` Volumes table | — | docs | unchanged (semantic) |
+
+## Breadboard
+
+| Affordance | Handler | Data |
+|---|---|---|
+| N1 `quadlet_containers()` | new `deploy/lib/quadlet-units.sh` | see hardened contract below |
+| N2 verify UNITS | `quadlet-install-verify.sh` sources N1, `mapfile -t UNITS < <(quadlet_containers)` + **floor guard** `[[ ${#UNITS[@]} -ge 9 ]] \|\| exit 1` | replaces lines 17–27 |
+| N3 converge fan-out | `converge.sh` sources N1, **array form** (¬`$(...)` in `for`): `mapfile -t _all < <(quadlet_containers)`; floor guard `≥9`; `mapfile -t _clients < <(printf '%s\n' "${_all[@]}" \| grep -v '^factory-nats$' \|\| true)`; `for svc in "${_clients[@]}"` | replaces the literal `for svc in …` |
+| N4 slim gate | `check_quadlet_manifest_install.sh` drops **only the two grep `if` arms** (lines 55–58 verify-array + 60–65 converge-fan-out); keeps the `while` loop + `count`, Makefile arm, volume/network/pod arms, reverse orphan-guard, zero-guard. Also update the stale header comment (7–24) + footer message (196–200), and patch the line-66 feed regex to the whitespace-tolerant form for consistency | net ~−15L, gate still guards orphans + #1858 |
+| N5 stack.yml | update `quadlet_manifest_install` description to drop the "verify UNITS + converge fan-out" forward claim | doc accuracy |
+
+### N1 — hardened helper contract (from expert review — blocking)
+
+```bash
+# deploy/lib/quadlet-units.sh  — sourced, never executed
+quadlet_containers() {
+    local toml
+    toml="$(dirname "${BASH_SOURCE[0]}")/../quadlet.toml"   # cwd-independent (¬$0)
+    [[ -f "${toml}" ]] || { echo "ERROR: quadlet.toml not found at ${toml}" >&2; return 1; }
+    local -a out
+    mapfile -t out < <(grep -oE '^container[[:space:]]*=[[:space:]]*"[^"]+"' "${toml}" \
+        | cut -d'"' -f2 | sed 's/\.container$//' | tr -d '[:space:]')
+    [[ ${#out[@]} -gt 0 ]] || { echo "ERROR: quadlet_containers parsed 0 containers from ${toml}" >&2; return 1; }
+    printf '%s\n' "${out[@]}"
+}
+```
+
+Requirements baked in: **(a)** `${BASH_SOURCE[0]}`-relative path (works from any cwd, sourced by `deploy/converge.sh` *and* `deploy/quadlet-install-verify.sh`); **(b)** file-existence guard; **(c)** whitespace-tolerant regex (`container=` / extra spaces both legal TOML); **(d)** `.container` suffix stripped + trailing-whitespace stripped (a leaked suffix would make N3's `grep -v '^factory-nats$'` miss → NATS restarted twice mid-converge); **(e)** hard-fail `return 1` on empty parse — never emit an empty list silently.
+
+### Confirmed safe by review (no action)
+
+- **Declaration order** is a safe canonical restart order: verify.sh, converge.sh, and quadlet.toml already have three *different* orderings, and every client unit declares `After=/Requires=factory-nats.service` so systemd enforces nats-first — no cross-client ordering dependency exists to lose.
+- **Gate slim is safe**: #1858 (declared-but-not-installed) stays caught by the Makefile arm; #1813 (volume not installed) by the volume arm; #1901 (orphan on-disk file) by the reverse guard; the zero-guard survives (only the two grep `if` blocks drop, not the `while` loop). The forward verify/converge arms *must* go — after derivation the names are no longer literal in those scripts, so the arms would false-positive on every container.
+- **`deploy/lib/` placement** matches `deploy-common.sh` / `env.sh`.
+
+## Slices
+
+| # | Slice | Demo |
+|---|---|---|
+| S1 | Add `deploy/lib/quadlet-units.sh` `quadlet_containers()` + a unit test asserting it emits the exact 9 current containers in declaration order | `bash -c 'source deploy/lib/quadlet-units.sh; quadlet_containers'` prints the 9 |
+| S2 | Rewire `quadlet-install-verify.sh` (N2) + `converge.sh` (N3) to source the helper; `factory-nats` exclusion preserved | `grep -c 'factory-' …` shows lists now derived; `make converge` dry-run (`NO_RESTART`/already-converged) unchanged |
+| S3 | Slim `check_quadlet_manifest_install.sh` (N4) + update `.claude/stack.yml` description (N5); gate still red on an orphan on-disk unit + on a toml entry whose `.container` file is missing | add a fake `[component.x]` with no file → gate FAILs; remove → passes |
+| S4 | Verify the existing manifest is unchanged end-to-end: derived verify UNITS == old 9, derived converge fan-out == old 8; run all pre-push gates | `tools/check_quadlet_manifest_install.sh` passes; lists match pre-change behavior |
+
+## Success Criteria
+
+- [ ] `deploy/lib/quadlet-units.sh::quadlet_containers()` emits exactly the 9 current containers, in `quadlet.toml` declaration order, with `.container` stripped.
+- [ ] `quadlet-install-verify.sh` no longer contains a hand-written `UNITS=(…)` literal; its list is sourced from the helper and equals the prior 9.
+- [ ] `converge.sh` no longer contains a hand-written `for svc in factory-…` literal; its list is sourced from the helper, equals the prior 8, and still excludes `factory-nats`.
+- [ ] Adding a 10th `[component.*]` to `quadlet.toml` (+ its `.container` file) makes it appear in both verify and converge with **zero** edits to those scripts (proven by test/dry-run).
+- [ ] `check_quadlet_manifest_install.sh` still FAILs on (a) an on-disk unit file absent from `quadlet.toml` (reverse orphan-guard) and (b) a `[component.*]` not installed by the Makefile arm; it no longer contains the verify-UNITS / converge-fan-out grep arms; its header comment + footer message no longer reference them.
+- [ ] `.claude/stack.yml` `quadlet_manifest_install` description no longer claims it checks "verify UNITS + converge fan-out".
+- [ ] **Fail-closed:** `quadlet_containers()` returns non-zero (¬empty list) when `quadlet.toml` is missing/unreadable; both `verify.sh` and `converge.sh` assert `[[ ${#…[@]} -ge 9 ]]` after populating their arrays and `exit 1` below the floor (no false-green install, no silent no-op converge).
+- [ ] **pipefail-safe:** `converge.sh` uses the array form (no `$(…)` in `for`), and the `grep -v factory-nats` stage cannot abort the script (`|| true`); `factory-nats` is still never in the client fan-out.
+- [ ] All pre-push gates pass; `make converge` on an already-converged tree is a no-op (no spurious restart).
+- [ ] Net deploy-tooling line count drops (lists + gate arms removed > helper added).
+
+## Scope correction vs frame (explicit)
+
+- `check_volumes_table.sh` (162L) is **NOT deleted** — the Volumes table is semantic. Frame's "-365L / delete 2 gates" is revised: we slim one gate (~−25L) and remove ~20L of hand-lists, add ~12L helper. Net is a **smaller line win** than the frame estimated, but the *structural* win (container-add = no script edits + a forward-drift class made impossible) stands.
+- If the gate panel wants the bigger line reduction, S4 can additionally fold the volume-list half of `check_volumes_table.sh` onto the helper — deferred as out-of-scope here to avoid touching semantic doc prose.

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -87,7 +87,9 @@ _do_converge() {
         # 8) Restart factory NATS clients (only on structural drift)
         echo "==> Lyra: restarting containers..."
         local failed=""
+        local -a _all_svcs _client_svcs
         mapfile -t _all_svcs < <(quadlet_containers)
+        # 9 = current factory container count in deploy/quadlet.toml; fail-fast on empty/partial parse — ¬a strict-equality check (adding a 10th is fine)
         [[ ${#_all_svcs[@]} -ge 9 ]] || { echo "ERROR: quadlet_containers returned ${#_all_svcs[@]} units (<9)" >&2; exit 1; }
         mapfile -t _client_svcs < <(printf '%s\n' "${_all_svcs[@]}" | grep -v '^factory-nats$' || true)
         for svc in "${_client_svcs[@]}"; do

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -6,7 +6,9 @@
 
 set -euo pipefail
 
-source "$(dirname "$0")/lib/deploy-common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/deploy-common.sh"
+# shellcheck source=lib/quadlet-units.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/quadlet-units.sh"
 
 # Guard against concurrent runs (exit 0 if locked)
 # NOTE: with_deploy_lock is called at the END of this file, after _do_converge is defined.
@@ -85,7 +87,10 @@ _do_converge() {
         # 8) Restart factory NATS clients (only on structural drift)
         echo "==> Lyra: restarting containers..."
         local failed=""
-        for svc in factory-hub factory-telegram factory-discord factory-clipool factory-turn-writer factory-gh-helper factory-blobstore factory-omp; do
+        mapfile -t _all_svcs < <(quadlet_containers)
+        [[ ${#_all_svcs[@]} -ge 9 ]] || { echo "ERROR: quadlet_containers returned ${#_all_svcs[@]} units (<9)" >&2; exit 1; }
+        mapfile -t _client_svcs < <(printf '%s\n' "${_all_svcs[@]}" | grep -v '^factory-nats$' || true)
+        for svc in "${_client_svcs[@]}"; do
             systemctl --user restart "${svc}" \
                 || { echo "ERROR: restart ${svc} failed"; failed="${failed} ${svc}"; }
         done

--- a/deploy/lib/quadlet-units.sh
+++ b/deploy/lib/quadlet-units.sh
@@ -1,0 +1,21 @@
+# deploy/lib/quadlet-units.sh — sourced, never executed
+#
+# Provides quadlet_containers() — parses deploy/quadlet.toml and emits
+# the container names (one per line, stripped .container suffix) in
+# declaration order.
+#
+# Usage (from a script in deploy/ or deploy/lib/):
+#   source "$(dirname "${BASH_SOURCE[0]}")/../lib/quadlet-units.sh"
+#   mapfile -t UNITS < <(quadlet_containers)
+#
+# Safe to source multiple times — function is idempotent.
+quadlet_containers() {
+    local toml
+    toml="$(dirname "${BASH_SOURCE[0]}")/../quadlet.toml"   # cwd-independent (¬$0)
+    [[ -f "${toml}" ]] || { echo "ERROR: quadlet.toml not found at ${toml}" >&2; return 1; }
+    local -a out
+    mapfile -t out < <(grep -oE '^container[[:space:]]*=[[:space:]]*"[^"]+"' "${toml}" \
+        | cut -d'"' -f2 | sed 's/\.container$//' | tr -d ' \t')
+    [[ ${#out[@]} -gt 0 ]] || { echo "ERROR: quadlet_containers parsed 0 containers from ${toml}" >&2; return 1; }
+    printf '%s\n' "${out[@]}"
+}

--- a/deploy/quadlet-install-verify.sh
+++ b/deploy/quadlet-install-verify.sh
@@ -11,20 +11,13 @@
 # Exits non-zero if any unit fails to reach `active`.
 set -euo pipefail
 # shellcheck source=lib/env.sh
-source "$(dirname "$0")/lib/env.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/env.sh"
+# shellcheck source=lib/quadlet-units.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/quadlet-units.sh"
 
-# Units derived from .container files.  Quadlet maps <name>.container → <name>.service.
-UNITS=(
-    factory-nats
-    factory-hub
-    factory-telegram
-    factory-discord
-    factory-clipool
-    factory-gh-helper
-    factory-blobstore
-    factory-turn-writer
-    factory-omp
-)
+# Units derived from deploy/quadlet.toml at runtime.  Quadlet maps <name>.container → <name>.service.
+mapfile -t UNITS < <(quadlet_containers)
+[[ ${#UNITS[@]} -ge 9 ]] || { echo "ERROR: quadlet_containers returned ${#UNITS[@]} units (<9)" >&2; exit 1; }
 
 # ── 1. Reload daemon so Quadlet generates fresh .service files ────────────────
 echo "[quadlet] daemon-reload ..."

--- a/deploy/quadlet-install-verify.sh
+++ b/deploy/quadlet-install-verify.sh
@@ -17,6 +17,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/quadlet-units.sh"
 
 # Units derived from deploy/quadlet.toml at runtime.  Quadlet maps <name>.container → <name>.service.
 mapfile -t UNITS < <(quadlet_containers)
+# 9 = current factory container count in deploy/quadlet.toml; fail-fast on empty/partial parse — ¬a strict-equality check (adding a 10th is fine)
 [[ ${#UNITS[@]} -ge 9 ]] || { echo "ERROR: quadlet_containers returned ${#UNITS[@]} units (<9)" >&2; exit 1; }
 
 # ── 1. Reload daemon so Quadlet generates fresh .service files ────────────────

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -33,7 +34,7 @@ EXPECTED_CONTAINERS = [
 def _source_and_run(helper: Path) -> subprocess.CompletedProcess[str]:
     """Source the helper and invoke quadlet_containers(), capturing output."""
     return subprocess.run(
-        ["bash", "-c", f"source {helper}; quadlet_containers"],
+        ["bash", "-c", f"source {shlex.quote(str(helper))}; quadlet_containers"],
         capture_output=True,
         text=True,
     )
@@ -76,7 +77,7 @@ def test_fail_closed_on_zero_components(tmp_path: Path) -> None:
     toml.write_text("[meta]\nx = 1\n")
 
     result = subprocess.run(
-        ["bash", "-c", f"source {helper_copy}; quadlet_containers"],
+        ["bash", "-c", f"source {shlex.quote(str(helper_copy))}; quadlet_containers"],
         capture_output=True,
         text=True,
     )
@@ -97,7 +98,7 @@ def test_fail_closed_on_missing_toml(tmp_path: Path) -> None:
     # deliberately do NOT create tmp_path/deploy/quadlet.toml
 
     result = subprocess.run(
-        ["bash", "-c", f"source {helper_copy}; quadlet_containers"],
+        ["bash", "-c", f"source {shlex.quote(str(helper_copy))}; quadlet_containers"],
         capture_output=True,
         text=True,
     )

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -1,0 +1,104 @@
+"""Tests for deploy/lib/quadlet-units.sh — quadlet_containers() function.
+
+Covers:
+  - emits exactly 9 container names from the real quadlet.toml
+  - declaration order matches the expected manifest list
+  - no output line ends with .container or contains whitespace
+  - fail-closed when quadlet.toml contains no container declarations
+  - fail-closed when quadlet.toml is missing entirely
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "deploy" / "lib" / "quadlet-units.sh"
+
+EXPECTED_CONTAINERS = [
+    "factory-nats",
+    "factory-hub",
+    "factory-telegram",
+    "factory-discord",
+    "factory-clipool",
+    "factory-gh-helper",
+    "factory-turn-writer",
+    "factory-blobstore",
+    "factory-omp",
+]
+
+
+def _source_and_run(helper: Path) -> subprocess.CompletedProcess[str]:
+    """Source the helper and invoke quadlet_containers(), capturing output."""
+    return subprocess.run(
+        ["bash", "-c", f"source {helper}; quadlet_containers"],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_emits_exactly_9_containers() -> None:
+    """Real helper against the real quadlet.toml → returncode 0, exactly 9 names."""
+    result = _source_and_run(HELPER)
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line]
+    assert len(lines) == 9, f"expected 9 containers, got {len(lines)}: {lines}"
+
+
+def test_declaration_order() -> None:
+    """The 9 lines equal EXPECTED_CONTAINERS in declaration order."""
+    result = _source_and_run(HELPER)
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line]
+    assert lines == EXPECTED_CONTAINERS, f"order mismatch: {lines}"
+
+
+def test_container_suffix_stripped() -> None:
+    """No output line ends with .container and none contains whitespace."""
+    result = _source_and_run(HELPER)
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line]
+    for line in lines:
+        assert not line.endswith(".container"), f"suffix not stripped: {line!r}"
+        assert " " not in line and "\t" not in line, f"whitespace in name: {line!r}"
+
+
+def test_fail_closed_on_zero_components(tmp_path: Path) -> None:
+    """quadlet_containers exits non-zero when quadlet.toml has no container lines."""
+    lib_dir = tmp_path / "deploy" / "lib"
+    lib_dir.mkdir(parents=True)
+    helper_copy = lib_dir / "quadlet-units.sh"
+    shutil.copy(HELPER, helper_copy)
+
+    toml = tmp_path / "deploy" / "quadlet.toml"
+    toml.write_text("[meta]\nx = 1\n")
+
+    result = subprocess.run(
+        ["bash", "-c", f"source {helper_copy}; quadlet_containers"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, "expected non-zero exit when 0 containers parsed"
+    # stdout must contain no container-shaped names
+    assert not any(
+        line.startswith("factory-") for line in result.stdout.splitlines()
+    ), f"unexpected container names in stdout: {result.stdout!r}"
+
+
+def test_fail_closed_on_missing_toml(tmp_path: Path) -> None:
+    """quadlet_containers exits non-zero when quadlet.toml does not exist."""
+    lib_dir = tmp_path / "deploy" / "lib"
+    lib_dir.mkdir(parents=True)
+    helper_copy = lib_dir / "quadlet-units.sh"
+    shutil.copy(HELPER, helper_copy)
+
+    # deliberately do NOT create tmp_path/deploy/quadlet.toml
+
+    result = subprocess.run(
+        ["bash", "-c", f"source {helper_copy}; quadlet_containers"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, "expected non-zero exit when quadlet.toml is absent"

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 # tools/check_quadlet_manifest_install.sh
 #
-# deploy/quadlet.toml is the authoritative unit manifest, but the install/restart
-# paths are hand-enumerated: a component declared in the manifest is NOT deployed
-# unless it also appears in
-#   1. the Makefile `quadlet-install` recipe (cp, or render_quadlet.py --dest),
-#   2. the UNITS array in deploy/quadlet-install-verify.sh,
-#   3. the structural-drift restart fan-out in deploy/converge.sh
-#      (factory-nats is exempt — it has its own _restart_nats path).
+# deploy/quadlet.toml is the authoritative unit manifest.  A component declared
+# in the manifest is NOT deployed unless it also appears in:
+#   1. the Makefile `quadlet-install` recipe (cp, or render_quadlet.py --dest).
 #
 # Gap class (#1867): PR #1858 shipped factory-omp.container + its manifest entry,
-# converge kept reporting "Converge complete" while the unit was never installed.
+# but the unit was never installed by the Makefile recipe.
 #
 # BIDIRECTIONAL CHECK (#1901):
 #   Reverse direction: every unit FILE in deploy/quadlet/ (*.container,
@@ -52,18 +48,7 @@ while IFS= read -r container; do
         fail=1
     fi
 
-    if ! grep -qE "^[[:space:]]+${unit}$" deploy/quadlet-install-verify.sh; then
-        echo "FAIL: ${unit} is missing from the UNITS array in deploy/quadlet-install-verify.sh"
-        fail=1
-    fi
-
-    if [ "${unit}" != "factory-nats" ] \
-       && ! grep -E '^[[:space:]]*for svc in ' deploy/converge.sh \
-            | grep -qE "[[:space:]]${unit}([[:space:]]|;)"; then
-        echo "FAIL: ${unit} is missing from the structural restart fan-out in deploy/converge.sh"
-        fail=1
-    fi
-done < <(grep -oE '^container = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+done < <(grep -oE '^container[[:space:]]*=[[:space:]]*"[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 
 # Volume units: a [volume.*] declared in the manifest must also be cp'd by the
 # Makefile quadlet-install recipe. If it is not, the Quadlet generator drops
@@ -193,8 +178,7 @@ fi
 if [ "${fail}" -ne 0 ]; then
     echo ""
     echo "Every [component.*] container in deploy/quadlet.toml must be wired into the"
-    echo "Makefile quadlet-install recipe, the quadlet-install-verify.sh UNITS array,"
-    echo "and the converge.sh restart fan-out — see #1867."
+    echo "Makefile quadlet-install recipe — see #1867."
     echo "Every [volume.*] volume must be cp'd by the quadlet-install recipe — see #1813."
     echo "Every unit FILE in deploy/quadlet/ must be declared in deploy/quadlet.toml — see #1901."
     exit 1

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -64,7 +64,7 @@ while IFS= read -r volume; do
         echo "FAIL: ${volume} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
         fail=1
     fi
-done < <(grep -oE '^volume = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+done < <(grep -oE '^volume[[:space:]]*=[[:space:]]*"[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 
 # Network units: a [network.*] declared in the manifest must be install-evidenced
 # by the Makefile quadlet-install recipe (same 2-arm check as volumes).
@@ -76,7 +76,7 @@ while IFS= read -r network; do
         echo "FAIL: ${network} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
         fail=1
     fi
-done < <(grep -oE '^network = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+done < <(grep -oE '^network[[:space:]]*=[[:space:]]*"[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 
 # Pod units: a [pod.*] declared in the manifest must be install-evidenced by
 # the Makefile quadlet-install recipe.
@@ -88,7 +88,7 @@ while IFS= read -r pod; do
         echo "FAIL: ${pod} is declared in deploy/quadlet.toml but never installed by 'make quadlet-install'"
         fail=1
     fi
-done < <(grep -oE '^pod = "[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
+done < <(grep -oE '^pod[[:space:]]*=[[:space:]]*"[^"]+"' deploy/quadlet.toml | cut -d'"' -f2)
 
 # ── REVERSE DIRECTION: every on-disk unit file must be declared in quadlet.toml ─
 # A single python3 heredoc reads quadlet.toml via tomllib, iterates deploy/quadlet/,


### PR DESCRIPTION
## Summary
- Introduce `deploy/lib/quadlet-units.sh::quadlet_containers()`, a sourced helper that derives the factory container list from `deploy/quadlet.toml` `[component.*]` at run time (cwd-independent via `BASH_SOURCE`, fail-closed on missing/empty). **Option B — runtime derivation**, chosen over the issue's "codegen" framing because it is strictly less machinery: no generated files, no generator, no drift gate (per the approved spec).
- Rewire the two hand-maintained copies of the list to source the helper:
  - `quadlet-install-verify.sh`: `UNITS=()` literal → `mapfile` + floor guard `≥9`.
  - `converge.sh`: literal `for svc in factory-…` fan-out → pipefail-safe array form (`mapfile`, floor guard, `grep -v factory-nats || true`); `factory-nats` is still excluded from the client restart loop.
- Slim `check_quadlet_manifest_install.sh`: the two forward-drift arms (verify-UNITS, converge-fan-out) are now unfalsifiable by construction → removed. **Kept**: Makefile-install arm (#1858/#1867), volume/network/pod arms (#1813), reverse orphan-guard (#1901), zero-count guard. Header/footer reworded; `.claude/stack.yml` description updated to match.

Adding/renaming a container is now a **`quadlet.toml`-only edit** — the two shell lists derive automatically.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1979: make quadlet.toml the single source of truth | OPEN |
| Analysis | — (F-lite, analyze skipped) | Absent |
| Spec | [1979-…-spec.mdx](artifacts/specs/1979-quadlet-toml-ssot-codegen-spec.mdx) | Present |
| Implementation | 3 commits on `feat/1979-quadlet-toml-ssot-codegen` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new) · pre-push gates ✅ · converge regression 9/9 ✅ | Passed |

## Test Plan
- [ ] `source deploy/lib/quadlet-units.sh; quadlet_containers` prints the 9 containers in `quadlet.toml` declaration order, `.container` stripped.
- [ ] Appending a `[component.*]` to `quadlet.toml` makes it appear in both `verify.sh` UNITS and `converge.sh` fan-out with **zero** edits to those scripts.
- [ ] `check_quadlet_manifest_install.sh` still FAILs on an orphan on-disk unit file (reverse guard) and on a declared-but-not-installed Makefile component.
- [ ] `quadlet_containers()` returns non-zero (no silent empty list) when `quadlet.toml` is missing/unreadable.

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1 helper emits 9, order, `.container` stripped | `test_quadlet_units.py :: test_emits_exactly_9_containers / test_declaration_order / test_container_suffix_stripped` | ✓ proven |
| SC2 verify.sh derived UNITS == 9 | manual derivation check + diff | ✓ proven |
| SC3 converge.sh derived fan-out == 8, ¬nats | manual derivation check + diff | ✓ proven |
| SC4 add-a-10th, zero script edits | dry append `[component.zzz]` → verify 10 / converge 9 | ✓ proven |
| SC5 gate fails on orphan + Makefile arm; no verify/converge arms | reverse-guard bite (exit 1→0); 0 dropped-arm refs; 4 Makefile arms intact | ✓ proven |
| SC6 stack.yml description updated | diff | ✓ proven |
| SC7 fail-closed (missing/empty → non-zero; floor ≥9) | `test_fail_closed_on_zero_components / test_fail_closed_on_missing_toml` + floor guards | ✓ proven |
| SC8 pipefail-safe (array form, `grep \|\| true`, nats never client) | derivation under `set -euo pipefail`, no abort | ✓ proven |
| SC9 all pre-push gates pass; converge no-op on converged tree | manifest/volumes/secrets/test_sleep/dup-basename/no-toml-bots ✅; converge regression 9/9 | ✓ proven |
| SC10 net deploy-tooling line count drops | numstat: helper +21, verify −7, converge +5, gate −16 = **+3** | ⚠ +3, not negative — see note |

**SC10 note (accepted):** Net is **+3 lines, not negative.** The helper carries a doc-comment header matching `deploy/lib/env.sh` idiom (~21L vs the spec's ~12L estimate) and the spec-mandated pipefail-safe array form in `converge.sh` costs +5 vs the old 1-line literal. The spec pre-downgraded this metric (*"a smaller line win than the frame estimated, but the structural win stands"*). The **primary goal is fully met**: 2 hand-lists → 0, container-add needs zero script edits, and the two forward-drift gate arms are eliminated. Gaming the line count (trimming docs) or folding `check_volumes_table.sh`'s list (scope creep) were both declined.

Fixes #1979

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
