### PR TITLE
chore(ops): retire deprecated deploy targets + fix doc drift (#1930)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,62 +215,16 @@ quadlet-secrets-install:  ## (re)create Podman secrets — delegates to install.
 
 # ── Deploy + remote ──────────────────────────────────────────────────────────
 
-deploy:
-	@echo "DEPRECATED: use make converge"
-	$(require_machine1)
-	@echo "Deploying quadlet units to $(DEPLOY_HOST)..."
-	@ssh $(DEPLOY_HOST) '\
-	set -eu; \
-	export XDG_RUNTIME_DIR="/run/user/$$(id -u)"; \
-	FACTORY_DIR=$(DEPLOY_DIR); \
-	VOICE_DIR=$$(grep "^VOICE_DEPLOY_DIR=" "$$FACTORY_DIR/.env" 2>/dev/null | cut -d= -f2); \
-	VOICE_DIR=$${VOICE_DIR:-$$HOME/projects/voiceCLI}; \
-	echo "==> factory: pulling staging..."; \
-	cd "$$FACTORY_DIR" && git pull origin staging; \
-	echo "==> factory: installing quadlet units..."; \
-	make -C "$$FACTORY_DIR" quadlet-install; \
-	if [ -d "$$VOICE_DIR/.git" ]; then \
-	    echo "==> voiceCLI: pulling staging..."; \
-	    cd "$$VOICE_DIR" && git pull origin staging; \
-	    echo "==> voiceCLI: installing quadlet units..."; \
-	    make -C "$$VOICE_DIR" quadlet-install; \
-	fi; \
-	echo ""; \
-	echo "Units installed + daemon-reload done."; \
-	echo "To restart: make remote factory reload  (or: systemctl --user restart voicecli-tts voicecli-stt)"'
-
-full-deploy:  ## atomic deploy: git pull → quadlet-install → regen auth.conf → secrets → restart NATS → restart factory
-	@echo "DEPRECATED: use make converge"
-	$(require_machine1)
-	@echo "Full deploy to $(DEPLOY_HOST)..."
-	@ssh $(DEPLOY_HOST) '\
-	set -eu; \
-	export XDG_RUNTIME_DIR="/run/user/$$(id -u)"; \
-	FACTORY_DIR=$(DEPLOY_DIR); \
-	VOICE_DIR=$$(grep "^VOICE_DEPLOY_DIR=" "$$FACTORY_DIR/.env" 2>/dev/null | cut -d= -f2); \
-	VOICE_DIR=$${VOICE_DIR:-$$HOME/projects/voiceCLI}; \
-	echo "==> factory: pulling staging..."; \
-	cd "$$FACTORY_DIR" && git pull origin staging; \
-	if [ -d "$$VOICE_DIR/.git" ]; then \
-	    echo "==> voiceCLI: pulling staging..."; \
-	    cd "$$VOICE_DIR" && git pull origin staging; \
-	    echo "==> voiceCLI: installing quadlet units..."; \
-	    make -C "$$VOICE_DIR" quadlet-install; \
-	fi; \
-	echo "==> factory: installing quadlet units..."; \
-	make -C "$$FACTORY_DIR" quadlet-install; \
-	echo "==> NATS: regenerating auth.conf from updated acl-matrix.json..."; \
-	sudo env "PATH=$$PATH" factory-acl genkeys --regen-authconf; \
-	echo "==> NATS: installing Podman secrets..."; \
-	make -C "$$FACTORY_DIR" quadlet-secrets-install; \
-	echo "==> NATS: restarting (refresh mount-typed Podman secret)..."; \
-	systemctl --user restart factory-nats; \
-	systemctl --user is-active --wait factory-nats \
-		|| { echo "ERROR: factory-nats failed to reach active state"; exit 1; }; \
-	echo "==> Lyra: restarting containers..."; \
-	systemctl --user restart factory-hub factory-telegram factory-discord factory-clipool; \
-	echo ""; \
-	echo "Full deploy complete."'
+# `deploy` and `full-deploy` were SSH-from-dev-machine remote deploy verbs. They
+# are RETIRED (#1930) — the production host converges itself via `make converge`
+# (run locally on M₁) plus the factory-quadlet-sync / factory-post-autoupdate
+# timers. Both targets now fail fast and redirect; the old SSH recipes live in
+# git history. See deploy/AGENTS.md § "Atomic deploy — make converge".
+deploy full-deploy:  ## RETIRED — remote SSH deploy; run `make converge` on the production host
+	@echo "ERROR: 'make $@' (remote SSH deploy) is retired (#1930)." >&2
+	@echo "       Run 'make converge' on the production host (M₁), or let the" >&2
+	@echo "       factory-quadlet-sync / factory-post-autoupdate timers converge automatically." >&2
+	@exit 1
 
 converge:  ## atomic, idempotent, change-gated local deploy
 	@bash deploy/converge.sh
@@ -306,8 +260,14 @@ remote:
 # `factory-nats` is restarted separately by the target itself before this list.
 FACTORY_NATS_CLIENTS := factory-hub factory-telegram factory-discord factory-web factory-clipool factory-turn-writer factory-gh-helper factory-blobstore factory-omp
 
-nats-setup:
-	@bash deploy/nats/setup.sh
+# Cold-path key bootstrap for the containerised NATS (#1930). The host NATS was
+# retired (big-bang consolidation) — this no longer installs a server, system
+# user, TLS, or firewall rule; it only renders the nkey seeds + auth.conf that
+# the factory-nats container bind-mounts. `--ack-external-distribution` pre-acks
+# the external-seed fan-out guard for a fresh box (operator still scp's external
+# seeds, e.g. voice-client → M₂). Routine deploys converge via `make converge`.
+nats-setup:  ## cold-path: render nkey seeds + auth.conf for the container NATS (deploy via `make converge`)
+	@factory-acl genkeys --ack-external-distribution
 
 nats-regen-specs:             ## re-render ACL spec table + parity fixture from acl-matrix.json
 	@uv run --frozen python scripts/render_acl_spec.py

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -49,7 +49,7 @@ warn() { echo "WARN: $*" >&2; }
 
 log "Checking ~/.roxabi/factory/nkeys/ ..."
 if [[ ! -d "${NKEYS_DIR}" ]]; then
-  echo "ERROR: ${NKEYS_DIR} not found. Run: make nats-setup" >&2
+  echo "ERROR: ${NKEYS_DIR} not found. Run: make nats-setup (renders nkey seeds + auth.conf)" >&2
   exit 1
 fi
 
@@ -216,7 +216,7 @@ for secret_name in "${!SEEDS[@]}"; do
 done
 unset _policy
 if [[ "$MISSING" -eq 1 ]]; then
-  echo "ERROR: Missing seed files — cannot install secrets. Run: make nats-setup" >&2
+  echo "ERROR: Missing seed files — cannot install secrets. Run: make nats-setup (renders nkey seeds + auth.conf)" >&2
   exit 1
 fi
 

--- a/deploy/nats/setup.sh
+++ b/deploy/nats/setup.sh
@@ -18,6 +18,17 @@
 # Safe to re-run after upgrades, re-provisioning, or permission drift.
 # To rotate keys: sudo rm -f /etc/nats/nkeys/auth.conf && rm -rf ~/.roxabi/factory/nkeys && make nats-setup
 
+# ── RETIRED (#1930) ──────────────────────────────────────────────────────────
+# The host nats.service is gone — production NATS is the rootless factory-nats
+# container. This script (server binary, system user, TLS, UFW) no longer maps
+# to the deployed topology and must NOT run on a post-cutover host. It is kept
+# below for rollback-reference only. Fail fast and point at the live paths.
+echo "ERROR: deploy/nats/setup.sh is retired — host NATS was replaced by the" >&2
+echo "       containerised factory-nats unit (big-bang consolidation)." >&2
+echo "       Cold-path key bootstrap:  make nats-setup   (factory-acl genkeys --ack-external-distribution)" >&2
+echo "       Production deploy:         make converge" >&2
+exit 1
+
 set -euo pipefail
 # shellcheck source=../lib/env.sh
 source "$(dirname "$0")/../lib/env.sh"

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -565,8 +565,8 @@ else
   echo ""
   echo "     claude"
   echo ""
-  echo "  5. Recommended — NATS setup for multi-machine production (embedded nats-server covers dev/single-machine use):"
+  echo "  5. Recommended — render NATS nkey seeds + auth.conf for the containerised NATS (embedded nats-server covers dev/single-machine use):"
   echo ""
-  echo "     cd ~/projects/roxabi-factory && make nats-setup"
+  echo "     cd ~/projects/roxabi-factory && make nats-setup   # cold-path; routine deploys converge via 'make converge'"
   echo ""
 fi

--- a/deploy/systemd/factory-post-autoupdate.service
+++ b/deploy/systemd/factory-post-autoupdate.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra post-autoupdate hook — run after container image updates
+Description=factory post-autoupdate hook — run `make converge` after a container image update
 After=network-online.target
 Wants=network-online.target
 OnFailure=factory-deploy-failure.service

--- a/deploy/systemd/factory-quadlet-sync.service
+++ b/deploy/systemd/factory-quadlet-sync.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyra Quadlet sync — pull staging and conditional install
+Description=factory Quadlet sync — pull staging, conditional quadlet-install (converge runs via factory-post-autoupdate)
 After=network-online.target
 Wants=network-online.target
 OnFailure=factory-deploy-failure.service

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -270,12 +270,11 @@ DEPLOY_DIR=~/projects/roxabi-factory # project path on the production host
 
 `make remote` fails fast if either variable is unset.
 
-### Deploy (SSH pull + quadlet install)
+### Deploy
 
 ```bash
-make converge          # preferred — run on the production host (idempotent, change-gated)
-# legacy SSH helper from dev machine (deprecated — prints warning):
-make deploy
+make converge          # run on the production host (M₁) — idempotent, change-gated
+# `make deploy` / `make full-deploy` (remote SSH deploy) are RETIRED (#1930) — they now fail fast.
 ```
 
 ### Remote service control

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -38,7 +38,7 @@ factory bot secret install telegram lyra   # store token encrypted
 factory start                           # hub + telegram + discord in one process
 ```
 
-No containers. No systemd. No `make deploy`. Stop with `Ctrl+C`.
+No containers. No systemd. No `make converge`. Stop with `Ctrl+C`.
 
 Move to Tier 3 (split processes, auto-deploy timer, health monitoring, embedded NATS replaced by a system service) only when you actually need 24/7 uptime. Tier 3 is what this guide covers from **Step 1** onward.
 
@@ -456,7 +456,7 @@ ssh -i ~/.ssh/lyra_agent lyra@<MACHINE_1_IP> "id && git --version"
 make factory status  # status of all factory containers (default when no target)
 make factory reload  # restart hub + adapters + clipool
 make factory logs    # journalctl for factory-hub
-make deploy          # pull latest staging, install quadlet units (from Machine 2)
+make converge        # pull latest staging + install quadlet units — run on the production host (M₁)
 ```
 
 ---


### PR DESCRIPTION
E3 of the architecture-simplification epic — retire the deploy verbs and host-NATS setup that no longer map to the deployed topology, and fix the resulting doc drift.

## Context

Host NATS was retired by the big-bang consolidation; production NATS is the rootless `factory-nats` container. The production host (M₁) converges itself via `make converge` plus the `factory-quadlet-sync` / `factory-post-autoupdate` / `podman-auto-update` timers (all **active on M₁**, verified). The remote-SSH `deploy`/`full-deploy` verbs and `deploy/nats/setup.sh` (server binary + system user + TLS + UFW) are dead paths.

## Change

| File | What |
|---|---|
| `Makefile` `nats-setup` | repointed to cold-path `factory-acl genkeys --ack-external-distribution` (renders nkey seeds + auth.conf only — no server/user/TLS/UFW). Flag verified present on M₁. |
| `Makefile` `deploy` / `full-deploy` | **RETIRED** — print a redirect to `make converge` and `exit 1`. Old SSH recipes preserved in git history. |
| `deploy/nats/setup.sh` | fail-fast `exit 1` + migration message; body kept for rollback reference. |
| `deploy/systemd/factory-post-autoupdate.service` · `factory-quadlet-sync.service` | drop stale "Lyra" Descriptions; post-autoupdate now states it runs `make converge`. |
| `docs/DEPLOYMENT.md` · `docs/GETTING-STARTED.md` | `make deploy` → `make converge`. |
| `deploy/install.sh` · `deploy/provision.sh` | clarify `make nats-setup` hints (renders seeds + auth.conf; routine deploys converge). |

`remote` (service start/stop/status/logs) is **kept** — it's operational, not a deploy verb.

## Validation

- All pre-push gates green: `secrets_drift`, `volumes_table`, `quadlet_manifest_install`, `doc_drift`, `doc_semantic_drift`, `architecture_snapshot` (0 drift), `debt_expiry`, `test_sleep`, `no_runtime_toml_bots`.
- `make -n {deploy,full-deploy,nats-setup}` render the new recipes correctly (Makefile parses).
- **M₁ (read-only):** `factory-acl genkeys --ack-external-distribution` flag present; all 3 converge timers `active`. No live mutation performed.
- No `src/` changes → ruff/pyright/pytest unaffected.

Closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
