### PR TITLE
feat(deploy): own the llmCLI cloud gateway (LiteLLM + Grok/Fireworks) on M₁

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,5 +85,7 @@ Unified: `factory start` → hub + adapters in 1 process + embedded NATS
 
 Prod: Podman Quadlet (systemd `--user`) on M₁ (`factory-hub` role). **16 active containers** per `deploy/quadlet.toml` (Langfuse ×6 + `factory-otel-collector` disabled): core (`factory-nats`, `factory-hub`, `factory-telegram`, `factory-discord`, `factory-dashboard`, `factory-clipool`, `factory-omp`, `factory-socialmedia-adapter`, `factory-gh-helper`, `factory-turn-writer`, `factory-blobstore`, `factory-ingress`, `factory-cloudflared`) + observability (`factory-loki`, `factory-promtail`, `factory-otel`). Install: `deploy/install.sh` (idempotent).
 
+Plus **3 llmCLI cloud-gateway units** vendored from Roxabi/llmCLI (LiteLLM proxy :18091 + xAI/Grok forwarder :18645 + Fireworks forwarder :18646) — deployment owned here (M₁ always-on cloud LLM gateway), image built + published by llmCLI CI and pinned by digest. Local GPU inference (llmcli-nats-worker, M₂) stays in Roxabi/llmCLI. See `deploy/AGENTS.md` § llmCLI cloud gateway.
+
 → `docs/runbooks/README.md` — ops runbooks (install, secrets, diagnostic)
 → `~/projects/docs/container-deployment-standard.md` — 18 standards (S7 secret target, S8 naming, S12 RestartSec=10)

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -52,6 +52,33 @@ Rollback: edit `Image=` to previous semver tag → `systemctl --user daemon-relo
 
 ---
 
+## llmCLI cloud gateway
+
+The M₁ always-on cloud LLM gateway — **`llmcli`** (LiteLLM proxy :18091), **`llmcli-xai-forwarder`** (:18645, xAI/Grok OAuth relay), **`llmcli-fw-forwarder`** (:18646, Fireworks) — is deployed from this repo (`deploy/quadlet/llmcli*.container` + `[component.litellm-proxy|xai-forwarder|fw-forwarder]`, `host_roles=["factory-hub"]`). Rationale: HA requires M₁ to answer LLM 24/7 (LiteLLM→cloud), so the always-on gateway belongs with the always-on hub.
+
+**Boundary** — factory owns *deployment* (host placement, converge lifecycle, digest pin, secret wiring); Roxabi/llmCLI owns *code + image* (`ghcr.io/roxabi/llmcli`, built + published by its CI) and the **M₂ local GPU worker** (`llmcli-nats-worker` + engines, `host_roles=["llm-worker"]`, unchanged — deferred). The units are byte-vendored from llmCLI; do not diverge them beyond the digest pin.
+
+**Carve-outs from § Hardening invariants** (intentional — do not "normalize"):
+- `UserNS=keep-id:uid=1502,gid=1502` — the llmCLI image runs as uid 1502 (distinct from factory 1500 / voicecli 1501). The `NoNewPrivileges`/`ReadOnly`/`DropCapability=all` trio is present.
+- The proxy master key is read from `~/.roxabi/llmcli/env/proxy.env` (grandfathered llmCLI data dir, `EnvironmentFile=`), **not** a `type=mount` secret — hence `required_secrets=[]`. Its value must equal `factory-litellm-key` (the bearer `factory-omp` sends); they are the same token today. Hardening to a `type=mount` `LLMCLI_API_KEY_FILE` secret needs an image change (follow-up).
+- xAI OAuth credentials live at `~/.roxabi/llmcli/credentials/` (rw bind-mount, per-host grant family — never a Podman secret, never Syncthing-synced, never copied between hosts).
+
+**Consumers** (ports + container-names are contract — do not rename): `factory-omp` → :18091/v1; Claude Code aliases + xai-research skill → host loopback :18091 / :18645; the proxy reaches the forwarders via roxabi.network DNS.
+
+### llmCLI cloud-gateway image
+
+Pinned by digest (¬autoupdate) so factory controls gateway bumps. To bump:
+
+```bash
+# 1. resolve the desired digest (current good staging on M₁, or a release tag)
+skopeo inspect docker://ghcr.io/roxabi/llmcli:staging --format '{{.Digest}}'
+# 2. set Image=ghcr.io/roxabi/llmcli@sha256:<digest> in all 3 deploy/quadlet/llmcli*.container
+# 3. commit → merge staging → M₁ converge picks it up
+#    (or manual: systemctl --user restart llmcli llmcli-xai-forwarder llmcli-fw-forwarder)
+```
+
+---
+
 ## Provisioning
 
 `provision.sh` — production host post-install script. Run once per machine, or after a full wipe.

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -133,6 +133,33 @@ container = "factory-otel.container"
 required_secrets = ["factory_otel_token"]
 host_roles = ["factory-hub"]
 
+# --- llmCLI cloud gateway (vendored from Roxabi/llmCLI) ----------------------
+# LiteLLM proxy (:18091) + xAI/Grok forwarder (:18645) + Fireworks forwarder
+# (:18646). Deployment owned here — M₁ always-on cloud LLM gateway (HA: M₁ must
+# answer LLM 24/7). Image is built + published by llmCLI CI, pinned by digest in
+# the .container files (¬autoupdate). Local GPU inference (llmcli-nats-worker,
+# M₂) stays in Roxabi/llmCLI. required_secrets=[]: the proxy master key is read
+# from ~/.roxabi/llmcli/env/proxy.env (grandfathered llmcli data dir), not a
+# Podman secret — hardening to a type=mount _FILE secret is a tracked follow-up.
+[component.litellm-proxy]
+container = "llmcli.container"
+required_secrets = []
+env_file = "~/.roxabi/llmcli/env/proxy.env"
+host_roles = ["factory-hub"]
+
+[component.xai-forwarder]
+container = "llmcli-xai-forwarder.container"
+required_secrets = []
+# xAI OAuth credentials via rw bind-mount (~/.roxabi/llmcli/credentials — per-host,
+# never a Podman secret, never Syncthing-synced); see the .container file.
+host_roles = ["factory-hub"]
+
+[component.fw-forwarder]
+container = "llmcli-fw-forwarder.container"
+required_secrets = []
+env_file = "~/.roxabi/llmcli/env/proxy.env"
+host_roles = ["factory-hub"]
+
 [volume.data]
 volume = "factory-data.volume"
 host_roles = ["factory-hub"]

--- a/deploy/quadlet/llmcli-fw-forwarder.container
+++ b/deploy/quadlet/llmcli-fw-forwarder.container
@@ -1,0 +1,48 @@
+[Unit]
+Description=llmCLI Fireworks forwarder (:18646)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+# Vendored from Roxabi/llmCLI — deployment owned by roxabi-factory (M₁ cloud gateway).
+# Image built + published by llmCLI CI; pinned by digest here (¬autoupdate) so factory
+# controls bumps. Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
+Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
+ContainerName=llmcli-fw-forwarder
+# No PublishPort — internal to roxabi.network only (reachable as
+# http://llmcli-fw-forwarder:18646 from other containers on roxabi.network)
+Network=roxabi.network
+EnvironmentFile=%h/.roxabi/llmcli/env/proxy.env
+Environment=LLMCLI_FORWARDER_PROVIDER=fireworks
+Environment=LLMCLI_FORWARDER_PORT=18646
+UserNS=keep-id:uid=1502,gid=1502
+Exec=forwarder
+# NB: Quadlet strips a trailing quote from a HealthCmd value that ends in one
+# (python -c "...'...'..." → unterminated shell string → probe always errors →
+# false unhealthy, ~13d). Ending the value with a non-quote (|| exit 1) keeps the
+# inner quoting intact so this HTTP /health probe generates and runs correctly.
+HealthCmd=python -c 'import urllib.request; urllib.request.urlopen("http://localhost:18646/health", timeout=5)' || exit 1
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+# ReadOnly rootfs — host-validated 2026-06-16 (D-6 ops-audit). Thin relay; runtime
+# writes (lib caches, /tmp) land on the tmpfs set below — 0 EROFS at boot. Uniform
+# with the proxy. mode=1777: a root-owned 0755 tmpfs EACCESes for non-root uid 1502.
+ReadOnly=true
+Tmpfs=/tmp:mode=1777
+Tmpfs=/home/llmcli/.local:mode=1777
+Tmpfs=/home/llmcli/.cache:mode=1777
+Tmpfs=/home/llmcli/.config:mode=1777
+
+[Service]
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=20s
+# Memory caps — contain a runaway to its cgroup instead of a global OOM freeze
+# (2026-06-01 M₂ freeze). Tiny relay; 1G/1.5G is generous.
+MemoryHigh=1G
+MemoryMax=1536M
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/llmcli-fw-forwarder.container
+++ b/deploy/quadlet/llmcli-fw-forwarder.container
@@ -17,11 +17,10 @@ Environment=LLMCLI_FORWARDER_PROVIDER=fireworks
 Environment=LLMCLI_FORWARDER_PORT=18646
 UserNS=keep-id:uid=1502,gid=1502
 Exec=forwarder
-# NB: Quadlet strips a trailing quote from a HealthCmd value that ends in one
-# (python -c "...'...'..." → unterminated shell string → probe always errors →
-# false unhealthy, ~13d). Ending the value with a non-quote (|| exit 1) keeps the
-# inner quoting intact so this HTTP /health probe generates and runs correctly.
-HealthCmd=python -c 'import urllib.request; urllib.request.urlopen("http://localhost:18646/health", timeout=5)' || exit 1
+# HealthCmd carries NO double-quotes: factory's quadlet-lint forbids them (the
+# Quadlet generator strips a closing double-quote → unterminated shell string).
+# The URL is passed as an unquoted argv so the -c body needs single-quotes only.
+HealthCmd=python -c 'import urllib.request,sys; urllib.request.urlopen(sys.argv[1], timeout=5)' http://localhost:18646/health || exit 1
 HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -1,0 +1,54 @@
+[Unit]
+Description=llmCLI xAI OAuth forwarder (:18645)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+# Vendored from Roxabi/llmCLI — deployment owned by roxabi-factory (M₁ cloud gateway).
+# Image built + published by llmCLI CI; pinned by digest here (¬autoupdate) so factory
+# controls bumps. Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
+Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
+ContainerName=llmcli-xai-forwarder
+# Reachable two ways:
+#  - container-to-container via roxabi.network DNS (http://llmcli-xai-forwarder:18645)
+#    — used by the LiteLLM proxy container.
+#  - host loopback via PublishPort below — used by host processes such as the
+#    xai-research skill (xai_research.py -> http://127.0.0.1:18645). Bound to
+#    127.0.0.1 only: no LAN exposure of the OAuth-injecting relay.
+PublishPort=127.0.0.1:18645:18645
+Network=roxabi.network
+Volume=%h/.roxabi/llmcli/credentials:/home/llmcli/.roxabi/llmcli/credentials:rw,Z
+Environment=LLMCLI_FORWARDER_PROVIDER=xai
+Environment=LLMCLI_FORWARDER_PORT=18645
+UserNS=keep-id:uid=1502,gid=1502
+Exec=forwarder
+# Single-quote outer / double-quote inner: podman 5.7.0 (quadlet, M₁ Ubuntu)
+# truncates a HealthCmd value that ENDS in an escaped double-quote, producing
+# `sh: Unterminated quoted string` -> permanent unhealthy. Ending in the outer
+# single quote sidesteps the bug; verified via `quadlet -dryrun` on 5.7.0 + 5.8.2.
+HealthCmd=python -c 'import urllib.request; urllib.request.urlopen("http://localhost:18645/health", timeout=5)'
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+# ReadOnly rootfs — host-validated 2026-06-16 (D-6 ops-audit). The credentials
+# Volume above is explicit :rw,Z → stays writable under ReadOnly, so xAI OAuth
+# token refresh is unaffected. Other runtime writes land on the tmpfs set below.
+# mode=1777: a root-owned 0755 tmpfs EACCESes for the non-root uid 1502.
+ReadOnly=true
+Tmpfs=/tmp:mode=1777
+Tmpfs=/home/llmcli/.local:mode=1777
+Tmpfs=/home/llmcli/.cache:mode=1777
+Tmpfs=/home/llmcli/.config:mode=1777
+
+[Service]
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=20s
+# Memory caps — contain a runaway to its cgroup instead of a global OOM freeze
+# (2026-06-01 M₂ freeze). Tiny OAuth relay; 1G/1.5G is generous.
+MemoryHigh=1G
+MemoryMax=1536M
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -22,11 +22,10 @@ Environment=LLMCLI_FORWARDER_PROVIDER=xai
 Environment=LLMCLI_FORWARDER_PORT=18645
 UserNS=keep-id:uid=1502,gid=1502
 Exec=forwarder
-# Single-quote outer / double-quote inner: podman 5.7.0 (quadlet, M₁ Ubuntu)
-# truncates a HealthCmd value that ENDS in an escaped double-quote, producing
-# `sh: Unterminated quoted string` -> permanent unhealthy. Ending in the outer
-# single quote sidesteps the bug; verified via `quadlet -dryrun` on 5.7.0 + 5.8.2.
-HealthCmd=python -c 'import urllib.request; urllib.request.urlopen("http://localhost:18645/health", timeout=5)'
+# HealthCmd carries NO double-quotes: factory's quadlet-lint forbids them (the
+# Quadlet generator strips a closing double-quote → unterminated shell string).
+# The URL is passed as an unquoted argv so the -c body needs single-quotes only.
+HealthCmd=python -c 'import urllib.request,sys; urllib.request.urlopen(sys.argv[1], timeout=5)' http://localhost:18645/health || exit 1
 HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true

--- a/deploy/quadlet/llmcli.container
+++ b/deploy/quadlet/llmcli.container
@@ -1,0 +1,54 @@
+[Unit]
+Description=llmCLI LiteLLM proxy (:18091)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+# Vendored from Roxabi/llmCLI (deploy/quadlet/). Deployment owned by roxabi-factory
+# (M₁ 24/7 cloud gateway, factory-hub role); the image is still built + published by
+# llmCLI CI. Pinned by digest so factory controls gateway bumps — ¬autoupdate label.
+# Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
+Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
+ContainerName=llmcli
+# Bridge membership enables container-to-container DNS routing (closes #60):
+# other services on roxabi.network reach this proxy as `http://llmcli:18091`
+# instead of hardcoded LAN IPs. PublishPort below keeps host-side clients
+# (Claude Code aliases, ssh/tailnet) reaching :18091 via loopback.
+Network=roxabi.network
+PublishPort=18091:18091
+Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
+EnvironmentFile=%h/.roxabi/llmcli/env/proxy.env
+Environment=LLMCLI_PROXY_PORT=18091
+Environment=LLMCLI_PROXY_HOST=0.0.0.0
+UserNS=keep-id:uid=1502,gid=1502
+Exec=proxy
+HealthCmd=pgrep -f litellm
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+# ReadOnly rootfs — host-validated 2026-06-16 (D-6 ops-audit, M₂). LiteLLM writes
+# the merged proxy config to ~/.local/state/llmcli/proxy.config.yaml; all runtime
+# writes (incl. a completion under load) land on the tmpfs set below — 0 EROFS.
+# mode=1777: a root-owned 0755 tmpfs EACCESes for the non-root uid 1502. The :ro
+# config mount above is unaffected. GPU units (llmcli-nats-worker) are EXCLUDED —
+# nvidia CDI hooks (create-symlinks/update-ldcache) mutate the rootfs → EROFS.
+ReadOnly=true
+Tmpfs=/tmp:mode=1777
+Tmpfs=/home/llmcli/.local:mode=1777
+Tmpfs=/home/llmcli/.cache:mode=1777
+Tmpfs=/home/llmcli/.config:mode=1777
+
+[Service]
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=20s
+# RestartForceExitStatus: skip restart on provider-key (1) and litellm-missing (127) errors
+RestartForceExitStatus=1 127
+# Memory caps — contain a runaway to its cgroup instead of a global OOM freeze
+# (2026-06-01 M₂ freeze). LiteLLM proxy is lightweight; 2G/3G is ample headroom.
+MemoryHigh=2G
+MemoryMax=3G
+
+[Install]
+WantedBy=default.target

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -213,6 +213,10 @@
 - **Required secrets:** factory-nats-discord, factory_blobstore_token
 - **Host roles:** factory-hub
 
+### fw-forwarder
+- **Container:** llmcli-fw-forwarder.container
+- **Host roles:** factory-hub
+
 ### gh-helper
 - **Container:** factory-gh-helper.container
 - **Required secrets:** factory-gh-pem, factory-nats-gh-helper
@@ -250,6 +254,10 @@
 
 ### langfuse-worker
 - **Container:** factory-langfuse-worker.container
+- **Host roles:** factory-hub
+
+### litellm-proxy
+- **Container:** llmcli.container
 - **Host roles:** factory-hub
 
 ### loki
@@ -291,6 +299,10 @@
 ### turn-writer
 - **Container:** factory-turn-writer.container
 - **Required secrets:** factory-nats-turn-writer
+- **Host roles:** factory-hub
+
+### xai-forwarder
+- **Container:** llmcli-xai-forwarder.container
 - **Host roles:** factory-hub
 
 ---

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -35,6 +35,11 @@ EXPECTED_CONTAINERS = [
     "factory-loki",
     "factory-promtail",
     "factory-otel",
+    # llmCLI cloud gateway — deployment owned by factory (vendored from Roxabi/llmCLI).
+    # Enabled + declared after factory-otel, so they join the converge restart set.
+    "llmcli",
+    "llmcli-xai-forwarder",
+    "llmcli-fw-forwarder",
 ]
 
 
@@ -47,12 +52,12 @@ def _source_and_run(helper: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_emits_exactly_10_containers() -> None:
+def test_emits_exactly_19_containers() -> None:
     """Real helper against the real quadlet.toml → returncode 0, enabled names only."""
     result = _source_and_run(HELPER)
     assert result.returncode == 0, result.stderr
     lines = [line for line in result.stdout.splitlines() if line]
-    assert len(lines) == 16, f"expected 16 containers, got {len(lines)}: {lines}"
+    assert len(lines) == 19, f"expected 19 containers, got {len(lines)}: {lines}"
 
 
 def test_declaration_order() -> None:


### PR DESCRIPTION
## What

Move **deployment ownership** of the llmCLI cloud gateway into roxabi-factory. Vendor the 3 M₁ cloud units so factory's manifest + converge govern them; **code + image stay in Roxabi/llmCLI** (built/published by its CI). Local M₂ GPU inference is untouched and deferred.

| Unit | Port | Role |
|---|---|---|
| `llmcli` (LiteLLM proxy) | :18091 | cloud passthrough, merged `/v1/models` |
| `llmcli-xai-forwarder` | :18645 | xAI/**Grok** OAuth relay |
| `llmcli-fw-forwarder` | :18646 | Fireworks |

## Why

HA requires M₁ to answer LLM 24/7 (LiteLLM→cloud) — the always-on gateway belongs with the always-on hub. Also removes a live landmine: llmCLI's merged host_roles rescope (proxy → `llm-worker`/M₂-only) would orphan-prune the M₁ proxy on the next `deploy.sh --prune`; a factory declaration for `factory-hub` makes M₁ ownership explicit and permanent.

## How

- Units vendored **byte-identical**; `Image` pinned by **digest** (¬autoupdate) so factory controls bumps.
- `required_secrets=[]` — proxy master key stays in `~/.roxabi/llmcli/env/proxy.env` (grandfathered llmCLI data dir), same value as `factory-litellm-key`. Hardening to a `type=mount` secret is a follow-up.
- **Ports + container-names unchanged** = contract for `factory-omp`, Claude Code aliases, xai-research skill.
- Carve-outs (uid 1502, env-file key) documented in `deploy/AGENTS.md § llmCLI cloud gateway`.

## Companion

Roxabi/llmCLI PR drops the 2 forwarder components from its manifest (keeps the M₂ `proxy`+`worker`). Transition guarded by an `orphan_ignore` stopgap in `projects-meta/hosts.toml` (removed post-converge).

## Validation

Local gates green: `quadlet_component_source`, `quadlet_manifest_install`, `secrets_drift`, `volumes_table`, `doc_drift`; `cluster_plan install-plan roxabituwer` installs all 3 for `factory-hub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)