### PR TITLE
fix(deploy): stop host-side uv.lock churn jamming factory-quadlet-sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      # Fail fast if pyproject.toml and uv.lock have drifted. A dependabot
+      # `pip`-ecosystem PR bumps a version specifier without regenerating the
+      # lock; every `uv sync --frozen` below then trusts the stale lock as-is
+      # and never catches the desync — which silently jams the M1 host deploy
+      # (see deploy/lib/deploy-common.sh; 12h outage 2026-07-02, hand-rescued
+      # ≥4× before). Root fix for the recurring lock desync.
+      - name: Verify uv.lock in sync with pyproject.toml
+        run: uv lock --check
+
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/deploy/fleet-digest-poll.sh
+++ b/deploy/fleet-digest-poll.sh
@@ -10,7 +10,11 @@ source "$(dirname "$0")/lib/deploy-common.sh"
 
 main() {
     mkdir -p "${HOME}/.roxabi/factory/state"
-    uv run --project "${FACTORY_DIR}" python "${FACTORY_DIR}/tools/fleet_digest_poll.py" \
+    # --frozen: never re-resolve/rewrite uv.lock on the live prod checkout (this
+    # runs from two 5-min timers; a bare `uv run` here jammed the M1 deploy for
+    # 12h on 2026-07-02). deploy-common.sh also exports UV_FROZEN=1 as the
+    # deploy-path default — this flag is the explicit belt-and-suspenders.
+    uv run --frozen --project "${FACTORY_DIR}" python "${FACTORY_DIR}/tools/fleet_digest_poll.py" \
         --output "${HOME}/.roxabi/factory/state/fleet-digests.json"
 }
 

--- a/deploy/lib/deploy-common.sh
+++ b/deploy/lib/deploy-common.sh
@@ -9,6 +9,18 @@ set -euo pipefail
 # %h in systemd unit specifiers maps to $HOME in shell.
 export PATH="${HOME}/projects/roxabi-factory/.venv/bin:${HOME}/.local/bin:${PATH}"
 
+# ── uv lockfile guard ────────────────────────────────────────────────────────
+# Every deploy script sources this lib and runs against the LIVE prod checkout.
+# A bare `uv run`/`uv sync` there re-resolves and rewrites uv.lock whenever
+# pyproject.toml has drifted from the committed lock (e.g. a dependabot `pip`
+# bump merged without the lock regen), dirtying the tree and jamming
+# factory-quadlet-sync's ff-only pull (12h M1 deploy outage, 2026-07-02).
+# UV_FROZEN makes "never mutate the lock on the host" the deploy-path default,
+# so a new script can't reintroduce the churn by forgetting `--frozen`.
+# NB: UV_NO_SYNC does NOT prevent this — it skips the venv sync, not the lock
+# refresh; only UV_FROZEN/`--frozen` does.
+export UV_FROZEN=1
+
 # ── Environment guards ─────────────────────────────────────────────────────
 source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
 # shellcheck source=operator-log.sh


### PR DESCRIPTION
## Root cause (investigated, not guessed)

M1's `factory-quadlet-sync` auto-deploy jammed for ~12h on 2026-07-02 (prod fell **126 commits** behind staging). Traced to an exact 3-layer chain:

1. **Trigger** — `.github/dependabot.yml` uses `package-ecosystem: pip`, so dep-bump PRs (#1888: `pytest >=9.1.0`) edit **pyproject.toml only, never uv.lock** → latent desync. CI (`uv sync --frozen`) trusts the stale lock as-is and never checks freshness → the PR merges green.
2. **Culprit** — `deploy/fleet-digest-poll.sh:13` runs a **bare `uv run`** (no `--frozen`), introduced by `1a75afd9` (14 days *after* #1905/`9d97e0fa` hardened the 6 Makefile call-sites, but added no enforcement). Fires from two 5-min timers (`factory-fleet-digest-poll` + `factory-post-autoupdate`, even the no-op branch). On the desynced tree it `uv sync`s implicitly → re-resolves `pytest 9.0.3→9.1.1` → **rewrites uv.lock on the live prod checkout**.
3. **Jam** — the dirty tree trips `factory-quadlet-sync`'s ff-only `require_clean_tree` guard → refuses to pull, every 5 min, indefinitely.

Same desync has been **hand-rescued ≥4×** (`8c943965`/`69b69211`/`c8ab3c1f`/`6fdd1c9c`) — symptom patched, root never closed. This PR closes it.

## Changes

| File | Change | Why |
|---|---|---|
| `deploy/lib/deploy-common.sh` | `export UV_FROZEN=1` | Sourced by **every** deploy script → "never mutate the lock on the host" becomes the deploy-path default, so a new script can't reintroduce the churn by forgetting `--frozen`. (`UV_NO_SYNC` does **not** prevent it — skips venv sync, not lock refresh.) |
| `deploy/fleet-digest-poll.sh` | add explicit `--frozen` | Belt-and-suspenders at the actual culprit call-site. |
| `.github/workflows/ci.yml` | `uv lock --check` gate | Fails any PR whose pyproject.toml/uv.lock have drifted → turns the silent desync into a red PR **before** it can reach staging and jam M1. |

## Test evidence
- `uv lock --check` on staging → exit 0 (`Resolved 128 packages`), lock **not** rewritten (read-only confirmed).
- `bash -n` clean on both scripts; pre-commit + pre-push quality gates green.

## Follow-ups (separate, not in this PR)
- Migrate `.github/dependabot.yml` `pip` → uv-native ecosystem so bump PRs carry the lock regen (removes the trigger at source). ⚠️ dependabot config is brittle (#2158) — handle carefully.
- Repo-wide lint for bare `uv run` under `deploy/**` so the `--frozen` convention is self-enforcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)