### PR TITLE
docs(contracts): unblock SDK tag-cutting — placeholder pins, CHANGELOG backfill, unified pin doctrine (#2199)

### DIFF
--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -86,8 +86,9 @@ Notable recent moves:
 The runtime dependency set is Pydantic only — `nats-py` never enters via this package, not even
 through its `[testing]` extra (transport-dependent testing moved to `roxabi-nats[testing]`).
 External consumers pin both SDK packages by git tag (`roxabi-nats/vX.Y.Z`) with a grouped
-Renovate rule so transport and schemas upgrade in lockstep; branch pinning is forbidden in
-production satellites.
+Renovate rule so transport and schemas upgrade in lockstep; branch pinning these two is forbidden
+in production satellites. The one sanctioned branch pin — the `roxabi-satellite` aggregator — and
+its rationale are in the Pin doctrine section below.
 
 → ADR-049
 
@@ -213,6 +214,53 @@ change, enumerate every producer per direction (in-repo vs. satellite), every st
 model that carries that field, and extend subject→envelope enforcement tests when adding
 work-plane fields. This enumeration is the actual gate — spec review alone has missed it before.
 
+## Pin doctrine (external consumers)
+
+One doctrine, one documented exception. This section is the SSoT; the package
+READMEs and the invariant below point here rather than restating it.
+
+**Default — pin the wire-contract SDK by tag.** External consumers pin
+`roxabi-nats` and `roxabi-contracts` by git **tag** (`roxabi-nats/vX.Y.Z`,
+`roxabi-contracts/vX.Y.Z`), grouped in a single Renovate `git-refs` rule
+(`groupName: "roxabi sdk"`) so transport and schemas move in lockstep. Branch
+pinning these two is **forbidden** in `staging`/`main` of any production
+satellite (permitted only in plugin-dev branches, per ADR-045). Rationale: a
+branch pin lets the wire `CONTRACT_VERSION` shift under a consumer with no
+coordinated version bump, and ungrouped tag pins can drift into a **partial
+upgrade** (schemas bumped, transport stale) that fails at envelope-parse time —
+the grouped tag rule is what prevents both.
+
+**Exception — the `roxabi-satellite` aggregator may pin `branch = "staging"`.**
+A CLI that consumes plumbing depends on `roxabi-satellite` *only* and receives
+`roxabi-contracts`, `roxabi-nats`, and `roxabi-blobs` transitively. This is
+sanctioned because:
+
+- `roxabi-satellite` is **plumbing, not the wire contract** — its surface is
+  validation/replies/blob-token helpers, not the `CONTRACT_VERSION` boundary.
+- Branch-tracking the aggregator **cannot produce a partial upgrade** — the
+  hazard the tag rule exists to prevent. All three SDK packages resolve from
+  the *same* staging commit (workspace deps), so the consumer always gets an
+  internally-consistent triple, never a schemas-ahead-of-transport skew.
+- `roxabi-satellite` (and `roxabi-blobs`) are pre-1.0 and **not yet
+  tag-released** (no `roxabi-satellite/*` tags exist); branch-tracking lets
+  plumbing fixes propagate without a manual repin per ADR-082.
+
+This is a bounded carve-out: once `roxabi-satellite` starts cutting tags it
+folds back into the default tag rule. Consumers must never branch-pin
+`roxabi-nats`/`roxabi-contracts` **directly** to dodge the tag rule — only the
+aggregator is branch-pinnable.
+
+**Release reminder (no gate).** Every `version =` bump in either wire-contract
+package's `pyproject.toml` MUST be followed by cutting the matching
+`<pkg>/vX.Y.Z` tag in the same release (post-merge on `staging`, or via
+`/promote`). A pyproject that is ahead of the newest tag is exactly what breaks
+external `uv add` resolution (issue #2199). This is a **release-runbook
+reminder, not a quality gate**: tags are cut post-merge, so at PR time the
+pyproject is legitimately ahead of the tag — a `version == latest-tag` gate
+would red every version-bump PR, which is the wrong shape. The proportionate
+control is this line plus the [Unreleased] "tag pending" note each package's
+CHANGELOG carries until its tag is cut.
+
 ## Key invariants
 
 - All cross-project NATS schemas and subject strings live in `packages/roxabi-contracts/`; none are re-implemented in satellite repos, and subjects are frozen `Literal`-typed constants (no inline f-string subject construction outside the contracts per-worker helpers).
@@ -220,7 +268,7 @@ work-plane fields. This enumeration is the actual gate — spec review alone has
 - `roxabi-contracts` runtime has zero transport dependency; transport-coupled test doubles enter only via `roxabi-nats[testing]`.
 - Test doubles are guarded against production contamination: extras gate, `assert_not_production` environment assertion, `assert_loopback_url` NATS URL check.
 - Satellite domain engines stay in satellite repos; only plumbing (validation, replies, blob/token/envelope helpers) may move into `roxabi-satellite`.
-- External consumers pin `roxabi-nats` and `roxabi-contracts` by tag with the grouped Renovate rule; branch pinning is forbidden in `staging`/`main` of any production satellite.
+- External consumers pin `roxabi-nats` and `roxabi-contracts` by tag with the grouped Renovate rule; branch pinning these two is forbidden in `staging`/`main` of any production satellite. The sole exception — branch-pinning the `roxabi-satellite` aggregator — is defined in the Pin doctrine section (partial-upgrade-safe, pre-tag plumbing).
 - Hub-side clients route exclusively via registry-scored per-worker subjects through `WorkerPoolClient`; queue-group fallback routing is forbidden.
 - No exceptions cross the transport boundary: transport methods return `Result`, and `SanitizedError.message` carries the exception type name only, never `str(exc)`.
 - Domain clients composing `WorkerPoolClient` must not add a second circuit-breaker.

--- a/packages/roxabi-contracts/CHANGELOG.md
+++ b/packages/roxabi-contracts/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.13.0] (2026-06-29)
+
+### Features
+
+* **contracts/fleet:** add `fleet` domain submodule — container/fleet observability models + `factory.fleet.*` subjects for the dashboard `/fleet` view (roxabi-obs) ([aa2e79e](https://github.com/Roxabi/roxabi-factory/commit/aa2e79e72)). Additive minor: new submodule, no change to existing domains.
+* **contracts/dashboard:** extend the `dashboard` domain submodule (models + one new subject) for fleet observability wiring.
+
+
+## [0.12.0] (2026-06-28)
+
+### Features
+
+* **contracts/voice:** add `VoiceLifecycleRequest` / `VoiceLifecycleResponse` and the `factory.voice.*.lifecycle.>` subject subtree for worker lifecycle control ([0cb9126](https://github.com/Roxabi/roxabi-factory/commit/0cb912641)). Additive minor; ACL specs regenerated for the new subjects.
+
+
 ## [0.11.0] (2026-06-11)
 
 ### Features

--- a/packages/roxabi-contracts/README.md
+++ b/packages/roxabi-contracts/README.md
@@ -9,9 +9,19 @@ Shared Pydantic schemas for Lyra cross-project NATS contracts. Per-domain submod
 roxabi-contracts = {
   git = "https://github.com/Roxabi/roxabi-factory.git",
   subdirectory = "packages/roxabi-contracts",
-  tag = "roxabi-contracts/v0.1.0"
+  tag = "roxabi-contracts/vX.Y.Z"  # pick a real tag — see below
 }
 ```
+
+Resolve the latest released tag (never hardcode one that may not exist):
+
+```bash
+git ls-remote --tags https://github.com/Roxabi/roxabi-factory.git 'roxabi-contracts/*'
+# or, in a local clone:
+git tag -l 'roxabi-contracts/*' | sort -V | tail -1
+```
+
+Pin by **tag**, not branch — see [Pin doctrine](../../docs/architecture/contracts.md#pin-doctrine-external-consumers).
 
 ## Satellite pin freshness (Renovate)
 
@@ -48,11 +58,9 @@ Renovate reads the `tag = "..."` pin in `[tool.uv.sources]`, observes a newer ta
 
 ## Public API contract
 
-The stable external contract is defined by `__all__` in `roxabi_contracts/__init__.py`. v0.1.0 ships:
+The stable external contract is the set of names in `__all__` in `roxabi_contracts/__init__.py` — the source is the SSoT, so this README does not freeze a copy (run `grep __all__ src/roxabi_contracts/__init__.py`). `ContractEnvelope` is the base Pydantic model every per-domain schema subclasses.
 
-- `ContractEnvelope` — base Pydantic model for all per-domain contract schemas
-
-Future domain submodules (voice, image, memory, llm) arrive in subsequent tags. See ADR-049 §Versioning for SemVer rules.
+Per-domain submodules (voice, jobs, image, memory, llm, …) each expose their own `SUBJECTS` + models and land as new submodules under a minor version bump. See ADR-049 §Versioning for SemVer rules.
 
 ## Voice domain
 

--- a/packages/roxabi-nats/CHANGELOG.md
+++ b/packages/roxabi-nats/CHANGELOG.md
@@ -4,39 +4,64 @@ All notable changes to the `roxabi-nats` package are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0](https://github.com/Roxabi/lyra/compare/roxabi-nats/v0.1.0...roxabi-nats/v0.2.0) (2026-04-17)
-
-
-### Features
-
-* **voice:** load-aware routing for multi-GPU STT/TTS workers ([#732](https://github.com/Roxabi/lyra/issues/732)) ([b928bb0](https://github.com/Roxabi/lyra/commit/b928bb0685ba78d04e2a4a62760d39d507e67ab9))
-
 ## [Unreleased]
+
+`pyproject.toml` is at `0.4.2`, but the matching `roxabi-nats/v0.4.2` tag has
+**not** been cut — an external `uv` pin referencing `roxabi-nats/v0.4.2` will
+fail to resolve until the tag is pushed. Cutting the tag is a release action on
+`staging` — see [Pin doctrine](../../docs/architecture/contracts.md#pin-doctrine-external-consumers).
+
+### Deprecated (still shipped)
+
+- `roxabi_nats.adapter_base.CONTRACT_VERSION` and top-level
+  `roxabi_nats.CONTRACT_VERSION` remain compat re-exports (lazy
+  `DeprecationWarning`); the canonical home is `roxabi_contracts.envelope`.
+  Removal was originally scheduled for `v0.3.0` (ADR-045 / ADR-049) but was
+  **never executed** — the re-exports still ship as of `0.4.2`. Removal is
+  deferred and unscheduled; whichever release finally cuts it MUST carry a
+  `BREAKING CHANGE:` trailer.
+
+
+## [0.4.2] (2026-06-03) — tag pending
 
 ### Changed
 
-- `CONTRACT_VERSION` canonical home moved to `roxabi_contracts.envelope`
-  (ADR-049 §Neutral consequence). `roxabi_nats.adapter_base.CONTRACT_VERSION`
-  and the top-level `roxabi_nats.CONTRACT_VERSION` are now compat re-exports
-  that emit a `DeprecationWarning` at module import time.
+- Part of the `lyra.* → factory.*` NATS wire-namespace rename ([#1670](https://github.com/Roxabi/roxabi-factory/issues/1670)): readiness-announce subject strings updated to the `factory.*` namespace.
 
-### Deprecated
 
-- `from roxabi_nats.adapter_base import CONTRACT_VERSION`
-- `from roxabi_nats import CONTRACT_VERSION`
+## [0.4.1] (2026-05-20)
 
-  Import from `roxabi_contracts.envelope` instead. Both compat re-exports are
-  scheduled for removal at `v0.3.0` (see below).
+### Features
 
-### Planned removal at v0.3.0 (BREAKING CHANGE)
+- Add a `wait_ready` opt-out for worker-class adapters so heartbeat-driven workers can skip the startup readiness gate ([#1147](https://github.com/Roxabi/roxabi-factory/issues/1147)).
 
-- The two `CONTRACT_VERSION` compat re-exports above will be removed. Consumers
-  must migrate to `from roxabi_contracts.envelope import CONTRACT_VERSION`.
-- The `v0.3.0` release commit will carry a `BREAKING CHANGE:` trailer so
-  release-please surfaces it in the changelog and Renovate opens a major-bump
-  PR across satellites.
+
+## [0.4.0] (2026-05-19)
+
+### Breaking
+
+- Rename `NatsDriverBase._stream_gen` → `_dict_stream_gen` ([#1254](https://github.com/Roxabi/roxabi-factory/issues/1254) / [#1258](https://github.com/Roxabi/roxabi-factory/issues/1258)). Private `_`-prefixed rename; per the versioning policy this does not force a major bump, but external callers reaching into the private name must update.
+
+
+## [0.3.0] (2026-04-27) — no tag cut
+
+### Changed
+
+- CliPool extracted into a dedicated NATS container (ADR-054) ([#946](https://github.com/Roxabi/roxabi-factory/issues/946)); driver-side plumbing moved with it. The `roxabi-nats/v0.3.0` tag was never pushed (the released tag chain is `v0.2.1 → v0.4.0 → v0.4.1`), and the `CONTRACT_VERSION` compat-re-export removal that earlier notes scheduled "at v0.3.0" did **not** land here — see [Unreleased].
+
+
+## [0.2.1](https://github.com/Roxabi/lyra/compare/roxabi-nats/v0.2.0...roxabi-nats/v0.2.1) (2026-04-22)
+
+### Bug Fixes
+
+- **nats:** thread `inbox_prefix` through `NatsAdapterBase` for voiceCLI satellites ([ead4fec](https://github.com/Roxabi/lyra/commit/ead4fec12246d387adcded91b6a4a8adb1efe311)).
+
 
 ## [0.2.0] — 2026-04-17
+
+### Features
+
+- **voice:** load-aware routing for multi-GPU STT/TTS workers ([#732](https://github.com/Roxabi/lyra/issues/732)) ([b928bb0](https://github.com/Roxabi/lyra/commit/b928bb0685ba78d04e2a4a62760d39d507e67ab9)).
 
 ### Breaking
 

--- a/packages/roxabi-nats/README.md
+++ b/packages/roxabi-nats/README.md
@@ -9,17 +9,36 @@
 roxabi-nats = {
   git = "https://github.com/Roxabi/roxabi-factory.git",
   subdirectory = "packages/roxabi-nats",
-  tag = "roxabi-nats/v0.1.0"
+  tag = "roxabi-nats/vX.Y.Z"  # pick a real tag — see below
 }
 ```
 
+Resolve the latest released tag (never hardcode one that may not exist):
+
+```bash
+git ls-remote --tags https://github.com/Roxabi/roxabi-factory.git 'roxabi-nats/*'
+# or, in a local clone:
+git tag -l 'roxabi-nats/*' | sort -V | tail -1
+```
+
+Pin by **tag**, not branch — see [Pin doctrine](../../docs/architecture/contracts.md#pin-doctrine-external-consumers).
+
 ## Public API contract
 
-The stable external contract is defined by `__all__` in `roxabi_nats/__init__.py`:
+The stable external contract is exactly the names in `__all__` in `roxabi_nats/__init__.py` (source is SSoT — `grep __all__ src/roxabi_nats/__init__.py`). It currently exports:
 
-- `NatsAdapterBase` — base class for NATS-backed adapter lifecycles
-- `nats_connect` — hardened connection helper (TLS, nkey, creds)
-- `CONTRACT_VERSION` — wire-protocol contract version (see ADR-044 (absorbed into ADR-049))
+| Name | Role |
+|---|---|
+| `NatsAdapterBase` | Base class for NATS-backed adapter lifecycles |
+| `NatsDriverBase` | Reusable hub-side request-dispatch base for worker drivers |
+| `WorkerUnavailableError` | Raised when a worker's heartbeat stops during an active stream |
+| `nats_connect` | Hardened connection helper (TLS, nkey, creds) |
+| `TypeHintResolver` | Public wrapper resolving `TYPE_CHECKING`-only hints during (de)serialization |
+| `sanitize_for_wire` | Sanitize an exception into a wire-safe, length-capped string |
+| `DEFAULT_MAX_LEN` | Default cap (chars) applied by `sanitize_for_wire` |
+| `CONTRACT_VERSION` | Wire-protocol contract version (compat re-export; canonical home is `roxabi_contracts.envelope`, see ADR-044 (absorbed into ADR-049)) |
+
+Public utility submodule `errors` also exports `sanitize_for_wire` / `DEFAULT_MAX_LEN`.
 
 **Underscore-prefixed submodules (`_serialize`, `_sanitize`, `_validate`, `_version_check`, `_tts_constants`) are hub-internal and may change without notice.** External consumers (voiceCLI, roxabi-vault, imageCLI) MUST NOT import from them. Lyra itself, as the workspace host, is the only permitted caller of these internals and does so via explicit `roxabi_nats._submodule` imports — the asymmetry is deliberate and documented in ADR-045.
 

--- a/packages/roxabi-satellite/README.md
+++ b/packages/roxabi-satellite/README.md
@@ -27,6 +27,14 @@ roxabi-satellite = {
 }
 ```
 
+> **Why `branch`, not `tag`, here?** `roxabi-nats` and `roxabi-contracts` MUST
+> be pinned by tag — but `roxabi-satellite` is the sanctioned exception. It is
+> pre-tag plumbing (no `roxabi-satellite/*` tags yet), and depending on it
+> pulls the whole SDK from one staging commit, so you get a coherent
+> `contracts`+`nats`+`blobs` triple with no partial-upgrade risk. Full
+> rationale: [Pin doctrine](../../docs/architecture/contracts.md#pin-doctrine-external-consumers).
+> Never branch-pin `roxabi-nats`/`roxabi-contracts` directly.
+
 ```toml
 [project.optional-dependencies]
 nats = ["roxabi-satellite", "nats-py>=2.6,<3", "nkeys>=0.1"]


### PR DESCRIPTION
Closes #2199

Lot 0.7 of the doc-strategy epic — SDK packages. The `roxabi-contracts` /
`roxabi-nats` READMEs pinned **hardcoded tags that do not exist on origin**
(`roxabi-contracts/v0.1.0`, `roxabi-nats/v0.1.0`), so a copy-pasted `uv add`
snippet fails to resolve. CHANGELOGs were frozen well behind `pyproject.toml`,
and the pin doctrine was self-contradictory (satellite says `branch=staging`,
nats/contracts require tags). This PR fixes the **docs/doctrine** only.

## Changes (docs only — 6 markdown files, zero code)

- **roxabi-contracts README**: pin → `vX.Y.Z` placeholder + `git tag -l 'roxabi-contracts/*'` / `git ls-remote` resolution hint; de-rot the "v0.1.0 ships" Public API frame to point at `__all__` (source is SSoT).
- **roxabi-nats README**: same placeholder + hint; **list the full `__all__`** (README listed 3 of 8 — added `NatsDriverBase`, `WorkerUnavailableError`, `TypeHintResolver`, `sanitize_for_wire`, `DEFAULT_MAX_LEN`).
- **roxabi-contracts CHANGELOG**: backfill `0.12.0` (voice lifecycle: `VoiceLifecycleRequest/Response`, `factory.voice.*.lifecycle.>`) and `0.13.0` (fleet + dashboard observability submodules) — `pyproject` is at `0.13.0`. Verified against current code.
- **roxabi-nats CHANGELOG**: backfill `0.2.1 → 0.4.2`, merge the two duplicate `0.2.0` entries, and **correct the never-executed "removal at v0.3.0" plan** — the `CONTRACT_VERSION` compat re-exports still ship as of `0.4.2` (confirmed in `adapter_base.py`); removal is now marked deferred/unscheduled.
- **contracts.md**: new SSoT **"Pin doctrine (external consumers)"** section arbitrating #4 — one rule (tag-pin the wire SDK `roxabi-nats`/`roxabi-contracts` with the grouped Renovate `git-refs` rule), one documented exception (**only** the `roxabi-satellite` aggregator may `branch = "staging"`, because it is partial-upgrade-safe — the whole SDK resolves from one staging commit — and is pre-tag plumbing, not the wire contract). The two previously-drifting pin statements now point at it. **roxabi-satellite README** gains an inline "why branch, not tag" note.

## #5 decision — reminder, not a gate

Recorded in the Pin doctrine section: cutting the tag on every version bump is a **release-runbook reminder, not a quality gate**. A `pyproject.version == latest-tag` gate would red **every** version-bump PR, because tags are cut post-merge — the wrong shape. The proportionate control is the doctrine line plus the `[Unreleased] tag pending` note each CHANGELOG now carries until its tag is cut.

## Gates

Local `pre-commit` + `pre-push` suites green (after symlinking the main `.venv` and `bun install` for biome — this worktree had no toolchain). doc_drift_bundle green (contracts.md scanned).

## Manual follow-ups (RELEASE actions — out of this PR's scope by design)

Per the issue's special constraint, **no git tags are cut or pushed here.** After this merges to `staging`:

1. Cut `roxabi-contracts/v0.13.0` on the staging merge commit (`pyproject` = 0.13.0; latest origin tag = v0.3.0). This is the actual unblock for intel-worker #2192.
2. Cut `roxabi-nats/v0.4.2` (`pyproject` = 0.4.2 > latest tag v0.4.1).
3. Once tags exist, consumers/satellites replace the `vX.Y.Z` placeholder with the real resolved tag.

Do these via a release action on `staging` (or `/promote`), not from a feature branch.