### PR TITLE
feat(access): CLI opérateur — factory agent grant/revoke/auth list

### DIFF
--- a/src/factory/agent_cmd/agents/__init__.py
+++ b/src/factory/agent_cmd/agents/__init__.py
@@ -12,3 +12,4 @@ import importlib
 importlib.import_module("factory.agent_cmd.agents.init")
 importlib.import_module("factory.agent_cmd.agents.list_cmd")
 importlib.import_module("factory.agent_cmd.agents.edit_cmd")
+importlib.import_module("factory.agent_cmd.agents.auth_cmd")

--- a/src/factory/agent_cmd/agents/auth_cmd.py
+++ b/src/factory/agent_cmd/agents/auth_cmd.py
@@ -1,0 +1,154 @@
+"""factory agent grant/revoke + agent auth list — ADR-090 §7 operator CLI.
+
+Manage the agent-scoped authorization matrix (agent × principal × capability)
+without a hub restart: writes land in ``auth.db``'s ``agent_grants`` table via
+``AgentGrantStore``, which the hub's ``AuthorizeAgentMiddleware`` reads from a
+warm cache. The MVP grants ``use`` only; ``admin`` is reserved (ADR-090 §1) and
+is accepted by ``--capability`` but not yet enforced by the authorizer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import typer
+
+from factory.cli._store_connect import _connect_grant_store
+from factory.cli.agent import agent_app
+from factory.core.auth.agent_grants import Capability, Principal, PrincipalKind
+
+# Audit-trail fields the store requires non-empty (ADR-090 §1). The CLI is the
+# operator surface, so "where" is fixed to ``cli``; "who" is a stable label
+# until per-operator identity resolution lands.
+_SOURCE = "cli"
+_GRANTED_BY = "operator"
+
+auth_app = typer.Typer(
+    name="auth", help="Inspect the agent authorization matrix (ADR-090)."
+)
+agent_app.add_typer(auth_app)
+
+_USER_OPT: Optional[str] = typer.Option(
+    None,
+    "--user",
+    help="Subject: a platform-prefixed user id, e.g. tg:user:7377831990.",
+)
+_ROLE_OPT: Optional[str] = typer.Option(
+    None, "--role", help="Subject: a platform-prefixed role id, e.g. dc:role:1234."
+)
+_CAP_OPT: str = typer.Option(
+    "use",
+    "--capability",
+    help="Capability (MVP enforces 'use'; 'admin' reserved, ADR-090 §1).",
+)
+
+
+def _resolve_principal(user: str | None, role: str | None) -> Principal:
+    """Map mutually-exclusive ``--user``/``--role`` to a Principal, or exit(1)."""
+    if (user is None) == (role is None):
+        typer.echo("Error: pass exactly one of --user or --role.", err=True)
+        raise typer.Exit(1)
+    kind = PrincipalKind.USER if user is not None else PrincipalKind.ROLE
+    ident = user if user is not None else role
+    assert ident is not None  # guaranteed by the exactly-one check above
+    try:
+        return Principal(kind=kind, id=ident)
+    except ValueError as exc:
+        typer.echo("Error: principal id must be non-empty.", err=True)
+        raise typer.Exit(1) from exc
+
+
+def _resolve_capability(raw: str) -> Capability:
+    """Parse the ``--capability`` value to the enum, or exit(1)."""
+    try:
+        return Capability(raw)
+    except ValueError as exc:
+        valid = ", ".join(c.value for c in Capability)
+        typer.echo(f"Error: invalid capability (expected one of: {valid}).", err=True)
+        raise typer.Exit(1) from exc
+
+
+@agent_app.command(name="grant")
+def grant(
+    agent_name: str = typer.Argument(..., help="Agent (tenant) to grant access to."),
+    user: Optional[str] = _USER_OPT,
+    role: Optional[str] = _ROLE_OPT,
+    capability: str = _CAP_OPT,
+) -> None:
+    """Grant a user or role access to an agent (ADR-090 §7, no restart)."""
+    principal = _resolve_principal(user, role)
+    cap = _resolve_capability(capability)
+
+    async def _run() -> None:
+        store = await _connect_grant_store()
+        try:
+            await store.grant(
+                agent_name,
+                principal,
+                capability=cap,
+                granted_by=_GRANTED_BY,
+                source=_SOURCE,
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_run())
+    subject = f"{principal.kind.value} {principal.id}"
+    typer.echo(f"Granted {cap.value} on {agent_name!r} to {subject}")
+
+
+@agent_app.command(name="revoke")
+def revoke(
+    agent_name: str = typer.Argument(..., help="Agent (tenant) to revoke access from."),
+    user: Optional[str] = _USER_OPT,
+    role: Optional[str] = _ROLE_OPT,
+    capability: str = _CAP_OPT,
+) -> None:
+    """Revoke a user's or role's access to an agent (ADR-090 §7, no restart)."""
+    principal = _resolve_principal(user, role)
+    cap = _resolve_capability(capability)
+    removed = False
+
+    async def _run() -> None:
+        nonlocal removed
+        store = await _connect_grant_store()
+        try:
+            removed = await store.revoke(agent_name, principal, capability=cap)
+        finally:
+            await store.close()
+
+    asyncio.run(_run())
+    subject = f"{principal.kind.value} {principal.id}"
+    if removed:
+        typer.echo(f"Revoked {cap.value} on {agent_name!r} from {subject}")
+    else:
+        typer.echo(f"No {cap.value} grant on {agent_name!r} for {subject}")
+
+
+@auth_app.command(name="list")
+def list_grants(
+    agent_name: str = typer.Argument(..., help="Agent whose grant matrix to list."),
+) -> None:
+    """List every grant recorded for an agent (ADR-090 §7)."""
+
+    async def _run() -> None:
+        store = await _connect_grant_store()
+        try:
+            grants = store.list_grants(agent_name)
+            if not grants:
+                typer.echo(f"  (no grants for agent {agent_name!r})")
+                return
+            typer.echo(
+                f"{'KIND':<5} {'PRINCIPAL':<26} {'CAP':<5} {'BY':<10} CREATED_AT"
+            )
+            for g in grants:
+                p = g.principal
+                typer.echo(
+                    f"{p.kind.value:<5} {p.id:<26} {g.capability.value:<5} "
+                    f"{g.granted_by:<10} {g.created_at.isoformat()}"
+                )
+        finally:
+            await store.close()
+
+    asyncio.run(_run())

--- a/src/factory/cli/_store_connect.py
+++ b/src/factory/cli/_store_connect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from factory.infrastructure.stores.identity.agent_grant_store import AgentGrantStore
 from factory.infrastructure.stores.registry.agent_store import AgentStore
 from factory.infrastructure.stores.registry.bot_store import BotStore
 from factory.paths import factory_data_dir
@@ -11,6 +12,10 @@ from factory.paths import factory_data_dir
 
 def _get_db_path() -> Path:
     return factory_data_dir() / "config.db"
+
+
+def _get_auth_db_path() -> Path:
+    return factory_data_dir() / "auth.db"
 
 
 async def _connect_store() -> AgentStore:
@@ -21,5 +26,11 @@ async def _connect_store() -> AgentStore:
 
 async def _connect_bot_store() -> BotStore:
     store = BotStore(db_path=_get_db_path())
+    await store.connect()
+    return store
+
+
+async def _connect_grant_store() -> AgentGrantStore:
+    store = AgentGrantStore(db_path=_get_auth_db_path())
     await store.connect()
     return store

--- a/tests/cli/test_agent_auth_cli.py
+++ b/tests/cli/test_agent_auth_cli.py
@@ -1,0 +1,125 @@
+"""Tests for the ADR-090 §7 operator CLI: `factory agent grant/revoke/auth list`.
+
+Each test isolates both ``config.db`` and ``auth.db`` under a pytest ``tmp_path``
+via ``ROXABI_FACTORY_DIR`` (the env var ``factory_data_dir()`` honours), so grants
+written by ``grant`` land in a throwaway ``auth.db`` and are read back by
+``auth list`` / cleared by ``revoke``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from factory.cli import agent_app
+
+runner = CliRunner()
+
+_AGENT = "lyra"
+_USER = "tg:user:7377831990"
+_ROLE = "dc:role:1234"
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point factory_data_dir() at a throwaway dir for this test."""
+    monkeypatch.setenv("ROXABI_FACTORY_DIR", str(tmp_path))
+
+
+class TestAgentGrant:
+    def test_grant_user_then_list_shows_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        granted = runner.invoke(agent_app, ["grant", _AGENT, "--user", _USER])
+        assert granted.exit_code == 0, granted.output
+        assert "granted use" in granted.output.lower()
+
+        listed = runner.invoke(agent_app, ["auth", "list", _AGENT])
+        assert listed.exit_code == 0, listed.output
+        assert _USER in listed.output
+        assert "user" in listed.output.lower()
+
+    def test_grant_role(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _isolate(tmp_path, monkeypatch)
+        result = runner.invoke(agent_app, ["grant", _AGENT, "--role", _ROLE])
+        assert result.exit_code == 0, result.output
+        listed = runner.invoke(agent_app, ["auth", "list", _AGENT])
+        assert _ROLE in listed.output
+        assert "role" in listed.output.lower()
+
+    def test_grant_is_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        for _ in range(2):
+            result = runner.invoke(agent_app, ["grant", _AGENT, "--user", _USER])
+            assert result.exit_code == 0, result.output
+        listed = runner.invoke(agent_app, ["auth", "list", _AGENT])
+        # One grant row only — the UNIQUE constraint upserts rather than dupes.
+        assert listed.output.count(_USER) == 1
+
+    def test_grant_requires_exactly_one_subject(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        neither = runner.invoke(agent_app, ["grant", _AGENT])
+        assert neither.exit_code == 1
+        assert "exactly one" in neither.output.lower()
+
+        both = runner.invoke(
+            agent_app, ["grant", _AGENT, "--user", _USER, "--role", _ROLE]
+        )
+        assert both.exit_code == 1
+        assert "exactly one" in both.output.lower()
+
+    def test_grant_empty_principal_id_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        result = runner.invoke(agent_app, ["grant", _AGENT, "--user", ""])
+        assert result.exit_code == 1
+        assert "non-empty" in result.output.lower()
+
+    def test_grant_invalid_capability_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        result = runner.invoke(
+            agent_app, ["grant", _AGENT, "--user", _USER, "--capability", "bogus"]
+        )
+        assert result.exit_code == 1
+        assert "invalid capability" in result.output.lower()
+
+
+class TestAgentRevoke:
+    def test_revoke_existing_grant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        runner.invoke(agent_app, ["grant", _AGENT, "--user", _USER])
+        revoked = runner.invoke(agent_app, ["revoke", _AGENT, "--user", _USER])
+        assert revoked.exit_code == 0, revoked.output
+        assert "revoked use" in revoked.output.lower()
+
+        listed = runner.invoke(agent_app, ["auth", "list", _AGENT])
+        assert _USER not in listed.output
+
+    def test_revoke_absent_grant_reports_no_op(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        result = runner.invoke(agent_app, ["revoke", _AGENT, "--user", _USER])
+        assert result.exit_code == 0, result.output
+        assert "no use grant" in result.output.lower()
+
+
+class TestAgentAuthList:
+    def test_list_empty_agent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate(tmp_path, monkeypatch)
+        result = runner.invoke(agent_app, ["auth", "list", _AGENT])
+        assert result.exit_code == 0, result.output
+        assert "no grants" in result.output.lower()


### PR DESCRIPTION
Closes #1983. Refs #1980 (epic: agent-scoped authorization), #1981/#1982 (substrate — `AgentGrantStore` + live-enforced `AuthorizeAgentMiddleware`, both merged).

## What

The ADR-090 §7 operator CLI to manage the agent authorization matrix **without a hub restart** (writes land in `auth.db`'s `agent_grants` table; the hub reads from a warm cache):

```
factory agent grant  <agent> --user tg:user:<id> [--capability use]
factory agent grant  <agent> --role dc:role:<id> [--capability use]
factory agent revoke <agent> --user tg:user:<id>
factory agent auth list <agent>
```

## How

| File | Change |
|---|---|
| `agent_cmd/agents/auth_cmd.py` (new) | `grant`/`revoke` on `agent_app` + nested `auth list`; goes through `AgentGrantStore.grant()/revoke()/list_grants()` |
| `agent_cmd/agents/__init__.py` | register the module (import side-effect idiom) |
| `cli/_store_connect.py` | `_connect_grant_store()` helper (`auth.db`, separate from `config.db`) |
| `tests/cli/test_agent_auth_cli.py` (new) | 9 cases |

## Scope / decisions

- Capability defaults to `use` (MVP); `admin` is accepted by `--capability` but **not yet enforced** (ADR-090 §1, deferred). `migrate-bot-grants` is a later phase, out of MVP.
- `--user`/`--role` mutually exclusive, exactly one required; empty principal id and invalid capability both exit 1.
- `granted_by="operator"`, `source="cli"` for the audit trail.
- No store changes needed — `grant`/`revoke`/`list_grants` already existed (#1981).

## Verification (local, `--frozen`)

- `pytest tests/cli/test_agent_auth_cli.py` → **9 passed**
- existing agent-CLI suite (`test_agent_cli_commands` + `test_agent_cli_workflows`) → **21 passed**, no regression
- `ruff` clean · `pyright` 0 errors · `lint-imports` **11/11 kept** (agent_cmd is the applicative layer, may import core/infra)
- `factory agent grant --help` / `factory agent auth list --help` reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)