### PR TITLE
docs(1674): close living-doc judgment tail + container counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Unified: `factory start` → hub + adapters in 1 process + embedded NATS
 
 ## Container deployment
 
-Prod: Podman Quadlet (systemd `--user`) on M₁ (`factory-hub` role). Containers include `factory-nats`, `factory-hub`, adapters, `factory-blobstore`, `factory-omp`, plus observability `factory-loki` + `factory-promtail`. Install: `deploy/install.sh` (idempotent). Manifest: `deploy/quadlet.toml`.
+Prod: Podman Quadlet (systemd `--user`) on M₁ (`factory-hub` role). **20 containers** per `deploy/quadlet.toml`: core (`factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-web`, `factory-clipool`, `factory-omp`, `factory-socialmedia-adapter`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`) + observability (`factory-loki`, `factory-promtail`, `factory-otel-collector`, `factory-langfuse-*`). Install: `deploy/install.sh` (idempotent).
 
 → `docs/runbooks/README.md` — ops runbooks (install, secrets, diagnostic)
 → `~/projects/docs/container-deployment-standard.md` — 18 standards (S7 secret target, S8 naming, S12 RestartSec=10)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ chat adapters                factory-hub              workers
                     infra (gh-helper·turn-writer·blobstore)
 ```
 
-**Production**: Nine containers on M₁ communicate via a single NATS server (`factory-nats`). Hub: `factory-hub`. Chat adapters: `factory-telegram`, `factory-discord`. Workers: `factory-clipool`, `factory-omp`. Infra: `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`. Each runs in its own container.
+**Production**: Twenty Quadlet containers on M₁ (`deploy/quadlet.toml` SSoT) share a single NATS server (`factory-nats`). Core factory: `factory-hub`, chat adapters (`factory-telegram`, `factory-discord`, `factory-web`), workers (`factory-clipool`, `factory-omp`, `factory-socialmedia-adapter`), and infra (`factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`). Observability stack: `factory-loki`, `factory-promtail`, `factory-otel-collector`, and the Langfuse bundle (`factory-langfuse-*`).
 
 **Development**: `factory start` runs everything in one process with an embedded NATS server.
 

--- a/artifacts/analyses/1674-living-doc-lyra-audit.md
+++ b/artifacts/analyses/1674-living-doc-lyra-audit.md
@@ -194,3 +194,19 @@
 - `plugins/lyra-ops/skills/lyra-debug/SKILL.md:88` — `/home/factory/.local/state/lyra/logs/` → `/home/factory/.local/state/factory/logs/`
 - `plugins/lyra-ops/skills/lyra-debug/SKILL.md:89` — `/home/factory/.local/state/lyra/logs/` → `/home/factory/.local/state/factory/logs/`
 - `deploy/CLAUDE.md:87` — `/run/user/<uid>/lyra-deploy.lock` → `/run/user/<uid>/factory-deploy.lock`
+
+---
+
+## Verification (2026-06-26, issue #1674 close-out)
+
+All success criteria from `artifacts/specs/1674-lyra-factory-judgment-tail-spec.mdx` verified on `staging`:
+
+| SC | Result |
+|----|--------|
+| SC-1 `state/lyra` in living docs | 0 hits |
+| SC-2 `STT_MODEL_SIZE` absent from `.env.example` | pass |
+| SC-3 `lyra-gh` / `git-credential-lyra-gh` in living docs | 0 hits |
+| SC-4 phantom error classes in backend/architecture patterns | 0 hits |
+| SC-5 error sections cite real `src/factory/` sites | pass (pre-#1668 rewrite) |
+| SC-6 audit table complete; 0 stale-and-unfixed | pass |
+| SC-7 `ruff`, `pyright`, `pytest`, `check_doc_drift.py` | pass after satellite test fix |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ aiogram long-poll                NatsBus                       discord.py gatewa
       ◄──────────────────────────────┴──────────────────────────────▶
 ```
 
-Nine containers run on Machine 1 (`factory-hub` role): `factory-nats` (single NATS server), `factory-hub`, `factory-telegram`, `factory-discord`, `factory-clipool`, `factory-omp`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`. NATS topics: `factory.inbound.<platform>.<bot_id>` (adapter→hub), `factory.outbound.<platform>.<bot_id>` (hub→adapter). `factory start` runs hub + adapters in one process with embedded NATS.
+Twenty Quadlet containers run on Machine 1 (`factory-hub` role, manifest `deploy/quadlet.toml`): core factory (`factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-web`, `factory-clipool`, `factory-omp`, `factory-socialmedia-adapter`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`) plus observability (`factory-loki`, `factory-promtail`, `factory-otel-collector`, `factory-langfuse-*`). NATS topics: `factory.inbound.<platform>.<bot_id>` (adapter→hub), `factory.outbound.<platform>.<bot_id>` (hub→adapter). `factory start` runs hub + adapters in one process with embedded NATS.
 
 ### Jobs & workers
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,7 +6,7 @@ Running factory as a managed service on Machine 1 (Ubuntu Server 26.04 LTS) usin
 
 ## Overview
 
-factory runs as **nine containers** on a shared `roxabi.network` bridge, managed by **Podman Quadlet** (systemd --user). A `linger`-enabled systemd user session ensures all containers auto-start on boot without a login session.
+factory runs as **twenty containers** on a shared `roxabi.network` bridge, managed by **Podman Quadlet** (systemd --user). The manifest SSoT is `deploy/quadlet.toml` (11 core factory units + 9 observability units: Loki, Promtail, OTel collector, Langfuse stack). A `linger`-enabled systemd user session ensures all containers auto-start on boot without a login session.
 
 ```
 Machine 1 (production hub)
@@ -115,7 +115,7 @@ Volume + secret layout is documented inline in `deploy/quadlet/factory-hub.conta
 
 ## Multi-Bot Deployment
 
-Multiple bots are configured in `config.toml` — no container changes needed. The nine-container
+Multiple bots are configured in `config.toml` — no container changes needed. The core factory
 topology (`deploy/quadlet.toml`) is fixed regardless of how many bots are configured.
 
 ### Adding a second bot
@@ -199,7 +199,7 @@ make discord reload
 make nats reload
 make clipool reload
 
-# Full stack (9 containers + NATS auth refresh) — on the production host after unit/image/git drift
+# Full stack (20 containers + NATS auth refresh) — on the production host after unit/image/git drift
 make converge
 
 # From your dev machine (requires .env — see §8)
@@ -214,8 +214,8 @@ container list from `deploy/quadlet.toml`, #1988):
 
 | Command | Where | Restarts |
 |---------|-------|----------|
-| `make factory reload` | production host | the **9 app containers** (every container except the bare `factory-nats`) — restart only |
-| `make converge` | production host | **NATS** + the **9 app containers** + voiceCLI if present; also pulls git, reinstalls quadlet units, and regenerates auth.conf when drift detected |
+| `make factory reload` | production host | the **19 app containers** (every container except the bare `factory-nats`) — restart only |
+| `make converge` | production host | **NATS** + the **19 app containers** + voiceCLI if present; also pulls git, reinstalls quadlet units, and regenerates auth.conf when drift detected |
 
 Use `make factory reload` for a quick app-container bounce (no git pull, unit reinstall, or auth regen). Use `make converge` after changing Quadlet units, images, or ACL — it is idempotent and no-ops when already converged.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -332,9 +332,7 @@ make quadlet-secrets-install
 # Start all factory containers now
 systemctl --user start factory-nats.service
 sleep 3  # wait for NATS to be ready
-systemctl --user start factory-hub.service factory-telegram.service factory-discord.service \
-  factory-clipool.service factory-gh-helper.service factory-blobstore.service \
-  factory-turn-writer.service factory-omp.service
+make factory start
 ```
 
 Or use the Makefile dispatcher:
@@ -370,18 +368,7 @@ cd ~/projects/roxabi-factory
 systemctl --user status 'factory-*.service'
 ```
 
-You should see all nine units active:
-```
-factory-nats.service         active (running)
-factory-hub.service          active (running)
-factory-telegram.service     active (running)
-factory-discord.service      active (running)
-factory-clipool.service      active (running)
-factory-gh-helper.service    active (running)
-factory-blobstore.service    active (running)
-factory-turn-writer.service  active (running)
-factory-omp.service          active (running)
-```
+You should see all twenty `factory-*.service` units active (SSoT: `deploy/quadlet.toml` via `quadlet_containers`). Core factory units include `factory-nats`, `factory-hub`, adapters, workers, and infra; observability units include `factory-loki`, `factory-promtail`, `factory-otel-collector`, and `factory-langfuse-*`.
 
 Or check the full container list:
 ```bash

--- a/packages/roxabi-satellite/tests/test_blobs.py
+++ b/packages/roxabi-satellite/tests/test_blobs.py
@@ -21,14 +21,14 @@ class _FakeHttpBlobStore:
 
 @pytest.fixture(autouse=True)
 def _reset(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-    monkeypatch.setattr(blobs, "_INSTANCE", None)
+    monkeypatch.setattr(blobs, "_blobstore_instance", None)
     monkeypatch.delenv("BLOBSTORE_BEARER_TOKEN_PATH", raising=False)
     monkeypatch.delenv("BLOBSTORE_URL", raising=False)
     monkeypatch.delenv("BLOBSTORE_BACKEND", raising=False)
     monkeypatch.delenv("FACTORY_BLOBSTORE_URL", raising=False)
     monkeypatch.delenv("FACTORY_BLOBSTORE_TOKEN_PATH", raising=False)
     yield
-    monkeypatch.setattr(blobs, "_INSTANCE", None)
+    monkeypatch.setattr(blobs, "_blobstore_instance", None)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Close out issue #1674: verify SC-1–SC-7 (mechanical doc fixes and error-section rewrites were already landed via #1668/#2025) and record verification in the living-doc audit.
- Fix `roxabi-satellite` blob tests: fixture targeted `_INSTANCE` but module uses `_blobstore_instance`.
- Doc hygiene: align README, ARCHITECTURE, DEPLOYMENT, GETTING-STARTED, and AGENTS.md with **20 containers** per `deploy/quadlet.toml` (11 core + 9 observability).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #1674: living-doc judgment tail | Open |
| Analysis | [1674-living-doc-lyra-audit.md](artifacts/analyses/1674-living-doc-lyra-audit.md) | Present |
| Spec | [1674-lyra-factory-judgment-tail-spec.mdx](artifacts/specs/1674-lyra-factory-judgment-tail-spec.mdx) | Present |
| Implementation | 1 commit on `feat/1674-living-doc-judgment-tail` | Complete |
| Verification | Lint ✅ Tests ✅ (6158 pass) doc_drift ✅ | Passed locally |

## Test Plan
- [x] `uv run pytest packages/roxabi-satellite/tests/test_blobs.py`
- [x] `uv run pytest` full suite
- [x] `uv run python tools/check_doc_drift.py`
- [x] #1674 SC greps (state/lyra, lyra-gh, phantom error classes)

Fixes #1674