### PR TITLE
fix(deploy): converge image digests + observability healthchecks

### DIFF
--- a/deploy/factory-post-autoupdate.sh
+++ b/deploy/factory-post-autoupdate.sh
@@ -16,10 +16,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/lib/deploy-common.sh"
 
-IMAGES=(
-    "ghcr.io/roxabi/factory:staging-svc"
-    "ghcr.io/roxabi/factory:staging"
-)
+# FACTORY_TRACKED_IMAGES sourced from deploy-common.sh (fields 5–6 of converge stamp).
 
 # ── Digest comparison ────────────────────────────────────────────────────────
 
@@ -48,7 +45,7 @@ local_repo_digests() {
 main() {
     local drifted=()
 
-    for image in "${IMAGES[@]}"; do
+    for image in "${FACTORY_TRACKED_IMAGES[@]}"; do
         local remote_digest_val local_digests_val
         remote_digest_val=$(remote_digest "${image}")
         local_digests_val=$(local_repo_digests "${image}")
@@ -92,7 +89,7 @@ main() {
 # `with_deploy_lock _do_converge`, so wrapping here too would cause the outer
 # flock to hold the lock while calling make converge → converge.sh's inner
 # flock -n fails → _do_converge silently exits 0 and no converge runs. (#1749)
-# The pull + stamp-invalidate above are idempotent and safe to run unlocked;
+# The pull + converge change-gate above are idempotent and safe to run unlocked;
 # converge.sh's lock provides the necessary mutual exclusion.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     main "$@"

--- a/deploy/factory-post-autoupdate.sh
+++ b/deploy/factory-post-autoupdate.sh
@@ -82,10 +82,8 @@ main() {
         podman pull "${image}"
     done
 
-    # Converge stamp does not include image digest, so invalidate it
-    # to force a full converge (restarts, auth.conf refresh, etc.).
-    rm -f "${CONVERGE_STAMP}"
-
+    # Image digests are fields 5–6 of the convergence fingerprint — converge's
+    # change-gate detects structural drift after pull (no stamp deletion needed).
     echo "==> Running make converge..."
     make -C "${FACTORY_DIR}" converge
 }

--- a/deploy/lib/deploy-common.sh
+++ b/deploy/lib/deploy-common.sh
@@ -61,7 +61,7 @@ require_clean_tree() {
 factory_image_index_digest() {
     local image="$1" digest
     digest=$(podman image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "${image}" 2>/dev/null \
-        | sed 's/.*@//') || true
+        | sed 's/.*@//' | sed 's/^sha256://') || true
     if [ -n "${digest}" ]; then
         echo "${digest}"
     else

--- a/deploy/lib/deploy-common.sh
+++ b/deploy/lib/deploy-common.sh
@@ -20,6 +20,11 @@ CONVERGE_STAMP="${HOME}/.roxabi/factory/.converge-stamp"
 QUADLET_DIR="${HOME}/.config/containers/systemd"
 FACTORY_NKEYS_DIR="${HOME}/.roxabi/factory/nkeys"
 DEPLOY_LOCK="/run/user/$(id -u)/factory-deploy.lock"
+# Tracked factory images — digests are field 5–6 of the convergence fingerprint.
+FACTORY_TRACKED_IMAGES=(
+    "ghcr.io/roxabi/factory:staging-svc"
+    "ghcr.io/roxabi/factory:staging"
+)
 
 # ── flock wrapper ────────────────────────────────────────────────────────────
 # Run a command under an exclusive lock. Exit 0 (no error) if the lock is held.
@@ -51,11 +56,37 @@ require_clean_tree() {
 
 # ── Change detection helpers ─────────────────────────────────────────────────
 
+# First RepoDigest for a locally-present image (index digest on multi-arch pulls).
+# Matches the membership check in factory-post-autoupdate.sh (#1749).
+factory_image_index_digest() {
+    local image="$1" digest
+    digest=$(podman image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "${image}" 2>/dev/null \
+        | sed 's/.*@//') || true
+    if [ -n "${digest}" ]; then
+        echo "${digest}"
+    else
+        echo "none"
+    fi
+}
+
+# Upgrade legacy 4-field stamps to the current 6-field schema.
+_normalize_convergence_fingerprint() {
+    local fp="${1}"
+    local n
+    n=$(awk -F: '{print NF}' <<< "${fp}")
+    case "${n}" in
+        4) echo "${fp}:none:none" ;;
+        6) echo "${fp}" ;;
+        *) echo "${fp}" ;;
+    esac
+}
+
 # Compute current convergence fingerprint: git HEAD + unit checksums + auth.conf SHA
-# (+ voiceCLI HEAD if present).
-# Output format: <git-head>:<units-sha256>:<authconf-sha256>[:<voicecli-head>]
+# + voiceCLI HEAD + tracked image index digests.
+# Output format:
+#   <git-head>:<units-sha256>:<authconf-sha256>:<voicecli-head>:<staging-svc-digest>:<staging-digest>
 compute_convergence_state() {
-    local git_head unit_sha auth_sha voicecli_head
+    local git_head unit_sha auth_sha voicecli_head image_svc_sha image_stg_sha
 
     git_head=$(cd "${FACTORY_DIR}" && git rev-parse HEAD 2>/dev/null || echo "none")
 
@@ -79,7 +110,10 @@ compute_convergence_state() {
         voicecli_head="none"
     fi
 
-    echo "${git_head}:${unit_sha}:${auth_sha}:${voicecli_head}"
+    image_svc_sha=$(factory_image_index_digest "${FACTORY_TRACKED_IMAGES[0]}")
+    image_stg_sha=$(factory_image_index_digest "${FACTORY_TRACKED_IMAGES[1]}")
+
+    echo "${git_head}:${unit_sha}:${auth_sha}:${voicecli_head}:${image_svc_sha}:${image_stg_sha}"
 }
 
 # Read the last recorded convergence state.
@@ -103,18 +137,22 @@ write_convergence_state() {
 #   _classify_drift <last> <current>
 #
 #   Both arguments are fingerprints in the format produced by compute_convergence_state:
-#     <git_head>:<unit_sha>:<auth_sha>:<voicecli_head>
-#   Any field may be the sentinel "none".
+#     <git_head>:<unit_sha>:<auth_sha>:<voicecli_head>:<staging-svc-digest>:<staging-digest>
+#   Legacy stamps omit the two image fields (4 colon-separated fields); they are
+#   normalized to :none:none before comparison. Any field may be the sentinel "none".
 #
 # Stdout (one word):
 #   none       — no change (current == last, or last == "none" sentinel meaning no stamp)
 #   auth       — ONLY auth_sha (field 2) differs; all structural fields are identical
-#   structural — at least one structural field (git_head, unit_sha, voicecli_head) differs
+#   structural — at least one structural field differs (git, units, voice, image digests)
 #
 # The function always succeeds (exit 0); callers branch on stdout.
 _classify_drift() {
     local last="${1}"
     local current="${2}"
+
+    last=$(_normalize_convergence_fingerprint "${last}")
+    current=$(_normalize_convergence_fingerprint "${current}")
 
     # Identical — no drift at all
     if [ "${last}" = "${current}" ]; then
@@ -128,29 +166,28 @@ _classify_drift() {
         return 0
     fi
 
-    # Field-count guard: fingerprints must have exactly 4 colon-separated fields.
-    # A future schema extension (5th field) would silently merge into the last variable
-    # without this check. Fail-safe to "structural" to force a full converge rather than
-    # risk misclassification (e.g. treating a revocation as auth-only).
+    # Field-count guard: fingerprints must have exactly 6 colon-separated fields
+    # after legacy normalization. Fail-safe to "structural".
     local last_fields cur_fields
     last_fields=$(awk -F: '{print NF}' <<< "${last}")
     cur_fields=$(awk -F:  '{print NF}' <<< "${current}")
-    if [ "${last_fields}" -ne 4 ] || [ "${cur_fields}" -ne 4 ]; then
+    if [ "${last_fields}" -ne 6 ] || [ "${cur_fields}" -ne 6 ]; then
         echo "structural"
         return 0
     fi
 
-    # Split both fingerprints into named fields (always 4 colon-separated fields)
-    local last_git last_unit last_auth last_voice
-    local cur_git  cur_unit  cur_auth  cur_voice
+    local last_git last_unit last_auth last_voice last_img_svc last_img_stg
+    local cur_git  cur_unit  cur_auth  cur_voice  cur_img_svc  cur_img_stg
 
-    IFS=':' read -r last_git last_unit last_auth last_voice <<< "${last}"
-    IFS=':' read -r cur_git  cur_unit  cur_auth  cur_voice  <<< "${current}"
+    IFS=':' read -r last_git last_unit last_auth last_voice last_img_svc last_img_stg <<< "${last}"
+    IFS=':' read -r cur_git  cur_unit  cur_auth  cur_voice  cur_img_svc  cur_img_stg  <<< "${current}"
 
-    # Check structural fields first
-    if [ "${last_git}"   != "${cur_git}"   ] \
-    || [ "${last_unit}"  != "${cur_unit}"  ] \
-    || [ "${last_voice}" != "${cur_voice}" ]; then
+    # Check structural fields first (image digests are structural — containers must restart)
+    if [ "${last_git}"      != "${cur_git}"      ] \
+    || [ "${last_unit}"     != "${cur_unit}"     ] \
+    || [ "${last_voice}"    != "${cur_voice}"    ] \
+    || [ "${last_img_svc}"  != "${cur_img_svc}"  ] \
+    || [ "${last_img_stg}"  != "${cur_img_stg}"  ]; then
         echo "structural"
         return 0
     fi

--- a/deploy/quadlet/factory-langfuse-minio.container
+++ b/deploy/quadlet/factory-langfuse-minio.container
@@ -11,7 +11,7 @@ Network=roxabi.network
 EnvironmentFile=%h/.roxabi/factory/env/langfuse.env
 Exec=server /data --address :9000 --console-address :9001
 Volume=factory-langfuse-minio-data.volume:/data:z
-HealthCmd=wget -q -O- http://127.0.0.1:9000/minio/health/live || exit 1
+HealthCmd=curl -sf http://127.0.0.1:9000/minio/health/live || exit 1
 HealthInterval=10s
 
 [Service]

--- a/deploy/quadlet/factory-langfuse-web.container
+++ b/deploy/quadlet/factory-langfuse-web.container
@@ -14,7 +14,7 @@ ReadOnly=true
 DropCapability=all
 EnvironmentFile=%h/.roxabi/factory/env/langfuse.env
 PublishPort=127.0.0.1:3000:3000
-HealthCmd=wget -q -O- http://127.0.0.1:3000/api/public/health || exit 1
+HealthCmd=wget -q -O- http://factory-langfuse-web:3000/api/public/health || exit 1
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/factory-langfuse-worker.container
+++ b/deploy/quadlet/factory-langfuse-worker.container
@@ -13,7 +13,7 @@ NoNewPrivileges=true
 ReadOnly=true
 DropCapability=all
 EnvironmentFile=%h/.roxabi/factory/env/langfuse.env
-HealthCmd=wget -q -O- http://127.0.0.1:3030/api/health || exit 1
+HealthCmd=wget -q -O- http://factory-langfuse-worker:3030/api/health || exit 1
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/factory-loki.container
+++ b/deploy/quadlet/factory-loki.container
@@ -14,7 +14,7 @@ Exec=-config.file=/etc/loki/config.yml -config.expand-env=false
 Volume=%h/projects/roxabi-factory/deploy/observability/loki-config.yml:/etc/loki/config.yml:ro,z
 Volume=factory-loki-data.volume:/loki:z
 PublishPort=127.0.0.1:3100:3100
-HealthCmd=wget -q -O- http://127.0.0.1:3100/ready || exit 1
+HealthCmd=/busybox/wget -q -O- http://127.0.0.1:3100/ready || exit 1
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/factory-otel-collector.container
+++ b/deploy/quadlet/factory-otel-collector.container
@@ -17,8 +17,6 @@ Volume=%h/projects/roxabi-factory/deploy/observability/otel-collector-config.yml
 EnvironmentFile=%h/.roxabi/factory/env/otel-collector.env
 PublishPort=127.0.0.1:4317:4317
 PublishPort=127.0.0.1:4318:4318
-HealthCmd=wget -q -O- http://127.0.0.1:13133/ || exit 1
-HealthInterval=30s
 
 [Service]
 Restart=on-failure

--- a/deploy/quadlet/factory-promtail.container
+++ b/deploy/quadlet/factory-promtail.container
@@ -18,7 +18,7 @@ Volume=%h/projects/roxabi-factory/deploy/observability/promtail-config.yml:/etc/
 Volume=%h/.local/state/factory/logs:/var/log/factory:ro,z
 Volume=/var/log/journal:/var/log/journal:ro,z
 Volume=%h/.local/state/factory/promtail:/promtail-positions:z
-HealthCmd=wget -q -O- http://127.0.0.1:9080/ready || exit 1
+HealthCmd=bash -c 'exec 3<>/dev/tcp/127.0.0.1/9080'
 HealthInterval=30s
 
 [Service]

--- a/tests/deploy/test_classify_drift.py
+++ b/tests/deploy/test_classify_drift.py
@@ -1,10 +1,15 @@
 """Tests for the _classify_drift shell function in deploy/lib/deploy-common.sh.
 
-Fingerprint format: <git_head>:<unit_sha>:<auth_sha>:<voicecli_head>
-  - field 0 (git_head)    → structural
-  - field 1 (unit_sha)    → structural
-  - field 2 (auth_sha)    → auth
-  - field 3 (voicecli_head) → structural
+Fingerprint format:
+  <git_head>:<unit_sha>:<auth_sha>:<voicecli_head>:<staging-svc-digest>:<staging-digest>
+  - field 0 (git_head)         → structural
+  - field 1 (unit_sha)         → structural
+  - field 2 (auth_sha)         → auth
+  - field 3 (voicecli_head)    → structural
+  - field 4 (staging-svc-digest) → structural
+  - field 5 (staging-digest)   → structural
+
+Legacy 4-field stamps are normalized to :none:none before comparison.
 
 The function exits 0 in all cases; callers branch on stdout.
 """
@@ -19,6 +24,8 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_COMMON = REPO_ROOT / "deploy" / "lib" / "deploy-common.sh"
+
+_FP = "a:b:c:d:img-svc:img-stg"
 
 
 def _classify(last: str, current: str) -> str:
@@ -40,75 +47,39 @@ def _classify(last: str, current: str) -> str:
     return result.stdout.strip()
 
 
-# ---------------------------------------------------------------------------
-# Parametrized contract cases
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize(
     "last, current, expected",
     [
         # 1. Identical fingerprints → no drift
-        (
-            "a:b:c:d",
-            "a:b:c:d",
-            "none",
-        ),
+        (_FP, _FP, "none"),
         # 2. No prior stamp (sentinel "none") → structural (full converge)
-        (
-            "none",
-            "a:b:c:d",
-            "structural",
-        ),
+        ("none", _FP, "structural"),
         # 3. Only auth field (index 2) differs → auth-only reload
-        (
-            "a:b:c:d",
-            "a:b:X:d",
-            "auth",
-        ),
+        (_FP, "a:b:X:d:img-svc:img-stg", "auth"),
         # 4. Field 0 (git_head) differs → structural
-        (
-            "a:b:c:d",
-            "A:b:c:d",
-            "structural",
-        ),
+        (_FP, "A:b:c:d:img-svc:img-stg", "structural"),
         # 5. Field 1 (unit_sha) differs → structural
-        (
-            "a:b:c:d",
-            "a:B:c:d",
-            "structural",
-        ),
+        (_FP, "a:B:c:d:img-svc:img-stg", "structural"),
         # 6. Field 3 (voicecli_head) differs → structural
-        (
-            "a:b:c:d",
-            "a:b:c:D",
-            "structural",
-        ),
-        # 7. Auth + structural both differ → structural dominates
-        (
-            "a:b:c:d",
-            "A:b:X:d",
-            "structural",
-        ),
-        # 8. None-sentinel guard — non-tautological case: current fields 0,1,3 all
-        #    equal "none" (matching last_git/unit/voice when split from "none"), so
-        #    WITHOUT the `last == "none"` early-exit guard the function would fall
-        #    through to field comparison, find only auth_sha differs ("X" vs "none"),
-        #    and emit "auth" — not "structural". Deleting the guard turns this RED.
+        (_FP, "a:b:c:D:img-svc:img-stg", "structural"),
+        # 7. Field 4 (staging-svc digest) differs → structural
+        (_FP, "a:b:c:d:NEW-svc:img-stg", "structural"),
+        # 8. Field 5 (staging digest) differs → structural
+        (_FP, "a:b:c:d:img-svc:NEW-stg", "structural"),
+        # 9. Auth + structural both differ → structural dominates
+        (_FP, "A:b:X:d:img-svc:img-stg", "structural"),
+        # 10. None-sentinel guard — non-tautological legacy-normalized case
         (
             "none",
-            "none:none:X:none",
+            "none:none:X:none:none:none",
             "structural",
         ),
-        # 9. Field-count guard: 5-field current fingerprint → structural (fail-safe).
-        #    Deleting the NF!=4 guard lets the function IFS-split and reach the
-        #    field comparison; "a"=="a", "b"=="b", "c" (field 4 overflows into field
-        #    3) ≠ "d" so it still emits structural — but the guard is the explicit
-        #    contract for schema-extension safety. Test exercises the guard path.
-        (
-            "a:b:c:d",
-            "a:b:c:d:e",
-            "structural",
-        ),
+        # 11. Field-count guard: 7-field fingerprint → structural (fail-safe)
+        (_FP, f"{_FP}:extra", "structural"),
+        # 12. Legacy 4-field stamp vs 6-field current (image fields added) → structural
+        ("a:b:c:d", _FP, "structural"),
+        # 13. Legacy equal after normalization (images still none) → none
+        ("a:b:c:d", "a:b:c:d:none:none", "none"),
     ],
     ids=[
         "equal_fingerprints→none",
@@ -117,39 +88,15 @@ def _classify(last: str, current: str) -> str:
         "field0_git_differs→structural",
         "field1_unit_differs→structural",
         "field3_voice_differs→structural",
+        "field4_image_svc_differs→structural",
+        "field5_image_stg_differs→structural",
         "auth_and_structural_both_differ→structural_dominates",
         "none_sentinel_nontautological→structural",
-        "field_count_5_fields→structural",
+        "field_count_7_fields→structural",
+        "legacy_4field_stamp→structural",
+        "legacy_4field_equal_normalized→none",
     ],
 )
 def test_classify_drift(last: str, current: str, expected: str) -> None:
-    """_classify_drift returns the correct drift category for each case.
-
-    Non-tautology rationale (per-case guard deletion analysis):
-    - equal_fingerprints→none: delete the `last == current` guard → falls through
-      to field-split path; all fields equal so emits "auth" (not "none") → RED
-    - no_prior_stamp→structural: delete the `last == "none"` guard → tries to
-      IFS-split "none" into 4 fields; last_git="none", cur_git="a", they differ →
-      still emits "structural" in this case. However the meaningful negative test
-      is the guard ordering: if the "none" check is removed and "none" is treated
-      as a 1-field fingerprint, the behaviour is implementation-undefined and
-      unpredictable. The test still exercises the dedicated early-exit path.
-    - only_auth_differs→auth: delete structural check → skips to `echo "auth"` →
-      still passes. Delete the `last == current` guard only → reaches field split,
-      structural fields all match, emits "auth" → still passes. The meaningful
-      negative: if auth field check is inverted to be structural, emits "structural"
-      not "auth" → RED.
-    - field0/1/3_differs→structural: delete the structural-fields guard (the `if`
-      block) → falls through to `echo "auth"` → emits "auth" not "structural" → RED
-    - auth_and_structural_both_differ→structural_dominates: same as above — if the
-      structural guard is deleted, emits "auth" → RED.
-    - none_sentinel_nontautological→structural: current="none:none:X:none" means
-      fields 0,1,3 all equal "none" which matches IFS-split of last="none" (all 4
-      vars get "none"). Only auth_sha differs ("X" vs "none"). Without the
-      `last == "none"` early-exit guard the function emits "auth", not "structural"
-      → deletion of that guard makes this test RED.
-    - field_count_5_fields→structural: current has 5 colon-fields; deleting the
-      NF!=4 guard lets IFS-split proceed with overflow behaviour, but the contract
-      is that any non-4-field fingerprint must always fail-safe to structural.
-    """
+    """_classify_drift returns the correct drift category for each case."""
     assert _classify(last, current) == expected

--- a/tests/deploy/test_classify_drift.py
+++ b/tests/deploy/test_classify_drift.py
@@ -25,7 +25,9 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_COMMON = REPO_ROOT / "deploy" / "lib" / "deploy-common.sh"
 
-_FP = "a:b:c:d:img-svc:img-stg"
+_SVC = "4f9b3264aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001"
+_STG = "6a7d28bcaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001"
+_FP = f"a:b:c:d:{_SVC}:{_STG}"
 
 
 def _classify(last: str, current: str) -> str:
@@ -55,19 +57,19 @@ def _classify(last: str, current: str) -> str:
         # 2. No prior stamp (sentinel "none") → structural (full converge)
         ("none", _FP, "structural"),
         # 3. Only auth field (index 2) differs → auth-only reload
-        (_FP, "a:b:X:d:img-svc:img-stg", "auth"),
+        (_FP, f"a:b:X:d:{_SVC}:{_STG}", "auth"),
         # 4. Field 0 (git_head) differs → structural
-        (_FP, "A:b:c:d:img-svc:img-stg", "structural"),
+        (_FP, f"A:b:c:d:{_SVC}:{_STG}", "structural"),
         # 5. Field 1 (unit_sha) differs → structural
-        (_FP, "a:B:c:d:img-svc:img-stg", "structural"),
+        (_FP, f"a:B:c:d:{_SVC}:{_STG}", "structural"),
         # 6. Field 3 (voicecli_head) differs → structural
-        (_FP, "a:b:c:D:img-svc:img-stg", "structural"),
+        (_FP, f"a:b:c:D:{_SVC}:{_STG}", "structural"),
         # 7. Field 4 (staging-svc digest) differs → structural
-        (_FP, "a:b:c:d:NEW-svc:img-stg", "structural"),
+        (_FP, f"a:b:c:d:deadbeefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001:{_STG}", "structural"),
         # 8. Field 5 (staging digest) differs → structural
-        (_FP, "a:b:c:d:img-svc:NEW-stg", "structural"),
+        (_FP, f"a:b:c:d:{_SVC}:deadbeefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0002", "structural"),
         # 9. Auth + structural both differ → structural dominates
-        (_FP, "A:b:X:d:img-svc:img-stg", "structural"),
+        (_FP, f"A:b:X:d:{_SVC}:{_STG}", "structural"),
         # 10. None-sentinel guard — non-tautological legacy-normalized case
         (
             "none",
@@ -80,6 +82,7 @@ def _classify(last: str, current: str) -> str:
         ("a:b:c:d", _FP, "structural"),
         # 13. Legacy equal after normalization (images still none) → none
         ("a:b:c:d", "a:b:c:d:none:none", "none"),
+
     ],
     ids=[
         "equal_fingerprints→none",

--- a/tests/deploy/test_post_autoupdate.sh
+++ b/tests/deploy/test_post_autoupdate.sh
@@ -89,6 +89,10 @@ cat > "$FAKE_DEPLOY_DIR/lib/deploy-common.sh" <<EOF
 set -euo pipefail
 FACTORY_DIR="$TMPDIR_WORK/factory"
 CONVERGE_STAMP="$TMPDIR_WORK/converge-stamp"
+FACTORY_TRACKED_IMAGES=(
+    "ghcr.io/roxabi/factory:staging-svc"
+    "ghcr.io/roxabi/factory:staging"
+)
 mkdir -p "\$FACTORY_DIR"
 # No-op lock wrapper for tests — converge.sh owns the real lock in production
 with_deploy_lock() { "\$@"; }


### PR DESCRIPTION
## Summary
- Extend the convergence fingerprint with `staging-svc` and `staging` image index digests so `factory-post-autoupdate` no longer deletes `.converge-stamp` on every GHCR pull.
- Normalize legacy 4-field stamps to the new 6-field schema and classify image digest drift as structural.
- Repair observability Quadlet health probes that were falsely `unhealthy` on M1 (Promtail TCP probe, Langfuse DNS bind, MinIO curl, Loki busybox wget); drop OTel healthcheck on distroless image.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | ad-hoc M1 log audit | Complete |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `fix/converge-fingerprint-obs-healthchecks` | Complete |
| Verification | `pytest tests/deploy/test_classify_drift.py` ✅ `test_post_autoupdate.sh` ✅ | Passed |

## Test Plan
- [x] `uv run pytest tests/deploy/test_classify_drift.py`
- [x] `bash tests/deploy/test_post_autoupdate.sh`
- [x] Manual M1 verification: observability containers healthy after quadlet reload

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| Image digest drift triggers structural converge | `tests/deploy/test_classify_drift.py :: field4_image_svc_differs→structural` | ✅ pass |
| Legacy 4-field stamp migrates safely | `tests/deploy/test_classify_drift.py :: legacy_4field_stamp→structural` | ✅ pass |
| Post-autoupdate digest membership unchanged | `tests/deploy/test_post_autoupdate.sh` cases A/B/C | ✅ pass |

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`