### PR TITLE
docs(runbooks): add credential rotation policy & schedule

### DIFF
--- a/docs/runbooks/gh-key-rotation.md
+++ b/docs/runbooks/gh-key-rotation.md
@@ -10,8 +10,8 @@ This runbook does **not** cover changing the GitHub App ID or installation ID �
 
 ## When to Rotate
 
-- **Compromise suspected** — PEM leaked in logs, visible in a build artifact, exfiltrated from disk, or accessible to an unauthorized party.
-- **Scheduled rotation** — recommended cadence: every 90 days for prod (M₁), every 180 days for dev (M₂). These are operational heuristics, not a policy requirement.
+- **Compromise suspected** — PEM leaked in logs, visible in a build artifact, exfiltrated from disk, or accessible to an unauthorized party. Rotate immediately — see the event-triggered rules in [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule), which apply to this credential too.
+- **Scheduled rotation** — cadence: every 90 days for prod (M₁), matching the max-seed-age policy in [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule); every 180 days for dev (M₂) as an intentional relaxation for the non-prod host. Not yet machine-enforced for either host — see that section's "Enforcement status."
 - **Operator key change** — the GitHub App "Generate a private key" action on github.com invalidates the previous key; rotation must follow immediately.
 
 ---
@@ -167,3 +167,4 @@ Record the rotation in your operations journal:
 - [`deploy/provision.sh`](../../deploy/provision.sh) — section "Lyra GitHub App PEM (Podman secret)" for first-time bootstrap
 - [`docs/runbooks/clipool-uid-model.md`](clipool-uid-model.md) — clipool git behavior + UID trust model (SSH rewrite, identity, `safe.directory`)
 - [`docs/runbooks/nkey-rotation.md`](nkey-rotation.md) — sibling runbook for NATS nkey rotation
+- [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule) — central max-seed-age policy, event triggers, rotation log format

--- a/docs/runbooks/gh-key-rotation.md
+++ b/docs/runbooks/gh-key-rotation.md
@@ -11,7 +11,7 @@ This runbook does **not** cover changing the GitHub App ID or installation ID �
 ## When to Rotate
 
 - **Compromise suspected** — PEM leaked in logs, visible in a build artifact, exfiltrated from disk, or accessible to an unauthorized party. Rotate immediately — see the event-triggered rules in [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule), which apply to this credential too.
-- **Scheduled rotation** — cadence: every 90 days for prod (M₁), matching the max-seed-age policy in [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule); every 180 days for dev (M₂) as an intentional relaxation for the non-prod host. Not yet machine-enforced for either host — see that section's "Enforcement status."
+- **Scheduled rotation** — cadence: every 90 days for prod (M₁), matching the max-seed-age policy in [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule); every 180 days for dev (M₂) as an intentional relaxation for the non-prod host. PEM is not covered by `make check-seed-age` (nkey-only) — calendar reminder + operator discipline; append to `rotation-log.md` manually after rotation (Section 5).
 - **Operator key change** — the GitHub App "Generate a private key" action on github.com invalidates the previous key; rotation must follow immediately.
 
 ---

--- a/docs/runbooks/nkey-rotation.md
+++ b/docs/runbooks/nkey-rotation.md
@@ -9,6 +9,8 @@ If you are here because `auth.conf` is out of date, an ACL grant is wrong, or a 
 - [nats-authconf-update.md](nats-authconf-update.md) — ACL/permission changes (`make nats-regen-authconf`)
 - [nats-identity-lifecycle.md](nats-identity-lifecycle.md) — adding (`make nats-add-identity`) or retiring an identity
 
+If you are here for the **quarterly scheduled rotation** (no compromise, just the calendar cadence) or want the max-seed-age policy, see [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule) — this runbook covers the compromise-response mechanics only.
+
 **If you are not responding to a suspected compromise, you do not want this runbook.**
 
 Rotation replaces the seed file (private key material) for one or more identities. The affected processes authenticate with new credentials after their consuming unit restarts. All other identities keep their existing seeds untouched.
@@ -314,6 +316,7 @@ ls ~/.roxabi/factory/nkeys/*.bak-* 2>/dev/null && echo "WARNING: backup files st
 ## Cross-references
 
 - [`deploy/nats/acl-matrix.json`](../../deploy/nats/acl-matrix.json) — identity registry (SSoT for the active set)
+- [secrets-rotation.md § Rotation policy & schedule](secrets-rotation.md#rotation-policy--schedule) — max seed age, scheduled cadence, event triggers, rotation log
 - [nats-authconf-update.md](nats-authconf-update.md) — routine ACL/permission changes; external seed distribution
 - [nats-identity-lifecycle.md](nats-identity-lifecycle.md) — adding / retiring identities (`make nats-add-identity`)
 - [`tools/check-nats-acls.sh`](../../tools/check-nats-acls.sh) — ACL violation detector used in Verification

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -18,6 +18,35 @@
 
 NATS `auth.conf` is an **inline bind mount**, not a Podman secret (ADR-085). Nkey seeds use `type=mount` (tmpfs). OAuth/LiteLLM use `type=env`.
 
+## Rotation policy & schedule
+
+Governs *when* a secret must rotate. The *how* is the per-secret procedures above and in the cross-referenced runbooks below.
+
+**Max seed age: 90 days.** Every identity in [`acl-matrix.json`](../../deploy/nats/acl-matrix.json) must not exceed 90 days since its last rotation (per the P2 recommendation in [nats-acl-inbox-case-postmortem.md](../history/nats-acl-inbox-case-postmortem.md)).
+
+**Event-triggered rotation — rotate immediately, regardless of the quarterly cadence:**
+
+- Suspected compromise (seed exfiltrated, exposed in a backup, etc.) — procedure: [nkey-rotation.md](nkey-rotation.md).
+- Personnel change with prod (M₁) access — an operator loses (or no longer needs) prod access.
+- A seed observed somewhere it shouldn't be — logs, a build artifact, a screen share.
+
+**Scheduled rotation.** Absent an event trigger, rotate every identity on a quarterly calendar reminder (~90 days). Rotating an identity resets its own clock only — it does not reset the age of any other identity.
+
+**Rotation log.** Every rotation — scheduled or event-triggered — gets one entry in `~/.roxabi/factory/rotation-log.md` (created on first write; see [operator-log.md](operator-log.md) for the full audit-log map). Entry format, written by `rotation_log_append()` in [`deploy/lib/operator-log.sh`](../../deploy/lib/operator-log.sh):
+
+```
+YYYY-MM-DD | secret:<identity> | reason:<reason> | by:<operator> | trigger:<manual|scheduled|compromise|...> | host:<hostname>
+```
+
+If a rotation runs outside an instrumented script (raw `podman secret create`, manual seed swap), append the entry by hand — see "Manual operations" in [operator-log.md](operator-log.md).
+
+**Enforcement status: not yet wired.** Today this is operator discipline, not a machine-checked control:
+
+- `rotation_log_append()` is only called from the disaster-recovery path ([`secrets_reset.py`](../../src/factory/cli/secrets_reset.py)) — routine per-identity rotation via [nkey-rotation.md](nkey-rotation.md) Path A/B does not yet log, so the rotation log is not a complete age source for every identity.
+- There is no `make check-seed-age` (or equivalent) target — nothing currently reads the log and fails a stale identity.
+
+Wiring the routine path and adding an age-check target is tracked in [#2246](https://github.com/Roxabi/roxabi-factory/issues/2246); until it ships, treat the 90-day max as a calendar reminder to act on, not a gate that will catch a missed rotation.
+
 ## Rotate one nkey
 
 ```bash

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -40,12 +40,13 @@ YYYY-MM-DD | secret:<identity> | reason:<reason> | by:<operator> | trigger:<manu
 
 If a rotation runs outside an instrumented script (raw `podman secret create`, manual seed swap), append the entry by hand — see "Manual operations" in [operator-log.md](operator-log.md).
 
-**Enforcement status: not yet wired.** Today this is operator discipline, not a machine-checked control:
+**Enforcement (nkey seeds, #2246).** For identities in [`acl-matrix.json`](../../deploy/nats/acl-matrix.json), the 90-day max is machine-checked on M₁:
 
-- `rotation_log_append()` is only called from the disaster-recovery path ([`secrets_reset.py`](../../src/factory/cli/secrets_reset.py)) — routine per-identity rotation via [nkey-rotation.md](nkey-rotation.md) Path A/B does not yet log, so the rotation log is not a complete age source for every identity.
-- There is no `make check-seed-age` (or equivalent) target — nothing currently reads the log and fails a stale identity.
+- **Logging.** Routine rotation via [nkey-rotation.md](nkey-rotation.md) Path A (`make nats-add-identity`) and Path B (`factory-acl genkeys`) calls `rotation_log_append()` automatically. Disaster recovery ([`secrets_reset.py`](../../src/factory/cli/secrets_reset.py)) and blobstore regen (`deploy/install.sh`) also append. Manual rotations outside those paths must still append by hand (see [operator-log.md](operator-log.md)).
+- **Age check.** `make check-seed-age` reads `rotation-log.md` as the sole authoritative age source: **warn at ≥75 days**, **fail at ≥90 days**. Seed-file mtime is informational only (Syncthing/rsync/restore reset it). Identities with **no log entry** are in bootstrap grace — the check never gates them until their first logged rotation.
+- **Schedule.** `factory-check-seed-age.timer` runs the check daily on M₁. It is **not** a CI/merge gate — a stale identity surfaces as `factory-check-seed-age.service` in `failed` state and `systemctl --user is-system-running` → `degraded`. Bootstrap grace, fail-open logging, and triage notes → [nkey-rotation.md § Bootstrap grace](nkey-rotation.md#bootstrap-grace--rotation-log-and-seed-age-policy).
 
-Wiring the routine path and adding an age-check target is tracked in [#2246](https://github.com/Roxabi/roxabi-factory/issues/2246); until it ships, treat the 90-day max as a calendar reminder to act on, not a gate that will catch a missed rotation.
+**Non-nkey secrets** (GitHub App PEM, OAuth, LiteLLM, blobstore) follow the same event-triggered and quarterly cadence rules above but are **not** covered by `check-seed-age` — operator discipline plus the rotation log for instrumented paths.
 
 ## Rotate one nkey
 


### PR DESCRIPTION
## Summary
- Add a "Rotation policy & schedule" section to `docs/runbooks/secrets-rotation.md`: 90-day max seed age, event-triggered rotation (compromise, personnel change with prod access, seed exposure), quarterly scheduled cadence, and the `rotation-log.md` entry format written by `rotation_log_append()`.
- Documents **live enforcement** from #2246: routine rotation paths log automatically, `make check-seed-age` warns at ≥75d / fails at ≥90d (daily timer on M₁, not a CI gate), bootstrap grace for unlogged identities. PEM and other non-nkey secrets remain calendar/operator discipline.
- Cross-link `nkey-rotation.md` and `gh-key-rotation.md` to the new section; reconcile `gh-key-rotation.md`'s prior "operational heuristic" wording (keeps 90d-prod/180d-dev split, ties prod cadence to central max age).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2204: docs(ops): document credential rotation policy | OPEN |
| Implementation | 2 commits on `feat/2204-document-credential-rotation-policy` | Complete |
| Verification | doc-drift ✅ doc-semantic-drift ✅ (rebased on staging post-#2246) | Pending CI |

## Test Plan
- [x] `tools/check_doc_drift.py` — 0 new violations
- [x] `tools/check_doc_semantic_drift.py` — 0 violations
- [ ] CI gates on rebased push
- [ ] Human read-through: PEM 90d-prod/180d-dev split vs nkey machine enforcement scope

Fixes #2204