### PR TITLE
fix(deploy): add postiz.network quadlet for socialmedia adapter lint

### DIFF
--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -150,6 +150,10 @@ host_roles = ["factory-hub"]
 network = "roxabi.network"
 host_roles = ["factory-hub"]
 
+[network.postiz]
+network = "postiz.network"
+host_roles = ["factory-hub"]
+
 [pod.gh]
 pod = "factory-gh.pod"
 host_roles = ["factory-hub"]

--- a/deploy/quadlet/postiz.network
+++ b/deploy/quadlet/postiz.network
@@ -1,0 +1,8 @@
+[Unit]
+Description=Postiz backing-service network (factory-socialmedia-adapter dual-homed)
+
+[Network]
+Driver=bridge
+# External Postiz stack (postiz-app) attaches here; adapter reaches it via
+# factory-socialmedia-adapter.container Network=postiz.network.
+Label=app=postiz


### PR DESCRIPTION
## Summary

Adds missing `deploy/quadlet/postiz.network` so `factory-socialmedia-adapter.container` passes `quadlet --dryrun` in CI.

## Test plan

- [ ] `quadlet-lint` CI green