### PR TITLE
fix(ci): docker-build must run on merge_group (now a required check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,12 +335,9 @@ jobs:
     # Runs in parallel with ci/integration (no needs:).
     # Does NOT push. Uses CI-scoped GHA cache (factory-agent-ci / factory-svc-ci)
     # so it never pollutes the publish job's factory-agent / factory-svc scopes.
-    # Queue entries don't need this: non-required, and staging-red-alert reads
-    # push runs only — a red here blocks nothing and alerts nobody, it's just
-    # duplicate compute (up to 5 concurrent queue builds).
-    # WARNING: drop this `if:` if the job ever becomes a required check — a
-    # skipped required check deadlocks the queue.
-    if: github.event_name != 'merge_group'
+    # docker-build is a REQUIRED check (added post python:3.14 incident, where an
+    # advisory red merged and broke staging publish) — it MUST run on merge_group:
+    # a skipped required check deadlocks every queue entry (30-min timeout each).
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Problem

`docker-build` became a **required** staging context between #2186's review (which verified required = ci + trufflehog) and the queue enablement. #2186's `if: github.event_name != 'merge_group'` on it — correct while advisory — would deadlock every queue entry (skipped required check → 30-min timeout each), the exact scenario its own warning comment describes.

## Fix

- Drop the merge_group skip on `docker-build` (runs on queue entries; comment explains it's required post python:3.14 incident).
- Keep the skip on `integration` (still non-required, red-alert reads push runs only).

## Ops sequencing (already done)

`docker-build` was temporarily removed from required contexts so this PR can merge through the fresh queue; it gets re-added immediately after this merges. This PR is also the queue's first live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)