### PR TITLE
fix(deploy): exclude host-local env files from Syncthing sync

### DIFF
--- a/deploy/templates/factory.stignore
+++ b/deploy/templates/factory.stignore
@@ -3,3 +3,8 @@
 nats/jetstream
 blobstore
 blobstore.tok
+# Host-specific Tailscale bind IPs — generated per machine by deploy/install.sh §4.
+# Must NOT sync M₁↔M₂ or PublishPort binds to the wrong tailnet address.
+env/web.env
+env/blobstore.env
+env/ingress.env


### PR DESCRIPTION
## Summary
- Add `env/web.env`, `env/blobstore.env`, and `env/ingress.env` to `deploy/templates/factory.stignore` so per-host Tailscale bind IPs are not overwritten when the factory vault syncs between M1 and M2.
- Prevents ingress/dashboard/blobstore `PublishPort` binds from drifting to the wrong tailnet address (observed on M1 when M2 IP leaked via Syncthing).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2058: Persona / soul blobstore + dashboard agent config | Closed (post-merge ops) |
| Implementation | 1 commit on `feat/019f14c9-persona-soul-blobstore` | Complete |
| Verification | Deploy template only — no runtime code change | N/A |

## Test Plan
- [ ] `make converge` on M1 regenerates `.stignore` with the three `env/*` entries
- [ ] After Syncthing sync, `TAILSCALE_IPV4` in `~/.roxabi/factory/env/*.env` stays host-local
- [ ] `factory-ingress` binds to the correct tailnet IP after converge + restart

Related to #2058

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`