### PR TITLE
fix(dashboard): correct harness online detection and ops engine URLs

### DIFF
--- a/deploy/quadlet/factory-dashboard.container
+++ b/deploy/quadlet/factory-dashboard.container
@@ -25,6 +25,10 @@ Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-web.seed
 Environment=FACTORY_TYPING_ENABLED=false
 Environment=FACTORY_WEB_HOST=0.0.0.0
 Environment=FACTORY_WEB_PORT=8765
+# Ops BFF probes headless engines on roxabi.network — not 127.0.0.1 (dashboard container).
+Environment=FACTORY_LOKI_URL=http://factory-loki:3100
+Environment=FACTORY_LANGFUSE_URL=http://factory-langfuse-web:3000
+Environment=FACTORY_OTEL_HEALTH_URL=http://factory-otel-collector:13133
 # Agent picker reads roster.web from factory-state KV (hub publishes at boot).
 # Phase 2 (ADR-094): roster.dashboard + platform rename.
 Volume=%h/.roxabi/factory/config.toml:/app/config.toml:ro,z

--- a/src/factory/bootstrap/factory/dashboard_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_rpc.py
@@ -50,8 +50,10 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_CLIPOOL_WORKER = "clipool-worker"
-_OMP_WORKER = "omp-worker"
+# Heartbeat worker_id is ``{queue_group}-{hostname}-{pid}`` (NatsAdapterBase).
+_CLIPOOL_QUEUE = "clipool-workers"
+_OMP_QUEUE = "omp-workers"
+_HARNESS_HB_TTL_S = 30.0
 _WEB_BOT = "smoke"
 _ALLOWED_JOB_NAMES = frozenset({"claude", "omp", "test"})
 _DEFAULT_OMP_MODEL = "grok-4-fast"
@@ -267,8 +269,8 @@ async def _handle_agents_status(
     agents: list[str] = list(payload.get("agents") or [])
     harness_by_agent: dict[str, str] = dict(payload.get("harness_by_agent") or {})
     freshness = getattr(hub, "_dashboard_worker_freshness", None)
-    clipool_alive = _worker_alive(freshness, _CLIPOOL_WORKER)
-    omp_alive = _worker_alive(freshness, _OMP_WORKER)
+    clipool_alive = _queue_group_alive(freshness, _CLIPOOL_QUEUE)
+    omp_alive = _queue_group_alive(freshness, _OMP_QUEUE)
     roster = set(hub.agent_registry)
     result = []
     for name in agents:
@@ -322,12 +324,27 @@ async def _handle_voice_capabilities(
     return DashboardVoiceCapabilitiesResponse(tts=tts, stt=stt).model_dump()
 
 
-def _worker_alive(freshness: Any, worker_id: str) -> bool:
+def _queue_group_alive(freshness: Any, queue_group: str) -> bool:
+    """True when any heartbeat for *queue_group* arrived within the TTL.
+
+    NatsAdapterBase publishes ``worker_id = f"{queue_group}-{host}-{pid}"``.
+    Freshness is keyed by that dynamic id — not the static ACL identity name.
+    """
     if not isinstance(freshness, dict):
         return False
     import time
 
-    ts = freshness.get(worker_id)
-    if ts is None:
-        return False
-    return (time.monotonic() - ts) <= 30.0
+    now = time.monotonic()
+    prefix = f"{queue_group}-"
+    for worker_id, ts in freshness.items():
+        if not isinstance(worker_id, str):
+            continue
+        if worker_id != queue_group and not worker_id.startswith(prefix):
+            continue
+        try:
+            seen_at = float(ts)
+        except (TypeError, ValueError):
+            continue
+        if (now - seen_at) <= _HARNESS_HB_TTL_S:
+            return True
+    return False

--- a/tests/bootstrap/test_dashboard_rpc.py
+++ b/tests/bootstrap/test_dashboard_rpc.py
@@ -12,6 +12,7 @@ from factory.bootstrap.factory.dashboard_rpc import (
     _handle_sessions_list,
     _handle_sessions_resume,
     _handle_sessions_turns,
+    _queue_group_alive,
 )
 from factory.core.hub.hub_protocol import Binding, RoutingKey
 from factory.core.messaging.message import Platform
@@ -67,20 +68,54 @@ async def test_agents_status_marks_offline_without_heartbeat() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agents_status_respects_harness_selection() -> None:
-    hub = MagicMock()
-    hub.agent_registry = ["lyra"]
-    hub._dashboard_worker_freshness = {"clipool-worker": 0.0}
+async def test_agents_status_online_with_dynamic_clipool_worker_id() -> None:
     import time
 
-    hub._dashboard_worker_freshness["clipool-worker"] = time.monotonic()
+    hub = MagicMock()
+    hub.agent_registry = ["lyra"]
+    hub._dashboard_worker_freshness = {
+        "clipool-workers-factory-clipool-12345": time.monotonic(),
+    }
+    out = await _handle_agents_status(hub, _NC, {"agents": ["lyra"]})
+    assert out["agents"][0]["harness_reachable"] is True
+    assert out["agents"][0]["online"] is True
+
+
+@pytest.mark.asyncio
+async def test_agents_status_respects_harness_selection() -> None:
+    import time
+
+    hub = MagicMock()
+    hub.agent_registry = ["lyra"]
+    hub._dashboard_worker_freshness = {
+        "clipool-workers-factory-clipool-12345": time.monotonic(),
+        "omp-workers-factory-omp-99": time.monotonic(),
+    }
     out = await _handle_agents_status(
         hub,
         _NC,
         {"agents": ["lyra"], "harness_by_agent": {"lyra": "omp-rpc"}},
     )
     assert out["agents"][0]["harness"] == "omp-rpc"
-    assert out["agents"][0]["online"] is False
+    assert out["agents"][0]["harness_reachable"] is True
+    assert out["agents"][0]["online"] is True
+
+
+def test_queue_group_alive_matches_dynamic_worker_id_prefix() -> None:
+    import time
+
+    freshness = {"clipool-workers-roxabituwer-42": time.monotonic()}
+    assert _queue_group_alive(freshness, "clipool-workers") is True
+    assert _queue_group_alive(freshness, "omp-workers") is False
+
+
+def test_queue_group_alive_rejects_stale_heartbeat() -> None:
+    import time
+
+    freshness = {
+        "clipool-workers-roxabituwer-42": time.monotonic() - 60.0,
+    }
+    assert _queue_group_alive(freshness, "clipool-workers") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes false "Hors ligne" / offline status across the factory dashboard.

- **Agents / harness**: hub `dashboard_rpc` now treats a worker as alive when any heartbeat keyed by `{queue_group}-{host}-{pid}` (e.g. `clipool-workers-factory-clipool-12345`) arrived within 30s — matching what `NatsAdapterBase` actually publishes. Previously it looked for the static ACL identity `clipool-worker`, which never matched.
- **Ops engines**: `factory-dashboard.container` sets `FACTORY_LOKI_URL`, `FACTORY_LANGFUSE_URL`, and `FACTORY_OTEL_HEALTH_URL` to the roxabi.network service names instead of defaulting to `127.0.0.1` inside the dashboard container.

## Test plan

- [x] `uv run pytest tests/bootstrap/test_dashboard_rpc.py` — 11 passed
- [ ] After merge on M₁: `make converge` (or restart `factory-hub` + `factory-dashboard`) → dashboard shows agents online and Loki/Langfuse/OTel reachable