### PR TITLE
fix(deploy): role-guard make quadlet-install (prevent off-host factory install)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,10 @@ quadlet-lint:  ## lint Quadlet unit files: dryrun parse check + inline-comment g
 	@echo "quadlet-lint passed"
 
 quadlet-install: quadlet-preflight  ## install Quadlet units → reload + verify (NO_RESTART=1 skips restart/verify)
+	@python3 "$(HOME)/projects/lib/cluster_plan.py" has-role "$$(hostname)" factory-hub >/dev/null 2>&1 \
+	  || { echo "REFUSED: host '$$(hostname)' lacks the 'factory-hub' role — 'make quadlet-install' installs the whole factory-hub stack." >&2; \
+	       echo "         Use ~/projects/deploy.sh (role-aware SSoT), or 'make converge' on M1. Guard mirrors converge.sh's require_host_role (prevents the M2 orphan-install incident)." >&2; \
+	       exit 1; }
 	@mkdir -p "$(QUADLET_DIR)"
 	@uv run --frozen factory bot init
 	@rm -f "$(QUADLET_DIR)"/factory*.{network,volume,container,pod} "$(QUADLET_DIR)"/factory*.{network,volume,container,pod} "$(QUADLET_DIR)/nats.container" \


### PR DESCRIPTION
## Problème
`make quadlet-install` copiait **et démarrait** toute la stack factory-hub sur **n'importe quel hôte**, sans aucun contrôle de rôle — cause racine de l'incident M₂ (20 units factory + un `factory-nats` live sur le dev box roxabitower, audit 2026-07-01). Seul `converge.sh` gardait (`require_host_role factory-hub`), trivialement contourné en appelant le Makefile directement.

## Fix
Guard en tête de `quadlet-install` qui mirror `converge.sh` via `cluster_plan.py has-role` : refuse sur tout hôte sans le rôle `factory-hub`, **avant toute mutation**.

## Vérifié
- M₂ (roxabitower, llm/image-worker) : `has-role factory-hub` → exit 1 → **REFUSED** ✓
- M₁ (roxabituwer, factory-hub) : → **PASS** ✓ (le `make quadlet-install NO_RESTART=1` de converge marche toujours)
- Aucun CI n'appelle `make quadlet-install` (grep .github/tools/scripts) → pas d'impact CI.

Fait suite au nettoyage live des 2 machines (M₂ 20 orphelins retirés, M₁ langfuse/otel-collector disabled retirés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)