### PR TITLE
feat(docs): add interactive workflow map with JSON-driven generator

### DIFF
--- a/docs/workflows/flows.json
+++ b/docs/workflows/flows.json
@@ -1,0 +1,848 @@
+{
+  "meta": {
+    "title": "factory — Package & Component Workflows",
+    "version": "1.0.0",
+    "updated": "2026-06-28",
+    "description": "Generated from acl-matrix.json + quadlet.toml + importlinter + overlay.",
+    "generated": {
+      "flows": 24,
+      "components": 36,
+      "sources": [
+        "deploy/nats/acl-matrix.json",
+        "deploy/quadlet.toml",
+        ".importlinter",
+        "packages/*"
+      ]
+    },
+    "overlay": {
+      "path": "docs/workflows/flows.overlay.json",
+      "flows": 3
+    }
+  },
+  "groups": [
+    {
+      "id": "process",
+      "label": "NATS Processes",
+      "order": 1,
+      "color": "#3b82f6"
+    },
+    {
+      "id": "packages",
+      "label": "Workspace Packages",
+      "order": 2,
+      "color": "#6366f1"
+    },
+    {
+      "id": "layers",
+      "label": "Code Layers",
+      "order": 3,
+      "color": "#8b5cf6"
+    },
+    {
+      "id": "ci",
+      "label": "CI / Deploy",
+      "order": 4,
+      "color": "#ef4444"
+    },
+    {
+      "id": "inprocess",
+      "label": "In-Process (overlay)",
+      "order": 5,
+      "color": "#ec4899"
+    },
+    {
+      "id": "stores",
+      "label": "Stores / Data",
+      "order": 6,
+      "color": "#64748b"
+    }
+  ],
+  "components": [
+    {
+      "id": "ci-docker-bake",
+      "label": "docker-bake.hcl",
+      "group": "ci",
+      "path": "docker-bake.hcl",
+      "description": "Multi-target image bake"
+    },
+    {
+      "id": "ci-ghcr",
+      "label": "GHCR",
+      "group": "ci",
+      "path": "ghcr.io/roxabi/factory",
+      "description": "Container registry"
+    },
+    {
+      "id": "ci-github-actions",
+      "label": "GitHub Actions",
+      "group": "ci",
+      "path": ".github/workflows/publish.yml",
+      "description": "CI publish pipeline"
+    },
+    {
+      "id": "ci-quadlet",
+      "label": "Quadlet deploy",
+      "group": "ci",
+      "path": "deploy/quadlet",
+      "description": "Podman/systemd units on M₁"
+    },
+    {
+      "id": "inproc-agent",
+      "label": "Agent",
+      "group": "inprocess",
+      "path": "src/factory/core/agent",
+      "description": "Stateless singleton; LlmProvider dispatch"
+    },
+    {
+      "id": "inproc-command-router",
+      "label": "CommandRouter",
+      "group": "inprocess",
+      "path": "src/factory/commands",
+      "description": "Builtin + plugin command dispatch"
+    },
+    {
+      "id": "inproc-inbound-pipeline",
+      "label": "InboundPipeline",
+      "group": "inprocess",
+      "path": "src/factory/inbound/pipeline.py",
+      "description": "parse → route → session → dispatch"
+    },
+    {
+      "id": "inproc-pairing-handlers",
+      "label": "Pairing Handlers",
+      "group": "inprocess",
+      "path": "src/factory/commands/pairing/handlers.py",
+      "description": "/invite, /join, /unpair"
+    },
+    {
+      "id": "inproc-pairing-manager",
+      "label": "PairingManager",
+      "group": "inprocess",
+      "path": "src/factory/infrastructure/stores/identity/pairing.py",
+      "description": "Invite codes + AgentGrantStore on validate"
+    },
+    {
+      "id": "inproc-pool",
+      "label": "Pool",
+      "group": "inprocess",
+      "path": "src/factory/core/pool",
+      "description": "Per-conversation state; pairing_manager injected at bootstrap"
+    },
+    {
+      "id": "layer-factory-adapters",
+      "label": "adapters",
+      "group": "layers",
+      "path": "src/factory/adapters",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-blobstore",
+      "label": "blobstore",
+      "group": "layers",
+      "path": "src/factory/blobstore",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-bootstrap",
+      "label": "bootstrap",
+      "group": "layers",
+      "path": "src/factory/bootstrap",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-core",
+      "label": "core",
+      "group": "layers",
+      "path": "src/factory/core",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-infrastructure",
+      "label": "infrastructure",
+      "group": "layers",
+      "path": "src/factory/infrastructure",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-llm",
+      "label": "llm",
+      "group": "layers",
+      "path": "src/factory/llm",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-nats",
+      "label": "nats",
+      "group": "layers",
+      "path": "src/factory/nats",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-outbound",
+      "label": "outbound",
+      "group": "layers",
+      "path": "src/factory/outbound",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-streaming",
+      "label": "streaming",
+      "group": "layers",
+      "path": "src/factory/streaming",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-transport",
+      "label": "transport",
+      "group": "layers",
+      "path": "src/factory/transport",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "layer-factory-typing",
+      "label": "typing",
+      "group": "layers",
+      "path": "src/factory/typing",
+      "description": "importlinter layer"
+    },
+    {
+      "id": "pkg-roxabi-blobs",
+      "label": "roxabi-blobs",
+      "group": "packages",
+      "path": "packages/roxabi-blobs",
+      "description": "Workspace package"
+    },
+    {
+      "id": "pkg-roxabi-contracts",
+      "label": "roxabi-contracts",
+      "group": "packages",
+      "path": "packages/roxabi-contracts",
+      "description": "Workspace package"
+    },
+    {
+      "id": "pkg-roxabi-nats",
+      "label": "roxabi-nats",
+      "group": "packages",
+      "path": "packages/roxabi-nats",
+      "description": "Workspace package"
+    },
+    {
+      "id": "pkg-roxabi-satellite",
+      "label": "roxabi-satellite",
+      "group": "packages",
+      "path": "packages/roxabi-satellite",
+      "description": "Workspace package"
+    },
+    {
+      "id": "proc-blobstore",
+      "label": "blobstore",
+      "group": "process",
+      "path": "factory-blobstore.container",
+      "description": "BlobStore HTTP service — publishes audit events to factory.audit.blobs.> and announces readiness via factory-state KV."
+    },
+    {
+      "id": "proc-clipool-worker",
+      "label": "clipool-worker",
+      "group": "process",
+      "path": "factory-clipool.container",
+      "description": "CliPool NATS worker — receives claude subprocess dispatch commands from hub, publishes heartbeat and reply-path responses. Inbox normalized to _inbox.clipool-worker.> (ADR-051 + postmortem Fix 1). Inbox grant derived from request_reply_flows (Fix 3 / #992)."
+    },
+    {
+      "id": "proc-dashboard-reader",
+      "label": "dashboard-reader",
+      "group": "process",
+      "path": "host",
+      "description": "Monitoring dashboard reader — consumes factory.event.> and factory.metric.> for future dashboard/visualization (Monitoring v2, #1035)."
+    },
+    {
+      "id": "proc-discord-adapter",
+      "label": "discord-adapter",
+      "group": "process",
+      "path": "factory-discord.container",
+      "description": "Discord bot adapter — inbox normalized to _inbox.discord-adapter.> (ADR-051 + postmortem Fix 1)."
+    },
+    {
+      "id": "proc-gh-helper",
+      "label": "gh-helper",
+      "group": "process",
+      "path": "factory-gh-helper.container",
+      "description": "publish-only mint-failure alerts, #1082"
+    },
+    {
+      "id": "proc-hub",
+      "label": "hub",
+      "group": "process",
+      "path": "factory-hub.container",
+      "description": "Hub core — routes inbound messages, dispatches to voice/LLM/image/clipool workers. Inbox normalized to lowercase _inbox.hub.> (ADR-051 + postmortem Fix 1)."
+    },
+    {
+      "id": "proc-image-worker",
+      "label": "image-worker",
+      "group": "process",
+      "path": "external",
+      "description": "imagecli nats-serve satellite (ADR-050 (absorbed into ADR-049), imageCLI#50 + #754). Inbox normalized to _inbox.image-worker.> (ADR-051 + postmortem Fix 1). Inbox grant derived from request_reply_flows (Fix 3 / #992)."
+    },
+    {
+      "id": "proc-llm-operator",
+      "label": "llm-operator",
+      "group": "process",
+      "path": "external",
+      "description": "llmCLI operator CLI — publishes lifecycle commands (swap/stop/status/list/reload-catalog) to llm-worker from M₂. Implements llmCLI spec #34 Slice 0 (A1). Creds installed at ~/.roxabi/llmcli/nkeys/operator.creds (S6 standard, llmCLI#38)."
+    },
+    {
+      "id": "proc-llm-worker",
+      "label": "llm-worker",
+      "group": "process",
+      "path": "external",
+      "description": "llmCLI nats-serve worker. Worker uses inbox_prefix=_inbox.llmcli-llm (does not match the llm-worker role name), so the renderer's request_reply_flows derivation cannot auto-grant it — the inbox is listed explicitly in subscribe. See #1142."
+    },
+    {
+      "id": "proc-omp-worker",
+      "label": "omp-worker",
+      "group": "process",
+      "path": "factory-omp.container",
+      "description": "OmpWorker — omp_rpc NATS runtime backend (#1812)"
+    },
+    {
+      "id": "proc-socialmedia-adapter",
+      "label": "socialmedia-adapter",
+      "group": "process",
+      "path": "factory-socialmedia-adapter.container",
+      "description": "Social media tool satellite — factory.tool.socialmedia.* → Postiz Public API v1 (#1713)."
+    },
+    {
+      "id": "proc-telegram-adapter",
+      "label": "telegram-adapter",
+      "group": "process",
+      "path": "factory-telegram.container",
+      "description": "Telegram bot adapter — inbox normalized to _inbox.telegram-adapter.> (ADR-051 + postmortem Fix 1)."
+    },
+    {
+      "id": "proc-turn-writer",
+      "label": "turn-writer",
+      "group": "process",
+      "path": "factory-turn-writer.container",
+      "description": "TurnWriter JetStream subscriber-writer — sole writer for turns.db (ADR-075, #1331). Consumes factory.turns.> durable consumer turn-writer-v1, queue group turn-writer. nkey seed delivered via factory-nats-turn-writer Podman secret (provisioned by install.sh T25)."
+    },
+    {
+      "id": "proc-voice-client",
+      "label": "voice-client",
+      "group": "process",
+      "path": "external",
+      "description": "VoiceCLI dictate (STT) and generate --via-nats (TTS) client — sends requests from local host to remote voice-stt / voice-tts workers. Inbox normalized to _inbox.voice-client.> (ADR-051). Inbox grant derived from request_reply_flows. TTS publish added 2026-05-27 (#1462) to unblock voiceCLI #178."
+    },
+    {
+      "id": "proc-voice-stt",
+      "label": "voice-stt",
+      "group": "process",
+      "path": "container",
+      "description": "voicecli nats-serve STT worker on Machine 1 (#689). Inbox normalized to _inbox.voice-stt.> (ADR-051 + postmortem Fix 1; voicecli confirmed lowercase 2026-04-28). Inbox grant derived from request_reply_flows (Fix 3 / #992)."
+    },
+    {
+      "id": "proc-voice-tts",
+      "label": "voice-tts",
+      "group": "process",
+      "path": "container",
+      "description": "voicecli nats-serve TTS worker on Machine 1 (#689). Inbox normalized to _inbox.voice-tts.> (ADR-051 + postmortem Fix 1; voicecli confirmed lowercase 2026-04-28). Inbox grant derived from request_reply_flows (Fix 3 / #992)."
+    },
+    {
+      "id": "proc-web-adapter",
+      "label": "web-adapter",
+      "group": "process",
+      "path": "factory-dashboard.container",
+      "description": "Web smoke adapter — browser chat UI + SSE on factory.{inbound,outbound}.web.smoke (#1977)."
+    },
+    {
+      "id": "store-auth-db",
+      "label": "auth.db",
+      "group": "stores",
+      "path": "~/.roxabi/factory/auth.db",
+      "description": "Pairing codes, grants, identity"
+    }
+  ],
+  "flows": [
+    {
+      "id": "nats-rr-hub-to-clipool-worker-factory-clipool-control",
+      "label": "hub → clipool-worker (factory.clipool.control)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-clipool-worker",
+          "label": "request-reply",
+          "payload": "Subject: factory.clipool.control (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-hub-to-voice-tts-factory-voice-tts-request-w",
+      "label": "hub → voice-tts (factory.voice.tts.request.>)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-voice-tts",
+          "label": "request-reply",
+          "payload": "Subject: factory.voice.tts.request.> (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-hub-to-voice-stt-factory-voice-stt-request-w",
+      "label": "hub → voice-stt (factory.voice.stt.request.>)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-voice-stt",
+          "label": "request-reply",
+          "payload": "Subject: factory.voice.stt.request.> (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-hub-to-llm-worker-factory-llm-generate-request",
+      "label": "hub → llm-worker (factory.llm.generate.request)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-llm-worker",
+          "label": "request-reply",
+          "payload": "Subject: factory.llm.generate.request (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-hub-to-image-worker-factory-image-generate-request",
+      "label": "hub → image-worker (factory.image.generate.request)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-image-worker",
+          "label": "request-reply",
+          "payload": "Subject: factory.image.generate.request (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-voice-client-to-voice-stt-factory-voice-stt-request",
+      "label": "voice-client → voice-stt (factory.voice.stt.request)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-voice-client",
+          "to": "proc-voice-stt",
+          "label": "request-reply",
+          "payload": "Subject: factory.voice.stt.request (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-voice-client-to-voice-tts-factory-voice-tts-request",
+      "label": "voice-client → voice-tts (factory.voice.tts.request)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-voice-client",
+          "to": "proc-voice-tts",
+          "label": "request-reply",
+          "payload": "Subject: factory.voice.tts.request (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-hub-to-socialmedia-adapter-factory-tool-socialmedia-w",
+      "label": "hub → socialmedia-adapter (factory.tool.socialmedia.>)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-socialmedia-adapter",
+          "label": "request-reply",
+          "payload": "Subject: factory.tool.socialmedia.> (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-rr-web-adapter-to-hub-factory-dashboard-w",
+      "label": "web-adapter → hub (factory.dashboard.>)",
+      "category": "NATS request-reply",
+      "summary": "Declared in acl-matrix.json request_reply_flows",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-web-adapter",
+          "to": "proc-hub",
+          "label": "request-reply",
+          "payload": "Subject: factory.dashboard.> (acl-matrix request_reply_flows)"
+        }
+      ]
+    },
+    {
+      "id": "nats-inbound-telegram",
+      "label": "Inbound message (telegram)",
+      "category": "NATS messaging",
+      "summary": "Adapter publishes user messages; hub consumes factory.inbound.telegram.>",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-telegram-adapter",
+          "to": "proc-hub",
+          "label": "publish inbound",
+          "payload": "factory.inbound.telegram.> — Core NATS, Messages plane"
+        }
+      ]
+    },
+    {
+      "id": "nats-outbound-telegram",
+      "label": "Outbound response (telegram)",
+      "category": "NATS messaging",
+      "summary": "Hub publishes response chunks; adapter delivers to platform API",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-telegram-adapter",
+          "label": "publish outbound",
+          "payload": "factory.outbound.telegram.> — Core NATS, Messages plane"
+        }
+      ]
+    },
+    {
+      "id": "nats-inbound-discord",
+      "label": "Inbound message (discord)",
+      "category": "NATS messaging",
+      "summary": "Adapter publishes user messages; hub consumes factory.inbound.discord.>",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-discord-adapter",
+          "to": "proc-hub",
+          "label": "publish inbound",
+          "payload": "factory.inbound.discord.> — Core NATS, Messages plane"
+        }
+      ]
+    },
+    {
+      "id": "nats-outbound-discord",
+      "label": "Outbound response (discord)",
+      "category": "NATS messaging",
+      "summary": "Hub publishes response chunks; adapter delivers to platform API",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-discord-adapter",
+          "label": "publish outbound",
+          "payload": "factory.outbound.discord.> — Core NATS, Messages plane"
+        }
+      ]
+    },
+    {
+      "id": "nats-inbound-web",
+      "label": "Inbound message (web)",
+      "category": "NATS messaging",
+      "summary": "Adapter publishes user messages; hub consumes factory.inbound.web.>",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-web-adapter",
+          "to": "proc-hub",
+          "label": "publish inbound",
+          "payload": "factory.inbound.web.> — Core NATS, Messages plane"
+        }
+      ]
+    },
+    {
+      "id": "nats-outbound-web",
+      "label": "Outbound response (web)",
+      "category": "NATS messaging",
+      "summary": "Hub publishes response chunks; adapter delivers to platform API",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-web-adapter",
+          "label": "publish outbound",
+          "payload": "factory.outbound.web.> — Core NATS, Messages plane"
+        }
+      ]
+    },
+    {
+      "id": "nats-js-hub-to-clipool-worker-claude",
+      "label": "Clipool job dispatch",
+      "category": "NATS JetStream",
+      "summary": "hub publishes factory.jobs.claude; clipool-worker consumes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-clipool-worker",
+          "label": "JetStream dispatch",
+          "payload": "Subject: factory.jobs.claude"
+        }
+      ]
+    },
+    {
+      "id": "nats-js-hub-to-omp-worker-omp",
+      "label": "OMP job dispatch",
+      "category": "NATS JetStream",
+      "summary": "hub publishes factory.jobs.omp; omp-worker consumes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-omp-worker",
+          "label": "JetStream dispatch",
+          "payload": "Subject: factory.jobs.omp"
+        }
+      ]
+    },
+    {
+      "id": "nats-js-hub-to-turn-writer-write",
+      "label": "Turn logging (JetStream)",
+      "category": "NATS JetStream",
+      "summary": "hub publishes factory.turns.write; turn-writer consumes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "proc-turn-writer",
+          "label": "JetStream dispatch",
+          "payload": "Subject: factory.turns.write"
+        }
+      ]
+    },
+    {
+      "id": "nats-result-clipool-worker-to-hub-factory-job-x-progress",
+      "label": "clipool-worker → hub (factory.job.*.progress)",
+      "category": "NATS worker results",
+      "summary": "Worker publishes factory.job.*.progress; hub subscribes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-clipool-worker",
+          "to": "proc-hub",
+          "label": "publish result",
+          "payload": "Subject: factory.job.*.progress"
+        }
+      ]
+    },
+    {
+      "id": "nats-result-clipool-worker-to-hub-factory-job-x-result",
+      "label": "clipool-worker → hub (factory.job.*.result)",
+      "category": "NATS worker results",
+      "summary": "Worker publishes factory.job.*.result; hub subscribes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-clipool-worker",
+          "to": "proc-hub",
+          "label": "publish result",
+          "payload": "Subject: factory.job.*.result"
+        }
+      ]
+    },
+    {
+      "id": "nats-result-omp-worker-to-hub-factory-job-x-progress",
+      "label": "omp-worker → hub (factory.job.*.progress)",
+      "category": "NATS worker results",
+      "summary": "Worker publishes factory.job.*.progress; hub subscribes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-omp-worker",
+          "to": "proc-hub",
+          "label": "publish result",
+          "payload": "Subject: factory.job.*.progress"
+        }
+      ]
+    },
+    {
+      "id": "nats-result-omp-worker-to-hub-factory-job-x-result",
+      "label": "omp-worker → hub (factory.job.*.result)",
+      "category": "NATS worker results",
+      "summary": "Worker publishes factory.job.*.result; hub subscribes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-omp-worker",
+          "to": "proc-hub",
+          "label": "publish result",
+          "payload": "Subject: factory.job.*.result"
+        }
+      ]
+    },
+    {
+      "id": "nats-result-gh-helper-to-hub-factory-gh-mint_failure->",
+      "label": "gh-helper → hub (factory.gh.mint_failure.>)",
+      "category": "NATS worker results",
+      "summary": "Worker publishes factory.gh.mint_failure.>; hub subscribes",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "proc-gh-helper",
+          "to": "proc-hub",
+          "label": "publish result",
+          "payload": "Subject: factory.gh.mint_failure.>"
+        }
+      ]
+    },
+    {
+      "id": "ci-container-publish",
+      "label": "Container publish (GHCR)",
+      "category": "CI / Deploy",
+      "summary": "push staging or factory/v* tag → bake → GHCR → Quadlet pull on M₁",
+      "source": "generated",
+      "steps": [
+        {
+          "from": "ci-github-actions",
+          "to": "ci-docker-bake",
+          "label": "Trigger publish.yml",
+          "payload": "on: push branches [staging] OR tags factory/v*"
+        },
+        {
+          "from": "ci-docker-bake",
+          "to": "ci-ghcr",
+          "label": "Bake + push",
+          "payload": "Targets: agent-runtime, svc-runtime → ghcr.io/roxabi/factory"
+        },
+        {
+          "from": "ci-ghcr",
+          "to": "ci-quadlet",
+          "label": "Deploy pull",
+          "payload": "M₁ Podman pulls :staging-svc or semver pin"
+        }
+      ]
+    },
+    {
+      "id": "overlay-invite-user",
+      "label": "Invite new user (/invite)",
+      "category": "Auth & Pairing",
+      "summary": "In-process path after NATS delivers /invite to hub (see nats-inbound-*)",
+      "source": "overlay",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "inproc-inbound-pipeline",
+          "label": "Hub intake",
+          "payload": "InboundMessage from NATS staging queue"
+        },
+        {
+          "from": "inproc-inbound-pipeline",
+          "to": "inproc-pool",
+          "label": "Route to pool",
+          "payload": "RoutingKey → pool_id; PoolManager.get_or_create_pool()"
+        },
+        {
+          "from": "inproc-pool",
+          "to": "inproc-command-router",
+          "label": "Command detected",
+          "payload": "CommandParser name=invite → plugin handler"
+        },
+        {
+          "from": "inproc-command-router",
+          "to": "inproc-pairing-handlers",
+          "label": "cmd_invite()",
+          "payload": "Requires msg.is_admin=True; pool.pairing_manager"
+        },
+        {
+          "from": "inproc-pairing-handlers",
+          "to": "inproc-pairing-manager",
+          "label": "generate_code()",
+          "payload": "admin_identity=msg.user_id; SHA-256 hash stored, plaintext returned once"
+        },
+        {
+          "from": "inproc-pairing-manager",
+          "to": "store-auth-db",
+          "label": "Persist code",
+          "payload": "INSERT pairing_codes (hash, admin_identity, expires_at)"
+        }
+      ]
+    },
+    {
+      "id": "overlay-join-pairing",
+      "label": "Join with pairing code (/join)",
+      "category": "Auth & Pairing",
+      "summary": "User redeems code → agent grant in auth.db",
+      "source": "overlay",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "inproc-pool",
+          "label": "Route to pool",
+          "payload": "pool.agent_name scopes the grant"
+        },
+        {
+          "from": "inproc-pool",
+          "to": "inproc-pairing-handlers",
+          "label": "cmd_join()",
+          "payload": "args=[CODE]; rate limit on identity_key"
+        },
+        {
+          "from": "inproc-pairing-handlers",
+          "to": "inproc-pairing-manager",
+          "label": "validate_code()",
+          "payload": "code + identity_key + agent_name"
+        },
+        {
+          "from": "inproc-pairing-manager",
+          "to": "store-auth-db",
+          "label": "Grant + consume",
+          "payload": "DELETE pairing_codes; AgentGrantStore.upsert Principal rx:user:<id>"
+        }
+      ]
+    },
+    {
+      "id": "overlay-basic-text",
+      "label": "Basic text message (in-process)",
+      "category": "Core Messaging",
+      "summary": "After NATS inbound delivery — hub core through agent to outbound NATS",
+      "source": "overlay",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "inproc-inbound-pipeline",
+          "label": "Parse + route",
+          "payload": "WireParser → InboundMessage; not a command → PROCESS"
+        },
+        {
+          "from": "inproc-inbound-pipeline",
+          "to": "inproc-pool",
+          "label": "Pool dispatch",
+          "payload": "resolve_binding() → pool._inbox.put(msg)"
+        },
+        {
+          "from": "inproc-pool",
+          "to": "inproc-agent",
+          "label": "Agent.process()",
+          "payload": "system_prompt + LlmProvider.complete() → Response"
+        },
+        {
+          "from": "inproc-agent",
+          "to": "proc-hub",
+          "label": "dispatch_response",
+          "payload": "Hub enqueues outbound → see nats-outbound-* flow"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/workflows/flows.overlay.json
+++ b/docs/workflows/flows.overlay.json
@@ -1,0 +1,167 @@
+{
+  "groups": [],
+  "components": [
+    {
+      "id": "inproc-pool",
+      "label": "Pool",
+      "group": "inprocess",
+      "path": "src/factory/core/pool",
+      "description": "Per-conversation state; pairing_manager injected at bootstrap"
+    },
+    {
+      "id": "inproc-command-router",
+      "label": "CommandRouter",
+      "group": "inprocess",
+      "path": "src/factory/commands",
+      "description": "Builtin + plugin command dispatch"
+    },
+    {
+      "id": "inproc-pairing-handlers",
+      "label": "Pairing Handlers",
+      "group": "inprocess",
+      "path": "src/factory/commands/pairing/handlers.py",
+      "description": "/invite, /join, /unpair"
+    },
+    {
+      "id": "inproc-pairing-manager",
+      "label": "PairingManager",
+      "group": "inprocess",
+      "path": "src/factory/infrastructure/stores/identity/pairing.py",
+      "description": "Invite codes + AgentGrantStore on validate"
+    },
+    {
+      "id": "store-auth-db",
+      "label": "auth.db",
+      "group": "stores",
+      "path": "~/.roxabi/factory/auth.db",
+      "description": "Pairing codes, grants, identity"
+    },
+    {
+      "id": "inproc-agent",
+      "label": "Agent",
+      "group": "inprocess",
+      "path": "src/factory/core/agent",
+      "description": "Stateless singleton; LlmProvider dispatch"
+    },
+    {
+      "id": "inproc-inbound-pipeline",
+      "label": "InboundPipeline",
+      "group": "inprocess",
+      "path": "src/factory/inbound/pipeline.py",
+      "description": "parse → route → session → dispatch"
+    }
+  ],
+  "flows": [
+    {
+      "id": "overlay-invite-user",
+      "label": "Invite new user (/invite)",
+      "category": "Auth & Pairing",
+      "summary": "In-process path after NATS delivers /invite to hub (see nats-inbound-*)",
+      "source": "overlay",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "inproc-inbound-pipeline",
+          "label": "Hub intake",
+          "payload": "InboundMessage from NATS staging queue"
+        },
+        {
+          "from": "inproc-inbound-pipeline",
+          "to": "inproc-pool",
+          "label": "Route to pool",
+          "payload": "RoutingKey → pool_id; PoolManager.get_or_create_pool()"
+        },
+        {
+          "from": "inproc-pool",
+          "to": "inproc-command-router",
+          "label": "Command detected",
+          "payload": "CommandParser name=invite → plugin handler"
+        },
+        {
+          "from": "inproc-command-router",
+          "to": "inproc-pairing-handlers",
+          "label": "cmd_invite()",
+          "payload": "Requires msg.is_admin=True; pool.pairing_manager"
+        },
+        {
+          "from": "inproc-pairing-handlers",
+          "to": "inproc-pairing-manager",
+          "label": "generate_code()",
+          "payload": "admin_identity=msg.user_id; SHA-256 hash stored, plaintext returned once"
+        },
+        {
+          "from": "inproc-pairing-manager",
+          "to": "store-auth-db",
+          "label": "Persist code",
+          "payload": "INSERT pairing_codes (hash, admin_identity, expires_at)"
+        }
+      ]
+    },
+    {
+      "id": "overlay-join-pairing",
+      "label": "Join with pairing code (/join)",
+      "category": "Auth & Pairing",
+      "summary": "User redeems code → agent grant in auth.db",
+      "source": "overlay",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "inproc-pool",
+          "label": "Route to pool",
+          "payload": "pool.agent_name scopes the grant"
+        },
+        {
+          "from": "inproc-pool",
+          "to": "inproc-pairing-handlers",
+          "label": "cmd_join()",
+          "payload": "args=[CODE]; rate limit on identity_key"
+        },
+        {
+          "from": "inproc-pairing-handlers",
+          "to": "inproc-pairing-manager",
+          "label": "validate_code()",
+          "payload": "code + identity_key + agent_name"
+        },
+        {
+          "from": "inproc-pairing-manager",
+          "to": "store-auth-db",
+          "label": "Grant + consume",
+          "payload": "DELETE pairing_codes; AgentGrantStore.upsert Principal rx:user:<id>"
+        }
+      ]
+    },
+    {
+      "id": "overlay-basic-text",
+      "label": "Basic text message (in-process)",
+      "category": "Core Messaging",
+      "summary": "After NATS inbound delivery — hub core through agent to outbound NATS",
+      "source": "overlay",
+      "steps": [
+        {
+          "from": "proc-hub",
+          "to": "inproc-inbound-pipeline",
+          "label": "Parse + route",
+          "payload": "WireParser → InboundMessage; not a command → PROCESS"
+        },
+        {
+          "from": "inproc-inbound-pipeline",
+          "to": "inproc-pool",
+          "label": "Pool dispatch",
+          "payload": "resolve_binding() → pool._inbox.put(msg)"
+        },
+        {
+          "from": "inproc-pool",
+          "to": "inproc-agent",
+          "label": "Agent.process()",
+          "payload": "system_prompt + LlmProvider.complete() → Response"
+        },
+        {
+          "from": "inproc-agent",
+          "to": "proc-hub",
+          "label": "dispatch_response",
+          "payload": "Hub enqueues outbound → see nats-outbound-* flow"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/workflows/index.html
+++ b/docs/workflows/index.html
@@ -1,0 +1,736 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>factory — Workflow Map</title>
+  <style>
+    :root {
+      --bg: #0c0f14;
+      --surface: #141a22;
+      --surface-2: #1a222d;
+      --border: #2a3544;
+      --text: #e8edf4;
+      --muted: #8b9bb4;
+      --accent: #38bdf8;
+      --accent-dim: #0e7490;
+      --highlight: #fbbf24;
+      --edge: #475569;
+      --edge-active: #38bdf8;
+      --font: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
+      --mono: "IBM Plex Mono", "SF Mono", Consolas, monospace;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--font);
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      overflow: hidden;
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      grid-template-rows: auto 1fr auto;
+    }
+
+    header {
+      grid-column: 1 / -1;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+      display: flex;
+      align-items: baseline;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    header h1 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+    }
+
+    header .meta {
+      font-size: 0.75rem;
+      color: var(--muted);
+      font-family: var(--mono);
+    }
+
+    aside {
+      grid-row: 2;
+      border-right: 1px solid var(--border);
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .search {
+      padding: 0.75rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .search input {
+      width: 100%;
+      padding: 0.5rem 0.65rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 0.8rem;
+    }
+
+    .search input:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+
+    .flow-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.5rem;
+    }
+
+    .flow-category {
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      padding: 0.75rem 0.5rem 0.35rem;
+      font-weight: 600;
+    }
+
+    .flow-btn {
+      display: block;
+      width: 100%;
+      text-align: left;
+      padding: 0.55rem 0.65rem;
+      margin-bottom: 2px;
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      color: var(--text);
+      font-size: 0.82rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .flow-btn:hover {
+      background: var(--surface-2);
+      border-color: var(--border);
+    }
+
+    .flow-btn.active {
+      background: rgba(56, 189, 248, 0.12);
+      border-color: var(--accent-dim);
+      color: var(--accent);
+    }
+
+    .flow-btn .src {
+      display: block;
+      font-size: 0.62rem;
+      color: var(--muted);
+      font-family: var(--mono);
+      margin-top: 0.15rem;
+    }
+
+    .flow-btn.active .src { color: var(--accent-dim); }
+
+    .detail-source {
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      color: var(--muted);
+      padding: 0.15rem 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+    }
+
+    .detail-source.generated { color: #38bdf8; border-color: #0e7490; }
+    .detail-source.overlay { color: #f472b6; border-color: #9d174d; }
+
+    main {
+      grid-row: 2;
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .canvas-wrap {
+      flex: 1;
+      position: relative;
+      overflow: auto;
+      padding: 1rem;
+    }
+
+    #canvas {
+      position: relative;
+      min-height: 100%;
+      min-width: min(100%, 1200px);
+    }
+
+    #edges {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      overflow: visible;
+    }
+
+    .groups {
+      display: flex;
+      gap: 0.75rem;
+      align-items: stretch;
+      position: relative;
+      z-index: 1;
+    }
+
+    .group-col {
+      flex: 1;
+      min-width: 130px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .group-header {
+      padding: 0.45rem 0.6rem;
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 600;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .group-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .group-nodes {
+      padding: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      flex: 1;
+    }
+
+    .node {
+      padding: 0.5rem 0.55rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      cursor: default;
+      transition: border-color 0.2s, box-shadow 0.2s, opacity 0.2s;
+      position: relative;
+    }
+
+    .node.dimmed { opacity: 0.25; }
+
+    .node.active {
+      border-color: var(--highlight);
+      box-shadow: 0 0 0 1px var(--highlight), 0 0 12px rgba(251, 191, 36, 0.2);
+    }
+
+    .node .label {
+      font-size: 0.78rem;
+      font-weight: 500;
+      line-height: 1.3;
+    }
+
+    .node .path {
+      font-size: 0.62rem;
+      color: var(--muted);
+      font-family: var(--mono);
+      margin-top: 0.2rem;
+      word-break: break-all;
+    }
+
+    .edge-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      fill: var(--muted);
+      pointer-events: none;
+    }
+
+    .edge-label.active { fill: var(--accent); }
+
+    footer {
+      grid-column: 1 / -1;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      max-height: 220px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .detail-header {
+      padding: 0.6rem 1rem;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .detail-header h2 {
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    .detail-header .summary {
+      font-size: 0.78rem;
+      color: var(--muted);
+      flex: 1;
+    }
+
+    .detail-header .step-count {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--accent);
+    }
+
+    .steps {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.5rem 1rem 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .step {
+      display: grid;
+      grid-template-columns: 28px 1fr;
+      gap: 0.65rem;
+      padding: 0.45rem 0.5rem;
+      border-radius: 4px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .step:hover, .step.focused {
+      background: var(--surface-2);
+      border-color: var(--border);
+    }
+
+    .step-num {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--accent);
+      text-align: right;
+      padding-top: 0.1rem;
+    }
+
+    .step-route {
+      font-size: 0.78rem;
+      font-weight: 500;
+      margin-bottom: 0.15rem;
+    }
+
+    .step-route span { color: var(--muted); font-weight: 400; }
+
+    .step-action {
+      font-size: 0.72rem;
+      color: var(--highlight);
+      font-family: var(--mono);
+      margin-bottom: 0.2rem;
+    }
+
+    .step-payload {
+      font-size: 0.72rem;
+      color: var(--muted);
+      line-height: 1.45;
+      font-family: var(--mono);
+    }
+
+    .empty-state {
+      padding: 3rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .legend {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.5rem 0.65rem;
+      font-size: 0.68rem;
+      color: var(--muted);
+      z-index: 2;
+      line-height: 1.5;
+    }
+
+    .legend strong { color: var(--text); }
+
+    .load-error {
+      padding: 2rem;
+      color: #f87171;
+      font-family: var(--mono);
+      font-size: 0.85rem;
+      line-height: 1.6;
+    }
+
+    @media (max-width: 900px) {
+      body { grid-template-columns: 1fr; grid-template-rows: auto auto 1fr auto; }
+      aside { grid-row: 2; max-height: 180px; border-right: none; border-bottom: 1px solid var(--border); }
+      .groups { flex-wrap: wrap; }
+      .group-col { min-width: 140px; }
+    }
+  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <header>
+    <h1 id="page-title">factory — Workflow Map</h1>
+    <span class="meta" id="page-meta"></span>
+  </header>
+
+  <aside>
+    <div class="search">
+      <input type="search" id="flow-search" placeholder="Filter flows…" autocomplete="off" />
+    </div>
+    <div class="flow-list" id="flow-list"></div>
+  </aside>
+
+  <main>
+    <div class="canvas-wrap" id="canvas-wrap">
+      <div class="legend">
+        <strong>Click a flow</strong> to highlight its path.<br />
+        Hover steps below for edge focus.
+      </div>
+      <div id="canvas">
+        <svg id="edges" xmlns="http://www.w3.org/2000/svg"></svg>
+        <div class="groups" id="groups"></div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="detail-header">
+      <h2 id="detail-title">Select a workflow</h2>
+      <span class="summary" id="detail-summary">Choose an action from the sidebar to trace packages and data passed between them.</span>
+      <span class="step-count" id="step-count"></span>
+    </div>
+    <div class="steps" id="steps"></div>
+  </footer>
+
+  <script>
+    const state = {
+      data: null,
+      activeFlowId: null,
+      focusedStep: null,
+      nodeEls: new Map(),
+    };
+
+    async function loadData() {
+      try {
+        const res = await fetch("./flows.json");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      } catch (err) {
+        document.getElementById("canvas").innerHTML = `
+          <div class="load-error">
+            Could not load flows.json (${err.message}).<br /><br />
+            Serve this folder locally:<br />
+            <code>python -m http.server 8080 -d docs/workflows</code><br />
+            then open <code>http://localhost:8080</code>
+          </div>`;
+        return null;
+      }
+    }
+
+    function groupByCategory(flows) {
+      const map = new Map();
+      for (const flow of flows) {
+        const cat = flow.category || "Other";
+        if (!map.has(cat)) map.set(cat, []);
+        map.get(cat).push(flow);
+      }
+      return map;
+    }
+
+    function renderFlowList() {
+      const list = document.getElementById("flow-list");
+      const query = document.getElementById("flow-search").value.toLowerCase();
+      const grouped = groupByCategory(state.data.flows);
+      list.innerHTML = "";
+
+      for (const [category, flows] of grouped) {
+        const filtered = flows.filter(
+          (f) =>
+            f.label.toLowerCase().includes(query) ||
+            f.category.toLowerCase().includes(query) ||
+            f.summary.toLowerCase().includes(query)
+        );
+        if (!filtered.length) continue;
+
+        const catEl = document.createElement("div");
+        catEl.className = "flow-category";
+        catEl.textContent = category;
+        list.appendChild(catEl);
+
+        for (const flow of filtered) {
+          const btn = document.createElement("button");
+          btn.className = "flow-btn" + (state.activeFlowId === flow.id ? " active" : "");
+          const src = flow.source ? `<span class="src">${flow.source}</span>` : "";
+          btn.innerHTML = `${flow.label}${src}`;
+          btn.dataset.flowId = flow.id;
+          btn.addEventListener("click", () => selectFlow(flow.id));
+          list.appendChild(btn);
+        }
+      }
+    }
+
+    function renderCanvas() {
+      const groupsEl = document.getElementById("groups");
+      groupsEl.innerHTML = "";
+      state.nodeEls.clear();
+
+      const sortedGroups = [...state.data.groups].sort((a, b) => a.order - b.order);
+      const componentsByGroup = new Map();
+      for (const c of state.data.components) {
+        if (!componentsByGroup.has(c.group)) componentsByGroup.set(c.group, []);
+        componentsByGroup.get(c.group).push(c);
+      }
+
+      for (const group of sortedGroups) {
+        const comps = componentsByGroup.get(group.id) || [];
+        if (!comps.length) continue;
+
+        const col = document.createElement("div");
+        col.className = "group-col";
+        col.dataset.groupId = group.id;
+
+        const header = document.createElement("div");
+        header.className = "group-header";
+        header.innerHTML = `<span class="group-dot" style="background:${group.color}"></span>${group.label}`;
+        col.appendChild(header);
+
+        const nodesWrap = document.createElement("div");
+        nodesWrap.className = "group-nodes";
+
+        for (const comp of comps) {
+          const node = document.createElement("div");
+          node.className = "node";
+          node.id = `node-${comp.id}`;
+          node.dataset.componentId = comp.id;
+          node.title = comp.description || "";
+          node.innerHTML = `
+            <div class="label">${comp.label}</div>
+            <div class="path">${comp.path || ""}</div>`;
+          nodesWrap.appendChild(node);
+          state.nodeEls.set(comp.id, node);
+        }
+
+        col.appendChild(nodesWrap);
+        groupsEl.appendChild(col);
+      }
+
+      requestAnimationFrame(drawEdges);
+    }
+
+    function getActiveFlow() {
+      return state.data.flows.find((f) => f.id === state.activeFlowId);
+    }
+
+    function getActiveNodeIds() {
+      const flow = getActiveFlow();
+      if (!flow) return new Set();
+      const ids = new Set();
+      for (const step of flow.steps) {
+        ids.add(step.from);
+        ids.add(step.to);
+      }
+      return ids;
+    }
+
+    function updateNodeHighlights() {
+      const activeIds = getActiveNodeIds();
+      const hasFlow = !!state.activeFlowId;
+
+      for (const [id, el] of state.nodeEls) {
+        el.classList.toggle("active", activeIds.has(id));
+        el.classList.toggle("dimmed", hasFlow && !activeIds.has(id));
+      }
+    }
+
+    function nodeCenter(id) {
+      const el = state.nodeEls.get(id);
+      const canvas = document.getElementById("canvas");
+      if (!el || !canvas) return null;
+      const cr = canvas.getBoundingClientRect();
+      const nr = el.getBoundingClientRect();
+      return {
+        x: nr.left - cr.left + nr.width / 2,
+        y: nr.top - cr.top + nr.height / 2,
+        right: nr.right - cr.left,
+        left: nr.left - cr.left,
+      };
+    }
+
+    function bezierPath(from, to) {
+      const dx = to.x - from.x;
+      const cx1 = from.x + dx * 0.4;
+      const cx2 = to.x - dx * 0.4;
+      return `M ${from.x} ${from.y} C ${cx1} ${from.y}, ${cx2} ${to.y}, ${to.x} ${to.y}`;
+    }
+
+    function drawEdges() {
+      const svg = document.getElementById("edges");
+      const canvas = document.getElementById("canvas");
+      const flow = getActiveFlow();
+
+      svg.setAttribute("width", canvas.scrollWidth);
+      svg.setAttribute("height", canvas.scrollHeight);
+      svg.innerHTML = "";
+
+      if (!flow) return;
+
+      const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+      const marker = document.createElementNS("http://www.w3.org/2000/svg", "marker");
+      marker.setAttribute("id", "arrow");
+      marker.setAttribute("viewBox", "0 0 10 10");
+      marker.setAttribute("refX", "9");
+      marker.setAttribute("refY", "5");
+      marker.setAttribute("markerWidth", "6");
+      marker.setAttribute("markerHeight", "6");
+      marker.setAttribute("orient", "auto-start-reverse");
+      const arrowPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      arrowPath.setAttribute("d", "M 0 0 L 10 5 L 0 10 z");
+      arrowPath.setAttribute("fill", "var(--edge-active)");
+      marker.appendChild(arrowPath);
+      defs.appendChild(marker);
+      svg.appendChild(defs);
+
+      flow.steps.forEach((step, i) => {
+        const from = nodeCenter(step.from);
+        const to = nodeCenter(step.to);
+        if (!from || !to) return;
+
+        const start = { x: from.right + 4, y: from.y };
+        const end = { x: to.left - 4, y: to.y };
+
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        const d = bezierPath(start, end);
+        path.setAttribute("d", d);
+        path.setAttribute("fill", "none");
+        const focused = state.focusedStep === i;
+        path.setAttribute("stroke", focused ? "var(--edge-active)" : "var(--edge)");
+        path.setAttribute("stroke-width", focused ? "2.5" : "1.5");
+        path.setAttribute("marker-end", "url(#arrow)");
+        path.setAttribute("opacity", state.focusedStep === null || focused ? "1" : "0.35");
+        svg.appendChild(path);
+
+        const mid = { x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8 };
+        const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        label.setAttribute("x", mid.x);
+        label.setAttribute("y", mid.y);
+        label.setAttribute("text-anchor", "middle");
+        label.setAttribute("class", "edge-label" + (focused ? " active" : ""));
+        label.textContent = step.label;
+        svg.appendChild(label);
+      });
+    }
+
+    function componentLabel(id) {
+      const c = state.data.components.find((x) => x.id === id);
+      return c ? c.label : id;
+    }
+
+    function renderSteps() {
+      const flow = getActiveFlow();
+      const stepsEl = document.getElementById("steps");
+      const title = document.getElementById("detail-title");
+      const summary = document.getElementById("detail-summary");
+      const count = document.getElementById("step-count");
+
+      if (!flow) {
+        title.textContent = "Select a workflow";
+        summary.textContent = "Choose an action from the sidebar to trace packages and data passed between them.";
+        count.textContent = "";
+        stepsEl.innerHTML = "";
+        return;
+      }
+
+      title.textContent = flow.label;
+      summary.textContent = flow.summary;
+      const srcLabel = flow.source || "unknown";
+      count.innerHTML = `<span class="detail-source ${srcLabel}">${srcLabel}</span> ${flow.steps.length} steps`;
+
+      stepsEl.innerHTML = "";
+      flow.steps.forEach((step, i) => {
+        const el = document.createElement("div");
+        el.className = "step" + (state.focusedStep === i ? " focused" : "");
+        el.innerHTML = `
+          <div class="step-num">${i + 1}</div>
+          <div>
+            <div class="step-route">${componentLabel(step.from)} <span>→</span> ${componentLabel(step.to)}</div>
+            <div class="step-action">${step.label}</div>
+            <div class="step-payload">${step.payload}</div>
+          </div>`;
+        el.addEventListener("mouseenter", () => {
+          state.focusedStep = i;
+          renderSteps();
+          drawEdges();
+        });
+        el.addEventListener("mouseleave", () => {
+          state.focusedStep = null;
+          renderSteps();
+          drawEdges();
+        });
+        stepsEl.appendChild(el);
+      });
+    }
+
+    function selectFlow(flowId) {
+      state.activeFlowId = flowId;
+      state.focusedStep = null;
+      renderFlowList();
+      updateNodeHighlights();
+      renderSteps();
+      requestAnimationFrame(drawEdges);
+    }
+
+    async function init() {
+      state.data = await loadData();
+      if (!state.data) return;
+
+      document.getElementById("page-title").textContent = state.data.meta.title;
+      const gen = state.data.meta.generated;
+      const ovl = state.data.meta.overlay;
+      const genFlows = gen ? gen.flows : "?";
+      const ovlFlows = ovl ? ovl.flows : "?";
+      document.getElementById("page-meta").textContent =
+        `v${state.data.meta.version} · ${state.data.meta.updated} · ${state.data.components.length} components · ${state.data.flows.length} flows (${genFlows} auto + ${ovlFlows} overlay)`;
+
+      renderCanvas();
+      renderFlowList();
+
+      document.getElementById("flow-search").addEventListener("input", renderFlowList);
+
+      window.addEventListener("resize", () => requestAnimationFrame(drawEdges));
+      document.getElementById("canvas-wrap").addEventListener("scroll", () => requestAnimationFrame(drawEdges));
+
+      if (state.data.flows.length) selectFlow(state.data.flows[0].id);
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/tools/check_workflows_snapshot.sh
+++ b/tools/check_workflows_snapshot.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# check_workflows_snapshot.sh — regenerate + diff workflow map JSON.
+#
+# Exit-code contract:
+#   0 = clean (no drift)
+#   1 = drift detected (file modified after regen)
+#   2 = generator crash
+#
+# Usage: bash tools/check_workflows_snapshot.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+uv run python "${REPO_ROOT}/tools/generate_workflows.py" "${REPO_ROOT}" || exit 2
+
+if ! git -C "${REPO_ROOT}" diff --exit-code docs/workflows/flows.json; then
+    echo "::error::docs/workflows/flows.json is stale. Run 'uv run python tools/generate_workflows.py .' and commit."
+    exit 1
+fi

--- a/tools/generate_workflows.py
+++ b/tools/generate_workflows.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Generate docs/workflows/flows.json from machine-readable SSoT + overlay.
+
+Sources (Tier A — automatic):
+  - deploy/nats/acl-matrix.json   — identities, request_reply_flows, pub/sub
+  - deploy/quadlet.toml           — container topology
+  - .importlinter                 — layer map
+  - packages/*/                   — workspace packages
+
+Overlay (Tier B — hand-maintained):
+  - docs/workflows/flows.overlay.json — in-process flows, payload annotations
+
+Usage:
+  uv run python tools/generate_workflows.py [REPO_ROOT]
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+_PLATFORM_ADAPTERS = (
+    ("telegram", "telegram-adapter"),
+    ("discord", "discord-adapter"),
+    ("web", "web-adapter"),
+)
+
+_JETSTREAM_DISPATCH = (
+    ("factory.jobs.claude", "hub", "clipool-worker", "Clipool job dispatch"),
+    ("factory.jobs.omp", "hub", "omp-worker", "OMP job dispatch"),
+    ("factory.turns.write", "hub", "turn-writer", "Turn logging (JetStream)"),
+)
+
+_WORKER_RESULT_SUBJECTS = (
+    ("factory.job.*.progress", "clipool-worker", "hub"),
+    ("factory.job.*.result", "clipool-worker", "hub"),
+    ("factory.job.*.progress", "omp-worker", "hub"),
+    ("factory.job.*.result", "omp-worker", "hub"),
+    ("factory.gh.mint_failure.>", "gh-helper", "hub"),
+)
+
+
+def _load_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_toml(path: Path) -> dict:
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _parse_importlinter_layers(root: Path) -> list[str]:
+    path = root / ".importlinter"
+    if not path.exists():
+        return []
+    config = configparser.ConfigParser()
+    config.read(path)
+    for section in config.sections():
+        if section.startswith("importlinter:contract:"):
+            if config.get(section, "type", fallback="") == "layers":
+                raw = config.get(section, "layers", fallback="")
+                layers: list[str] = []
+                for line in raw.split("\n"):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    for part in line.split("|"):
+                        layers.append(part.strip())
+                return layers
+    return []
+
+
+def _proc_id(identity: str) -> str:
+    return f"proc-{identity}"
+
+
+def _package_id(name: str) -> str:
+    return f"pkg-{name}"
+
+
+def _layer_id(layer: str) -> str:
+    return f"layer-{layer.replace('.', '-')}"
+
+
+def build_groups() -> list[dict]:
+    return [
+        {"id": "process", "label": "NATS Processes", "order": 1, "color": "#3b82f6"},
+        {"id": "packages", "label": "Workspace Packages", "order": 2, "color": "#6366f1"},
+        {"id": "layers", "label": "Code Layers", "order": 3, "color": "#8b5cf6"},
+        {"id": "ci", "label": "CI / Deploy", "order": 4, "color": "#ef4444"},
+        {"id": "inprocess", "label": "In-Process (overlay)", "order": 5, "color": "#ec4899"},
+        {"id": "stores", "label": "Stores / Data", "order": 6, "color": "#64748b"},
+    ]
+
+
+def build_process_components(acl: dict, topology: dict) -> list[dict]:
+    components: list[dict] = []
+    identities = acl.get("identities", {})
+    quadlet = topology.get("component", {})
+
+    quadlet_by_identity: dict[str, str] = {
+        "hub": "hub",
+        "telegram-adapter": "telegram",
+        "discord-adapter": "discord",
+        "web-adapter": "dashboard",
+        "clipool-worker": "clipool",
+        "turn-writer": "turn-writer",
+        "blobstore": "blobstore",
+        "omp-worker": "omp",
+        "socialmedia-adapter": "socialmedia-adapter",
+        "gh-helper": "gh-helper",
+        "voice-stt": "voice-stt",
+        "voice-tts": "voice-tts",
+        "llm-worker": "llm-worker",
+        "image-worker": "image-worker",
+    }
+
+    for name, ident in sorted(identities.items()):
+        if ident.get("status") == "retired":
+            continue
+        qkey = quadlet_by_identity.get(name)
+        qcomp = quadlet.get(qkey, {}) if qkey else {}
+        container = qcomp.get("container", ident.get("deploy", {}).get("type", ""))
+        desc = ident.get("description", "")
+        components.append(
+            {
+                "id": _proc_id(name),
+                "label": name,
+                "group": "process",
+                "path": container or f"deploy/nats identity:{name}",
+                "description": desc,
+            }
+        )
+    return components
+
+
+def build_package_components(root: Path) -> list[dict]:
+    components: list[dict] = []
+    packages_dir = root / "packages"
+    if not packages_dir.is_dir():
+        return components
+    for pkg_dir in sorted(packages_dir.iterdir()):
+        if not pkg_dir.is_dir() or pkg_dir.name == "shared":
+            continue
+        if not (pkg_dir / "pyproject.toml").exists():
+            continue
+        components.append(
+            {
+                "id": _package_id(pkg_dir.name),
+                "label": pkg_dir.name,
+                "group": "packages",
+                "path": f"packages/{pkg_dir.name}",
+                "description": "Workspace package",
+            }
+        )
+    return components
+
+
+def build_layer_components(layers: list[str]) -> list[dict]:
+    return [
+        {
+            "id": _layer_id(layer),
+            "label": layer.removeprefix("factory."),
+            "group": "layers",
+            "path": f"src/{layer.replace('.', '/')}",
+            "description": "importlinter layer",
+        }
+        for layer in layers
+        if layer.startswith("factory.")
+    ]
+
+
+def build_ci_components() -> list[dict]:
+    return [
+        {
+            "id": "ci-github-actions",
+            "label": "GitHub Actions",
+            "group": "ci",
+            "path": ".github/workflows/publish.yml",
+            "description": "CI publish pipeline",
+        },
+        {
+            "id": "ci-docker-bake",
+            "label": "docker-bake.hcl",
+            "group": "ci",
+            "path": "docker-bake.hcl",
+            "description": "Multi-target image bake",
+        },
+        {
+            "id": "ci-ghcr",
+            "label": "GHCR",
+            "group": "ci",
+            "path": "ghcr.io/roxabi/factory",
+            "description": "Container registry",
+        },
+        {
+            "id": "ci-quadlet",
+            "label": "Quadlet deploy",
+            "group": "ci",
+            "path": "deploy/quadlet",
+            "description": "Podman/systemd units on M₁",
+        },
+    ]
+
+
+def _step(
+    from_id: str,
+    to_id: str,
+    label: str,
+    payload: str,
+) -> dict:
+    return {"from": from_id, "to": to_id, "label": label, "payload": payload}
+
+
+def build_nats_flows(acl: dict) -> list[dict]:
+    flows: list[dict] = []
+
+    for entry in acl.get("request_reply_flows", []):
+        req = entry["requester"]
+        resp = entry["responder"]
+        subject = entry["subject"]
+        flows.append(
+            {
+                "id": f"nats-rr-{req}-to-{resp}-{subject.replace('.', '-').replace('>', 'w')}",
+                "label": f"{req} → {resp} ({subject})",
+                "category": "NATS request-reply",
+                "summary": f"Declared in acl-matrix.json request_reply_flows",
+                "source": "generated",
+                "steps": [
+                    _step(
+                        _proc_id(req),
+                        _proc_id(resp),
+                        "request-reply",
+                        f"Subject: {subject} (acl-matrix request_reply_flows)",
+                    )
+                ],
+            }
+        )
+
+    for platform, adapter in _PLATFORM_ADAPTERS:
+        flows.append(
+            {
+                "id": f"nats-inbound-{platform}",
+                "label": f"Inbound message ({platform})",
+                "category": "NATS messaging",
+                "summary": f"Adapter publishes user messages; hub consumes factory.inbound.{platform}.>",
+                "source": "generated",
+                "steps": [
+                    _step(
+                        _proc_id(adapter),
+                        _proc_id("hub"),
+                        "publish inbound",
+                        f"factory.inbound.{platform}.> — Core NATS, Messages plane",
+                    )
+                ],
+            }
+        )
+        flows.append(
+            {
+                "id": f"nats-outbound-{platform}",
+                "label": f"Outbound response ({platform})",
+                "category": "NATS messaging",
+                "summary": f"Hub publishes response chunks; adapter delivers to platform API",
+                "source": "generated",
+                "steps": [
+                    _step(
+                        _proc_id("hub"),
+                        _proc_id(adapter),
+                        "publish outbound",
+                        f"factory.outbound.{platform}.> — Core NATS, Messages plane",
+                    )
+                ],
+            }
+        )
+
+    for subject, publisher, subscriber, title in _JETSTREAM_DISPATCH:
+        flows.append(
+            {
+                "id": f"nats-js-{publisher}-to-{subscriber}-{subject.split('.')[-1]}",
+                "label": title,
+                "category": "NATS JetStream",
+                "summary": f"{publisher} publishes {subject}; {subscriber} consumes",
+                "source": "generated",
+                "steps": [
+                    _step(
+                        _proc_id(publisher),
+                        _proc_id(subscriber),
+                        "JetStream dispatch",
+                        f"Subject: {subject}",
+                    )
+                ],
+            }
+        )
+
+    for subject, publisher, subscriber in _WORKER_RESULT_SUBJECTS:
+        flows.append(
+            {
+                "id": f"nats-result-{publisher}-to-{subscriber}-{subject.replace('.', '-').replace('*', 'x')}",
+                "label": f"{publisher} → {subscriber} ({subject})",
+                "category": "NATS worker results",
+                "summary": f"Worker publishes {subject}; hub subscribes",
+                "source": "generated",
+                "steps": [
+                    _step(
+                        _proc_id(publisher),
+                        _proc_id(subscriber),
+                        "publish result",
+                        f"Subject: {subject}",
+                    )
+                ],
+            }
+        )
+
+    return flows
+
+
+def build_ci_flows() -> list[dict]:
+    return [
+        {
+            "id": "ci-container-publish",
+            "label": "Container publish (GHCR)",
+            "category": "CI / Deploy",
+            "summary": "push staging or factory/v* tag → bake → GHCR → Quadlet pull on M₁",
+            "source": "generated",
+            "steps": [
+                _step(
+                    "ci-github-actions",
+                    "ci-docker-bake",
+                    "Trigger publish.yml",
+                    "on: push branches [staging] OR tags factory/v*",
+                ),
+                _step(
+                    "ci-docker-bake",
+                    "ci-ghcr",
+                    "Bake + push",
+                    "Targets: agent-runtime, svc-runtime → ghcr.io/roxabi/factory",
+                ),
+                _step(
+                    "ci-ghcr",
+                    "ci-quadlet",
+                    "Deploy pull",
+                    "M₁ Podman pulls :staging-svc or semver pin",
+                ),
+            ],
+        }
+    ]
+
+
+def merge_overlay(base: dict, overlay: dict) -> dict:
+    groups = {g["id"]: g for g in base.get("groups", [])}
+    for g in overlay.get("groups", []):
+        groups[g["id"]] = g
+
+    components = {c["id"]: c for c in base.get("components", [])}
+    for c in overlay.get("components", []):
+        components[c["id"]] = c
+
+    flows = base.get("flows", []) + overlay.get("flows", [])
+
+    return {
+        "meta": base["meta"],
+        "groups": sorted(groups.values(), key=lambda g: g.get("order", 99)),
+        "components": sorted(components.values(), key=lambda c: (c.get("group", ""), c["id"])),
+        "flows": flows,
+    }
+
+
+def generate(root: Path) -> dict:
+    acl_path = root / "deploy" / "nats" / "acl-matrix.json"
+    quadlet_path = root / "deploy" / "quadlet.toml"
+    overlay_path = root / "docs" / "workflows" / "flows.overlay.json"
+
+    acl = _load_json(acl_path)
+    topology = _load_toml(quadlet_path)
+    layers = _parse_importlinter_layers(root)
+
+    overlay: dict = {"groups": [], "components": [], "flows": []}
+    if overlay_path.exists():
+        overlay = _load_json(overlay_path)
+
+    components: list[dict] = []
+    components.extend(build_process_components(acl, topology))
+    components.extend(build_package_components(root))
+    components.extend(build_layer_components(layers))
+    components.extend(build_ci_components())
+
+    flows: list[dict] = []
+    flows.extend(build_nats_flows(acl))
+    flows.extend(build_ci_flows())
+
+    generated_count = len(flows)
+    overlay_count = len(overlay.get("flows", []))
+
+    base = {
+        "meta": {
+            "title": "factory — Package & Component Workflows",
+            "version": "1.0.0",
+            "updated": date.today().isoformat(),
+            "description": "Generated from acl-matrix.json + quadlet.toml + importlinter + overlay.",
+            "generated": {
+                "flows": generated_count,
+                "components": len(components),
+                "sources": [
+                    "deploy/nats/acl-matrix.json",
+                    "deploy/quadlet.toml",
+                    ".importlinter",
+                    "packages/*",
+                ],
+            },
+            "overlay": {
+                "path": "docs/workflows/flows.overlay.json",
+                "flows": overlay_count,
+            },
+        },
+        "groups": build_groups(),
+        "components": components,
+        "flows": flows,
+    }
+
+    return merge_overlay(base, overlay)
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    output = root / "docs" / "workflows" / "flows.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    data = generate(root)
+    output.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    gen = data["meta"]["generated"]["flows"]
+    ovl = data["meta"]["overlay"]["flows"]
+    total = len(data["flows"])
+    print(
+        f"Generated {output} — {total} flows "
+        f"({gen} auto + {ovl} overlay), {len(data['components'])} components"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an interactive workflow map for exploring how packages and NATS processes interact in factory.

- **`docs/workflows/index.html`** — single-page viewer: click a flow to highlight nodes and edge annotations
- **`docs/workflows/flows.json`** — generated output (27 flows, 43 components)
- **`docs/workflows/flows.overlay.json`** — hand-maintained in-process flows (`/invite`, `/join`, basic text)
- **`tools/generate_workflows.py`** — builds flows from `acl-matrix.json`, `quadlet.toml`, `.importlinter`, `packages/*`
- **`tools/check_workflows_snapshot.sh`** — drift gate for `flows.json`

## How to view

```bash
python -m http.server 8090 -d docs/workflows
# open http://localhost:8090
```

## Regenerate

```bash
uv run python tools/generate_workflows.py .
bash tools/check_workflows_snapshot.sh
```

## Test plan

- [x] Generator runs and produces 24 auto + 3 overlay flows
- [x] `check_workflows_snapshot.sh` passes
- [x] HTML loads `flows.json` and highlights flows on click