### PR TITLE
ci: merge-queue readiness — merge_group triggers + retire update-behind-prs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,8 +23,6 @@ name: Auto Merge
 on:
   pull_request:
     types: [labeled, synchronize, closed]
-  check_suite:
-    types: [completed]
 
 permissions:
   contents: write

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,16 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (merge commit) once the "reviewed" label is present.
-# GitHub natively waits for all required status checks before merging.
+#
+# Queue flow: "reviewed" label -> `gh pr merge --auto --merge` arms GitHub's
+# native merge-when-ready. With the merge queue enabled on staging, that call
+# ENQUEUES the PR once its PR-level required checks pass; the queue then builds
+# a temporary gh-readonly-queue/staging/* ref (PR merged onto the current queue
+# head), runs the required checks there via the merge_group event (ci.yml +
+# secret-scan.yml both trigger on it), and merges on green.
+#
+# The queue tests freshness itself — no update-branch calls needed. The former
+# "Update branch if behind" step and "update-behind-prs" job (rebase-all-reviewed
+# -PRs-on-every-staging-push) are retired: with strict up-to-date checks off,
+# that churn (67.7% of ALL CI runs pre-#2136) has no purpose.
 #
 # Project convention: merge commits only (¬squash) — see ~/projects/CLAUDE.md
 # "Release Convention". Squash merges flatten the per-commit history that
@@ -15,8 +25,6 @@ on:
     types: [labeled, synchronize, closed]
   check_suite:
     types: [completed]
-  push:
-    branches: [staging, main]
 
 permissions:
   contents: write
@@ -44,63 +52,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # With the merge queue on staging this arms merge-when-ready = enqueue
+      # once PR-level required checks pass. The queue re-validates the actual
+      # merge result on a temporary ref, so no branch-update step is needed.
       - name: Enable auto-merge (merge commit)
         run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      # strict=true requires up-to-date branches, but native auto-merge never
-      # updates them itself. update-behind-prs only covers reviewed PRs on the
-      # NEXT staging push — update immediately so a quiet repo can't strand a
-      # freshly labeled PR. 422 (already up to date) is fine.
-      - name: Update branch if behind
-        run: |
-          gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/update-branch" \
-            --method PUT || true
-        env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-  update-behind-prs:
-    name: Update behind PRs
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    timeout-minutes: 5
-    steps:
-      # roxabi-ci App token (ephemeral, 1 h) — replaces the shared org PAT: its pushes
-      # re-trigger CI and it can merge workflow-file PRs, which GITHUB_TOKEN cannot.
-      - name: Mint app token (roxabi-ci)
-        id: app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
-        with:
-          app-id: ${{ vars.ROXABI_CI_APP_ID }}
-          private-key: ${{ secrets.ROXABI_CI_APP_PRIVATE_KEY }}
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      # Only merge-ready (reviewed) PRs: updating ALL open PRs edit-poisons
-      # dependabot PRs (dependabot refuses to update/supersede/close a PR edited
-      # by someone else → zombie PRs re-CI'd on every staging push; 67% of all
-      # workflow runs in the 2026-06/07 window) and churns human WIP branches.
-      - name: Update reviewed PRs targeting this branch
-        run: |
-          BRANCH="${GITHUB_REF_NAME}"
-          PRS=$(gh pr list --base "$BRANCH" --state open --label reviewed --json number,headRefOid,isDraft --jq '.[] | select(.isDraft | not)')
-          if [ -z "$PRS" ]; then
-            echo "No open reviewed PRs targeting $BRANCH"
-            exit 0
-          fi
-          echo "$PRS" | while IFS= read -r pr; do
-            NUM=$(echo "$pr" | jq -r .number)
-            SHA=$(echo "$pr" | jq -r .headRefOid)
-            echo "Updating PR #$NUM..."
-            gh api "repos/${{ github.repository }}/pulls/$NUM/update-branch" \
-              --method PUT -f expected_head_sha="$SHA" || true
-          done
-        env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
 
   close-linked-issues:
     name: Close linked issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ env:
 concurrency:
   group: ci-${{ github.ref }}
   # Cancel only on feature branches; protected branches (main, staging) run to completion so every merge-commit SHA has a recorded status.
-  # Merge-queue refs (gh-readonly-queue/staging/*) evaluate as cancelable here —
-  # fine: each queue entry gets a unique ref (unique group), and a rebuilt entry
-  # gets a NEW ref, so cancel-in-progress never preempts a live entry's run.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/staging' }}
+  # merge_group runs are NEVER cancelled: GitHub advises against cancelling
+  # queue runs — a cancelled run fails the entry and silently dequeues the PR,
+  # and ref uniqueness doesn't cover a dequeue→re-enqueue that rebuilds an
+  # entry on the identical queue head (same ref → same group → preemption).
+  cancel-in-progress: ${{ github.event_name != 'merge_group' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/staging' }}
 
 jobs:
   # 3-way split of the former monolithic `ci` job (~4m50 serial → ~2m45 wall):
@@ -255,6 +256,12 @@ jobs:
   # never wire a typing publisher; the disabled branch is unit-covered
   # (tests/core/test_pool_processor_exec.py, tests/adapters/*/test_typing_shims.py).
   integration:
+    # Queue entries don't need this: non-required, and staging-red-alert reads
+    # push runs only — a red here blocks nothing and alerts nobody, it's just
+    # duplicate compute (up to 5 concurrent queue builds).
+    # WARNING: drop this `if:` if the job ever becomes a required check — a
+    # skipped required check deadlocks the queue.
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -283,6 +290,12 @@ jobs:
     # Runs in parallel with ci/integration (no needs:).
     # Does NOT push. Uses CI-scoped GHA cache (factory-agent-ci / factory-svc-ci)
     # so it never pollutes the publish job's factory-agent / factory-svc scopes.
+    # Queue entries don't need this: non-required, and staging-red-alert reads
+    # push runs only — a red here blocks nothing and alerts nobody, it's just
+    # duplicate compute (up to 5 concurrent queue builds).
+    # WARNING: drop this `if:` if the job ever becomes a required check — a
+    # skipped required check deadlocks the queue.
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+  # Merge queue entries run CI on temporary gh-readonly-queue/staging/* refs.
+  # The required "ci" context MUST report on merge_group or every queue entry
+  # times out (repo-wide merge deadlock).
+  merge_group: {}
   workflow_dispatch: {}  # dispatch resolves from default branch — per-branch re-triggers require the branch to contain a compatible ci.yml
 
 # Single declaration site: the installer step is duplicated in the tests and
@@ -19,6 +23,9 @@ env:
 concurrency:
   group: ci-${{ github.ref }}
   # Cancel only on feature branches; protected branches (main, staging) run to completion so every merge-commit SHA has a recorded status.
+  # Merge-queue refs (gh-readonly-queue/staging/*) evaluate as cancelable here —
+  # fine: each queue entry gets a unique ref (unique group), and a rebuilt entry
+  # gets a NEW ref, so cancel-in-progress never preempts a live entry's run.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/staging' }}
 
 jobs:
@@ -84,8 +91,9 @@ jobs:
         env:
           # PR-only: honor gates' files: filters against the merge-base diff
           # (origin/<base> exists thanks to fetch-depth: 0). Empty on push to
-          # staging/main, workflow_dispatch, or any future merge_group event →
-          # scripts/qg fails OPEN and runs ALL gates (previous behavior).
+          # staging/main, workflow_dispatch, and merge_group (queue entries) →
+          # scripts/qg fails OPEN and runs ALL gates — intentional: queue runs
+          # validate the full merge result, not a diff-scoped subset.
           QG_DIFF_RANGE: ${{ github.event_name == 'pull_request' && format('origin/{0}...HEAD', github.base_ref) || '' }}
         run: scripts/qg run --stage ci
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,7 +8,7 @@
 #
 # Cascade: dependabot opens PR -> (patch|minor) -> add `reviewed` label via PAT ->
 #   PAT-applied label fires auto-merge.yml `labeled` event -> arms GitHub auto-merge
-#   -> update-behind-prs keeps it current on each staging push -> merges when green.
+#   -> merge queue validates the merge result on a temporary ref -> merges when green.
 # Major bumps are NOT labelled -> they wait for human review.
 name: Dependabot Auto-merge
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -11,6 +11,7 @@ on:
   # Merge queue entries run checks on temporary gh-readonly-queue/staging/*
   # refs. The required "trufflehog" context MUST report on merge_group or
   # every queue entry times out (repo-wide merge deadlock).
+  # On merge_group the action's BASE/HEAD autodetection has no branch → empty args → trufflehog scans FULL history (~13s): strictly more coverage than a diff scan, not less.
   merge_group: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -8,6 +8,10 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+  # Merge queue entries run checks on temporary gh-readonly-queue/staging/*
+  # refs. The required "trufflehog" context MUST report on merge_group or
+  # every queue entry times out (repo-wide merge deadlock).
+  merge_group: {}
   workflow_dispatch: {}
 
 concurrency:

--- a/docs/ops/pr-automation.md
+++ b/docs/ops/pr-automation.md
@@ -3,39 +3,54 @@
 ## Overview
 
 `roxabi-factory` auto-merges PRs via two workflows: `.github/workflows/auto-merge.yml` (the
-merge/rebase/close machinery) and `.github/workflows/dependabot-automerge.yml` (auto-labels
+merge/close machinery) and `.github/workflows/dependabot-automerge.yml` (auto-labels
 Dependabot PRs so they enter that machinery). Both mint a short-lived `roxabi-ci` GitHub App
 token rather than using `GITHUB_TOKEN` or a shared PAT.
 
 The whole thing keys off one label: **`reviewed`** (`#0075ca`, "Code reviewed and approved") —
 not `viewed` (a different, similarly-named label used elsewhere for acknowledgement).
 
+Merging goes through GitHub's **merge queue** on `staging`, enabled via the "staging merge
+queue" repository ruleset (a ruleset, not branch protection). Flow: `reviewed` label → arm
+merge-when-ready → the PR **enqueues** once its PR-level required checks pass → the queue
+builds a temporary `gh-readonly-queue/staging/*` ref (the PR merged onto the current queue
+head), re-runs the required checks there via the `merge_group` event (`ci.yml` and
+`secret-scan.yml` both trigger on it), and lands the merge commit on green.
+
 ## `auto-merge.yml`
 
 | Job | Trigger | What it does |
 |---|---|---|
-| `auto-merge` | PR `labeled` / `synchronize` / `closed` (`check_suite` also listed in YAML but **inert** for GHA-origin suites — GitHub suppresses the workflow when the suite was created by Actions; `github.event.pull_request.labels` is empty on `check_suite` anyway) | If the PR carries `reviewed`, runs `gh pr merge --auto --merge` (merge commit — squash is forbidden project-wide, see `~/projects/ssot/conventions.ssot.md`). Arms GitHub's native auto-merge; it fires once required checks go green. **Arming is driven by `labeled` + `synchronize` in practice.** |
-| `update-behind-prs` | `push` to `staging`/`main` | Rebases every open **non-draft** PR targeting that branch via the `update-branch` API (additive merge-update, not a force-push). Runs on ALL open non-draft PRs, not just `reviewed` ones, so PRs don't rot as BEHIND while waiting for review. |
+| `auto-merge` | PR `labeled` / `synchronize` / `closed` | If the PR carries `reviewed`, runs `gh pr merge --auto --merge` (merge commit — squash is forbidden project-wide, see `~/projects/ssot/conventions.ssot.md`). Arms GitHub's merge-when-ready: the PR enqueues as soon as its PR-level required checks pass; the queue does the rest. |
 | `close-linked-issues` | PR `closed` + merged | Closes `Closes #N` references in the PR body — `GITHUB_TOKEN`-initiated auto-merges don't trigger GitHub's native issue-closing behavior, so this job does it explicitly. |
 
-Branch protection on `staging`: `required_status_checks` = `ci` + `trufflehog` (strict/up-to-date
-required), `enforce_admins: false`, and **no required PR review count** — merge only needs the
-`reviewed` label + green required checks + an up-to-date branch. `main` requires the `/promote`
-flow instead (see `~/projects/ssot/conventions.ssot.md`).
+The former update-behind-prs job (rebase every open non-draft PR on every `staging`/`main`
+push) is **retired**: the queue validates each entry as the *actual merge result* against the
+queue head, so freshness is the queue's job now — no update-branch churn (that fan-out was
+67.7% of ALL CI runs pre-#2136).
 
-### `gh pr merge --auto` clean-status race
+Branch protection on `staging`: `required_status_checks` = `ci` + `trufflehog` with
+`strict: false` — the queue owns freshness, so up-to-date branches are **no longer** required
+at merge time — `enforce_admins: false`, and **no required PR review count**: merge only needs
+the `reviewed` label + green required checks. `main` requires the `/promote` flow instead (see
+`~/projects/ssot/conventions.ssot.md`).
 
-If a PR is **already fully green** at the moment `reviewed` is applied, `gh pr merge --auto
---merge` errors ("Pull request is in clean status, nothing to wait for") and the PR does **not**
-merge — the job goes red, the PR shows `UNSTABLE`, `autoMerge` stays off. Only PRs that still had
-a check in flight at label-time arm and merge automatically. Labelling several PRs in the same
-batch: expect only one to merge outright.
+### Queue stalls: a flaky red dequeues the PR
 
-**Recovery:** re-run `gh pr merge <N> --auto --merge` manually. Once the first merge lands on
-`staging`, the remaining PRs become `BEHIND` (no longer "clean"), so `--auto` arms cleanly on
-them and `update-behind-prs` rebases them — the cascade self-sustains until all are merged.
-Plain `gh pr merge --merge` (no `--auto`) is rejected by branch protection while a PR is BEHIND
-("base branch policy prohibits the merge"); always use `--auto`, not `--admin`.
+If a queue entry goes red (flaky test, transient infra), GitHub **dequeues the PR and disarms
+merge-when-ready**. The PR then sits indefinitely with green PR-level checks and the
+`reviewed` label still applied — nothing retries it automatically, and no workflow goes red on
+the PR itself (the failure lives on the temporary queue ref's run).
+
+**Recovery:** re-arm with `gh pr merge <N> --auto --merge`, or remove + re-add the `reviewed`
+label (the `labeled` event re-fires the `auto-merge` job, which re-arms). Either path
+re-enqueues the PR.
+
+**Rollback (queue off):** delete the "staging merge queue" ruleset
+(`gh api repos/Roxabi/roxabi-factory/rulesets/<id> --method DELETE`) and restore
+`strict: true` on the `staging` branch protection — the `merge_group:` triggers in
+`ci.yml`/`secret-scan.yml` are inert without a queue, so that restores pre-queue behavior
+exactly.
 
 ## `dependabot-automerge.yml`
 
@@ -75,6 +90,7 @@ auto-labelled** — they wait for human review.
 ## Troubleshooting
 
 If a human-authored PR "won't merge" despite green CI: check for the `reviewed` label — that's
-the only merge gate on `staging`. If a Dependabot PR is stuck: check its update-type (majors are
-never auto-labelled) and whether it landed *before* the current version of
-`dependabot-automerge.yml`.
+the only merge gate on `staging`. If the label is on and the PR is green but neither queued nor
+merging, it was probably dequeued by a red queue entry — see § Queue stalls above. If a
+Dependabot PR is stuck: check its update-type (majors are never auto-labelled) and whether it
+landed *before* the current version of `dependabot-automerge.yml`.


### PR DESCRIPTION
Prepares the workflows for a GitHub merge queue on `staging`. The queue itself is enabled **after** this PR merges (see post-merge checklist). This PR only makes the required checks queue-ready and removes the machinery the queue replaces.

## Mechanics

With a merge queue, `gh pr merge --auto --merge` (fired by the `reviewed` label) **enqueues** the PR once its PR-level required checks pass. The queue then merges the PR onto the current queue head on a temporary `gh-readonly-queue/staging/...` ref and runs the required checks there via a `merge_group:` event. Required checks that do not report on `merge_group` time out **every** queue entry — a repo-wide merge deadlock. Hence the trigger additions below.

The queue tests freshness itself (each entry is validated as the actual merge result against the queue head), so branch-update machinery and `strict` up-to-date checks become obsolete.

## Checks × events matrix

| Check context | Workflow / job | `pull_request` | `merge_group` | `push` (staging) | Required? |
|---|---|---|---|---|---|
| `ci` | `ci.yml` → aggregate job `ci` (needs gates/tests/package-coverage) | ✅ | ✅ **(added)** | ✅ | **yes** |
| `trufflehog` | `secret-scan.yml` → job `trufflehog` | ✅ | ✅ **(added)** | ✅ | **yes** |
| `pr-title` | `pr-title.yml` | ✅ | — | — | no (PR-level, not required → no merge_group needed) |
| integration / docker-build | `ci.yml` (non-required jobs) | ✅ | ✅ (same workflow) | ✅ | no |

Notes:
- Both required job ids (`ci`, `trufflehog`) are **unchanged** — zero branch-protection edits needed for the contexts themselves.
- No job in either workflow has an `if:` keyed on event type — nothing skips on `merge_group` (the aggregate `ci` job's `if: always()` is orthogonal).
- `QG_DIFF_RANGE` stays `pull_request`-only → merge_group runs **ALL** gates (fail-open by design: queue runs validate the full merge result, not a diff-scoped subset). Comment updated in `ci.yml`.
- Concurrency: `ci-${{ github.ref }}` is unique per queue entry; the cancel-in-progress expression treats queue refs as cancelable, which is safe — a rebuilt queue entry gets a **new** ref, so no live entry's run is ever preempted. Comment added.
- `publish.yml` / `staging-red-alert.yml` gate on `workflow_run.event == 'push'` → merge_group-triggered CI completions are correctly ignored; the queue's final merge is still a push to staging, so the publish path is unchanged.
- `dependabot-automerge.yml` only applies the `reviewed` label (queue-compatible as-is); its cascade comment was updated (comment-only change).

## Removed from auto-merge.yml, and why

1. **"Update branch if behind" step** (auto-merge job) — existed only because `strict=true` requires up-to-date branches and native auto-merge never updates them. The queue validates the merge result itself; strict goes off post-merge.
2. **Entire `update-behind-prs` job + its `push: [staging, main]` trigger** — rebased every reviewed PR on every staging push. This edit-poisoning fan-out was **67.7% of ALL CI runs** pre-#2136 (dependabot refuses to update/supersede PRs edited by someone else → zombie PRs re-CI'd on every push). The queue makes the entire pattern obsolete. The `push` trigger fed only this job (`close-linked-issues` keys on `pull_request closed` + merged), so it goes too.

Kept: `reviewed` label → `gh pr merge --auto --merge` (= enqueue once a queue exists) and `close-linked-issues`.

~~Observed but left as-is (possible follow-up)~~ **Dropped in the review-fix commit:** the `check_suite: [completed]` trigger produced runs whose jobs could never match their `if:` conditions (no `pull_request` in payload) — dead weight, removed while the `on:` block was already under surgery.

## Post-merge enablement (orchestrator)

1. Create a repository ruleset enabling the merge queue on `refs/heads/staging`:

```bash
gh api repos/Roxabi/roxabi-factory/rulesets --method POST --input - <<'EOF'
{
  "name": "staging merge queue",
  "target": "branch",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["refs/heads/staging"], "exclude": [] } },
  "rules": [
    {
      "type": "merge_queue",
      "parameters": {
        "merge_method": "MERGE",
        "max_entries_to_build": 5,
        "min_entries_to_merge": 1,
        "max_entries_to_merge": 5,
        "min_entries_to_merge_wait_minutes": 5,
        "grouping_strategy": "ALLGREEN",
        "check_response_timeout_minutes": 30
      }
    }
  ]
}
EOF
```

> **Flip-order window (expected, self-healing):** between step 1 (ruleset created) and step 2 (strict still `true`), PRs that are BEHIND `staging` may refuse to enqueue — the strict up-to-date requirement is still enforced at enqueue time. This clears on its own the moment step 2 lands; no branch updates needed.

2. Turn off strict up-to-date on staging branch protection, keeping required contexts `ci`,`trufflehog` unchanged:

```bash
gh api repos/Roxabi/roxabi-factory/branches/staging/protection/required_status_checks \
  --method PATCH -F strict=false
```

3. Verify: `gh api repos/Roxabi/roxabi-factory/branches/staging/protection --jq '.required_status_checks'` → `{"strict": false, "contexts": ["ci", "trufflehog"]}`.

## Rollback

Delete the ruleset (`gh api repos/Roxabi/roxabi-factory/rulesets/<id> --method DELETE`) + `PATCH strict=true` restores today's behavior exactly — this PR's `merge_group:` triggers are inert without a queue, and the retired update-branch machinery can be restored by reverting the merge commit if ever needed.

## Ordering

Merges **after** sibling `perf/ci-resilience` — both touch `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

