### PR TITLE
fix(build): content-address the factory image (drop build-revision + provenance)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,7 @@ jobs:
           push: true
           set: |
             ${{ steps.tags.outputs.bake_set }}
-            *.args.ROXABI_BUILD_REVISION=${{ github.event.workflow_run.head_sha || github.sha }}
             *.labels.org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            *.labels.org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha || github.sha }}
             *.labels.org.opencontainers.image.version=${{ github.ref_name }}
 
       - name: Verify forbidden binaries absent (SC-3)

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ RUN bun run build:dashboard
 #   docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ghcr.io/roxabi/base-svc:latest
 FROM ghcr.io/roxabi/base-svc@sha256:42b1d64e6e4a98d0840539aee73f3c3a43ab46683c9d6fe777b5cc725f5629c7 AS svc-runtime
 
-ARG ROXABI_BUILD_REVISION=""
-
 USER root
 
 # UID 1500 pinned per ADR-053 (Quadlet container UID stability)
@@ -48,10 +46,6 @@ RUN useradd -u 1500 -m factory
 
 COPY --from=builder --chown=factory:factory /app /app
 COPY --from=dashboard-builder --chown=factory:factory /app/apps/dashboard/dist /app/apps/dashboard/dist
-RUN if [ -n "$ROXABI_BUILD_REVISION" ]; then \
-      printf '{"revision":"%s"}\n' "$ROXABI_BUILD_REVISION" > /app/.roxabi-build-info.json \
-      && chown factory:factory /app/.roxabi-build-info.json; \
-    fi
 
 WORKDIR /app
 
@@ -68,8 +62,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 # NOTE: amd64 child digest (valid — single-platform build). Re-pin to the multi-arch INDEX
 # digest before adding `platforms` to docker-bake.hcl (see base-svc note above).
 FROM ghcr.io/roxabi/base@sha256:dab0e1477f5e6cea6d8090e0f15421cfb2cbcd237dace12717afba5d9be14bbc AS agent-runtime
-
-ARG ROXABI_BUILD_REVISION=""
 
 USER root
 
@@ -101,10 +93,6 @@ RUN useradd -u 1500 -m factory \
 COPY --from=ghcr.io/roxabi/factory-omp-base:16.2.12 /opt/omp/omp /opt/omp/omp
 
 COPY --from=builder --chown=factory:factory /app /app
-RUN if [ -n "$ROXABI_BUILD_REVISION" ]; then \
-      printf '{"revision":"%s"}\n' "$ROXABI_BUILD_REVISION" > /app/.roxabi-build-info.json \
-      && chown factory:factory /app/.roxabi-build-info.json; \
-    fi
 
 # ── factory-gh helper user (#1078) ─────────────────────────────────────────────
 # uid 1501 ≠ 1500 (factory's uid) so the token cache file

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,10 +2,17 @@ group "default" {
   targets = ["agent-runtime", "svc-runtime"]
 }
 
+# provenance/sbom disabled: buildx attestations embed per-build metadata (timestamps) into
+# the pushed OCI index, so the index digest changed on EVERY build even when no code changed —
+# which flipped the convergence fingerprint (fields 4/5) and forced a full-fleet restart on
+# every commit. Disabling them (+ dropping the baked ROXABI_BUILD_REVISION file) makes the
+# pushed digest content-addressed: same source → same digest (audit 2026-07-01, lot 4a).
 target "agent-runtime" {
   dockerfile = "Dockerfile"
   context    = "."
   target     = "agent-runtime"
+  provenance = false
+  sbom       = false
   cache-from = ["type=gha,scope=factory-agent"]
   cache-to   = ["type=gha,mode=min,scope=factory-agent"]
 }
@@ -14,6 +21,8 @@ target "svc-runtime" {
   dockerfile = "Dockerfile"
   context    = "."
   target     = "svc-runtime"
+  provenance = false
+  sbom       = false
   cache-from = ["type=gha,scope=factory-svc"]
   cache-to   = ["type=gha,mode=min,scope=factory-svc"]
 }


### PR DESCRIPTION
**Lot 4a — stabiliser le digest image** (prérequis du fix churn).

L'image `factory:staging` est un **index OCI + attestation provenance** (buildx défaut) dont les métadonnées (timestamps) changent le digest **à chaque build** ; en plus le Dockerfile bakait le git SHA dans `/app/.roxabi-build-info.json` (couche contenu). → les champs image du fingerprint (4/5) flippaient à **chaque commit**, même docs-only → full restart. Rien ne lit ce fichier au runtime (vérifié).

**Changements :** retrait de la revision (2 stages Dockerfile) + `provenance=false`+`sbom=false` (bake) + retrait arg/label revision (publish). → même source = même digest.

⚠️ **Seul, ce PR ne réduit PAS encore le churn** : `field0` (git HEAD repo entier) flippe toujours à chaque commit → toujours `structural`. Le **lot 4b** (ne plus traiter un bump git-HEAD nu comme `structural` dans `_classify_drift`, + passe de vérif) est requis pour compléter. Les deux sont couplés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)