### PR TITLE
feat(dashboard): soul secret lint + goal plan closure (#2058)

### DIFF
--- a/apps/dashboard/src/lib/soul-secret-lint.test.ts
+++ b/apps/dashboard/src/lib/soul-secret-lint.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatSoulSecretWarning, scanSoulMarkdownForSecrets } from "@/lib/soul-secret-lint";
+
+describe("soul-secret-lint", () => {
+  it("detects OpenAI and GitHub token patterns", () => {
+    const md = "Use sk-abcdefghijklmnopqrstuvwx and ghp_1234567890123456789012345678901234";
+    const findings = scanSoulMarkdownForSecrets(md);
+    expect(findings.map((f) => f.kind)).toContain("openai_key");
+    expect(findings.map((f) => f.kind)).toContain("github_token");
+    expect(formatSoulSecretWarning(findings)).toMatch(/Possible secret/);
+  });
+
+  it("detects Bearer and PEM patterns", () => {
+    const md = "Auth: Bearer eyJhbGciOiJIUzI1NiJ9.abc\n-----BEGIN RSA PRIVATE KEY-----";
+    const findings = scanSoulMarkdownForSecrets(md);
+    expect(findings.map((f) => f.kind)).toContain("bearer");
+    expect(findings.map((f) => f.kind)).toContain("pem");
+  });
+
+  it("returns empty for benign soul text", () => {
+    expect(scanSoulMarkdownForSecrets("## Identity\nI am Lyra.")).toEqual([]);
+    expect(formatSoulSecretWarning([])).toBe("");
+  });
+});

--- a/apps/dashboard/src/lib/soul-secret-lint.ts
+++ b/apps/dashboard/src/lib/soul-secret-lint.ts
@@ -1,0 +1,35 @@
+/** Soft warnings for likely secrets embedded in soul markdown (operator lint). */
+
+export type SoulSecretKind = "openai_key" | "github_token" | "bearer" | "pem";
+
+export interface SoulSecretFinding {
+  kind: SoulSecretKind;
+  label: string;
+}
+
+const PATTERNS: ReadonlyArray<{ kind: SoulSecretKind; label: string; re: RegExp }> = [
+  { kind: "openai_key", label: "OpenAI-style key (sk-…)", re: /\bsk-[A-Za-z0-9]{8,}\b/ },
+  { kind: "github_token", label: "GitHub token (ghp_…)", re: /\bghp_[A-Za-z0-9]{20,}\b/ },
+  { kind: "bearer", label: "Bearer token", re: /\bBearer\s+[A-Za-z0-9._-]{8,}\b/ },
+  {
+    kind: "pem",
+    label: "PEM private key block",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+  },
+];
+
+export function scanSoulMarkdownForSecrets(markdown: string): SoulSecretFinding[] {
+  const findings: SoulSecretFinding[] = [];
+  for (const { kind, label, re } of PATTERNS) {
+    if (re.test(markdown)) {
+      findings.push({ kind, label });
+    }
+  }
+  return findings;
+}
+
+export function formatSoulSecretWarning(findings: SoulSecretFinding[]): string {
+  if (findings.length === 0) return "";
+  const labels = findings.map((f) => f.label).join(", ");
+  return `Possible secret detected in soul text (${labels}). Remove before saving if unintended.`;
+}

--- a/apps/dashboard/src/pages/AgentsPage.test.tsx
+++ b/apps/dashboard/src/pages/AgentsPage.test.tsx
@@ -146,4 +146,14 @@ describe("AgentDetailPage", () => {
       expect(screen.getByText(/Active chat sessions keep the previous soul/)).toBeTruthy();
     });
   });
+
+  it("shows secret lint warning when soul text matches token patterns", async () => {
+    const user = userEvent.setup();
+    renderAgentDetail();
+    await waitFor(() => expect(screen.getByText("Identity")).toBeTruthy());
+    const soulTextarea = screen.getAllByRole("textbox")[2];
+    await user.clear(soulTextarea);
+    await user.type(soulTextarea, "key sk-abcdefghijklmnopqrstuvwx");
+    expect(screen.getByRole("alert").textContent).toMatch(/Possible secret detected/);
+  });
 });

--- a/apps/dashboard/src/pages/AgentsPage.tsx
+++ b/apps/dashboard/src/pages/AgentsPage.tsx
@@ -19,6 +19,16 @@ import {
   type SoulSections,
 } from "@/lib/agents-api";
 import { SOUL_SECTIONS } from "@/lib/agents-constants";
+import { formatSoulSecretWarning, scanSoulMarkdownForSecrets } from "@/lib/soul-secret-lint";
+
+function composeSoulMarkdown(sections: SoulSections): string {
+  return SOUL_SECTIONS.map((s) => {
+    const body = sections[s]?.trim() ?? "";
+    return body ? `## ${s}\n${body}` : "";
+  })
+    .filter(Boolean)
+    .join("\n\n");
+}
 
 export function AgentsListPage() {
   const { t } = useTranslation();
@@ -93,24 +103,18 @@ export function AgentDetailPage() {
     }
   }, [soulQ.data]);
 
-  const docBytes = useMemo(() => {
-    const md = SOUL_SECTIONS.map((s) => {
-      const body = sections[s]?.trim() ?? "";
-      return body ? `## ${s}\n${body}` : "";
-    })
-      .filter(Boolean)
-      .join("\n\n");
-    return new TextEncoder().encode(md).length;
-  }, [sections]);
+  const soulMarkdown = useMemo(() => composeSoulMarkdown(sections), [sections]);
+
+  const docBytes = useMemo(() => new TextEncoder().encode(soulMarkdown).length, [soulMarkdown]);
+
+  const secretWarning = useMemo(
+    () => formatSoulSecretWarning(scanSoulMarkdownForSecrets(soulMarkdown)),
+    [soulMarkdown],
+  );
 
   const saveMut = useMutation({
     mutationFn: async () => {
-      const md = SOUL_SECTIONS.map((s) => {
-        const body = sections[s]?.trim() ?? "";
-        return body ? `## ${s}\n${body}` : "";
-      })
-        .filter(Boolean)
-        .join("\n\n");
+      const md = soulMarkdown;
       await patchAgentConfig(name, {
         backend: harness,
         model,
@@ -230,6 +234,14 @@ export function AgentDetailPage() {
         <p className="mt-2 text-xs text-muted-foreground">
           Document size: {docBytes} / 49152 bytes
         </p>
+        {secretWarning ? (
+          <p
+            className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            {secretWarning}
+          </p>
+        ) : null}
         <div className="mt-4 flex flex-wrap gap-2">
           <Button type="button" variant="secondary" onClick={() => previewMut.mutate()}>
             Preview compose

--- a/artifacts/plans/persona-soul-blobstore-dashboard-goal.md
+++ b/artifacts/plans/persona-soul-blobstore-dashboard-goal.md
@@ -740,6 +740,12 @@ Layer C — Turn resolution (hub stage)
 - `make qg` ×2 green ; CI PR #2059 green (5313+ tests) ; `/ci-watch` → ci=pass.
 - **PR #2059 mergée** vers `staging` (`d030e7a2`).
 
+### 2026-06-30 — Session 8 : follow-up secret lint + goal closure
+
+- Branche `feat/019f14c9-goal-followup` (base `refs/remotes/origin/staging`, ancestry OK).
+- Implémenté secret lint dashboard (`sk-`, `ghp_`, `Bearer `, PEM) + tests vitest.
+- Plan goal `done` ; `make qg` ×2 green sur branche follow-up.
+
 ### 2026-06-29 — Session 6 : `/goal` exécution
 
 - Branche `feat/019f14c9-persona-soul-blobstore` (base `staging`).

--- a/artifacts/plans/persona-soul-blobstore-dashboard-goal.md
+++ b/artifacts/plans/persona-soul-blobstore-dashboard-goal.md
@@ -13,7 +13,7 @@
 | **ADR** | [ADR-029](../../docs/architecture/adr/029-db-first-agent-config-and-hot-reload.mdx), [ADR-073](../../docs/architecture/adr/073-axial-stage-of-pipeline-decomposition.mdx), [ADR-094](../../docs/architecture/adr/094-control-plane-dashboard-consolidation.mdx) |
 | **Base PR** | `staging` |
 | **Branche de travail** | feature locale dédiée (ex. `feat/<issue>-persona-soul-blobstore`) — **pas** de commit direct sur `staging` |
-| **Statut global** | `in_review` — impl complete, PR pending |
+| **Statut global** | `done` — PR #2059 merged to staging |
 | **Panel review** | 2026-06-29 — 5 experts (produit, architecte, devops, sécurité, axial-drift) → **CONDITIONAL GO** |
 | **Dernière MAJ** | 2026-06-29 (session 5 — workflow PR validé) |
 | **Workflow PR** | Branche feature → `/goal` → `/pr` → review/fix loop → CI green → `reviewed` + `/ci-watch` |
@@ -645,7 +645,7 @@ Layer C — Turn resolution (hub stage)
 
 - [x] Docs à jour
 - [x] `make qg` complet green
-- [ ] PR mergée vers `staging` (via workflow review + `reviewed` + `/ci-watch`)
+- [x] PR mergée vers `staging` (via workflow review + `reviewed` + `/ci-watch`)
 - [ ] smoke Tailnet : edit soul dashboard → nouveau chat → soul appliquée clipool + omp
 
 ---
@@ -733,6 +733,12 @@ Layer C — Turn resolution (hub stage)
 - Implémentation sur **branche feature dédiée** (pas `staging` direct).
 - Boucle : `/pr` → `/code-review` → `/fix` (loop) → CI verte → `reviewed` → `/ci-watch`.
 - Block 5 done-when : merge via PR, plus « push staging » direct.
+
+### 2026-06-29 — Session 7 : vérification + merge
+
+- Corrigé gaps vérification : tests RPC/handlers, UX Block4, harness parity, evidence logs.
+- `make qg` ×2 green ; CI PR #2059 green (5313+ tests) ; `/ci-watch` → ci=pass.
+- **PR #2059 mergée** vers `staging` (`d030e7a2`).
 
 ### 2026-06-29 — Session 6 : `/goal` exécution
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2059 — closes remaining goal verification gaps:

- **Soul secret lint** on agent detail page: warns when composed soul markdown matches `sk-`, `ghp_`, `Bearer `, or PEM patterns (non-blocking alert).
- **Goal plan** marked `done` with session 8 journal entry.

## Changes

- `apps/dashboard/src/lib/soul-secret-lint.ts` + tests
- `AgentsPage.tsx` integration + `AgentsPage.test.tsx` secret warning case
- `artifacts/plans/persona-soul-blobstore-dashboard-goal.md` journal update

## Verification

- `make qg` ×2 green (local)
- Vitest: 38 passed (includes secret lint + AgentsPage)
- Playwright: dist index load OK; `/agents` UI covered by vitest

Closes #2058 (follow-up after #2059).

## Deferred (unchanged)

- Drop `persona_json` column
- `prompt_sha256` on JobEnvelope metadata
- Tailnet smoke test