### PR TITLE
chore(make): drop legacy hub.mk include from factory Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,9 @@
 # which silently skips unmatched brace expansions.
 SHELL := /bin/bash -o pipefail
 
-SUPERVISOR_HUB ?= $(HOME)/projects
-HUB_SERVICES   := factory telegram discord nats clipool
--include $(SUPERVISOR_HUB)/hub.mk
+HUB_SERVICES := factory telegram discord nats clipool
 
-# Fallback SVC_CMD parsing — used when hub.mk is not present (e.g. prod).
+# Sub-command capture: `make factory reload` → SVC_CMD=reload
 ifndef SVC_CMD
 ifneq (,$(filter $(HUB_SERVICES),$(firstword $(MAKECMDGOALS))))
   SVC_CMD := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))


### PR DESCRIPTION
## Summary
- Remove legacy supervisord hub references (conf.d, hub.mk, make register, supervisorctl)
- Align service management with Quadlet + systemd --user standard

## Test Plan
- [x] Makefiles parse (`make help` / `make -n <target> status`)
- [x] No functional code paths call supervisorctl

---
Generated with Claude Code