### PR TITLE
feat(telegram): collapsible tg-thinking tool recap card

### DIFF
--- a/artifacts/frames/1952-telegram-tool-recap-tg-thinking-frame.mdx
+++ b/artifacts/frames/1952-telegram-tool-recap-tg-thinking-frame.mdx
@@ -1,0 +1,82 @@
+---
+title: Richer Telegram tool recap card — collapsible tg-thinking block
+issue: 1952
+status: approved
+tier: F-lite
+date: 2026-06-24
+---
+
+## Problem
+
+The per-turn tool recap card in Telegram is a **flat, always-visible text message**
+edited in-place via MarkdownV2. It lists file edits, shell commands, web fetches,
+and agent calls — useful context, but secondary to the agent's actual answer.
+
+With Bot API 10.1 rich messages now live in staging (#1950 backtick audit done,
+#1951 reasoning trace streaming to `<tg-thinking>` done), the recap card is the
+remaining noisy UI element: it competes visually with the answer while users only
+need the breakdown on demand.
+
+`TelegramTraceFormatter.edit_tool_recap()` still calls `edit_text_with_fallback`
+(plain markdown) even in rich mode, unlike `edit_reasoning()` which already routes
+through `build_thinking_message()` → collapsible `<tg-thinking>` HTML. The recap
+should follow the same pattern so tool activity collapses by default and the chat
+stays clean.
+
+## Who
+
+- **Primary:** Telegram users in private chats running multi-tool agent turns —
+  they want to see *what happened* without a permanent wall of tool lines above
+  the answer.
+- **Secondary:** Developers debugging agent behaviour who expand the thinking
+  block to inspect per-tool counts and commands.
+
+## Constraints
+
+- Dependencies #1950 (backtick-protection audit) and #1951 (thinking-block UX)
+  are closed — safe to build on `build_thinking_message()` and rich-message path.
+- Phase 1 (this issue's MVP): move recap into `<tg-thinking>` in rich mode only;
+  MarkdownV2 fallback path unchanged for `FACTORY_TELEGRAM_RICH_MESSAGES=0`.
+- Reuse existing `format_recap_lines()` output from `factory.outbound._tool_recap`
+  — formatting logic stays adapter-agnostic; only the Telegram delivery layer changes.
+- Discord recap (embed-based) is out of scope — different platform contract.
+- HTML inside `<tg-thinking>` must escape user/LLM-derived content (same as
+  reasoning trace); no clickable hyperlinks for web URLs in Phase 1.
+
+## Out of Scope
+
+- Discord or web adapter changes.
+- New NATS / render-event contract changes.
+- Phase 2 polish (section headers, per-file operation counts, hyperlink URLs) —
+  tracked as follow-up within this epic but not required for frame approval gate.
+- Spinner emoji cycle for Working state (investigate in spec; may defer if
+  message-replace flash is unavoidable).
+- CLI adapter rendering (terminal shows tools inline already).
+
+## Premise Validity
+
+**Success in 6 months:** In Telegram rich mode, every multi-tool turn shows the
+tool recap inside a collapsible `<tg-thinking>` block; users report cleaner chat
+layout; zero regressions in recap content accuracy vs current flat card.
+
+**Failure in 6 months:** After 3 months in staging, ≥1 of: recap still renders as
+flat visible text in rich mode, OR `<tg-thinking>` recap causes edit failures
+on >5% of multi-tool turns, OR backtick/HTML injection regressions reopen #1950.
+
+**Simplest alternative:** Leave recap as flat MarkdownV2 text (status quo).
+**Why not simplest:** Recap is secondary UI — always visible it clutters the chat
+and duplicates information the user may never need; collapsible thinking blocks
+are the established Telegram pattern (#1951) and cost one routing change in
+`edit_tool_recap`.
+
+## Complexity
+
+**Tier: F-lite** — clear scope, single domain (Telegram adapter delivery layer),
+known pattern (`build_thinking_message` already wired for reasoning), 2–4 files
+expected (formatter, tests, possibly placeholder lifecycle).
+
+Signals observed:
+- Issue label `size:F-lite` matches.
+- Single platform, no new architecture — mirror reasoning trace delivery path.
+- Formatter output (`format_recap_lines`) unchanged; adapter-only delta.
+- Phase 2 formatting is additive follow-up, not a blocker for Phase 1 ship.

--- a/artifacts/plans/1952-telegram-tool-recap-tg-thinking-plan.mdx
+++ b/artifacts/plans/1952-telegram-tool-recap-tg-thinking-plan.mdx
@@ -1,0 +1,250 @@
+---
+title: "Plan: richer Telegram tool recap — collapsible tg-thinking block"
+issue: 1952
+spec: artifacts/specs/1952-telegram-tool-recap-tg-thinking-spec.mdx
+complexity: 3/10
+tier: F-lite
+generated: "2026-06-24T12:00:00Z"
+---
+
+## Summary
+
+Three-slice F-lite delivery. SL1 routes `edit_tool_recap` through the existing
+`_edit_trace_with_text` + `build_thinking_message` path (mirror `edit_reasoning`).
+SL2 wraps `send_trace_placeholder` initial send in `<tg-thinking>`. SL3 updates
+unit + integration tests (extend `test_telegram_tool_recap.py`, add formatter-level
+rich-mode tests patterned on `test_telegram_reasoning.py`). Touch: 2 production
+files + 1–2 test files; no outbound/emitter changes.
+
+## Architecture
+
+### Data Flow
+
+```mermaid
+flowchart TD
+  subgraph "outbound (UNCHANGED)"
+    EM["OutboundEmitter._on_toolcall_v2"]
+    FRL["format_recap_lines"]
+  end
+
+  subgraph "telegram_formatter.py (MODIFY)"
+    ETR["edit_tool_recap"]
+    STP["send_trace_placeholder"]
+    ETT["_edit_trace_with_text"]
+  end
+
+  subgraph "telegram_rich.py (MODIFY optional)"
+    BTM["build_thinking_message"]
+    STR["send_thinking_message (NEW helper, if needed)"]
+  end
+
+  EM --> FRL
+  FRL -->|lines[]| ETR
+  ETR -->|rich mode| ETT
+  ETT --> BTM
+  BTM -->|InputRichMessage.html| API["bot.edit_message_text"]
+  STP -->|rich mode| STR
+  STR --> BTM
+  BTM -->|initial send| API2["bot.send_rich_message"]
+  ETR -->|fallback| FB["edit_text_with_fallback"]
+  STP -->|fallback| FB2["send_markdownv2_text"]
+```
+
+### File × Function Map
+
+```mermaid
+flowchart LR
+  subgraph "telegram_formatter.py"
+    ETR["edit_tool_recap"]
+    STP["send_trace_placeholder"]
+    ETT["_edit_trace_with_text"]
+    ER["edit_reasoning (reference)"]
+  end
+
+  subgraph "telegram_rich.py"
+    BTM["build_thinking_message"]
+    STM["send_thinking_message (optional)"]
+    RTE["rich_messages_enabled"]
+  end
+
+  subgraph "tests/"
+    T1["test_telegram_tool_recap.py (UPDATE)"]
+    T2["test_telegram_formatter_tool_recap_rich.py (NEW, optional)"]
+  end
+
+  ER --> ETT
+  ETR --> ETT
+  ETT --> BTM
+  STP --> STM
+  STM --> BTM
+  T1 -.integration.-> ETR
+  T2 -.unit.-> ETR & STP
+```
+
+## Bootstrap Context
+
+- Source spec: `artifacts/specs/1952-telegram-tool-recap-tg-thinking-spec.mdx`
+  (8 SCs, 0 χ, 3 slices).
+- Reference pattern: `edit_reasoning` + `_edit_trace_with_text` in
+  `telegram_formatter.py` (#1951).
+- Reference tests: `tests/adapters/test_telegram_reasoning.py`
+  `test_reasoning_rich_mode_no_truncation_no_literal_asterisks`.
+- Existing recap tests: `tests/adapters/test_telegram_tool_recap.py` assert
+  `rich_message.markdown` — must migrate to `rich_message.html` + `<tg-thinking>`
+  after SL1 (SC1/SC6).
+- `build_thinking_message` already HTML-escapes content (#1950 backtick audit
+  satisfied upstream in `_tool_recap._sanitize` + escape layer).
+
+## Agents
+
+| Agent instance | Role | Slice | Files |
+|----------------|------|-------|-------|
+| backend-dev-A | Production | SL1, SL2 | `telegram_formatter.py`, `telegram_rich.py` |
+| tester-A | Tests | SL3 | `test_telegram_tool_recap.py`, optional new unit test file |
+
+## Wave Structure
+
+2 waves, max 2 parallel agents. Elapsed ~1 session vs ~2 sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 1 | backend-dev-A: T1→T2 |
+| 2 | Wave 1 done | 1 | tester-A: T3→T4→T5 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 — edit_tool_recap via _edit_trace_with_text | 1 | bounded | 4 | — |
+| T2 — send_trace_placeholder thinking wrap | 1 | bounded | 5 | — |
+| T3 — unit tests formatter rich mode | 3 | judgmental | 12 | — |
+| T4 — update integration tests markdown→html | 2 | judgmental | 10 | — |
+| T5 — full pytest gate | 1 | trivial | 2 | — |
+
+**Total estimated ops: 33**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2 | 9 | telegram-formatter | — |
+| tester-A | T3, T4, T5 | 24 | telegram-tests | — |
+
+## Consistency Report
+
+- Criteria covered: 8/8 (SC1–SC8)
+- Uncovered criteria: none
+- Tasks without spec backing: none
+- Gold plating exemptions: SC8 enforced by omission (no Phase 2 formatting)
+
+## Micro-Tasks
+
+### Slice SL1: Rich edit_tool_recap path
+
+#### Task T1: Route edit_tool_recap through _edit_trace_with_text → backend-dev-A
+- **File:** `src/factory/adapters/telegram/telegram_formatter.py`
+- **Snippet:**
+  ```python
+  async def edit_tool_recap(self, trace_obj, lines, done):
+      del done
+      if not lines:
+          return
+      text = "\n".join(lines)
+      await self._edit_trace_with_text(trace_obj, text)
+  ```
+- **Verify:** `uv run pytest tests/adapters/test_telegram_reasoning.py -q` (ready)
+- **Expected:** no regressions in reasoning path
+- **Time:** 3 min
+- **Difficulty:** 2
+- **Traces:** SC1, SC2, SC6
+- **Phase:** GREEN
+
+### Slice SL2: Rich send_trace_placeholder
+
+#### Task T2: Send initial trace in build_thinking_message wrapper → backend-dev-A
+- **File:** `src/factory/adapters/telegram/telegram_formatter.py` (+ optional `telegram_rich.py` helper)
+- **Snippet:**
+  ```python
+  # rich branch in send_trace_placeholder:
+  sent = await bot.send_rich_message(
+      chat_id=..., rich_message=build_thinking_message("🔧 …"), ...
+  )
+  ```
+- **Verify:** `uv run python -c "from factory.adapters.telegram.telegram_formatter import TelegramFormatter"` (ready)
+- **Expected:** import OK
+- **Time:** 5 min
+- **Difficulty:** 3
+- **Traces:** SC3
+- **Phase:** GREEN
+
+#### RED-GATE: SL1+SL2 production complete → tester-A
+- **Verify:** T1 + T2 marked complete
+- **Phase:** RED-GATE
+
+### Slice SL3: Tests
+
+#### Task T3: Add formatter-level rich recap unit tests [P] → tester-A
+- **File:** `tests/adapters/test_telegram_formatter_tool_recap_rich.py` (new) OR extend `test_telegram_reasoning.py` pattern
+- **Snippet:**
+  ```python
+  async def test_tool_recap_rich_mode_uses_tg_thinking():
+      # edit_tool_recap → rich_message.html contains <tg-thinking> + recap lines
+      # assert "*" not in html
+  ```
+- **Verify:** `uv run pytest tests/adapters/test_telegram_formatter_tool_recap_rich.py -q` (deferred until file exists)
+- **Expected:** pass
+- **Time:** 8 min
+- **Difficulty:** 3
+- **Traces:** SC1, SC2, SC5
+- **Phase:** GREEN
+
+#### Task T4: Update integration tests markdown→html assertions → tester-A
+- **File:** `tests/adapters/test_telegram_tool_recap.py`
+- **Snippet:**
+  ```python
+  def _rich_html(call) -> str:
+      rich = call.kwargs.get("rich_message")
+      return (rich.html or "") if rich else ""
+  ```
+- **Verify:** `uv run pytest tests/adapters/test_telegram_tool_recap.py -q` (deferred)
+- **Expected:** pass with html assertions
+- **Time:** 10 min
+- **Difficulty:** 3
+- **Traces:** SC1, SC4, SC6, SC7
+- **Phase:** GREEN
+
+#### Task T5: Fallback-mode regression + full suite → tester-A
+- **File:** `tests/adapters/test_telegram_tool_recap.py`
+- **Snippet:** `monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "0")` → assert MarkdownV2 path unchanged
+- **Verify:** `uv run pytest tests/adapters/ -q --tb=short` (ready)
+- **Expected:** all green
+- **Time:** 5 min
+- **Difficulty:** 2
+- **Traces:** SC4, SC7
+- **Phase:** GREEN
+
+## Task Seeding Blueprint
+
+### Wave 1 — production, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | telegram-formatter |
+| T2 | backend-dev-A | T1 | telegram-formatter |
+
+### Wave 2 — tests after production
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | tester-A | T2 | telegram-tests |
+| T4 | tester-A | T3 | telegram-tests |
+| T5 | tester-A | T4 | telegram-tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: impl-t1 — telegram-formatter
+- T2: impl-t2 — telegram-formatter
+- T3: impl-t3 — telegram-tests
+- T4: impl-t4 — telegram-tests
+- T5: impl-t5 — telegram-tests

--- a/artifacts/specs/1952-telegram-tool-recap-tg-thinking-spec.mdx
+++ b/artifacts/specs/1952-telegram-tool-recap-tg-thinking-spec.mdx
@@ -1,0 +1,173 @@
+---
+title: Richer Telegram tool recap card — collapsible tg-thinking block
+issue: 1952
+status: approved
+tier: F-lite
+date: 2026-06-24
+promoted_from: artifacts/frames/1952-telegram-tool-recap-tg-thinking-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/1952-telegram-tool-recap-tg-thinking-frame.mdx` (approved
+2026-06-24).
+
+#1214 rebuilt the tool recap card on v2 events; content formatting lives in
+`factory.outbound._tool_recap.format_recap_lines`. Telegram delivery still uses
+plain MarkdownV2 via `edit_text_with_fallback` in `edit_tool_recap`, while
+reasoning trace already routes through `build_thinking_message()` → collapsible
+`<tg-thinking>` HTML (#1951). Dependencies #1950 (backtick audit) and #1951
+(thinking-block streaming) are closed.
+
+**Phase 1 (this spec):** move recap delivery into `<tg-thinking>` in rich mode.
+**Phase 2 (follow-up):** section headers, per-file operation counts, hyperlink
+URLs — out of scope here.
+
+## Goal
+
+In Telegram rich mode, the per-turn tool recap renders inside a collapsible
+`<tg-thinking>` block so secondary tool activity is hidden by default while
+preserving the exact recap line content from `format_recap_lines`.
+
+## Users
+
+- **Primary:** Telegram users in private/group chats running multi-tool agent
+  turns — cleaner chat layout with expandable tool breakdown.
+- **Secondary:** Developers inspecting agent activity by expanding the thinking
+  block during debugging.
+
+## Expected Behavior
+
+### Rich mode (`FACTORY_TELEGRAM_RICH_MESSAGES=1`)
+
+1. On first tool event, `send_trace_placeholder` creates a trace message whose
+   body is wrapped in `<tg-thinking>` (initial content: `🔧 …`).
+2. Each `edit_tool_recap` call edits that message with
+   `rich_message=build_thinking_message(joined_lines)` — same escape/HTML path
+   as `edit_reasoning`.
+3. Recap text inside the block preserves `format_recap_lines` output verbatim
+   (emoji headers, backtick-wrapped paths/commands, silent counts). No markdown
+   italic wrapper (`*…*`) is applied.
+4. Final state shows `🔧 Done ✅` header inside the collapsed block.
+5. Intermediate state shows `🔧 Working…` header inside the collapsed block.
+6. Reasoning + tool recap continue sharing the single `StreamingSession._trace_obj`
+   slot (last writer during stream; recap wins on `done=True` — unchanged #1214
+   invariant).
+
+### Fallback mode (`FACTORY_TELEGRAM_RICH_MESSAGES=0`)
+
+Behavior unchanged: `send_trace_placeholder` and `edit_tool_recap` use existing
+MarkdownV2 paths (`send_markdownv2_text` / `edit_text_with_fallback`).
+
+### Edge cases
+
+| Case | Handling |
+|------|----------|
+| Empty `lines` in `edit_tool_recap` | No-op (unchanged) |
+| `trace_obj is None` | Emitter skips edit (unchanged) |
+| Telegram API edit failure | Log at `debug`, non-fatal (same as reasoning) |
+| LLM-derived content with `<`, `>`, `&` | `html.escape` via `build_thinking_message` |
+| Backticks in paths/commands | Preserved as literal text inside escaped HTML |
+| Web URLs in recap | Remain backtick-neutralised (no hyperlinks) in Phase 1 |
+
+## Data Model & Consumers
+
+### Data structure diagram
+
+```mermaid
+classDiagram
+    class ToolRecapAccumulator {
+      +dict files
+      +list bash_commands
+      +list web_fetches
+      +observe_start(event)
+      +observe_args(event)
+      +observe_end(event)
+    }
+    class format_recap_lines {
+      +list~str~ lines
+      +bool done
+    }
+    class build_thinking_message {
+      +InputRichMessage rich_message
+      +str html
+    }
+    class TelegramFormatter {
+      +edit_tool_recap(trace_obj, lines, done)
+      +send_trace_placeholder()
+      +_edit_trace_with_text(trace_obj, text)
+    }
+    ToolRecapAccumulator --> format_recap_lines : accum
+    format_recap_lines --> TelegramFormatter : lines[]
+    build_thinking_message --> TelegramFormatter : rich_message
+    TelegramFormatter --> build_thinking_message : edit_tool_recap (rich)
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    E[OutboundEmitter] -->|lines, done| F[TelegramFormatter.edit_tool_recap]
+    F -->|rich mode| B[build_thinking_message]
+    B -->|InputRichMessage.html| T[Telegram Bot API editMessageText]
+    F -->|fallback| M[edit_text_with_fallback / MarkdownV2]
+    E -->|lazy first tool| S[TelegramFormatter.send_trace_placeholder]
+    S -->|rich mode| B2[build_thinking_message initial]
+    S -->|fallback| M2[send_markdownv2_text]
+```
+
+### Consumer summary
+
+| Consumer | Fields / output | When | Status |
+|----------|-----------------|------|--------|
+| `edit_tool_recap` | `lines: list[str]`, `done: bool` | Each debounced tool-recap edit + final | **This issue** |
+| `send_trace_placeholder` | initial `🔧 …` text | First tool/reasoning trace per turn | **This issue** (rich wrap) |
+| `format_recap_lines` | recap line strings | Upstream in emitter | Unchanged (#1214) |
+| Discord `edit_tool_recap` | embed lines | Multi-tool turns | Future / out of scope |
+
+## Breadboard
+
+### UI affordances
+
+| ID | Affordance | Handler | Data |
+|----|------------|---------|------|
+| U1 | Collapsible tool recap block | `edit_tool_recap` | `lines[]` from `format_recap_lines` |
+| U2 | Trace placeholder seed message | `send_trace_placeholder` | `"🔧 …"` initial text |
+
+### Nodes
+
+| ID | Node | Input | Output |
+|----|------|-------|--------|
+| N1 | `TelegramFormatter.edit_tool_recap` | `trace_obj`, `lines`, `done` | `edit_message_text(rich_message=…)` |
+| N2 | `TelegramFormatter._edit_trace_with_text` | `trace_obj`, `text` | shared rich/fallback edit path |
+| N3 | `build_thinking_message` | plain text | `InputRichMessage` with `<tg-thinking>` HTML |
+| N4 | `TelegramFormatter.send_trace_placeholder` | — | new trace `Message` |
+| N5 | `format_recap_lines` | `ToolRecapAccumulator`, `done` | ordered `list[str]` |
+
+### Wiring
+
+```
+ToolCall* events → OutboundEmitter._tool_recap → format_recap_lines
+  → N1.edit_tool_recap → (rich?) N3.build_thinking_message → Telegram API
+First tool event → N4.send_trace_placeholder → (rich?) N3("🔧 …") → Telegram API
+Reasoning events → N2._edit_trace_with_text → N3 → same trace_obj slot as U1
+```
+
+## Slices
+
+| Slice | Scope | Files (expected) | Demo |
+|-------|-------|------------------|------|
+| SL1 | Rich `edit_tool_recap` via `_edit_trace_with_text` / `build_thinking_message`; fallback unchanged | `telegram_formatter.py` | Unit test: edit call carries `<tg-thinking>` HTML with recap lines |
+| SL2 | Rich `send_trace_placeholder` initial message wrapped in `<tg-thinking>` | `telegram_formatter.py` | Unit test: first send uses thinking block HTML |
+| SL3 | Regression tests: content parity, HTML escape, no `*` wrapper, fallback path | `tests/adapters/test_telegram_tool_recap_rich.py` (new) or extend existing telegram adapter tests | `uv run pytest` green |
+
+## Success Criteria
+
+- [ ] Rich mode `edit_tool_recap` calls `edit_message_text` with `rich_message` whose `html` contains `<tg-thinking>` and the joined recap lines (SC1)
+- [ ] Rich mode `edit_tool_recap` does NOT wrap recap text in markdown italic `*` characters (SC2)
+- [ ] Rich mode `send_trace_placeholder` sends initial trace content inside `<tg-thinking>` (SC3)
+- [ ] Fallback mode (`FACTORY_TELEGRAM_RICH_MESSAGES=0`) behavior is unchanged for both methods (SC4)
+- [ ] HTML metacharacters in tool paths/commands are escaped and do not break the thinking block (SC5)
+- [ ] `format_recap_lines` output order and content are unchanged — adapter-only delivery change (SC6)
+- [ ] New/updated tests cover SC1–SC5; full pytest suite passes (SC7)
+- [ ] Phase 2 formatting (section headers, per-file counts, hyperlinks) is NOT implemented in this issue (SC8)

--- a/src/factory/adapters/telegram/telegram_formatter.py
+++ b/src/factory/adapters/telegram/telegram_formatter.py
@@ -19,6 +19,7 @@ from factory.adapters.telegram.telegram_rich import (
     send_markdownv2_text,
     send_rich_draft,
     send_text_with_fallback,
+    send_thinking_with_fallback,
     use_rich_draft,
 )
 from factory.core.messaging.render_events import (
@@ -192,7 +193,7 @@ class TelegramFormatter(BaseFormatter):
 
     async def send_trace_placeholder(self) -> tuple[Any, int | None]:
         if rich_messages_enabled():
-            sent = await send_text_with_fallback(
+            sent = await send_thinking_with_fallback(
                 self._adapter.bot,
                 self._chat_id,
                 "🔧 …",
@@ -305,13 +306,4 @@ class TelegramFormatter(BaseFormatter):
         del done
         if not lines:
             return
-        text = "\n".join(lines)
-        try:
-            await edit_text_with_fallback(
-                self._adapter.bot,
-                self._chat_id,
-                trace_obj.message_id,
-                text,
-            )
-        except TelegramAPIError as exc:
-            log.debug("Tool recap edit skipped: type=%s", type(exc).__name__)
+        await self._edit_trace_with_text(trace_obj, "\n".join(lines))

--- a/src/factory/adapters/telegram/telegram_rich.py
+++ b/src/factory/adapters/telegram/telegram_rich.py
@@ -210,6 +210,41 @@ async def edit_markdownv2_text(
     )
 
 
+async def send_thinking_with_fallback(  # noqa: PLR0913 — mirrors Telegram send kwargs surface
+    bot: Any,
+    chat_id: int,
+    text: str,
+    *,
+    reply_to: int | None = None,
+    topic_id: int | None = None,
+    reply_markup: Any = None,
+) -> Any:
+    """Prefer sendRichMessage with <tg-thinking>; fall back to MarkdownV2."""
+    if rich_messages_enabled() and text:
+        try:
+            kwargs: dict[str, Any] = {
+                "chat_id": chat_id,
+                "rich_message": build_thinking_message(text),
+                **_thread_kwargs(reply_to, topic_id),
+            }
+            if reply_markup is not None:
+                kwargs["reply_markup"] = reply_markup
+            return await bot.send_rich_message(**kwargs)
+        except Exception as exc:  # noqa: BLE001 — rich path is best-effort; fallback follows
+            log.debug(
+                "sendRichMessage(thinking) failed, will fallback: type=%s",
+                type(exc).__name__,
+            )
+    return await send_markdownv2_text(
+        bot,
+        chat_id,
+        text,
+        reply_to=reply_to,
+        topic_id=topic_id,
+        reply_markup=reply_markup,
+    )
+
+
 async def send_text_with_fallback(  # noqa: PLR0913 — mirrors Telegram send kwargs surface
     bot: Any,
     chat_id: int,

--- a/tests/adapters/test_telegram_formatter_tool_recap_rich.py
+++ b/tests/adapters/test_telegram_formatter_tool_recap_rich.py
@@ -1,0 +1,89 @@
+"""Unit tests for TelegramFormatter tool recap in rich <tg-thinking> mode (#1952)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.adapters.telegram.telegram_formatter import TelegramFormatter
+from tests.adapters.conftest import _make_telegram_adapter
+
+
+def _make_trace(message_id: int = 777) -> MagicMock:
+    trace = MagicMock()
+    trace.message_id = message_id
+    return trace
+
+
+def _make_formatter(adapter) -> TelegramFormatter:
+    return TelegramFormatter(
+        adapter,
+        chat_id=123,
+        get_msg=lambda k, fb: fb,
+        placeholder_text="…",
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_tool_recap_rich_mode_uses_tg_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "1")
+    adapter = _make_telegram_adapter()
+    adapter.bot = MagicMock()
+    adapter.bot.edit_message_text = AsyncMock()
+
+    formatter = _make_formatter(adapter)
+    lines = ["🔧 Done ✅", "✏️ `src/foo.py` (Edit)"]
+
+    await formatter.edit_tool_recap(_make_trace(), lines, done=True)
+
+    adapter.bot.edit_message_text.assert_awaited_once()
+    rich = adapter.bot.edit_message_text.call_args.kwargs["rich_message"]
+    assert rich.html is not None
+    assert "<tg-thinking>" in rich.html
+    assert "🔧 Done ✅" in rich.html
+    assert "src/foo.py" in rich.html
+    assert "*" not in rich.html
+
+
+@pytest.mark.asyncio
+async def test_send_trace_placeholder_rich_mode_uses_tg_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "1")
+    adapter = _make_telegram_adapter()
+    sent = MagicMock(message_id=888)
+    adapter.bot = MagicMock()
+    adapter.bot.send_rich_message = AsyncMock(return_value=sent)
+
+    formatter = _make_formatter(adapter)
+    trace_obj, message_id = await formatter.send_trace_placeholder()
+
+    adapter.bot.send_rich_message.assert_awaited_once()
+    rich = adapter.bot.send_rich_message.call_args.kwargs["rich_message"]
+    assert rich.html is not None
+    assert "<tg-thinking>" in rich.html
+    assert "🔧 …" in rich.html
+    assert trace_obj is sent
+    assert message_id == 888
+
+
+@pytest.mark.asyncio
+async def test_edit_tool_recap_escapes_html_metacharacters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "1")
+    adapter = _make_telegram_adapter()
+    adapter.bot = MagicMock()
+    adapter.bot.edit_message_text = AsyncMock()
+
+    formatter = _make_formatter(adapter)
+    lines = ["🔧 Working…", "💻 `<script>alert(1)</script>`"]
+
+    await formatter.edit_tool_recap(_make_trace(), lines, done=False)
+
+    rich = adapter.bot.edit_message_text.call_args.kwargs["rich_message"]
+    assert "<script>" not in rich.html
+    assert "&lt;script&gt;" in rich.html

--- a/tests/adapters/test_telegram_tool_recap.py
+++ b/tests/adapters/test_telegram_tool_recap.py
@@ -16,6 +16,8 @@ import json
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from factory.core.messaging.render_events import (
     RenderEvent,
     RunFinishedRenderEvent,
@@ -39,11 +41,26 @@ from tests.adapters.conftest import (
 _TRACE_MSG_ID = 999
 
 
+def _rich_html(call) -> str:
+    rich = call.kwargs.get("rich_message")
+    if rich is None:
+        return ""
+    return rich.html or ""
+
+
 def _rich_markdown(call) -> str:
     rich = call.kwargs.get("rich_message")
     if rich is None:
         return ""
     return rich.markdown or ""
+
+
+def _recap_payload(call) -> str:
+    """Recap content lives in <tg-thinking> html (#1952); fallback uses markdown."""
+    html = _rich_html(call)
+    if html:
+        return html
+    return _rich_markdown(call)
 
 
 def _make_bot_mocks() -> tuple[MagicMock, MagicMock, MagicMock]:
@@ -85,7 +102,7 @@ async def test_multi_tool_turn_renders_recap_card_via_edit_message_text() -> Non
     Asserts:
     - bot.edit_message_text was called at least once.
     - At least one call targets the trace placeholder message_id.
-    - At least one call's ``rich_message.markdown`` contains recap header '🔧 Done ✅'.
+    - At least one recap edit uses <tg-thinking> html with '🔧 Done ✅' header.
     - At least one call contains '✏️' (edit tool icon) AND '💻' (bash icon).
 
     This test FAILS on the unmodified codebase because ``edit_tool_recap`` is the
@@ -151,13 +168,16 @@ async def test_multi_tool_turn_renders_recap_card_via_edit_message_text() -> Non
     matching = [
         c
         for c in recap_calls
-        if done_header in _rich_markdown(c)
-        and edit_icon in _rich_markdown(c)
-        and bash_icon in _rich_markdown(c)
+        if done_header in _recap_payload(c)
+        and edit_icon in _recap_payload(c)
+        and bash_icon in _recap_payload(c)
     ]
     assert len(matching) >= 1, (
         f"No edit_message_text call contained recap header + icons. "
-        f"Recap calls texts: {[_rich_markdown(c) for c in recap_calls]}"
+        f"Recap calls texts: {[_recap_payload(c) for c in recap_calls]}"
+    )
+    assert any("<tg-thinking>" in _rich_html(c) for c in matching), (
+        "Recap edits must use <tg-thinking> html in rich mode"
     )
 
 
@@ -203,7 +223,10 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
     _TRACE_PLACEHOLDER_TEXT = "\U0001f527 …"  # "🔧 …"
     send_calls = bot.send_rich_message.call_args_list
     trace_sends = [
-        c for c in send_calls if _rich_markdown(c) == _TRACE_PLACEHOLDER_TEXT
+        c
+        for c in send_calls
+        if _TRACE_PLACEHOLDER_TEXT in _recap_payload(c)
+        or _rich_markdown(c) == _TRACE_PLACEHOLDER_TEXT
     ]
     assert len(trace_sends) == 0, (
         f"Expected no trace placeholder send, but found: {trace_sends}"
@@ -216,7 +239,7 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
     recap_edits = [
         c
         for c in edit_calls
-        if recap_header in _rich_markdown(c) or recap_working in _rich_markdown(c)
+        if recap_header in _recap_payload(c) or recap_working in _recap_payload(c)
     ]
     assert len(recap_edits) == 0, (
         f"Expected no recap card edit_message_text calls, found: {recap_edits}"
@@ -229,10 +252,10 @@ async def test_text_only_turn_does_not_send_telegram_trace_placeholder() -> None
 
 
 async def test_recap_text_is_markdownv2_escaped() -> None:
-    """Smoke: bash recap content is sent via rich_message.markdown (unescaped).
+    """Smoke: bash recap content is sent via <tg-thinking> html (unescaped markdown).
 
     Drive a single bash tool call with command 'echo *hi*' (contains MarkdownV2-
-    special '*'). Rich messages preserve the raw command in markdown.
+    special '*'). Thinking-block html preserves the raw command.
 
     This test FAILS on the unmodified codebase because edit_tool_recap is a no-op
     and bot.edit_message_text is never called.
@@ -284,19 +307,67 @@ async def test_recap_text_is_markdownv2_escaped() -> None:
         f"No edit_message_text call targeted trace message_id={_TRACE_MSG_ID}"
     )
 
-    # Rich path: no parse_mode; markdown carries unescaped special chars
+    # Rich path: no parse_mode; thinking html carries unescaped special chars
     for c in recap_calls:
         assert c.kwargs.get("parse_mode") is None
         assert c.kwargs.get("rich_message") is not None
+        assert "<tg-thinking>" in _rich_html(c)
 
     # The text must contain the bash icon (proof it is recap content, not some
     # other edit — e.g. the response placeholder edit)
     bash_icon = "\U0001f4bb"  # 💻
-    recap_with_bash = [c for c in recap_calls if bash_icon in _rich_markdown(c)]
-    texts = [_rich_markdown(c) for c in recap_calls]
+    recap_with_bash = [c for c in recap_calls if bash_icon in _recap_payload(c)]
+    texts = [_recap_payload(c) for c in recap_calls]
     assert len(recap_with_bash) >= 1, (
         f"No recap call contained bash icon. Texts: {texts}"
     )
     assert any("*hi*" in t for t in texts), (
-        f"Expected unescaped '*hi*' in recap markdown, got: {texts}"
+        f"Expected unescaped '*hi*' in recap payload, got: {texts}"
     )
+
+
+async def test_recap_fallback_mode_uses_markdownv2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SC4: rich disabled → edit_tool_recap keeps MarkdownV2 fallback path."""
+    monkeypatch.setenv("FACTORY_TELEGRAM_RICH_MESSAGES", "0")
+    adapter = _make_telegram_adapter()
+
+    placeholder_msg = MagicMock()
+    placeholder_msg.message_id = 42
+    trace_msg = MagicMock()
+    trace_msg.message_id = _TRACE_MSG_ID
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=[placeholder_msg, trace_msg])
+    bot.edit_message_text = AsyncMock(return_value=None)
+    adapter.bot = bot
+    original_msg = _make_telegram_message()
+
+    await adapter.send_streaming(
+        original_msg,
+        _gen(
+            RunStartedRenderEvent(run_id="r3"),
+            ToolCallStartRenderEvent(tool_call_id="t3", tool_name="bash"),
+            ToolCallArgsRenderEvent(
+                tool_call_id="t3",
+                delta=json.dumps({"command": "pwd"}),
+            ),
+            ToolCallEndRenderEvent(tool_call_id="t3"),
+            TextStartRenderEvent(message_id="msg-3"),
+            TextDeltaRenderEvent(message_id="msg-3", delta="ok"),
+            TextEndRenderEvent(message_id="msg-3"),
+            RunFinishedRenderEvent(run_id="r3", outcome="success"),
+        ),
+        outbound=None,
+    )
+
+    recap_calls = [
+        c
+        for c in bot.edit_message_text.call_args_list
+        if c.kwargs.get("message_id") == _TRACE_MSG_ID
+    ]
+    assert len(recap_calls) >= 1
+    for c in recap_calls:
+        assert c.kwargs.get("rich_message") is None
+        assert c.kwargs.get("parse_mode") == "MarkdownV2"


### PR DESCRIPTION
## Summary

Move the Telegram tool recap card into a collapsible `<tg-thinking>` block in rich mode, matching the reasoning trace delivery pattern (#1951). Phase 1 only — formatting logic in `format_recap_lines` is unchanged.

## Changes

- `edit_tool_recap` routes through `_edit_trace_with_text` → `build_thinking_message`
- `send_trace_placeholder` uses new `send_thinking_with_fallback` for initial `🔧 …` seed
- MarkdownV2 fallback path unchanged when `FACTORY_TELEGRAM_RICH_MESSAGES=0`
- Unit + integration tests updated for html assertions

## Test plan

- [x] `uv run pytest tests/adapters/test_telegram_formatter_tool_recap_rich.py -q`
- [x] `uv run pytest tests/adapters/test_telegram_tool_recap.py -q`
- [x] `uv run ruff check . && uv run pyright`

## Artifacts

- Frame: `artifacts/frames/1952-telegram-tool-recap-tg-thinking-frame.mdx`
- Spec: `artifacts/specs/1952-telegram-tool-recap-tg-thinking-spec.mdx`
- Plan: `artifacts/plans/1952-telegram-tool-recap-tg-thinking-plan.mdx`

Closes #1952