### PR TITLE
chore(monitoring): thin V1-pull detection slice — re-arm NATS ACL/log alerting

### DIFF
--- a/artifacts/frames/2245-thin-v1-pull-detection-slice-frame.mdx
+++ b/artifacts/frames/2245-thin-v1-pull-detection-slice-frame.mdx
@@ -1,0 +1,106 @@
+---
+title: "chore(monitoring): thin V1-pull detection slice — re-arm NATS ACL/log alerting without reviving the frozen host-timer"
+issue: 2245
+status: approved
+tier: F-lite
+date: 2026-07-05
+---
+
+## Problem
+
+The 2026-04-27 NATS ACL incident took 2h44m to detect — zero alerts fired, found only
+by a human manually reading container logs. The alerting logic that would have caught
+it (`check_nats_log_errors` in `src/factory/monitoring/checks_log.py`, scans container
+logs for "permissions violation", escalates via `src/factory/monitoring/escalation.py`
+→ Telegram) already exists and was marked done in the original postmortem. Its
+scheduler — the host-side `deploy/lyra-monitor.{service,timer}` systemd timer — was
+removed in `deploy/provision.sh` ("superseded by Monitoring v2, tracked in #1035").
+#1035 (Monitoring v2 — NATS event stream + Tauri dashboard) closed without shipping
+that replacement (no `lyra.event.*`/`lyra.metric.*` producers in `src/`, no dashboard).
+ADR-091 (four observability planes) reframes monitoring a third time but also has zero
+shipped plane③ runtime today. Net: three generations of monitoring plans, zero shipped
+detection in production — the April 2h44m gap is still open.
+
+**Why now:** split out of #2203 (incident-response runbook) per architect/axial-drift/
+security/devops panel review (2026-07-04) — the runbook only defines process *after* a
+human notices; without this slice, detection stays manual. **Observable impact:** any
+repeat NATS ACL misconfiguration or hub `_dict_stream_gen` stall goes undetected until
+someone happens to read logs.
+
+## Who
+
+- **Primary:** Mickael (sole on-call operator) — needs a Telegram page instead of a
+  cold log read when a permissions-violation burst or hub stream-gen timeout occurs.
+- **Secondary:** future Sentinelle/Monitoring-v2 work (#1035) — this slice must not
+  foreclose the plane③ V2 subscribe-based design; it is explicitly the V1-pull
+  placeholder ADR-091 already prescribes.
+
+## Constraints
+
+- ADR-091 plane③ boundary rule: infra health is **state**, consumed via **V1: pull**
+  (`/health/detail`, monitoring checks) until #1035's V2 (`factory.metric.*` subscribe)
+  ships — this slice is the V1-pull mechanism, nothing upstream of it.
+- Must **not** re-arm `deploy/lyra-monitor.{service,timer}` verbatim — #1035 explicitly
+  said "do not extend the host-timer monitor," and flagged its host-systemd-dependency
+  problems (`systemctl --user` service introspection via `check_process`, direct
+  `localhost:8443` HTTP assumption via `check_http_health`).
+- Must reuse the existing pure check functions (`check_nats_log_errors`,
+  `check_hub_dict_stream_gen_timeout` in `checks_log.py`) — they only shell out to
+  `podman logs <container>`, no host systemd coupling.
+- Must reuse the existing Telegram escalation path (`escalation.py`) — still
+  functional, no changes needed to its contract.
+- Interval ≤5 minutes (matches the acceptance criterion and the existing
+  `check_interval_minutes` default in `MonitoringConfig`).
+- `deploy/lyra-monitor.{service,timer}` stays retired/untouched — no file changes there.
+- Depends on #2203 (incident-response runbook) only for a documentation cross-reference
+  (this issue's PR should point at the runbook path once it exists) — not a build
+  dependency; #2203 may land before or after this PR.
+- Size `F-lite`, `P1-high` — single domain (`src/factory/monitoring/` + one new
+  deploy surface), no new architecture, panel-reviewed scope.
+
+## Out of Scope
+
+- Reviving `deploy/lyra-monitor.{service,timer}` as-is, or any host-side `--user`
+  systemd timer that re-implements `check_process`'s `systemctl --user is-active`
+  introspection or `check_http_health`'s `localhost:8443` assumption.
+- Monitoring v2 / full Sentinelle (`factory.metric.*` JetStream producers/subscribers,
+  Tauri dashboard, event-bus plane③) — that is #1035, explicitly future work.
+- Any other check beyond the two named log checks (disk, blobstore, audio-lag,
+  process-liveness, queue-depth, etc. from the full `run_checks()` pipeline) — those
+  stay on their current path (or unmonitored) and are not this issue's concern.
+- Writing #2203's incident-response runbook content — this issue only references it.
+- New alert channels beyond Telegram (Discord, PagerDuty, etc.).
+
+## Premise Validity
+
+**Success in 6 months:** a periodic, container-native check (≤5 min interval) runs
+`check_nats_log_errors` (and `check_hub_dict_stream_gen_timeout`) against the
+NATS/hub containers with no host-timer/`systemctl --user` dependency; on a real
+anomaly a Telegram alert fires via `escalation.py` within one check interval — a
+repeat of an April-2026-class incident is caught by an automated alert, not by a
+human reading logs.
+
+**Failure in 6 months (falsifiable):** at ≥6 months (2027-01), a NATS
+permissions-violation burst or hub `_dict_stream_gen` stall occurs in production logs
+but zero Telegram alert is found in the corresponding window — i.e. the periodic
+check silently stopped running, was never wired into the deploy surface, or its
+escalation path was broken — verified by diffing incident log timestamps against
+Telegram alert history.
+
+**Simplest alternative:** re-enable `deploy/lyra-monitor.{service,timer}` unchanged.
+**Why not simplest:** it re-introduces exactly the host-systemd-dependency problems
+(`systemctl --user` introspection of other services, `localhost:8443` host-network
+assumption) that #1035 flagged when retiring it, and reviving it verbatim directly
+contradicts that closed epic's own directive ("do not extend the host-timer
+monitor") — it does not fit the now fully-containerized (Quadlet) deployment model
+this repo has since standardized on.
+
+## Complexity
+
+**Tier: F-lite** — label `size:F-lite`; single domain (`src/factory/monitoring/` +
+one new small deploy/scheduling surface), clear panel-reviewed scope, no new
+architecture pattern beyond picking a container-native scheduling mechanism among the
+two options ADR-091/the issue already names (Quadlet timer vs. in-process scheduler
+with scoped podman-socket mount) — that choice is deferred to `/spec` + `/plan`.
+
+Signals: clear scope ∨ single domain ∨ issue label F-lite — all present.

--- a/artifacts/plans/2245-thin-v1-pull-detection-slice-plan.mdx
+++ b/artifacts/plans/2245-thin-v1-pull-detection-slice-plan.mdx
@@ -131,8 +131,13 @@ flowchart LR
 | Agent | Instances | Task count | Files |
 |-------|-----------|------------|-------|
 | backend-dev | A, B | 6 (A: 3, B: 3) | `src/factory/monitoring/checks_log.py`, `src/factory/monitoring/log_watch.py` (new), `src/factory/monitoring/__init__.py`, `src/factory/bootstrap/standalone/worker_standalone.py`, `src/factory/cli/main.py` |
-| tester | A | 4 | `tests/test_monitoring_checks_log.py` (new), `tests/test_monitoring_log_watch.py` (new), `tests/bootstrap/test_log_monitor_standalone_paths.py` (new), `tests/test_monitoring_deprecation.py` (new) |
-| devops | A | 3 | `deploy/quadlet/factory-log-monitor.container` (new), `deploy/quadlet.toml` |
+| tester | A, B | 5 (A: 3, B: 2) | `tests/test_monitoring_checks_log.py` (new), `tests/test_monitoring_log_watch.py` (new), `tests/bootstrap/test_log_monitor_standalone_paths.py` (new), `tests/test_monitoring_deprecation.py` (new) |
+| devops | A | 3 | `deploy/quadlet/factory-log-monitor.container` (new), `deploy/quadlet.toml`, `deploy/secrets-policy.toml`, `docs/CONFIGURATION.md` |
+
+**Post-`/plan` correction (advisor review, pre-`/implement`):** the tester agent force-splits into
+A/B because Wave 0's new baseline task (T0, see below) pushes tester-A's task count to 5 (>4 cap).
+T0 + T4 + T6 → tester-A (checks_log/log_watch subject-chain); T13 + T8 → tester-B (deprecation +
+CLI-smoke subject-chain).
 
 No frontend-dev (no UI surface), no architect/security-auditor/doc-writer instance needed for
 implementation — architecture and security tradeoffs (Podman-socket rejection, Loki pivot) were
@@ -148,7 +153,7 @@ Every Success Criterion (SC1–SC10, SC3b) traces to ≥1 micro-task; every micr
 |----|-----------|
 | SC1 (≤5min interval, no systemctl/host-timer) | T5, T9 |
 | SC2 (Loki fetch, no Podman socket/CLI, no new image) | T2, T9 |
-| SC3 (default-fetcher behavior unchanged) | T1, T3, T4 |
+| SC3 (default-fetcher behavior unchanged) | T0, T1, T3 |
 | SC3b (unified `LogFetchError`) | T1, T2, T3, T4 |
 | SC4 (Telegram alert on failure) | T5, T6 |
 | SC5 (all-pass → zero Telegram calls) | T5, T6 |
@@ -158,11 +163,11 @@ Every Success Criterion (SC1–SC10, SC3b) traces to ≥1 micro-task; every micr
 | SC9 (`quadlet-lint` passes) | T9, T10, T11 |
 | SC10 (no event/metric bus producer) | T5, T7, T8 |
 
-Slices: SL1→T1–T4, SL2→T5–T6, SL3→T7–T8, SL4→T9–T11, SL5→T12–T13, SL6→exempted (PR-description
+Slices: SL1→T0–T4, SL2→T5–T6, SL3→T7–T8, SL4→T9–T11, SL5→T12–T13, SL6→exempted (PR-description
 deliverable, written during `/pr`, not a code micro-task — consistent with `/plan`'s "Tier F"
 process, which generates micro-tasks for code slices only).
 
-Covered: 11/11 SC · 6/6 slices (5 code slices → 13 tasks, 1 doc slice → PR-step). Uncovered: none.
+Covered: 11/11 SC · 6/6 slices (5 code slices → 14 tasks, 1 doc slice → PR-step). Uncovered: none.
 
 ## Reference Patterns (Step 3)
 
@@ -174,8 +179,47 @@ Covered: 11/11 SC · 6/6 slices (5 code slices → 13 tasks, 1 doc slice → PR-
   `asyncio.run(coro_factory(raw_config))`. Not NATS-specific; safe to reuse for a non-NATS loop.
 - Quadlet unit conventions: `deploy/quadlet/factory-turn-writer.container` (hardening flags,
   `UserNS=keep-id`, `Secret=...,type=mount,...` for nkey) and `deploy/quadlet/factory-clipool.container`
-  (`Secret=<name>,type=env,target=<VAR>` — the pattern to mirror for `TELEGRAM_TOKEN`/
-  `TELEGRAM_ADMIN_CHAT_ID`).
+  (`Secret=factory-claude-oauth,type=env,target=CLAUDE_CODE_OAUTH_TOKEN` — the exact pattern to
+  mirror for `TELEGRAM_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID`).
+- **Resolved (post-`/plan` investigation, do not re-derive at `/implement`): no existing Podman
+  secret carries a bare Telegram bot API token.** `factory-nats-telegram` (used by
+  `factory-telegram.container`) is a NATS NKey seed, not a bot token; the conversational multi-bot
+  tokens live in `secret-class.bot-token` (`factory-bot-{platform}-{bot_id}`, policy
+  `bot-provisioned`, sourced from `~/.roxabi/factory/config.db` via `BotStore` — a different
+  credential entirely, for a different Telegram bot). `MonitoringConfig`
+  (`src/factory/monitoring/config.py::load_monitoring_config`) hard-requires bare
+  `TELEGRAM_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID` env vars (raises `ValueError` if absent) — this is
+  pre-existing, unchanged by this slice. The retired `deploy/lyra-monitor.service` supplied them via
+  a host-side `EnvironmentFile=%h/projects/lyra/.env` (plaintext), which is exactly the
+  host-dependency model this issue must not reproduce. **T9 must mint two new `policy = "optional"`
+  secrets** in `deploy/secrets-policy.toml` — `factory-telegram-monitor-token` (source
+  `telegram-monitor-token.tok`) and `factory-telegram-monitor-chat-id` (source
+  `telegram-monitor-chat-id.tok`) — wired via `Secret=factory-telegram-monitor-token,type=env,target=TELEGRAM_TOKEN`
+  / `Secret=factory-telegram-monitor-chat-id,type=env,target=TELEGRAM_ADMIN_CHAT_ID`, with a
+  `# Bootstrap: podman secret create factory-telegram-monitor-token - <<< "<token>"`-style comment
+  mirroring `factory-clipool.container`'s `# Bootstrap: claude setup-token | podman secret create
+  factory-claude-oauth -` convention. `policy = "optional"` is safe pre-provisioning — confirmed via
+  `deploy/install.sh:255` and `tools/check_secrets_drift.sh` (optional secrets are skipped, never
+  fail validation/drift-check); the new container will crash-loop (`Restart=on-failure`) until the
+  operator provisions the actual token post-merge — an expected, documented rollout step, not a
+  converge-breaking regression. `docs/CONFIGURATION.md:440,442` currently documents
+  `TELEGRAM_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID` as "legacy single-bot path only... see #1035" — this is
+  now stale once this slice ships (they become the live credential path for
+  `factory-log-monitor`); T9 must update that table row.
+- **Resolved (post-`/plan` investigation): unfiltered Loki fetch risks silent truncation under load.**
+  `GET /loki/api/v1/query_range` returns at most `limit` lines, newest-first, within the query
+  window — unlike `podman logs --since`, which has no such cap. On a container emitting >5000 lines
+  in the check window, older violation lines could fall outside an unfiltered fetch and go
+  uncounted — defeating detection at exactly the load where an incident is likely. Fix: the
+  `LogFetcher` protocol's `fetch()` gains a required `pattern: str` parameter (the check functions'
+  own search string — `"permissions violation"` / `"_dict_stream_gen timeout"`).
+  `SubprocessLogFetcher.fetch()` accepts `pattern` for protocol conformance but ignores it (full
+  fetch, behavior byte-for-byte unchanged — no truncation risk locally, `podman logs --since` has no
+  line cap). `LokiLogFetcher.fetch()` uses `pattern` to build a server-side LogQL filter:
+  `{{systemd_unit="<container>.service"}} |~ "(?i)<re.escape(pattern)>"` — case-insensitive regex
+  match (a safe superset of both checks' needs) applied *before* Loki's `limit`, so the exact
+  client-side counting logic downstream (unchanged from today) never sees a truncated window. `T1`,
+  `T2`, `T3` below are updated accordingly.
 - `deploy/quadlet.toml`: 20 `[component.*]` entries already present (e.g. `[component.turn-writer]`
   at line 42) — add `[component.log-monitor]` following the same shape.
 - Test precedent: `tests/bootstrap/test_turn_writer_standalone_paths.py` — mirror for
@@ -183,9 +227,16 @@ Covered: 11/11 SC · 6/6 slices (5 code slices → 13 tasks, 1 doc slice → PR-
 - **Verified via grep: no existing tests reference `check_nats_log_errors` or
   `check_hub_dict_stream_gen_timeout` anywhere in the tree today** (only `checks_log.py` and
   `checks.py` itself reference the symbols). SC3's "all pre-existing tests... pass without
-  modification" is vacuously true — but this means T4 must **write new regression/baseline tests**
-  for current default-fetcher behavior (not just add Loki-fetcher tests), so the refactor has any
-  coverage at all. Folded into T4 below.
+  modification" is vacuously true — this means a characterization/baseline test must be authored
+  **before** the refactor touches `checks_log.py`, or SC3 can never be falsified (there is nothing
+  to prove "unchanged" against). **Post-`/plan` correction (advisor review): T4 originally combined
+  baseline + Loki tests and was scheduled entirely after T1–T3 (test-after) — that proves nothing
+  about behavior preservation.** Split into `T0` (new — Wave 0, before T1: write the
+  characterization tests against the *current*, unmodified `checks_log.py` signature, confirm GREEN
+  now) and `T4` (Loki-fetcher + fetcher-seam tests only, Wave 2 after T3, genuine RED-GATE — these
+  import symbols that don't exist yet). T0's tests are re-run unmodified after T3 (Wave 2) as the
+  actual SC3 falsification: still-GREEN proves the refactor preserved behavior; a regression turns
+  them RED.
 - Quadlet CI gate: `.github/workflows/quadlet-lint.yml` — `podman quadlet --dryrun --user` (env
   `QUADLET_UNIT_DIRS=deploy/quadlet`) + `HealthCmd=` double-quote grep + inline-`#`-comment grep +
   `tools/check_quadlet_template_purity.sh`. Requires Podman ≥5 (not guaranteed on the local dev
@@ -196,45 +247,54 @@ Covered: 11/11 SC · 6/6 slices (5 code slices → 13 tasks, 1 doc slice → PR-
 
 ## Wave Structure
 
-3 waves, max 3 parallel agent instances. Elapsed ~3 sequential stages vs 13 tasks fully serial —
-roughly 4-5x parallelism inside Wave 1.
+4 waves, max 3 parallel agent instances. Wave 0 is a hard ordering gate (advisor-driven correction,
+see Reference Patterns): T0's characterization tests must be authored and confirmed GREEN against
+the *unmodified* `checks_log.py` before T1 starts editing it — otherwise SC3 ("default-fetcher
+behavior unchanged") has nothing to prove "unchanged" against.
 
 | Wave | Trigger | Agents | Tasks |
 |------|---------|--------|-------|
-| 1 | start | 3 ∥ | backend-dev-A: T1→T2→T3 · backend-dev-B: T12 · devops-A: T9→T10→T11 |
-| 2 | Wave 1 done | 2 ∥ | backend-dev-B: T5→T7 · tester-A: T4, T13 |
-| 3 | Wave 2 done | 1 | tester-A: T6, T8 |
+| 0 | start | 3 ∥ | tester-A: T0 · backend-dev-B: T12 · devops-A: T9→T10→T11 |
+| 1 | T0 done | 2 ∥ | backend-dev-A: T1→T2→T3 · tester-B: T13 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-B: T5→T7 · tester-A: T4 |
+| 3 | Wave 2 done | 2 ∥ | tester-A: T6 · tester-B: T8 |
+
+T12/T9–T11 have no dependency on T0 and run in Wave 0 alongside it; T13 only depends on T12
+(Wave 0) so it starts in Wave 1 rather than waiting for T3.
 
 ### Budget — per task
 
 | Task | Items | Class | Est. ops | Split? |
 |------|-------|-------|----------|--------|
+| T0 — baseline characterization tests (current behavior) | 2 | judgmental | 5 | — |
 | T1 — LogFetcher protocol + LogFetchError + SubprocessLogFetcher | 1 | judgmental | 5 | — |
-| T2 — LokiLogFetcher | 1 | judgmental | 5 | — |
-| T3 — wire `fetcher` param into both check functions | 2 | bounded | 3 | — |
-| T4 — regression + Loki-fetcher tests | 3 | judgmental | 6 | — |
+| T2 — LokiLogFetcher (pattern-filtered LogQL) | 1 | judgmental | 6 | — |
+| T3 — wire `fetcher`+`pattern` param into both check functions | 2 | bounded | 4 | — |
+| T4 — Loki-fetcher + fetcher-seam tests | 2 | judgmental | 4 | — |
 | T5 — LogMonitorLoop | 1 | judgmental | 6 | — |
 | T6 — LogMonitorLoop tests | 3 | judgmental | 5 | — |
 | T7 — bootstrap fn + CLI command registration | 2 | bounded | 4 | — |
 | T8 — CLI/bootstrap smoke test + bus-producer grep check | 2 | bounded | 3 | — |
-| T9 — `factory-log-monitor.container` unit | 1 | bounded | 4 | — |
+| T9 — `factory-log-monitor.container` unit + secrets + doc fix | 3 | judgmental | 6 | — |
 | T10 — `[component.log-monitor]` in `quadlet.toml` | 1 | trivial | 2 | — |
 | T11 — quadlet-lint local run + fixups | 1 | trivial | 2 | — |
 | T12 — narrow `DeprecationWarning` + `pyproject.toml` filter | 2 | bounded | 3 | — |
 | T13 — deprecation-warning test | 1 | bounded | 3 | — |
 
-**Total estimated ops: 51**
+**Total estimated ops: 58**
 
 ### Budget — per agent instance
 
 | Instance | Tasks | Σ ops | Subjects | Split? |
 |----------|-------|-------|----------|--------|
-| backend-dev-A | T1, T2, T3 | 13 | monitoring | — |
+| backend-dev-A | T1, T2, T3 | 15 | monitoring | — |
 | backend-dev-B | T5, T7, T12 | 13 | monitoring | — |
-| tester-A | T4, T6, T8, T13 | 17 | monitoring | — |
-| devops-A | T9, T10, T11 | 8 | deploy | — |
+| tester-A | T0, T4, T6 | 14 | monitoring | — |
+| tester-B | T13, T8 | 6 | monitoring | — |
+| devops-A | T9, T10, T11 | 10 | deploy | — |
 
-No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each.
+No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each. (tester force-split
+into A/B is itself the fix for the pre-correction budget violation — see Agents table note.)
 
 ## Task Seeding Blueprint
 
@@ -245,17 +305,27 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
      so parallel tasks map to distinct spawned agents.
      Seed in wave order; within a wave all rows are parallel (∥). -->
 
-### Wave 1 — no deps, 3 agents ∥
+### Wave 0 — no deps, 3 agents ∥
+
+<!-- T0 gates T1 (see Wave Structure) — /implement must confirm T0's tests are authored and
+     GREEN against the unmodified checks_log.py before spawning backend-dev-A for T1. -->
 
 | Task | Agent instance | blockedBy | Subject |
 |------|---------------|-----------|---------|
-| T1 | backend-dev-A | — | monitoring |
-| T2 | backend-dev-A | T1 | monitoring |
-| T3 | backend-dev-A | T2 | monitoring |
+| T0 | tester-A | — | monitoring |
 | T12 | backend-dev-B | — | monitoring |
 | T9 | devops-A | — | deploy |
 | T10 | devops-A | T9 | deploy |
 | T11 | devops-A | T10 | deploy |
+
+### Wave 1 — after T0, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | T0 | monitoring |
+| T2 | backend-dev-A | T1 | monitoring |
+| T3 | backend-dev-A | T2 | monitoring |
+| T13 | tester-B | T12 | monitoring |
 
 ### Wave 2 — after Wave 1, 2 agents ∥
 
@@ -264,28 +334,54 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
 | T5 | backend-dev-B | T3 | monitoring |
 | T7 | backend-dev-B | T5 | monitoring |
 | T4 | tester-A | T3 | monitoring |
-| T13 | tester-A | T12 | monitoring |
 
-### Wave 3 — after Wave 2, 1 agent
+### Wave 3 — after Wave 2, 2 agents ∥
 
 | Task | Agent instance | blockedBy | Subject |
 |------|---------------|-----------|---------|
 | T6 | tester-A | T5 | monitoring |
-| T8 | tester-A | T7 | monitoring |
+| T8 | tester-B | T7 | monitoring |
 
 ## Micro-Tasks
 
 ### Slice SL1 — Injectable log-fetch seam (`checks_log.py`)
 
+#### T0 — Baseline characterization tests (current behavior) [Wave 0 — gates T1]
+
+- **Description:** Create `tests/test_monitoring_checks_log.py` **against the current, unmodified**
+  `check_nats_log_errors(container_name, max_age_minutes)` /
+  `check_hub_dict_stream_gen_timeout(container_name, max_age_minutes, threshold)` signatures — no
+  `fetcher` param exists yet. Mock `subprocess.run` to return known log text and assert: correct
+  pass/fail + count for "permissions violation" substring matching; correct pass/fail + count for
+  `_dict_stream_gen timeout` case-insensitive matching vs `threshold`; all three
+  `_LOG_EXCEPTIONS` (`TimeoutExpired`, `FileNotFoundError`, `CalledProcessError`) surface as a
+  failing `CheckResult` (current behavior, pre-`LogFetchError`). **Run pytest now, before T1
+  touches the file, and confirm every test is GREEN** — this is the "current" baseline; T4 will
+  re-run this exact file unmodified after T3 (Wave 2) to prove the refactor didn't silently change
+  counting behavior (SC3's actual falsification). This task must complete before T1 starts (Wave 0
+  → Wave 1 gate) — if T1 edits `checks_log.py` first, there is nothing left to characterize
+  "before."
+- **File:** `tests/test_monitoring_checks_log.py` (new)
+- **Verify:** `.venv/bin/pytest tests/test_monitoring_checks_log.py -v`
+- **Expected:** all tests pass **against today's `checks_log.py`, unmodified**.
+- **Time:** 12 min · **Difficulty:** 3 · **Trace:** SC3 · **Slice:** SL1 · **Phase:** BASELINE
+  (GREEN now, re-verified GREEN again after T3 — not a RED-GATE in the traditional sense: it never
+  needs to fail, its failure *after* the refactor is the signal, not its failure before)
+
 #### T1 — Add `LogFetchError` + `LogFetcher` protocol + `SubprocessLogFetcher`
 
 - **Description:** In `src/factory/monitoring/checks_log.py`, add a `LogFetchError(Exception)`
-  class, a `LogFetcher` `Protocol` with `fetch(self, container_name: str, since_minutes: int) -> str`,
-  and a `SubprocessLogFetcher` class whose `fetch()` body is the current inline
+  class, a `LogFetcher` `Protocol` with
+  `fetch(self, container_name: str, since_minutes: int, pattern: str) -> str`, and a
+  `SubprocessLogFetcher` class whose `fetch()` body is the current inline
   `subprocess.run(["podman", "logs", "--since", f"{max_age_minutes}m", container_name], ...)` call,
   moved verbatim (same args, same timeout, same text decoding) so behavior is byte-for-byte
-  unchanged. Map the existing `_LOG_EXCEPTIONS` tuple (`subprocess.TimeoutExpired`,
-  `FileNotFoundError`, `subprocess.CalledProcessError`) to `raise LogFetchError(...) from e` inside
+  unchanged. **`pattern` is accepted for protocol conformance but ignored by
+  `SubprocessLogFetcher`** — `podman logs --since` has no line cap, so there is no truncation risk
+  to guard against locally, and ignoring it keeps this fetcher's behavior identical to today (see
+  Reference Patterns "truncation" note — the param exists for `LokiLogFetcher`, added in T2). Map
+  the existing `_LOG_EXCEPTIONS` tuple (`subprocess.TimeoutExpired`, `FileNotFoundError`,
+  `subprocess.CalledProcessError`) to `raise LogFetchError(...) from e` inside
   `SubprocessLogFetcher.fetch()`.
 - **File:** `src/factory/monitoring/checks_log.py`
 - **Snippet skeleton:**
@@ -294,10 +390,12 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
       """Raised by any LogFetcher implementation on fetch failure."""
 
   class LogFetcher(Protocol):
-      def fetch(self, container_name: str, since_minutes: int) -> str: ...
+      def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str: ...
 
   class SubprocessLogFetcher:
-      def fetch(self, container_name: str, since_minutes: int) -> str:
+      def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str:
+          # pattern unused: no server-side filter needed for a local, uncapped `podman logs`
+          # fetch — kept for LogFetcher protocol conformance with LokiLogFetcher (T2).
           try:
               result = subprocess.run(
                   ["podman", "logs", "--since", f"{since_minutes}m", container_name],
@@ -314,13 +412,18 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
 #### T2 — Add `LokiLogFetcher`
 
 - **Description:** Add a `LokiLogFetcher` class to `checks_log.py` with `loki_url: str` (default
-  `http://factory-loki:3100`) and a synchronous `fetch(container_name, since_minutes)` that issues
-  `GET {loki_url}/loki/api/v1/query_range` with LogQL query
-  `{{systemd_unit="{container_name}.service"}}` over a `since_minutes`-wide time window (epoch-ns
-  `start`/`end` params), using `httpx.Client` (sync, matching the sync `LogFetcher` protocol — no
-  `asyncio` inside this class). Concatenate matched log lines into a single string (same return
-  shape as `SubprocessLogFetcher.fetch`). On HTTP error, timeout, or malformed JSON response, raise
-  `LogFetchError`.
+  `http://factory-loki:3100`) and a synchronous `fetch(container_name, since_minutes, pattern)` that
+  issues `GET {loki_url}/loki/api/v1/query_range` with LogQL query
+  `{{systemd_unit="{container_name}.service"}} |~ "(?i){re.escape(pattern)}"` over a
+  `since_minutes`-wide time window (epoch-ns `start`/`end` params), using `httpx.Client` (sync,
+  matching the sync `LogFetcher` protocol — no `asyncio` inside this class). **The `|~ "(?i)..."`
+  server-side filter is load-bearing, not cosmetic** — without it, Loki returns only the newest
+  `limit` lines within the window (unlike `podman logs --since`, which has no cap); a busy container
+  could push true violations outside an unfiltered fetch and go uncounted (see Reference Patterns
+  "truncation" note). Case-insensitive regex is a safe superset for both checks — the exact
+  case-sensitive/insensitive counting still happens client-side afterward, unchanged. Concatenate
+  matched log lines into a single string (same return shape as `SubprocessLogFetcher.fetch`). On
+  HTTP error, timeout, or malformed JSON response, raise `LogFetchError`.
 - **File:** `src/factory/monitoring/checks_log.py`
 - **Snippet skeleton:**
   ```python
@@ -328,8 +431,8 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
       def __init__(self, loki_url: str = "http://factory-loki:3100") -> None:
           self.loki_url = loki_url
 
-      def fetch(self, container_name: str, since_minutes: int) -> str:
-          query = f'{{systemd_unit="{container_name}.service"}}'
+      def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str:
+          query = f'{{systemd_unit="{container_name}.service"}} |~ "(?i){re.escape(pattern)}"'
           try:
               resp = httpx.get(
                   f"{self.loki_url}/loki/api/v1/query_range",
@@ -346,40 +449,42 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
 - **Expected:** instantiates without error; no network call at import/construction time.
 - **Time:** 10 min · **Difficulty:** 4 · **Trace:** SC2, SC3b · **Slice:** SL1 · **Phase:** GREEN
 
-#### T3 — Wire `fetcher` param into both check functions
+#### T3 — Wire `fetcher`+`pattern` param into both check functions
 
 - **Description:** Update `check_nats_log_errors(container_name, max_age_minutes, fetcher:
   LogFetcher = SubprocessLogFetcher())` and `check_hub_dict_stream_gen_timeout(container_name,
   max_age_minutes, threshold, fetcher: LogFetcher = SubprocessLogFetcher())` to call
-  `fetcher.fetch(container_name, max_age_minutes)` instead of the inline `subprocess.run` call, and
-  catch `LogFetchError` (replacing the old direct `_LOG_EXCEPTIONS` catch at the call site — the
-  exception mapping now lives inside the fetcher). Preserve exact counting/threshold logic
-  ("permissions violation" substring count; `_dict_stream_gen timeout` case-insensitive count vs
-  `threshold`) unchanged.
+  `fetcher.fetch(container_name, max_age_minutes, pattern="permissions violation")` and
+  `fetcher.fetch(container_name, max_age_minutes, pattern="_dict_stream_gen timeout")` respectively
+  instead of the inline `subprocess.run` call, and catch `LogFetchError` (replacing the old direct
+  `_LOG_EXCEPTIONS` catch at the call site — the exception mapping now lives inside the fetcher).
+  Preserve exact counting/threshold logic ("permissions violation" substring count;
+  `_dict_stream_gen timeout` case-insensitive count vs `threshold`) unchanged — the `pattern` arg
+  only feeds the fetcher's own (optional) server-side filter; client-side counting is untouched.
 - **File:** `src/factory/monitoring/checks_log.py`
 - **Verify:** `grep -n "fetcher: LogFetcher" src/factory/monitoring/checks_log.py | wc -l` → `2`
 - **Expected:** both function signatures show the new param; `grep -c "subprocess.run" src/factory/monitoring/checks_log.py` → `1` (only inside `SubprocessLogFetcher.fetch`, not duplicated at call sites).
 - **Time:** 6 min · **Difficulty:** 2 · **Trace:** SC1, SC3, SC3b · **Slice:** SL1 · **Phase:** GREEN
 
-#### T4 — Regression + Loki-fetcher tests [RED-GATE]
+#### T4 — Loki-fetcher + fetcher-seam tests [RED-GATE]
 
-- **Description:** Create `tests/test_monitoring_checks_log.py`. **No tests currently exist for
-  either check function (grep-confirmed empty) — this task establishes the baseline, not just new
-  coverage.** Cover: (a) `check_nats_log_errors`/`check_hub_dict_stream_gen_timeout` with the
-  default `SubprocessLogFetcher` — mock `subprocess.run` to return known log text, assert correct
-  pass/fail + counts (permissions-violation substring, `_dict_stream_gen timeout` case-insensitive
-  vs threshold); (b) same two functions with an injected fake/mock `LogFetcher` returning
-  controlled text, proving the fetcher seam actually decouples fetch from logic; (c)
-  `LokiLogFetcher.fetch` against a mocked `httpx` response — success (matched lines), malformed
-  JSON, and HTTP error → all three assert `LogFetchError` is raised where applicable; (d) confirm
-  `SubprocessLogFetcher` failure paths (`TimeoutExpired`, `FileNotFoundError`,
-  `CalledProcessError`) all surface as `LogFetchError`.
-- **File:** `tests/test_monitoring_checks_log.py` (new)
+- **Description:** Extend `tests/test_monitoring_checks_log.py` (created by T0). This task is a
+  genuine RED-GATE — unlike T0, these tests import symbols (`LokiLogFetcher`, the `fetcher=` kwarg)
+  that don't exist before T1–T3 land, so they fail/don't-collect beforehand and pass after. Cover:
+  (a) `check_nats_log_errors`/`check_hub_dict_stream_gen_timeout` with an injected fake/mock
+  `LogFetcher` returning controlled text, proving the fetcher seam actually decouples fetch from
+  logic; (b) `LokiLogFetcher.fetch` against a mocked `httpx` response — success (matched lines),
+  malformed JSON, and HTTP error → all three assert `LogFetchError` is raised where applicable; (c)
+  assert the LogQL query string sent to `httpx` includes the `|~ "(?i)..."` filter with the correct
+  escaped pattern (regression guard for the truncation fix — a future edit that silently drops the
+  filter must fail this test); (d) confirm `SubprocessLogFetcher` failure paths (`TimeoutExpired`,
+  `FileNotFoundError`, `CalledProcessError`) all surface as `LogFetchError`.
+- **File:** `tests/test_monitoring_checks_log.py` (extends T0's file)
 - **Verify:** `.venv/bin/pytest tests/test_monitoring_checks_log.py -v`
-- **Expected:** all new tests pass; this is the RED-GATE for SL1 — before T1–T3 exist, these tests
-  fail/don't-collect; after, they pass. Run once before T1 starts (RED) and again after T3
-  completes (GREEN) to falsify the refactor didn't silently change counting behavior.
-- **Time:** 15 min · **Difficulty:** 3 · **Trace:** SC3, SC3b · **Slice:** SL1 · **Phase:** RED-GATE
+- **Expected:** all tests pass (T0's baseline tests + T4's new tests, same file). RED before T1–T3
+  exist (import fails), GREEN after — **and T0's original assertions must still pass unmodified in
+  the same run**, which is the SC3 falsification proper.
+- **Time:** 12 min · **Difficulty:** 3 · **Trace:** SC3b · **Slice:** SL1 · **Phase:** RED-GATE
 
 ### Slice SL2 — `LogMonitorLoop` (`log_watch.py`)
 
@@ -449,7 +554,7 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
 
 ### Slice SL4 — Quadlet unit + manifest entry
 
-#### T9 — `factory-log-monitor.container` Quadlet unit
+#### T9 — `factory-log-monitor.container` Quadlet unit + secrets + doc fix
 
 - **Description:** Create `deploy/quadlet/factory-log-monitor.container`, mirroring
   `factory-turn-writer.container`'s structure: `Image=ghcr.io/roxabi/factory:staging-svc` (reuse
@@ -457,18 +562,43 @@ No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each
   `After=factory-hub.service factory-nats.service factory-loki.service` (no `Requires=` — matches
   the "adapter pattern" the spec calls for, not a hard dependency), hardening flags
   (`NoNewPrivileges=true`, `ReadOnly=true`, `DropCapability=all`, `UserNS=keep-id:uid=1500,gid=1500`
-  per ADR-053/ADR-054), and Telegram secret wiring via `Secret=<name>,type=env,target=TELEGRAM_TOKEN`
-  / `Secret=<name>,type=env,target=TELEGRAM_ADMIN_CHAT_ID`, mirroring `factory-clipool.container`'s
-  `type=env` secret pattern. Resolve the exact secret name(s) against whatever already-provisioned
-  Telegram bot secret identity the existing `factory-telegram`/`factory-discord` components use
-  (grep `deploy/quadlet/factory-telegram.container` and `deploy/quadlet.toml`'s
-  `[component.telegram]` `required_secrets` for the established name) — do not mint a new bot
-  token unless none exists.
-- **File:** `deploy/quadlet/factory-log-monitor.container` (new)
+  per ADR-053/ADR-054). **Secret identity already resolved (see Reference Patterns — do not
+  re-derive):** no existing secret carries a bare Telegram bot token (`factory-nats-telegram` is an
+  NKey seed; the multi-bot tokens are a different credential in `config.db`). Add two new
+  `policy = "optional"` entries to `deploy/secrets-policy.toml`:
+  ```toml
+  [secret.factory-telegram-monitor-token]
+  policy = "optional"
+  source = "telegram-monitor-token.tok"
+
+  [secret.factory-telegram-monitor-chat-id]
+  policy = "optional"
+  source = "telegram-monitor-chat-id.tok"
+  ```
+  Wire them into the unit exactly like `factory-clipool.container`'s `type=env` pattern:
+  ```
+  # Bootstrap: podman secret create factory-telegram-monitor-token - <<< "<bot-token>"
+  Secret=factory-telegram-monitor-token,type=env,target=TELEGRAM_TOKEN
+  # Bootstrap: podman secret create factory-telegram-monitor-chat-id - <<< "<chat-id>"
+  Secret=factory-telegram-monitor-chat-id,type=env,target=TELEGRAM_ADMIN_CHAT_ID
+  ```
+  `policy = "optional"` means `deploy/install.sh` and `tools/check_secrets_drift.sh` skip these if
+  absent (confirmed — will not break `make converge` on M1); the container itself will
+  `Restart=on-failure`-loop until the operator provisions the real token post-merge — call this out
+  explicitly in the PR description, it is a rollout step, not a bug. Also fix the now-stale doc row
+  in `docs/CONFIGURATION.md` (~line 440/442): `TELEGRAM_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID` are
+  currently documented as "legacy single-bot path only... see #1035" — once this slice ships they
+  are the live credential path for `factory-log-monitor`; update the "Required"/description column
+  accordingly.
+- **File:** `deploy/quadlet/factory-log-monitor.container` (new), `deploy/secrets-policy.toml`,
+  `docs/CONFIGURATION.md`
 - **Verify:** `grep -c "^Exec=factory log-monitor$" deploy/quadlet/factory-log-monitor.container` →
-  `1`; no inline `#` comment on any value line (`grep -P '^\s*[^#;].*[[:space:]]#'` → no match).
-- **Expected:** unit file present, passes the two greps above.
-- **Time:** 10 min · **Difficulty:** 3 · **Trace:** SC1, SC2, SC9 · **Slice:** SL4 · **Phase:** GREEN
+  `1`; no inline `#` comment on any value line (`grep -P '^\s*[^#;].*[[:space:]]#'` → no match);
+  `python3 -c "import tomllib; tomllib.load(open('deploy/secrets-policy.toml','rb'))"` — no
+  `TOMLDecodeError`.
+- **Expected:** unit file present, passes the greps above; secrets-policy.toml still parses;
+  `docs/CONFIGURATION.md` no longer calls these vars "legacy... see #1035".
+- **Time:** 14 min · **Difficulty:** 3 · **Trace:** SC1, SC2, SC9 · **Slice:** SL4 · **Phase:** GREEN
 
 #### T10 — `[component.log-monitor]` in `deploy/quadlet.toml`
 
@@ -532,6 +662,16 @@ availability residual-risk statement — content already drafted in spec §Expec
 SC6 (`lyra-monitor.*` zero diff) is verified the same way — by construction, since no task above
 touches that path; confirm via `git diff --stat origin/staging..HEAD -- deploy/lyra-monitor.*`
 returning empty at `/pr` time.
+
+**Post-`/plan` addition (advisor review):** the design note must also address one sentence ADR-091
+itself invites as an obvious review question: ADR-091 states Sentinelle is "a capability inside
+`factory-hub`, not a standalone container" (hub-module default). This slice ships
+`factory-log-monitor` as a **standalone** container instead. That's intentional, not a
+contradiction — ADR-091/ADR-038 preserve "external monitor = safety-net batch probe" as a distinct
+layer from Sentinelle's in-process hub capability (the same reasoning that already justified
+`deploy/lyra-monitor.*`'s original design, before it was frozen for a host-timer reason unrelated to
+in-process-vs-standalone). The PR description should say this in one sentence so a reviewer doesn't
+have to reconstruct it from ADR-091 alone.
 
 ## Task IDs
 

--- a/artifacts/plans/2245-thin-v1-pull-detection-slice-plan.mdx
+++ b/artifacts/plans/2245-thin-v1-pull-detection-slice-plan.mdx
@@ -1,0 +1,547 @@
+---
+title: "Plan: chore(monitoring): thin V1-pull detection slice — re-arm NATS ACL/log alerting without reviving the frozen host-timer"
+issue: 2245
+spec: artifacts/specs/2245-thin-v1-pull-detection-slice-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-07-05
+---
+
+## Summary
+
+Refactor `checks_log.py`'s two log-check functions behind an injectable, synchronous
+`LogFetcher` seam (subprocess default unchanged + new Loki-backed fetcher), compose
+them into a new `LogMonitorLoop` scheduler, wire it to a `factory log-monitor` CLI
+subcommand and a new Quadlet unit that reuses the existing `svc-runtime` image — no
+new container image, no Podman-socket mount, no host-timer, no event-bus code.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph CFG["deploy/quadlet.toml + factory-log-monitor.container"]
+        Q1["Quadlet unit: Exec=factory log-monitor"]
+    end
+    subgraph CLIF["src/factory/cli/main.py"]
+        C1["@factory_app.command('log-monitor')"]
+    end
+    subgraph BOOT["src/factory/bootstrap/standalone/worker_standalone.py"]
+        B1["_bootstrap_log_monitor_standalone(raw_config)"]
+    end
+    subgraph WATCH["src/factory/monitoring/log_watch.py (new)"]
+        L1["LogMonitorLoop.run_forever"]
+        L2["LogMonitorLoop.run_once"]
+    end
+    subgraph CHECKS["src/factory/monitoring/checks_log.py (modified)"]
+        F1["LogFetcher protocol (new)"]
+        F2["SubprocessLogFetcher — default, behavior unchanged"]
+        F3["LokiLogFetcher (new)"]
+        K1["check_nats_log_errors"]
+        K2["check_hub_dict_stream_gen_timeout"]
+    end
+    subgraph ESC["src/factory/monitoring/escalation.py (unmodified)"]
+        E1["send_telegram_raw_alert"]
+    end
+    subgraph LOKISTACK["existing infra (ADR-093, unmodified)"]
+        LOKI[("factory-loki:3100")]
+    end
+
+    Q1 --> C1 --> B1 --> L1
+    L1 --> L2
+    L2 -->|asyncio.to_thread| K1
+    L2 -->|asyncio.to_thread| K2
+    K1 -->|fetcher=| F3
+    K2 -->|fetcher=| F3
+    F3 -->|GET /loki/api/v1/query_range LogQL| LOKI
+    F2 -.->|LogFetcher seam| F1
+    F3 -.->|LogFetcher seam| F1
+    K1 --> R1[CheckResult]
+    K2 --> R2[CheckResult]
+    R1 --> H1[HealthReport]
+    R2 --> H1
+    H1 -->|not all_passed| E1
+    E1 --> TG[Telegram Bot API]
+    H1 -->|all_passed| NOOP[no-op, sleep, next tick]
+
+    style F3 fill:#2b6,stroke:#333
+    style L1 fill:#2b6,stroke:#333
+    style Q1 fill:#2b6,stroke:#333
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+    subgraph checks_log["checks_log.py"]
+        LFE[LogFetchError]
+        LF["LogFetcher (protocol)"]
+        SPF["SubprocessLogFetcher.fetch"]
+        LKF["LokiLogFetcher.fetch"]
+        CN[check_nats_log_errors]
+        CH[check_hub_dict_stream_gen_timeout]
+    end
+    subgraph log_watch["log_watch.py"]
+        LML[LogMonitorLoop]
+    end
+    subgraph worker_standalone["bootstrap/standalone/worker_standalone.py"]
+        BLM[_bootstrap_log_monitor_standalone]
+    end
+    subgraph clim["cli/main.py"]
+        CMD["factory log-monitor command"]
+    end
+    subgraph unit["deploy/quadlet/factory-log-monitor.container"]
+        UNIT["Exec=factory log-monitor"]
+    end
+    subgraph initpy["monitoring/__init__.py"]
+        WARN["DeprecationWarning (narrowed)"]
+    end
+
+    UNIT --> CMD --> BLM --> LML
+    LML --> CN
+    LML --> CH
+    CN --> SPF
+    CN --> LKF
+    CH --> SPF
+    CH --> LKF
+    SPF -. implements .-> LF
+    LKF -. implements .-> LF
+    SPF -. raises .-> LFE
+    LKF -. raises .-> LFE
+
+    subgraph tests["tests/"]
+        T1T[test_monitoring_checks_log.py]
+        T2T[test_monitoring_log_watch.py]
+        T3T[bootstrap/test_log_monitor_standalone_paths.py]
+        T4T[test_monitoring_deprecation.py]
+    end
+    T1T -. tests .-> CN
+    T1T -. tests .-> CH
+    T1T -. tests .-> LKF
+    T1T -. tests .-> SPF
+    T2T -. tests .-> LML
+    T3T -. tests .-> BLM
+    T3T -. tests .-> CMD
+    T4T -. tests .-> WARN
+```
+
+## Agents
+
+| Agent | Instances | Task count | Files |
+|-------|-----------|------------|-------|
+| backend-dev | A, B | 6 (A: 3, B: 3) | `src/factory/monitoring/checks_log.py`, `src/factory/monitoring/log_watch.py` (new), `src/factory/monitoring/__init__.py`, `src/factory/bootstrap/standalone/worker_standalone.py`, `src/factory/cli/main.py` |
+| tester | A | 4 | `tests/test_monitoring_checks_log.py` (new), `tests/test_monitoring_log_watch.py` (new), `tests/bootstrap/test_log_monitor_standalone_paths.py` (new), `tests/test_monitoring_deprecation.py` (new) |
+| devops | A | 3 | `deploy/quadlet/factory-log-monitor.container` (new), `deploy/quadlet.toml` |
+
+No frontend-dev (no UI surface), no architect/security-auditor/doc-writer instance needed for
+implementation — architecture and security tradeoffs (Podman-socket rejection, Loki pivot) were
+already resolved at `/spec` Step 4 expert review; SL6 (PR design note) is a `/pr`-step deliverable,
+not an implementation micro-task.
+
+## Consistency Report
+
+Every Success Criterion (SC1–SC10, SC3b) traces to ≥1 micro-task; every micro-task traces to
+≥1 SC or Slice. No orphans.
+
+| SC | Covered by |
+|----|-----------|
+| SC1 (≤5min interval, no systemctl/host-timer) | T5, T9 |
+| SC2 (Loki fetch, no Podman socket/CLI, no new image) | T2, T9 |
+| SC3 (default-fetcher behavior unchanged) | T1, T3, T4 |
+| SC3b (unified `LogFetchError`) | T1, T2, T3, T4 |
+| SC4 (Telegram alert on failure) | T5, T6 |
+| SC5 (all-pass → zero Telegram calls) | T5, T6 |
+| SC6 (`lyra-monitor.*` zero diff) | verified at `/pr` (`git diff --stat deploy/lyra-monitor.*` — no task touches this path by construction) |
+| SC7 (deprecation warning narrowing) | T12, T13 |
+| SC8 (PR design note) | SL6 — `/pr`-step deliverable, not an implementation task |
+| SC9 (`quadlet-lint` passes) | T9, T10, T11 |
+| SC10 (no event/metric bus producer) | T5, T7, T8 |
+
+Slices: SL1→T1–T4, SL2→T5–T6, SL3→T7–T8, SL4→T9–T11, SL5→T12–T13, SL6→exempted (PR-description
+deliverable, written during `/pr`, not a code micro-task — consistent with `/plan`'s "Tier F"
+process, which generates micro-tasks for code slices only).
+
+Covered: 11/11 SC · 6/6 slices (5 code slices → 13 tasks, 1 doc slice → PR-step). Uncovered: none.
+
+## Reference Patterns (Step 3)
+
+- CLI subcommand registration: `src/factory/cli/main.py:175` (`@factory_app.command("turn-writer")`
+  → `_boot(_bootstrap_turn_writer_standalone)`) — mirror exactly for `log-monitor`.
+- Standalone bootstrap function shape: `src/factory/bootstrap/standalone/worker_standalone.py:108`
+  (`_bootstrap_turn_writer_standalone(raw_config: dict) -> None`).
+- `_boot(coro_factory)` (`src/factory/cli/main.py:104`) is generic — loads config, sets up logging,
+  `asyncio.run(coro_factory(raw_config))`. Not NATS-specific; safe to reuse for a non-NATS loop.
+- Quadlet unit conventions: `deploy/quadlet/factory-turn-writer.container` (hardening flags,
+  `UserNS=keep-id`, `Secret=...,type=mount,...` for nkey) and `deploy/quadlet/factory-clipool.container`
+  (`Secret=<name>,type=env,target=<VAR>` — the pattern to mirror for `TELEGRAM_TOKEN`/
+  `TELEGRAM_ADMIN_CHAT_ID`).
+- `deploy/quadlet.toml`: 20 `[component.*]` entries already present (e.g. `[component.turn-writer]`
+  at line 42) — add `[component.log-monitor]` following the same shape.
+- Test precedent: `tests/bootstrap/test_turn_writer_standalone_paths.py` — mirror for
+  `tests/bootstrap/test_log_monitor_standalone_paths.py`.
+- **Verified via grep: no existing tests reference `check_nats_log_errors` or
+  `check_hub_dict_stream_gen_timeout` anywhere in the tree today** (only `checks_log.py` and
+  `checks.py` itself reference the symbols). SC3's "all pre-existing tests... pass without
+  modification" is vacuously true — but this means T4 must **write new regression/baseline tests**
+  for current default-fetcher behavior (not just add Loki-fetcher tests), so the refactor has any
+  coverage at all. Folded into T4 below.
+- Quadlet CI gate: `.github/workflows/quadlet-lint.yml` — `podman quadlet --dryrun --user` (env
+  `QUADLET_UNIT_DIRS=deploy/quadlet`) + `HealthCmd=` double-quote grep + inline-`#`-comment grep +
+  `tools/check_quadlet_template_purity.sh`. Requires Podman ≥5 (not guaranteed on the local dev
+  box) — CI is the authoritative gate; T11 runs what's locally available and defers full
+  confirmation to `/ci-watch`.
+- `pyproject.toml:123` — existing `ignore:factory.monitoring is deprecated:DeprecationWarning`
+  pytest filter, to be updated in lockstep with T12.
+
+## Wave Structure
+
+3 waves, max 3 parallel agent instances. Elapsed ~3 sequential stages vs 13 tasks fully serial —
+roughly 4-5x parallelism inside Wave 1.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | backend-dev-A: T1→T2→T3 · backend-dev-B: T12 · devops-A: T9→T10→T11 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-B: T5→T7 · tester-A: T4, T13 |
+| 3 | Wave 2 done | 1 | tester-A: T6, T8 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 — LogFetcher protocol + LogFetchError + SubprocessLogFetcher | 1 | judgmental | 5 | — |
+| T2 — LokiLogFetcher | 1 | judgmental | 5 | — |
+| T3 — wire `fetcher` param into both check functions | 2 | bounded | 3 | — |
+| T4 — regression + Loki-fetcher tests | 3 | judgmental | 6 | — |
+| T5 — LogMonitorLoop | 1 | judgmental | 6 | — |
+| T6 — LogMonitorLoop tests | 3 | judgmental | 5 | — |
+| T7 — bootstrap fn + CLI command registration | 2 | bounded | 4 | — |
+| T8 — CLI/bootstrap smoke test + bus-producer grep check | 2 | bounded | 3 | — |
+| T9 — `factory-log-monitor.container` unit | 1 | bounded | 4 | — |
+| T10 — `[component.log-monitor]` in `quadlet.toml` | 1 | trivial | 2 | — |
+| T11 — quadlet-lint local run + fixups | 1 | trivial | 2 | — |
+| T12 — narrow `DeprecationWarning` + `pyproject.toml` filter | 2 | bounded | 3 | — |
+| T13 — deprecation-warning test | 1 | bounded | 3 | — |
+
+**Total estimated ops: 51**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3 | 13 | monitoring | — |
+| backend-dev-B | T5, T7, T12 | 13 | monitoring | — |
+| tester-A | T4, T6, T8, T13 | 17 | monitoring | — |
+| devops-A | T9, T10, T11 | 8 | deploy | — |
+
+No force-splits required — all instances ≤4 tasks, ≤50 ops, 1 subject each.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs).
+     Agent instances are named (tester-A/B, backend-dev-A/B/C, devops-A/B)
+     so parallel tasks map to distinct spawned agents.
+     Seed in wave order; within a wave all rows are parallel (∥). -->
+
+### Wave 1 — no deps, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | monitoring |
+| T2 | backend-dev-A | T1 | monitoring |
+| T3 | backend-dev-A | T2 | monitoring |
+| T12 | backend-dev-B | — | monitoring |
+| T9 | devops-A | — | deploy |
+| T10 | devops-A | T9 | deploy |
+| T11 | devops-A | T10 | deploy |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | backend-dev-B | T3 | monitoring |
+| T7 | backend-dev-B | T5 | monitoring |
+| T4 | tester-A | T3 | monitoring |
+| T13 | tester-A | T12 | monitoring |
+
+### Wave 3 — after Wave 2, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T6 | tester-A | T5 | monitoring |
+| T8 | tester-A | T7 | monitoring |
+
+## Micro-Tasks
+
+### Slice SL1 — Injectable log-fetch seam (`checks_log.py`)
+
+#### T1 — Add `LogFetchError` + `LogFetcher` protocol + `SubprocessLogFetcher`
+
+- **Description:** In `src/factory/monitoring/checks_log.py`, add a `LogFetchError(Exception)`
+  class, a `LogFetcher` `Protocol` with `fetch(self, container_name: str, since_minutes: int) -> str`,
+  and a `SubprocessLogFetcher` class whose `fetch()` body is the current inline
+  `subprocess.run(["podman", "logs", "--since", f"{max_age_minutes}m", container_name], ...)` call,
+  moved verbatim (same args, same timeout, same text decoding) so behavior is byte-for-byte
+  unchanged. Map the existing `_LOG_EXCEPTIONS` tuple (`subprocess.TimeoutExpired`,
+  `FileNotFoundError`, `subprocess.CalledProcessError`) to `raise LogFetchError(...) from e` inside
+  `SubprocessLogFetcher.fetch()`.
+- **File:** `src/factory/monitoring/checks_log.py`
+- **Snippet skeleton:**
+  ```python
+  class LogFetchError(Exception):
+      """Raised by any LogFetcher implementation on fetch failure."""
+
+  class LogFetcher(Protocol):
+      def fetch(self, container_name: str, since_minutes: int) -> str: ...
+
+  class SubprocessLogFetcher:
+      def fetch(self, container_name: str, since_minutes: int) -> str:
+          try:
+              result = subprocess.run(
+                  ["podman", "logs", "--since", f"{since_minutes}m", container_name],
+                  capture_output=True, text=True, timeout=..., check=True,
+              )
+          except _LOG_EXCEPTIONS as e:
+              raise LogFetchError(str(e)) from e
+          return result.stdout
+  ```
+- **Verify:** `.venv/bin/python -c "from factory.monitoring.checks_log import LogFetchError, LogFetcher, SubprocessLogFetcher"`
+- **Expected:** import succeeds, no `ImportError`/`AttributeError`.
+- **Time:** 8 min · **Difficulty:** 3 · **Trace:** SC3, SC3b · **Slice:** SL1 · **Phase:** GREEN
+
+#### T2 — Add `LokiLogFetcher`
+
+- **Description:** Add a `LokiLogFetcher` class to `checks_log.py` with `loki_url: str` (default
+  `http://factory-loki:3100`) and a synchronous `fetch(container_name, since_minutes)` that issues
+  `GET {loki_url}/loki/api/v1/query_range` with LogQL query
+  `{{systemd_unit="{container_name}.service"}}` over a `since_minutes`-wide time window (epoch-ns
+  `start`/`end` params), using `httpx.Client` (sync, matching the sync `LogFetcher` protocol — no
+  `asyncio` inside this class). Concatenate matched log lines into a single string (same return
+  shape as `SubprocessLogFetcher.fetch`). On HTTP error, timeout, or malformed JSON response, raise
+  `LogFetchError`.
+- **File:** `src/factory/monitoring/checks_log.py`
+- **Snippet skeleton:**
+  ```python
+  class LokiLogFetcher:
+      def __init__(self, loki_url: str = "http://factory-loki:3100") -> None:
+          self.loki_url = loki_url
+
+      def fetch(self, container_name: str, since_minutes: int) -> str:
+          query = f'{{systemd_unit="{container_name}.service"}}'
+          try:
+              resp = httpx.get(
+                  f"{self.loki_url}/loki/api/v1/query_range",
+                  params={"query": query, "start": ..., "end": ..., "limit": 5000},
+                  timeout=10.0,
+              )
+              resp.raise_for_status()
+              data = resp.json()
+          except (httpx.HTTPError, ValueError) as e:
+              raise LogFetchError(str(e)) from e
+          return "\n".join(_extract_lines(data))
+  ```
+- **Verify:** `.venv/bin/python -c "from factory.monitoring.checks_log import LokiLogFetcher; LokiLogFetcher()"`
+- **Expected:** instantiates without error; no network call at import/construction time.
+- **Time:** 10 min · **Difficulty:** 4 · **Trace:** SC2, SC3b · **Slice:** SL1 · **Phase:** GREEN
+
+#### T3 — Wire `fetcher` param into both check functions
+
+- **Description:** Update `check_nats_log_errors(container_name, max_age_minutes, fetcher:
+  LogFetcher = SubprocessLogFetcher())` and `check_hub_dict_stream_gen_timeout(container_name,
+  max_age_minutes, threshold, fetcher: LogFetcher = SubprocessLogFetcher())` to call
+  `fetcher.fetch(container_name, max_age_minutes)` instead of the inline `subprocess.run` call, and
+  catch `LogFetchError` (replacing the old direct `_LOG_EXCEPTIONS` catch at the call site — the
+  exception mapping now lives inside the fetcher). Preserve exact counting/threshold logic
+  ("permissions violation" substring count; `_dict_stream_gen timeout` case-insensitive count vs
+  `threshold`) unchanged.
+- **File:** `src/factory/monitoring/checks_log.py`
+- **Verify:** `grep -n "fetcher: LogFetcher" src/factory/monitoring/checks_log.py | wc -l` → `2`
+- **Expected:** both function signatures show the new param; `grep -c "subprocess.run" src/factory/monitoring/checks_log.py` → `1` (only inside `SubprocessLogFetcher.fetch`, not duplicated at call sites).
+- **Time:** 6 min · **Difficulty:** 2 · **Trace:** SC1, SC3, SC3b · **Slice:** SL1 · **Phase:** GREEN
+
+#### T4 — Regression + Loki-fetcher tests [RED-GATE]
+
+- **Description:** Create `tests/test_monitoring_checks_log.py`. **No tests currently exist for
+  either check function (grep-confirmed empty) — this task establishes the baseline, not just new
+  coverage.** Cover: (a) `check_nats_log_errors`/`check_hub_dict_stream_gen_timeout` with the
+  default `SubprocessLogFetcher` — mock `subprocess.run` to return known log text, assert correct
+  pass/fail + counts (permissions-violation substring, `_dict_stream_gen timeout` case-insensitive
+  vs threshold); (b) same two functions with an injected fake/mock `LogFetcher` returning
+  controlled text, proving the fetcher seam actually decouples fetch from logic; (c)
+  `LokiLogFetcher.fetch` against a mocked `httpx` response — success (matched lines), malformed
+  JSON, and HTTP error → all three assert `LogFetchError` is raised where applicable; (d) confirm
+  `SubprocessLogFetcher` failure paths (`TimeoutExpired`, `FileNotFoundError`,
+  `CalledProcessError`) all surface as `LogFetchError`.
+- **File:** `tests/test_monitoring_checks_log.py` (new)
+- **Verify:** `.venv/bin/pytest tests/test_monitoring_checks_log.py -v`
+- **Expected:** all new tests pass; this is the RED-GATE for SL1 — before T1–T3 exist, these tests
+  fail/don't-collect; after, they pass. Run once before T1 starts (RED) and again after T3
+  completes (GREEN) to falsify the refactor didn't silently change counting behavior.
+- **Time:** 15 min · **Difficulty:** 3 · **Trace:** SC3, SC3b · **Slice:** SL1 · **Phase:** RED-GATE
+
+### Slice SL2 — `LogMonitorLoop` (`log_watch.py`)
+
+#### T5 — `LogMonitorLoop`
+
+- **Description:** Create `src/factory/monitoring/log_watch.py` with a `LogMonitorLoop` class:
+  `__init__(self, interval_minutes: int = 5, fetcher: LogFetcher | None = None)` (default to
+  `LokiLogFetcher()`); `async def run_once(self) -> HealthReport` — calls
+  `check_nats_log_errors("factory-nats", ..., fetcher=self.fetcher)` and
+  `check_hub_dict_stream_gen_timeout("factory-hub", ..., fetcher=self.fetcher)` each via
+  `asyncio.to_thread` (matching the existing pattern already used in `checks.py`), assembles a
+  `HealthReport`; `async def run_forever(self) -> None` — loops `run_once()`, calls
+  `escalation.send_telegram_raw_alert(report)` iff `not report.all_passed`, then
+  `asyncio.sleep(self.interval_minutes * 60)`.
+- **File:** `src/factory/monitoring/log_watch.py` (new)
+- **Verify:** `.venv/bin/python -c "from factory.monitoring.log_watch import LogMonitorLoop; import inspect, asyncio; assert asyncio.iscoroutinefunction(LogMonitorLoop.run_once)"`
+- **Expected:** no import error; `run_once`/`run_forever` are coroutine functions.
+- **Time:** 12 min · **Difficulty:** 3 · **Trace:** SC1, SC4, SC5 · **Slice:** SL2 · **Phase:** GREEN
+
+#### T6 — `LogMonitorLoop` tests [RED-GATE]
+
+- **Description:** Create `tests/test_monitoring_log_watch.py`. Mock `check_nats_log_errors` and
+  `check_hub_dict_stream_gen_timeout` (or mock the fetcher and let real check logic run) plus
+  `escalation.send_telegram_raw_alert`. Assert: all-pass → `send_telegram_raw_alert` NOT called
+  (SC5); one-fail → called once with a `HealthReport` containing both results (SC4); both-fail →
+  called once, single alert listing both failures (per spec's edge-case table — no per-check
+  duplicate alerts).
+- **File:** `tests/test_monitoring_log_watch.py` (new)
+- **Verify:** `.venv/bin/pytest tests/test_monitoring_log_watch.py -v`
+- **Expected:** all pass. RED before T5 exists (import fails), GREEN after.
+- **Time:** 12 min · **Difficulty:** 3 · **Trace:** SC4, SC5 · **Slice:** SL2 · **Phase:** RED-GATE
+
+### Slice SL3 — CLI subcommand
+
+#### T7 — Bootstrap function + CLI registration
+
+- **Description:** Add `_bootstrap_log_monitor_standalone(raw_config: dict) -> None` (async) to
+  `src/factory/bootstrap/standalone/worker_standalone.py`, mirroring
+  `_bootstrap_turn_writer_standalone`'s shape: construct `MonitoringConfig` from `raw_config`
+  (reads `TELEGRAM_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID` per its existing contract), construct
+  `LogMonitorLoop(interval_minutes=config.check_interval_minutes)`, `await loop.run_forever()`.
+  Register `@factory_app.command("log-monitor")` in `src/factory/cli/main.py` (next to the
+  `"turn-writer"` command at line ~175) calling `_boot(_bootstrap_log_monitor_standalone)`. Add a
+  test-only single-tick path (e.g. a `--once` flag or `FACTORY_LOG_MONITOR_ONCE=1` env check) that
+  calls `run_once()` instead of `run_forever()` and exits 0/1 based on `HealthReport.all_passed` —
+  needed for T8's smoke test and for manual verification without waiting a full interval.
+- **File:** `src/factory/bootstrap/standalone/worker_standalone.py`, `src/factory/cli/main.py`
+- **Verify:** `.venv/bin/python -m factory.cli.main log-monitor --help` (or equivalent Typer help
+  invocation)
+- **Expected:** command listed, `--help` exits 0, no import-time side effects (no network call
+  before invocation).
+- **Time:** 10 min · **Difficulty:** 3 · **Trace:** SC1, SC10 · **Slice:** SL3 · **Phase:** GREEN
+
+#### T8 — CLI/bootstrap smoke test + bus-producer grep check [RED-GATE]
+
+- **Description:** Create `tests/bootstrap/test_log_monitor_standalone_paths.py` mirroring
+  `tests/bootstrap/test_turn_writer_standalone_paths.py`'s structure. Mock `LogMonitorLoop` (or its
+  dependencies) to smoke-test that `_bootstrap_log_monitor_standalone`/the `--once` CLI path exits
+  0 on all-pass and non-zero on a failed check. Add a static grep-based test asserting no
+  `factory.event.*` or `factory.metric.*` subject string appears in
+  `src/factory/monitoring/log_watch.py`, `worker_standalone.py`'s new function, or the CLI
+  registration — guarding SC10 (no event/metric bus producer introduced).
+- **File:** `tests/bootstrap/test_log_monitor_standalone_paths.py` (new)
+- **Verify:** `.venv/bin/pytest tests/bootstrap/test_log_monitor_standalone_paths.py -v`
+- **Expected:** all pass. RED before T7 exists, GREEN after.
+- **Time:** 10 min · **Difficulty:** 2 · **Trace:** SC10 · **Slice:** SL3 · **Phase:** RED-GATE
+
+### Slice SL4 — Quadlet unit + manifest entry
+
+#### T9 — `factory-log-monitor.container` Quadlet unit
+
+- **Description:** Create `deploy/quadlet/factory-log-monitor.container`, mirroring
+  `factory-turn-writer.container`'s structure: `Image=ghcr.io/roxabi/factory:staging-svc` (reuse
+  `svc-runtime`, no new image), `Exec=factory log-monitor`, `Network=roxabi.network`,
+  `After=factory-hub.service factory-nats.service factory-loki.service` (no `Requires=` — matches
+  the "adapter pattern" the spec calls for, not a hard dependency), hardening flags
+  (`NoNewPrivileges=true`, `ReadOnly=true`, `DropCapability=all`, `UserNS=keep-id:uid=1500,gid=1500`
+  per ADR-053/ADR-054), and Telegram secret wiring via `Secret=<name>,type=env,target=TELEGRAM_TOKEN`
+  / `Secret=<name>,type=env,target=TELEGRAM_ADMIN_CHAT_ID`, mirroring `factory-clipool.container`'s
+  `type=env` secret pattern. Resolve the exact secret name(s) against whatever already-provisioned
+  Telegram bot secret identity the existing `factory-telegram`/`factory-discord` components use
+  (grep `deploy/quadlet/factory-telegram.container` and `deploy/quadlet.toml`'s
+  `[component.telegram]` `required_secrets` for the established name) — do not mint a new bot
+  token unless none exists.
+- **File:** `deploy/quadlet/factory-log-monitor.container` (new)
+- **Verify:** `grep -c "^Exec=factory log-monitor$" deploy/quadlet/factory-log-monitor.container` →
+  `1`; no inline `#` comment on any value line (`grep -P '^\s*[^#;].*[[:space:]]#'` → no match).
+- **Expected:** unit file present, passes the two greps above.
+- **Time:** 10 min · **Difficulty:** 3 · **Trace:** SC1, SC2, SC9 · **Slice:** SL4 · **Phase:** GREEN
+
+#### T10 — `[component.log-monitor]` in `deploy/quadlet.toml`
+
+- **Description:** Add a `[component.log-monitor]` entry to `deploy/quadlet.toml`, mirroring the
+  shape of `[component.turn-writer]` (line 42) — component name, unit file reference, any
+  `required_secrets` list matching T9's `Secret=` lines.
+- **File:** `deploy/quadlet.toml`
+- **Verify:** `python3 -c "import tomllib; tomllib.load(open('deploy/quadlet.toml','rb'))"` — no
+  `TOMLDecodeError`.
+- **Expected:** file parses; `grep -n "\[component.log-monitor\]" deploy/quadlet.toml` → 1 match.
+- **Time:** 5 min · **Difficulty:** 1 · **Trace:** SC9 · **Slice:** SL4 · **Phase:** GREEN
+
+#### T11 — Quadlet lint (local best-effort)
+
+- **Description:** Run the checks from `.github/workflows/quadlet-lint.yml` locally against the new
+  unit where the local toolchain allows: `HealthCmd=` double-quote grep, inline-`#`-comment grep,
+  and `bash tools/check_quadlet_template_purity.sh`. If `podman quadlet --dryrun --user` (Podman
+  ≥5) is unavailable locally, note it explicitly and defer full confirmation to CI (`/ci-watch`) —
+  do not skip silently.
+- **File:** `deploy/quadlet/factory-log-monitor.container`, `deploy/quadlet.toml` (verification only, no new edits unless lint fails)
+- **Verify:** `bash tools/check_quadlet_template_purity.sh` (exit 0); `grep -nP 'HealthCmd=(?!python3 -c '"'"').*"' deploy/quadlet/*.container` (no match, or only the pre-existing exempted pattern)
+- **Expected:** purity script exits 0; no double-quote or inline-comment violations introduced.
+- **Time:** 8 min · **Difficulty:** 2 · **Trace:** SC9 · **Slice:** SL4 · **Phase:** GREEN
+
+### Slice SL5 — Deprecation-warning narrowing
+
+#### T12 — Narrow `DeprecationWarning`
+
+- **Description:** Edit `src/factory/monitoring/__init__.py` so the package-level
+  `DeprecationWarning` ("factory.monitoring is deprecated... will be removed when v2 lands") no
+  longer fires on `import factory.monitoring.checks_log` / `import factory.monitoring.escalation`.
+  Preferred approach: remove the blanket `warnings.warn(...)` from `__init__.py` and move an
+  equivalent warning into `checks.py` and `__main__.py`'s own module top-level (the two modules
+  that remain dormant/host-bound) — so the warning becomes module-scoped rather than
+  package-scoped. Update `pyproject.toml:123`'s
+  `"ignore:factory.monitoring is deprecated:DeprecationWarning"` pytest filter in lockstep (keep it
+  if the warning text/category is unchanged and still needed to silence `checks.py`/`__main__.py`
+  imports in other tests; adjust the match string only if the warning's wording changes).
+- **File:** `src/factory/monitoring/__init__.py`, `pyproject.toml`
+- **Verify:** `.venv/bin/python -W error::DeprecationWarning -c "import factory.monitoring.checks_log, factory.monitoring.escalation"`
+- **Expected:** exits 0 (no `DeprecationWarning` raised as error).
+- **Time:** 8 min · **Difficulty:** 2 · **Trace:** SC7 · **Slice:** SL5 · **Phase:** GREEN
+
+#### T13 — Deprecation-warning test [RED-GATE]
+
+- **Description:** Create `tests/test_monitoring_deprecation.py` asserting (a) `import
+  factory.monitoring.checks_log` and `import factory.monitoring.escalation` emit no
+  `DeprecationWarning` (use `pytest.warns(None)`/`warnings.catch_warnings(record=True)` and assert
+  empty), and (b) `import factory.monitoring.checks` / `import factory.monitoring.__main__` still
+  do emit it (whichever module now carries the warning per T12's implementation).
+- **File:** `tests/test_monitoring_deprecation.py` (new)
+- **Verify:** `.venv/bin/pytest tests/test_monitoring_deprecation.py -v`
+- **Expected:** all pass. RED before T12 (checks_log/escalation still warn), GREEN after.
+- **Time:** 8 min · **Difficulty:** 2 · **Trace:** SC7 · **Slice:** SL5 · **Phase:** RED-GATE
+
+### Slice SL6 — PR design note (not a code task)
+
+No micro-task generated. SL6's deliverable is prose in the PR description, written during `/pr`
+(design note: ADR-091 plane③ V1-pull framing, explicit non-host-timer/non-Sentinelle framing, Loki-
+availability residual-risk statement — content already drafted in spec §Expected Behavior point 7).
+SC6 (`lyra-monitor.*` zero diff) is verified the same way — by construction, since no task above
+touches that path; confirm via `git diff --stat origin/staging..HEAD -- deploy/lyra-monitor.*`
+returning empty at `/pr` time.
+
+## Task IDs
+
+<!-- Generated by /plan. TaskCreate/TaskList tools are unavailable in this session
+     (confirmed via ToolSearch during /frame and /spec — same gap, consistent handling).
+     No session task IDs were minted. The Task Seeding Blueprint above (T1-T13, wave-grouped,
+     with agent-instance + blockedBy + subject) is the authoritative machine-readable task list
+     for /implement to consume directly from this committed artifact — per this skill's own
+     documentation, "artifacts remain authoritative across sessions." -->
+
+- T1–T13: no task_id (TaskCreate unavailable) — see `## Task Seeding Blueprint` and
+  `## Micro-Tasks` above for the full spec (agent instance, dependencies, subject, verify
+  command) that `/implement` should re-derive tasks from.

--- a/artifacts/specs/2245-thin-v1-pull-detection-slice-spec.mdx
+++ b/artifacts/specs/2245-thin-v1-pull-detection-slice-spec.mdx
@@ -1,0 +1,265 @@
+---
+title: "chore(monitoring): thin V1-pull detection slice — re-arm NATS ACL/log alerting without reviving the frozen host-timer"
+issue: 2245
+status: approved
+tier: F-lite
+date: 2026-07-05
+promoted_from: artifacts/frames/2245-thin-v1-pull-detection-slice-frame.mdx
+---
+
+## Context
+
+Source: `artifacts/frames/2245-thin-v1-pull-detection-slice-frame.mdx` (approved
+2026-07-05). Split out of #2203 (incident-response runbook) per architect/
+axial-drift/security/devops panel review, 2026-07-04.
+
+The 2026-04-27 NATS ACL incident took 2h44m to detect because its only detector —
+`check_nats_log_errors` in `src/factory/monitoring/checks_log.py`, escalating via
+`src/factory/monitoring/escalation.py` → Telegram — had no scheduler. Its old
+scheduler, the host-side `deploy/lyra-monitor.{service,timer}` systemd unit, was
+retired in `deploy/provision.sh` when #1035 ("Monitoring v2") closed without
+shipping a replacement. ADR-091 plane③ prescribes **V1: pull** (`/health/detail`,
+monitoring checks) as the current-correct mechanism until #1035's V2
+(`factory.metric.*` subscribe) ships.
+
+This spec designs the V1-pull scheduler: reuse the two pure log-check functions
+and the existing Telegram escalation path, run them on a ≤5 min cadence from
+inside the container stack, with no host-timer / `systemctl --user` dependency.
+
+## Goal
+
+A new, minimal, always-on container periodically scans `factory-nats` and
+`factory-hub` container logs for permissions violations and
+`_dict_stream_gen` timeouts, and fires a Telegram alert on anomaly — closing
+the April 2026 detection gap without resurrecting the host-timer or previewing
+full Monitoring v2/Sentinelle.
+
+## Users
+
+- **Primary:** Mickael (sole on-call operator) — gets paged via Telegram instead
+  of discovering an incident by manually reading container logs.
+- **Secondary:** future Sentinelle/#1035 work — this V1-pull mechanism must stay
+  swappable for the eventual V2 subscribe-based plane③ implementation; it must
+  not hard-code assumptions that would need undoing later (e.g. it must not
+  itself become a `factory.event.*`/`factory.metric.*` producer — that is #1035's
+  job, not this slice's).
+
+## Expected Behavior
+
+1. A new container (`factory-log-monitor`) starts as part of the normal Quadlet
+   fleet and runs a loop with a configurable interval (default 5 minutes, hard
+   cap ≤5 minutes per acceptance criteria).
+2. Each tick, it calls `check_nats_log_errors(container="factory-nats", ...)` and
+   `check_hub_dict_stream_gen_timeout(container="factory-hub", ...)` — the exact
+   same pure functions and thresholds already shipped in `checks_log.py`.
+3. Log text for those two functions is fetched via **Loki HTTP query
+   (`GET http://factory-loki:3100/loki/api/v1/query_range`, LogQL
+   `{systemd_unit="<container>.service"} |= "<pattern>"`)** over the existing
+   `roxabi.network`, not by shelling out to a `podman` CLI binary or mounting
+   the Podman socket. Two alternatives were rejected during expert review:
+   mounting the rootless Podman socket (even read-only) grants full Podman
+   control-plane access — start/stop/exec/create on every container, readable
+   env vars/secrets of every other container — because Podman's REST API does
+   not enforce read-only at the protocol level, only the bind-mount's
+   filesystem flag does; independent architect and devops review both called
+   this out as the "`docker.sock`-mount antipattern" and rejected it outright.
+   Adding the Podman CLI to a container image was rejected because none of the
+   existing runtime images (`svc-runtime`, `agent-runtime`) ship it, and
+   building/publishing a brand-new image target is out of proportion for this
+   slice. Loki is already the destination for exactly these logs
+   (`factory-promtail.container` ships journald → Loki per ADR-093, already
+   labeled `systemd_unit="factory-nats.service"` /
+   `systemd_unit="factory-hub.service"` — see
+   `deploy/observability/promtail-config.yml`), so this reuses existing,
+   already-running infra with zero new image and zero new privileged mount.
+   **Accepted residual risk (documented, not solved by this slice):** if
+   Promtail or Loki itself is down, this detector goes silently blind — the
+   same class of gap #2245 exists to close. Monitoring Loki's own liveness is
+   out of scope here (that edges toward full Sentinelle/#1035); this is the
+   thin V1-pull slice, not the complete answer.
+   `checks_log.py`'s log-fetch step is refactored behind a small injectable,
+   **synchronous** seam (see Data Model) so the **counting/threshold logic is
+   byte-for-byte reused**, unchanged for any other caller (the default
+   `SubprocessLogFetcher` still shells `podman logs`, exactly as today), while
+   the new component supplies a `LokiLogFetcher` instead. Both fetchers raise a
+   single new `LogFetchError` on failure so the check functions' exception
+   handling stays fetcher-agnostic (today's `_LOG_EXCEPTIONS` tuple is
+   subprocess-specific and would not catch an HTTP failure).
+4. On any failed check, the monitor calls `escalation.py`'s existing raw-alert
+   path (`send_telegram_raw_alert`) with a synthesized `HealthReport` containing
+   just the two check results — reusing the exact Telegram formatting/delivery
+   code already shipped. LLM diagnosis (`escalate_to_llm`, which shells to the
+   `claude` CLI) is intentionally **not** wired in this container — it would add
+   a heavyweight, unnecessary dependency to a container whose only job is a
+   2-check safety net; the raw-alert path alone satisfies the acceptance
+   criterion ("a Telegram alert fires via the existing `escalation.py` path").
+5. `src/factory/monitoring/__init__.py`'s package-level `DeprecationWarning`
+   ("factory.monitoring is deprecated... will be removed when v2 lands") is
+   corrected: `checks_log.py` and `escalation.py` are now live production code
+   (imported by a container that ships and runs continuously), not "retained for
+   spec mining." The warning is narrowed so it no longer fires for these two
+   modules — the rest of the package (`checks.py`'s `run_checks()` pipeline,
+   `check_process`/`check_http_health`, `__main__.py`) remains explicitly
+   deprecated/host-bound and untouched.
+6. `deploy/lyra-monitor.{service,timer}` is not modified, added back, or
+   referenced by the new code path.
+7. The PR description includes a design note stating explicitly: this is the
+   ADR-091 plane③ V1-pull mechanism (pull via `podman logs`-equivalent, not
+   subscribe via `factory.metric.*`); it is not a revival of the retired
+   host-timer (no `systemctl --user`, no bare host process, no `localhost:8443`
+   dependency); it is not a preview of full Monitoring v2/Sentinelle (no event
+   bus producer/consumer, no dashboard).
+
+### Edge cases
+
+| Case | Handling |
+|------|----------|
+| Loki temporarily unreachable / query error | `LokiLogFetcher` raises `LogFetchError`; check functions catch it (fetcher-agnostic, same code path as a subprocess failure) and return a failed `CheckResult` with the error as detail — loggable, does NOT crash the loop; next tick retries. This is the documented accepted-risk case (detection blind while Loki is down) |
+| Telegram delivery fails after a real anomaly | `escalation.py`'s existing fallback: log the full report at `error` level (already implemented in `send_telegram_raw_alert`'s caller contract) — no new fallback needed, mirrors `__main__.py`'s existing pattern |
+| Both checks pass | No-op, no alert, loop continues |
+| Sustained/repeated anomaly (log keeps matching every tick) | Re-alerts every tick (≤5 min) — no dedup/cooldown. This is inherited, unmodified `escalation.py` behavior (no debounce exists anywhere in `src/factory/monitoring/` today), not a regression introduced here; accepted as-is for this thin slice |
+| Container restarts mid-incident | Next tick after restart re-evaluates the same `max_age_minutes` window — no state carried across restarts is required by the acceptance criteria (unlike `checks_varz.py`'s stateful counters, these two checks are stateless window-scans) |
+| `factory-nats`/`factory-hub` unit renamed or Loki has no matching label | Empty/error result from Loki is treated as a failed `CheckResult` (fail-safe: absent data reports as anomaly rather than silently passing) |
+
+## Data Model & Consumers
+
+### Data structure diagram
+
+```mermaid
+classDiagram
+    class CheckResult {
+      +str name
+      +bool passed
+      +str detail
+      +datetime timestamp
+    }
+    class HealthReport {
+      +list~CheckResult~ checks
+      +bool all_passed
+      +int failed_count
+      +datetime timestamp
+    }
+    class LogFetchError {
+      <<exception>>
+      +str message
+    }
+    class LogFetcher {
+      <<injectable seam, sync>>
+      +fetch(container_name, since_minutes) str
+    }
+    class SubprocessLogFetcher {
+      +fetch(container_name, since_minutes) str
+    }
+    class LokiLogFetcher {
+      +str loki_url
+      +fetch(container_name, since_minutes) str
+    }
+    class check_nats_log_errors {
+      +CheckResult check(container_name, max_age_minutes, fetcher)
+    }
+    class check_hub_dict_stream_gen_timeout {
+      +CheckResult check(container_name, max_age_minutes, threshold, fetcher)
+    }
+    class LogMonitorLoop {
+      +int interval_minutes
+      +run_forever()
+      +run_once() HealthReport
+    }
+    LogFetcher <|.. SubprocessLogFetcher
+    LogFetcher <|.. LokiLogFetcher
+    LogFetcher ..> LogFetchError : raises on failure
+    check_nats_log_errors --> LogFetcher : uses
+    check_hub_dict_stream_gen_timeout --> LogFetcher : uses
+    check_nats_log_errors --> CheckResult : returns
+    check_hub_dict_stream_gen_timeout --> CheckResult : returns
+    LogMonitorLoop --> check_nats_log_errors : calls via asyncio.to_thread
+    LogMonitorLoop --> check_hub_dict_stream_gen_timeout : calls via asyncio.to_thread
+    LogMonitorLoop --> HealthReport : builds
+    LogMonitorLoop --> LokiLogFetcher : injects
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    T[LogMonitorLoop tick, every ≤5min] --> C1[check_nats_log_errors]
+    T --> C2[check_hub_dict_stream_gen_timeout]
+    C1 -->|LogFetcher seam, sync| PF[LokiLogFetcher]
+    C2 -->|LogFetcher seam, sync| PF
+    PF -->|GET /loki/api/v1/query_range LogQL| LOKI[(factory-loki:3100, roxabi.network)]
+    LOKI -.->|labeled systemd_unit=factory-*.service| PROMTAIL[factory-promtail journald scrape, ADR-093]
+    C1 --> R[HealthReport]
+    C2 --> R
+    R -->|any failed| ESC[escalation.send_telegram_raw_alert]
+    ESC --> TG[Telegram Bot API]
+    R -->|all passed| NOOP[no-op, next tick]
+    ExistingCaller[factory.monitoring.checks.run_checks - unchanged, host-only] -.->|still uses default subprocess fetcher| C1
+    ExistingCaller -.-> C2
+```
+
+### Consumer summary
+
+| Consumer | Fields / output | When | Status |
+|----------|------------------|------|--------|
+| `LogMonitorLoop` (new) | `HealthReport` from the 2 log checks | Every ≤5 min tick, inside `factory-log-monitor` | **This issue** |
+| `escalation.send_telegram_raw_alert` | Formatted alert text | On any failed check | **This issue** (reused, unmodified) |
+| `factory-loki` (existing, ADR-093) | Log lines matching LogQL query | Each tick's fetch | Existing infra, newly read by this issue (not modified) |
+| `factory.monitoring.checks.run_checks` (existing, host-only, dormant) | Same `CheckResult`s, via default `SubprocessLogFetcher` | N/A — not invoked in production today (no scheduler wires it; kept behavior-identical) | Unchanged — explicitly out of scope |
+| Future Sentinelle plane③ V2 (#1035) | Would replace pull with `factory.metric.*` subscribe | Not yet built | Future / out of scope |
+
+## Breadboard
+
+### Affordances
+
+| ID | Affordance | Handler | Data |
+|----|------------|---------|------|
+| A1 | Periodic tick (≤5 min) | `LogMonitorLoop.run_forever` | `interval_minutes` config |
+| A2 | NATS log scan | `check_nats_log_errors` | `factory-nats` logs via `LogFetcher` |
+| A3 | Hub log scan | `check_hub_dict_stream_gen_timeout` | `factory-hub` logs via `LogFetcher` |
+| A4 | Telegram alert | `send_telegram_raw_alert` | synthesized `HealthReport` |
+
+### Nodes
+
+| ID | Node | Input | Output |
+|----|------|-------|--------|
+| N1 | `LokiLogFetcher.fetch` | container name, minutes | raw matched log lines (text) |
+| N2 | `check_nats_log_errors` (refactored, seam added) | container name, minutes, fetcher | `CheckResult` |
+| N3 | `check_hub_dict_stream_gen_timeout` (refactored, seam added) | container name, minutes, threshold, fetcher | `CheckResult` |
+| N4 | `LogMonitorLoop.run_once` | config | `HealthReport` |
+| N5 | `LogMonitorLoop.run_forever` | `HealthReport` from N4 | calls `send_telegram_raw_alert` iff `not all_passed` |
+| N6 | `factory log-monitor` CLI subcommand | — | invokes N5, mirrors `factory hub`/`factory turn-writer` entrypoint pattern |
+| N7 | `factory-log-monitor.container` Quadlet unit | `Exec=factory log-monitor`, `Network=roxabi.network`, Telegram secrets | running container, existing `svc-runtime` image (no image change) |
+
+### Wiring
+
+```
+Quadlet start → N7 → N6 (factory log-monitor) → N5.run_forever
+  loop tick → N4.run_once → asyncio.to_thread(N2) + asyncio.to_thread(N3) (via N1 fetcher) → HealthReport
+  HealthReport.all_passed=false → send_telegram_raw_alert → Telegram API
+  HealthReport.all_passed=true → no-op, sleep(interval_minutes), repeat
+```
+
+## Slices
+
+| Slice | Scope | Files (expected) | Demo |
+|-------|-------|-------------------|------|
+| SL1 | Injectable, synchronous log-fetch seam in `checks_log.py` — `SubprocessLogFetcher` (default, current behavior, unchanged) + `LokiLogFetcher` (new); both check functions gain an optional `fetcher` param defaulting to the subprocess one; unify error handling behind a single `LogFetchError` raised by either fetcher | `src/factory/monitoring/checks_log.py` | Existing tests for `check_nats_log_errors`/`check_hub_dict_stream_gen_timeout` pass unmodified (behavior-identical default) + new unit tests for `LokiLogFetcher` (mocked Loki HTTP response, including malformed/error response → `LogFetchError`) |
+| SL2 | `LogMonitorLoop` (run_once/run_forever) composing the 2 checks (via `asyncio.to_thread`, matching `checks.py`'s existing pattern) + `escalation.send_telegram_raw_alert` | `src/factory/monitoring/log_watch.py` (new) | Unit test: anomaly in one check → `send_telegram_raw_alert` called once with both results; all-pass → not called; both-fail → single alert with both failures listed |
+| SL3 | `factory log-monitor` CLI subcommand wiring `LogMonitorLoop.run_forever` | `src/factory/cli.py` (or wherever the Typer app registers subcommands) | `factory log-monitor --once` (test-only flag) runs one tick and exits 0/1; `grep` confirms no `factory.event.*`/`factory.metric.*` producer registration (SC10) |
+| SL4 | `factory-log-monitor` Quadlet unit + `deploy/quadlet.toml` component entry — `Network=roxabi.network` (reaches `factory-loki:3100`), `After=factory-hub.service factory-nats.service factory-loki.service` (no `Requires=`, matching the adapter pattern), Telegram secret wiring via `Secret=<name>,type=env,target=TELEGRAM_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID` (exact secret identity — which bot/chat — resolved in `/plan`; the mechanism mirrors `factory-clipool.container`'s `type=env` secret pattern) | `deploy/quadlet/factory-log-monitor.container`, `deploy/quadlet.toml` | `quadlet-lint` passes; unit renders via existing Quadlet validation gate; no new image/Dockerfile/docker-bake.hcl/publish.yml changes (reuses `svc-runtime`) |
+| SL5 | `factory.monitoring.__init__` deprecation-warning narrowing | `src/factory/monitoring/__init__.py`, `pyproject.toml` (matching `ignore:factory.monitoring is deprecated` filter updated in lockstep) | Importing `factory.monitoring.checks_log`/`escalation` no longer emits the "will be removed" warning; importing `factory.monitoring.checks`/`__main__` still does (or an equivalent module-level warning moves there) |
+| SL6 | PR design note (plane③ V1-pull, not host-timer, not Sentinelle preview) + explicit statement of the accepted Loki-availability residual risk | PR description; `git diff` confirms zero changes under `deploy/lyra-monitor.*` (SC6) | Reviewer can confirm the note answers all 3 framings from acceptance #4, and that no event-bus code was added (SC10) |
+
+## Success Criteria
+
+- [ ] `factory-log-monitor` runs `check_nats_log_errors` and `check_hub_dict_stream_gen_timeout` against `factory-nats`/`factory-hub` on an interval ≤5 minutes, with no `systemctl --user` call and no host-timer unit anywhere in the change (SC1)
+- [ ] Log content is fetched via a Loki LogQL query over the existing `roxabi.network` — no Podman socket mounted, no Podman CLI binary added to any image, no new image/Dockerfile/docker-bake.hcl/publish.yml changes (SC2)
+- [ ] `check_nats_log_errors`/`check_hub_dict_stream_gen_timeout`'s existing counting/threshold behavior is unchanged for the default (subprocess) fetcher — all pre-existing tests for these functions pass without modification (SC3)
+- [ ] Both fetchers (subprocess, Loki) raise a single shared `LogFetchError` on failure, caught uniformly by the check functions (SC3b)
+- [ ] On a failed check, `send_telegram_raw_alert` is called and a Telegram alert is sent via the existing `escalation.py` path — verified by a unit test asserting the call with the correct `HealthReport` (SC4)
+- [ ] All checks passing produces zero Telegram calls (SC5)
+- [ ] `deploy/lyra-monitor.{service,timer}` has zero diff in this PR (SC6)
+- [ ] `factory.monitoring`'s package-level `DeprecationWarning` no longer fires on `import factory.monitoring.checks_log` / `import factory.monitoring.escalation` (SC7 — value-add beyond the issue's 4 literal acceptance bullets, flagged for reviewer sign-off since the panel didn't explicitly scope it; justified because these modules become live production code by this change, no longer "spec mining only")
+- [ ] PR description contains a design note explicitly framing this as ADR-091 plane③ V1-pull, distinguishing it from both the retired host-timer and full Monitoring-v2/Sentinelle, and states the accepted Loki-availability residual risk (SC8)
+- [ ] `quadlet-lint` (or equivalent CI validation for Quadlet units) passes for the new `.container` unit (SC9)
+- [ ] No `factory.event.*`/`factory.metric.*` bus producer or consumer is introduced by this change (SC10 — guards against V2/Sentinelle scope creep)

--- a/deploy/generated/secrets-manifest.sh
+++ b/deploy/generated/secrets-manifest.sh
@@ -23,6 +23,8 @@ declare -A SECRET_SOURCES=(
     [factory-nats-turn-writer]="nkeys/turn-writer.seed"
     [factory-nats-web]="nkeys/web-adapter.seed"
     [factory-socialmedia-api-key]="socialmedia-api-key.tok"
+    [factory-telegram-monitor-chat-id]="telegram-monitor-chat-id.tok"
+    [factory-telegram-monitor-token]="telegram-monitor-token.tok"
     [factory_blobstore_token]="n/a"
     [factory_otel_token]="n/a"
 )
@@ -47,6 +49,8 @@ declare -A SECRET_POLICY=(
     [factory-nats-turn-writer]="nats-seed"
     [factory-nats-web]="nats-seed"
     [factory-socialmedia-api-key]="optional"
+    [factory-telegram-monitor-chat-id]="optional"
+    [factory-telegram-monitor-token]="optional"
     [factory_blobstore_token]="generated"
     [factory_otel_token]="generated"
 )

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -84,6 +84,11 @@ container = "factory-promtail.container"
 required_secrets = []
 host_roles = ["factory-hub"]
 
+[component.log-monitor]
+container = "factory-log-monitor.container"
+required_secrets = ["factory-telegram-monitor-token", "factory-telegram-monitor-chat-id"]
+host_roles = ["factory-hub"]
+
 # Langfuse stack — optional / deferred in otel-raw v1 (ADR-097). disabled = true:
 # units stay in deploy/quadlet/ for manual opt-in; converge/install skip them.
 [component.langfuse-postgres]

--- a/deploy/quadlet/factory-log-monitor.container
+++ b/deploy/quadlet/factory-log-monitor.container
@@ -1,0 +1,46 @@
+[Unit]
+Description=Factory LogMonitor — Loki-backed NATS ACL / hub-timeout log alerting (#2245)
+# After= orders startup; no Requires=/BindsTo= so a hub/nats/loki restart does not
+# propagate a stop to this adapter (adapter pattern — it re-fetches from Loki on its
+# own next tick, no state to reconcile after a dependency bounce).
+After=factory-hub.service factory-nats.service factory-loki.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+# #1989: SIGTERM grace before Podman's 10s-default SIGKILL (the omp
+# double-restart SIGKILL during converge). NB [Container] StopTimeout=
+# is the podman container stop window, NOT [Service] TimeoutStopSec=
+# (which only bounds systemd's wait on the podman process).
+StopTimeout=120
+Image=ghcr.io/roxabi/factory:staging-svc
+Label=io.containers.autoupdate=registry
+ContainerName=factory-log-monitor
+Environment=CONTAINER_NAME=factory-log-monitor
+Environment=IMAGE_REF=ghcr.io/roxabi/factory:staging-svc
+Network=roxabi.network
+# Hardening — defense in depth (see issue #652).
+NoNewPrivileges=true
+ReadOnly=true
+DropCapability=all
+# ADR-054 Decision 2: UserNS=keep-id maps container UID to host UID 1000 (mickael),
+# which owns ~/.roxabi/factory/*. uid=1500 is the factory service user inside the container.
+UserNS=keep-id:uid=1500,gid=1500
+# Bootstrap: podman secret create factory-telegram-monitor-token - <<< "<bot-token>"
+Secret=factory-telegram-monitor-token,type=env,target=TELEGRAM_TOKEN
+# Bootstrap: podman secret create factory-telegram-monitor-chat-id - <<< "<chat-id>"
+Secret=factory-telegram-monitor-chat-id,type=env,target=TELEGRAM_ADMIN_CHAT_ID
+Environment=PYTHONUNBUFFERED=1
+Exec=factory log-monitor
+HealthCmd=grep -q log-monitor /proc/1/cmdline
+HealthInterval=30s
+
+[Service]
+Restart=on-failure
+# #1989: must exceed [Container] StopTimeout=120 or systemd SIGKILLs the
+# podman wrapper first (user-service default is 90s), capping the grace.
+TimeoutStopSec=130
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/deploy/secrets-policy.toml
+++ b/deploy/secrets-policy.toml
@@ -103,6 +103,14 @@ source = "ingress-github-webhook.tok"
 policy = "optional"
 source = "ingress-cloudflare-webhook.tok"
 
+[secret.factory-telegram-monitor-token]
+policy = "optional"
+source = "telegram-monitor-token.tok"
+
+[secret.factory-telegram-monitor-chat-id]
+policy = "optional"
+source = "telegram-monitor-chat-id.tok"
+
 # ── Dynamic secret classes (rendered at install, not enumerated in required_secrets) ─────
 
 # Bot API tokens: one per configured bot per platform.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -437,9 +437,9 @@ health_secret = ""                            # optional health endpoint auth
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `TELEGRAM_TOKEN` | No (legacy single-bot path only; multi-bot production uses Podman secrets — see `## Bot credentials`) | Bot token |
+| `TELEGRAM_TOKEN` | Yes (factory-log-monitor) | Bot token — live credential path for the `factory-log-monitor` Quadlet unit (`deploy/quadlet/factory-log-monitor.container`, #2245); multi-bot production adapters use Podman secrets instead — see `## Bot credentials` |
 | `TELEGRAM_WEBHOOK_SECRET` | Yes (hub) | Webhook secret |
-| `TELEGRAM_ADMIN_CHAT_ID` | No (legacy single-bot path only; see #1035) | Chat ID for alerts |
+| `TELEGRAM_ADMIN_CHAT_ID` | Yes (factory-log-monitor) | Chat ID for alerts — live credential path for the `factory-log-monitor` Quadlet unit (`deploy/quadlet/factory-log-monitor.container`, #2245) |
 | `TELEGRAM_BOT_USERNAME` | No | Bot username for help text |
 
 ### Discord

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -664,9 +664,11 @@ startup
 
 ---
 
-## Monitoring — removed; superseded by Monitoring v2 (#1035)
+## Monitoring — mostly dormant; two modules live via `factory-log-monitor` (#2245)
 
-The host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. The Python module `src/factory/monitoring/` is retained for [Monitoring v2 (#1035)](https://github.com/Roxabi/roxabi-factory/issues/1035) spec mining. It pokes `systemctl --user`, `podman logs`, and host loopback ports — none of which translate cleanly to a containerised world — and offers no UI beyond a Telegram message.
+The host-timer units (`lyra-monitor.{service,timer}`) have been removed from `deploy/`. Most of the Python module `src/factory/monitoring/` (`checks.py`'s aggregate Layer-1 runner, `check_process`/`check_http_health`, `__main__.py`) is retained for [Monitoring v2 (#1035)](https://github.com/Roxabi/roxabi-factory/issues/1035) spec mining — it pokes `systemctl --user`, `podman logs`, and host loopback ports, none of which translate cleanly to a containerised world, and offers no UI beyond a Telegram message. This dormant path still emits a `DeprecationWarning` on import (`checks.py`, suppressed suite-wide in `pyproject.toml`'s `filterwarnings`).
+
+`checks_log.py`, `log_watch.py`, and `escalation.py`'s raw-alert path are the exception: as of #2245 they are live production code, shipped and run continuously by the standalone `factory-log-monitor` Quadlet container (`deploy/quadlet/factory-log-monitor.container`) as a thin, V1-pull safety net (ADR-091 plane③ — pull, not subscribe; see `docs/architecture/observability.md`). They never emit the deprecation warning and should be retired/subsumed once Monitoring v2 (#1035) ships log-scanning as a hub-native consumer.
 
 For ad-hoc hub-health probes, hit `/health/detail` directly:
 

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -262,6 +262,11 @@
 - **Container:** factory-litellm.container
 - **Host roles:** factory-hub
 
+### log-monitor
+- **Container:** factory-log-monitor.container
+- **Required secrets:** factory-telegram-monitor-chat-id, factory-telegram-monitor-token
+- **Host roles:** factory-hub
+
 ### loki
 - **Container:** factory-loki.container
 - **Host roles:** factory-hub

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -53,6 +53,19 @@ and alerts on Discord) is ratified design — it is not yet implemented in
 `src/factory`. Current live consumers of plane ① are the hub read-model
 projectors (below).
 
+**Standalone log monitor (`factory-log-monitor`, #2245) — plane ③, V1-pull.**
+A dedicated Quadlet container (`deploy/quadlet/factory-log-monitor.container`)
+periodically pulls NATS/hub container logs from Loki (`src/factory/monitoring/
+log_watch.py`, `checks_log.py`) and fires a raw Telegram alert
+(`escalation.py`) on threshold breach — no NATS connection, no
+`factory.metric.>` producer. It is explicitly a thin, temporary safety net:
+pull, not subscribe (plane ③'s existing HTTP-health mode, not a new plane),
+and it is not a preview of Monitoring v2/Sentinelle (no event bus, no
+dashboard surface). It should be retired or subsumed once Monitoring v2
+(#1035) ships log-scanning as a hub-native plane ③/④ consumer — see the
+`factory.monitoring` package docstring and `docs/CONFIGURATION.md`'s
+Monitoring section for the dormant-vs-live module split.
+
 ### Control-plane dashboard — sole human surface
 
 The dashboard is the **only** operator-facing surface (ADR-092). Every engine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,11 @@ filterwarnings = [
     "ignore:websockets.legacy is deprecated:DeprecationWarning",
     "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
     # Temporary suppression — remove when #1035 lands (module deletion)
-    "ignore:factory.monitoring is deprecated:DeprecationWarning",
+    # Message pattern is matched via re.match (prefix, not full-string): match on the
+    # "factory.monitoring.checks" prefix shared by checks.py's warning text, since the
+    # full wording ("... (the aggregate Layer-1 runner) is deprecated ...") breaks a
+    # naive "factory.monitoring.checks is deprecated" substring match.
+    "ignore:factory.monitoring.checks:DeprecationWarning",
 ]
 markers = [
     "nats_integration: NATS integration tests requiring Docker Compose",

--- a/src/factory/bootstrap/standalone/worker_standalone.py
+++ b/src/factory/bootstrap/standalone/worker_standalone.py
@@ -218,3 +218,25 @@ async def _bootstrap_omp_standalone(raw_config: dict) -> None:  # noqa: ARG001
     finally:
         await cancel_fleet_reporter(fleet_reporter_task)
         await nc.close()
+
+
+async def _bootstrap_log_monitor_standalone(raw_config: dict) -> None:  # noqa: ARG001
+    """Run the standalone log-monitor loop (V1-pull detection, #2245).
+
+    No NATS connection — this is a periodic pull-based health probe, not an
+    event/metric bus producer (ADR-091 plane③ V1: pull; V2 subscribe is #1035,
+    future work). Runs until SIGTERM/SIGINT, or once if FACTORY_LOG_MONITOR_ONCE is set.
+    """
+    from factory.monitoring.config import load_monitoring_config
+    from factory.monitoring.log_watch import LogMonitorLoop
+
+    config = load_monitoring_config()
+    loop = LogMonitorLoop(config)
+
+    log.info("log-monitor: starting (interval=%dm)", config.check_interval_minutes)
+
+    if os.environ.get("FACTORY_LOG_MONITOR_ONCE"):
+        report = await loop.run_once()
+        sys.exit(0 if report.all_passed else 1)
+
+    await loop.run_forever()

--- a/src/factory/cli/main.py
+++ b/src/factory/cli/main.py
@@ -182,6 +182,16 @@ def _turn_writer() -> None:
     _boot(_bootstrap_turn_writer_standalone)
 
 
+@factory_app.command("log-monitor")
+def _log_monitor() -> None:
+    """Run standalone log-monitor process (V1-pull detection, #2245 — no NATS)."""
+    from factory.bootstrap.standalone.worker_standalone import (
+        _bootstrap_log_monitor_standalone,
+    )
+
+    _boot(_bootstrap_log_monitor_standalone)
+
+
 @factory_app.command("socialmedia-adapter")
 def _socialmedia_adapter() -> None:
     """Run the social media NATS satellite (tool.socialmedia → Postiz v1)."""

--- a/src/factory/monitoring/__init__.py
+++ b/src/factory/monitoring/__init__.py
@@ -4,12 +4,3 @@ The host-timer units (lyra-monitor.{service,timer}) have been removed from
 deploy/. This module remains as the canonical health-probe implementation
 (`python -m factory.monitoring`) and a reference for Monitoring v2 (#1035).
 """
-
-import warnings
-
-warnings.warn(
-    "factory.monitoring is deprecated — superseded by Monitoring v2 (#1035). "
-    "This package will be removed when v2 lands.",
-    DeprecationWarning,
-    stacklevel=1,
-)

--- a/src/factory/monitoring/__init__.py
+++ b/src/factory/monitoring/__init__.py
@@ -1,6 +1,16 @@
-"""Monitoring package — Python module retained for spec reference.
+"""Monitoring package — mostly retained for spec reference, two modules live.
 
 The host-timer units (lyra-monitor.{service,timer}) have been removed from
-deploy/. This module remains as the canonical health-probe implementation
-(`python -m factory.monitoring`) and a reference for Monitoring v2 (#1035).
+deploy/. Most of this package (`checks.py`'s aggregate Layer-1 runner,
+`check_process`/`check_http_health`, `__main__.py`) remains the canonical
+health-probe implementation (`python -m factory.monitoring`) and a reference
+for Monitoring v2 (#1035) — that path still warns `DeprecationWarning` on
+import (see `checks.py`).
+
+`checks_log.py`, `log_watch.py`, and `escalation.py`'s raw-alert path are the
+exception: as of #2245 they are live production code, run continuously by the
+standalone `factory-log-monitor` Quadlet container as a thin V1-pull safety
+net (ADR-091 plane③). They do not warn on import and should be retired or
+subsumed once Monitoring v2 (#1035) ships log-scanning as a hub-native
+consumer.
 """

--- a/src/factory/monitoring/checks.py
+++ b/src/factory/monitoring/checks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import subprocess
+import warnings
 from datetime import datetime, timezone
 
 import httpx
@@ -14,6 +15,13 @@ from .checks_log import check_hub_dict_stream_gen_timeout, check_nats_log_errors
 from .checks_varz import check_disk, check_disk_pct, check_inode_pct, check_nats_varz
 from .config import MonitoringConfig
 from .models import CheckResult, HealthReport
+
+warnings.warn(
+    "factory.monitoring.checks (the aggregate Layer-1 runner) is deprecated — "
+    "superseded by Monitoring v2 (#1035). This module will be removed when v2 lands.",
+    DeprecationWarning,
+    stacklevel=1,
+)
 
 
 def check_process(service_names: list[str]) -> list[CheckResult]:

--- a/src/factory/monitoring/checks_log.py
+++ b/src/factory/monitoring/checks_log.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
+import time
 from datetime import datetime, timezone
+from typing import Protocol
+
+import httpx
 
 from .models import CheckResult
 
@@ -14,91 +19,156 @@ _LOG_EXCEPTIONS = (
 )
 
 
-def check_nats_log_errors(container_name: str, max_age_minutes: int) -> CheckResult:
+class LogFetchError(Exception):
+    """Raised by any LogFetcher implementation on fetch failure."""
+
+
+class LogFetcher(Protocol):
+    def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str: ...
+
+
+class SubprocessLogFetcher:
+    """Default fetcher — shells out to `podman logs`, behavior unchanged from before
+    this refactor."""
+
+    def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str:
+        # pattern unused: podman logs --since has no line-count cap, so there is no
+        # truncation risk to guard against locally — kept only for LogFetcher protocol
+        # conformance with LokiLogFetcher (T2), which DOES need it.
+        try:
+            result = subprocess.run(
+                ["podman", "logs", "--since", f"{since_minutes}m", container_name],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except _LOG_EXCEPTIONS as e:
+            raise LogFetchError(str(e)) from e
+        return result.stdout + result.stderr
+
+
+class LokiLogFetcher:
+    """Fetches container logs from Loki (ADR-093) instead of local `podman logs`."""
+
+    def __init__(self, loki_url: str = "http://factory-loki:3100") -> None:
+        self.loki_url = loki_url
+
+    def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str:
+        # Server-side |~ "(?i)..." filter is load-bearing, not cosmetic: Loki's
+        # query_range returns at most `limit` lines, NEWEST-FIRST, within the window —
+        # unlike `podman logs --since` (no cap). On a busy container this could push
+        # true violations outside an unfiltered fetch. Case-insensitive regex is a
+        # safe superset for both checks; exact counting still happens client-side
+        # after fetch (unchanged from today).
+        escaped = re.escape(pattern)
+        query = f'{{systemd_unit="{container_name}.service"}} |~ "(?i){escaped}"'
+        now_ns = time.time_ns()
+        start_ns = now_ns - since_minutes * 60 * 1_000_000_000
+        params = {
+            "query": query,
+            "start": start_ns,
+            "end": now_ns,
+            "limit": 5000,
+        }
+        try:
+            resp = httpx.get(
+                f"{self.loki_url}/loki/api/v1/query_range",
+                params=params,
+                timeout=10.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            lines = [
+                value[1]
+                for result in data["data"]["result"]
+                for value in result["values"]
+            ]
+        except (httpx.HTTPError, KeyError, ValueError) as e:
+            raise LogFetchError(str(e)) from e
+        return "\n".join(lines)
+
+
+def check_nats_log_errors(
+    container_name: str,
+    max_age_minutes: int,
+    fetcher: LogFetcher = SubprocessLogFetcher(),
+) -> CheckResult:
     """Check NATS container logs for permissions violation errors.
 
-    Runs `podman logs --since {max_age_minutes}m {container_name}` and counts
-    lines containing "permissions violation". Any count > 0 is a failure.
+    Fetches logs via `fetcher` (default: local `podman logs --since`) and
+    counts lines containing "permissions violation". Any count > 0 is a
+    failure.
     """
     now = datetime.now(timezone.utc)
     try:
-        result = subprocess.run(
-            ["podman", "logs", "--since", f"{max_age_minutes}m", container_name],
-            capture_output=True,
-            text=True,
-            timeout=15,
+        combined = fetcher.fetch(
+            container_name, max_age_minutes, pattern="permissions violation"
         )
-        combined = result.stdout + result.stderr
-        count = sum(
-            1 for line in combined.splitlines() if "permissions violation" in line
-        )
-        if count > 0:
-            return CheckResult(
-                name="nats:permissions_violation",
-                passed=False,
-                detail=f"permissions violation: {count} in last {max_age_minutes}m",
-                timestamp=now,
-            )
-        return CheckResult(
-            name="nats:permissions_violation",
-            passed=True,
-            detail=f"0 violations in last {max_age_minutes}m",
-            timestamp=now,
-        )
-    except _LOG_EXCEPTIONS as exc:
+    except LogFetchError as exc:
         return CheckResult(
             name="nats:permissions_violation",
             passed=False,
             detail=str(exc),
             timestamp=now,
         )
+    count = sum(1 for line in combined.splitlines() if "permissions violation" in line)
+    if count > 0:
+        return CheckResult(
+            name="nats:permissions_violation",
+            passed=False,
+            detail=f"permissions violation: {count} in last {max_age_minutes}m",
+            timestamp=now,
+        )
+    return CheckResult(
+        name="nats:permissions_violation",
+        passed=True,
+        detail=f"0 violations in last {max_age_minutes}m",
+        timestamp=now,
+    )
 
 
 def check_hub_dict_stream_gen_timeout(
-    container_name: str, max_age_minutes: int, threshold: int
+    container_name: str,
+    max_age_minutes: int,
+    threshold: int,
+    fetcher: LogFetcher = SubprocessLogFetcher(),
 ) -> CheckResult:
     """Check hub container logs for _dict_stream_gen timeout occurrences.
 
-    Runs `podman logs --since {max_age_minutes}m {container_name}` and counts
-    lines containing "_dict_stream_gen timeout" (case-insensitive). Fails when
-    count >= threshold.
+    Fetches logs via `fetcher` (default: local `podman logs --since`) and
+    counts lines containing "_dict_stream_gen timeout" (case-insensitive).
+    Fails when count >= threshold.
     """
     now = datetime.now(timezone.utc)
     try:
-        result = subprocess.run(
-            ["podman", "logs", "--since", f"{max_age_minutes}m", container_name],
-            capture_output=True,
-            text=True,
-            timeout=15,
+        combined = fetcher.fetch(
+            container_name, max_age_minutes, pattern="_dict_stream_gen timeout"
         )
-        combined = result.stdout + result.stderr
-        count = sum(
-            1
-            for line in combined.splitlines()
-            if "_dict_stream_gen timeout" in line.lower()
-        )
-        if count >= threshold:
-            return CheckResult(
-                name="hub:dict_stream_gen_timeout",
-                passed=False,
-                detail=(
-                    f"_dict_stream_gen timeout: {count} in last {max_age_minutes}m"
-                    f" (threshold={threshold})"
-                ),
-                timestamp=now,
-            )
-        return CheckResult(
-            name="hub:dict_stream_gen_timeout",
-            passed=True,
-            detail=(
-                f"{count} timeouts in last {max_age_minutes}m (threshold={threshold})"
-            ),
-            timestamp=now,
-        )
-    except _LOG_EXCEPTIONS as exc:
+    except LogFetchError as exc:
         return CheckResult(
             name="hub:dict_stream_gen_timeout",
             passed=False,
             detail=str(exc),
             timestamp=now,
         )
+    count = sum(
+        1
+        for line in combined.splitlines()
+        if "_dict_stream_gen timeout" in line.lower()
+    )
+    if count >= threshold:
+        return CheckResult(
+            name="hub:dict_stream_gen_timeout",
+            passed=False,
+            detail=(
+                f"_dict_stream_gen timeout: {count} in last {max_age_minutes}m"
+                f" (threshold={threshold})"
+            ),
+            timestamp=now,
+        )
+    return CheckResult(
+        name="hub:dict_stream_gen_timeout",
+        passed=True,
+        detail=(f"{count} timeouts in last {max_age_minutes}m (threshold={threshold})"),
+        timestamp=now,
+    )

--- a/src/factory/monitoring/checks_log.py
+++ b/src/factory/monitoring/checks_log.py
@@ -10,6 +10,7 @@ from typing import Protocol
 
 import httpx
 
+from ._errors import _MONITORING_HTTP_ERRORS
 from .models import CheckResult
 
 _LOG_EXCEPTIONS = (
@@ -17,6 +18,16 @@ _LOG_EXCEPTIONS = (
     FileNotFoundError,
     subprocess.CalledProcessError,
 )
+
+# Loki's query_range response is untrusted JSON shape, not just untrusted
+# transport: beyond the shared HTTP/parse errors (_MONITORING_HTTP_ERRORS —
+# httpx.HTTPError, ValueError incl. JSONDecodeError, TypeError, OSError),
+# a malformed-but-200-OK body can also raise KeyError (missing "data"/
+# "result"/"values" keys) or IndexError (a "values" entry with < 2 elements).
+# All of these must become LogFetchError, never escape raw — an unhandled
+# exception here kills LogMonitorLoop.run_once() and, on a deterministic
+# response shape, exhausts systemd's Restart=on-failure burst limit.
+_LOKI_FETCH_ERRORS = (*_MONITORING_HTTP_ERRORS, KeyError, IndexError)
 
 
 class LogFetchError(Exception):
@@ -83,7 +94,7 @@ class LokiLogFetcher:
                 for result in data["data"]["result"]
                 for value in result["values"]
             ]
-        except (httpx.HTTPError, KeyError, ValueError) as e:
+        except _LOKI_FETCH_ERRORS as e:
             raise LogFetchError(str(e)) from e
         return "\n".join(lines)
 

--- a/src/factory/monitoring/config.py
+++ b/src/factory/monitoring/config.py
@@ -85,6 +85,19 @@ class MonitoringConfig(BaseModel):
                 )
         return v
 
+    @field_validator("nats_container_name", "hub_container_name")
+    @classmethod
+    def _validate_container_name(cls, v: str) -> str:
+        # Same charset as service_names: both are operator-controlled
+        # identifiers that get interpolated into shell argv (podman/systemctl)
+        # and a LogQL label matcher (checks_log.py) — parity closes the one
+        # field left ungated when that seam was added.
+        if not _SERVICE_NAME_RE.match(v):
+            raise ValueError(
+                f"container name must match [a-zA-Z0-9_@.-]+, got {v!r}"
+            )
+        return v
+
     @field_validator("health_endpoint_url")
     @classmethod
     def _validate_health_endpoint_url(cls, v: str) -> str:

--- a/src/factory/monitoring/log_watch.py
+++ b/src/factory/monitoring/log_watch.py
@@ -65,9 +65,27 @@ class LogMonitorLoop:
         )
 
     async def run_forever(self) -> None:
-        """Loop run_once() on config.check_interval_minutes, alerting on any failure."""
+        """Loop run_once() on config.check_interval_minutes, alerting on any failure.
+
+        `run_once()` itself is guarded: the underlying check functions already
+        translate expected fetch failures into a failing `CheckResult`, but a
+        genuinely unexpected exception (e.g. a Loki response shape neither
+        `checks_log.py` nor this code anticipated) must not be allowed to kill
+        this coroutine. A deterministic bug here would reproduce on every
+        restart and exhaust systemd's `Restart=on-failure` burst limit,
+        permanently disabling the safety net this loop exists to provide —
+        one bad tick must cost at most one missed cycle, never the process.
+        """
         while True:
-            report = await self.run_once()
+            try:
+                report = await self.run_once()
+            except Exception:
+                log.exception(
+                    "log-monitor: run_once() failed unexpectedly; skipping this tick"
+                )
+                await asyncio.sleep(self.config.check_interval_minutes * 60)
+                continue
+
             if not report.all_passed:
                 log.warning(
                     "log-monitor: %d/%d checks failed",

--- a/src/factory/monitoring/log_watch.py
+++ b/src/factory/monitoring/log_watch.py
@@ -1,0 +1,83 @@
+"""LogMonitorLoop — V1-pull periodic scheduler for the two log-scanning checks (#2245).
+
+No NATS connection, no event/metric bus producer — ADR-091 plane③ V1: pull, not V2:
+subscribe (#1035, future work). This is a thin scheduler around the existing pure
+check functions in checks_log.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from . import escalation
+from ._errors import _MONITORING_ESCALATION_ERRORS
+from .checks_log import (
+    LogFetcher,
+    LokiLogFetcher,
+    check_hub_dict_stream_gen_timeout,
+    check_nats_log_errors,
+)
+from .config import MonitoringConfig
+from .models import CheckResult, HealthReport
+
+log = logging.getLogger(__name__)
+
+
+class LogMonitorLoop:
+    """Periodically runs the NATS-permissions and hub-stream-gen log checks."""
+
+    def __init__(
+        self,
+        config: MonitoringConfig,
+        fetcher: LogFetcher = LokiLogFetcher(),
+    ) -> None:
+        # Default is Loki (ADR-093), not SubprocessLogFetcher: the deployed
+        # factory-log-monitor container has no Podman socket/CLI (plan SC2) —
+        # a subprocess default would silently fail every check in prod.
+        self.config = config
+        self.fetcher = fetcher
+
+    async def run_once(self) -> HealthReport:
+        """Run both log checks once and return an aggregated HealthReport."""
+        checks: list[CheckResult] = [
+            await asyncio.to_thread(
+                check_nats_log_errors,
+                self.config.nats_container_name,
+                self.config.nats_log_check_minutes,
+                fetcher=self.fetcher,
+            ),
+            await asyncio.to_thread(
+                check_hub_dict_stream_gen_timeout,
+                self.config.hub_container_name,
+                self.config.stream_gen_timeout_minutes,
+                self.config.stream_gen_timeout_threshold,
+                fetcher=self.fetcher,
+            ),
+        ]
+        failed = [c for c in checks if not c.passed]
+        return HealthReport(
+            checks=checks,
+            all_passed=len(failed) == 0,
+            failed_count=len(failed),
+            timestamp=datetime.now(timezone.utc),
+        )
+
+    async def run_forever(self) -> None:
+        """Loop run_once() on config.check_interval_minutes, alerting on any failure."""
+        while True:
+            report = await self.run_once()
+            if not report.all_passed:
+                log.warning(
+                    "log-monitor: %d/%d checks failed",
+                    report.failed_count,
+                    len(report.checks),
+                )
+                try:
+                    await escalation.send_telegram_raw_alert(report, self.config)
+                except _MONITORING_ESCALATION_ERRORS:
+                    log.exception("log-monitor: Telegram alert delivery failed")
+            else:
+                log.info("log-monitor: all checks passed")
+            await asyncio.sleep(self.config.check_interval_minutes * 60)

--- a/tests/bootstrap/test_log_monitor_standalone_paths.py
+++ b/tests/bootstrap/test_log_monitor_standalone_paths.py
@@ -1,0 +1,212 @@
+"""Bootstrap wiring tests for _bootstrap_log_monitor_standalone (#2245).
+
+Covers the FACTORY_LOG_MONITOR_ONCE single-tick mechanism (once-mode exits
+with the report's pass/fail status; forever-mode never calls sys.exit) and a
+static SC10 guard: this V1-pull slice must never grow a V2 event/metric-bus
+publish/subscribe surface (that's #1035, explicitly out of scope).
+
+Patch targets: load_monitoring_config and LogMonitorLoop are imported via
+function-local `from ... import ...` statements inside
+_bootstrap_log_monitor_standalone, so they are never bound as module-level
+attributes of worker_standalone (confirmed: `dir(worker_standalone)` does not
+contain either name). Patching
+`factory.bootstrap.standalone.worker_standalone.load_monitoring_config`
+would raise AttributeError at patch-setup time. The deferred import re-reads
+the name from its *defining* module at call time, so the correct patch
+targets are the source modules: `factory.monitoring.config.load_monitoring_config`
+and `factory.monitoring.log_watch.LogMonitorLoop`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.monitoring.models import HealthReport
+
+
+def _make_report(*, all_passed: bool, failed_count: int) -> HealthReport:
+    return HealthReport(
+        checks=[],
+        all_passed=all_passed,
+        failed_count=failed_count,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+class TestLogMonitorOnceMode:
+    @pytest.mark.asyncio
+    async def test_once_mode_all_pass_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FACTORY_LOG_MONITOR_ONCE set + all checks pass → SystemExit(0)."""
+        from factory.bootstrap.standalone.worker_standalone import (
+            _bootstrap_log_monitor_standalone,
+        )
+
+        monkeypatch.setenv("FACTORY_LOG_MONITOR_ONCE", "1")
+
+        report = _make_report(all_passed=True, failed_count=0)
+        mock_loop = MagicMock()
+        mock_loop.run_once = AsyncMock(return_value=report)
+        mock_loop.run_forever = AsyncMock()
+
+        with (
+            patch(
+                "factory.monitoring.config.load_monitoring_config",
+                return_value=MagicMock(check_interval_minutes=5),
+            ),
+            patch(
+                "factory.monitoring.log_watch.LogMonitorLoop",
+                return_value=mock_loop,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await _bootstrap_log_monitor_standalone({})
+
+        assert exc_info.value.code == 0
+        mock_loop.run_once.assert_awaited_once()
+        mock_loop.run_forever.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_once_mode_failure_exits_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FACTORY_LOG_MONITOR_ONCE set + a check fails → SystemExit(1)."""
+        from factory.bootstrap.standalone.worker_standalone import (
+            _bootstrap_log_monitor_standalone,
+        )
+
+        monkeypatch.setenv("FACTORY_LOG_MONITOR_ONCE", "1")
+
+        report = _make_report(all_passed=False, failed_count=1)
+        mock_loop = MagicMock()
+        mock_loop.run_once = AsyncMock(return_value=report)
+        mock_loop.run_forever = AsyncMock()
+
+        with (
+            patch(
+                "factory.monitoring.config.load_monitoring_config",
+                return_value=MagicMock(check_interval_minutes=5),
+            ),
+            patch(
+                "factory.monitoring.log_watch.LogMonitorLoop",
+                return_value=mock_loop,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await _bootstrap_log_monitor_standalone({})
+
+        assert exc_info.value.code == 1
+        mock_loop.run_once.assert_awaited_once()
+        mock_loop.run_forever.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_once_mode_never_calls_run_forever(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Once-mode never touches run_forever, regardless of pass/fail outcome."""
+        from factory.bootstrap.standalone.worker_standalone import (
+            _bootstrap_log_monitor_standalone,
+        )
+
+        monkeypatch.setenv("FACTORY_LOG_MONITOR_ONCE", "1")
+
+        report = _make_report(all_passed=True, failed_count=0)
+        mock_loop = MagicMock()
+        mock_loop.run_once = AsyncMock(return_value=report)
+        mock_loop.run_forever = AsyncMock()
+
+        with (
+            patch(
+                "factory.monitoring.config.load_monitoring_config",
+                return_value=MagicMock(check_interval_minutes=5),
+            ),
+            patch(
+                "factory.monitoring.log_watch.LogMonitorLoop",
+                return_value=mock_loop,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            await _bootstrap_log_monitor_standalone({})
+
+        mock_loop.run_forever.assert_not_awaited()
+
+
+class TestLogMonitorForeverMode:
+    @pytest.mark.asyncio
+    async def test_no_once_env_calls_run_forever_not_sys_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FACTORY_LOG_MONITOR_ONCE unset → run_forever awaited, no SystemExit."""
+        from factory.bootstrap.standalone.worker_standalone import (
+            _bootstrap_log_monitor_standalone,
+        )
+
+        monkeypatch.delenv("FACTORY_LOG_MONITOR_ONCE", raising=False)
+
+        mock_loop = MagicMock()
+        mock_loop.run_once = AsyncMock()
+        # Simulate a clean shutdown: run_forever returns immediately.
+        mock_loop.run_forever = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "factory.monitoring.config.load_monitoring_config",
+                return_value=MagicMock(check_interval_minutes=5),
+            ),
+            patch(
+                "factory.monitoring.log_watch.LogMonitorLoop",
+                return_value=mock_loop,
+            ),
+        ):
+            # Should return normally — no SystemExit raised in forever-mode.
+            await _bootstrap_log_monitor_standalone({})
+
+        mock_loop.run_forever.assert_awaited_once()
+        mock_loop.run_once.assert_not_called()
+
+
+class TestNoEventMetricSubjects:
+    """SC10 static guard: this V1-pull slice must never grow a V2 event/metric-bus
+    publish/subscribe surface (that's #1035, explicitly out of scope).
+
+    Pure source inspection — no mocking, no async. Scoped to the exact
+    functions/module touched by this slice (not whole shared files) to avoid
+    false positives from unrelated code sharing a file.
+    """
+
+    def test_log_watch_module_has_no_event_or_metric_subjects(self) -> None:
+        import factory.monitoring.log_watch as log_watch
+
+        source = inspect.getsource(log_watch)
+        assert "factory.event." not in source
+        assert "factory.metric." not in source
+
+    def test_bootstrap_log_monitor_standalone_has_no_event_or_metric_subjects(
+        self,
+    ) -> None:
+        from factory.bootstrap.standalone.worker_standalone import (
+            _bootstrap_log_monitor_standalone,
+        )
+
+        source = inspect.getsource(_bootstrap_log_monitor_standalone)
+        assert "factory.event." not in source
+        assert "factory.metric." not in source
+
+    def test_cli_log_monitor_command_has_no_event_or_metric_subjects(self) -> None:
+        # factory.cli.__init__ re-exports `main` (from factory.cli.main import
+        # main), which shadows the `main` submodule attribute on the `factory.cli`
+        # package. `import factory.cli.main as m` would therefore resolve `m` to
+        # the *function*, not the module. Go through sys.modules via
+        # importlib.import_module to get the real module unambiguously.
+        cli_main = importlib.import_module("factory.cli.main")
+        log_monitor_command = cli_main._log_monitor
+
+        source = inspect.getsource(log_monitor_command)
+        assert "factory.event." not in source
+        assert "factory.metric." not in source

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -34,6 +34,7 @@ EXPECTED_CONTAINERS = [
     "factory-cloudflared",
     "factory-loki",
     "factory-promtail",
+    "factory-log-monitor",
     "factory-otel",
     # llmCLI cloud gateway — deployment owned by factory (vendored from Roxabi/llmCLI).
     # Enabled + declared after factory-otel, so they join the converge restart set.
@@ -54,12 +55,12 @@ def _source_and_run(helper: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_emits_exactly_19_containers() -> None:
+def test_emits_exactly_20_containers() -> None:
     """Real helper against the real quadlet.toml → returncode 0, enabled names only."""
     result = _source_and_run(HELPER)
     assert result.returncode == 0, result.stderr
     lines = [line for line in result.stdout.splitlines() if line]
-    assert len(lines) == 19, f"expected 19 containers, got {len(lines)}: {lines}"
+    assert len(lines) == 20, f"expected 20 containers, got {len(lines)}: {lines}"
 
 
 def test_declaration_order() -> None:

--- a/tests/test_monitoring_checks_log.py
+++ b/tests/test_monitoring_checks_log.py
@@ -132,7 +132,7 @@ class TestCheckHubDictStreamGenTimeout:
     def test_passes_when_count_below_threshold(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        stdout = "_dict_stream_gen timeout on turn abc\n" "unrelated line\n"
+        stdout = "_dict_stream_gen timeout on turn abc\nunrelated line\n"
         monkeypatch.setattr(
             "factory.monitoring.checks_log.subprocess.run",
             lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
@@ -182,8 +182,7 @@ class TestCheckHubDictStreamGenTimeout:
     ) -> None:
         """Upper/mixed-case occurrences ARE counted — check is case-insensitive."""
         stdout = (
-            "_DICT_STREAM_GEN TIMEOUT on turn a\n"
-            "_Dict_Stream_Gen Timeout on turn b\n"
+            "_DICT_STREAM_GEN TIMEOUT on turn a\n_Dict_Stream_Gen Timeout on turn b\n"
         )
         monkeypatch.setattr(
             "factory.monitoring.checks_log.subprocess.run",
@@ -406,8 +405,7 @@ class TestLokiLogFetcher:
         )
 
         assert result == (
-            "permissions violation on subject foo\n"
-            "permissions violation on subject bar"
+            "permissions violation on subject foo\npermissions violation on subject bar"
         )
 
     def test_fetch_raises_log_fetch_error_on_malformed_json(
@@ -422,9 +420,7 @@ class TestLokiLogFetcher:
         monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
 
         with pytest.raises(LogFetchError):
-            LokiLogFetcher().fetch(
-                "factory-nats", 10, pattern="permissions violation"
-            )
+            LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
 
     def test_fetch_raises_log_fetch_error_on_http_error(
         self, monkeypatch: pytest.MonkeyPatch
@@ -439,9 +435,7 @@ class TestLokiLogFetcher:
         monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
 
         with pytest.raises(LogFetchError):
-            LokiLogFetcher().fetch(
-                "factory-nats", 10, pattern="permissions violation"
-            )
+            LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
 
     def test_fetch_query_param_includes_case_insensitive_regex_filter(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_monitoring_checks_log.py
+++ b/tests/test_monitoring_checks_log.py
@@ -13,12 +13,17 @@ style replacement of the module under test.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from factory.monitoring.checks_log import (
+    LogFetchError,
+    LokiLogFetcher,
+    SubprocessLogFetcher,
     check_hub_dict_stream_gen_timeout,
     check_nats_log_errors,
 )
@@ -302,3 +307,194 @@ class TestSubprocessInvocationShape:
         assert kwargs["capture_output"] is True
         assert kwargs["text"] is True
         assert kwargs["timeout"] == 15
+
+
+# ---------------------------------------------------------------------------
+# T4 (issue #2245, plan task T4) — tests against the POST-refactor
+# LogFetcher seam. These import symbols (`LogFetchError`, `LokiLogFetcher`,
+# `SubprocessLogFetcher`) that did not exist before this issue's T1-T3
+# refactor, so — unlike T0 above — this is a genuine RED-GATE against the
+# refactor itself, not just a characterization of pre-existing behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestFetcherSeam:
+    """Prove the injectable `fetcher` seam actually decouples log-fetch from
+    the counting logic: an injected fetcher's `.fetch()` receives the right
+    args, and `subprocess.run` is never touched when it is used."""
+
+    def test_check_nats_log_errors_uses_injected_fetcher(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fail_if_called(*args, **kwargs):
+            raise AssertionError(
+                "subprocess.run must not be called when a fetcher is injected"
+            )
+
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run", _fail_if_called
+        )
+
+        fake_fetcher = MagicMock()
+        fake_fetcher.fetch.return_value = "all quiet\n"
+
+        result = check_nats_log_errors("factory-nats", 10, fetcher=fake_fetcher)
+
+        fake_fetcher.fetch.assert_called_once_with(
+            "factory-nats", 10, pattern="permissions violation"
+        )
+        assert result.passed is True
+
+    def test_check_hub_dict_stream_gen_timeout_uses_injected_fetcher(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fail_if_called(*args, **kwargs):
+            raise AssertionError(
+                "subprocess.run must not be called when a fetcher is injected"
+            )
+
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run", _fail_if_called
+        )
+
+        fake_fetcher = MagicMock()
+        fake_fetcher.fetch.return_value = ""
+
+        result = check_hub_dict_stream_gen_timeout(
+            "factory-hub", 10, threshold=1, fetcher=fake_fetcher
+        )
+
+        fake_fetcher.fetch.assert_called_once_with(
+            "factory-hub", 10, pattern="_dict_stream_gen timeout"
+        )
+        assert result.passed is True
+
+
+class TestLokiLogFetcher:
+    """`LokiLogFetcher.fetch` talks to Loki via module-level `httpx.get`
+    (not `httpx.Client`) — mock target is
+    `factory.monitoring.checks_log.httpx.get`."""
+
+    def test_fetch_returns_joined_log_lines_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "data": {
+                "result": [
+                    {
+                        "values": [
+                            [
+                                "1700000000000000000",
+                                "permissions violation on subject foo",
+                            ],
+                            [
+                                "1700000001000000000",
+                                "permissions violation on subject bar",
+                            ],
+                        ]
+                    }
+                ]
+            }
+        }
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        result = LokiLogFetcher().fetch(
+            "factory-nats", 10, pattern="permissions violation"
+        )
+
+        assert result == (
+            "permissions violation on subject foo\n"
+            "permissions violation on subject bar"
+        )
+
+    def test_fetch_raises_log_fetch_error_on_malformed_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing expected keys (`data`/`result`/`values`) must surface as
+        `LogFetchError`, not a raw KeyError/ValueError escaping the fetcher."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"unexpected": "shape"}
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        with pytest.raises(LogFetchError):
+            LokiLogFetcher().fetch(
+                "factory-nats", 10, pattern="permissions violation"
+            )
+
+    def test_fetch_raises_log_fetch_error_on_http_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500 Internal Server Error",
+            request=MagicMock(),
+            response=MagicMock(),
+        )
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        with pytest.raises(LogFetchError):
+            LokiLogFetcher().fetch(
+                "factory-nats", 10, pattern="permissions violation"
+            )
+
+    def test_fetch_query_param_includes_case_insensitive_regex_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard for the truncation-risk fix: the server-side
+        `|~ "(?i)<escaped-pattern>"` LogQL filter must survive future edits.
+        Without it, Loki's `limit`-capped, newest-first `query_range`
+        response on a busy container could silently drop true violations
+        under load (see checks_log.py's comment on LokiLogFetcher.fetch)."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": {"result": []}}
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
+
+        mock_get.assert_called_once()
+        _, kwargs = mock_get.call_args
+        query = kwargs["params"]["query"]
+        escaped = re.escape("permissions violation")
+        assert f'|~ "(?i){escaped}"' in query
+
+
+class TestSubprocessLogFetcherIgnoresPattern:
+    """`pattern` is accepted for `LogFetcher` protocol conformance but has
+    no effect on the local subprocess fetch — a deliberate design choice
+    (podman's `--since` has no line-count cap, so there is no truncation
+    risk to filter against locally), not an oversight."""
+
+    def test_fetch_ignores_pattern_argument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[tuple, dict]] = []
+
+        def mock_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return MagicMock(
+                returncode=0, stdout="stdout content\n", stderr="stderr content\n"
+            )
+
+        monkeypatch.setattr("factory.monitoring.checks_log.subprocess.run", mock_run)
+
+        result_a = SubprocessLogFetcher().fetch("c", 5, pattern="anything")
+        result_b = SubprocessLogFetcher().fetch("c", 5, pattern="permissions violation")
+
+        assert result_a == "stdout content\nstderr content\n"
+        assert result_b == "stdout content\nstderr content\n"
+        # The command passed to subprocess.run must be identical regardless
+        # of `pattern` — proving it is truly not threaded into the command.
+        assert len(calls) == 2
+        args_a, _ = calls[0]
+        args_b, _ = calls[1]
+        assert args_a[0] == args_b[0] == ["podman", "logs", "--since", "5m", "c"]
+        assert "anything" not in args_a[0]
+        assert "permissions violation" not in args_b[0]

--- a/tests/test_monitoring_checks_log.py
+++ b/tests/test_monitoring_checks_log.py
@@ -1,0 +1,304 @@
+"""Baseline characterization tests for `factory.monitoring.checks_log`.
+
+Written against the CURRENT, UNMODIFIED source (issue #2245, plan task T0) — no
+`fetcher`/`LogFetcher` seam exists yet. This file locks in today's exact
+behavior of `check_nats_log_errors` and `check_hub_dict_stream_gen_timeout`
+BEFORE a later refactor (T1-T3) introduces an injectable log-fetch seam, so a
+behavior regression during that refactor shows up as a red test here
+(SC3's falsification, per the plan).
+
+Do not modify `checks_log.py` from this file — mocking only, never `vi.mock`-
+style replacement of the module under test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from factory.monitoring.checks_log import (
+    check_hub_dict_stream_gen_timeout,
+    check_nats_log_errors,
+)
+
+# ---------------------------------------------------------------------------
+# check_nats_log_errors — case-SENSITIVE substring count of
+# "permissions violation"; count > 0 -> failed.
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNatsLogErrors:
+    def test_passes_with_zero_occurrences(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """0 occurrences of the exact-case substring -> passed."""
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(
+                returncode=0, stdout="all quiet\nnothing to see\n", stderr=""
+            ),
+        )
+
+        result = check_nats_log_errors("factory-nats", 10)
+
+        assert result.passed is True
+        assert result.name == "nats:permissions_violation"
+        assert "0 violations" in result.detail
+
+    def test_fails_with_correct_count_on_occurrences(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """>0 occurrences -> failed, with the exact count reflected in detail."""
+        stdout = (
+            "line one ok\n"
+            "permissions violation on subject foo\n"
+            "line three ok\n"
+            "permissions violation on subject bar\n"
+        )
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_nats_log_errors("factory-nats", 10)
+
+        assert result.passed is False
+        assert result.name == "nats:permissions_violation"
+        assert "2" in result.detail
+
+    def test_case_sensitive_near_misses_not_counted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mixed-case near-misses must NOT be counted — check is case-sensitive."""
+        stdout = (
+            "Permissions Violation on subject foo\n"
+            "PERMISSIONS VIOLATION on subject bar\n"
+            "permissions Violation on subject baz\n"
+        )
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_nats_log_errors("factory-nats", 10)
+
+        # None of the near-misses match the exact-case substring.
+        assert result.passed is True
+        assert "0 violations" in result.detail
+
+    def test_reads_both_stdout_and_stderr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Occurrences in stderr must be counted too (stdout + stderr combined)."""
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(
+                returncode=0,
+                stdout="line ok\n",
+                stderr="permissions violation on subject foo\n",
+            ),
+        )
+
+        result = check_nats_log_errors("factory-nats", 10)
+
+        assert result.passed is False
+        assert "1" in result.detail
+
+    def test_name_is_stable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout="", stderr=""),
+        )
+
+        result = check_nats_log_errors("factory-nats", 10)
+
+        assert result.name == "nats:permissions_violation"
+
+
+# ---------------------------------------------------------------------------
+# check_hub_dict_stream_gen_timeout — case-INSENSITIVE substring count of
+# "_dict_stream_gen timeout"; count >= threshold -> failed.
+# ---------------------------------------------------------------------------
+
+
+class TestCheckHubDictStreamGenTimeout:
+    def test_passes_when_count_below_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stdout = "_dict_stream_gen timeout on turn abc\n" "unrelated line\n"
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=3)
+
+        assert result.passed is True
+        assert result.name == "hub:dict_stream_gen_timeout"
+
+    def test_fails_when_count_meets_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stdout = (
+            "_dict_stream_gen timeout on turn a\n"
+            "_dict_stream_gen timeout on turn b\n"
+            "_dict_stream_gen timeout on turn c\n"
+        )
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=3)
+
+        assert result.passed is False
+        assert result.name == "hub:dict_stream_gen_timeout"
+        assert "3" in result.detail
+        assert "threshold=3" in result.detail
+
+    def test_fails_when_count_exceeds_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stdout = "_dict_stream_gen timeout\n" * 5
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=3)
+
+        assert result.passed is False
+        assert "5" in result.detail
+
+    def test_case_insensitive_matching_is_counted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Upper/mixed-case occurrences ARE counted — check is case-insensitive."""
+        stdout = (
+            "_DICT_STREAM_GEN TIMEOUT on turn a\n"
+            "_Dict_Stream_Gen Timeout on turn b\n"
+        )
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=2)
+
+        assert result.passed is False
+        assert "2" in result.detail
+
+    def test_name_is_stable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout="", stderr=""),
+        )
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=1)
+
+        assert result.name == "hub:dict_stream_gen_timeout"
+
+
+# ---------------------------------------------------------------------------
+# Exception handling — both functions catch
+# (TimeoutExpired, FileNotFoundError, CalledProcessError) and return a
+# failing CheckResult with detail=str(exc).
+# ---------------------------------------------------------------------------
+
+_EXCEPTION_CASES = [
+    pytest.param(
+        subprocess.TimeoutExpired(cmd=["podman", "logs"], timeout=15),
+        id="timeout-expired",
+    ),
+    pytest.param(
+        FileNotFoundError("podman: command not found"),
+        id="file-not-found",
+    ),
+    pytest.param(
+        subprocess.CalledProcessError(returncode=1, cmd=["podman", "logs"]),
+        id="called-process-error",
+    ),
+]
+
+
+class TestLogCheckExceptionHandling:
+    @pytest.mark.parametrize("exc", _EXCEPTION_CASES)
+    def test_check_nats_log_errors_returns_failing_result(
+        self, monkeypatch: pytest.MonkeyPatch, exc: Exception
+    ) -> None:
+        def mock_run(*args, **kwargs):
+            raise exc
+
+        monkeypatch.setattr("factory.monitoring.checks_log.subprocess.run", mock_run)
+
+        result = check_nats_log_errors("factory-nats", 10)
+
+        assert result.passed is False
+        assert result.name == "nats:permissions_violation"
+        assert result.detail == str(exc)
+
+    @pytest.mark.parametrize("exc", _EXCEPTION_CASES)
+    def test_check_hub_dict_stream_gen_timeout_returns_failing_result(
+        self, monkeypatch: pytest.MonkeyPatch, exc: Exception
+    ) -> None:
+        def mock_run(*args, **kwargs):
+            raise exc
+
+        monkeypatch.setattr("factory.monitoring.checks_log.subprocess.run", mock_run)
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=1)
+
+        assert result.passed is False
+        assert result.name == "hub:dict_stream_gen_timeout"
+        assert result.detail == str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — exact subprocess invocation shape. A later refactor
+# (injectable LogFetcher seam) must not silently change these args without
+# failing this test.
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessInvocationShape:
+    def test_check_nats_log_errors_invokes_podman_logs_exactly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[tuple, dict]] = []
+
+        def mock_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("factory.monitoring.checks_log.subprocess.run", mock_run)
+
+        check_nats_log_errors("factory-nats", 10)
+
+        assert len(calls) == 1
+        args, kwargs = calls[0]
+        assert args[0] == ["podman", "logs", "--since", "10m", "factory-nats"]
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 15
+
+    def test_check_hub_dict_stream_gen_timeout_invokes_podman_logs_exactly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[tuple, dict]] = []
+
+        def mock_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("factory.monitoring.checks_log.subprocess.run", mock_run)
+
+        check_hub_dict_stream_gen_timeout("factory-hub", 7, threshold=2)
+
+        assert len(calls) == 1
+        args, kwargs = calls[0]
+        assert args[0] == ["podman", "logs", "--since", "7m", "factory-hub"]
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 15

--- a/tests/test_monitoring_checks_log.py
+++ b/tests/test_monitoring_checks_log.py
@@ -163,6 +163,25 @@ class TestCheckHubDictStreamGenTimeout:
         assert "3" in result.detail
         assert "threshold=3" in result.detail
 
+    def test_passes_at_threshold_minus_one_with_default_threshold(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tight boundary at the realistic default threshold (3, per
+        MonitoringConfig): exactly threshold-1 occurrences must still pass."""
+        stdout = (
+            "_dict_stream_gen timeout on turn a\n"
+            "_dict_stream_gen timeout on turn b\n"
+        )
+        monkeypatch.setattr(
+            "factory.monitoring.checks_log.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=0, stdout=stdout, stderr=""),
+        )
+
+        result = check_hub_dict_stream_gen_timeout("factory-hub", 10, threshold=3)
+
+        assert result.passed is True
+        assert "2" in result.detail
+
     def test_fails_when_count_exceeds_threshold(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -422,6 +441,38 @@ class TestLokiLogFetcher:
         with pytest.raises(LogFetchError):
             LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
 
+    def test_fetch_raises_log_fetch_error_on_null_data_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`data["data"]` being `None` (a real Loki degraded-response shape)
+        raises `TypeError` on subscript — must surface as `LogFetchError`,
+        not escape the fetcher raw and kill the caller."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": None}
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        with pytest.raises(LogFetchError):
+            LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
+
+    def test_fetch_raises_log_fetch_error_on_short_values_entry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `values` entry with fewer than 2 elements raises `IndexError` on
+        `value[1]` — must surface as `LogFetchError`, not escape the fetcher
+        raw and kill the caller."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "data": {"result": [{"values": [["1700000000000000000"]]}]}
+        }
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        with pytest.raises(LogFetchError):
+            LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
+
     def test_fetch_raises_log_fetch_error_on_http_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -458,6 +509,48 @@ class TestLokiLogFetcher:
         query = kwargs["params"]["query"]
         escaped = re.escape("permissions violation")
         assert f'|~ "(?i){escaped}"' in query
+
+    def test_fetch_returns_empty_string_on_zero_matching_streams(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A well-formed response with zero matching streams (`"result": []`)
+        must return `""` directly — not raise, not `None`, exact empty
+        string, so `splitlines()` on the caller side sees zero lines."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": {"result": []}}
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        result = LokiLogFetcher().fetch(
+            "factory-nats", 10, pattern="permissions violation"
+        )
+
+        assert result == ""
+
+    def test_fetch_query_params_include_limit_and_time_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`limit` is called out in checks_log.py's own comment as
+        load-bearing (Loki caps + truncates newest-first without it); `start`/
+        `end` must bound the query to the requested `since_minutes` window."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": {"result": []}}
+        mock_get = MagicMock(return_value=mock_response)
+        monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
+
+        LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
+
+        mock_get.assert_called_once()
+        _, kwargs = mock_get.call_args
+        params = kwargs["params"]
+        assert params["limit"] == 5000
+        assert isinstance(params["start"], int)
+        assert isinstance(params["end"], int)
+        assert params["end"] > params["start"]
+        # 10 minutes, in nanoseconds.
+        assert params["end"] - params["start"] == 10 * 60 * 1_000_000_000
 
 
 class TestSubprocessLogFetcherIgnoresPattern:

--- a/tests/test_monitoring_config.py
+++ b/tests/test_monitoring_config.py
@@ -168,3 +168,41 @@ class TestMonitoringConfigValidation:
                 telegram_token="fake",
                 telegram_admin_chat_id="12345",
             )
+
+    def test_invalid_nats_container_name_rejected(self) -> None:
+        """nats_container_name must match the same charset as service_names —
+        it is interpolated into a LogQL label matcher unescaped."""
+        from factory.monitoring.config import MonitoringConfig
+
+        with pytest.raises(ValueError, match="container name"):
+            MonitoringConfig(
+                nats_container_name="factory-nats\"} |~ \".*",
+                telegram_token="fake",
+                telegram_admin_chat_id="12345",
+            )
+
+    def test_invalid_hub_container_name_rejected(self) -> None:
+        """hub_container_name is gated by the same validator as
+        nats_container_name."""
+        from factory.monitoring.config import MonitoringConfig
+
+        with pytest.raises(ValueError, match="container name"):
+            MonitoringConfig(
+                hub_container_name="factory hub",
+                telegram_token="fake",
+                telegram_admin_chat_id="12345",
+            )
+
+    def test_valid_container_names_accepted(self) -> None:
+        """Default and other conventionally-named containers pass validation."""
+        from factory.monitoring.config import MonitoringConfig
+
+        config = MonitoringConfig(
+            nats_container_name="factory-nats",
+            hub_container_name="factory-hub",
+            telegram_token="fake",
+            telegram_admin_chat_id="12345",
+        )
+
+        assert config.nats_container_name == "factory-nats"
+        assert config.hub_container_name == "factory-hub"

--- a/tests/test_monitoring_deprecation.py
+++ b/tests/test_monitoring_deprecation.py
@@ -26,6 +26,38 @@ assertions are evidence about the source, not an artifact of import order.
 `test_live_v1_pull_modules_no_deprecation_warning` doesn't strictly need
 this (those modules never warn, cached or not) but uses the same helper for
 consistency and because the plan explicitly asks for reload-safety here.
+
+Parent-package eviction gotcha (verified empirically, see PR/task notes):
+`also_evict` must NOT `sys.modules.pop("factory.monitoring")` + plain
+reimport for the *parent package* itself. A pop+reimport swaps in a
+brand-new `factory.monitoring` module object; already-imported submodules
+that some *other* test file set as an attribute on the OLD object (e.g.
+`factory.monitoring.checks_varz`, imported by
+`tests/test_monitoring_escalation.py` on the same xdist worker) are never
+re-attached to the new object, because nothing re-imports them. Any later
+test on that worker that dotted-accesses such a submodule through the
+parent (e.g. `monkeypatch.setattr("factory.monitoring.checks_varz...")`)
+then gets a spurious `AttributeError` — reproduced: running
+`test_monitoring_deprecation.py` and `test_monitoring_escalation.py` on one
+worker turned 3 previously-passing escalation tests into setup errors.
+`importlib.reload()` re-executes a cached *package's* top-level code (still
+catching a regressed `warnings.warn()`) in place, preserving object
+identity and every already-set submodule attribute.
+
+Leaf-module eviction is the opposite case, and conflating the two is itself
+a trap (verified empirically): `test_dormant_modules_still_warn` evicts
+`factory.monitoring.checks` — a *leaf* module, not a package — ahead of
+re-importing `factory.monitoring.__main__`, specifically so `__main__`'s own
+`from .checks import run_checks` line is what re-triggers `checks.py`'s
+warning (proving the warning propagates *transitively*, not just when
+`checks.py` is imported directly). If a leaf target were reloaded instead
+of popped, `importlib.reload()` re-executes it immediately, inside the same
+`catch_warnings` block, regardless of whether `__main__` ever imports it —
+the assertion would then pass even if `__main__`'s import line were deleted
+entirely, silently testing nothing about `__main__`. So `also_evict`
+distinguishes the two by `hasattr(cached, "__path__")` (true only for
+packages): packages are reloaded in place; leaf modules are popped so the
+*importer's own import statement* is what's on the hook for re-execution.
 """
 
 from __future__ import annotations
@@ -47,12 +79,24 @@ def _fresh_import(
     module-level code even if it (or a module it transitively imports) is
     already cached in `sys.modules` from an earlier test's import.
 
+    `also_evict` names are handled per the module docstring's two gotchas:
+    a cached *package* (has `__path__`) is reloaded in place, so its
+    top-level code re-executes without losing sibling submodule attributes;
+    a cached *leaf* module is popped, so the caller's own import of
+    `module_name` is what's responsible for re-executing it transitively
+    (proving propagation, not just re-triggering it directly here).
+
     Returns the list of warnings recorded during the (re-)import.
     """
-    for name in (*also_evict, module_name):
-        sys.modules.pop(name, None)
+    sys.modules.pop(module_name, None)
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
+        for name in also_evict:
+            cached = sys.modules.get(name)
+            if cached is not None and hasattr(cached, "__path__"):
+                importlib.reload(cached)
+            else:
+                sys.modules.pop(name, None)
         importlib.import_module(module_name)
     return caught
 
@@ -60,9 +104,23 @@ def _fresh_import(
 def test_live_v1_pull_modules_no_deprecation_warning():
     """checks_log.py and escalation.py never import .checks — importing (or
     re-importing) either must not emit the Layer-1-aggregate
-    DeprecationWarning (or any DeprecationWarning at all)."""
-    caught = _fresh_import("factory.monitoring.checks_log")
-    caught += _fresh_import("factory.monitoring.escalation")
+    DeprecationWarning (or any DeprecationWarning at all).
+
+    Both calls also evict the parent `factory.monitoring` package itself
+    (`also_evict`), not just the named submodule: a plain child-module
+    re-import does NOT re-execute the parent's already-cached `__init__.py`,
+    so without this eviction a future regression that moves the
+    `warnings.warn(...)` call (back) into `factory/monitoring/__init__.py`
+    would go undetected whenever an earlier test in the same worker session
+    already imported anything under `factory.monitoring` — which, under this
+    repo's real xdist collection, is effectively always.
+    """
+    caught = _fresh_import(
+        "factory.monitoring.checks_log", also_evict=("factory.monitoring",)
+    )
+    caught += _fresh_import(
+        "factory.monitoring.escalation", also_evict=("factory.monitoring",)
+    )
 
     deprecation_warnings = [
         w for w in caught if issubclass(w.category, DeprecationWarning)

--- a/tests/test_monitoring_deprecation.py
+++ b/tests/test_monitoring_deprecation.py
@@ -1,0 +1,170 @@
+"""Tests for factory.monitoring deprecation-warning routing (issue #2245, T13).
+
+Verifies the T12 outcome: the DeprecationWarning that flags the deprecated
+Layer-1 aggregate runner lives ONLY on `factory.monitoring.checks` (and
+anything that imports it, e.g. `factory.monitoring.__main__`) — NOT on the
+live V1-pull modules (`checks_log`, `escalation`) that survive into the thin
+V1-pull slice.
+
+Caching gotcha (verified empirically, see PR/task notes): this repo's pytest
+config runs under xdist (`-n auto --dist=loadgroup`), and several *other*
+test files (`tests/test_monitoring_checks_http_idle_reaper.py`,
+`tests/test_monitoring_escalation.py`) import `factory.monitoring.checks` /
+`factory.monitoring.__main__` themselves. `factory.monitoring.checks` sorts
+before `factory.monitoring.deprecation` alphabetically, so on any xdist
+worker that happens to collect both files, `factory.monitoring.checks` is
+ALREADY in `sys.modules` by the time this file's tests run. A plain `import`
+statement against an already-cached module is a no-op — it does NOT
+re-execute the module-level `warnings.warn(...)` call. Relying on plain
+`import` here would make `test_dormant_modules_still_warn` pass or fail
+depending on xdist worker assignment (flaky-by-scheduling), not on the
+behavior under test.
+
+Fix: force a fresh execution via `sys.modules.pop(...)` +
+`importlib.import_module(...)` inside each `catch_warnings` block, so the
+assertions are evidence about the source, not an artifact of import order.
+`test_live_v1_pull_modules_no_deprecation_warning` doesn't strictly need
+this (those modules never warn, cached or not) but uses the same helper for
+consistency and because the plan explicitly asks for reload-safety here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+import tomllib
+import warnings
+from pathlib import Path
+
+_PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _fresh_import(
+    module_name: str, *, also_evict: tuple[str, ...] = ()
+) -> list[warnings.WarningMessage]:
+    """Import `module_name` from scratch, forcing re-execution of its
+    module-level code even if it (or a module it transitively imports) is
+    already cached in `sys.modules` from an earlier test's import.
+
+    Returns the list of warnings recorded during the (re-)import.
+    """
+    for name in (*also_evict, module_name):
+        sys.modules.pop(name, None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.import_module(module_name)
+    return caught
+
+
+def test_live_v1_pull_modules_no_deprecation_warning():
+    """checks_log.py and escalation.py never import .checks — importing (or
+    re-importing) either must not emit the Layer-1-aggregate
+    DeprecationWarning (or any DeprecationWarning at all)."""
+    caught = _fresh_import("factory.monitoring.checks_log")
+    caught += _fresh_import("factory.monitoring.escalation")
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert not deprecation_warnings, (
+        "checks_log/escalation must not emit any DeprecationWarning on "
+        f"import, got: {[str(w.message) for w in deprecation_warnings]}"
+    )
+
+
+def test_dormant_modules_still_warn():
+    """factory.monitoring.checks (module-level warnings.warn) and
+    factory.monitoring.__main__ (transitively, via `from .checks import
+    run_checks`) must still emit the deprecation warning.
+
+    Self-validates the cache-eviction premise from the module docstring: we
+    first import `factory.monitoring.checks` ONCE, outside any
+    catch_warnings block, to seed `sys.modules` the way an earlier test file
+    would on a shared xdist worker. If `_fresh_import`'s
+    `sys.modules.pop(...)` did nothing, the subsequent assertions would find
+    zero recorded warnings (plain `import` against a cached module is a
+    no-op) — so a pass here is proof the eviction is load-bearing, not
+    coincidental.
+    """
+    importlib.import_module("factory.monitoring.checks")  # seed the cache
+    assert "factory.monitoring.checks" in sys.modules
+
+    checks_caught = _fresh_import("factory.monitoring.checks")
+    checks_deprecations = [
+        w for w in checks_caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert checks_deprecations, (
+        "factory.monitoring.checks did not warn on import (was the cached "
+        "module reused instead of re-executed?)"
+    )
+    assert any(
+        "factory.monitoring.checks" in str(w.message) and "deprecated" in str(w.message)
+        for w in checks_deprecations
+    ), [str(w.message) for w in checks_deprecations]
+
+    # Evict BOTH __main__ and .checks so re-importing __main__ forces a fresh
+    # execution of its `from .checks import run_checks` line — otherwise the
+    # cached .checks module (just re-imported above) would satisfy that
+    # import without re-running checks.py's warnings.warn call, producing a
+    # false pass that doesn't actually prove __main__ transitively warns.
+    main_caught = _fresh_import(
+        "factory.monitoring.__main__", also_evict=("factory.monitoring.checks",)
+    )
+    main_deprecations = [
+        w for w in main_caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert main_deprecations, (
+        "factory.monitoring.__main__ did not transitively warn on import "
+        "(expected `from .checks import run_checks` to re-trigger checks.py's "
+        "module-level warnings.warn)"
+    )
+    assert any(
+        "factory.monitoring.checks" in str(w.message) and "deprecated" in str(w.message)
+        for w in main_deprecations
+    ), [str(w.message) for w in main_deprecations]
+
+
+def test_pyproject_filterwarnings_regex_matches_actual_message():
+    """Sanity cross-check: pyproject.toml's `[tool.pytest.ini_options]
+    filterwarnings` carries an `ignore:factory.monitoring.checks:...` entry
+    meant to suppress this exact warning suite-wide. pytest's filterwarnings
+    strings use `action:message:category` where `message` is matched via
+    `re.compile(message, re.I).match(...)` against the warning's message —
+    i.e. a case-insensitive PREFIX match, not substring/full-string.
+
+    This test reads the actual filter string out of pyproject.toml (rather
+    than hardcoding a copy of the regex) so it breaks if someone edits or
+    removes that entry, and proves the pattern it declares really matches
+    the real message text `checks.py` emits — so every OTHER test file that
+    happens to import checks.py/__main__.py incidentally is correctly
+    shielded from this warning turning into a `filterwarnings = ["error"]`
+    -style failure.
+    """
+    with _PYPROJECT_PATH.open("rb") as fh:
+        pyproject = tomllib.load(fh)
+
+    filters: list[str] = pyproject["tool"]["pytest"]["ini_options"]["filterwarnings"]
+    matching = [f for f in filters if "factory.monitoring.checks" in f]
+    assert matching, (
+        "expected a pyproject.toml filterwarnings entry mentioning "
+        "'factory.monitoring.checks' (temporary suppression for #1035); "
+        "found none — either it was removed, or checks.py's deprecation "
+        "warning is no longer suppressed suite-wide"
+    )
+
+    # filterwarnings entries are "action:message:category:module:lineno";
+    # only the first three fields are populated here.
+    action, message_pattern, category = matching[0].split(":")[:3]
+    assert action == "ignore"
+    assert category == "DeprecationWarning"
+
+    caught = _fresh_import("factory.monitoring.checks")
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "expected a DeprecationWarning from importing checks.py"
+
+    actual_message = str(deprecations[0].message)
+    assert re.compile(message_pattern, re.IGNORECASE).match(actual_message), (
+        f"pyproject.toml filterwarnings pattern {message_pattern!r} no longer "
+        f"matches the actual warning message: {actual_message!r}"
+    )

--- a/tests/test_monitoring_log_watch.py
+++ b/tests/test_monitoring_log_watch.py
@@ -1,0 +1,252 @@
+"""Tests for `factory.monitoring.log_watch.LogMonitorLoop` (issue #2245, plan task T6).
+
+`LogMonitorLoop` is a thin V1-pull scheduler composing the two real, pure check
+functions from `checks_log.py` (`check_nats_log_errors`,
+`check_hub_dict_stream_gen_timeout`) — no NATS connection, no event/metric bus
+producer (ADR-091 plane③ V1: pull, not V2: subscribe).
+
+`TestRunOnce` exercises the real check functions through the real `LogFetcher`
+seam via a fake fetcher that branches on the `pattern` argument — no mocking of
+the module under test, no mocking of the check functions themselves.
+
+`TestRunForever` breaks the `while True` loop deterministically by patching
+`asyncio.sleep` with an `AsyncMock` whose `side_effect` raises a local sentinel
+(`_StopLoop`) on its first call, letting exactly one `run_once()` iteration
+(plus any alert dispatch) complete before the loop is forced to exit.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.monitoring.config import MonitoringConfig
+from factory.monitoring.log_watch import LogMonitorLoop
+
+# ---------------------------------------------------------------------------
+# Fake LogFetcher — branches on `pattern` to return controlled log text for
+# each of the two checks without touching subprocess/httpx at all.
+# ---------------------------------------------------------------------------
+
+
+class _FakeFetcher:
+    """Fake `LogFetcher` — routes by `pattern` so the real check functions
+    (`check_nats_log_errors`, `check_hub_dict_stream_gen_timeout`) run for
+    real against controlled input, exercising the actual counting/threshold
+    logic in `checks_log.py`."""
+
+    def __init__(self, nats_log: str = "", hub_log: str = "") -> None:
+        self.nats_log = nats_log
+        self.hub_log = hub_log
+
+    def fetch(self, container_name: str, since_minutes: int, pattern: str) -> str:
+        if pattern == "permissions violation":
+            return self.nats_log
+        if pattern == "_dict_stream_gen timeout":
+            return self.hub_log
+        raise AssertionError(f"unexpected pattern passed to fetcher: {pattern!r}")
+
+
+class _StopLoop(Exception):
+    """Local sentinel used to break `run_forever`'s `while True` loop
+    deterministically after exactly one iteration, via the `asyncio.sleep`
+    patch below."""
+
+
+# ---------------------------------------------------------------------------
+# run_once — aggregates both real checks into a HealthReport.
+# ---------------------------------------------------------------------------
+
+
+class TestRunOnce:
+    async def test_run_once_all_pass(self) -> None:
+        """Clean logs for both checks -> HealthReport reports zero failures."""
+        config = MonitoringConfig()
+        fetcher = _FakeFetcher(
+            nats_log="all quiet\nnothing to see here\n",
+            hub_log="all quiet\nnothing to see here\n",
+        )
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        report = await loop.run_once()
+
+        assert report.all_passed is True
+        assert report.failed_count == 0
+        assert len(report.checks) == 2
+
+    async def test_run_once_one_check_fails(self) -> None:
+        """Only the nats check trips -> failed_count=1, correct failing name."""
+        config = MonitoringConfig()
+        fetcher = _FakeFetcher(
+            nats_log="permissions violation on subject foo\n",
+            hub_log="all quiet\nnothing to see here\n",
+        )
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        report = await loop.run_once()
+
+        assert report.all_passed is False
+        assert report.failed_count == 1
+        failed = [c for c in report.checks if not c.passed]
+        assert len(failed) == 1
+        assert failed[0].name == "nats:permissions_violation"
+
+    async def test_run_once_both_checks_fail(self) -> None:
+        """Both checks trip -> failed_count=2.
+
+        Default `stream_gen_timeout_threshold` is 3 (MonitoringConfig), so the
+        hub log needs >=3 matching lines to fail per the real threshold logic
+        in `check_hub_dict_stream_gen_timeout`.
+        """
+        config = MonitoringConfig()
+        assert config.stream_gen_timeout_threshold == 3
+        fetcher = _FakeFetcher(
+            nats_log="permissions violation on subject foo\n",
+            hub_log=(
+                "_dict_stream_gen timeout on turn a\n"
+                "_dict_stream_gen timeout on turn b\n"
+                "_dict_stream_gen timeout on turn c\n"
+            ),
+        )
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        report = await loop.run_once()
+
+        assert report.all_passed is False
+        assert report.failed_count == 2
+
+
+# ---------------------------------------------------------------------------
+# run_forever — loops run_once() and alerts via escalation on failure.
+#
+# The `while True` loop is broken deterministically by patching
+# `asyncio.sleep` to raise `_StopLoop` on its first call, after exactly one
+# `run_once()` iteration (and any alert dispatch) has completed.
+# ---------------------------------------------------------------------------
+
+
+class TestRunForever:
+    async def test_run_forever_all_pass_does_not_alert(self) -> None:
+        """SC5: all checks pass -> zero Telegram alert calls."""
+        config = MonitoringConfig()
+        fetcher = _FakeFetcher(nats_log="all quiet\n", hub_log="all quiet\n")
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        with (
+            patch(
+                "factory.monitoring.log_watch.asyncio.sleep",
+                new=AsyncMock(side_effect=_StopLoop),
+            ),
+            patch(
+                "factory.monitoring.log_watch.escalation.send_telegram_raw_alert",
+                new=AsyncMock(),
+            ) as mock_alert,
+        ):
+            with pytest.raises(_StopLoop):
+                await loop.run_forever()
+
+        mock_alert.assert_not_called()
+
+    async def test_run_forever_one_fail_alerts_once_with_both_results(self) -> None:
+        """One check fails -> exactly one alert call, report carries both
+        CheckResults (not just the failing one)."""
+        config = MonitoringConfig()
+        fetcher = _FakeFetcher(
+            nats_log="permissions violation on subject foo\n",
+            hub_log="all quiet\n",
+        )
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        with (
+            patch(
+                "factory.monitoring.log_watch.asyncio.sleep",
+                new=AsyncMock(side_effect=_StopLoop),
+            ),
+            patch(
+                "factory.monitoring.log_watch.escalation.send_telegram_raw_alert",
+                new=AsyncMock(),
+            ) as mock_alert,
+        ):
+            with pytest.raises(_StopLoop):
+                await loop.run_forever()
+
+        mock_alert.assert_called_once()
+        call_args = mock_alert.call_args
+        report = call_args.args[0]
+        assert len(report.checks) == 2
+        assert report.all_passed is False
+        assert report.failed_count == 1
+        # send_telegram_raw_alert(report, config) — second positional arg is config.
+        assert call_args.args[1] is config
+
+    async def test_run_forever_both_fail_alerts_once_no_duplicates(self) -> None:
+        """Both checks fail -> still exactly one alert call, not one per
+        failing check — guards against per-check alert duplication."""
+        config = MonitoringConfig()
+        fetcher = _FakeFetcher(
+            nats_log="permissions violation on subject foo\n",
+            hub_log=(
+                "_dict_stream_gen timeout on turn a\n"
+                "_dict_stream_gen timeout on turn b\n"
+                "_dict_stream_gen timeout on turn c\n"
+            ),
+        )
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        with (
+            patch(
+                "factory.monitoring.log_watch.asyncio.sleep",
+                new=AsyncMock(side_effect=_StopLoop),
+            ),
+            patch(
+                "factory.monitoring.log_watch.escalation.send_telegram_raw_alert",
+                new=AsyncMock(),
+            ) as mock_alert,
+        ):
+            with pytest.raises(_StopLoop):
+                await loop.run_forever()
+
+        mock_alert.assert_called_once()
+        report = mock_alert.call_args.args[0]
+        assert report.failed_count == 2
+
+    async def test_run_forever_alert_delivery_failure_is_caught(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Alert dispatch raising a `_MONITORING_ESCALATION_ERRORS` member must
+        be swallowed/logged, not propagate and crash the loop — the
+        `_StopLoop` sentinel from the `asyncio.sleep` patch must still be the
+        exception that surfaces."""
+        config = MonitoringConfig()
+        fetcher = _FakeFetcher(
+            nats_log="permissions violation on subject foo\n",
+            hub_log="all quiet\n",
+        )
+        loop = LogMonitorLoop(config, fetcher=fetcher)
+
+        mock_alert = AsyncMock(side_effect=RuntimeError("telegram down"))
+
+        with (
+            patch(
+                "factory.monitoring.log_watch.asyncio.sleep",
+                new=AsyncMock(side_effect=_StopLoop),
+            ),
+            patch(
+                "factory.monitoring.log_watch.escalation.send_telegram_raw_alert",
+                new=mock_alert,
+            ),
+            caplog.at_level(logging.ERROR),
+        ):
+            # If the RuntimeError were NOT caught, it (not _StopLoop) would
+            # propagate here and pytest.raises would report the wrong
+            # exception type, failing the test.
+            with pytest.raises(_StopLoop):
+                await loop.run_forever()
+
+        mock_alert.assert_called_once()
+        assert any(
+            "Telegram alert delivery failed" in record.message
+            for record in caplog.records
+        )

--- a/tests/test_monitoring_log_watch.py
+++ b/tests/test_monitoring_log_watch.py
@@ -250,3 +250,41 @@ class TestRunForever:
             "Telegram alert delivery failed" in record.message
             for record in caplog.records
         )
+
+    async def test_run_forever_survives_unexpected_run_once_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A single unexpected exception out of `run_once()` (e.g. a Loki
+        response-shape bug not caught anywhere below) must be logged and
+        skipped, not propagate and kill the loop — the `_StopLoop` sentinel
+        from the `asyncio.sleep` patch must still be the exception that
+        surfaces, proving the loop reached its next-tick sleep instead of
+        dying on the `run_once()` call."""
+        config = MonitoringConfig()
+        loop = LogMonitorLoop(config, fetcher=_FakeFetcher())
+
+        with (
+            patch.object(
+                loop, "run_once", new=AsyncMock(side_effect=RuntimeError("boom"))
+            ),
+            patch(
+                "factory.monitoring.log_watch.asyncio.sleep",
+                new=AsyncMock(side_effect=_StopLoop),
+            ),
+            patch(
+                "factory.monitoring.log_watch.escalation.send_telegram_raw_alert",
+                new=AsyncMock(),
+            ) as mock_alert,
+            caplog.at_level(logging.ERROR),
+        ):
+            # If the RuntimeError were NOT caught, it (not _StopLoop) would
+            # propagate here and pytest.raises would report the wrong
+            # exception type, failing the test.
+            with pytest.raises(_StopLoop):
+                await loop.run_forever()
+
+        mock_alert.assert_not_called()
+        assert any(
+            "run_once() failed unexpectedly" in record.message
+            for record in caplog.records
+        )

--- a/tests/tools/test_emit_secrets_manifest.py
+++ b/tests/tools/test_emit_secrets_manifest.py
@@ -640,7 +640,7 @@ class TestOptionalSecretSkip:
             assert "SKIP" in result.stdout
 
     def test_policy_toml_optional_count(self) -> None:
-        """Policy file must declare exactly 6 optional secrets."""
+        """Policy file must declare exactly 8 optional secrets."""
         with POLICY_TOML.open("rb") as f:
             policy = tomllib.load(f)
         optionals = [
@@ -655,6 +655,8 @@ class TestOptionalSecretSkip:
             "factory-socialmedia-api-key",
             "factory-ingress-github-webhook",
             "factory-ingress-cloudflare-webhook",
+            "factory-telegram-monitor-token",
+            "factory-telegram-monitor-chat-id",
         }, f"Unexpected optional secrets: {optionals}"
 
 


### PR DESCRIPTION
## Summary
- Adds `factory-log-monitor`, a standalone Quadlet container that periodically re-runs the two existing log-scanning checks (`check_nats_log_errors`, `check_hub_dict_stream_gen_timeout`) via a Loki LogQL pull, alerting to Telegram on failure — restoring detection for the class of incident that took 2h44m to notice on 2026-04-27.
- Refactors `checks_log.py` behind an injectable `LogFetcher` seam (`SubprocessLogFetcher` default, unchanged behavior; new `LokiLogFetcher` for the deployed container, which has no Podman socket/CLI).
- Narrows `factory.monitoring`'s package-level `DeprecationWarning` off the two modules this change makes live again (`checks_log.py`, `escalation.py`), leaving the aggregate Layer-1 `checks.py` runner still deprecated.

## Design note (ADR-091 plane③, SC8)

This is the **V1-pull** mechanism ADR-091 already prescribes for plane③ (infra health as *state*, consumed via pull — `/health/detail`, monitoring checks) — **not** a revived host-timer and **not** Monitoring v2 / full Sentinelle (`factory.metric.*` JetStream subscribe, Tauri dashboard — that's #1035, unshipped, explicitly out of scope here). `deploy/lyra-monitor.{service,timer}` is untouched (see SC6 below); no `systemctl --user` introspection, no `localhost:8443` host-network assumption — the two problems #1035 flagged when retiring the old timer.

**Standalone container vs. ADR-091's "Sentinelle is a hub-module, not a standalone container" default:** ADR-091 describes Sentinelle (the eventual V2 in-process capability) as living inside `factory-hub`. This slice deliberately ships a **separate, standalone** `factory-log-monitor` container instead. That is not a contradiction: `factory-log-monitor` is not Sentinelle — it's an external, independent safety-net layer with no dependency on hub process health, so a hub crash/restart/stall (exactly the failure mode this alerting exists to catch) can't silently take the monitor down with it. When V2/Sentinelle ships as a hub-module, this slice's pull-based container can be retired or downgraded to a dead-man's-switch without re-architecting the detection story.

**Accepted residual risk:** this mechanism depends on Loki being up and receiving container logs (ADR-093). If Loki itself is down, `LokiLogFetcher` raises `LogFetchError`, which is reported as a failing `CheckResult` (visible failure, not silent) but does not independently alert on Loki's own health — monitoring the monitor is out of scope for this slice.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2245: thin V1-pull detection slice | Approved |
| Frame | [2245-thin-v1-pull-detection-slice-frame.mdx](artifacts/frames/2245-thin-v1-pull-detection-slice-frame.mdx) | Present |
| Spec | [2245-thin-v1-pull-detection-slice-spec.mdx](artifacts/specs/2245-thin-v1-pull-detection-slice-spec.mdx) | Present |
| Plan | [2245-thin-v1-pull-detection-slice-plan.mdx](artifacts/plans/2245-thin-v1-pull-detection-slice-plan.mdx) | Present |
| Implementation | 17 commits on `feat/2245-thin-v1-pull-detection-slice` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (39 new: 25 checks_log + 7 log_watch + 7 standalone-paths, + 3 deprecation) | Passed |

## Test Plan
- [x] `PYTHONPATH=src pytest tests/test_monitoring_checks_log.py tests/test_monitoring_log_watch.py tests/bootstrap/ tests/test_monitoring_deprecation.py` — 366 passed
- [x] Full suite: `PYTHONPATH=src pytest -q` — 6537 passed, 26 skipped, 1 xfailed
- [x] `podman quadlet --dryrun --user` against `factory-log-monitor.container` (Podman 6.0.0 local)
- [x] `tools/check_quadlet_template_purity.sh` — exit 0
- [ ] Post-merge: mint `~/.roxabi/factory/telegram-monitor-{token,chat-id}.tok` on M1 (currently `policy=optional` — container will crash-loop with a clear "optional secret missing" log until provisioned, by design, does not block `make converge`)

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1: `factory-log-monitor` runs both checks on ≤5min interval, no `systemctl --user`, no host-timer unit | `tests/test_monitoring_log_watch.py :: TestRunOnce` (all 3), `tests/test_monitoring_checks_log.py :: TestSubprocessInvocationShape` (both — proves `podman logs`, never `systemctl`) | ✓ proven |
| SC2: Loki LogQL over `roxabi.network`, no Podman socket/CLI in image, no image/Dockerfile/publish.yml changes | `tests/test_monitoring_checks_log.py :: TestLokiLogFetcher` (all 4) + `git diff --stat origin/staging..HEAD -- '*.hcl' '*Dockerfile*' '.github/workflows/publish.yml'` (empty) | ✓ proven |
| SC3: default (subprocess) fetcher behavior unchanged — pre-existing tests pass unmodified | `tests/test_monitoring_checks_log.py :: TestCheckNatsLogErrors`, `TestCheckHubDictStreamGenTimeout`, `TestLogCheckExceptionHandling` (T0 baseline, 18 tests, green before AND after the T1-T3 refactor) | ✓ proven |
| SC3b: both fetchers raise shared `LogFetchError`, caught uniformly | `tests/test_monitoring_checks_log.py :: TestLogCheckExceptionHandling` (subprocess side) + `TestLokiLogFetcher::test_fetch_raises_log_fetch_error_on_malformed_json`, `test_fetch_raises_log_fetch_error_on_http_error` | ✓ proven |
| SC4: failed check → `send_telegram_raw_alert` called with correct `HealthReport` | `tests/test_monitoring_log_watch.py :: TestRunForever::test_run_forever_one_fail_alerts_once_with_both_results`, `test_run_forever_both_fail_alerts_once_no_duplicates` | ✓ proven |
| SC5: all-pass → zero Telegram calls | `tests/test_monitoring_log_watch.py :: TestRunForever::test_run_forever_all_pass_does_not_alert` | ✓ proven |
| SC6: `deploy/lyra-monitor.{service,timer}` zero diff | `git diff --stat origin/staging..HEAD -- 'deploy/lyra-monitor.*'` (empty) | ✓ proven |
| SC7: package-level `DeprecationWarning` no longer fires on `checks_log`/`escalation` import | `tests/test_monitoring_deprecation.py` (all 3) | ✓ proven |
| SC8: PR description design note (ADR-091 plane③, non-host-timer, non-Sentinelle framing, Loki residual risk) | — (this PR description, "Design note" section above) | ✓ proven |
| SC9: `quadlet-lint` passes for the new unit | `podman quadlet --dryrun --user` (local, Podman 6.0.0) + `tools/check_quadlet_template_purity.sh` — CI's `quadlet-lint.yml` is authoritative, confirmed via `/ci-watch` | ⏳ not run (CI) |
| SC10: no `factory.event.*`/`factory.metric.*` bus producer/consumer introduced | `tests/bootstrap/test_log_monitor_standalone_paths.py :: TestNoEventMetricSubjects` (all 3) | ✓ proven |

## Falsification Evidence (Gate #280)

```
broke checks_log.py (LokiLogFetcher LogQL filter removed) → test_fetch_query_param_includes_case_insensitive_regex_filter FAILED
  assert '|~ "(?i)permissions\ violation"' in '{systemd_unit="factory-nats.service"}'
→ reverted → 25/25 GREEN

broke checks_log.py (count = 0 unconditionally, both check functions) → test_fails_with_correct_count_on_occurrences
  AND test_fails_when_count_meets_threshold FAILED (assert True is False)
→ reverted → 25/25 GREEN

broke log_watch.py (alert guard bypassed, always fires) → test_run_forever_all_pass_does_not_alert FAILED
  AssertionError: Expected 'mock' to not have been called. Called 1 times.
→ reverted → 7/7 GREEN

broke worker_standalone.py (once-mode sys.exit removed) → test_once_mode_all_pass_exits_zero,
  test_once_mode_failure_exits_one, test_once_mode_never_calls_run_forever all FAILED
  ("DID NOT RAISE SystemExit")
→ reverted → 9/9 GREEN

broke log_watch.py (inserted "# factory.metric.foo" literal) → test_log_watch_module_has_no_event_or_metric_subjects
  FAILED (AssertionError: 'factory.metric.' in source)
→ reverted → 9/9 GREEN
```

Fixes #2245

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
