### PR TITLE
fix(dashboard): polyfill randomUUID for plain HTTP on Tailnet

### DIFF
--- a/apps/dashboard/src/lib/chats-storage.test.ts
+++ b/apps/dashboard/src/lib/chats-storage.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { randomId } from "@/lib/chats-storage";
 
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 describe("randomId", () => {
   it("uses crypto.randomUUID when available", () => {
-    const spy = vi.spyOn(crypto, "randomUUID").mockReturnValue(
-      "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-    );
+    const spy = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValue("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
     expect(randomId()).toBe("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
     spy.mockRestore();
   });

--- a/apps/dashboard/src/lib/chats-storage.test.ts
+++ b/apps/dashboard/src/lib/chats-storage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { randomId } from "@/lib/chats-storage";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("randomId", () => {
+  it("uses crypto.randomUUID when available", () => {
+    const spy = vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    );
+    expect(randomId()).toBe("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
+    spy.mockRestore();
+  });
+
+  it("falls back when crypto.randomUUID is unavailable (plain HTTP)", () => {
+    const native = crypto.randomUUID;
+    // @ts-expect-error — simulate non-secure context
+    crypto.randomUUID = undefined;
+    try {
+      const id = randomId();
+      expect(id).toMatch(UUID_RE);
+      expect(randomId()).not.toBe(id);
+    } finally {
+      crypto.randomUUID = native;
+    }
+  });
+});

--- a/apps/dashboard/src/lib/chats-storage.ts
+++ b/apps/dashboard/src/lib/chats-storage.ts
@@ -1,3 +1,16 @@
+/** UUID v4 — works on plain HTTP (crypto.randomUUID is secure-context only). */
+export function randomId(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 export type HarnessKind = "claude-cli" | "omp-rpc";
 
 export interface ChatTab {
@@ -29,7 +42,7 @@ export function saveTabs(tabs: ChatTab[]): void {
 
 export function newTab(agent: string): ChatTab {
   return {
-    id: crypto.randomUUID(),
+    id: randomId(),
     agent,
     harness: "claude-cli",
     model: "sonnet",


### PR DESCRIPTION
## Summary
- Add `randomId()` fallback using `crypto.getRandomValues` when `crypto.randomUUID` is unavailable
- Fixes dashboard crash on `http://roxabituwer:8765` (`crypto.randomUUID is not a function`)

## Test plan
- [x] `bun run --filter @roxabi-factory/dashboard test` (11 tests green)