### PR TITLE
chore: remove global-patterns import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,6 @@ Let:
 
 - Entry: `/dev #N` → tier (S/F-lite/F-full) → lifecycle
 - Close checklist (pre-cleanup, from worktree): `docs/process/dev-cycle.md` — run **before** worktree removal; `/dev` skill integration pending (roxabi-plugins)
-- Decisions → global-patterns.md
 - ¬`--force` | ¬`--hard` | ¬`--amend`
 
 ## Axial Review (mandatory)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,2 @@
 @.claude/stack.yml
-@~/.claude/shared/global-patterns.md
 @AGENTS.md

--- a/docs/claude-md-registry.md
+++ b/docs/claude-md-registry.md
@@ -1,6 +1,6 @@
 # CLAUDE.md / AGENTS.md Registry
 
-Instruction content lives in `AGENTS.md`. Each `CLAUDE.md` is a thin shim (`@AGENTS.md`; root also `@.claude/stack.yml` + `@~/.claude/shared/global-patterns.md`). Update here on add/rename/delete.
+Instruction content lives in `AGENTS.md`. Each `CLAUDE.md` is a thin shim (`@AGENTS.md`; root also `@.claude/stack.yml`). Update here on add/rename/delete.
 
 | P (shim) | AGENTS.md | Scope |
 |---|---|---|


### PR DESCRIPTION
Lands a local commit authored by @MickaelV0 (`338a4358`) that was sitting unpushed on a local `pr-1978` branch — cherry-picked cleanly onto current `origin/staging` (no conflict with #1995).

Removes the `@~/.claude/shared/global-patterns.md` import from the root shim and its references:
- `CLAUDE.md` — drop `@~/.claude/shared/global-patterns.md`
- `AGENTS.md` — drop the `Decisions → global-patterns.md` line
- `docs/claude-md-registry.md` — drop the global-patterns mention from the shim description

No dangling active references (remaining `global-patterns` mentions are historical prose in `.claude/context-audit-log.md` + `artifacts/`). Doc gates (doc_drift, doc_semantic_drift) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)