### PR TITLE
feat(contracts): move factory.clipool.* subjects to roxabi-contracts

### DIFF
--- a/packages/roxabi-contracts/src/roxabi_contracts/cli/__init__.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/cli/__init__.py
@@ -8,6 +8,7 @@ from .models import (
     CliControlCmd,
     CliHeartbeat,
 )
+from .subjects import SUBJECTS
 
 __all__ = [
     "CliCmdPayload",
@@ -15,4 +16,5 @@ __all__ = [
     "CliControlAck",
     "CliControlCmd",
     "CliHeartbeat",
+    "SUBJECTS",
 ]

--- a/packages/roxabi-contracts/src/roxabi_contracts/cli/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/cli/subjects.py
@@ -1,0 +1,28 @@
+"""CliPool-domain NATS subject strings and queue group.
+
+Canonical values from ADR-054 (absorbed into ADR-055).
+Literal strings (no f-strings, no derivation) so grep can locate every reference
+across the monorepo.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = ["SUBJECTS"]
+
+
+@dataclass(frozen=True, slots=True)
+class _Subjects:
+    """Frozen namespace of CliPool-domain subject strings.
+
+    Attribute access is pyright-checked: typos fail at type-check time
+    rather than silently returning None.
+    """
+
+    cmd: Literal["factory.clipool.cmd"] = "factory.clipool.cmd"
+    control: Literal["factory.clipool.control"] = "factory.clipool.control"
+    heartbeat: Literal["factory.clipool.heartbeat"] = "factory.clipool.heartbeat"
+    clipool_workers: Literal["clipool-workers"] = "clipool-workers"
+
+
+SUBJECTS = _Subjects()

--- a/packages/roxabi-contracts/tests/test_cli_subjects.py
+++ b/packages/roxabi-contracts/tests/test_cli_subjects.py
@@ -1,0 +1,19 @@
+"""Tests locking CliPool-domain subject strings."""
+
+from roxabi_contracts.cli import SUBJECTS
+
+
+def test_cmd_subject() -> None:
+    assert SUBJECTS.cmd == "factory.clipool.cmd"
+
+
+def test_control_subject() -> None:
+    assert SUBJECTS.control == "factory.clipool.control"
+
+
+def test_heartbeat_subject() -> None:
+    assert SUBJECTS.heartbeat == "factory.clipool.heartbeat"
+
+
+def test_queue_group_constant() -> None:
+    assert SUBJECTS.clipool_workers == "clipool-workers"

--- a/src/factory/adapters/clipool/clipool_worker.py
+++ b/src/factory/adapters/clipool/clipool_worker.py
@@ -2,8 +2,8 @@
 
 (ADR-054 (absorbed into ADR-055)).
 
-Subscribes to ``factory.clipool.cmd`` (queue group ``clipool-workers``) and
-``factory.clipool.control``.  Routes inbound messages to _handle_cmd or
+Subscribes to ``SUBJECTS.cmd`` (queue group ``SUBJECTS.clipool_workers``) and
+``SUBJECTS.control``.  Routes inbound messages to _handle_cmd or
 _handle_control based on subject.  Streams CLI output back to the caller
 via NATS request-reply inbox.
 """
@@ -26,6 +26,7 @@ from factory.core.agent.agent_config import ModelConfig
 from factory.core.cli.cli_pool import CliPool
 from factory.core.messaging.events import ResultLlmEvent, TextLlmEvent, ToolUseLlmEvent
 from factory.core.messaging.utils.metrics import emit_populated_total
+from roxabi_contracts.cli import SUBJECTS
 from roxabi_contracts.cli.models import (
     CliCmdPayload,
     CliControlCmd,
@@ -35,10 +36,6 @@ from roxabi_nats.adapter_base import NatsAdapterBase
 
 log = logging.getLogger(__name__)
 
-_CMD_SUBJECT = "factory.clipool.cmd"
-_CONTROL_SUBJECT = "factory.clipool.control"
-_HEARTBEAT_SUBJECT = "factory.clipool.heartbeat"
-_QUEUE_GROUP = "clipool-workers"
 _ENVELOPE_NAME = "CliCmdPayload"
 _SCHEMA_VERSION = 1
 _HEARTBEAT_INTERVAL = 30.0
@@ -48,8 +45,8 @@ class CliPoolNatsWorker(NatsAdapterBase):
     """NATS worker adapter that exposes CliPool over request-reply subjects.
 
     Routing:
-      - ``factory.clipool.cmd``     (queue group) → _handle_cmd
-      - ``factory.clipool.control`` (broadcast)   → _handle_control
+      - ``SUBJECTS.cmd``     (queue group) → _handle_cmd
+      - ``SUBJECTS.control`` (broadcast)   → _handle_control
 
     The caller sends a JSON envelope (CliCmdPayload / CliControlCmd) and
     provides a reply-to inbox.  Streaming chunks are published to that inbox
@@ -65,12 +62,12 @@ class CliPoolNatsWorker(NatsAdapterBase):
         identity_name: str | None = None,
     ) -> None:
         super().__init__(
-            subject=_CMD_SUBJECT,
-            queue_group=_QUEUE_GROUP,
+            subject=SUBJECTS.cmd,
+            queue_group=SUBJECTS.clipool_workers,
             envelope_name=_ENVELOPE_NAME,
             schema_version=_SCHEMA_VERSION,
             timeout=timeout,
-            heartbeat_subject=_HEARTBEAT_SUBJECT,
+            heartbeat_subject=SUBJECTS.heartbeat,
             heartbeat_interval=_HEARTBEAT_INTERVAL,
             identity_name=identity_name,
             wait_ready=False,  # worker semantics — see NatsAdapterBase docstring
@@ -82,10 +79,10 @@ class CliPoolNatsWorker(NatsAdapterBase):
     # ------------------------------------------------------------------
 
     def _extra_subjects(self) -> list[str]:
-        return [_CONTROL_SUBJECT]
+        return [SUBJECTS.control]
 
     async def handle(self, msg: Any, payload: dict) -> None:
-        if msg.subject == _CONTROL_SUBJECT:
+        if msg.subject == SUBJECTS.control:
             await self._handle_control(msg, payload)
         else:
             await self._handle_cmd(msg, payload)

--- a/src/factory/bootstrap/factory/hub/hub_llm_client.py
+++ b/src/factory/bootstrap/factory/hub/hub_llm_client.py
@@ -25,12 +25,13 @@ async def build_llm_client(
     from factory.transport.nats_request_response import NatsTransport
     from factory.transport.worker_pool_client import WorkerPoolClient
     from roxabi_contracts._nats_utils import validate_worker_id
+    from roxabi_contracts.cli import SUBJECTS
 
     transport = NatsTransport(nc)
     pool = WorkerPoolClient(
         transport,
         registry=WorkerRegistry(),
-        hb_subject="factory.clipool.heartbeat",
+        hb_subject=SUBJECTS.heartbeat,
         validate_worker_id=validate_worker_id,
         name="clipool",
     )
@@ -39,5 +40,5 @@ async def build_llm_client(
         pool,
         CliPoolCodec(),
         timeout=timeout,
-        request_subject="factory.clipool.cmd",
+        request_subject=SUBJECTS.cmd,
     )

--- a/src/factory/llm/cli_pool_codec.py
+++ b/src/factory/llm/cli_pool_codec.py
@@ -1,6 +1,6 @@
 """CliPoolCodec — encode/decode boundary for the NATS CliPool path.
 
-Implements LlmCodec Protocol for factory.clipool.cmd / factory.clipool.control.
+Implements LlmCodec Protocol for ``roxabi_contracts.cli.SUBJECTS``.
 Encodes CliCmdPayload; decodes CliChunkEvent into LlmResult / LlmEvent.
 """
 
@@ -58,7 +58,7 @@ def _validate_worker_error(we: WorkerError | None) -> WorkerError | None:
 
 
 class CliPoolCodec:
-    """Codec for CliPool-over-NATS (factory.clipool.cmd)."""
+    """Codec for CliPool-over-NATS (``roxabi_contracts.cli.SUBJECTS.cmd``)."""
 
     def encode(
         self,

--- a/src/factory/llm/llm_client.py
+++ b/src/factory/llm/llm_client.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from factory.core.messaging.events import LlmEvent, ResultLlmEvent
 from factory.core.ports.llm import LlmResult
+from roxabi_contracts.cli import SUBJECTS as CLI_SUBJECTS
 from roxabi_contracts.cli.models import CliControlCmd
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.llm import SUBJECTS
@@ -27,8 +28,6 @@ if TYPE_CHECKING:
     from factory.transport.worker_pool_client import WorkerPoolClient
 
 log = logging.getLogger(__name__)
-
-_SUBJECT_CONTROL = "factory.clipool.control"
 
 
 class _CliSessionStore(Protocol):
@@ -171,7 +170,7 @@ class LlmClient:
         )
         payload = self._codec.encode_control(cmd)
         await self._pool._transport.call(  # type: ignore[attr-defined]  # noqa: SLF001
-            _SUBJECT_CONTROL, payload, timeout=self._timeout
+            CLI_SUBJECTS.control, payload, timeout=self._timeout
         )
 
     async def queue_resume(self, pool_id: str, session_id: str) -> bool:
@@ -212,5 +211,5 @@ class LlmClient:
         )
         payload = self._codec.encode_control(cmd)
         await self._pool._transport.call(  # type: ignore[attr-defined]  # noqa: SLF001
-            _SUBJECT_CONTROL, payload, timeout=self._timeout
+            CLI_SUBJECTS.control, payload, timeout=self._timeout
         )


### PR DESCRIPTION
## Summary
- Add `roxabi_contracts.cli.subjects.SUBJECTS` with frozen `cmd`, `control`, `heartbeat`, and `clipool_workers` constants
- Replace inline `factory.clipool.*` literals in `clipool_worker`, `llm_client`, `hub_llm_client`, and `cli_pool_codec`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1932: feat(contracts): move factory.clipool.* subjects to roxabi-contracts | OPEN |
| Implementation | 1 commit on `feat/1932-feat-contracts-move-factory-clipool-subjects-to-roxabi-contracts` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (47 targeted) | Passed |

## Test Plan
- [x] `pytest packages/roxabi-contracts/tests/test_cli_subjects.py`
- [x] `pytest tests/llm/test_llm_client_control.py tests/adapters/test_clipool_worker.py tests/bootstrap/test_hub_builder.py`

Fixes #1932

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`