### PR TITLE
fix(dashboard): isolate test files into their own tsc program — close the node-types leak

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "vite",
     "dev:live": "DASHBOARD_MOCK=0 vite",
-    "build": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.test.json --noEmit && vite build",
+    "build": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.test.json --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "lint": "cd ../.. && biome check apps/dashboard",
     "test": "vitest run",
     "astryx": "node node_modules/@astryxdesign/cli/bin/astryx.mjs",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "vite",
     "dev:live": "DASHBOARD_MOCK=0 vite",
-    "build": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
+    "build": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.test.json --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "lint": "cd ../.. && biome check apps/dashboard",
     "test": "vitest run",
     "astryx": "node node_modules/@astryxdesign/cli/bin/astryx.mjs",

--- a/apps/dashboard/src/no-node-ambients.probe.ts
+++ b/apps/dashboard/src/no-node-ambients.probe.ts
@@ -1,0 +1,16 @@
+// Permanent tripwire — do not delete (PR #2184).
+//
+// The browser app program (tsconfig.app.json) must never see Node ambient
+// globals. The test/node programs allow them; the split is enforced only by
+// filename globs, so a stray vitest import from non-test src (or a widened
+// types array) would silently re-open the leak. This file makes that loud:
+// while the app program is clean, `process` is an unresolved name and the
+// directive below suppresses exactly that error. If Node ambients ever leak
+// back in, `process` resolves, the directive becomes unused, and tsc fails
+// with "Unused '@ts-expect-error' directive".
+//
+// This file is only a member of the app program: the test program includes
+// nothing but *.test/*.spec/test-setup, and vitest never executes it.
+
+// @ts-expect-error node ambients must not leak into the browser program (tripwire — see PR #2184)
+export type NodeAmbientTripwire = typeof process;

--- a/apps/dashboard/tsconfig.app.json
+++ b/apps/dashboard/tsconfig.app.json
@@ -1,0 +1,43 @@
+{
+  // NOT an orphan (unlike the stray tsconfig.app.json #2179 deleted): this is
+  // the browser app program, executed via the solution tsconfig.json
+  // `references` and the package.json typecheck/build scripts.
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "types": [],
+    "jsx": "react-jsx",
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"],
+  // Test files import vitest, whose d.ts chain (vitest -> its nested vite
+  // d.ts) carries `/// <reference types="node" />` — keeping them in this
+  // program leaks Node ambient globals (process, Buffer, ...) into the whole
+  // browser-only app program despite `"types": []`. They typecheck in their
+  // own program instead: tsconfig.test.json. (.spec.* excluded too — vitest
+  // executes those, so they must not re-open the leak via this program.)
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test-setup.ts"
+  ]
+}

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,33 +1,21 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "Bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "types": [],
-    "jsx": "react-jsx",
-    "strict": true,
-    "resolveJsonModule": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["src"],
-  // Test files import vitest, whose d.ts chain (vitest -> its nested vite
-  // d.ts) carries `/// <reference types="node" />` — keeping them in this
-  // program leaks Node ambient globals (process, Buffer, ...) into the whole
-  // browser-only app program despite `"types": []`. They typecheck in their
-  // own program instead: tsconfig.test.json.
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts"]
+  // Solution-style config: no files of its own, only project references.
+  // tsserver (VS Code) walks up to the NEAREST tsconfig.json and never probes
+  // sibling tsconfig.*.json files — without this indirection the excluded
+  // test files fall into the editor's inferred project (no @/* paths, no
+  // strict/jsx). References route every file to its real program:
+  //   tsconfig.app.json  — browser-only app program (no Node ambients)
+  //   tsconfig.node.json — vite/vitest config + dev-mock (Node)
+  //   tsconfig.test.json — *.test/*.spec + test-setup (Node ambients OK)
+  // Deliberately NOT composite / `tsc -b`: the test program imports app src
+  // files it does not list, which composite forbids (TS6307) unless the app
+  // project emits declarations — incompatible with noEmit +
+  // allowImportingTsExtensions. CLI stays 3x `tsc -p` (package.json);
+  // references here exist purely so tsserver routes files correctly.
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -23,5 +23,11 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Test files import vitest, whose d.ts chain (vitest -> its nested vite
+  // d.ts) carries `/// <reference types="node" />` — keeping them in this
+  // program leaks Node ambient globals (process, Buffer, ...) into the whole
+  // browser-only app program despite `"types": []`. They typecheck in their
+  // own program instead: tsconfig.test.json.
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts"]
 }

--- a/apps/dashboard/tsconfig.test.json
+++ b/apps/dashboard/tsconfig.test.json
@@ -1,14 +1,21 @@
 {
-  // Test-only tsc program (see tsconfig.json for why tests are split out).
+  // Test-only tsc program (see tsconfig.app.json for why tests are split out).
   // Inherits the app compilerOptions (jsx, DOM lib, @/* paths) — tests render
   // components, so they need the exact same browser surface — but allows Node
   // ambient types: vitest executes under Node, and its d.ts chain references
   // them anyway.
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts", "src/vite-env.d.ts"],
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test-setup.ts",
+    "src/vite-env.d.ts"
+  ],
   // Must reset: the inherited exclude would filter this program's own include.
   "exclude": []
 }

--- a/apps/dashboard/tsconfig.test.json
+++ b/apps/dashboard/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  // Test-only tsc program (see tsconfig.json for why tests are split out).
+  // Inherits the app compilerOptions (jsx, DOM lib, @/* paths) — tests render
+  // components, so they need the exact same browser surface — but allows Node
+  // ambient types: vitest executes under Node, and its d.ts chain references
+  // them anyway.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts", "src/vite-env.d.ts"],
+  // Must reset: the inherited exclude would filter this program's own include.
+  "exclude": []
+}


### PR DESCRIPTION
Follow-up to #2179 (documented residual hole).

## Leak mechanism

`apps/dashboard/tsconfig.json` (app program, `"types": []`) included `src/**/*.test.ts(x)`. Those files import `vitest`, whose d.ts chain — vitest → its own nested vite@7 d.ts — carries `/// <reference types="node" />`. Triple-slash references in library d.ts are honored regardless of the `types` compiler option, so Node ambient globals (`process`, `Buffer`, …) leaked into the **entire** app program via the test files.

## Probe proof

| Step | Probe (`src/lib/__node_leak_probe.ts`: `process.cwd() + Buffer.from("x")` — non-test src file) | `tsc --noEmit` |
|---|---|---|
| Before split | present | **exit 0** (leak) |
| After split | present | **exit 2** — `TS2591: Cannot find name 'process'` + `TS2591: Cannot find name 'Buffer'` (leak closed) |

Probe was scratch-only, not committed (a committed always-failing file would be odd); this table is the verification record.

## Program layout

| Program | Files | `types` |
|---|---|---|
| `tsconfig.json` (app) | `src/**` **minus** `src/**/*.test.ts`, `src/**/*.test.tsx`, `src/test-setup.ts` | `[]` — browser-only |
| `tsconfig.node.json` | `vite.config.ts`, `vitest.config.ts`, `dev-mock/` | `["node"]` |
| `tsconfig.test.json` (new) | `src/**/*.test.ts(x)` + `src/test-setup.ts` + `src/vite-env.d.ts` | `["node"]` — vitest runs under Node; its d.ts references node anyway |

`tsconfig.test.json` extends the app config (same `jsx`, DOM `lib`, `@/*` paths — tests render components) and resets `exclude: []` since the inherited exclude would filter its own include. Both `typecheck` and `build` scripts now chain all three programs (app → node → test); repo-root `build:dashboard` / `typecheck` delegate to the package scripts, so they pick this up automatically.

## Runtime behavior unchanged

Vitest does not read tsconfig program membership to decide what to execute — file selection and the `@/*` alias come from `vitest.config.ts` (`resolve.alias`). Same for vite builds. The split is typecheck-only.

## Verification matrix

| Check | Result |
|---|---|
| `tsc --noEmit` (app) | green |
| `tsc -p tsconfig.node.json --noEmit` | green |
| `tsc -p tsconfig.test.json --noEmit` | green |
| root `bun run typecheck` | green (shared + dashboard exit 0) |
| root `bun run build:dashboard` + `test -f apps/dashboard/dist/index.html` | green |
| `bun run --filter @roxabi-factory/dashboard test` | 135/135 (39 files) |
| `bun run lint` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)