### PR TITLE
fix(build): pin builder base to python 3.12.x + dependabot guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,15 @@ updates:
     # semver-*-days: pip-only (see github-actions block above).
     cooldown:
       default-days: 3
+    ignore:
+      # The builder base image (Dockerfile line 1) MUST stay on python 3.12.x —
+      # requires-python = ">=3.12,<3.13". A 3.13/3.14 bump makes uv build the
+      # venv against a managed interpreter outside /app, so /app/.venv/bin/python
+      # dangles in the base-* runtime stages (docker-build red, staging-wide,
+      # 2026-07-02 via #2160). Allow only patch bumps within 3.12.x; base-*
+      # digest bumps (roxabi/base, base-svc) are a different dependency-name and
+      # stay enabled.
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM python:3.14.6-slim AS builder
+# Pinned to 3.12.x — requires-python = ">=3.12,<3.13" (pyproject.toml). On a
+# 3.13/3.14 base, `uv sync` below downloads a managed CPython 3.12 OUTSIDE /app
+# and points /app/.venv/bin/python at it; that symlink then dangles once /app is
+# COPYed into the base-* runtime stages (agent-runtime `uv pip install` fails:
+# "No virtual environment found for /app/.venv/bin/python" — staging-wide
+# docker-build outage 2026-07-02 via #2160). Bump only within 3.12.x, in lockstep
+# with requires-python. dependabot ignores python major/minor for this reason
+# (.github/dependabot.yml docker block).
+FROM python:3.12.10-slim AS builder
 
 # Install system deps (git needed for GitHub-sourced Python deps)
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem
`origin/staging` Dockerfile builder base was bumped to `python:3.14.6-slim` (dependabot #2160), but the project is `requires-python = ">=3.12,<3.13"`.

On a 3.14 base, `uv sync` (Dockerfile line ~29) **downloads a managed CPython 3.12 outside `/app`** and symlinks `/app/.venv/bin/python` to it. That symlink **dangles** once `/app` is `COPY`ed into the `ghcr.io/roxabi/base*` runtime stages → `agent-runtime` `uv pip install` fails:

```
error: No virtual environment or system Python installation found for path `/app/.venv/bin/python`
```

**Blast radius:** `docker-build` red on staging + all 14 open PRs, and the **publish pipeline** (gated on build-check) is blocked → no fresh M1 images.

## Fix
- Revert builder base → `python:3.12.10-slim` (known-good; venv symlinks to system python present in the base runtime images).
- Add a dependabot **docker `ignore`** for `python` major/minor so the bump can't recur. Base-image **digest** bumps (`roxabi/base`, `base-svc`) are a different `dependency-name` and stay enabled.
- Inline rationale comment on the `FROM` line for humans.

## Recurrence class
Same family as #2173 (dependabot pip desync) — a dependabot bump silently jams the deploy/publish pipeline. This closes the docker-ecosystem variant at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)