### PR TITLE
fix(dashboard): table column collapse on Fleet and Agents (#2156)

### DIFF
--- a/apps/dashboard/src/components/agents/AgentsListPanel.tsx
+++ b/apps/dashboard/src/components/agents/AgentsListPanel.tsx
@@ -359,8 +359,10 @@ export function AgentsListPanel({ agents, isLoading, isError }: AgentsListPanelP
                         <AgentIdentity agentId={a.name} avatarSize="sm" />
                       </Link>
                     </TableCell>
-                    <TableCell className="max-w-[140px] text-xs text-muted-foreground">
-                      <span className="line-clamp-2">{persona.tagline}</span>
+                    <TableCell className="text-xs text-muted-foreground">
+                      <div className="max-w-[140px]">
+                        <span className="line-clamp-2">{persona.tagline}</span>
+                      </div>
                     </TableCell>
                     <TableCell>
                       <Badge

--- a/apps/dashboard/src/components/agents/AgentsListPanel.tsx
+++ b/apps/dashboard/src/components/agents/AgentsListPanel.tsx
@@ -360,7 +360,7 @@ export function AgentsListPanel({ agents, isLoading, isError }: AgentsListPanelP
                       </Link>
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      <div className="max-w-[140px]">
+                      <div className="min-w-0 max-w-[140px]">
                         <span className="line-clamp-2">{persona.tagline}</span>
                       </div>
                     </TableCell>

--- a/apps/dashboard/src/pages/FleetPage.test.tsx
+++ b/apps/dashboard/src/pages/FleetPage.test.tsx
@@ -95,5 +95,11 @@ describe("FleetPage", () => {
     // Astryx Table semantics + a sortable columnheader survive the migration.
     expect(screen.getByRole("table")).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: /container/i })).toBeTruthy();
+    // Regression guard (#2156): all 7 columns must stay visible (max-w on <td> collapses siblings).
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers).toHaveLength(7);
+    for (const header of headers) {
+      expect((header.textContent ?? "").replace(/[↑↓]/g, "").trim().length).toBeGreaterThan(0);
+    }
   });
 });

--- a/apps/dashboard/src/pages/FleetPage.tsx
+++ b/apps/dashboard/src/pages/FleetPage.tsx
@@ -211,7 +211,7 @@ export function FleetPage() {
                   </TableCell>
                   <TableCell className="capitalize text-muted-foreground">{row.health}</TableCell>
                   <TableCell className="text-xs text-muted-foreground">
-                    <div className="max-w-[220px] truncate">{row.image_ref}</div>
+                    <div className="min-w-0 max-w-[220px] truncate">{row.image_ref}</div>
                   </TableCell>
                   <TableCell className="font-mono text-xs text-muted-foreground">
                     {row.image_revision ?? "—"}

--- a/apps/dashboard/src/pages/FleetPage.tsx
+++ b/apps/dashboard/src/pages/FleetPage.tsx
@@ -210,8 +210,8 @@ export function FleetPage() {
                     />
                   </TableCell>
                   <TableCell className="capitalize text-muted-foreground">{row.health}</TableCell>
-                  <TableCell className="max-w-[220px] truncate text-xs text-muted-foreground">
-                    {row.image_ref}
+                  <TableCell className="text-xs text-muted-foreground">
+                    <div className="max-w-[220px] truncate">{row.image_ref}</div>
                   </TableCell>
                   <TableCell className="font-mono text-xs text-muted-foreground">
                     {row.image_revision ?? "—"}


### PR DESCRIPTION
## Summary

Fixes table auto-layout collapse on Fleet and Agents list views (#2156).

`max-w-*` + `truncate` on Astryx `<TableCell>` (raw `<td>`) forces sibling columns to 0px under HTML table auto-layout. Moves width constraints to inner `<div>` wrappers so columns keep fair share while long text still clips.

## Changes

- `FleetPage.tsx` — image ref column: `max-w-[220px] truncate` moved inside `<TableCell>`
- `AgentsListPanel.tsx` — tagline column: `max-w-[140px]` moved inside `<TableCell>`

## Verification

- [x] `bun run --filter @roxabi-factory/dashboard test` — 135 tests green
- [x] `bun run lint` clean
- [x] `bun run build:dashboard` clean

## Context

Follow-up #2 from the Astryx quality regression audit (`artifacts/analyses/astryx-dashboard-quality-regression.claude.md`, carried forward in #2155). Padding regression (#2148/#2152) already fixed on staging.

Closes #2156