### PR TITLE
feat(deploy): bind factory-web to Tailnet via ${TAILSCALE_IPV4} (#1992)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Unified: `factory start` → hub + adapters in 1 process + embedded NATS
 
 ## Container deployment
 
-Prod: Podman Quadlet (systemd `--user`) on M₁ (`factory-hub` role). Nine containers: `factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`, `factory-omp`. Install: `deploy/install.sh` (idempotent). Manifest: `deploy/quadlet.toml`.
+Prod: Podman Quadlet (systemd `--user`) on M₁ (`factory-hub` role). Ten containers: `factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-web`, `factory-clipool`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`, `factory-omp`. Install: `deploy/install.sh` (idempotent). Manifest: `deploy/quadlet.toml`.
 
 → `docs/runbooks/README.md` — ops runbooks (install, secrets, diagnostic)
 → `~/projects/docs/container-deployment-standard.md` — 18 standards (S7 secret target, S8 naming, S12 RestartSec=10)

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -97,7 +97,7 @@ deploy verb on the production host. It reconciles the running system with the de
    - **Pure identity add** (`make nats-add-identity`): atomic write to `auth.conf` on host → `systemctl --user reload factory-nats` (fires `ExecReload=` → `podman kill --signal=HUP factory-nats`). Zero client restarts, zero dropped connections.
    - **ACL permission change** (`make nats-regen-authconf`): atomic write to `auth.conf` on host → `systemctl --user restart factory-nats` (required per #1390 — stale-subject-auth risk on ACL changes). Waits for `is-active`.
    Converge always **restarts** factory-nats on any drift (auth → factory-nats only; structural → factory-nats + clients) — it never reloads, because it cannot prove a change is a pure identity-add (#1390). Clients reconnect automatically via `allow_reconnect`.
-7. **Restart factory clients** — `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-turn-writer`, `factory-gh-helper`, `factory-blobstore`, `factory-omp` (unconditional `systemctl restart` — also starts units that were inactive; any failure aborts the converge). Restarted only on **structural** drift. On **auth-only** drift, converge restarts factory-nats alone; clients reconnect via `allow_reconnect` without explicit restart.
+7. **Restart factory clients** — `factory-hub`, `factory-telegram`, `factory-discord`, `factory-web`, `factory-clipool`, `factory-turn-writer`, `factory-gh-helper`, `factory-blobstore`, `factory-omp` (unconditional `systemctl restart` — also starts units that were inactive; any failure aborts the converge). Restarted only on **structural** drift. On **auth-only** drift, converge restarts factory-nats alone; clients reconnect via `allow_reconnect` without explicit restart.
 8. **Restart voiceCLI** — `voicecli-tts`, `voicecli-stt` (if voiceCLI directory exists).
 9. **Record stamp** — writes the new convergence fingerprint to `~/.roxabi/factory/.converge-stamp`.
 
@@ -140,6 +140,25 @@ bash -c 'source deploy/lib/deploy-common.sh; _classify_drift "$(read_convergence
 
 ---
 
+## Network exposure tiers
+
+Host `PublishPort` bind = the access boundary. Every service exposed beyond localhost
+carries its own auth — bind tier and auth mechanism are chosen **together**:
+
+| Service | Bind | Reachable | Auth boundary |
+|---|---|---|---|
+| `factory-nats` 4222 | `0.0.0.0` | LAN + Tailnet | NKey (mandatory, per-identity) |
+| `factory-nats` 8222 (monitoring) | `127.0.0.1` | host only | — |
+| `factory-blobstore` 8449 | `${TAILSCALE_IPV4}` | Tailnet only | bearer token (#1330) |
+| `factory-web` 8765 | `${TAILSCALE_IPV4}` | Tailnet only | **none** — Tailnet membership is the boundary (#1992) |
+| `factory-hub` 8443 | `127.0.0.1` | host only | — |
+
+Rules:
+- **`0.0.0.0` (LAN + Tailnet) requires strong per-request auth** — only `factory-nats` (NKey) qualifies today. UFW additionally scopes 4222 to the LAN subnet (`deploy/nats/setup.sh`).
+- **No / weak app auth → bind `${TAILSCALE_IPV4}`** (Tailnet-only) + the fail-closed `ExecStartPre` guard; never `0.0.0.0`. Tailnet-IP bind needs no UFW rule (only the tailscale0 address accepts).
+- **Internal-only surfaces → `127.0.0.1`.**
+- New exposed unit → pick a row, pair it with an auth boundary, document it here.
+
 ## Hardening invariants (∀ `.container` file)
 
 `NoNewPrivileges=true` | `ReadOnly=true` | `DropCapability=all`
@@ -177,6 +196,16 @@ empty, unset, **and whitespace-only** values are all rejected at the systemd lay
 Prior to #1368, `[ -n "   " ]` was TRUE in POSIX sh — a whitespace-only value passed the
 guard and Podman's downstream parse error provided fail-closed behaviour by accident, not
 by design. The guard is now the authoritative rejection point.
+
+### Known residual risk — factory-web has NO auth on the Tailnet (#1992)
+
+`factory-web.container` binds PublishPort to `${TAILSCALE_IPV4}:8765:8765` (same pattern +
+fail-closed `ExecStartPre` guard as blobstore above). Unlike blobstore, the web smoke adapter
+has **no application auth** — any Tailnet member who reaches `http://roxabituwer:8765` can pick
+an agent and chat (LLM token spend; session_id is client-supplied → cross-session read, see
+#1992). Tailnet membership is the **sole** access boundary; this is why it is bound to the
+Tailscale IP and never `0.0.0.0` (no LAN exposure). Per-session tokens / real auth are tracked
+in #1992 before any wider exposure.
 
 ### Known residual risk — clipool `core.hooksPath` override (tracked #1245)
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -172,23 +172,27 @@ fi
 # Wire generated token path into SEEDS so the policy loop can install it.
 SEEDS[factory_blobstore_token]="${BLOBSTORE_TOK}"
 
-# ── 3. Bootstrap blobstore.env (idempotent) ─────────────────────────────────
-
-ENV_FILE="${HOME}/.roxabi/factory/env/blobstore.env"
-if [[ ! -f "${ENV_FILE}" || "$FORCE" -eq 1 ]]; then
-  log "Generating ${ENV_FILE} ..."
-  run mkdir -p "$(dirname "${ENV_FILE}")"
-  if [[ "$DRY_RUN" -eq 0 ]]; then
-    TS_IP=$(tailscale ip -4 2>/dev/null | head -1 || true)
-    # `run` only wraps exec; stream redirection (>) is dry-run-gated via the if block above.
-    (umask 0077; printf 'TAILSCALE_IPV4=%s\n' "${TS_IP}" > "${ENV_FILE}")
-    log "[ok] generated ${ENV_FILE} (TAILSCALE_IPV4=${TS_IP:-<empty>})"
+# ── 3. Bootstrap tailnet env files (idempotent) ─────────────────────────────
+# TAILSCALE_IPV4 is host-global (M₁'s tailnet IP); written per-service so each unit's
+# EnvironmentFile is self-contained. Consumed by tailnet-bound PublishPort + the
+# fail-closed ExecStartPre guard in factory-blobstore (#1330) and factory-web (#1992).
+TS_IP=$(tailscale ip -4 2>/dev/null | head -1 || true)
+for _svc in blobstore web; do
+  ENV_FILE="${HOME}/.roxabi/factory/env/${_svc}.env"
+  if [[ ! -f "${ENV_FILE}" || "$FORCE" -eq 1 ]]; then
+    log "Generating ${ENV_FILE} ..."
+    run mkdir -p "$(dirname "${ENV_FILE}")"
+    if [[ "$DRY_RUN" -eq 0 ]]; then
+      # `run` only wraps exec; stream redirection (>) is dry-run-gated via the if block above.
+      (umask 0077; printf 'TAILSCALE_IPV4=%s\n' "${TS_IP}" > "${ENV_FILE}")
+      log "[ok] generated ${ENV_FILE} (TAILSCALE_IPV4=${TS_IP:-<empty>})"
+    else
+      echo "[dry-run] would generate ${ENV_FILE} (TAILSCALE_IPV4 from tailscale ip -4)"
+    fi
   else
-    echo "[dry-run] would generate ${ENV_FILE} (TAILSCALE_IPV4 from tailscale ip -4)"
+    echo "  [skip] ${ENV_FILE} already exists (use --force to regenerate)"
   fi
-else
-  echo "  [skip] ${ENV_FILE} already exists (use --force to regenerate)"
-fi
+done
 
 # Validate that all required (non-optional) seed files are present before touching podman.
 MISSING=0

--- a/deploy/quadlet/factory-web.container
+++ b/deploy/quadlet/factory-web.container
@@ -16,6 +16,9 @@ NoNewPrivileges=true
 ReadOnly=true
 DropCapability=all
 UserNS=keep-id:uid=1500,gid=1500
+# web.env holds TAILSCALE_IPV4 (M₁'s tailnet IP) for the PublishPort bind below;
+# generated idempotently by deploy/install.sh §3. No `-` prefix (Podman 5.7 literal).
+EnvironmentFile=%h/.roxabi/factory/env/web.env
 Environment=NATS_URL=nats://factory-nats:4222
 Secret=factory-nats-web,type=mount,target=factory-nats-web.seed,uid=1500,gid=1500,mode=0400
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-web.seed
@@ -24,14 +27,26 @@ Environment=FACTORY_WEB_HOST=0.0.0.0
 Environment=FACTORY_WEB_PORT=8765
 # Agent picker reads roster.web from factory-state KV (hub publishes at boot).
 Volume=%h/.roxabi/factory/config.toml:/app/config.toml:ro,z
-# Localhost-only — smoke UI is not a public ingress surface (phase 1).
-PublishPort=127.0.0.1:8765:8765
+# Bind to M₁'s Tailscale IPv4 so the smoke UI is reachable from the Tailnet but NOT the
+# LAN. This adapter has NO auth (unlike factory-blobstore's bearer token, #1330) — Tailnet
+# membership is the sole access boundary. ${TAILSCALE_IPV4} comes from web.env. Fail-closed:
+# the [Service] ExecStartPre guard blocks startup if unset, so PublishPort never silently
+# falls back to 0.0.0.0:8765 (LAN). See deploy/AGENTS.md §Network exposure tiers (#1992).
+PublishPort=${TAILSCALE_IPV4}:8765:8765
 Exec=factory adapter web
 HealthCmd=python3 -c 'import urllib.request,sys; r=urllib.request.urlopen("http://127.0.0.1:8765/api/agents",timeout=3); sys.exit(0 if r.status==200 else 1)' || exit 1
 HealthInterval=30s
 HealthStartPeriod=45s
 
 [Service]
+# Re-declare web.env in [Service] scope so ${TAILSCALE_IPV4} is visible to ExecStartPre —
+# the [Container] EnvironmentFile is Podman's --env-file (container scope) only; the
+# generated [Service] otherwise carries no env vars (mirrors factory-blobstore #1330).
+EnvironmentFile=%h/.roxabi/factory/env/web.env
+# Fail-closed guard: refuse to start when TAILSCALE_IPV4 is empty/unset/whitespace-only,
+# else Podman resolves PublishPort to 0.0.0.0:8765 (LAN-exposed). tr-strip before -n
+# because POSIX `[ -n "   " ]` is TRUE on whitespace-only values (#1368).
+ExecStartPre=/bin/sh -c 'v=$(printf "%s" "${TAILSCALE_IPV4}" | tr -d "[:space:]"); [ -n "$v" ] || exit 1'
 Restart=on-failure
 RestartSec=10
 CPUQuota=100%

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -476,13 +476,16 @@ degrades to `None`: audio attachments are disabled and a warning is logged; no c
 
 #### BlobStore env file
 
-`~/.roxabi/factory/env/blobstore.env` is a Quadlet env file consumed by `factory-blobstore.container` at
-container start via `EnvironmentFile=%h/.roxabi/factory/env/blobstore.env`. It is NOT loaded by the
-factory application itself.
+`~/.roxabi/factory/env/blobstore.env` and `~/.roxabi/factory/env/web.env` are Quadlet env files
+consumed at container start via `EnvironmentFile=` by `factory-blobstore.container` and
+`factory-web.container` respectively. They are NOT loaded by the factory application itself — each
+carries `TAILSCALE_IPV4` for the unit's Tailnet-bound publish port (see `deploy/AGENTS.md
+§Network exposure tiers`).
 
 | File | Versioned | Purpose |
 |------|-----------|---------|
-| `~/.roxabi/factory/env/blobstore.env` (on M₁) | No (operator copy) | Live env file read by the container at startup |
+| `~/.roxabi/factory/env/blobstore.env` (on M₁) | No (operator copy) | Live env file read by `factory-blobstore` at startup |
+| `~/.roxabi/factory/env/web.env` (on M₁) | No (operator copy) | Live env file read by `factory-web` at startup |
 
 **Bootstrap:** `deploy/install.sh` §1c generates this file idempotently — it skips creation
 if the file already exists, and regenerates it with `--force`.


### PR DESCRIPTION
## What

`factory-web` (the web smoke adapter, merged in #1978) was localhost-only (`127.0.0.1:8765`) → unreachable from LAN/Tailnet. This binds it to **M₁'s Tailscale IP** so it's reachable on the Tailnet (incl. roaming devices), following the established **factory-blobstore pattern (#1330)** rather than a raw `0.0.0.0` bind.

## Why the Tailnet pattern, not 0.0.0.0 + UFW

The house convention (now documented — see the new `deploy/AGENTS.md §Network exposure tiers`) is: **`0.0.0.0` (LAN+Tailnet) requires strong per-request auth** — only `factory-nats` (NKey) qualifies. The web smoke adapter has **no app auth**, so it gets the Tailnet-IP bind (`${TAILSCALE_IPV4}`) + fail-closed guard. Tailnet membership is the access boundary. No UFW/sudo needed (binding the tailscale0 address is self-scoping).

## Changes
- **`deploy/quadlet/factory-web.container`** — `PublishPort=${TAILSCALE_IPV4}:8765:8765` + `EnvironmentFile=web.env` in `[Container]` (Podman `--env-file`) and `[Service]` (for the `ExecStartPre` fail-closed guard — blocks startup if `TAILSCALE_IPV4` unset, so the port never silently falls back to `0.0.0.0`/LAN).
- **`deploy/install.sh §3`** — generate `web.env` (TAILSCALE_IPV4) alongside `blobstore.env`. Runs under `--secrets-only`, so `make converge` provisions it automatically.
- **`deploy/AGENTS.md`** — new **§Network exposure tiers** table (closes the undocumented convention gap the operator flagged) + factory-web residual-risk note; add factory-web to the converge client list.
- **`AGENTS.md`** — nine → ten containers (factory-web, drift since #1978).
- **`docs/CONFIGURATION.md`** — document `web.env`.

## Verification
- `bash -n install.sh` ✅ · web.env generation loop validated (isolated run) ✅
- Gates green: secrets_drift, volumes_table, quadlet_manifest_install, doc_drift, doc_semantic_drift, architecture_snapshot (no drift) ✅
- No `src/` change → ruff/pyright/pytest unaffected.

## Deploy
On merge: standard converge (structural drift → `web.env` generated, unit reinstalled, `factory-web` restarted with the Tailnet bind). Then reachable at `http://roxabituwer:8765`.

Origin: operator request to expose factory-web on LAN + Tailnet; slice of #1992 (the `bind` hardening item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)