### PR TITLE
fix(deploy): skip full-fleet restart for docs/CI-only commits (code-only drift)

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -125,7 +125,7 @@ Implemented in `deploy/lib/deploy-common.sh` (`compute_convergence_state`, `_cla
 
 | Field | Source | Drift kind |
 |---|---|---|
-| 0 `git-head` | `git rev-parse HEAD` in `~/projects/roxabi-factory` | structural |
+| 0 `git-head` | `git rev-parse HEAD` in `~/projects/roxabi-factory` | code-only (structural if another field also differs) — see Drift classification below |
 | 1 `units-sha256` | `sha256sum` of sorted `~/.config/containers/systemd/factory*` unit files | structural |
 | 2 `authconf-sha256` | `sha256sum` of `~/.roxabi/factory/nkeys/auth.conf` | auth |
 | 3 `voicecli-head` | `git rev-parse HEAD` in `~/projects/voiceCLI` (or `none`) | structural |
@@ -140,7 +140,8 @@ Implemented in `deploy/lib/deploy-common.sh` (`compute_convergence_state`, `_cla
 |---|---|---|
 | `none` | Stamp matches current state | Exit 0 immediately |
 | `auth` | Only field 2 differs | Restart `factory-nats` only; clients reconnect via `allow_reconnect` |
-| `structural` | Any of fields 0, 1, 3, 4, 5 differ (or no prior stamp) | Full converge: NATS + all factory clients + voiceCLI |
+| `code-only` | **Only** field 0 (`git-head`) differs — every artifact (units / auth / voice / image digests) is unchanged | `converge.sh` calls `_code_change_is_inert` (a `git diff --name-only` over the commit range): if every changed path is non-runtime (`docs/`, `tests/`, `artifacts/`, `.github/`, `*.md`, …) → record the new stamp and **skip** (no restart); any runtime-relevant path, or an undecidable diff (missing commit) → fall through to **structural**. Fail-safe by construction: a mis-classification can only over-restart (the old behaviour), never silently under-restart. Requires content-addressed images (provenance/revision removed, lot 4a) so a docs-only commit does not move fields 4–5. |
+| `structural` | Any of fields 1, 3, 4, 5 differ, **or** field 0 differs alongside another field, **or** no prior stamp | Full converge: NATS + all factory clients + voiceCLI |
 
 Legacy 4-field stamps (pre-image-digest schema) are normalized to `:none:none` on fields 4–5 before comparison — one structural converge migrates them.
 
@@ -173,7 +174,7 @@ Three systemd user timers drive convergence **automatically**:
 | Timer | Period | Service | Role |
 |---|---|---|---|
 | `podman-auto-update.timer` | `*:4/5` (5 min, offset +4 min — #1989) | `podman-auto-update.service` | Host-static apt unit (installed by `provision.sh`/`install.sh`); drop-in sets `OnCalendar=*:4/5`. Polls GHCR digests for containers labelled `io.containers.autoupdate=registry`; pulls and restarts on new digest. **Staggered off `*:0/5` (#1989):** podman-auto-update restarts containers directly, OUTSIDE `converge.sh`'s flock; at `*:0/5` it collided in-phase with `factory-quadlet-sync` and double-bounced each container ~1s apart (omp SIGKILL, hub WAL crash, telegram teardown). At `*:4/5` it trails `factory-post-autoupdate` (`*:2/5`), which has already converged the new image, so it usually no-ops and serves as a catch-up net for timer-miss runs (post-autoupdate skipped / flock held) rather than a primary restarter. |
-| `factory-quadlet-sync.timer` | `*:0/5` (5 min) | `factory-quadlet-sync.service` | Pulls `origin/staging` for roxabi-factory; **if HEAD advanced at all, runs the full `make converge`** (`deploy/factory-quadlet-sync.sh`: fetch → if `HEAD == origin/staging` exit → `git pull --ff-only` → `make converge`). It does **not** branch on which paths changed — **any** staging merge converges M₁, including `deploy/nats/acl-matrix.json`-only or docs-only changes (regen auth.conf + restart nats; verified #1848). Cheap when there's no real drift: converge is change-gated by the `.converge-stamp` fingerprint, so a no-op converge short-circuits. |
+| `factory-quadlet-sync.timer` | `*:0/5` (5 min) | `factory-quadlet-sync.service` | Pulls `origin/staging` for roxabi-factory; **if HEAD advanced, runs `make converge`** (`deploy/factory-quadlet-sync.sh`: fetch → if `HEAD == origin/staging` exit → `git pull --ff-only` → `make converge`). Converge's change-gate then classifies the drift: a `deploy/nats/acl-matrix.json`-only change is still structural (regen auth.conf + restart, #1848), but a **pure docs/tests/CI/`*.md` commit is `code-only`** and is **skipped** (stamp recorded, no restart) via `_code_change_is_inert`'s paths git-diff — see Drift classification above (lot 4b). Any runtime path, or an undecidable diff, falls through to structural (fail-safe). Cheap when there's no real drift: a no-op converge short-circuits on the `.converge-stamp` fingerprint. |
 | `factory-post-autoupdate.timer` | `*:2/5` (5 min, offset +2 min — #1751) | `factory-post-autoupdate.service` | Polls GHCR index digests for `FACTORY_TRACKED_IMAGES` (`staging-svc`, `staging`). On drift: `podman pull`, then `make converge` (stamp fields 4–5 detect image drift — no stamp deletion). Fires 2 min after `factory-quadlet-sync` so converge short-circuits when quadlet-sync already converged the same HEAD. |
 
 `podman-auto-update` handles **image pulls** (CI-driven, registry-labelled containers); fires at `*:4/5` — staggered off the `*:0/5` converge slot (#1989) so its direct restart never collides with `factory-quadlet-sync`.
@@ -226,7 +227,7 @@ Syncthing: `deploy/install.sh` maintains `~/.roxabi/factory/.stignore` (excludes
 # Full atomic converge (operator-initiated)
 make converge
 
-# Check convergence state without changing anything (prints none|auth|structural)
+# Check convergence state without changing anything (prints none|auth|code-only|structural)
 bash -c 'source deploy/lib/deploy-common.sh; _classify_drift "$(read_convergence_state)" "$(compute_convergence_state)"'
 ```
 

--- a/deploy/converge.sh
+++ b/deploy/converge.sh
@@ -32,6 +32,22 @@ _do_converge() {
         exit 0
     fi
 
+    # code-only drift: git HEAD advanced but no tracked artifact changed. Skip the full-fleet
+    # restart ONLY when the commit range touches purely non-runtime files (docs/tests/ci/*.md);
+    # a runtime-relevant path — or any undecidable diff — falls through to a structural converge
+    # (fail-safe: over-restart, never silently under-restart). Fixes "a docs commit restarts
+    # the whole fleet" (audit 2026-07-01, lot 4b) — paired with content-addressed images (4a).
+    if [ "${_drift_kind}" = "code-only" ]; then
+        if _code_change_is_inert "${_last}" "${_current}"; then
+            op_log converge_skip drift=code-only reason=non_runtime_paths
+            echo "Only non-runtime files changed (docs/tests/ci) — recording stamp, no restart."
+            write_convergence_state "${_current}"
+            exit 0
+        fi
+        echo "==> code-only drift touched runtime paths — treating as structural."
+        _drift_kind=structural
+    fi
+
     op_log converge_start drift="${_drift_kind}"
     echo "==> Convergence drift detected (${_drift_kind}) — beginning deploy..."
 

--- a/deploy/lib/deploy-common.sh
+++ b/deploy/lib/deploy-common.sh
@@ -215,7 +215,12 @@ write_convergence_state() {
 # Stdout (one word):
 #   none       — no change (current == last, or last == "none" sentinel meaning no stamp)
 #   auth       — ONLY auth_sha (field 2) differs; all structural fields are identical
-#   structural — at least one structural field differs (git, units, voice, image digests)
+#   code-only  — ONLY git_head (field 0) differs; every tracked artifact (units, auth, voice,
+#                image digests) is unchanged. The caller must resolve this via a paths git-diff
+#                (see _code_change_is_inert): a docs/CI-only commit is inert (skip), while a
+#                source change whose new units/image are not installed/pulled yet at gate time
+#                must still run a full converge. Fail-safe: undecidable → structural.
+#   structural — at least one structural field differs (git+artifact, units, voice, image digests)
 #
 # The function always succeeds (exit 0); callers branch on stdout.
 _classify_drift() {
@@ -253,6 +258,19 @@ _classify_drift() {
     IFS=':' read -r last_git last_unit last_auth last_voice last_img_svc last_img_stg <<< "${last}"
     IFS=':' read -r cur_git  cur_unit  cur_auth  cur_voice  cur_img_svc  cur_img_stg  <<< "${current}"
 
+    # code-only: git HEAD advanced but every tracked artifact is unchanged. Emitted so the
+    # caller can cheaply skip a full converge for a docs/CI-only commit (paths git-diff),
+    # while still converging when a source change's units/image aren't installed/pulled yet.
+    if [ "${last_git}"     != "${cur_git}"     ] \
+    && [ "${last_unit}"    =  "${cur_unit}"    ] \
+    && [ "${last_auth}"    =  "${cur_auth}"    ] \
+    && [ "${last_voice}"   =  "${cur_voice}"   ] \
+    && [ "${last_img_svc}" =  "${cur_img_svc}" ] \
+    && [ "${last_img_stg}" =  "${cur_img_stg}" ]; then
+        echo "code-only"
+        return 0
+    fi
+
     # Check structural fields first (image digests are structural — containers must restart)
     if [ "${last_git}"      != "${cur_git}"      ] \
     || [ "${last_unit}"     != "${cur_unit}"     ] \
@@ -266,5 +284,46 @@ _classify_drift() {
     # Structural fields match; auth_sha is the only thing that can differ here
     # (we already ruled out full equality above).
     echo "auth"
+    return 0
+}
+
+# Decide whether a 'code-only' drift (git HEAD advanced, no tracked artifact changed) is INERT —
+# i.e. the commit range touches only non-runtime files and needs no converge/restart.
+#
+#   _code_change_is_inert <last_fingerprint> <current_fingerprint>
+#
+# Returns 0 (inert → safe to skip) ONLY if EVERY file changed between the two stamps' git_head
+# (field 0) matches a conservative non-runtime allowlist (docs / tests / CI / artifacts / *.md).
+# Returns 1 (NOT inert → run a full converge) for any runtime-relevant path (src, packages, apps,
+# deploy, tools, config, Dockerfile, lockfiles, …) AND for any undecidable case (a git_head is
+# "none"/empty, or `git diff` fails because a commit is missing). This is a NEGATIVE allowlist:
+# a mis-classification can only ever over-restart (current behaviour), never silently under-restart.
+_code_change_is_inert() {
+    local last_git cur_git changed p
+    last_git=$(cut -d: -f1 <<< "${1}")
+    cur_git=$(cut -d: -f1 <<< "${2}")
+
+    # Both commits must be real and resolvable — else fail-safe to a full converge.
+    [ -n "${last_git}" ] && [ "${last_git}" != "none" ] || return 1
+    [ -n "${cur_git}" ]  && [ "${cur_git}"  != "none" ] || return 1
+
+    changed=$(cd "${FACTORY_DIR}" && git diff --name-only "${last_git}" "${cur_git}" 2>/dev/null) \
+        || return 1
+    # Empty diff = identical trees (e.g. a no-op/empty commit) → genuinely inert.
+    [ -z "${changed}" ] && return 0
+
+    # `*.md`/`*.txt` are inert anywhere in the tree: no runtime config is a bind-mounted,
+    # read-at-startup .md/.txt today (all mounted config is *.json/*.conf/*.yml/*.toml — grep
+    # `Volume=` in deploy/quadlet/ before ever adding one), and any .md/.txt baked into the image
+    # moves image digest fields 4/5, so factory-post-autoupdate's independent digest poll still
+    # converges the fleet even when this git-diff path skips. Adversarially reviewed (0 holes).
+    while IFS= read -r p; do
+        [ -z "${p}" ] && continue
+        case "${p}" in
+            docs/*|tests/*|artifacts/*|.github/*) ;;
+            *.md|*.txt|LICENSE|CHANGELOG|CHANGELOG.md|.gitignore|.editorconfig|.pre-commit-config.yaml) ;;
+            *) return 1 ;;  # a runtime-relevant path changed → NOT inert → full converge
+        esac
+    done <<< "${changed}"
     return 0
 }

--- a/tests/deploy/test_classify_drift.py
+++ b/tests/deploy/test_classify_drift.py
@@ -2,7 +2,9 @@
 
 Fingerprint format:
   <git_head>:<unit_sha>:<auth_sha>:<voicecli_head>:<staging-svc-digest>:<staging-digest>
-  - field 0 (git_head)         → structural
+  - field 0 (git_head) ALONE   → code-only (git advanced but no artifact changed; converge.sh
+                                  resolves inert docs/CI commits via _code_change_is_inert).
+                                  git_head + any other field → structural.
   - field 1 (unit_sha)         → structural
   - field 2 (auth_sha)         → auth
   - field 3 (voicecli_head)    → structural
@@ -40,7 +42,12 @@ def _classify(last: str, current: str) -> str:
         ],
         capture_output=True,
         text=True,
-        env={**os.environ, "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")},
+        env={
+            **os.environ,
+            "XDG_RUNTIME_DIR": os.environ.get(
+                "XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"
+            ),
+        },
         timeout=10,
     )
     assert result.returncode == 0, (
@@ -58,16 +65,25 @@ def _classify(last: str, current: str) -> str:
         ("none", _FP, "structural"),
         # 3. Only auth field (index 2) differs → auth-only reload
         (_FP, f"a:b:X:d:{_SVC}:{_STG}", "auth"),
-        # 4. Field 0 (git_head) differs → structural
-        (_FP, f"A:b:c:d:{_SVC}:{_STG}", "structural"),
+        # 4. Field 0 (git_head) ALONE differs → code-only (converge.sh then does a paths git-diff:
+        #    docs/CI-only commit → skip; runtime path or undecidable → structural, fail-safe).
+        (_FP, f"A:b:c:d:{_SVC}:{_STG}", "code-only"),
         # 5. Field 1 (unit_sha) differs → structural
         (_FP, f"a:B:c:d:{_SVC}:{_STG}", "structural"),
         # 6. Field 3 (voicecli_head) differs → structural
         (_FP, f"a:b:c:D:{_SVC}:{_STG}", "structural"),
         # 7. Field 4 (staging-svc digest) differs → structural
-        (_FP, f"a:b:c:d:deadbeefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001:{_STG}", "structural"),
+        (
+            _FP,
+            f"a:b:c:d:deadbeefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001:{_STG}",
+            "structural",
+        ),
         # 8. Field 5 (staging digest) differs → structural
-        (_FP, f"a:b:c:d:{_SVC}:deadbeefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0002", "structural"),
+        (
+            _FP,
+            f"a:b:c:d:{_SVC}:deadbeefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0002",
+            "structural",
+        ),
         # 9. Auth + structural both differ → structural dominates
         (_FP, f"A:b:X:d:{_SVC}:{_STG}", "structural"),
         # 10. None-sentinel guard — non-tautological legacy-normalized case
@@ -82,13 +98,12 @@ def _classify(last: str, current: str) -> str:
         ("a:b:c:d", _FP, "structural"),
         # 13. Legacy equal after normalization (images still none) → none
         ("a:b:c:d", "a:b:c:d:none:none", "none"),
-
     ],
     ids=[
         "equal_fingerprints→none",
         "no_prior_stamp→structural",
         "only_auth_differs→auth",
-        "field0_git_differs→structural",
+        "field0_git_only_differs→code_only",
         "field1_unit_differs→structural",
         "field3_voice_differs→structural",
         "field4_image_svc_differs→structural",
@@ -103,3 +118,103 @@ def _classify(last: str, current: str) -> str:
 def test_classify_drift(last: str, current: str, expected: str) -> None:
     """_classify_drift returns the correct drift category for each case."""
     assert _classify(last, current) == expected
+
+
+def _fp_git(git_head: str) -> str:
+    """6-field fingerprint whose only meaningful field is git_head (rest fixed)."""
+    return f"{git_head}:u:a:v:{_SVC}:{_STG}"
+
+
+def _inert(repo: Path, last_git: str, cur_git: str, env: dict) -> bool:
+    """True iff _code_change_is_inert exits 0 (inert → safe to skip) for this repo + range."""
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source {DEPLOY_COMMON} >/dev/null 2>&1; FACTORY_DIR="{repo}"; '
+            f'_code_change_is_inert "{_fp_git(last_git)}" "{_fp_git(cur_git)}"',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    return result.returncode == 0
+
+
+def test_code_change_is_inert(tmp_path: Path) -> None:
+    """Fail-safe negative allowlist: only pure docs/tests/CI/artifacts commits are inert (skip);
+    any runtime path OR an undecidable diff is NOT inert (→ full converge, never under-restart)."""
+    repo = tmp_path / "factory"
+    repo.mkdir()
+
+    # Isolate from the real repo: strip inherited git env so a pre-push hook's GIT_DIR cannot
+    # redirect these git ops at ~/projects/roxabi-factory (memory: git fixture GIT_DIR leak).
+    env = {**os.environ}
+    for v in subprocess.run(
+        ["git", "rev-parse", "--local-env-vars"], capture_output=True, text=True
+    ).stdout.split():
+        env.pop(v, None)
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, env=env, capture_output=True
+        )
+
+    def head() -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            env=env,
+        ).stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (repo / "README.md").write_text("base\n")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    base = head()
+
+    # inert commit: only docs/, *.md, .github/, tests/
+    (repo / "docs").mkdir()
+    (repo / "docs" / "x.md").write_text("d\n")
+    (repo / ".github").mkdir()
+    (repo / ".github" / "wf.yml").write_text("w\n")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "t.py").write_text("t\n")
+    git("add", "-A")
+    git("commit", "-qm", "docs+ci+tests")
+    inert_head = head()
+
+    # runtime commit: touches src/
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("code\n")
+    git("add", "-A")
+    git("commit", "-qm", "src change")
+    runtime_head = head()
+
+    # deploy commit: touches deploy/
+    (repo / "deploy").mkdir()
+    (repo / "deploy" / "converge.sh").write_text("#\n")
+    git("add", "-A")
+    git("commit", "-qm", "deploy change")
+    deploy_head = head()
+
+    assert _inert(repo, base, inert_head, env) is True, (
+        "docs/ci/tests-only must be inert"
+    )
+    assert _inert(repo, base, runtime_head, env) is False, (
+        "src/ change must NOT be inert"
+    )
+    assert _inert(repo, inert_head, deploy_head, env) is False, (
+        "deploy/ change must NOT be inert"
+    )
+    # undecidable → fail-safe NOT inert
+    assert _inert(repo, "none", inert_head, env) is False, (
+        "missing last git_head → not inert"
+    )
+    assert _inert(repo, base, "none", env) is False, (
+        "missing current git_head → not inert"
+    )

--- a/tests/deploy/test_converge_nats_restart.py
+++ b/tests/deploy/test_converge_nats_restart.py
@@ -51,9 +51,7 @@ def _make_stub(stubs: Path, name: str, script: str) -> None:
     """Write a stub executable to the stubs directory."""
     p = stubs / name
     p.write_text(script, encoding="utf-8")
-    p.chmod(
-        stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
-    )
+    p.chmod(stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
 
 def _run_converge(
@@ -120,7 +118,7 @@ def _run_converge(
             stubs,
             "systemctl",
             f'#!/bin/sh\necho "$@" >> "{systemctl_log}"\n'
-            "case \"$*\" in\n"
+            'case "$*" in\n'
             "  *is-failed*) exit 1;;\n"
             "  *) exit 0;;\n"
             "esac\n",
@@ -241,9 +239,14 @@ def _auth_drift_fingerprints() -> tuple[str, str]:
 
 
 def _structural_drift_fingerprints() -> tuple[str, str]:
-    """Return (last, current) where git_head (field 0) differs → structural drift."""
-    last = "git_OLD:unit222:auth333:voice444"
-    current = "git_NEW:unit222:auth333:voice444"
+    """Return (last, current) where unit_sha (field 1) differs → structural drift.
+
+    NOTE: field 0 (git_head) differing ALONE is now classified 'code-only' (converge.sh
+    resolves it via a paths git-diff), so it is no longer an unambiguous structural trigger.
+    field 1 (installed unit hash) is — a units change always means containers must restart.
+    """
+    last = "git111:unit_OLD:auth333:voice444"
+    current = "git111:unit_NEW:auth333:voice444"
     return last, current
 
 
@@ -284,8 +287,7 @@ class TestAuthDrift:
         _, lines = self._run()
         for client in STRUCTURAL_CLIENTS:
             assert not any(f"restart {client}" in line for line in lines), (
-                f"auth drift must NOT restart {client}; "
-                f"systemctl log: {lines!r}"
+                f"auth drift must NOT restart {client}; systemctl log: {lines!r}"
             )
 
     def test_daemon_reload_called(self) -> None:
@@ -306,9 +308,7 @@ class TestAuthDrift:
             None,
         )
         assert reload_idx is not None, f"expected daemon-reload; got: {lines!r}"
-        assert restart_idx is not None, (
-            f"expected restart factory-nats; got: {lines!r}"
-        )
+        assert restart_idx is not None, f"expected restart factory-nats; got: {lines!r}"
         assert reload_idx < restart_idx, (
             f"daemon-reload (idx {reload_idx}) must precede restart factory-nats "
             f"(idx {restart_idx}); got: {lines!r}"
@@ -364,8 +364,7 @@ class TestStructuralDrift:
         _, lines = self._run()
         for client in STRUCTURAL_CLIENTS:
             assert any(f"restart {client}" in line for line in lines), (
-                f"structural drift must restart {client}; "
-                f"systemctl log: {lines!r}"
+                f"structural drift must restart {client}; systemctl log: {lines!r}"
             )
 
     def test_daemon_reload_called(self) -> None:
@@ -386,9 +385,7 @@ class TestStructuralDrift:
             None,
         )
         assert reload_idx is not None, f"expected daemon-reload; got: {lines!r}"
-        assert restart_idx is not None, (
-            f"expected restart factory-nats; got: {lines!r}"
-        )
+        assert restart_idx is not None, f"expected restart factory-nats; got: {lines!r}"
         assert reload_idx < restart_idx, (
             f"daemon-reload (idx {reload_idx}) must precede restart factory-nats "
             f"(idx {restart_idx}); got: {lines!r}"


### PR DESCRIPTION
**Lot 4b — le vrai fix de « on redéploie tout à chaque changement »** (avec lot 4a mergé).

## Problème
converge reclassait **tout** avancement de git-HEAD en `structural` → restart NATS + 18 clients + voiceCLI à **chaque commit**, même un README.

## Fix (fail-safe by design)
- `_classify_drift` : nouvelle classe **`code-only`** (seul field0/git_head diffère ; units/auth/voice/2 digests images identiques).
- `converge.sh` : sur `code-only`, appelle `_code_change_is_inert` (`git diff --name-only` sur la plage) → si **uniquement** des chemins non-runtime (`docs/`, `tests/`, `artifacts/`, `.github/`, `*.md`, `*.txt`, …) → **stamp + skip, 0 restart** ; sinon (ou diff indécidable) → `structural`.
- **Allowlist négatif** : une erreur ne peut que **sur-redémarrer** (comportement actuel), **jamais** sous-redémarrer silencieusement.

## Sûreté (le moteur tourne toutes les 5 min sur le hub 24/7)
- Dépend de lot 4a (images content-addressed) → un commit docs ne bouge plus les digests 4/5.
- **Filet** : tout changement d'image reste rattrapé par `factory-post-autoupdate` (trigger indépendant sur digest GHCR).
- **Validé** : 25 tests unitaires (classify + helper avec fixture git isolée GIT_DIR) · historique staging réel (docs seul→skip, src/deploy/Dockerfile→converge) · **panel adversarial 3 lentilles → 0 trou de sous-restart**.
- Docs SSoT `deploy/AGENTS.md` (table drift + trigger-wiring) à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)