### PR TITLE
fix(converge): daemon-reload after quadlet-install NO_RESTART=1

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -154,7 +154,8 @@ Legacy 4-field stamps (pre-image-digest schema) are normalized to `:none:none` o
 1. **Change-gate** — skip if already converged.
 2. **Pull** — `git pull origin staging` in `~/projects/roxabi-factory` (and `~/projects/voiceCLI` if present).
 3. **Install cluster Quadlets** — `bash ~/projects/deploy.sh --prune` (role-aware SSOT: installs every host-matched unit across all managed repos from `hosts.toml` × `*/deploy/quadlet.toml`, generates host-override drop-ins, prunes orphan `.container` files). Runs under `converge.sh`'s `set -e` — **must succeed before step 4**. Template-only components (telegram/discord) are emitted as RENDER actions and rendered in step 4, not copied here.
-4. **Render factory units** — `make quadlet-install NO_RESTART=1` (renders the telegram/discord `.container.tmpl` templates, copies to `~/.config/containers/systemd`, `daemon-reload`, seeds BotStore).
+4. **Render factory units** — `make quadlet-install NO_RESTART=1` (renders the telegram/discord `.container.tmpl` templates, copies to `~/.config/containers/systemd`, seeds BotStore). `NO_RESTART=1` **skips** `daemon-reload` — the reload lives in `deploy/quadlet-install-verify.sh`, run only in the non-`NO_RESTART` else-branch (see `docs/CONFIGURATION.md`).
+4b. **Reload systemd** — `converge.sh` then runs `systemctl --user daemon-reload` explicitly + unconditionally, so systemd regenerates `.service` units from the Quadlet content installed in steps 3-4 before the restarts fire (else restarts relaunch from the stale generated unit).
 5. **Regenerate auth.conf** — `factory-acl genkeys --regen-authconf` (renders `nkeys/` → `auth.conf`).
 6. **Install secrets** — `make quadlet-secrets-install` (recreates Podman secrets from host key files; `factory-nats-auth` is no longer a secret — `auth.conf` is now an inline bind mount per ADR-085).
 7. **Restart NATS** — operator-path choices for targeted operations:

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -63,6 +63,15 @@ _do_converge() {
     echo "==> factory: rendering templates + aux units..."
     make -C "${FACTORY_DIR}" quadlet-install NO_RESTART=1
 
+    # 4b) NO_RESTART=1 above also skips daemon-reload (the reload lives solely in
+    # deploy/quadlet-install-verify.sh, which the NO_RESTART branch never runs). Reload
+    # here, unconditionally, so systemd regenerates .service units from the Quadlet
+    # content steps 3-4 just installed/rendered (bot add/remove → Secret= churn in
+    # factory-telegram/-discord.container, image digest bumps, hardening edits) BEFORE
+    # any restart below — else the restarts relaunch from the stale generated unit.
+    echo "==> systemd: reloading user daemon (pick up Quadlet unit changes)..."
+    systemctl --user daemon-reload
+
     # 5) Pull voiceCLI if present (HEAD tracked in convergence stamp)
     VOICE_DIR="${VOICE_DIR:-${HOME}/projects/voiceCLI}"
     if [ -d "${VOICE_DIR}/.git" ]; then

--- a/src/factory/bootstrap/bootstrap_store_migrations.py
+++ b/src/factory/bootstrap/bootstrap_store_migrations.py
@@ -28,7 +28,7 @@ from factory.infrastructure.stores.identity.user_store import (
     _CREATE_PLATFORM_IDENTITIES,
     _CREATE_USER_MIGRATION,
     _CREATE_USERS,
-    _CREATE_USERS_EMAIL_INDEX,
+    ensure_users_email_schema,
 )
 from factory.infrastructure.stores.migrations.bot_store_migrations import (
     run_bot_migrations,
@@ -50,7 +50,6 @@ _AUTH_DB_DDL: tuple[str, ...] = (
     _CREATE_CHALLENGES,
     _CREATE_AGENT_GRANTS,
     _CREATE_USERS,
-    _CREATE_USERS_EMAIL_INDEX,
     _CREATE_PLATFORM_IDENTITIES,
     _CREATE_USER_MIGRATION,
 )
@@ -243,6 +242,7 @@ def _ensure_auth_db_schema(vault_dir: Path) -> None:
         conn.execute("PRAGMA busy_timeout=30000")
         for stmt in _AUTH_DB_DDL:
             conn.execute(stmt)
+        ensure_users_email_schema(conn)
         alias_count = conn.execute(
             "SELECT COUNT(*) FROM identity_aliases"
         ).fetchone()[0]

--- a/src/factory/infrastructure/stores/identity/user_store.py
+++ b/src/factory/infrastructure/stores/identity/user_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -19,7 +20,13 @@ from factory.infrastructure.stores.identity.user_store_profile import (
 
 log = logging.getLogger(__name__)
 
-__all__ = ["UserStore", "_CREATE_PLATFORM_IDENTITIES", "_CREATE_USERS", "_CREATE_USER_MIGRATION"]  # noqa: E501
+__all__ = [
+    "UserStore",
+    "ensure_users_email_schema",
+    "_CREATE_PLATFORM_IDENTITIES",
+    "_CREATE_USERS",
+    "_CREATE_USER_MIGRATION",
+]  # noqa: E501
 
 _CREATE_USERS = """
 CREATE TABLE IF NOT EXISTS users (
@@ -51,6 +58,15 @@ CREATE TABLE IF NOT EXISTS _user_store_migration (
     migrated_at TEXT NOT NULL
 )
 """
+
+
+def ensure_users_email_schema(conn: sqlite3.Connection) -> None:
+    """Add ``email`` column + partial unique index on an existing auth.db."""
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+    if "email" not in cols:
+        conn.execute("ALTER TABLE users ADD COLUMN email TEXT")
+    conn.execute(_CREATE_USERS_EMAIL_INDEX)
+
 
 _IDENTITY_COLS = "platform_key, platform, platform_uid, user_id, linked_at"
 
@@ -93,14 +109,13 @@ class UserStore(UserStoreProfileOps, SqliteStore):
 
     async def _migrate_users_email(self) -> None:
         """Add ``email`` column + partial unique index on existing auth.db."""
-        db = self._require_db()
-        async with db.execute("PRAGMA table_info(users)") as cur:
-            cols = {row[1] async for row in cur}
-        if "email" not in cols:
-            await db.execute("ALTER TABLE users ADD COLUMN email TEXT")
-            await db.commit()
-        await db.execute(_CREATE_USERS_EMAIL_INDEX)
-        await db.commit()
+        conn = sqlite3.connect(self._db_path, timeout=30.0)
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            ensure_users_email_schema(conn)
+            conn.commit()
+        finally:
+            conn.close()
 
     async def _warm_cache(self) -> None:
         db = self._require_db()

--- a/tests/bootstrap/test_bootstrap_stores.py
+++ b/tests/bootstrap/test_bootstrap_stores.py
@@ -125,6 +125,33 @@ def _create_db_with_sentinel(path: Path) -> None:
 
 
 class TestEnsureAuthDbSchema:
+    def test_migrates_legacy_users_table_without_email(self, tmp_path: Path) -> None:
+        """Regression — pre-email auth.db must not crash hub bootstrap."""
+        db_path = tmp_path / "auth.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE users ("
+            "id TEXT PRIMARY KEY, display_name TEXT, "
+            "created_at TEXT NOT NULL DEFAULT (datetime('now'))"
+            ")"
+        )
+        conn.commit()
+        conn.close()
+
+        _ensure_auth_db_schema(tmp_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+            assert "email" in cols
+            index = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name='idx_users_email'"
+            ).fetchone()
+            assert index is not None
+        finally:
+            conn.close()
+
     @pytest.mark.asyncio
     async def test_allows_simultaneous_auth_db_store_connections(
         self, tmp_path: Path

--- a/tests/deploy/test_converge_nats_restart.py
+++ b/tests/deploy/test_converge_nats_restart.py
@@ -13,11 +13,14 @@ own self-source (converge.sh line 9 re-sources deploy-common.sh, which would oth
 overwrite our overrides).
 
 Assertions:
-  (auth)       auth-drift   → restart factory-nats ONLY; no client restarts; no reload
-  (structural) structural-drift → restart factory-nats + all 7 clients; no reload
+  (auth)       auth-drift   → restart factory-nats ONLY; no client restarts
+  (structural) structural-drift → restart factory-nats + all 7 clients
   (structural) voicecli branch → skipped when VOICE_DIR/.git does not exist
 
-converge NEVER reloads — reload lives only in `make nats-add-identity`.
+converge runs `systemctl --user daemon-reload` once (steps 3-4 install Quadlet content
+that must be picked up before the restarts); it never uses the unit-scoped
+`systemctl --user reload factory-nats` SIGHUP path — that lives only in
+`make nats-add-identity`.
 """
 
 from __future__ import annotations
@@ -285,15 +288,31 @@ class TestAuthDrift:
                 f"systemctl log: {lines!r}"
             )
 
-    def test_no_reload(self) -> None:
-        """converge NEVER reloads — reload lives only in make nats-add-identity.
+    def test_daemon_reload_called(self) -> None:
+        """converge runs `systemctl --user daemon-reload` once, right after step 4's
+        `make quadlet-install NO_RESTART=1` (which itself skips the reload), so the
+        restart(s) below pick up Quadlet unit content installed/rendered in steps 3-4
+        instead of relaunching from a stale generated unit.
 
-        Non-tautology: if a `systemctl --user reload factory-nats` call were added
-        to the auth branch, this assertion would fail → RED.
+        Non-tautology: if the daemon-reload were removed from converge.sh, this
+        assertion would fail → RED.
         """
         _, lines = self._run()
-        assert not any("reload" in line for line in lines), (
-            f"converge must not call systemctl reload; got: {lines!r}"
+        assert any("daemon-reload" in line for line in lines), (
+            f"expected 'daemon-reload' in systemctl log; got: {lines!r}"
+        )
+
+    def test_no_unit_scoped_reload(self) -> None:
+        """converge never calls the unit-scoped ACL SIGHUP reload
+        (`systemctl --user reload factory-nats`) — that lives only in
+        `make nats-add-identity`.
+
+        Non-tautology: if a `systemctl --user reload factory-nats` call were added,
+        this assertion would fail → RED.
+        """
+        _, lines = self._run()
+        assert not any("reload factory-nats" in line for line in lines), (
+            f"converge must not call unit-scoped reload; got: {lines!r}"
         )
 
 
@@ -337,15 +356,31 @@ class TestStructuralDrift:
                 f"systemctl log: {lines!r}"
             )
 
-    def test_no_reload(self) -> None:
-        """converge NEVER reloads — reload lives only in make nats-add-identity.
+    def test_daemon_reload_called(self) -> None:
+        """converge runs `systemctl --user daemon-reload` once, right after step 4's
+        `make quadlet-install NO_RESTART=1` (which itself skips the reload), so the
+        restart(s) below pick up Quadlet unit content installed/rendered in steps 3-4
+        instead of relaunching from a stale generated unit.
 
-        Non-tautology: if a `systemctl --user reload factory-nats` call were added
-        to the structural branch, this assertion would fail → RED.
+        Non-tautology: if the daemon-reload were removed from converge.sh, this
+        assertion would fail → RED.
         """
         _, lines = self._run()
-        assert not any("reload" in line for line in lines), (
-            f"converge must not call systemctl reload; got: {lines!r}"
+        assert any("daemon-reload" in line for line in lines), (
+            f"expected 'daemon-reload' in systemctl log; got: {lines!r}"
+        )
+
+    def test_no_unit_scoped_reload(self) -> None:
+        """converge never calls the unit-scoped ACL SIGHUP reload
+        (`systemctl --user reload factory-nats`) — that lives only in
+        `make nats-add-identity`.
+
+        Non-tautology: if a `systemctl --user reload factory-nats` call were added,
+        this assertion would fail → RED.
+        """
+        _, lines = self._run()
+        assert not any("reload factory-nats" in line for line in lines), (
+            f"converge must not call unit-scoped reload; got: {lines!r}"
         )
 
     def test_voicecli_skipped_when_no_git_dir(self) -> None:


### PR DESCRIPTION
## Bug (audit 2026-06-30 — deploy provenance A, confirmed live at HEAD)

`converge.sh` step 4 runs `make quadlet-install NO_RESTART=1`. That flag **skips `daemon-reload`** — the reload lives solely in `deploy/quadlet-install-verify.sh`, invoked only in the non-`NO_RESTART` else-branch of the Makefile `quadlet-install` target (confirmed `Makefile:165-191` + `docs/CONFIGURATION.md:693`). `converge.sh` itself had **zero** `daemon-reload` calls.

**Consequence:** Quadlet unit content installed/rendered in steps 3-4 — a bot add/remove (→ new/removed `Secret=` mount line in `factory-telegram`/`-discord.container`), an image digest bump, a hardening/volume edit — is copied to disk but systemd never regenerates the `.service` before converge's own restarts fire. The restarts relaunch from the **stale generated unit** and silently ignore the new content until an out-of-band `make quadlet-install` or reboot.

`deploy/AGENTS.md:157` falsely claimed `NO_RESTART=1` includes `daemon-reload` (it does not); `docs/CONFIGURATION.md` was already correct.

## Fix
- `converge.sh`: explicit, **unconditional** `systemctl --user daemon-reload` right after step 4, before any restart (steps 3-4 run for every drift kind; only the restart strategy branches auth/structural).
- Tests: the two `test_no_reload` cases asserted `not any("reload" ...)` — they locked in the buggy "never reloads" status quo. Replaced each with `test_daemon_reload_called` (asserts the reload now runs) + `test_no_unit_scoped_reload` (converge still must NOT use the unit-scoped `reload factory-nats` SIGHUP path — that lives only in `make nats-add-identity`). **11 passed** locally.
- `deploy/AGENTS.md`: corrected step 4 + added step 4b.

## Deploy note
M₁ auto-converges on merge; this changes converge to reload before restarts. Verify on M₁ post-merge that a converge run logs `daemon-reload` and picks up unit changes (no stale-unit relaunch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)