### PR TITLE
fix(hub): re-hydrate trace context for deferred outbound streaming

### DIFF
--- a/src/factory/core/hub/outbound/_dispatch.py
+++ b/src/factory/core/hub/outbound/_dispatch.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, Any
 
 from ...config.dispatch_config import DispatchConfig
 from ...lifecycle.circuit_breaker import CircuitBreaker
-from ...messaging.message import RoutingContext
+from ...messaging.message import InboundMessage, RoutingContext
 from ...messaging.utils.callbacks import unwrap_callback
+from ...pool.pool_trace_context import turn_trace_context
 from .outbound_errors import (
     _CIRCUIT_NOTIFY_DEBOUNCE,
     _CIRCUIT_OPEN_MSG,
@@ -112,7 +113,9 @@ async def _try_send(
             async for _ in payload:
                 pass
             return False
-        await adapter.send_streaming(msg, payload, outbound)
+        assert isinstance(msg, InboundMessage)
+        with turn_trace_context(msg):
+            await adapter.send_streaming(msg, payload, outbound)
     return True
 
 

--- a/src/factory/core/hub/outbound/outbound_streaming.py
+++ b/src/factory/core/hub/outbound/outbound_streaming.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from ...messaging.message import InboundMessage, OutboundMessage, Platform
 from ...messaging.utils.callbacks import unwrap_callback
+from ...pool.pool_trace_context import turn_trace_context
 
 if TYPE_CHECKING:
     from ...messaging.render_events import RenderEvent
@@ -102,7 +103,8 @@ class StreamingDispatch:
                 "Call register_adapter() before dispatching responses."
             )
         if hasattr(adapter, "send_streaming"):
-            await adapter.send_streaming(msg, chunks, outbound)
+            with turn_trace_context(msg):
+                await adapter.send_streaming(msg, chunks, outbound)
         else:
             if outbound is not None:
                 log.warning(

--- a/src/factory/core/pool/pool_trace_context.py
+++ b/src/factory/core/pool/pool_trace_context.py
@@ -1,4 +1,4 @@
-"""TraceContext hydration for async pool workers (#2069)."""
+"""TraceContext hydration for pool turns and deferred outbound streaming (#2069)."""
 
 from __future__ import annotations
 
@@ -12,26 +12,44 @@ from factory.core.trace import TraceContext
 
 
 @contextmanager
+def turn_trace_context(
+    msg: InboundMessage,
+    *,
+    pool_id: str | None = None,
+    agent_name: str | None = None,
+) -> Generator[str, None, None]:
+    """Re-hydrate trace correlation vars from a stamped InboundMessage."""
+    stamped_trace = msg.trace_id if isinstance(msg.trace_id, str) else None
+    trace_id = stamped_trace or TraceContext.get_trace_id() or uuid4().hex
+    token_t = TraceContext.set_trace_id(trace_id)
+    token_p: Token[str] | None = None
+    if pool_id is not None:
+        token_p = TraceContext.set_pool_id(pool_id)
+    token_j: Token[str] | None = None
+    if isinstance(msg.root_job_id, str) and msg.root_job_id:
+        token_j = TraceContext.set_root_job_id(msg.root_job_id)
+    token_an: Token[str] | None = None
+    if agent_name is not None:
+        token_an = TraceContext.set_agent_name(agent_name)
+    try:
+        yield trace_id
+    finally:
+        if token_an is not None:
+            TraceContext.reset_agent_name(token_an)
+        if token_j is not None:
+            TraceContext.reset_root_job_id(token_j)
+        if token_p is not None:
+            TraceContext.reset_pool_id(token_p)
+        TraceContext.reset_trace_id(token_t)
+
+
+@contextmanager
 def pool_turn_trace_context(
     msg: InboundMessage,
     *,
     pool_id: str,
     agent_name: str,
 ) -> Generator[str, None, None]:
-    """Re-hydrate trace correlation vars for the duration of a pool turn."""
-    stamped_trace = msg.trace_id if isinstance(msg.trace_id, str) else None
-    trace_id = stamped_trace or TraceContext.get_trace_id() or uuid4().hex
-    token_t = TraceContext.set_trace_id(trace_id)
-    token_p = TraceContext.set_pool_id(pool_id)
-    token_j: Token[str] | None = None
-    if isinstance(msg.root_job_id, str) and msg.root_job_id:
-        token_j = TraceContext.set_root_job_id(msg.root_job_id)
-    token_an = TraceContext.set_agent_name(agent_name)
-    try:
+    """Pool turn wrapper — always stamps pool_id + agent_name."""
+    with turn_trace_context(msg, pool_id=pool_id, agent_name=agent_name) as trace_id:
         yield trace_id
-    finally:
-        TraceContext.reset_agent_name(token_an)
-        if token_j is not None:
-            TraceContext.reset_root_job_id(token_j)
-        TraceContext.reset_pool_id(token_p)
-        TraceContext.reset_trace_id(token_t)

--- a/tests/core/test_trace.py
+++ b/tests/core/test_trace.py
@@ -471,6 +471,46 @@ class TestGuardedProcessOneTraceHydration:
         assert TraceContext.get_root_job_id() is None
 
 
+class TestOutboundStreamingTraceHydration:
+    @pytest.mark.no_default_trace
+    async def test_try_send_streaming_restores_trace_from_message(self) -> None:
+        """Deferred outbound streaming must re-hydrate TraceContext from msg."""
+        from collections.abc import AsyncIterator
+
+        from factory.core.envelope_fields import mint_work_envelope_fields
+        from factory.core.hub.outbound._dispatch import _try_send
+        from factory.core.messaging.render_events import TextDeltaRenderEvent
+
+        captured_trace: list[str | None] = []
+
+        async def chunks() -> AsyncIterator[TextDeltaRenderEvent]:
+            captured_trace.append(TraceContext.get_trace_id())
+            fields = mint_work_envelope_fields()
+            captured_trace.append(fields.trace_id)
+            yield TextDeltaRenderEvent(message_id="msg-1", delta="hi")
+
+        adapter = MagicMock()
+
+        async def _send_streaming(
+            _msg: InboundMessage,
+            events: AsyncIterator[TextDeltaRenderEvent],
+            _outbound: object,
+        ) -> None:
+            async for _ in events:
+                pass
+
+        adapter.send_streaming = _send_streaming
+
+        stamped = "cccccccc-dddd-eeee-ffff-000000000001"
+        msg = dataclasses.replace(make_inbound_message(), trace_id=stamped)
+
+        sent = await _try_send(adapter, "streaming", msg, chunks(), None)
+
+        assert sent is True
+        assert captured_trace == [stamped, stamped]
+        assert TraceContext.get_trace_id() is None
+
+
 # ──────────────────────────────────────────────────────────────────────
 # TelegramTokenFilter
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

PR #2265 fixed trace_id in pool workers, but Discord/Telegram streaming still fails with:

```
ValueError: mint_work_envelope_fields: trace_id required (set TraceContext or pass explicit)
```

Logs on M₁ show this in `NatsChannelProxy.send_streaming` when the OutboundDispatcher drains the iterator **after** `pool_turn_trace_context` has exited.

## Fix

- Generalize `turn_trace_context(msg)` from stamped `InboundMessage.trace_id` / `root_job_id`
- Wrap streaming sends in `outbound/_dispatch._try_send` and `outbound_streaming` direct adapter path

## Test plan

- [x] `TestOutboundStreamingTraceHydration` — mint_work_envelope_fields works inside deferred streaming iterator
- [x] Existing pool trace hydration tests still pass