### PR TITLE
fix(dashboard): file-length gate for dashboard_rpc

### DIFF
--- a/src/factory/bootstrap/factory/dashboard_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_rpc.py
@@ -15,6 +15,7 @@ from factory.core.hub.hub_protocol import RoutingKey
 from factory.core.hub.job_catalog import list_active_jobs
 from factory.core.hub.session_catalog import list_sessions_for_agent
 from factory.core.messaging.message import Platform
+from factory.dashboard.heartbeat import CLIPOOL_QUEUE, OMP_QUEUE, queue_group_alive
 from roxabi_contracts.dashboard import (
     SUBJECTS,
     AgentHealth,
@@ -50,10 +51,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# Heartbeat worker_id is ``{queue_group}-{hostname}-{pid}`` (NatsAdapterBase).
-_CLIPOOL_QUEUE = "clipool-workers"
-_OMP_QUEUE = "omp-workers"
-_HARNESS_HB_TTL_S = 30.0
 _WEB_BOT = "smoke"
 _ALLOWED_JOB_NAMES = frozenset({"claude", "omp", "test"})
 _DEFAULT_OMP_MODEL = "grok-4-fast"
@@ -269,8 +266,8 @@ async def _handle_agents_status(
     agents: list[str] = list(payload.get("agents") or [])
     harness_by_agent: dict[str, str] = dict(payload.get("harness_by_agent") or {})
     freshness = getattr(hub, "_dashboard_worker_freshness", None)
-    clipool_alive = _queue_group_alive(freshness, _CLIPOOL_QUEUE)
-    omp_alive = _queue_group_alive(freshness, _OMP_QUEUE)
+    clipool_alive = queue_group_alive(freshness, CLIPOOL_QUEUE)
+    omp_alive = queue_group_alive(freshness, OMP_QUEUE)
     roster = set(hub.agent_registry)
     result = []
     for name in agents:
@@ -322,29 +319,3 @@ async def _handle_voice_capabilities(
             error="voice_workers_unreachable",
         ).model_dump()
     return DashboardVoiceCapabilitiesResponse(tts=tts, stt=stt).model_dump()
-
-
-def _queue_group_alive(freshness: Any, queue_group: str) -> bool:
-    """True when any heartbeat for *queue_group* arrived within the TTL.
-
-    NatsAdapterBase publishes ``worker_id = f"{queue_group}-{host}-{pid}"``.
-    Freshness is keyed by that dynamic id — not the static ACL identity name.
-    """
-    if not isinstance(freshness, dict):
-        return False
-    import time
-
-    now = time.monotonic()
-    prefix = f"{queue_group}-"
-    for worker_id, ts in freshness.items():
-        if not isinstance(worker_id, str):
-            continue
-        if worker_id != queue_group and not worker_id.startswith(prefix):
-            continue
-        try:
-            seen_at = float(ts)
-        except (TypeError, ValueError):
-            continue
-        if (now - seen_at) <= _HARNESS_HB_TTL_S:
-            return True
-    return False

--- a/src/factory/dashboard/heartbeat.py
+++ b/src/factory/dashboard/heartbeat.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 HB_TTL = 30.0  # const-ok: dashboard harness freshness window
+
+CLIPOOL_QUEUE = "clipool-workers"
+OMP_QUEUE = "omp-workers"
 
 
 @dataclass
@@ -22,3 +26,26 @@ class HeartbeatTracker:
         if ts is None:
             return False
         return (time.monotonic() - ts) <= HB_TTL
+
+
+def queue_group_alive(freshness: Any, queue_group: str) -> bool:
+    """True when any heartbeat for *queue_group* arrived within :data:`HB_TTL`.
+
+    NatsAdapterBase publishes ``worker_id = f"{queue_group}-{host}-{pid}"``.
+    """
+    if not isinstance(freshness, dict):
+        return False
+    now = time.monotonic()
+    prefix = f"{queue_group}-"
+    for worker_id, ts in freshness.items():
+        if not isinstance(worker_id, str):
+            continue
+        if worker_id != queue_group and not worker_id.startswith(prefix):
+            continue
+        try:
+            seen_at = float(ts)
+        except (TypeError, ValueError):
+            continue
+        if (now - seen_at) <= HB_TTL:
+            return True
+    return False

--- a/tests/bootstrap/test_dashboard_rpc.py
+++ b/tests/bootstrap/test_dashboard_rpc.py
@@ -12,8 +12,8 @@ from factory.bootstrap.factory.dashboard_rpc import (
     _handle_sessions_list,
     _handle_sessions_resume,
     _handle_sessions_turns,
-    _queue_group_alive,
 )
+from factory.dashboard.heartbeat import queue_group_alive
 from factory.core.hub.hub_protocol import Binding, RoutingKey
 from factory.core.messaging.message import Platform
 
@@ -105,8 +105,8 @@ def test_queue_group_alive_matches_dynamic_worker_id_prefix() -> None:
     import time
 
     freshness = {"clipool-workers-roxabituwer-42": time.monotonic()}
-    assert _queue_group_alive(freshness, "clipool-workers") is True
-    assert _queue_group_alive(freshness, "omp-workers") is False
+    assert queue_group_alive(freshness, "clipool-workers") is True
+    assert queue_group_alive(freshness, "omp-workers") is False
 
 
 def test_queue_group_alive_rejects_stale_heartbeat() -> None:
@@ -115,7 +115,7 @@ def test_queue_group_alive_rejects_stale_heartbeat() -> None:
     freshness = {
         "clipool-workers-roxabituwer-42": time.monotonic() - 60.0,
     }
-    assert _queue_group_alive(freshness, "clipool-workers") is False
+    assert queue_group_alive(freshness, "clipool-workers") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
CI failed on #2053: dashboard_rpc.py exceeded 300 lines. Moves `queue_group_alive` to `factory/dashboard/heartbeat.py` — no behavior change.