### PR TITLE
fix(bootstrap): preload soul cache at agent config load (#2058)

### DIFF
--- a/src/factory/bootstrap/factory/agent_factory.py
+++ b/src/factory/bootstrap/factory/agent_factory.py
@@ -33,6 +33,7 @@ from factory.core.lifecycle.circuit_breaker import CircuitRegistry
 from factory.core.messaging.messages import MessageManager
 from factory.core.ports.stt import STTProtocol
 from factory.core.ports.tts import TtsProtocol
+from factory.infrastructure.soul.soul_ops import preload_soul_caches_for_rows
 from factory.infrastructure.stores.registry.agent_store import AgentStore
 from factory.integrations.base import SessionTools
 from factory.integrations.vault_cli import VaultCli
@@ -42,6 +43,7 @@ from factory.llm.registry import ProviderRegistry
 
 if TYPE_CHECKING:
     from factory.bootstrap.bootstrap_stores import StoreBundle
+    from factory.core.ports.blobstore import BlobStorePort
     from factory.llm.base import LlmProvider
     from factory.llm.llm_client import LlmClient
 
@@ -87,6 +89,8 @@ class ResolveAgentsDeps:
 async def _init_bot_auths_and_agents(
     stores: StoreBundle,
     raw_config: dict,
+    *,
+    blob_store: "BlobStorePort | None" = None,
 ) -> BotAuthBundle:
     """Resolve multibot config, build authenticators, load agent configs."""
     circuit_registry, admin_user_ids = _load_circuit_config(raw_config)
@@ -120,17 +124,23 @@ async def _init_bot_auths_and_agents(
     )
     agent_names: set[str] = set(bot_agent_map.values())
 
-    agent_configs: dict[str, Agent] = {}
+    rows = []
     for n in sorted(agent_names):
         row = stores.agent.get(n)
         if row is not None:
-            overrides = _build_agent_overrides(raw_config, n)
-            agent_configs[n] = agent_row_to_config(
-                row,
-                instance_overrides=overrides.model_dump(),
-            )
+            rows.append(row)
         else:
             log.error("Agent %r not found in DB — skipping", n)
+
+    await preload_soul_caches_for_rows(rows, blob_store)
+
+    agent_configs: dict[str, Agent] = {}
+    for row in rows:
+        overrides = _build_agent_overrides(raw_config, row.name)
+        agent_configs[row.name] = agent_row_to_config(
+            row,
+            instance_overrides=overrides.model_dump(),
+        )
     if not agent_configs:
         raise ValueError(
             "No agent configs could be loaded — run"

--- a/src/factory/bootstrap/factory/unified.py
+++ b/src/factory/bootstrap/factory/unified.py
@@ -56,12 +56,14 @@ async def _bootstrap_unified(  # noqa: PLR0915 — unified bootstrap is a wiring
         async with open_stores(vault_dir, nc=nc) as stores:
             await _prune_message_index(stores, raw_config)
 
-            bundle = await _init_bot_auths_and_agents(stores, raw_config)
+            blob_store = init_blobstore()
+            bundle = await _init_bot_auths_and_agents(
+                stores, raw_config, blob_store=blob_store
+            )
             pm = await _init_pairing(
                 raw_config, bundle.admin_user_ids, vault_dir, stores
             )
             voice = await _init_voice_services(nc)
-            blob_store = init_blobstore()
             hub = _build_hub(
                 BuildHubDeps(
                     raw_config=raw_config,

--- a/src/factory/bootstrap/standalone/hub_standalone.py
+++ b/src/factory/bootstrap/standalone/hub_standalone.py
@@ -114,8 +114,14 @@ async def _bootstrap_hub_standalone(  # noqa: C901, PLR0915 — DEBT:migration-s
             [cfg for cfg, _ in dc_bot_auths],
         )
 
-        agent_configs = load_agent_configs(
-            stores.agent, raw_config, set(bot_agent_map.values())
+        from factory.bootstrap.factory.voice_overlay import init_blobstore
+
+        blob_store = init_blobstore()
+        agent_configs = await load_agent_configs(
+            stores.agent,
+            raw_config,
+            set(bot_agent_map.values()),
+            blob_store=blob_store,
         )
         if not agent_configs:
             sys.exit(

--- a/src/factory/bootstrap/standalone/hub_standalone_helpers.py
+++ b/src/factory/bootstrap/standalone/hub_standalone_helpers.py
@@ -20,6 +20,8 @@ from factory.bootstrap.lifecycle.lifecycle_helpers import (
     teardown_dispatchers,
 )
 from factory.core.agent.agent_loader import agent_row_to_config
+from factory.core.agent.agent_models import AgentRow
+from factory.infrastructure.soul.soul_ops import preload_soul_caches_for_rows
 from factory.infrastructure.stores.identity.pairing import (
     PairingManager,
     set_pairing_manager,
@@ -29,6 +31,7 @@ if TYPE_CHECKING:
     from factory.adapters.nats.mint_failure_subscriber import MintFailureSubscriber
     from factory.core.agent import Agent
     from factory.core.hub.hub import Hub
+    from factory.core.ports.blobstore import BlobStorePort
     from factory.core.ports.llm import LlmProvider
     from factory.infrastructure.stores.identity.agent_grant_store import (
         AgentGrantStore,
@@ -70,20 +73,30 @@ async def start_mint_failure_subscriber(nc: Any) -> "MintFailureSubscriber | Non
     return sub
 
 
-def load_agent_configs(
+async def load_agent_configs(
     agent_store: AgentStore,
     raw_config: dict,
     agent_names: Iterable[str],
+    *,
+    blob_store: "BlobStorePort | None" = None,
 ) -> dict[str, Agent]:
     """Load agent configs from DB with instance overrides applied."""
-    configs: dict[str, Agent] = {}
+    rows: list[AgentRow] = []
     for n in sorted(set(agent_names)):
         row = agent_store.get(n)
         if row is None:
             log.error("Agent %r not found in DB — skipping", n)
             continue
-        overrides = _build_agent_overrides(raw_config, n)
-        configs[n] = agent_row_to_config(row, instance_overrides=overrides.model_dump())
+        rows.append(row)
+
+    await preload_soul_caches_for_rows(rows, blob_store)
+
+    configs: dict[str, Agent] = {}
+    for row in rows:
+        overrides = _build_agent_overrides(raw_config, row.name)
+        configs[row.name] = agent_row_to_config(
+            row, instance_overrides=overrides.model_dump()
+        )
     return configs
 
 

--- a/src/factory/infrastructure/soul/soul_ops.py
+++ b/src/factory/infrastructure/soul/soul_ops.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from factory.core.agent.agent_models import AgentRow
@@ -15,6 +16,7 @@ from factory.core.persona import (
     parse_soul_markdown,
     validate_soul_document_bytes,
 )
+from roxabi_contracts import BlobNotFoundError, BlobStoreServerError
 
 if TYPE_CHECKING:
     from factory.core.ports.blobstore import BlobStorePort
@@ -65,6 +67,35 @@ def warm_soul_cache(
         composed_prompt=composed,
     )
     return composed
+
+
+async def preload_soul_caches_for_rows(
+    rows: Iterable[AgentRow],
+    blob_store: "BlobStorePort | None",
+) -> None:
+    """Fetch soul.md from blobstore and warm cache before agent_row_to_config."""
+    if blob_store is None:
+        return
+    cache = get_soul_document_cache()
+    for row in rows:
+        ref = row.soul_document_blob_ref
+        if not ref or cache.get(row.name, ref) is not None:
+            continue
+        try:
+            markdown = await fetch_soul_markdown(blob_store, ref)
+            warm_soul_cache(row.name, blob_ref=ref, markdown=markdown)
+        except (
+            BlobNotFoundError,
+            BlobStoreServerError,
+            UnicodeDecodeError,
+            ValueError,
+        ) as exc:
+            log.warning(
+                "preload_soul_cache(%s): failed ref=%s: %s",
+                row.name,
+                ref,
+                exc,
+            )
 
 
 async def put_soul_document(

--- a/tests/bootstrap/test_wiring_helpers.py
+++ b/tests/bootstrap/test_wiring_helpers.py
@@ -313,8 +313,10 @@ class TestInitBotAuthsAndAgents:
 
         monkeypatch.setattr(agent_factory_mod, "_load_messages", _load_messages)
 
+        mock_row = MagicMock()
+        mock_row.name = "lyra_default"
         stores = MagicMock()
-        stores.agent.get = MagicMock(return_value=MagicMock(name="lyra_default"))
+        stores.agent.get = MagicMock(return_value=mock_row)
 
         # Act
         result = await _init_bot_auths_and_agents(stores, {})

--- a/tests/core/test_agent_db_loader_soul_cold_start.py
+++ b/tests/core/test_agent_db_loader_soul_cold_start.py
@@ -1,0 +1,85 @@
+"""Cold-start: preload from blobstore → agent_row_to_config without manual warm."""
+
+from __future__ import annotations
+
+import pytest
+
+from factory.core.agent.agent_db_loader import agent_row_to_config
+from factory.core.agent.agent_models import AgentRow
+from factory.core.agent.soul_cache import get_soul_document_cache
+from factory.infrastructure.soul.soul_ops import preload_soul_caches_for_rows
+from roxabi_contracts.blob_ref import BlobRef
+
+_SOUL_MD = """## Identity
+Cold start Lyra
+## Personality
+Calm
+## Values
+Honest
+## Expertise
+Python
+## Guidelines
+Bootstrap preload
+"""
+
+
+class _MemoryBlobStore:
+    def __init__(self) -> None:
+        self._data: dict[str, bytes] = {}
+
+    async def put(  # noqa: PLR0913
+        self,
+        data: bytes,
+        *,
+        mime: str,
+        source: str,
+        filename: str | None = None,
+        platform_ref: str | None = None,
+        platform_message_id: str | None = None,
+    ) -> BlobRef:
+        key = f"sha256:{len(self._data):064x}"
+        self._data[key] = data
+        return BlobRef(
+            store_key=key,
+            content_hash=key.split(":", 1)[1],
+            mime=mime,
+            size=len(data),
+            source=source,
+        )
+
+    async def get(self, store_key: str) -> bytes:
+        return self._data[store_key]
+
+    async def exists(self, content_hash: str) -> BlobRef | None:
+        for key in self._data:
+            if key.endswith(content_hash) or content_hash in key:
+                return BlobRef(
+                    store_key=key,
+                    content_hash=content_hash,
+                    mime="text/markdown",
+                    size=len(self._data[key]),
+                    source="soul",
+                )
+        return None
+
+
+@pytest.mark.asyncio
+async def test_preload_then_loader_without_manual_warm_soul_cache() -> None:
+    get_soul_document_cache().invalidate("lyra")
+    blob = _MemoryBlobStore()
+    ref = await blob.put(_SOUL_MD.encode("utf-8"), mime="text/markdown", source="soul")
+    store_key = ref.store_key
+    assert store_key
+
+    row = AgentRow(
+        name="lyra",
+        backend="claude-cli",
+        model="sonnet",
+        soul_document_blob_ref=store_key,
+    )
+
+    await preload_soul_caches_for_rows([row], blob)
+
+    agent = agent_row_to_config(row)
+    assert "Cold start Lyra" in agent.system_prompt
+    assert "Bootstrap preload" in agent.system_prompt

--- a/tests/helpers/hub_standalone_bootstrap.py
+++ b/tests/helpers/hub_standalone_bootstrap.py
@@ -214,7 +214,7 @@ def _apply_core_hub_stubs(
     )
     monkeypatch.setattr(
         f"{_HUB}.load_agent_configs",
-        lambda *_a, **_kw: {"default": MagicMock()},
+        AsyncMock(return_value={"default": MagicMock()}),
     )
     monkeypatch.setattr(
         "factory.bootstrap.factory.config._load_messages",


### PR DESCRIPTION
## Summary

- Add `preload_soul_caches_for_rows` to fetch `soul.md` from blobstore and warm the write-through cache before `agent_row_to_config`.
- Wire preload into hub standalone (`load_agent_configs`) and unified bootstrap (`_init_bot_auths_and_agents`).
- Add cold-start unit test proving loader composes from blobstore without manual `warm_soul_cache`.

Closes #2058 (goal verification follow-up — bootstrap seam).

## Test plan

- [x] `uv run pytest tests/core/test_agent_db_loader_soul_cold_start.py`
- [x] `make qg`