### PR TITLE
refactor(deploy): derive Makefile container lists from quadlet.toml (#1988)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,17 @@ FACTORY_DISCORD_UNIT  := factory-discord
 FACTORY_WEB_UNIT      := factory-web
 FACTORY_NATS_UNIT     := factory-nats
 FACTORY_CLIPOOL_UNIT  := factory-clipool
-FACTORY_UNITS         := $(FACTORY_HUB_UNIT) $(FACTORY_TELEGRAM_UNIT) $(FACTORY_DISCORD_UNIT) $(FACTORY_WEB_UNIT) $(FACTORY_CLIPOOL_UNIT)
+
+# Container list — SSoT is deploy/quadlet.toml via quadlet_containers() (#1979,
+# #1988). Derived once at parse time so adding/renaming a container in
+# quadlet.toml flows into `make factory` and the nats-regen-authconf restart set
+# with no Makefile edit. The individual FACTORY_*_UNIT vars above remain for
+# per-unit targets (telegram:, nats:, …).
+FACTORY_ALL_CONTAINERS := $(shell bash -c 'source deploy/lib/quadlet-units.sh && quadlet_containers 2>/dev/null')
+# App units = every container except the bare NATS server, which is infra
+# managed on its own (`make nats`, converge, #1390) and must not be bounced by a
+# routine `make factory reload`. Same set as FACTORY_NATS_CLIENTS below today.
+FACTORY_UNITS          := $(filter-out $(FACTORY_NATS_UNIT),$(FACTORY_ALL_CONTAINERS))
 
 # $(call factory_sctl,<unit1> [unit2 ...]) — dispatches SVC_CMD to systemctl --user.
 # Defaults (empty SVC_CMD) to `status`. `logs`/`errors` tail the first unit.
@@ -255,10 +265,11 @@ remote:
 
 # ── Dev tools ────────────────────────────────────────────────────────────────
 
-# Shared list of services that hold NATS subject auth and must restart
-# whenever `auth.conf` is regenerated or a new identity is added. The bare
-# `factory-nats` is restarted separately by the target itself before this list.
-FACTORY_NATS_CLIENTS := factory-hub factory-telegram factory-discord factory-web factory-clipool factory-turn-writer factory-gh-helper factory-blobstore factory-omp
+# Services that hold NATS subject auth and must restart whenever `auth.conf` is
+# regenerated or a new identity is added. Derived from deploy/quadlet.toml
+# (#1988) = every container minus the bare `factory-nats` server, which the
+# target restarts separately before this list. See FACTORY_ALL_CONTAINERS.
+FACTORY_NATS_CLIENTS := $(filter-out $(FACTORY_NATS_UNIT),$(FACTORY_ALL_CONTAINERS))
 
 # Cold-path key bootstrap for the containerised NATS (#1930). The host NATS was
 # retired (big-bang consolidation) — this no longer installs a server, system
@@ -283,6 +294,10 @@ nats-regen-authconf:          ## re-render auth.conf from acl-matrix.json, resta
 	@systemctl --user restart factory-nats
 	@systemctl --user is-active --wait factory-nats \
 		|| { echo "ERROR: factory-nats failed to reach active state"; exit 1; }
+	@# Derived list must be non-empty — an empty FACTORY_NATS_CLIENTS (quadlet.toml
+	@# unreadable / helper failure) would silently skip the #1390 client restarts.
+	@test -n "$(FACTORY_NATS_CLIENTS)" \
+		|| { echo "ERROR: FACTORY_NATS_CLIENTS empty — quadlet_containers() failed; refusing to skip client restarts (#1390)"; exit 1; }
 	@# All NATS clients hold stale subject auth after an ACL change (#1390).
 	@failed=""; \
 	for svc in $(FACTORY_NATS_CLIENTS); do \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -75,8 +75,8 @@ On Machine 1:
 cd ~/projects/roxabi-factory
 make quadlet-install    # copy unit files to ~/.config/containers/systemd/
 make converge           # idempotent full deploy (preferred after unit changes)
-# or restart core path only:
-make factory reload     # hub + telegram + discord + clipool
+# or restart the app containers only (no pull / install / auth regen):
+make factory reload     # all factory app containers
 ```
 
 **Graceful drain** — on restart, the running container finishes any in-flight Claude CLI turns (up to 60 s) before stopping. Conversations that complete within the window are transparent to users; only turns that outlast 60 s receive a "please resend" notification.
@@ -186,10 +186,10 @@ All commands can be run from Machine 1 or from Machine 2 via SSH (`make remote <
 ```bash
 # From Machine 1
 cd ~/projects/roxabi-factory
-make factory            # status — hub + telegram + discord + clipool (default)
-make factory reload     # restart those four only
-make factory start      # start those four
-make factory stop       # stop those four
+make factory            # status — all factory app containers (default)
+make factory reload     # restart all app containers
+make factory start      # start all app containers
+make factory stop       # stop all app containers
 make factory logs       # journalctl -u factory-hub -f
 make factory errors     # journalctl -u factory-hub -f -p err
 
@@ -209,14 +209,15 @@ make remote logs
 make remote errors
 ```
 
-**`make factory reload` vs `make converge`** — two scopes:
+**`make factory reload` vs `make converge`** — two scopes (both derive the
+container list from `deploy/quadlet.toml`, #1988):
 
 | Command | Where | Restarts |
 |---------|-------|----------|
-| `make factory reload` | production host | **4** units: hub, telegram, discord, clipool |
-| `make converge` | production host | **NATS** + **8** factory clients (adds turn-writer, blobstore, gh-helper, omp) + voiceCLI if present; also pulls git, reinstalls quadlet units when drift detected |
+| `make factory reload` | production host | the **9 app containers** (every container except the bare `factory-nats`) — restart only |
+| `make converge` | production host | **NATS** + the **9 app containers** + voiceCLI if present; also pulls git, reinstalls quadlet units, and regenerates auth.conf when drift detected |
 
-Use `make factory reload` for a quick hub/adapters bounce. Use `make converge` after changing Quadlet units, images, or ACL — it is idempotent and no-ops when already converged.
+Use `make factory reload` for a quick app-container bounce (no git pull, unit reinstall, or auth regen). Use `make converge` after changing Quadlet units, images, or ACL — it is idempotent and no-ops when already converged.
 
 ## 5. Enable debug logging
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -453,8 +453,8 @@ ssh -i ~/.ssh/lyra_agent lyra@<MACHINE_1_IP> "id && git --version"
 
 **Daily commands** (from `~/projects/roxabi-factory`):
 ```bash
-make factory status  # status of all factory containers (default when no target)
-make factory reload  # restart hub + adapters + clipool
+make factory status  # status of all factory app containers (NATS: `make nats status`)
+make factory reload  # restart all factory app containers (NATS managed separately)
 make factory logs    # journalctl for factory-hub
 make converge        # pull latest staging + install quadlet units — run on the production host (M₁)
 ```


### PR DESCRIPTION
Finish the container-list SSoT started in #1979 — wire the Makefile's hand-enumerated lists to `deploy/lib/quadlet-units.sh::quadlet_containers()` (the same helper `converge.sh` / `quadlet-install-verify.sh` already consume), so adding/renaming a container in `deploy/quadlet.toml` needs no Makefile edit.

## Change

| Var | Before | After |
|---|---|---|
| `FACTORY_ALL_CONTAINERS` | — | **new** — derived once at parse time from `quadlet.toml` |
| `FACTORY_NATS_CLIENTS` (post-ACL restart set, #1390) | literal 9-unit list | `$(filter-out factory-nats,$(FACTORY_ALL_CONTAINERS))` — **identical set**, now self-maintaining |
| `FACTORY_UNITS` (`make factory` bulk control) | stale hand-curated 5 (web drifted in; omp/turn-writer/gh-helper/blobstore missing) | same derived app-unit set |

- **Guard:** `nats-regen-authconf` now aborts if the derived list is empty (helper failure) rather than silently skipping the #1390 client restarts.
- **#1988's 3rd sub-task** (literal restart list inside `full-deploy`) was already removed by **#1930** when that target was retired — nothing left to wire there.
- **Docs:** DEPLOYMENT.md + GETTING-STARTED.md now frame `make factory` as *restart-only over the app containers* vs `make converge` as *full reconcile* (the prior "4 units" wording was already stale). Individual `FACTORY_*_UNIT` vars kept for per-unit targets.

## Validation

- `make -n {factory,nats-regen-authconf}` expand to the correct derived 9-unit lists; guard present.
- doc_drift / doc_semantic_drift / architecture_snapshot (0 drift) green.
- **M₁:** `quadlet_containers()` → the 10 deployed containers; derived client set == the prior literal == the running app units → **behavior-preserving**.
- Pure refactor, no `src/` changes (ruff/pyright/pytest unaffected).

> Observation (out of scope): `factory-gh-infra` runs on M₁ but is **not** in `quadlet.toml` (off-manifest) — excluded by both the old and new lists, so no regression. Flagged for triage.

Closes #1988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
