### PR TITLE
fix(ci): dependabot cooldown schema — semver-* keys are pip-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,11 +34,11 @@ updates:
     labels:
       - dependencies
       - ci
+    # semver-*-days cooldowns are pip-only — dependabot rejects them for
+    # github-actions/docker, and ONE invalid property disables the whole file
+    # (live check-run ".github/dependabot.yml" red after #2136).
     cooldown:
       default-days: 3
-      semver-major-days: 3
-      semver-minor-days: 3
-      semver-patch-days: 3
 
   # Dockerfile pins ghcr.io/roxabi/base* by sha256 digest — without this
   # ecosystem the base-image update path is fully manual and digests rot
@@ -51,8 +51,6 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - dependencies
+    # semver-*-days: pip-only (see github-actions block above).
     cooldown:
       default-days: 3
-      semver-major-days: 3
-      semver-minor-days: 3
-      semver-patch-days: 3


### PR DESCRIPTION
## Summary
#2136's dependabot volume-reduction added \`cooldown\` blocks to all three ecosystems. The \`semver-{major,minor,patch}-days\` keys are **pip-only**: dependabot's parser rejects them for \`github-actions\` and \`docker\`, and one invalid property invalidates the **whole file** — the live check-run \`.github/dependabot.yml\` is red on staging and dependabot is fully disabled until this lands.

\`\`\`
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
...
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
\`\`\`

## Fix
Keep \`default-days: 3\` (same effective cooldown) on both blocks, drop the pip-only keys. pip block unchanged.

## Verification
Config now matches the dependabot v2 schema; the check-run re-validates on merge to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)