### PR TITLE
fix(deploy): hub BlobStore URL and dashboard NATS ACL hotfix

### DIFF
--- a/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
+++ b/artifacts/specs/706-per-role-nkeys-acls-spec.mdx
@@ -31,6 +31,7 @@ The row will grant `subscribe: factory.typing.>` to `code-worker` (it consumes t
 | `$JS.API.CONSUMER.CREATE.FACTORY_TURNS.turn-writer-v1.>` | — | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — | — | — | — |
 | `$JS.API.CONSUMER.INFO.FACTORY_OUTBOUND_AUDIO.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$JS.API.CONSUMER.INFO.FACTORY_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — | — | — | — |
+| `$JS.API.CONSUMER.INFO.KV_factory-state.*` | — | — | — | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$JS.API.CONSUMER.MSG.NEXT.FACTORY_OUTBOUND_AUDIO.*` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$JS.API.CONSUMER.MSG.NEXT.FACTORY_TURNS.turn-writer-v1` | — | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — | — | — | — |
 | `$JS.API.DIRECT.GET.KV_factory-state.hub.ready` | — | PUB | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | PUB |
@@ -43,6 +44,7 @@ The row will grant `subscribe: factory.typing.>` to `code-worker` (it consumes t
 | `$JS.API.STREAM.INFO.KV_factory_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$JS.API.STREAM.MSG.GET.KV_factory-state` | — | PUB | PUB | PUB | PUB | PUB | PUB | — | PUB | PUB | — | — | — | — | — | PUB | — | PUB |
 | `$JS.API.STREAM.MSG.GET.KV_factory_outbound_audio_sent` | — | PUB | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `$JS.API.STREAM.NAMES` | — | — | — | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$JS.API.STREAM.UPDATE.FACTORY_TURNS` | — | — | — | — | — | — | — | — | — | — | — | — | PUB | — | — | — | — | — |
 | `$KV.factory-active-jobs.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 | `$KV.factory-msg-index.>` | PUB | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |

--- a/deploy/nats/acl-matrix.json
+++ b/deploy/nats/acl-matrix.json
@@ -154,7 +154,7 @@
       "created_at": "2026-06-21",
       "owner": "factory",
       "description": "Web smoke adapter — browser chat UI + SSE on factory.{inbound,outbound}.web.smoke (#1977).",
-      "notes": "Lean adapter ACL: no outbound-audio JetStream consumer (NullAudioConsumer fallback). wait_for_hub uses STREAM.INFO + STREAM.MSG.GET on KV_factory-state (#1572).",
+      "notes": "Lean adapter ACL: no outbound-audio JetStream consumer (NullAudioConsumer fallback). wait_for_hub uses STREAM.INFO + STREAM.MSG.GET on KV_factory-state (#1572); kv.watch() fallback still needs STREAM.NAMES + CONSUMER.CREATE (dashboard crash-loop hotfix 2026-06-30).",
       "allow_responses": true,
       "publish": [
         "factory.inbound.web.>",
@@ -166,6 +166,8 @@
         "$JS.API.DIRECT.GET.KV_factory-state.hub.ready",
         "$JS.API.INFO",
         "$JS.API.CONSUMER.CREATE.*",
+        "$JS.API.CONSUMER.INFO.KV_factory-state.*",
+        "$JS.API.STREAM.NAMES",
         "$JS.API.STREAM.INFO.KV_factory-state",
         "$JS.API.STREAM.MSG.GET.KV_factory-state"
       ],

--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -40,7 +40,7 @@ authorization {
       nkey: "UDETWEBADAPTER"
       # web-adapter
       permissions: {
-        publish:   { allow: ["factory.inbound.web.>","factory.dashboard.>","factory.system.ready","factory.event.>","factory.metric.>","factory.metric.host.container_report","$JS.API.DIRECT.GET.KV_factory-state.hub.ready","$JS.API.INFO","$JS.API.CONSUMER.CREATE.*","$JS.API.STREAM.INFO.KV_factory-state","$JS.API.STREAM.MSG.GET.KV_factory-state"] }
+        publish:   { allow: ["factory.inbound.web.>","factory.dashboard.>","factory.system.ready","factory.event.>","factory.metric.>","factory.metric.host.container_report","$JS.API.DIRECT.GET.KV_factory-state.hub.ready","$JS.API.INFO","$JS.API.CONSUMER.CREATE.*","$JS.API.CONSUMER.INFO.KV_factory-state.*","$JS.API.STREAM.NAMES","$JS.API.STREAM.INFO.KV_factory-state","$JS.API.STREAM.MSG.GET.KV_factory-state"] }
         subscribe: { allow: ["factory.outbound.web.>","factory.typing.web.>","_inbox.web-adapter.>","$KV.factory-state.>"] }
         allow_responses: true
       }

--- a/deploy/quadlet/factory-hub.container
+++ b/deploy/quadlet/factory-hub.container
@@ -40,6 +40,11 @@ Environment=NATS_URL=nats://factory-nats:4222
 # ADR-054 Decision 5 (revised): nkey seed delivered as Podman secret.
 Secret=factory-nats-hub,type=mount,target=factory-nats-hub.seed,uid=1500,gid=1500,mode=0400
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-hub.seed
+# BlobStore — hub voice overlay + attachment ingest (#1551); localhost:8449 is wrong
+# inside the container (blobstore is factory-blobstore on roxabi.network).
+Environment=FACTORY_BLOBSTORE_URL=http://factory-blobstore:8449
+Environment=FACTORY_BLOBSTORE_TOKEN_PATH=/run/secrets/factory_blobstore_token
+Secret=factory_blobstore_token,type=mount,uid=1500,gid=1500,mode=0400,target=/run/secrets/factory_blobstore_token
 Volume=factory-data.volume:/home/factory/.roxabi/factory:z
 # T26 (#1331): hub is now a READER — turns.db must be ro; factory-turn-writer owns writes.
 # Directory bind (not file-only): SQLite WAL requires turns.db-wal / turns.db-shm siblings

--- a/deploy/quadlet/hub.env.example
+++ b/deploy/quadlet/hub.env.example
@@ -26,5 +26,6 @@ FACTORY_TYPING_ENABLED=false
 # BlobStore client — read by init_blobstore() at hub startup (restart-not-HUP).
 # If FACTORY_BLOBSTORE_TOKEN_PATH is absent, blob_store degrades to None (audio attachments
 # disabled, warning logged; no crash).
-#FACTORY_BLOBSTORE_URL=http://localhost:8449
-#FACTORY_BLOBSTORE_TOKEN_PATH=~/.roxabi/factory/blobstore.tok
+# In-container hub must use the roxabi.network DNS name (not localhost:8449).
+#FACTORY_BLOBSTORE_URL=http://factory-blobstore:8449
+#FACTORY_BLOBSTORE_TOKEN_PATH=/run/secrets/factory_blobstore_token

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -183,7 +183,7 @@
 - **Subscribe:** $KV.factory-state.>, _inbox.voice-tts.>, factory.voice.tts.lifecycle.>, factory.voice.tts.request, factory.voice.tts.request.>
 
 ### web-adapter
-- **Publish:** $JS.API.CONSUMER.CREATE.*, $JS.API.DIRECT.GET.KV_factory-state.hub.ready, $JS.API.INFO, $JS.API.STREAM.INFO.KV_factory-state, $JS.API.STREAM.MSG.GET.KV_factory-state, factory.dashboard.>, factory.event.>, factory.inbound.web.>, factory.metric.>, factory.metric.host.container_report, factory.system.ready
+- **Publish:** $JS.API.CONSUMER.CREATE.*, $JS.API.CONSUMER.INFO.KV_factory-state.*, $JS.API.DIRECT.GET.KV_factory-state.hub.ready, $JS.API.INFO, $JS.API.STREAM.INFO.KV_factory-state, $JS.API.STREAM.MSG.GET.KV_factory-state, $JS.API.STREAM.NAMES, factory.dashboard.>, factory.event.>, factory.inbound.web.>, factory.metric.>, factory.metric.host.container_report, factory.system.ready
 - **Subscribe:** $KV.factory-state.>, _inbox.web-adapter.>, factory.outbound.web.>, factory.typing.web.>
 
 ## Process Topology

--- a/src/factory/bootstrap/factory/dashboard_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_rpc.py
@@ -58,6 +58,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _WEB_BOT = "smoke"
+
+
 async def start_dashboard_rpc(hub: Hub, nc: NATS) -> list[Any]:
     """Subscribe hub responders for dashboard BFF request-reply."""
     import time
@@ -241,8 +243,9 @@ async def _handle_connectors_list(
     _ = hub, nc
     req = DashboardConnectorInstallationsListRequest.model_validate(payload)
     if req.connector not in _SUPPORTED_CONNECTORS:
-        empty = DashboardConnectorInstallationsListResponse(installations=[])
-        return empty.model_dump()
+        return DashboardConnectorInstallationsListResponse(
+            installations=[]
+        ).model_dump()
     store = await get_installation_store()
     rows = await store.list_rows()
     installations = [

--- a/tests/bootstrap/test_unified.py
+++ b/tests/bootstrap/test_unified.py
@@ -54,7 +54,8 @@ def _patch_unified_boundaries(  # noqa: PLR0915
     # -- ensure_nats & lockfile (replace the no-op stubs with tracking versions)
     fake_nc = AsyncMock()
     fake_nc.close = AsyncMock()
-    fake_nc.jetstream = MagicMock(return_value=MagicMock())
+    fake_js = AsyncMock()
+    fake_nc.jetstream = MagicMock(return_value=fake_js)
     fake_embedded = MagicMock()
     fake_embedded.stop = AsyncMock()
 
@@ -170,13 +171,11 @@ def _patch_unified_boundaries(  # noqa: PLR0915
 
     # ensure_stream / ensure_kv are imported locally inside _bootstrap_unified;
     # patch at the source module so all tests using this fixture get no-ops.
+    import factory.infrastructure.events.stream_setup as _events_stream_setup_mod
     import factory.infrastructure.outbound_audio.stream_setup as _stream_setup_mod
 
     monkeypatch.setattr(_stream_setup_mod, "ensure_stream", AsyncMock())
     monkeypatch.setattr(_stream_setup_mod, "ensure_kv", AsyncMock())
-
-    import factory.infrastructure.events.stream_setup as _events_stream_setup_mod
-
     monkeypatch.setattr(
         _events_stream_setup_mod, "ensure_observability_streams", AsyncMock()
     )
@@ -459,6 +458,7 @@ async def test_audio_provisioning_before_wire_adapters(
 
     mock_ensure_stream = AsyncMock()
     mock_ensure_kv = AsyncMock()
+    mock_ensure_observability = AsyncMock()
 
     with (
         patch(
@@ -469,12 +469,17 @@ async def test_audio_provisioning_before_wire_adapters(
             "factory.infrastructure.outbound_audio.stream_setup.ensure_kv",
             mock_ensure_kv,
         ),
+        patch(
+            "factory.infrastructure.events.stream_setup.ensure_observability_streams",
+            mock_ensure_observability,
+        ),
     ):
         await _bootstrap_unified({})
 
     # Provisioning calls must have fired
     mock_ensure_stream.assert_awaited_once_with(fake_js)
     mock_ensure_kv.assert_awaited_once_with(fake_js)
+    mock_ensure_observability.assert_awaited_once_with(fake_js)
 
     # Provisioning must have happened after agent registration but before wiring
     assert "_register_agents" in order

--- a/tests/scripts/fixtures/v3-current.json
+++ b/tests/scripts/fixtures/v3-current.json
@@ -197,7 +197,7 @@
       "created_at": "2026-06-21",
       "owner": "factory",
       "description": "Web smoke adapter \u2014 browser chat UI + SSE on factory.{inbound,outbound}.web.smoke (#1977).",
-      "notes": "Lean adapter ACL: no outbound-audio JetStream consumer (NullAudioConsumer fallback). wait_for_hub uses STREAM.INFO + STREAM.MSG.GET on KV_factory-state (#1572).",
+      "notes": "Lean adapter ACL: no outbound-audio JetStream consumer (NullAudioConsumer fallback). wait_for_hub uses STREAM.INFO + STREAM.MSG.GET on KV_factory-state (#1572); kv.watch() fallback still needs STREAM.NAMES + CONSUMER.CREATE (dashboard crash-loop hotfix 2026-06-30).",
       "allow_responses": true,
       "publish": [
         "factory.inbound.web.>",
@@ -209,6 +209,8 @@
         "$JS.API.DIRECT.GET.KV_factory-state.hub.ready",
         "$JS.API.INFO",
         "$JS.API.CONSUMER.CREATE.*",
+        "$JS.API.CONSUMER.INFO.KV_factory-state.*",
+        "$JS.API.STREAM.NAMES",
         "$JS.API.STREAM.INFO.KV_factory-state",
         "$JS.API.STREAM.MSG.GET.KV_factory-state"
       ],

--- a/tests/scripts/fixtures/v3-pre-grant-group.json
+++ b/tests/scripts/fixtures/v3-pre-grant-group.json
@@ -196,7 +196,7 @@
       "created_at": "2026-06-21",
       "owner": "factory",
       "description": "Web smoke adapter \u2014 browser chat UI + SSE on factory.{inbound,outbound}.web.smoke (#1977).",
-      "notes": "Lean adapter ACL: no outbound-audio JetStream consumer (NullAudioConsumer fallback). wait_for_hub uses STREAM.INFO + STREAM.MSG.GET on KV_factory-state (#1572). Mirrored inline into this v3 snapshot (#1978): web-adapter references no group, so it renders identically to deploy/nats/acl-matrix.json.",
+      "notes": "Lean adapter ACL: no outbound-audio JetStream consumer (NullAudioConsumer fallback). wait_for_hub uses STREAM.INFO + STREAM.MSG.GET on KV_factory-state (#1572); kv.watch() fallback still needs STREAM.NAMES + CONSUMER.CREATE (dashboard crash-loop hotfix 2026-06-30). Mirrored inline into this v3 snapshot (#1978): web-adapter references no group, so it renders identically to deploy/nats/acl-matrix.json.",
       "allow_responses": true,
       "publish": [
         "factory.inbound.web.>",
@@ -208,6 +208,8 @@
         "$JS.API.DIRECT.GET.KV_factory-state.hub.ready",
         "$JS.API.INFO",
         "$JS.API.CONSUMER.CREATE.*",
+        "$JS.API.CONSUMER.INFO.KV_factory-state.*",
+        "$JS.API.STREAM.NAMES",
         "$JS.API.STREAM.INFO.KV_factory-state",
         "$JS.API.STREAM.MSG.GET.KV_factory-state"
       ],


### PR DESCRIPTION
## Summary

- Fix `factory-hub` quadlet to reach BlobStore on `roxabi.network` (`FACTORY_BLOBSTORE_URL=http://factory-blobstore:8449`) instead of the broken in-container default `localhost:8449`, which caused hub crash loops on M₁ after staging converge.
- Restore minimal `web-adapter` JetStream ACL grants required by `wait_for_hub()` when it falls back to `kv.watch()`: `$JS.API.STREAM.NAMES` and `$JS.API.CONSUMER.INFO.KV_factory-state.*`. Without these, `factory-dashboard` crashed on boot with permissions violations / NATS timeouts.

Validated live on **roxabituwer** (M₁ prod): hub stable, dashboard boots (`Hub ready (KV immediate)`), `/api/bff/fleet` returns 200 on the tailnet.

**Note:** M₁ also had a corrupted `KV_factory-state` bucket (`no message cache`); repaired operationally via `delete_key_value("factory-state")` + hub restart. That data repair is not in this diff.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Implementation | 2 commits on `fix/hub-blobstore-url-quadlet` | Complete |
| Verification | Live M₁ smoke (hub + dashboard + `/api/bff/fleet`) | Passed |

## Test Plan

- [ ] `make converge` on M₁ — hub starts without BlobStore `ConnectError`
- [ ] `factory-dashboard` reaches `active` without NATS ACL violations on boot
- [ ] `curl http://<tailscale-ip>:8765/api/bff/fleet` returns 200
- [ ] `deploy/nats/auth.conf` regenerated via `factory-acl genkeys --regen-authconf` picks up web-adapter grants

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`