### PR TITLE
fix(bootstrap): migrate users.email before idx_users_email on legacy auth.db

### DIFF
--- a/src/factory/bootstrap/bootstrap_store_migrations.py
+++ b/src/factory/bootstrap/bootstrap_store_migrations.py
@@ -28,7 +28,7 @@ from factory.infrastructure.stores.identity.user_store import (
     _CREATE_PLATFORM_IDENTITIES,
     _CREATE_USER_MIGRATION,
     _CREATE_USERS,
-    _CREATE_USERS_EMAIL_INDEX,
+    ensure_users_email_schema,
 )
 from factory.infrastructure.stores.migrations.bot_store_migrations import (
     run_bot_migrations,
@@ -50,7 +50,6 @@ _AUTH_DB_DDL: tuple[str, ...] = (
     _CREATE_CHALLENGES,
     _CREATE_AGENT_GRANTS,
     _CREATE_USERS,
-    _CREATE_USERS_EMAIL_INDEX,
     _CREATE_PLATFORM_IDENTITIES,
     _CREATE_USER_MIGRATION,
 )
@@ -243,6 +242,7 @@ def _ensure_auth_db_schema(vault_dir: Path) -> None:
         conn.execute("PRAGMA busy_timeout=30000")
         for stmt in _AUTH_DB_DDL:
             conn.execute(stmt)
+        ensure_users_email_schema(conn)
         alias_count = conn.execute(
             "SELECT COUNT(*) FROM identity_aliases"
         ).fetchone()[0]

--- a/src/factory/infrastructure/stores/identity/user_store.py
+++ b/src/factory/infrastructure/stores/identity/user_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -19,7 +20,13 @@ from factory.infrastructure.stores.identity.user_store_profile import (
 
 log = logging.getLogger(__name__)
 
-__all__ = ["UserStore", "_CREATE_PLATFORM_IDENTITIES", "_CREATE_USERS", "_CREATE_USER_MIGRATION"]  # noqa: E501
+__all__ = [
+    "UserStore",
+    "ensure_users_email_schema",
+    "_CREATE_PLATFORM_IDENTITIES",
+    "_CREATE_USERS",
+    "_CREATE_USER_MIGRATION",
+]  # noqa: E501
 
 _CREATE_USERS = """
 CREATE TABLE IF NOT EXISTS users (
@@ -51,6 +58,19 @@ CREATE TABLE IF NOT EXISTS _user_store_migration (
     migrated_at TEXT NOT NULL
 )
 """
+
+
+def ensure_users_email_schema(conn: sqlite3.Connection) -> None:
+    """Add ``email`` column + partial unique index on an existing auth.db."""
+    if conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='users'"
+    ).fetchone() is None:
+        return
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+    if "email" not in cols:
+        conn.execute("ALTER TABLE users ADD COLUMN email TEXT")
+    conn.execute(_CREATE_USERS_EMAIL_INDEX)
+
 
 _IDENTITY_COLS = "platform_key, platform, platform_uid, user_id, linked_at"
 

--- a/tests/bootstrap/test_bootstrap_stores.py
+++ b/tests/bootstrap/test_bootstrap_stores.py
@@ -125,6 +125,33 @@ def _create_db_with_sentinel(path: Path) -> None:
 
 
 class TestEnsureAuthDbSchema:
+    def test_migrates_legacy_users_table_without_email(self, tmp_path: Path) -> None:
+        """Regression — pre-email auth.db must not crash hub bootstrap."""
+        db_path = tmp_path / "auth.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE users ("
+            "id TEXT PRIMARY KEY, display_name TEXT, "
+            "created_at TEXT NOT NULL DEFAULT (datetime('now'))"
+            ")"
+        )
+        conn.commit()
+        conn.close()
+
+        _ensure_auth_db_schema(tmp_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+            assert "email" in cols
+            index = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name='idx_users_email'"
+            ).fetchone()
+            assert index is not None
+        finally:
+            conn.close()
+
     @pytest.mark.asyncio
     async def test_allows_simultaneous_auth_db_store_connections(
         self, tmp_path: Path


### PR DESCRIPTION
## Problem
`factory-hub` crashed on M₁ with `OperationalError: no such column: email` when bootstrapping a pre-email `auth.db`.

## Fix
- Extract shared `ensure_users_email_schema()` (ALTER + index)
- Call it from `_ensure_auth_db_schema` before hub opens stores
- Regression test for legacy `users` table without `email`

## Verification
- `pytest tests/bootstrap/test_bootstrap_stores.py::TestEnsureAuthDbSchema` — 2 passed
- M₁ hotfix applied; hub healthy pending image deploy