### PR TITLE
fix(dashboard): preload soul editor from persona_json fallback (#2058)

### DIFF
--- a/apps/dashboard/src/pages/AgentsPage.tsx
+++ b/apps/dashboard/src/pages/AgentsPage.tsx
@@ -52,8 +52,19 @@ export function AgentsListPage() {
                 className="flex items-center justify-between rounded-lg border bg-card px-4 py-3 hover:bg-muted/40"
               >
                 <span className="font-medium">{a.name}</span>
-                <span className="text-xs text-muted-foreground">
-                  {a.backend} · {a.model}
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span
+                    className={
+                      a.has_soul
+                        ? "rounded bg-emerald-500/15 px-1.5 py-0.5 text-emerald-700 dark:text-emerald-300"
+                        : "rounded bg-muted px-1.5 py-0.5"
+                    }
+                  >
+                    {a.has_soul ? "soul.md" : "no soul"}
+                  </span>
+                  <span>
+                    {a.backend} · {a.model}
+                  </span>
                 </span>
               </Link>
             </li>
@@ -143,13 +154,70 @@ export function AgentDetailPage() {
     setDirty(true);
   }, []);
 
-  if (configQ.isLoading) {
-    return <p className="p-6 text-sm text-muted-foreground">Loading…</p>;
+  const cfg = configQ.data;
+  const soulSections = soulQ.data?.sections ?? {};
+  const hasSoulBlob = Boolean(cfg?.soul_document_blob_ref);
+  const hasSectionContent = SOUL_SECTIONS.some((s) => (soulSections[s] ?? "").trim().length > 0);
+  const soulSource = hasSoulBlob
+    ? "blobstore"
+    : hasSectionContent
+      ? "legacy persona_json"
+      : "empty";
+
+  if (configQ.isLoading || soulQ.isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading agent config…</p>;
+  }
+
+  if (configQ.isError) {
+    return (
+      <p className="p-6 text-sm text-destructive" role="alert">
+        Failed to load agent config — is the hub reachable?
+      </p>
+    );
   }
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-6">
       <h1 className="font-[family-name:var(--font-head)] text-2xl font-bold">{name}</h1>
+
+      <Card className="flex flex-wrap items-center gap-3 border-dashed p-3 text-sm">
+        <span className="font-medium text-muted-foreground">Active defaults (DB)</span>
+        <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs">
+          {cfg?.backend ?? harness}
+        </span>
+        <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs">
+          {cfg?.model ?? model}
+        </span>
+        <span
+          className={
+            hasSoulBlob
+              ? "rounded bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-800 dark:text-emerald-200"
+              : "rounded bg-amber-500/15 px-2 py-0.5 text-xs text-amber-900 dark:text-amber-100"
+          }
+        >
+          soul: {soulSource}
+        </span>
+        {cfg?.updated_at ? (
+          <span className="text-xs text-muted-foreground">updated {cfg.updated_at}</span>
+        ) : null}
+      </Card>
+
+      {soulQ.isError ? (
+        <p
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+        >
+          Soul sections could not be loaded — check hub + blobstore wiring.
+        </p>
+      ) : null}
+
+      {!soulQ.isError && !hasSectionContent ? (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-950 dark:text-amber-50">
+          No soul content yet. Run{" "}
+          <code className="font-mono text-xs">scripts/backfill_soul_documents.py</code> or edit
+          sections below, then Save.
+        </p>
+      ) : null}
 
       {dirty ? (
         <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm">

--- a/src/factory/bootstrap/factory/dashboard_agents_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_agents_rpc.py
@@ -60,7 +60,34 @@ async def _soul_markdown_for_row(hub: Hub, row: AgentRow) -> str:
             md = await fetch_soul_markdown(blob, row.soul_document_blob_ref)
             warm_soul_cache(row.name, blob_ref=row.soul_document_blob_ref, markdown=md)
             return md
+        log.warning(
+            "soul.get(%s): blobstore unavailable ref=%s — persona_json fallback",
+            row.name,
+            row.soul_document_blob_ref,
+        )
     return ""
+
+
+def _legacy_persona_sections(row: AgentRow) -> dict[str, str]:
+    if not row.persona_json:
+        return {}
+    try:
+        from factory.core.persona import legacy_persona_json_to_sections
+
+        persona = json.loads(row.persona_json)
+        return legacy_persona_json_to_sections(persona)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        log.warning("soul.get(%s): invalid persona_json — ignored", row.name)
+        return {}
+
+
+async def _soul_sections_for_row(hub: Hub, row: AgentRow) -> dict[str, str]:
+    from factory.core.persona import parse_soul_markdown
+
+    md = await _soul_markdown_for_row(hub, row)
+    if md:
+        return parse_soul_markdown(md)
+    return _legacy_persona_sections(row)
 
 
 def _meta_envelope(row: AgentRow) -> SoulMetaEnvelope | None:
@@ -189,10 +216,7 @@ async def handle_agents_soul_get(hub: Hub, _nc: NATS, payload: dict[str, Any]) -
     row = store.get(name)
     if row is None:
         return {"error": "not_found"}
-    md = await _soul_markdown_for_row(hub, row)
-    from factory.core.persona import parse_soul_markdown
-
-    sections = parse_soul_markdown(md) if md else {}
+    sections = await _soul_sections_for_row(hub, row)
     return DashboardAgentSoulSectionsResponse(
         sections=sections,
         soul_document_blob_ref=row.soul_document_blob_ref,

--- a/tests/bootstrap/test_dashboard_agents_rpc.py
+++ b/tests/bootstrap/test_dashboard_agents_rpc.py
@@ -145,6 +145,30 @@ async def test_handle_agents_soul_get_reads_cache_after_put() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_agents_soul_get_falls_back_to_persona_json() -> None:
+    persona = {
+        "identity": {"display_name": "Legacy Lyra", "goal": "Help operators"},
+        "personality": {"traits": ["calm"], "tone": "direct"},
+        "expertise": {"areas": ["Python"], "instructions": ["Be concise"]},
+    }
+    row = AgentRow(
+        name="lyra",
+        backend="claude-cli",
+        model="sonnet",
+        persona_json=json.dumps(persona),
+    )
+    hub = _hub_with_store(row)
+    hub._blob_store = None
+
+    out = await handle_agents_soul_get(hub, _NC, {"name": "lyra"})
+
+    assert "Legacy Lyra" in out["sections"]["Identity"]
+    assert "calm" in out["sections"]["Personality"]
+    assert out["sections"]["Guidelines"] == "- Be concise"
+    assert out["soul_document_blob_ref"] is None
+
+
+@pytest.mark.asyncio
 async def test_handle_agents_soul_preview_composes_via_hub() -> None:
     hub = MagicMock()
     out = await handle_agents_soul_preview(


### PR DESCRIPTION
## Summary

- `GET /agents/{name}/soul` now preloads editor sections from blobstore **or** maps legacy `persona_json` when no `soul.md` ref is reachable.
- Agents UI shows active DB defaults (backend, model, soul source) and explicit empty/error states instead of blank fields.

Fixes operator report: dashboard `/agents` appeared empty with no indication of what is active.

Closes #2058

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2058: Persona / soul blobstore + dashboard agent config | Closed (follow-up) |
| Implementation | 1 commit on `feat/019f14c9-persona-soul-blobstore` | Complete |
| Verification | `make qg` | Passed |

## Test Plan

- [x] `uv run pytest tests/bootstrap/test_dashboard_agents_rpc.py` (persona_json fallback)
- [x] `bun --filter @roxabi-factory/dashboard test src/pages/AgentsPage.test.tsx`
- [x] `make qg`
- [ ] Manual: open `/agents/{name}` — sections populated from blob or legacy persona; status strip shows harness/model/soul source