### PR TITLE
docs(ops): sync pr-automation for Renovate + merge queue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ feature/fix branch → PR → staging → (promote) → main
 1. Create a branch from `staging` with a descriptive name: `feat/discord-voice`, `fix/pool-lock-timeout`
 2. Open a PR targeting `staging`
 3. Pass CI (lint, typecheck, tests)
-4. Merge — auto-merge is enabled once a PR carries the `reviewed` label (no PR review count is required on `staging`); see [docs/ops/pr-automation.md](docs/ops/pr-automation.md) for the full mechanism (label gate, Dependabot auto-labelling, rebase-on-push)
+4. Merge — auto-merge is enabled once a PR carries the `reviewed` label (no PR review count is required on `staging`); see [docs/ops/pr-automation.md](docs/ops/pr-automation.md) for the full mechanism (label gate, Renovate auto-labelling, merge queue)
 
 ## Commit conventions
 

--- a/docs/ops/pr-automation.md
+++ b/docs/ops/pr-automation.md
@@ -3,9 +3,13 @@
 ## Overview
 
 `roxabi-factory` auto-merges PRs via two workflows: `.github/workflows/auto-merge.yml` (the
-merge/close machinery) and `.github/workflows/dependabot-automerge.yml` (auto-labels
-Dependabot PRs so they enter that machinery). Both mint a short-lived `roxabi-ci` GitHub App
+merge/close machinery) and `.github/workflows/renovate-automerge.yml` (auto-labels Renovate
+dependency PRs so they enter that machinery). Both mint a short-lived `roxabi-ci` GitHub App
 token rather than using `GITHUB_TOKEN` or a shared PAT.
+
+Dependency bumps are handled by **Renovate** (`.github/renovate.json`) — uv/pep621, bun,
+dockerfile, and github-actions, with `uv.lock` regen in the same PR and a global
+`minimumReleaseAge` of 3 days. Dependabot version updates were removed (#2188).
 
 The whole thing keys off one label: **`reviewed`** (`#0075ca`, "Code reviewed and approved") —
 not `viewed` (a different, similarly-named label used elsewhere for acknowledgement).
@@ -29,11 +33,11 @@ push) is **retired**: the queue validates each entry as the *actual merge result
 queue head, so freshness is the queue's job now — no update-branch churn (that fan-out was
 67.7% of ALL CI runs pre-#2136).
 
-Branch protection on `staging`: `required_status_checks` = `ci` + `trufflehog` with
-`strict: false` — the queue owns freshness, so up-to-date branches are **no longer** required
-at merge time — `enforce_admins: false`, and **no required PR review count**: merge only needs
-the `reviewed` label + green required checks. `main` requires the `/promote` flow instead (see
-`~/projects/ssot/conventions.ssot.md`).
+Branch protection on `staging`: `required_status_checks` = `ci` + `trufflehog` +
+`docker-build` with `strict: false` — the queue owns freshness, so up-to-date branches are
+**no longer** required at merge time — `enforce_admins: false`, and **no required PR review
+count**: merge only needs the `reviewed` label + green required checks. `main` requires the
+`/promote` flow instead (see `~/projects/ssot/conventions.ssot.md`).
 
 ### Queue stalls: a flaky red dequeues the PR
 
@@ -52,45 +56,40 @@ re-enqueues the PR.
 `ci.yml`/`secret-scan.yml` are inert without a queue, so that restores pre-queue behavior
 exactly.
 
-## `dependabot-automerge.yml`
+## `renovate-automerge.yml`
 
-Dependabot PRs only get the `dependencies` (and, for GitHub Actions bumps, `ci`) label from
-`.github/dependabot.yml` — never `reviewed` — so left alone they never enter the `auto-merge`
-job and (pre-fix) never got rebased either, causing a pileup of unmergeable BEHIND PRs.
+Renovate PRs only get the `dependencies` (and, for GitHub Actions bumps, `ci`) label from
+`.github/renovate.json` — never `reviewed` — so left alone they never enter the merge queue.
 
-The fix is a `pull_request_target` workflow (`opened`/`reopened`/`synchronize`, guarded to
-`github.actor == 'dependabot[bot]'`) that runs `dependabot/fetch-metadata` and, for
-`version-update:semver-{patch,minor}` bumps (including grouped `minor-and-patch` PRs), adds the
-`reviewed` label. That label add fires the `labeled` event on `auto-merge.yml`, which arms
-GitHub's native auto-merge — merge happens only if CI is actually green. **Major bumps are never
-auto-labelled** — they wait for human review.
+The fix is a `pull_request_target` workflow (`opened`/`reopened`, guarded to
+`github.actor == 'renovate[bot]'`) that adds the `reviewed` label when the PR does **not**
+carry the `major` label (Renovate applies `major` via `packageRules` for semver-major bumps).
+That label add fires the `labeled` event on `auto-merge.yml`, which arms merge-when-ready —
+the PR enqueues only if CI is actually green. **Major bumps are never auto-labelled** — they
+wait for human review.
+
+**Satellites** (`voiceCLI`, `imageCLI`, `llmCLI`) use the same pattern with one extra guard:
+PRs labelled `roxabi-sdk` (grouped `git-refs` bumps for `roxabi-contracts` / `roxabi-nats` /
+`roxabi-blobs`) are **not** auto-labelled — wire/SDK freshness stays human-gated. See
+`packages/roxabi-contracts/README.md` § Satellite pin freshness.
 
 **Load-bearing details:**
 
-- `pull_request_target` is required, not plain `pull_request`: Dependabot-triggered runs on a
-  plain `pull_request` trigger only receive Dependabot's own restricted secret set, not repo
-  Actions secrets — the App token mint would fail. `pull_request_target` runs in base-repo
-  context with full Actions secrets. This is safe here specifically because the workflow never
-  checks out or executes PR-authored code — it only reads Dependabot metadata via the API and
-  applies a label.
-- The label must be applied by a real-actor token (the `roxabi-ci` App token here — historically
-  a shared PAT, migrated off in the 2026-06 secrets overhaul), **not** the default
-  `GITHUB_TOKEN`: labels applied by `GITHUB_TOKEN` do not trigger downstream `labeled`-event
-  workflows, so the `auto-merge.yml` cascade would silently never fire.
-- `fetch-metadata`'s `update-type` output correctly resolves Dependabot's *grouped* pip PRs
-  (`dependabot.yml` groups `minor-and-patch` updates) — `maxSemver()` across the group still
-  yields `patch`/`minor` when appropriate, so grouped PRs still get labelled.
-- The automation only takes effect starting with the **next** Dependabot PR opened after the
+- `pull_request_target` runs in base-repo context with full Actions secrets. This is safe here
+  because the workflow never checks out or executes PR-authored code — it only applies a label.
+- The label must be applied by a real-actor token (the `roxabi-ci` App token), **not** the
+  default `GITHUB_TOKEN`: labels applied by `GITHUB_TOKEN` do not trigger downstream
+  `labeled`-event workflows, so the `auto-merge.yml` cascade would silently never fire.
+- The automation only takes effect starting with the **next** Renovate PR opened after the
   workflow itself changes: `pull_request_target` always runs the workflow definition from the
   base branch, so a PR that modifies this workflow can't self-test against its own diff.
-- CI is the actual safety gate, not the label: a labelled PR with a breaking bump still needs
-  green `ci`/`trufflehog` to merge (e.g. a `typer` 0.26 minor bump that broke two tests stayed
-  open despite being labelled).
+- CI (+ `docker-build` on factory) is the actual safety gate, not the label: a labelled PR with
+  a breaking bump still needs green required checks to merge.
 
 ## Troubleshooting
 
 If a human-authored PR "won't merge" despite green CI: check for the `reviewed` label — that's
 the only merge gate on `staging`. If the label is on and the PR is green but neither queued nor
-merging, it was probably dequeued by a red queue entry — see § Queue stalls above. If a
-Dependabot PR is stuck: check its update-type (majors are never auto-labelled) and whether it
-landed *before* the current version of `dependabot-automerge.yml`.
+merging, it was probably dequeued by a red queue entry — see § Queue stalls above. If a Renovate
+PR is stuck: check for the `major` label (never auto-labelled on factory) or `roxabi-sdk` on
+satellites; also whether it landed *before* the current version of `renovate-automerge.yml`.

--- a/docs/ops/quality-gates.md
+++ b/docs/ops/quality-gates.md
@@ -77,9 +77,10 @@ Before a **deploy PR**, `scripts/qg run --stage pre-push` or `make qg` is suffic
 
 Explicit steps in `.github/workflows/ci.yml` after the QG bundle:
 
+- `uv lock --check` in the `gates` job (pyproject.toml ↔ `uv.lock` desync tripwire; #2173)
 - Gate self-tests (`tests/tools/test_check_*.sh`, `tests/scripts/test_qg.sh`)
 - Dashboard Playwright e2e, package coverage thresholds
-- Jobs `integration`, `docker-build`
+- Jobs `integration`, `docker-build` (`docker-build` is a required check on `staging`)
 
 ACL scanners (`acl_matrix_retired`, `request_reply_flows`, `acl_grants`, `inbox_prefix`, `subject_literals`) are declared in `stack.yml` and run inside `qg run --stage ci`.
 


### PR DESCRIPTION
Stale dependabot references → Renovate, docker-build required, uv lock --check, satellite roxabi-sdk.