### PR TITLE
fix(dashboard): mint root trace for operator-launched jobs (launch 502) + quiet empty-registry read

### DIFF
--- a/src/factory/bootstrap/factory/dashboard_jobs_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_jobs_rpc.py
@@ -61,11 +61,12 @@ async def handle_jobs_launch(hub: Hub, nc: NATS, payload: dict[str, Any]) -> dic
         req.pool_id
         or RoutingKey(Platform.WEB, _WEB_BOT, f"agent:{req.agent}").to_pool_id()
     )
-    # Operator-initiated launch is a fresh root entry point — unlike hub
-    # work-path codecs it has no ambient TraceContext, so mint a root trace
-    # explicitly (mint_work_envelope_fields raises without one, #2069).
+    # Operator-initiated launch is a fresh root entry point — it runs in its own
+    # dashboard-RPC subscription task that TraceMiddleware never touches, so it
+    # always mints a NEW root trace (like inbound), never reuses ambient context.
+    # mint_work_envelope_fields raises without a trace_id (#2069).
     fields = mint_work_envelope_fields(
-        trace_id=TraceContext.get_trace_id() or TraceContext.generate(),
+        trace_id=TraceContext.generate(),
         pool_id=pool_id,
     )
     job_id = fields.job_id

--- a/src/factory/bootstrap/factory/dashboard_jobs_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_jobs_rpc.py
@@ -8,6 +8,7 @@ from factory.core.hub.hub_protocol import RoutingKey
 from factory.core.hub.job_catalog import list_active_jobs
 from factory.core.messaging.message import Platform
 from factory.core.prompt_resolution import resolve_agent_runtime_defaults
+from factory.core.trace import TraceContext
 from factory.nats.envelope_fields import mint_work_envelope_fields
 from factory.obs.hub_tracer import nats_client_span
 from roxabi_contracts.dashboard import (
@@ -56,11 +57,15 @@ async def handle_jobs_launch(hub: Hub, nc: NATS, payload: dict[str, Any]) -> dic
             message=f"job_name not allowed: {req.job_name!r}",
         ).model_dump()
 
-    pool_id = req.pool_id or RoutingKey(
-        Platform.WEB, _WEB_BOT, f"agent:{req.agent}"
-    ).to_pool_id()
+    pool_id = (
+        req.pool_id
+        or RoutingKey(Platform.WEB, _WEB_BOT, f"agent:{req.agent}").to_pool_id()
+    )
+    # Operator-initiated launch is a fresh root entry point — unlike hub
+    # work-path codecs it has no ambient TraceContext, so mint a root trace
+    # explicitly (mint_work_envelope_fields raises without one, #2069).
     fields = mint_work_envelope_fields(
-
+        trace_id=TraceContext.get_trace_id() or TraceContext.generate(),
         pool_id=pool_id,
     )
     job_id = fields.job_id

--- a/src/factory/infrastructure/stores/jobs/active_jobs_kv.py
+++ b/src/factory/infrastructure/stores/jobs/active_jobs_kv.py
@@ -41,6 +41,7 @@ from nats.js.errors import (
     BucketNotFoundError,
     KeyNotFoundError,
     KeyWrongLastSequenceError,
+    NoKeysError,
     NotFoundError,
 )
 
@@ -299,6 +300,10 @@ class KvActiveJobsStore:
         kv = self._require_kv()
         try:
             keys = await kv.keys(filters=["job."])
+        except NoKeysError:
+            # Empty bucket (no active jobs): nats-py raises instead of
+            # returning [] — the normal empty state, not a failure.
+            return []
         except nats.errors.Error:
             log.exception("active-jobs: list_all keys() failed")
             return []

--- a/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
+++ b/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -71,7 +73,8 @@ class TestJobsLaunch:
         assert result["job_id"]
         nc.publish.assert_awaited_once()
         _, payload = nc.publish.await_args.args
-        assert b'"trace_id"' in payload
+        data = json.loads(payload)
+        uuid.UUID(data["trace_id"])  # a well-formed root trace was minted
 
     @pytest.mark.asyncio
     async def test_rejects_unknown_agent(self, hub: MagicMock, nc: AsyncMock) -> None:

--- a/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
+++ b/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
@@ -54,6 +54,25 @@ class TestJobsLaunch:
         assert subject == "factory.jobs.omp"
         assert b"hello operator" in payload
 
+    @pytest.mark.no_default_trace
+    @pytest.mark.asyncio
+    async def test_launch_mints_trace_without_ambient_context(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        # Prod repro: the dashboard RPC entry point has NO ambient TraceContext
+        # (unlike hub work-path codecs). handle_jobs_launch must mint its own
+        # root trace, not raise — regression from #2069 that shipped a launch 502.
+        result = await handle_jobs_launch(
+            hub,
+            nc,
+            {"agent": "lyra", "prompt": "no ambient trace", "job_name": "omp"},
+        )
+        assert result["accepted"] is True
+        assert result["job_id"]
+        nc.publish.assert_awaited_once()
+        _, payload = nc.publish.await_args.args
+        assert b'"trace_id"' in payload
+
     @pytest.mark.asyncio
     async def test_rejects_unknown_agent(self, hub: MagicMock, nc: AsyncMock) -> None:
         result = await handle_jobs_launch(

--- a/tests/infrastructure/stores/test_active_jobs_kv.py
+++ b/tests/infrastructure/stores/test_active_jobs_kv.py
@@ -11,6 +11,7 @@ from nats.js.errors import (
     BucketNotFoundError,
     KeyNotFoundError,
     KeyWrongLastSequenceError,
+    NoKeysError,
 )
 
 from factory.core.ports.active_jobs import ActiveJobEntry, RegistryConflictError
@@ -57,6 +58,35 @@ def _kv_entry(value: bytes, revision: int = 1) -> MagicMock:
 # ---------------------------------------------------------------------------
 # KvActiveJobsStore — open()
 # ---------------------------------------------------------------------------
+
+
+class TestListAll:
+    async def test_empty_bucket_returns_empty_without_error_log(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty bucket: nats-py raises NoKeysError; list_all must treat it as
+        'no active jobs' (return []) WITHOUT the ERROR-log spam.
+
+        Value-equality alone is tautological — the generic
+        ``except nats.errors.Error`` branch also returns [] — so assert the
+        dedicated NoKeysError branch is taken by proving ``log.exception`` is
+        never called.
+        """
+        kv = AsyncMock()
+        kv.keys.side_effect = NoKeysError
+        js = AsyncMock()
+        js.key_value.return_value = kv
+        store = KvActiveJobsStore(js)
+        await store.connect()
+
+        fake_log = MagicMock()
+        monkeypatch.setattr(
+            "factory.infrastructure.stores.jobs.active_jobs_kv.log", fake_log
+        )
+        result = await store.list_all()
+
+        assert result == []
+        fake_log.exception.assert_not_called()
 
 
 class TestOpen:


### PR DESCRIPTION
## Why

Operator "Launch OMP job" from the dashboard returned **502 Bad Gateway**:
```
1 validation error for DashboardJobsLaunchResponse
accepted  Field required [input_value={'error': 'internal_error'}]
```
Reproduced live on M₁ + traced to the hub.

## Root cause (regression from #2069)

`handle_jobs_launch` calls `mint_work_envelope_fields(pool_id=…)` with **no `trace_id`** and **no ambient `TraceContext`** — an operator launch is a fresh root entry point, unlike hub work-path codecs (which run inside an inbound-established trace). #2069 made `trace_id` required → `mint_work_envelope_fields` raised `ValueError` → the RPC replied `{'error':'internal_error'}` → the dashboard BFF failed to parse that as `DashboardJobsLaunchResponse` → **502**.

**Why CI was green:** #2069 also added an **autouse** `conftest` fixture that sets a default `TraceContext` for every test — so `handle_jobs_launch` tests passed with an ambient trace that **prod never has**. Classic fake-masks-reality.

## Fixes

1. **`handle_jobs_launch`** — mint a root trace explicitly: `trace_id=TraceContext.get_trace_id() or TraceContext.generate()` (idiom from `middleware_guards`). + regression test marked `@pytest.mark.no_default_trace` that reproduces the **no-ambient-context** prod condition (fails without the fix).
2. **`active_jobs_kv.list_all()`** — was logging `NoKeysError` (empty bucket) as `ERROR` + traceback every ~5s on the dashboard poll. Empty bucket = no active jobs, not a failure → catch `NoKeysError` → return `[]` silently.

## Validation (local)
ruff · pyright 0 · **32 pytest** (dashboard-jobs RPC incl. the no-ambient-trace repro + active-jobs KV).

Regression from #2069. Refs #2125 (jobs live view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
