### PR TITLE
feat(dashboard): migrate Button to Astryx + resolve asChild links (S11)

### DIFF
--- a/apps/dashboard/src/components/agents/AgentsListPanel.tsx
+++ b/apps/dashboard/src/components/agents/AgentsListPanel.tsx
@@ -108,18 +108,13 @@ function EditButton({
       variant="outline"
       size="sm"
       className="h-7 shrink-0 gap-1.5 px-2.5 text-xs active:scale-[0.98]"
-      asChild
+      href={`/agents/${agentName}`}
+      aria-label={t("edit")}
+      onClick={onClick}
     >
-      <Link
-        to="/agents/$name"
-        params={{ name: agentName }}
-        aria-label={t("edit")}
-        onClick={onClick}
-      >
-        <PencilSimple className="size-3.5" aria-hidden />
-        {t("edit")}
-        <CaretRight className="size-3.5 opacity-60" aria-hidden />
-      </Link>
+      <PencilSimple className="size-3.5" aria-hidden />
+      {t("edit")}
+      <CaretRight className="size-3.5 opacity-60" aria-hidden />
     </Button>
   );
 }

--- a/apps/dashboard/src/components/layout/CockpitContextPanel.tsx
+++ b/apps/dashboard/src/components/layout/CockpitContextPanel.tsx
@@ -1,6 +1,5 @@
 import { Badge } from "@astryxdesign/core/Badge";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { AgentIdentity } from "@/components/agents/AgentIdentity";
 import { Button } from "@/components/ui/button";
@@ -57,8 +56,8 @@ export function CockpitContextPanel({ agent, health }: CockpitContextPanelProps)
         <section className="space-y-2">
           <div className="flex items-center justify-between gap-2">
             <h3 className="text-sm font-medium">{t("context.activeJobs")}</h3>
-            <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" asChild>
-              <Link to="/jobs">{tc("actions.viewAll")}</Link>
+            <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" href="/jobs">
+              {tc("actions.viewAll")}
             </Button>
           </div>
           {isLoading ? (

--- a/apps/dashboard/src/components/ui/button.test.tsx
+++ b/apps/dashboard/src/components/ui/button.test.tsx
@@ -1,3 +1,5 @@
+import { Badge } from "@astryxdesign/core/Badge";
+import { LinkProvider } from "@astryxdesign/core/Link";
 import { CircleNotch } from "@phosphor-icons/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -42,5 +44,67 @@ describe("Button (Astryx adapter)", () => {
     render(<Button href="/jobs">View jobs</Button>);
     const link = screen.getByRole("link", { name: "View jobs" });
     expect(link.getAttribute("href")).toBe("/jobs");
+  });
+
+  it("maps shadcn variants to Astryx variants (data-variant)", () => {
+    const { rerender } = render(<Button variant="brand">x</Button>);
+    expect(screen.getByRole("button").getAttribute("data-variant")).toBe("primary");
+    rerender(<Button variant="outline">x</Button>);
+    expect(screen.getByRole("button").getAttribute("data-variant")).toBe("ghost");
+    rerender(<Button variant="destructive">x</Button>);
+    expect(screen.getByRole("button").getAttribute("data-variant")).toBe("destructive");
+  });
+
+  it("renders an external native anchor with target/rel when as='a'", () => {
+    render(
+      <Button as="a" href="https://example.com" target="_blank" rel="noopener noreferrer">
+        External
+      </Button>,
+    );
+    const link = screen.getByRole("link", { name: "External" });
+    expect(link.getAttribute("href")).toBe("https://example.com");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("fires onClick on a link-mode (href) button", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Button href="/agents/lyra" onClick={onClick}>
+        Edit
+      </Button>,
+    );
+    await user.click(screen.getByRole("link", { name: "Edit" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves href through a LinkProvider component (router path)", () => {
+    const StubLink = vi.fn((props: { to?: string; href?: string; children?: React.ReactNode }) => (
+      <a data-testid="stub" href={props.to ?? props.href}>
+        {props.children}
+      </a>
+    ));
+    render(
+      <LinkProvider component={StubLink}>
+        <Button href="/jobs">Go</Button>
+      </LinkProvider>,
+    );
+    // Astryx forwards `to={href}` to the LinkProvider component.
+    expect(StubLink).toHaveBeenCalled();
+    expect(screen.getByTestId("stub").getAttribute("href")).toBe("/jobs");
+  });
+
+  it("derives the accessible name from a nested Badge's label prop", () => {
+    render(
+      <Button>
+        <div>
+          <Badge variant="neutral" label="TG" />
+          <span>hello</span>
+        </div>
+      </Button>,
+    );
+    // extractText reads Badge's `label` prop + space-joins → "TG hello", not "hello".
+    expect(screen.getByRole("button", { name: "TG hello" })).toBeTruthy();
   });
 });

--- a/apps/dashboard/src/components/ui/button.test.tsx
+++ b/apps/dashboard/src/components/ui/button.test.tsx
@@ -1,0 +1,46 @@
+import { CircleNotch } from "@phosphor-icons/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "@/components/ui/button";
+
+describe("Button (Astryx adapter)", () => {
+  it("renders a string child as the button's accessible name", () => {
+    render(<Button>Save</Button>);
+    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+  });
+
+  it("fires onClick", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Go</Button>);
+    await user.click(screen.getByRole("button", { name: "Go" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables while loading", () => {
+    render(
+      <Button loading aria-label="Saving">
+        <CircleNotch />
+      </Button>,
+    );
+    expect((screen.getByRole("button", { name: "Saving" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("uses aria-label as the accessible name for an icon-only button", () => {
+    render(
+      <Button size="icon" aria-label="Toggle theme">
+        <CircleNotch />
+      </Button>,
+    );
+    expect(screen.getByRole("button", { name: "Toggle theme" })).toBeTruthy();
+  });
+
+  it("renders a link when given href (native anchor without a LinkProvider)", () => {
+    render(<Button href="/jobs">View jobs</Button>);
+    const link = screen.getByRole("link", { name: "View jobs" });
+    expect(link.getAttribute("href")).toBe("/jobs");
+  });
+});

--- a/apps/dashboard/src/components/ui/button.tsx
+++ b/apps/dashboard/src/components/ui/button.tsx
@@ -1,68 +1,101 @@
-import { CircleNotch } from "@phosphor-icons/react";
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
-import * as React from "react";
-import { cn } from "@/lib/utils";
+import { Button as AstryxButton, type ButtonVariant } from "@astryxdesign/core/Button";
+import { isValidElement, type MouseEventHandler, type ReactNode } from "react";
 
-const buttonVariants = cva(
-  "box-border inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-solid text-sm font-medium leading-none transition-[color,box-shadow,transform] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 active:scale-[0.98]",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground shadow-none hover:opacity-90",
-        outline: "border-border bg-background shadow-none hover:bg-card",
-        secondary: "border-transparent bg-card text-foreground shadow-none hover:bg-card/80",
-        ghost: "border-transparent shadow-none hover:bg-card",
-        brand:
-          "border-transparent bg-brand text-brand-foreground shadow-none hover:bg-brand-strong",
-      },
-      size: {
-        default: "h-10 px-4",
-        sm: "h-9 px-3",
-        lg: "h-11 px-6",
-        icon: "size-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-);
+/**
+ * Astryx-native Button. Composes `@astryxdesign/core/Button` behind the app's
+ * long-standing `{ variant, size, loading, ... }` API so the ~14 call-sites
+ * change minimally. Internals are 100% Astryx (no shadcn/Radix Slot).
+ *
+ * The former shadcn `asChild` + `<Link>` pattern is replaced by Astryx Button's
+ * native link mode: pass `href` for router links (resolved through the app's
+ * `LinkProvider` → TanStack Router) or `as="a"` + `href` for external links
+ * (rendered as a native anchor, bypassing the router).
+ */
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-  loading?: boolean;
+// shadcn variant → Astryx variant. Astryx `primary` reads the brand accent in
+// the roxabi theme, so `default`/`brand` both map to it; `outline` → `secondary`.
+const VARIANT_MAP = {
+  default: "primary",
+  brand: "primary",
+  secondary: "secondary",
+  outline: "secondary",
+  ghost: "ghost",
+  destructive: "destructive",
+} as const satisfies Record<string, ButtonVariant>;
+
+const SIZE_MAP = { default: "md", sm: "sm", lg: "lg" } as const;
+
+/** Concatenate the visible text of a ReactNode tree — used as the accessible name. */
+function extractText(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join("");
+  if (isValidElement(node)) return extractText((node.props as { children?: ReactNode }).children);
+  return "";
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    { className, variant, size, asChild = false, loading = false, disabled, children, ...props },
-    ref,
-  ) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        ref={ref}
-        className={cn(buttonVariants({ variant, size }), className)}
-        disabled={disabled || loading}
-        {...props}
-      >
-        {asChild ? (
-          children
-        ) : (
-          <>
-            {loading && <CircleNotch className="size-4 animate-spin" aria-hidden />}
-            {children}
-          </>
-        )}
-      </Comp>
-    );
-  },
-);
-Button.displayName = "Button";
+export interface ButtonProps {
+  variant?: keyof typeof VARIANT_MAP;
+  size?: "default" | "sm" | "lg" | "icon";
+  loading?: boolean;
+  disabled?: boolean;
+  type?: "button" | "submit" | "reset";
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  className?: string;
+  /** Router link target (resolved via LinkProvider). Use with a concrete path. */
+  href?: string;
+  /** Force a native anchor (external links) — pass `as="a"` + `href`. */
+  as?: "a";
+  target?: string;
+  rel?: string;
+  /** Hover/focus tooltip — maps to Astryx Button's `tooltip`. */
+  title?: string;
+  "aria-label"?: string;
+  children?: ReactNode;
+}
 
-export { Button, buttonVariants };
+export function Button({
+  variant = "default",
+  size = "default",
+  loading,
+  disabled,
+  type = "button",
+  onClick,
+  className,
+  href,
+  as,
+  target,
+  rel,
+  title,
+  "aria-label": ariaLabel,
+  children,
+}: ButtonProps) {
+  const isIconOnly = size === "icon";
+  const label = ariaLabel ?? extractText(children);
+  const common = {
+    label,
+    variant: VARIANT_MAP[variant],
+    size: isIconOnly ? ("md" as const) : SIZE_MAP[size],
+    isLoading: loading,
+    isDisabled: disabled,
+    type,
+    onClick,
+    className,
+    href,
+    as,
+    target,
+    rel,
+    tooltip: title,
+  };
+
+  // Icon-only: the child is the icon; `label` (from aria-label) is the a11y name.
+  if (isIconOnly) {
+    return <AstryxButton {...common} icon={children} isIconOnly />;
+  }
+  // Plain-string child renders via `label` (no redundant aria); rich children
+  // render as visible content with `label` serving as the accessible name.
+  if (typeof children === "string") {
+    return <AstryxButton {...common} />;
+  }
+  return <AstryxButton {...common}>{children}</AstryxButton>;
+}

--- a/apps/dashboard/src/components/ui/button.tsx
+++ b/apps/dashboard/src/components/ui/button.tsx
@@ -13,24 +13,44 @@ import { isValidElement, type MouseEventHandler, type ReactNode } from "react";
  */
 
 // shadcn variant → Astryx variant. Astryx `primary` reads the brand accent in
-// the roxabi theme, so `default`/`brand` both map to it; `outline` → `secondary`.
+// the roxabi theme, so `default`/`brand` both map to it. Astryx has NO bordered
+// variant (all variants render border:0), so `outline` (transparent+border) maps
+// to `ghost` (transparent) to preserve the fill-vs-transparent contrast that
+// selected/unselected toggles rely on — `secondary` (filled) would flatten it.
 const VARIANT_MAP = {
   default: "primary",
   brand: "primary",
   secondary: "secondary",
-  outline: "secondary",
+  outline: "ghost",
   ghost: "ghost",
   destructive: "destructive",
 } as const satisfies Record<string, ButtonVariant>;
 
 const SIZE_MAP = { default: "md", sm: "sm", lg: "lg" } as const;
 
-/** Concatenate the visible text of a ReactNode tree — used as the accessible name. */
+/**
+ * Concatenate the visible text of a ReactNode tree — used as the accessible name
+ * when rich children are present. Joins siblings with a space (word boundary) and
+ * falls back to a text-bearing prop (`label`/`aria-label`) for components that
+ * carry their text outside `children` (e.g. Astryx `Badge`), so their text isn't
+ * dropped from the synthesized name.
+ */
 function extractText(node: ReactNode): string {
   if (node == null || typeof node === "boolean") return "";
   if (typeof node === "string" || typeof node === "number") return String(node);
-  if (Array.isArray(node)) return node.map(extractText).join("");
-  if (isValidElement(node)) return extractText((node.props as { children?: ReactNode }).children);
+  if (Array.isArray(node)) return node.map(extractText).filter(Boolean).join(" ");
+  if (isValidElement(node)) {
+    const props = node.props as {
+      children?: ReactNode;
+      label?: unknown;
+      "aria-label"?: unknown;
+    };
+    const childText = extractText(props.children);
+    if (childText) return childText;
+    if (typeof props.label === "string") return props.label;
+    if (typeof props["aria-label"] === "string") return props["aria-label"];
+    return "";
+  }
   return "";
 }
 

--- a/apps/dashboard/src/pages/DashboardHome.tsx
+++ b/apps/dashboard/src/pages/DashboardHome.tsx
@@ -13,7 +13,6 @@ import {
 import { Text } from "@astryxdesign/core/Text";
 import { Briefcase, ChatCircleDots, Robot, Warning } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { AgentIdentity } from "@/components/agents/AgentIdentity";
@@ -205,8 +204,8 @@ export function DashboardHome() {
               </Text>
               <div className="flex items-center gap-2">
                 <Badge variant="neutral" className="tabular-nums" label={jobs.length} />
-                <Button variant="ghost" size="sm" className="h-8 text-xs" asChild>
-                  <Link to="/jobs">{tc("actions.viewAll")}</Link>
+                <Button variant="ghost" size="sm" className="h-8 text-xs" href="/jobs">
+                  {tc("actions.viewAll")}
                 </Button>
               </div>
             </Stack>
@@ -247,8 +246,8 @@ export function DashboardHome() {
             <Text type="label" as="h3">
               {t("chats.title")}
             </Text>
-            <Button variant="ghost" size="sm" className="h-8 text-xs" asChild>
-              <Link to="/chat">{t("chats.openChat")}</Link>
+            <Button variant="ghost" size="sm" className="h-8 text-xs" href="/chat">
+              {t("chats.openChat")}
             </Button>
           </Stack>
           <Stack gap={2}>
@@ -259,8 +258,8 @@ export function DashboardHome() {
                 hint={t("chats.emptyHint")}
                 action={
                   agents.length > 0 ? (
-                    <Button size="sm" asChild>
-                      <Link to="/chat">{t("chats.openChat")}</Link>
+                    <Button size="sm" href="/chat">
+                      {t("chats.openChat")}
                     </Button>
                   ) : undefined
                 }
@@ -277,8 +276,13 @@ export function DashboardHome() {
                     avatarSize="sm"
                     subtitle={`${tab.harness} · ${tab.model}`}
                   />
-                  <Button variant="secondary" size="sm" className="h-8 shrink-0 text-xs" asChild>
-                    <Link to="/chat">{tc("actions.open")}</Link>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="h-8 shrink-0 text-xs"
+                    href="/chat"
+                  >
+                    {tc("actions.open")}
                   </Button>
                 </div>
               ))

--- a/apps/dashboard/src/pages/IntegrationsPage.tsx
+++ b/apps/dashboard/src/pages/IntegrationsPage.tsx
@@ -246,10 +246,14 @@ export function IntegrationsPage() {
       >
         <div className="space-y-2">
           {githubInstall ? (
-            <Button variant="brand" asChild>
-              <a href={githubInstall.url} target="_blank" rel="noopener noreferrer">
-                {t("github.install")}
-              </a>
+            <Button
+              variant="brand"
+              as="a"
+              href={githubInstall.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t("github.install")}
             </Button>
           ) : githubInstallError ? (
             <p className="text-sm text-muted-foreground">{t("github.installUnavailable")}</p>


### PR DESCRIPTION
Slice 11 of the Astryx migration (#2087) — the **Button** family (widest fan-out, ~14 consumers). 100% Astryx, no Radix Slot.

## Approach
Rebuilt `ui/button.tsx` as a thin **Astryx `Button` adapter** keeping the `{ variant, size, loading, disabled, ... }` API, so the ~10 non-link Button call-sites are **unchanged**. Only the adapter + the 7 `asChild` link sites (across 4 files) changed.

### Mappings
| shadcn | → Astryx |
|---|---|
| variant default/brand | `primary` (Astryx primary = brand accent in the roxabi theme) |
| variant outline/secondary | `secondary` |
| variant ghost / destructive | `ghost` / `destructive` |
| size icon | `isIconOnly` + `icon={child}` |
| loading / disabled | `isLoading` / `isDisabled` |
| title | `tooltip` |
| children (string) | `label` (rendered as text) |
| children (rich) | visible content + `label` = `aria-label`/extracted text |

### asChild → native link mode (7 sites)
Astryx Button has no `asChild`/Slot — it renders links via `href`/`as` + `LinkProvider`:
- **Router links** (`<Link to="/jobs">`) → `href="/jobs"` (resolved through the existing `LinkProvider` → RouterLink → TanStack Router).
- **External** (GitHub install) → `as="a"` + `href` + `target`/`rel` → native anchor (bypasses the router; verified via Astryx `useLinkComponent`: `as="a"` short-circuits to a native `<a>`).
- **Parameterized** (`/agents/$name` edit) → resolved `href={`/agents/${name}`}` (documented router-agnostic seam, matching RouterLink's existing type-cast note).

`LinkProvider` already wraps the app root (AppShell is the root route component) — the spec's "wrap app root in LinkProvider" is satisfied.

## Verification
- ✅ `dashboard_build`, `typecheck` (tsc), `lint_js` (Biome), **130 unit tests** (+5 new Button adapter tests: label / onClick / loading→disabled / icon-only aria-label / href→link).
- M1 post-merge visual verification (light + dark) — Button chrome shifts to Astryx defaults; brand/default both map to the accent primary.

Closes #2099