### PR TITLE
docs(spec): CI diff-scoped plan phase 0–1 (#2249)

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -84,6 +84,7 @@ quality_gates:
     # pre-push (not pre-commit): pyright costs ~10-22s per run — too heavy for
     # every commit, still blocks type errors before they reach CI.
     stages: [pre-push, ci]
+    files: ^(src/|packages/[^/]+/src/|tests/|pyproject\.toml$)
 
   file_length:
     enabled: true
@@ -296,11 +297,13 @@ quality_gates:
     enabled: true
     script: tools/check_str_exc_bus_bound.sh
     stages: [ci]
+    files: ^src/
 
   omp_pin_lockstep:
     enabled: true
     script: tools/check_omp_pin_lockstep.sh
     stages: [ci]
+    files: ^(deploy/omp|src/factory/adapters/omp)
 
   acl_matrix_retired:
     enabled: true
@@ -332,6 +335,7 @@ quality_gates:
     script: bash scripts/check-astryx-doctor.sh
     requires: bun
     stages: [ci]
+    files: ^(apps/dashboard/src/astryx-theme/|brand/)|^(bun\.lock|package\.json)$
     description: Astryx design-system setup health (Node floor, core<->cli alignment, peer deps) — #2088
 
   theme_build_drift:
@@ -339,9 +343,29 @@ quality_gates:
     script: bash scripts/check-theme-build-drift.sh
     requires: bun
     stages: [ci]
+    files: ^(apps/dashboard/src/astryx-theme/|brand/)|^(bun\.lock|package\.json)$
     description: committed roxabi built/ theme artifacts must match a fresh build of the source (#2089)
 
 qg:
+  change_classes:
+    docs:
+      paths: ^(docs/|artifacts/)|AGENTS\.md$|\.md$|^\.claude/
+    python:
+      paths: ^(src/|packages/[^/]+/src/|tests/|pyproject\.toml$|uv\.lock$)
+    frontend:
+      paths: ^(apps/|packages/shared/|brand/)|^(biome\.json|bun\.lock|package\.json)$
+    deploy:
+      paths: ^(deploy/|docker/)
+    tooling:
+      paths: ^(scripts/|\.github/|\.claude/stack\.yml$|tools/)
+  tripwires:
+    - ^pyproject\.toml$
+    - ^uv\.lock$
+    - ^package\.json$
+    - ^bun\.lock$
+    - ^\.claude/stack\.yml$
+    - ^\.github/workflows/ci\.yml$
+    - ^scripts/qg$
   run_order:
     pre-commit:
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,20 @@ jobs:
           sudo install -m 755 /tmp/yq /usr/local/bin/yq
           yq --version
 
+      - name: CI plan (diff-scoped)
+        env:
+          QG_DIFF_RANGE: ${{ github.event_name == 'pull_request' && format('origin/{0}...HEAD', github.base_ref) || '' }}
+        run: |
+          scripts/qg plan --stage ci --format github >> "${GITHUB_STEP_SUMMARY}"
+          scripts/qg plan --stage ci --format json --output ci-plan.json
+
+      - name: Upload CI plan artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ci-plan
+          path: ci-plan.json
+          retention-days: 5
+
       - name: Quality gates (stack.yml)
         env:
           # PR-only: honor gates' files: filters against the merge-base diff
@@ -264,17 +278,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Verify all CI jobs succeeded
         env:
           RESULTS: ${{ join(needs.*.result, ' ') }}
         run: |
           echo "needed job results: ${RESULTS}"
-          for result in ${RESULTS}; do
-            if [[ "${result}" != "success" ]]; then
-              echo "::error::a needed job finished with result '${result}' — failing the aggregate ci gate"
-              exit 1
-            fi
-          done
+          # success and skipped are OK (skipped enables phase-2 conditional jobs).
+          scripts/ci-aggregate-results.sh ${RESULTS}
 
   # Self-contained (own checkout/uv sync/docker compose; no artifact from ci),
   # so it runs in parallel from t=0 — the former needs:[ci] edge was ordering-only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,7 @@ jobs:
       - name: CI plan (diff-scoped)
         env:
           QG_DIFF_RANGE: ${{ github.event_name == 'pull_request' && format('origin/{0}...HEAD', github.base_ref) || '' }}
-        run: |
-          scripts/qg plan --stage ci --format github >> "${GITHUB_STEP_SUMMARY}"
-          scripts/qg plan --stage ci --format json --output ci-plan.json
+        run: scripts/qg plan --stage ci --format github --output ci-plan.json >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload CI plan artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/artifacts/specs/2249-ci-diff-scoped-plan-phase-0-1-spec.mdx
+++ b/artifacts/specs/2249-ci-diff-scoped-plan-phase-0-1-spec.mdx
@@ -1,0 +1,258 @@
+---
+title: "feat(ci): Diff-scoped CI plan — phase 0–1 (aggregate + qg plan)"
+issue: 2249
+status: approved
+tier: F-lite
+date: 2026-07-04
+adr: docs/architecture/adr/086-documentation-architecture.mdx
+source: artifacts/analyses/2026-07-04-multi-axis-comprehension-semctx.md
+---
+
+## Context
+
+Promoted from multi-agent validation (DevOps + architecte + pratiques industrie Google presubmit / Pants skip-jobs) and discussion 2026-07-04.
+
+Factory already diff-scopes **quality gates** on `pull_request` via `QG_DIFF_RANGE` + `files:` regex in `.claude/stack.yml` (`scripts/qg`, #2176). Merge queue and push to protected branches intentionally **fail-open** (full suite).
+
+Gaps today:
+
+| Gap | Impact |
+|-----|--------|
+| Job `tests` + `package-coverage` | Always full pytest/e2e (~5–8 min) even for `.md`-only PRs |
+| ~31/36 CI gates sans `files:` | Ruff, pyright, ACL, deploy drift run on every PR |
+| Aggregate `ci` rejects `skipped` | Blocks future job-level `if:` skips (deadlock branch protection) |
+| No `qg plan` contract | Job skip logic would duplicate `stack.yml` in `ci.yml` |
+
+**Policy (ADR-worthy, recorded here until dedicated ADR):**
+
+- `pull_request` → affected validation (fast feedback)
+- `merge_group` / `push` `main`/`staging` → full validation (integration point hard gate)
+- `stack.yml` + `scripts/qg` = **single SSoT** for change classification — no parallel `dorny/paths-filter` rules in `ci.yml`
+- `doc_drift_bundle` stays **always-on** when diff touches doc paths (ADR-086 oracle)
+
+## Goal
+
+Phase **0–1** only (phase 2 = conditional test jobs; phase 3 = `verify_change.py`):
+
+1. **Phase 0** — Aggregate required check `ci` accepts `success` **and** `skipped`; fails on `failure` / `cancelled` only.
+2. **Phase 1** — `scripts/qg plan --stage ci` emits stable JSON; `stack.yml` gains change taxonomy + tripwires; extend `files:` on high-cost gates.
+
+## Constraints
+
+- **Do not** add a separate required check `ci-docs` (branch protection stays single context `ci`).
+- **Do not** add workflow-level `paths:` / `paths-ignore` (GitHub Pending deadlock).
+- **Do not** fail-closed when `git diff` fails — preserve fail-open (documented in `ci.yml` L104–106).
+- **Do not** diff-scope `docker-build` or `trufflehog` (separate required checks; merge queue policy).
+- **Do not** weaken `doc_drift_bundle` filtering — bundle composes doc gates; must run on any PR touching `docs/`, `artifacts/`, `AGENTS.md`, root `*.md`.
+- Tripwire files force **full** plan (`tests`, `package-coverage` = run in phase 2; all gates in phase 1).
+
+## Out of Scope
+
+- Phase 2: `ci.yml` jobs `tests` / `package-coverage` / `integration` conditional on `qg plan` outputs.
+- Absorbing satellite workflows (`quadlet-lint.yml`, `context-lint.yml`, `renderer-roundtrip.yml`) into `stack.yml`.
+- `ccm_axis` tags on every gate (CCM V1 — follow-up).
+- Dedicated ADR file (optional follow-up; decisions listed in §ADR decisions).
+
+## Users
+
+| User | Workflow |
+|------|----------|
+| Contributor | Doc-only PR gets faster `gates` job; full suite still runs in merge queue |
+| Maintainer | One place (`stack.yml`) to tune what runs when |
+| Agent / reviewer | `qg plan` JSON explains skip/run decisions in CI logs |
+
+## Expected Behavior
+
+### Phase 0 — Smart aggregate `ci`
+
+**File:** `.github/workflows/ci.yml` job `ci`
+
+Replace result loop:
+
+```bash
+# success OR skipped → OK; failure OR cancelled → fail
+[[ "${result}" == "success" || "${result}" == "skipped" ]] || exit 1
+```
+
+Add comment: skipped is expected once phase 2 enables conditional `tests`/`package-coverage`; until then all jobs still run (no behavior change except forward-compatible).
+
+**Tests:** `tests/scripts/test_qg.sh` section **G** (new) — bash fixture simulating result vectors:
+
+| Input results | Expected exit |
+|---------------|---------------|
+| `success success success` | 0 |
+| `success skipped success` | 0 |
+| `failure success success` | 1 |
+| `success cancelled success` | 1 |
+
+Extract aggregate loop to `scripts/ci-aggregate-results.sh` **only if** testability requires it; otherwise inline test via sourced function.
+
+### Phase 1 — `scripts/qg plan`
+
+**CLI:**
+
+```bash
+scripts/qg plan --stage ci [--format json|github]
+# Env: QG_DIFF_RANGE (same as `qg run` — set by ci.yml on pull_request only)
+```
+
+**Output JSON schema** (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "filter_active": true,
+  "diff_range": "origin/staging...HEAD",
+  "changed_files": ["artifacts/analyses/foo.md"],
+  "taxonomy": ["docs"],
+  "tripwire_hit": false,
+  "fail_open": false,
+  "gates": [
+    {"name": "lint", "action": "skip", "reason": "no_matching_files"},
+    {"name": "doc_drift_bundle", "action": "run", "reason": "taxonomy_docs"}
+  ],
+  "jobs": {
+    "gates": {"action": "run"},
+    "tests": {"action": "skip", "reason": "docs_only"},
+    "package-coverage": {"action": "skip", "reason": "docs_only"},
+    "integration": {"action": "skip", "reason": "docs_only"}
+  }
+}
+```
+
+**Semantics:**
+
+| Field | Rule |
+|-------|------|
+| `filter_active` | `1` iff `QG_DIFF_RANGE` set **and** `git diff` succeeded (mirror `CI_FILTER_ACTIVE`) |
+| `fail_open` | `true` when diff unavailable → all gates `run`, all jobs `run` |
+| `taxonomy` | Union of matched classes from changed files |
+| `tripwire_hit` | Any changed file matches `qg.tripwires` → force full plan |
+| `gates[].action` | `run` \| `skip` — same logic as `should_run_gate` + doc_drift_bundle rules |
+| `jobs` | Phase 1: **informational** + CI log annotation; phase 2 wires `if:` |
+
+**`--format github`:** multiline `::notice::` / job summary markdown for Actions UI.
+
+**Usage in phase 1 CI:** add step after checkout in `gates` job:
+
+```yaml
+- name: CI plan (diff-scoped)
+  env:
+    QG_DIFF_RANGE: ${{ ... }}
+  run: scripts/qg plan --stage ci --format github
+```
+
+No job skipping yet — observability + contract hardening only.
+
+### Phase 1 — `stack.yml` extensions
+
+**Section `qg.change_classes`** (taxonomy):
+
+| Class | `paths` regex (grep -E, same engine as `files:`) |
+|-------|--------------------------------------------------|
+| `docs` | `^docs/`, `^artifacts/`, `AGENTS\.md$`, `\.md$`, `^\.claude/` |
+| `python` | `^src/`, `^packages/[^/]+/src/`, `^tests/`, `^pyproject\.toml$`, `^uv\.lock$` |
+| `frontend` | `^apps/`, `^packages/shared/`, `^brand/`, `^biome\.json$`, `^bun\.lock$` |
+| `deploy` | `^deploy/`, `^docker/` |
+| `tooling` | `^scripts/`, `^\.github/`, `^\.claude/stack\.yml$`, `^tools/` |
+
+**Section `qg.tripwires`** — any match forces full plan (all gates run, all jobs `run`):
+
+```yaml
+qg:
+  tripwires:
+    - ^pyproject\.toml$
+    - ^uv\.lock$
+    - ^package\.json$
+    - ^bun\.lock$
+    - ^\.claude/stack\.yml$
+    - ^\.github/workflows/ci\.yml$
+    - ^scripts/qg$
+```
+
+**`docs_only` definition** (for `jobs.*.skip`):
+
+```
+taxonomy == ["docs"] AND NOT tripwire_hit AND filter_active
+```
+
+**Extend `files:` on gates** (minimum set — phase 1):
+
+| Gate | `files:` pattern (add or refine) |
+|------|----------------------------------|
+| `typecheck` | `^src/`, `^packages/[^/]+/src/`, `^tests/`, `^pyproject\.toml$` |
+| `theme_build_drift` | `^brand/`, `^packages/roxabi/` (match existing theme paths) |
+| `astryx_doctor` | `^brand/`, `^packages/roxabi/` |
+| `str_exc_bus_bound` | `^src/` |
+| `omp_pin_lockstep` | `^deploy/omp`, `^src/factory/adapters/omp` (verify paths in repo) |
+
+`doc_drift_bundle` — **no** `files:` entry (bundle always evaluates; internal doc paths trigger via changed file list + legacy grep in bundle).
+
+**`lint` (ruff)** — remains global in phase 1 (cheap); optional `files:` in phase 2.
+
+### Phase 1 — Tests (`tests/scripts/test_qg.sh`)
+
+New sections:
+
+| ID | Case |
+|----|------|
+| **G** | Aggregate results script (phase 0) |
+| **H1** | `qg plan` docs-only diff → `jobs.tests.action=skip`, `doc_drift_bundle` run |
+| **H2** | Tripwire: diff touches `uv.lock` + `.md` → `tripwire_hit=true`, all jobs run |
+| **H3** | `QG_DIFF_RANGE` unset → `fail_open=true`, all gates run |
+| **H4** | Bad diff ref → `fail_open=true` (mirror E2b) |
+| **H5** | `typecheck` skipped on docs-only plan gate list |
+
+Update `tests/scripts/test_check_qg_conf_drift.sh` if `qg` section shape changes.
+
+## Slices
+
+| Slice | Scope | Acceptance |
+|-------|-------|------------|
+| **S0** | Aggregate `ci` loop + test G | PR with only phase 0 still runs full tests; aggregate green; skipped simulation passes |
+| **S1** | `qg plan` command + JSON schema + tests H1–H5 | `scripts/qg plan --stage ci` locally with `QG_DIFF_RANGE=origin/staging...HEAD` |
+| **S2** | `stack.yml` taxonomy + tripwires + `files:` extensions | Doc-only PR: fewer gates execute in `gates` job (CI log shows skips); merge queue unchanged (full) |
+| **S3** | `ci.yml` plan step + upload artifact `ci-plan.json` | Plan visible in Actions summary; artifact retained 5 days |
+
+**Order:** S0 → S1 → S2 → S3 (S0 unblocks phase 2 PRs).
+
+## Acceptance Criteria
+
+- [ ] Aggregate `ci` accepts `skipped` without failing (S0)
+- [ ] `tests/scripts/test_qg.sh` section G green
+- [ ] `scripts/qg plan --stage ci --format json` exits 0; output validates against embedded schema check in test
+- [ ] Docs-only fixture: `taxonomy` includes `docs`, `jobs.tests.action` is `skip`, `doc_drift_bundle` action is `run`
+- [ ] Tripwire fixture (`uv.lock`): `tripwire_hit=true`, all jobs `run`
+- [ ] `merge_group` / empty `QG_DIFF_RANGE`: `fail_open=true` (test + manual queue verification post-merge)
+- [ ] At least 4 new `files:` gates skip on docs-only PR (S2)
+- [ ] `doc_drift_bundle` still runs on PR touching `artifacts/analyses/*.md`
+- [ ] No new required check contexts; branch protection unchanged
+- [ ] `scripts/check-qg-conf-drift.sh` green (if applicable)
+
+## ADR Decisions (record in follow-up ADR or amend 086)
+
+1. `stack.yml` is the sole SSoT for gate `files:`, change taxonomy, tripwires, and (phase 2) CI job run/skip.
+2. `scripts/qg plan` is the machine contract consumed by `ci.yml` — no duplicate path rules in workflows.
+3. PR = affected validation; merge queue = full validation (fail-open preserved).
+4. `doc_drift_bundle` is never filtered by `files:` on the bundle gate; taxonomy `docs` forces run.
+5. Tripwires prevent `docs_only` classification when lockfiles or CI tooling change.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Stale `files:` regex | `qg_conf_drift` + H5 fixtures |
+| Gaming via docs-only PR | Merge queue full suite; tripwires |
+| Aggregate accepts wrongful skip | Phase 1 does not skip jobs yet; S0 only enables future phase 2 |
+| `grep -E` vs picomatch drift | Reject `dorny/paths-filter`; one engine in `qg` |
+
+## References
+
+- Issue #2249
+- `artifacts/analyses/2026-07-04-multi-axis-comprehension-semctx.md`
+- `.github/workflows/ci.yml` — `QG_DIFF_RANGE`, jobs `gates`/`tests`/`ci`
+- `scripts/qg` — `CI_FILTER_ACTIVE`, fail-open
+- `tests/scripts/test_qg.sh` — sections E (filtering)
+- [Pants — skipping jobs without breaking branch protection](https://www.pantsbuild.org/blog/2022/10/10/skipping-github-actions-jobs-without-breaking-branch-protection)
+- [GitHub — merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+- [Google SWE Book — Continuous Integration (ch.23)](https://abseil.io/resources/swe-book/html/ch23.html)

--- a/scripts/ci-aggregate-results.sh
+++ b/scripts/ci-aggregate-results.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Aggregate CI job results for the required "ci" check context.
+# success and skipped are OK; failure and cancelled fail the aggregate.
+# See artifacts/specs/2249-ci-diff-scoped-plan-phase-0-1-spec.mdx (phase 0).
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: ci-aggregate-results.sh <result>..." >&2
+  exit 2
+fi
+
+for result in "$@"; do
+  case "$result" in
+    success | skipped) ;;
+    *)
+      echo "::error::aggregate ci: needed job result '${result}' is not success or skipped" >&2
+      exit 1
+      ;;
+  esac
+done

--- a/scripts/qg
+++ b/scripts/qg
@@ -7,6 +7,7 @@
 #   scripts/qg run --stage ci
 #   scripts/qg run --profile local
 #   scripts/qg run [--stage STAGE] GATE_NAME
+#   scripts/qg plan --stage ci [--format json|github] [--output PATH]
 #
 # Requires: yq (https://github.com/mikefarah/yq) — checked in tools/dev-setup.sh
 #
@@ -18,7 +19,8 @@
 #   fails (bad ref, shallow clone), the runner FAILS OPEN: all gates run.
 set -euo pipefail
 
-REPO_ROOT="${QG_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+QG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${QG_REPO_ROOT:-$(cd "${QG_SCRIPT_DIR}/.." && pwd)}"
 STACK="${QG_STACK:-${REPO_ROOT}/.claude/stack.yml}"
 
 # 1 only when a CI changed-files list was successfully computed (QG_DIFF_RANGE
@@ -26,6 +28,9 @@ STACK="${QG_STACK:-${REPO_ROOT}/.claude/stack.yml}"
 # nothing matches → filtered gates skip) from "diff unavailable" (fail open:
 # run everything). Never fail-closed — a broken diff must not skip checks.
 CI_FILTER_ACTIVE=0
+QG_FAIL_OPEN=0
+QG_TRIPWIRE_HIT=0
+QG_TAXONOMY=()
 
 # Gates invoke `uv run <tool>`; without no-sync, uv re-resolves and rewrites
 # uv.lock / bakes worktree paths into the shared symlinked .venv when a gate
@@ -42,6 +47,7 @@ Usage:
   scripts/qg run --stage pre-commit|pre-push|ci
   scripts/qg run --profile NAME
   scripts/qg run [--stage STAGE] GATE_NAME
+  scripts/qg plan --stage ci [--format json|github] [--output PATH]
 EOF
 }
 
@@ -146,6 +152,177 @@ should_run_gate() {
     return 1
   fi
   files_match_pattern "$pattern" "$@"
+}
+
+# Populate CI_FILTER_ACTIVE and the changed-files array for the ci stage.
+# Sets QG_FAIL_OPEN=1 when the diff range is absent or git diff failed.
+load_ci_changed() {
+  local -n _out_changed=$1
+  CI_FILTER_ACTIVE=0
+  QG_FAIL_OPEN=0
+  _out_changed=()
+
+  if [[ -z "${QG_DIFF_RANGE:-}" ]]; then
+    QG_FAIL_OPEN=1
+    return 0
+  fi
+
+  local difftmp errtmp git_err
+  difftmp=$(mktemp)
+  errtmp=$(mktemp)
+  if git -C "$REPO_ROOT" diff --name-only -z --no-renames "$QG_DIFF_RANGE" >"$difftmp" 2>"$errtmp"; then
+    CI_FILTER_ACTIVE=1
+    mapfile -d '' -t _out_changed <"$difftmp"
+  else
+    git_err=$(tr '\n' ' ' <"$errtmp")
+    echo "::warning::qg: git diff '${QG_DIFF_RANGE}' failed (${git_err:-no stderr}) — files: filters disabled, running ALL ci gates (fail-open)" >&2
+    QG_FAIL_OPEN=1
+  fi
+  rm -f "$difftmp" "$errtmp"
+}
+
+change_class_names() {
+  yq_read '.qg.change_classes | keys | .[]?' 2>/dev/null || true
+}
+
+change_class_pattern() {
+  local class="$1"
+  yq_read ".qg.change_classes[\"${class}\"].paths // \"\""
+}
+
+tripwire_patterns() {
+  yq_read '.qg.tripwires[]?' 2>/dev/null || true
+}
+
+# Sets QG_TAXONOMY (sorted unique class names) and QG_TRIPWIRE_HIT (0|1).
+classify_changed_files() {
+  local -a changed=("$@")
+  local -a taxonomy=()
+  QG_TRIPWIRE_HIT=0
+
+  local class pattern tw f match_rc
+  while IFS= read -r class; do
+    [[ -n "$class" ]] || continue
+    pattern=$(change_class_pattern "$class")
+    [[ -n "$pattern" && "$pattern" != "null" ]] || continue
+    for f in "${changed[@]}"; do
+      [[ -n "$f" ]] || continue
+      set +e
+      [[ "$f" =~ $pattern ]]
+      match_rc=$?
+      set -e
+      if [[ "$match_rc" -eq 2 ]]; then
+        echo "::error::invalid change_classes.${class} regex: ${pattern}" >&2
+        return 2
+      fi
+      if [[ "$match_rc" -eq 0 ]]; then
+        taxonomy+=("$class")
+        break
+      fi
+    done
+  done < <(change_class_names)
+
+  if [[ ${#taxonomy[@]} -gt 0 ]]; then
+    mapfile -t QG_TAXONOMY < <(printf '%s\n' "${taxonomy[@]}" | LC_ALL=C sort -u)
+  else
+    QG_TAXONOMY=()
+  fi
+
+  while IFS= read -r tw; do
+    [[ -n "$tw" && "$tw" != "null" ]] || continue
+    for f in "${changed[@]}"; do
+      [[ -n "$f" ]] || continue
+      set +e
+      [[ "$f" =~ $tw ]]
+      match_rc=$?
+      set -e
+      if [[ "$match_rc" -eq 2 ]]; then
+        echo "::error::invalid tripwire regex: ${tw}" >&2
+        return 2
+      fi
+      if [[ "$match_rc" -eq 0 ]]; then
+        QG_TRIPWIRE_HIT=1
+        return 0
+      fi
+    done
+  done < <(tripwire_patterns)
+
+  return 0
+}
+
+plan_gate_decision() {
+  local gate="$1" stage="$2"
+  shift 2
+  local -a changed=("$@")
+
+  if [[ "$gate" == "doc_drift_bundle" ]]; then
+    if [[ "$QG_FAIL_OPEN" -eq 1 ]]; then
+      printf '%s' "run|fail_open"
+      return 0
+    fi
+    if [[ "$QG_TRIPWIRE_HIT" -eq 1 ]]; then
+      printf '%s' "run|tripwire"
+      return 0
+    fi
+    local c
+    for c in "${QG_TAXONOMY[@]}"; do
+      if [[ "$c" == "docs" ]]; then
+        printf '%s' "run|taxonomy_docs"
+        return 0
+      fi
+    done
+    printf '%s' "run|always_on"
+    return 0
+  fi
+
+  if ! gate_enabled "$gate"; then
+    printf '%s' "skip|disabled"
+    return 0
+  fi
+
+  if [[ -n "$stage" ]] && ! gate_has_stage "$gate" "$stage"; then
+    printf '%s' "skip|not_in_stage"
+    return 0
+  fi
+
+  if [[ "$QG_FAIL_OPEN" -eq 1 ]]; then
+    printf '%s' "run|fail_open"
+    return 0
+  fi
+
+  if [[ "$QG_TRIPWIRE_HIT" -eq 1 ]]; then
+    printf '%s' "run|tripwire"
+    return 0
+  fi
+
+  local pattern
+  pattern=$(gate_field "$gate" 'files // ""')
+  if [[ -z "$pattern" || "$pattern" == "null" ]]; then
+    printf '%s' "run|no_files_filter"
+    return 0
+  fi
+
+  if [[ "$CI_FILTER_ACTIVE" -ne 1 ]]; then
+    printf '%s' "run|fail_open"
+    return 0
+  fi
+
+  if [[ ${#changed[@]} -eq 0 ]]; then
+    printf '%s' "skip|no_matching_files"
+    return 0
+  fi
+
+  local run_decision=0
+  should_run_gate "$gate" "$stage" "${changed[@]}"
+  run_decision=$?
+  if [[ "$run_decision" -eq 2 ]]; then
+    return 2
+  fi
+  if [[ "$run_decision" -eq 0 ]]; then
+    printf '%s' "run|matching_files"
+  else
+    printf '%s' "skip|no_matching_files"
+  fi
 }
 
 default_script() {
@@ -359,26 +536,8 @@ cmd_run() {
     return 2
   fi
 
-  # CI stage: compute the PR merge-base diff when ci.yml provided a range.
-  # Triple-dot includes deletions and --no-renames splits a move into D+A —
-  # deliberate: deleting or moving a file OUT of a filtered tree must still
-  # trigger its gates. -z (NUL-delimited) keeps non-ASCII/control-char paths
-  # intact — default core.quotePath C-quotes them ("caf\303\251.ts"), which
-  # would never match a files: regex and silently skip gates. Any git failure
-  # (bad ref, shallow clone) → fail OPEN with a warning: CI_FILTER_ACTIVE
-  # stays 0 and every gate runs.
-  if [[ "$stage" == "ci" && -n "${QG_DIFF_RANGE:-}" ]]; then
-    local difftmp errtmp git_err
-    difftmp=$(mktemp)
-    errtmp=$(mktemp)
-    if git -C "$REPO_ROOT" diff --name-only -z --no-renames "$QG_DIFF_RANGE" >"$difftmp" 2>"$errtmp"; then
-      CI_FILTER_ACTIVE=1
-      mapfile -d '' -t changed <"$difftmp"
-    else
-      git_err=$(tr '\n' ' ' <"$errtmp")
-      echo "::warning::qg: git diff '${QG_DIFF_RANGE}' failed (${git_err:-no stderr}) — files: filters disabled, running ALL ci gates (fail-open)" >&2
-    fi
-    rm -f "$difftmp" "$errtmp"
+  if [[ "$stage" == "ci" ]]; then
+    load_ci_changed changed
   fi
 
   local failed=0 rc=0 n
@@ -398,9 +557,115 @@ cmd_run() {
   return "$failed"
 }
 
+cmd_plan() {
+  local stage="" format="json" output_path=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --stage)
+        stage="$2"
+        shift 2
+        ;;
+      --format)
+        format="$2"
+        shift 2
+        ;;
+      --output)
+        output_path="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      plan)
+        shift
+        ;;
+      -*)
+        echo "::error::unknown option $1" >&2
+        usage >&2
+        return 2
+        ;;
+      *)
+        echo "::error::unexpected argument $1" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  require_yq
+  [[ -f "$STACK" ]] || { echo "::error::missing ${STACK}" >&2; return 2; }
+  [[ "$stage" == "ci" ]] || { echo "::error::plan requires --stage ci" >&2; return 2; }
+  case "$format" in
+    json | github) ;;
+    *)
+      echo "::error::unknown format ${format}" >&2
+      return 2
+      ;;
+  esac
+
+  local -a changed=()
+  local -a names=()
+  QG_FAIL_OPEN=0
+  QG_TRIPWIRE_HIT=0
+  QG_TAXONOMY=()
+
+  load_ci_changed changed
+  classify_changed_files "${changed[@]}" || return $?
+
+  mapfile -t names < <(ordered_gates stage "$stage") || return $?
+
+  local -a gate_lines=()
+  local n decision rc=0
+  for n in "${names[@]}"; do
+    [[ -n "$n" ]] || continue
+    decision=$(plan_gate_decision "$n" "$stage" "${changed[@]}") || rc=$?
+    if [[ "$rc" -eq 2 ]]; then
+      return 2
+    fi
+    gate_lines+=("${n}|${decision}")
+  done
+
+  local -a changed_json=()
+  local f
+  for f in "${changed[@]}"; do
+    [[ -n "$f" ]] || continue
+    changed_json+=("$f")
+  done
+
+  local meta_json
+  meta_json=$(
+    QG_DIFF_RANGE="${QG_DIFF_RANGE:-}" \
+    QG_STAGE="$stage" \
+    QG_FORMAT="$format" \
+    QG_OUTPUT="$output_path" \
+    QG_FILTER_ACTIVE="$CI_FILTER_ACTIVE" \
+    QG_FAIL_OPEN="$QG_FAIL_OPEN" \
+    QG_TRIPWIRE_HIT="$QG_TRIPWIRE_HIT" \
+    QG_TAXONOMY_JSON="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "${QG_TAXONOMY[@]}")" \
+    QG_CHANGED_JSON="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "${changed_json[@]}")" \
+    python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "stage": os.environ["QG_STAGE"],
+    "format": os.environ["QG_FORMAT"],
+    "output_path": os.environ.get("QG_OUTPUT") or "",
+    "filter_active": os.environ.get("QG_FILTER_ACTIVE") == "1",
+    "fail_open": os.environ.get("QG_FAIL_OPEN") == "1",
+    "tripwire_hit": os.environ.get("QG_TRIPWIRE_HIT") == "1",
+    "diff_range": os.environ.get("QG_DIFF_RANGE") or "",
+    "changed_files": json.loads(os.environ.get("QG_CHANGED_JSON") or "[]"),
+    "taxonomy": json.loads(os.environ.get("QG_TAXONOMY_JSON") or "[]"),
+}))
+PY
+  )
+
+  printf '%s\n' "${gate_lines[@]}" | python3 "${QG_SCRIPT_DIR}/qg_plan_emit.py" "$meta_json"
+}
+
 main() {
   case "${1:-}" in
     run) shift; cmd_run "$@" ;;
+    plan) shift; cmd_plan "$@" ;;
     -h|--help|"") usage ;;
     *) usage >&2; exit 2 ;;
   esac

--- a/scripts/qg_plan_emit.py
+++ b/scripts/qg_plan_emit.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Emit CI plan JSON for scripts/qg plan — stdin: gate lines name|action|reason."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def parse_gates() -> list[dict[str, str]]:
+    gates: list[dict[str, str]] = []
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        name, action, reason = line.split("|", 2)
+        gates.append({"name": name, "action": action, "reason": reason})
+    return gates
+
+
+def job_action(
+    *,
+    filter_active: bool,
+    fail_open: bool,
+    tripwire_hit: bool,
+    docs_only: bool,
+) -> dict[str, str]:
+    if fail_open or tripwire_hit or not filter_active:
+        return {"action": "run", "reason": "fail_open_or_tripwire_or_no_filter"}
+    if docs_only:
+        return {"action": "skip", "reason": "docs_only"}
+    return {"action": "run", "reason": "not_docs_only"}
+
+
+def build_plan(meta: dict[str, Any], gates: list[dict[str, str]]) -> dict[str, Any]:
+    filter_active = bool(meta["filter_active"])
+    fail_open = bool(meta["fail_open"])
+    tripwire_hit = bool(meta["tripwire_hit"])
+    taxonomy: list[str] = list(meta["taxonomy"])
+    docs_only = (
+        filter_active
+        and not fail_open
+        and not tripwire_hit
+        and taxonomy == ["docs"]
+    )
+    jobs = job_action(
+        filter_active=filter_active,
+        fail_open=fail_open,
+        tripwire_hit=tripwire_hit,
+        docs_only=docs_only,
+    )
+    return {
+        "schema_version": 1,
+        "stage": meta["stage"],
+        "filter_active": filter_active,
+        "diff_range": meta.get("diff_range") or "",
+        "changed_files": meta.get("changed_files") or [],
+        "taxonomy": taxonomy,
+        "tripwire_hit": tripwire_hit,
+        "fail_open": fail_open,
+        "docs_only": docs_only,
+        "gates": gates,
+        "jobs": {
+            "gates": {"action": "run"},
+            "tests": jobs,
+            "package-coverage": jobs,
+            "integration": jobs,
+        },
+    }
+
+
+def emit_github_summary(doc: dict[str, Any]) -> None:
+    gates = doc["gates"]
+    skipped = [g["name"] for g in gates if g["action"] == "skip"]
+    run = [g["name"] for g in gates if g["action"] == "run"]
+    print("### CI plan (diff-scoped)")
+    print(f"- filter_active: {doc['filter_active']}")
+    print(f"- fail_open: {doc['fail_open']}")
+    print(f"- tripwire_hit: {doc['tripwire_hit']}")
+    print(f"- taxonomy: {', '.join(doc['taxonomy']) or '(none)'}")
+    print(f"- docs_only: {doc['docs_only']}")
+    print(f"- changed_files: {len(doc['changed_files'])}")
+    print(f"- gates run: {len(run)} · skip: {len(skipped)}")
+    for job, info in doc["jobs"].items():
+        print(f"- job {job}: {info['action']} ({info.get('reason', '')})")
+    if skipped:
+        sample = ", ".join(skipped[:12])
+        extra = f" … +{len(skipped) - 12}" if len(skipped) > 12 else ""
+        print(f"\n**Skipped gates:** {sample}{extra}")
+
+
+def main() -> int:
+    meta = json.loads(sys.argv[1])
+    doc = build_plan(meta, parse_gates())
+    text = json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+    output_path = meta.get("output_path") or ""
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(text)
+    fmt = meta.get("format") or "json"
+    if fmt == "json":
+        sys.stdout.write(text)
+    elif fmt == "github":
+        emit_github_summary(doc)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qg_plan_emit.py
+++ b/scripts/qg_plan_emit.py
@@ -74,6 +74,7 @@ def emit_github_summary(doc: dict[str, Any]) -> None:
     gates = doc["gates"]
     skipped = [g["name"] for g in gates if g["action"] == "skip"]
     run = [g["name"] for g in gates if g["action"] == "run"]
+    print("::notice title=CI plan (diff-scoped)::")
     print("### CI plan (diff-scoped)")
     print(f"- filter_active: {doc['filter_active']}")
     print(f"- fail_open: {doc['fail_open']}")

--- a/tests/scripts/test_qg.sh
+++ b/tests/scripts/test_qg.sh
@@ -13,6 +13,8 @@
 #      gates; pre-commit ignores QG_DIFF_RANGE (staged diff wins).
 #   F. dashboard_build.files stays byte-identical to dashboard_dist_assert.files
 #      in the real stack.yml (dist_assert is a guaranteed red if build skipped).
+#   G. ci-aggregate-results.sh accepts success/skipped, rejects failure/cancelled.
+#   H. qg plan --stage ci — docs-only, tripwire, fail-open, typecheck skip (H1–H5).
 #
 # Usage: bash tests/scripts/test_qg.sh
 
@@ -27,6 +29,8 @@ fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 QG="${REPO_ROOT}/scripts/qg"
+AGG="${REPO_ROOT}/scripts/ci-aggregate-results.sh"
+PLAN_EMIT="${REPO_ROOT}/scripts/qg_plan_emit.py"
 
 if [[ ! -x "$QG" ]]; then
   echo "ERROR: qg runner not found at $QG" >&2
@@ -37,6 +41,19 @@ if ! command -v yq >/dev/null 2>&1; then
   echo "ERROR: yq required for test_qg.sh" >&2
   exit 1
 fi
+
+if [[ ! -x "$AGG" ]]; then
+  echo "ERROR: ci-aggregate-results.sh not found at $AGG" >&2
+  exit 1
+fi
+
+plan_json_body() {
+  python3 -c 'import json,re,sys; t=sys.stdin.read(); m=re.search(r"\{.*\}\s*$", t, re.S); d=json.loads(m.group(0) if m else t); print(json.dumps(d))'
+}
+
+plan_json_field() {
+  plan_json_body | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d'"$1"')'
+}
 
 # ---------------------------------------------------------------------------
 # A. Smoke — real repo, single gate
@@ -53,7 +70,7 @@ fi
 WORK="$(mktemp -d)"
 # WORK2/WORK3 are created later; ${VAR:+...} keeps the trap safe (set -u)
 # and covers aborts between fixture creation and the inline rm -rf.
-cleanup() { rm -rf "$WORK" ${WORK2:+"$WORK2"} ${WORK3:+"$WORK3"}; }
+cleanup() { rm -rf "$WORK" ${WORK2:+"$WORK2"} ${WORK3:+"$WORK3"} ${WORK4:+"$WORK4"}; }
 trap cleanup EXIT
 
 mkdir -p "$WORK/.claude"
@@ -348,6 +365,187 @@ else
 fi
 
 rm -rf "$WORK3"
+
+# ---------------------------------------------------------------------------
+# G. Aggregate CI results (phase 0)
+# ---------------------------------------------------------------------------
+set +e
+"$AGG" success success success >/dev/null 2>&1
+g_rc=$?
+"$AGG" success skipped success >/dev/null 2>&1
+g_skip_rc=$?
+"$AGG" failure success success >/dev/null 2>&1
+g_fail_rc=$?
+"$AGG" success cancelled success >/dev/null 2>&1
+g_cancel_rc=$?
+set -e
+
+if [[ "$g_rc" -eq 0 ]]; then
+  pass "aggregate: all success → exit 0"
+else
+  fail "aggregate all success" "expected 0, got $g_rc"
+fi
+
+if [[ "$g_skip_rc" -eq 0 ]]; then
+  pass "aggregate: success + skipped → exit 0"
+else
+  fail "aggregate skipped" "expected 0, got $g_skip_rc"
+fi
+
+if [[ "$g_fail_rc" -eq 1 ]]; then
+  pass "aggregate: failure → exit 1"
+else
+  fail "aggregate failure" "expected 1, got $g_fail_rc"
+fi
+
+if [[ "$g_cancel_rc" -eq 1 ]]; then
+  pass "aggregate: cancelled → exit 1"
+else
+  fail "aggregate cancelled" "expected 1, got $g_cancel_rc"
+fi
+
+# ---------------------------------------------------------------------------
+# H. qg plan — diff-scoped CI contract (phase 1)
+# ---------------------------------------------------------------------------
+WORK4="$(mktemp -d)"
+
+mkdir -p "$WORK4/.claude"
+cat >"$WORK4/.claude/stack.yml" <<'EOF'
+quality_gates:
+  typecheck:
+    enabled: true
+    script: true
+    stages: [ci]
+    files: ^(src/|packages/[^/]+/src/|tests/|pyproject\.toml$)
+  lint:
+    enabled: true
+    script: true
+    stages: [ci]
+  doc_drift_bundle:
+    enabled: true
+    stages: [ci]
+qg:
+  change_classes:
+    docs:
+      paths: ^(docs/|artifacts/)|AGENTS\.md$|\.md$|^\.claude/
+    python:
+      paths: ^(src/|packages/[^/]+/src/|tests/|pyproject\.toml$|uv\.lock$)
+  tripwires:
+    - ^uv\.lock$
+    - ^pyproject\.toml$
+  run_order:
+    ci:
+      - lint
+      - typecheck
+      - doc_drift_bundle
+EOF
+
+git init "$WORK4" >/dev/null 2>&1
+git -C "$WORK4" config user.email "tester@example.com"
+git -C "$WORK4" config user.name "tester"
+git -C "$WORK4" config commit.gpgsign false
+git -C "$WORK4" config core.hooksPath "$WORK4/.git/hooks"
+mkdir -p "$WORK4/artifacts/analyses"
+echo base >"$WORK4/artifacts/analyses/base.md"
+git -C "$WORK4" add artifacts/analyses/base.md
+git -C "$WORK4" commit -m base >/dev/null 2>&1
+PLAN_BASE="$(git -C "$WORK4" rev-parse HEAD)"
+
+run_plan_fixture() {
+  local range="$1"
+  set +e
+  if [[ "$range" == "--unset" ]]; then
+    plan_out="$(
+      env -u QG_DIFF_RANGE QG_REPO_ROOT="$WORK4" QG_STACK="$WORK4/.claude/stack.yml" \
+        "$QG" plan --stage ci --format json 2>&1
+    )"
+  else
+    plan_out="$(
+      QG_REPO_ROOT="$WORK4" QG_STACK="$WORK4/.claude/stack.yml" QG_DIFF_RANGE="$range" \
+        "$QG" plan --stage ci --format json 2>&1
+    )"
+  fi
+  plan_rc=$?
+  set -e
+}
+
+# H1. docs-only diff → jobs.tests skip, doc_drift_bundle run
+echo doc >"$WORK4/artifacts/analyses/only-doc.md"
+git -C "$WORK4" add artifacts/analyses/only-doc.md
+git -C "$WORK4" commit -m doc >/dev/null 2>&1
+DOC_ONLY_SHA="$(git -C "$WORK4" rev-parse HEAD)"
+run_plan_fixture "${PLAN_BASE}...HEAD"
+if [[ "$plan_rc" -eq 0 ]]; then
+  jobs_tests="$(printf '%s\n' "$plan_out" | plan_json_field "['jobs']['tests']['action']")"
+  bundle_action="$(printf '%s\n' "$plan_out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(g["action"] for g in d["gates"] if g["name"]=="doc_drift_bundle"))')"
+  taxonomy="$(printf '%s\n' "$plan_out" | plan_json_field "['taxonomy']")"
+  if [[ "$jobs_tests" == "skip" && "$bundle_action" == "run" && "$taxonomy" == *docs* ]]; then
+    pass "plan H1: docs-only → jobs.tests skip, doc_drift_bundle run"
+  else
+    fail "plan H1" "tests=$jobs_tests bundle=$bundle_action taxonomy=$taxonomy"
+  fi
+else
+  fail "plan H1 exit" "rc=$plan_rc output: $plan_out"
+fi
+
+# H2. tripwire (uv.lock) + doc in one diff → tripwire_hit, all jobs run
+echo lock >"$WORK4/uv.lock"
+echo more >"$WORK4/artifacts/analyses/trip.md"
+git -C "$WORK4" add uv.lock artifacts/analyses/trip.md
+git -C "$WORK4" commit -m tripwire >/dev/null 2>&1
+run_plan_fixture "${DOC_ONLY_SHA}...HEAD"
+if [[ "$plan_rc" -eq 0 ]]; then
+  trip_hit="$(printf '%s\n' "$plan_out" | plan_json_field "['tripwire_hit']")"
+  tests_action="$(printf '%s\n' "$plan_out" | plan_json_field "['jobs']['tests']['action']")"
+  if [[ "$trip_hit" == "True" && "$tests_action" == "run" ]]; then
+    pass "plan H2: tripwire_hit forces all jobs run"
+  else
+    fail "plan H2" "tripwire_hit=$trip_hit tests=$tests_action"
+  fi
+else
+  fail "plan H2 exit" "rc=$plan_rc output: $plan_out"
+fi
+
+# H3. QG_DIFF_RANGE unset → fail_open
+run_plan_fixture "--unset"
+if [[ "$plan_rc" -eq 0 ]]; then
+  fail_open="$(printf '%s\n' "$plan_out" | plan_json_field "['fail_open']")"
+  if [[ "$fail_open" == "True" ]]; then
+    pass "plan H3: unset QG_DIFF_RANGE → fail_open"
+  else
+    fail "plan H3" "fail_open=$fail_open"
+  fi
+else
+  fail "plan H3 exit" "rc=$plan_rc output: $plan_out"
+fi
+
+# H4. invalid diff ref → fail_open (mirror E2b)
+run_plan_fixture "definitely-not-a-ref...HEAD"
+if [[ "$plan_rc" -eq 0 ]]; then
+  fail_open="$(printf '%s\n' "$plan_out" | plan_json_field "['fail_open']")"
+  if [[ "$fail_open" == "True" ]] && printf '%s\n' "$plan_out" | grep -q 'files: filters disabled'; then
+    pass "plan H4: invalid QG_DIFF_RANGE → fail_open"
+  else
+    fail "plan H4" "fail_open=$fail_open output: $plan_out"
+  fi
+else
+  fail "plan H4 exit" "rc=$plan_rc output: $plan_out"
+fi
+
+# H5. docs-only plan skips typecheck gate
+run_plan_fixture "${PLAN_BASE}...${DOC_ONLY_SHA}"
+if [[ "$plan_rc" -eq 0 ]]; then
+  tc_action="$(printf '%s\n' "$plan_out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(g["action"] for g in d["gates"] if g["name"]=="typecheck"))')"
+  if [[ "$tc_action" == "skip" ]]; then
+    pass "plan H5: docs-only diff skips typecheck gate"
+  else
+    fail "plan H5" "typecheck action=$tc_action"
+  fi
+else
+  fail "plan H5 exit" "rc=$plan_rc output: $plan_out"
+fi
+
+rm -rf "$WORK4"
 
 # ---------------------------------------------------------------------------
 # F. dashboard_build.files ≡ dashboard_dist_assert.files — real stack.yml.

--- a/tests/scripts/test_qg.sh
+++ b/tests/scripts/test_qg.sh
@@ -30,7 +30,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 QG="${REPO_ROOT}/scripts/qg"
 AGG="${REPO_ROOT}/scripts/ci-aggregate-results.sh"
-PLAN_EMIT="${REPO_ROOT}/scripts/qg_plan_emit.py"
 
 if [[ ! -x "$QG" ]]; then
   echo "ERROR: qg runner not found at $QG" >&2
@@ -53,6 +52,36 @@ plan_json_body() {
 
 plan_json_field() {
   plan_json_body | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d'"$1"')'
+}
+
+plan_gate_action() {
+  local gate_name="$1"
+  plan_json_body | python3 -c 'import json,sys; d=json.load(sys.stdin); g=sys.argv[1]; print(next(x["action"] for x in d["gates"] if x["name"]==g))' "$gate_name"
+}
+
+validate_plan_schema() {
+  plan_json_body | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+required = (
+    "schema_version", "stage", "filter_active", "diff_range", "changed_files",
+    "taxonomy", "tripwire_hit", "fail_open", "docs_only", "gates", "jobs",
+)
+for key in required:
+    if key not in d:
+        raise SystemExit(f"missing key: {key}")
+if d["schema_version"] != 1:
+    raise SystemExit(f"schema_version={d['"'"'schema_version'"'"']}")
+for gate in d["gates"]:
+    for field in ("name", "action", "reason"):
+        if field not in gate:
+            raise SystemExit(f"gate missing {field}: {gate}")
+    if gate["action"] not in ("run", "skip"):
+        raise SystemExit(f"invalid gate action: {gate}")
+for job in ("gates", "tests", "package-coverage", "integration"):
+    if job not in d["jobs"] or "action" not in d["jobs"][job]:
+        raise SystemExit(f"jobs.{job} missing action")
+'
 }
 
 # ---------------------------------------------------------------------------
@@ -477,7 +506,7 @@ DOC_ONLY_SHA="$(git -C "$WORK4" rev-parse HEAD)"
 run_plan_fixture "${PLAN_BASE}...HEAD"
 if [[ "$plan_rc" -eq 0 ]]; then
   jobs_tests="$(printf '%s\n' "$plan_out" | plan_json_field "['jobs']['tests']['action']")"
-  bundle_action="$(printf '%s\n' "$plan_out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(g["action"] for g in d["gates"] if g["name"]=="doc_drift_bundle"))')"
+  bundle_action="$(printf '%s\n' "$plan_out" | plan_gate_action doc_drift_bundle)"
   taxonomy="$(printf '%s\n' "$plan_out" | plan_json_field "['taxonomy']")"
   if [[ "$jobs_tests" == "skip" && "$bundle_action" == "run" && "$taxonomy" == *docs* ]]; then
     pass "plan H1: docs-only → jobs.tests skip, doc_drift_bundle run"
@@ -535,7 +564,7 @@ fi
 # H5. docs-only plan skips typecheck gate
 run_plan_fixture "${PLAN_BASE}...${DOC_ONLY_SHA}"
 if [[ "$plan_rc" -eq 0 ]]; then
-  tc_action="$(printf '%s\n' "$plan_out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(g["action"] for g in d["gates"] if g["name"]=="typecheck"))')"
+  tc_action="$(printf '%s\n' "$plan_out" | plan_gate_action typecheck)"
   if [[ "$tc_action" == "skip" ]]; then
     pass "plan H5: docs-only diff skips typecheck gate"
   else
@@ -543,6 +572,14 @@ if [[ "$plan_rc" -eq 0 ]]; then
   fi
 else
   fail "plan H5 exit" "rc=$plan_rc output: $plan_out"
+fi
+
+# H6. plan JSON matches embedded schema (spec acceptance)
+run_plan_fixture "${PLAN_BASE}...${DOC_ONLY_SHA}"
+if [[ "$plan_rc" -eq 0 ]] && printf '%s\n' "$plan_out" | validate_plan_schema; then
+  pass "plan H6: JSON output validates embedded schema"
+else
+  fail "plan H6 schema" "rc=$plan_rc output: $plan_out"
 fi
 
 rm -rf "$WORK4"


### PR DESCRIPTION
## Summary

Implements [#2249](https://github.com/Roxabi/roxabi-factory/issues/2249) diff-scoped CI **phase 0–1** (spec + code):

- **Phase 0**: aggregate `ci` accepts `skipped` jobs via `scripts/ci-aggregate-results.sh` (unblocks phase 2 conditional jobs)
- **Phase 1**: `scripts/qg plan --stage ci` JSON contract + GitHub summary; `stack.yml` taxonomy/tripwires; extended `files:` on high-cost gates; `ci-plan.json` artifact in Actions

## Spec

`artifacts/specs/2249-ci-diff-scoped-plan-phase-0-1-spec.mdx`

## Tests

`bash tests/scripts/test_qg.sh` — sections G (aggregate) + H1–H5 (plan)

Closes #2249