### PR TITLE
ci(omp): enforce 3-way omp version pin lockstep

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -139,3 +139,8 @@ quality_gates:
     enabled: true
     script: tools/check_str_exc_bus_bound.sh
     description: block str(exc)/f"{exc}"/repr(exc) from flowing into SanitizedError construction or NATS-bus-bound message fields (SanitizedError discipline #1212, ADR-073)
+
+  omp_pin_lockstep:
+    enabled: true
+    script: tools/check_omp_pin_lockstep.sh
+    description: assert the omp release pin stays in lockstep across the three files — OMP_SHA256 (deploy/omp-base/Containerfile) == _PINNED_SHA256 (src/factory/adapters/omp/_rpc_digest.py) and OMP_VERSION == Dockerfile factory-omp-base tag — so a version bump can't ship a partial pin → runtime DigestMismatchError (#1873)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,12 @@ jobs:
       - name: Test hardcoded-constants gate
         run: bash tests/tools/test_check_hardcoded_constants.sh
 
+      - name: "Check omp pin lockstep (omp-base / Dockerfile / _PINNED_SHA256, #1873)"
+        run: bash tools/check_omp_pin_lockstep.sh
+
+      - name: Test omp-pin-lockstep gate
+        run: bash tests/tools/test_check_omp_pin_lockstep.sh
+
       - name: Check qg.conf drift (stack.yml is source of truth)
         run: bash scripts/check-qg-conf-drift.sh
 

--- a/tests/tools/test_check_omp_pin_lockstep.sh
+++ b/tests/tools/test_check_omp_pin_lockstep.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# test_check_omp_pin_lockstep.sh — verify the #1873 gate passes in-lockstep and
+# fails (exit 1) on a mutated digest/version, and breaks (exit 2) on a missing
+# file. Uses OMP_PIN_ROOT to point the gate at throwaway fixture trees.
+# Exit 0 = all cases pass.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$REPO/tools/check_omp_pin_lockstep.sh"
+
+fail() { echo "TEST FAIL: $1" >&2; exit 1; }
+
+# Mirror the three pinned files into an isolated fixture root.
+fixture() {
+  local dir="$1"
+  mkdir -p "$dir/deploy/omp-base" "$dir/src/factory/adapters/omp"
+  cp "$REPO/deploy/omp-base/Containerfile" "$dir/deploy/omp-base/Containerfile"
+  cp "$REPO/Dockerfile" "$dir/Dockerfile"
+  cp "$REPO/src/factory/adapters/omp/_rpc_digest.py" \
+     "$dir/src/factory/adapters/omp/_rpc_digest.py"
+}
+
+run() {  # run <root>; echoes the gate's exit code without tripping set -e
+  local rc=0
+  OMP_PIN_ROOT="$1" bash "$GATE" >/dev/null 2>&1 || rc=$?
+  printf '%s' "$rc"
+}
+
+# 1. The real repo tree is in lockstep → exit 0.
+[ "$(run "$REPO")" -eq 0 ] || fail "gate should pass on the in-lockstep repo tree"
+
+# 2. Mutated runtime digest → exit 1.
+t="$(mktemp -d)"; fixture "$t"
+sed -i 's/_PINNED_SHA256 = "[0-9a-f]*"/_PINNED_SHA256 = "'"$(printf '0%.0s' {1..64})"'"/' \
+  "$t/src/factory/adapters/omp/_rpc_digest.py"
+[ "$(run "$t")" -eq 1 ] || fail "gate should exit 1 on digest mismatch"
+rm -rf "$t"
+
+# 3. Mutated carrier version → exit 1.
+t="$(mktemp -d)"; fixture "$t"
+sed -i 's/OMP_VERSION=v[0-9.]*/OMP_VERSION=v0.0.0/' "$t/deploy/omp-base/Containerfile"
+[ "$(run "$t")" -eq 1 ] || fail "gate should exit 1 on version mismatch"
+rm -rf "$t"
+
+# 4. Missing pinned file → exit 2 (script broke, not a violation).
+t="$(mktemp -d)"; fixture "$t"; rm "$t/Dockerfile"
+[ "$(run "$t")" -eq 2 ] || fail "gate should exit 2 when a pinned file is missing"
+rm -rf "$t"
+
+echo "check_omp_pin_lockstep: all cases pass"

--- a/tools/check_omp_pin_lockstep.sh
+++ b/tools/check_omp_pin_lockstep.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# check_omp_pin_lockstep.sh — assert the omp pin trio stays in lockstep (#1873).
+#
+# A single omp release is pinned in three files; a version bump that updates one
+# but not the others ships a runtime DigestMismatchError (the binary the carrier
+# downloads no longer matches the sha the adapter re-verifies at startup). This
+# gate fails the build before that can land:
+#
+#   1. deploy/omp-base/Containerfile             — OMP_VERSION (vX.Y.Z) + OMP_SHA256 (binary digest)
+#   2. Dockerfile                                — factory-omp-base:X.Y.Z tag (carrier the binary is copied from)
+#   3. src/factory/adapters/omp/_rpc_digest.py   — _PINNED_SHA256 (digest re-verified at runtime)
+#
+# Invariants:
+#   A. OMP_SHA256 (Containerfile) == _PINNED_SHA256 (_rpc_digest.py)        [binary digest lockstep]
+#   B. OMP_VERSION without 'v' (Containerfile) == factory-omp-base tag (Dockerfile)  [version lockstep]
+#
+# Note: _rpc_digest.py holds the literal; _rpc_bridge.py only re-exports it (#1873) — grep the literal.
+#
+# Exit: 0 = in lockstep · 1 = mismatch (gate fails) · 2 = script broke (missing file / pin pattern moved).
+set -euo pipefail
+
+ROOT="${OMP_PIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CONTAINERFILE="$ROOT/deploy/omp-base/Containerfile"
+DOCKERFILE="$ROOT/Dockerfile"
+DIGEST_PY="$ROOT/src/factory/adapters/omp/_rpc_digest.py"
+
+for f in "$CONTAINERFILE" "$DOCKERFILE" "$DIGEST_PY"; do
+  [ -f "$f" ] || { echo "check_omp_pin_lockstep: missing $f" >&2; exit 2; }
+done
+
+# Extract a single value via grep; empty result = the pin pattern moved → exit 2.
+grab() {  # grab <egrep-pattern> <file> <strip-prefix>
+  local match
+  match="$(grep -oE "$1" "$2" | head -1 || true)"
+  [ -n "$match" ] || { echo "check_omp_pin_lockstep: pattern $1 not found in $2 (pin moved?)" >&2; exit 2; }
+  printf '%s' "${match#$3}"
+}
+
+omp_version="$(grab 'OMP_VERSION=v[0-9.]+' "$CONTAINERFILE" 'OMP_VERSION=v')"
+omp_sha="$(grab 'OMP_SHA256=[0-9a-f]{64}' "$CONTAINERFILE" 'OMP_SHA256=')"
+docker_tag="$(grab 'factory-omp-base:[0-9.]+' "$DOCKERFILE" 'factory-omp-base:')"
+pinned_sha="$(grab '_PINNED_SHA256 = "[0-9a-f]{64}"' "$DIGEST_PY" '_PINNED_SHA256 = "')"
+pinned_sha="${pinned_sha%\"}"
+
+rc=0
+if [ "$omp_sha" != "$pinned_sha" ]; then
+  echo "MISMATCH binary digest: omp-base OMP_SHA256=$omp_sha != _rpc_digest _PINNED_SHA256=$pinned_sha" >&2
+  rc=1
+fi
+if [ "$omp_version" != "$docker_tag" ]; then
+  echo "MISMATCH omp version: omp-base OMP_VERSION=v$omp_version != Dockerfile factory-omp-base:$docker_tag" >&2
+  rc=1
+fi
+
+[ "$rc" -eq 0 ] && echo "omp pin lockstep OK — version=$omp_version sha=${omp_sha:0:12}…"
+exit "$rc"


### PR DESCRIPTION
Closes #1873. Refs #1871.

## Problem

The omp release is pinned in **three** files. Bump one and forget the others → the agent-runtime ships, the adapter re-verifies the binary sha at startup, and it raises `DigestMismatchError`. Nothing catches a partial bump today.

## Gate

`tools/check_omp_pin_lockstep.sh` asserts two equalities and fails the build on drift:

| Invariant | Source A | Source B |
|---|---|---|
| binary digest | `OMP_SHA256` — `deploy/omp-base/Containerfile` | `_PINNED_SHA256` — `src/factory/adapters/omp/_rpc_digest.py` |
| version | `OMP_VERSION` (minus `v`) — `deploy/omp-base/Containerfile` | `factory-omp-base:<tag>` — `Dockerfile` |

Greps the **literal** in `_rpc_digest.py:9`, not `_rpc_bridge.py` (which only re-exports it — the #1873 body correction). Exit codes follow the repo contract: `0` lockstep · `1` mismatch · `2` script broke (missing file / pin pattern moved). `OMP_PIN_ROOT` overrides the tree root so the gate is unit-testable.

## Wiring

- `.github/workflows/ci.yml` — runs the gate **and** its test (mirrors the `check_hardcoded_constants` pattern).
- `.claude/stack.yml` — registers `omp_pin_lockstep` (the gate SSoT). qg.conf-drift unaffected — that gate only renders `file_length`/`folder_size` params (verified green).

## Validation (local)

- `bash tools/check_omp_pin_lockstep.sh` → exit 0, `omp pin lockstep OK — version=15.10.8 sha=b877091c91eb…`
- `bash tests/tools/test_check_omp_pin_lockstep.sh` → all cases pass (in-lockstep→0, digest-mismatch→1, version-mismatch→1, missing-file→2)
- `scripts/check-qg-conf-drift.sh` → ✓ no drift after the stack.yml edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)