### PR TITLE
refactor(deploy): rename cloud-gateway proxy unit llmcli → factory-litellm

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -54,7 +54,7 @@ Rollback: edit `Image=` to previous semver tag → `systemctl --user daemon-relo
 
 ## llmCLI cloud gateway
 
-The M₁ always-on cloud LLM gateway — **`llmcli`** (LiteLLM proxy :18091), **`llmcli-xai-forwarder`** (:18645, xAI/Grok OAuth relay), **`llmcli-fw-forwarder`** (:18646, Fireworks) — is deployed from this repo (`deploy/quadlet/llmcli*.container` + `[component.litellm-proxy|xai-forwarder|fw-forwarder]`, `host_roles=["factory-hub"]`). Rationale: HA requires M₁ to answer LLM 24/7 (LiteLLM→cloud), so the always-on gateway belongs with the always-on hub.
+The M₁ always-on cloud LLM gateway — **`factory-litellm`** (LiteLLM proxy :18091), **`llmcli-xai-forwarder`** (:18645, xAI/Grok OAuth relay), **`llmcli-fw-forwarder`** (:18646, Fireworks) — is deployed from this repo (`deploy/quadlet/{factory-litellm,llmcli-xai-forwarder,llmcli-fw-forwarder}.container` + `[component.litellm-proxy|xai-forwarder|fw-forwarder]`, `host_roles=["factory-hub"]`). The proxy container was renamed `llmcli`→`factory-litellm` (factory-`<component>` convention) to avoid a filename collision with llmCLI's own M₂ `llmcli.container` — `cluster_plan` matches by filename, so a shared name leaked llmCLI's M₂ proxy into M₁'s install-plan. Rationale: HA requires M₁ to answer LLM 24/7 (LiteLLM→cloud), so the always-on gateway belongs with the always-on hub.
 
 **Boundary** — factory owns *deployment* (host placement, converge lifecycle, digest pin, secret wiring); Roxabi/llmCLI owns *code + image* (`ghcr.io/roxabi/llmcli`, built + published by its CI) and the **M₂ local GPU worker** (`llmcli-nats-worker` + engines, `host_roles=["llm-worker"]`, unchanged — deferred). The units are byte-vendored from llmCLI; do not diverge them beyond the digest pin.
 
@@ -63,7 +63,7 @@ The M₁ always-on cloud LLM gateway — **`llmcli`** (LiteLLM proxy :18091), **
 - The proxy master key is read from `~/.roxabi/llmcli/env/proxy.env` (grandfathered llmCLI data dir, `EnvironmentFile=`), **not** a `type=mount` secret — hence `required_secrets=[]`. Its value must equal `factory-litellm-key` (the bearer `factory-omp` sends); they are the same token today. Hardening to a `type=mount` `LLMCLI_API_KEY_FILE` secret needs an image change (follow-up).
 - xAI OAuth credentials live at `~/.roxabi/llmcli/credentials/` (rw bind-mount, per-host grant family — never a Podman secret, never Syncthing-synced, never copied between hosts).
 
-**Consumers** (ports + container-names are contract — do not rename): `factory-omp` → :18091/v1; Claude Code aliases + xai-research skill → host loopback :18091 / :18645; the proxy reaches the forwarders via roxabi.network DNS.
+**Consumers** (ports are the contract; **forwarder** container-names too — the proxy reaches them by DNS): `factory-omp` → :18091/v1; Claude Code aliases + xai-research skill → host loopback :18091 / :18645. The proxy is consumed only via PublishPort/tailnet :18091, so its own container name is free to be `factory-litellm`; the forwarder names (`llmcli-xai-forwarder`/`llmcli-fw-forwarder`) must NOT change.
 
 ### llmCLI cloud-gateway image
 
@@ -72,9 +72,9 @@ Pinned by digest (¬autoupdate) so factory controls gateway bumps. To bump:
 ```bash
 # 1. resolve the desired digest (current good staging on M₁, or a release tag)
 skopeo inspect docker://ghcr.io/roxabi/llmcli:staging --format '{{.Digest}}'
-# 2. set Image=ghcr.io/roxabi/llmcli@sha256:<digest> in all 3 deploy/quadlet/llmcli*.container
+# 2. set Image=ghcr.io/roxabi/llmcli@sha256:<digest> in all 3 deploy/quadlet/{factory-litellm,llmcli-xai-forwarder,llmcli-fw-forwarder}.container
 # 3. commit → merge staging → M₁ converge picks it up
-#    (or manual: systemctl --user restart llmcli llmcli-xai-forwarder llmcli-fw-forwarder)
+#    (or manual: systemctl --user restart factory-litellm llmcli-xai-forwarder llmcli-fw-forwarder)
 ```
 
 ---

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -142,7 +142,7 @@ host_roles = ["factory-hub"]
 # from ~/.roxabi/llmcli/env/proxy.env (grandfathered llmcli data dir), not a
 # Podman secret — hardening to a type=mount _FILE secret is a tracked follow-up.
 [component.litellm-proxy]
-container = "llmcli.container"
+container = "factory-litellm.container"
 required_secrets = []
 env_file = "~/.roxabi/llmcli/env/proxy.env"
 host_roles = ["factory-hub"]

--- a/deploy/quadlet/factory-litellm.container
+++ b/deploy/quadlet/factory-litellm.container
@@ -9,11 +9,13 @@ StartLimitBurst=5
 # llmCLI CI. Pinned by digest so factory controls gateway bumps — ¬autoupdate label.
 # Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
 Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
-ContainerName=llmcli
-# Bridge membership enables container-to-container DNS routing (closes #60):
-# other services on roxabi.network reach this proxy as `http://llmcli:18091`
-# instead of hardcoded LAN IPs. PublishPort below keeps host-side clients
-# (Claude Code aliases, ssh/tailnet) reaching :18091 via loopback.
+ContainerName=factory-litellm
+# Renamed llmcli → factory-litellm: factory-<component> convention + avoids a filename
+# collision with llmCLI's own M₂ llmcli.container (cluster_plan matches by filename, so
+# a shared name leaked llmCLI's M₂ proxy into M₁'s install-plan). Nothing reaches this
+# proxy by container DNS (consumers use PublishPort/tailnet :18091); container-to-container
+# DNS would be http://factory-litellm:18091. PublishPort below keeps host-side clients
+# (Claude Code aliases, ssh/tailnet, factory-omp) reaching :18091 via loopback.
 Network=roxabi.network
 PublishPort=18091:18091
 Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -257,7 +257,7 @@
 - **Host roles:** factory-hub
 
 ### litellm-proxy
-- **Container:** llmcli.container
+- **Container:** factory-litellm.container
 - **Host roles:** factory-hub
 
 ### loki

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -37,7 +37,9 @@ EXPECTED_CONTAINERS = [
     "factory-otel",
     # llmCLI cloud gateway — deployment owned by factory (vendored from Roxabi/llmCLI).
     # Enabled + declared after factory-otel, so they join the converge restart set.
-    "llmcli",
+    # Proxy container renamed llmcli → factory-litellm (factory-<component> convention;
+    # avoids a filename collision with llmCLI's own M₂ llmcli.container).
+    "factory-litellm",
     "llmcli-xai-forwarder",
     "llmcli-fw-forwarder",
 ]


### PR DESCRIPTION
## Why
`cluster_plan` matches quadlet units by **filename**. Factory's `llmcli.container` (factory-hub) and llmCLI's own M₂ `llmcli.container` (llm-worker) share the name, so M₁'s install-plan listed **both** → which image installs is non-deterministic (factory digest-pin vs llmCLI `:staging`). Follow-up to #2079.

## What
Rename factory's proxy unit + `ContainerName` `llmcli` → **`factory-litellm`** (factory-`<component>` convention) so the filenames are distinct and factory's digest-pinned proxy always wins on M₁.

- `git mv llmcli.container → factory-litellm.container` (+ ContainerName)
- `quadlet.toml` `litellm-proxy.container` → `factory-litellm.container`
- `test_quadlet_units.py` + arch snapshot regen + `deploy/AGENTS.md`
- **Forwarder names unchanged** (proxy → forwarders by DNS). Nothing consumes the proxy by container DNS (omp / Claude Code aliases / xai-research use PublishPort/tailnet :18091) → transparent.

## Deploy
Needs a small M₁ cutover (stop `llmcli`, start `factory-litellm` on :18091, ~seconds) — done post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)