### PR TITLE
fix(nats): emit deny-all for empty ACL grants (#2267)

### DIFF
--- a/deploy/nats/auth.conf
+++ b/deploy/nats/auth.conf
@@ -103,7 +103,7 @@ authorization {
       nkey: "UDETDASHBOARDREADER"
       # dashboard-reader
       permissions: {
-        publish:   { allow: [] }
+        publish:   { deny: [">"] }
         subscribe: { allow: ["factory.event.>","factory.metric.>"] }
         allow_responses: false
       }
@@ -140,7 +140,7 @@ authorization {
       # gh-helper
       permissions: {
         publish:   { allow: ["factory.metric.host.container_report","factory.gh.mint_failure.>"] }
-        subscribe: { allow: [] }
+        subscribe: { deny: [">"] }
         allow_responses: false
       }
     }
@@ -158,7 +158,7 @@ authorization {
       # ingress
       permissions: {
         publish:   { allow: ["factory.metric.host.container_report","factory.event.github.>","factory.event.cloudflare.>"] }
-        subscribe: { allow: [] }
+        subscribe: { deny: [">"] }
         allow_responses: false
       }
     }

--- a/scripts/_renderer.py
+++ b/scripts/_renderer.py
@@ -30,6 +30,17 @@ def _quoted_list(items: list[str]) -> str:
     return ",".join(f'"{s}"' for s in items)
 
 
+def _perm_block(allow: list[str]) -> str:
+    """Render one publish/subscribe permissions block.
+
+    nats-server treats an explicit empty allow list as unrestricted (not deny-all)
+    because per-user permissions replace default_permissions wholesale (#2267).
+    """
+    if allow:
+        return f"{{ allow: [{_quoted_list(allow)}] }}"
+    return '{ deny: [">"] }'
+
+
 def _emit_user(
     name: str,
     pubkey: str,
@@ -44,8 +55,8 @@ def _emit_user(
         f'      nkey: "{pubkey}"\n'
         f"      # {name}\n"
         f"      permissions: {{\n"
-        f"        publish:   {{ allow: [{_quoted_list(pub_allow)}] }}\n"
-        f"        subscribe: {{ allow: [{_quoted_list(sub_allow)}] }}\n"
+        f"        publish:   {_perm_block(pub_allow)}\n"
+        f"        subscribe: {_perm_block(sub_allow)}\n"
         f"        allow_responses: {ar}\n"
         f"      }}\n"
         f"    }}"

--- a/src/factory/monitoring/checks_log.py
+++ b/src/factory/monitoring/checks_log.py
@@ -71,7 +71,8 @@ class LokiLogFetcher:
         # true violations outside an unfiltered fetch. Case-insensitive regex is a
         # safe superset for both checks; exact counting still happens client-side
         # after fetch (unchanged from today).
-        escaped = re.escape(pattern)
+        # LogQL/RE2 rejects re.escape's `\ ` for literal spaces — keep spaces literal.
+        escaped = re.escape(pattern).replace(r"\ ", " ")
         query = f'{{systemd_unit="{container_name}.service"}} |~ "(?i){escaped}"'
         now_ns = time.time_ns()
         start_ns = now_ns - since_minutes * 60 * 1_000_000_000

--- a/tests/nats/test_gen_nkeys_acls.sh
+++ b/tests/nats/test_gen_nkeys_acls.sh
@@ -75,6 +75,12 @@ extract_block() {
 # Fails with non-zero + diagnostic if: missing expected, or extra unexpected.
 assert_allow_list_equals() {
   local block="$1" direction="$2" expected="$3" name="$4"
+  # Empty matrix grant → renderer emits deny-all, not allow: [] (#2267).
+  if [ -z "$expected" ]; then
+    echo "$block" | grep -qE "${direction}:[[:space:]]*\{[[:space:]]*deny:[[:space:]]*\[\">\"\]" \
+      || { echo "FAIL: ${name} ${direction} expected deny: [\">\"] for empty grant"; exit 1; }
+    return 0
+  fi
   # Extract the `<direction>: { allow: [ ... ] }` list content
   local line
   line=$(echo "$block" | grep -oE "${direction}:[[:space:]]*\{[[:space:]]*allow:[[:space:]]*\[[^]]*\]" | head -1)

--- a/tests/scripts/test_parity_e2e.py
+++ b/tests/scripts/test_parity_e2e.py
@@ -133,61 +133,9 @@ def _flow_id(flow: dict) -> str:
     return f"{flow['requester']}-{flow['responder']}"
 
 
-def _identity_params_xfail_empty_grant(direction_index: int, direction: str) -> list:
-    """Parametrize ACTIVE_IDENTITIES, xfail(strict)-marking empty-allow-list cases.
-
-    **Live gap found while implementing #2247, not a test bug — documented
-    here, flagged in the PR description, out of scope to fix under this
-    issue.** Confirmed by isolated reproduction against a real nats-server
-    2.10.22: a user permissions block with an explicit empty allow list
-    (`publish: { allow: [] }` or `subscribe: { allow: [] }`) is NOT deny-all.
-    nats-server only builds a restrictive allow-sublist when the list is
-    non-empty; an empty list leaves that direction's allow-set nil, i.e.
-    "unrestricted" — and because the per-user `permissions` block replaces
-    `default_permissions` wholesale (not merged), the top-level
-    `deny: [">"]` fallback rendered by scripts/_renderer.py never applies
-    either. Reproduced with zero prior probes on the connection and
-    re-checked after `nc.drain()`, ruling out the `_probe()` timing race
-    that `_settle_deny` (above) exists to absorb — this is a distinct,
-    deterministic gap, not flakiness.
-
-    In `deploy/nats/acl-matrix.json` today this affects `dashboard-reader`
-    (publish: []), `gh-helper` (subscribe: []), and `ingress`
-    (subscribe: []) — computed here from EFFECTIVE_GRANTS, not hardcoded,
-    so any future identity added with an empty allow-list on either
-    direction is automatically caught by the same xfail rather than
-    silently green.
-
-    Root-cause fix tracked in #2267 (scripts/_renderer.py: emit an explicit
-    `deny: [">"]` for a direction whose intended allow-list is empty) — out
-    of scope for #2247
-    (test-only; acl-matrix.json/_renderer.py/_effective.py/ops.py are all
-    reused as-is per the approved spec's Out of Scope section). `strict=True`
-    is deliberate: once the renderer bug is fixed, this deny-probe starts
-    passing, XPASS fails the suite, and the marker must be removed by
-    whoever lands that fix — the gap cannot silently regress further nor
-    bit-rot silently once fixed.
-    """
-    params: list = []
-    for identity in ACTIVE_IDENTITIES:
-        if EFFECTIVE_GRANTS[identity][direction_index]:
-            params.append(identity)
-            continue
-        params.append(
-            pytest.param(
-                identity,
-                marks=pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        f"{identity}: effective {direction} allow-list is "
-                        "empty — nats-server treats an empty `allow: []` as "
-                        "unrestricted, not deny-all (live gap — tracked #2267; "
-                        "xfail(strict) until renderer fix lands)"
-                    ),
-                ),
-            )
-        )
-    return params
+def _identity_params() -> list[str]:
+    """Parametrize over every active identity in the ACL matrix."""
+    return list(ACTIVE_IDENTITIES)
 
 
 def _non_flow_pair_target(flow: dict) -> str:
@@ -748,7 +696,7 @@ def test_ci_hardfail_guard_silent_in_github_actions_with_all_deps_present() -> N
     not NATS_PY_AVAILABLE,
     reason="nats-py not installed — skipping live ACL test",
 )
-@pytest.mark.parametrize("identity", _identity_params_xfail_empty_grant(0, "publish"))
+@pytest.mark.parametrize("identity", _identity_params())
 def test_acl_matrix_publish(
     identity: str, nats_server: NatsServerEndpoints, rendered_auth_conf: Path
 ) -> None:
@@ -801,7 +749,7 @@ def test_acl_matrix_publish(
     not NATS_PY_AVAILABLE,
     reason="nats-py not installed — skipping live ACL test",
 )
-@pytest.mark.parametrize("identity", _identity_params_xfail_empty_grant(1, "subscribe"))
+@pytest.mark.parametrize("identity", _identity_params())
 def test_acl_matrix_subscribe(
     identity: str, nats_server: NatsServerEndpoints, rendered_auth_conf: Path
 ) -> None:

--- a/tests/scripts/test_parity_e2e.py
+++ b/tests/scripts/test_parity_e2e.py
@@ -220,9 +220,8 @@ async def _settle_deny(
     observed empirically, both timing-shaped: (a) back-to-back probes on an
     already-"warm" connection needing one extra ~0.2s tick, and (b) a
     deny-probe that is the FIRST operation on a freshly-opened connection
-    (identities with an empty allow-list on the probed direction, e.g.
-    dashboard-reader/gh-helper/ingress) needing more cumulative elapsed time
-    than a single 0.2s wait — a one-shot wait left 3/68 nodes flaky. A
+    needing more cumulative elapsed time than a single 0.2s wait — a
+    one-shot wait left 3/68 nodes flaky. A
     bounded poll (5 × 0.2s = up to 1s total) covers both without loosening
     the assertion itself or touching the reused primitive (out of scope —
     see spec Out of Scope).

--- a/tests/scripts/test_renderer.py
+++ b/tests/scripts/test_renderer.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 # This import will fail at collection time — that is the intended RED state.
 from scripts._acl_models import LoadedMatrix
 from scripts._renderer import parse_auth_conf, render_auth_conf
@@ -89,26 +91,55 @@ class TestAllowResponsesHonored:
 
 
 class TestEmptyGrantDenyAll:
-    def test_empty_allow_list_renders_deny_all(self) -> None:
+    @pytest.mark.parametrize(
+        ("name", "empty_direction", "deny_fragment"),
+        [
+            ("ingress", "subscribe", "subscribe: { deny: [\">\"] }"),
+            ("dashboard-reader", "publish", "publish:   { deny: [\">\"] }"),
+        ],
+    )
+    def test_empty_grant_renders_deny_all(
+        self, name: str, empty_direction: str, deny_fragment: str
+    ) -> None:
         """Empty matrix grant must emit deny: [\">\"], not allow: [] (#2267)."""
+        publish = (
+            []
+            if empty_direction == "publish"
+            else ["factory.event.github.>"]
+        )
+        subscribe = (
+            []
+            if empty_direction == "subscribe"
+            else ["factory.event.>"]
+        )
         matrix: LoadedMatrix = {
             "version": "2",
             "request_reply_flows": [],
             "identities": {
-                "ingress": {
+                name: {
                     "status": "active",
                     "created_at": "2026-04-21",
                     "owner": "factory",
-                    "description": "ingress",
+                    "description": name,
                     "allow_responses": False,
-                    "publish": ["factory.event.github.>"],
-                    "subscribe": [],
+                    "publish": publish,
+                    "subscribe": subscribe,
                 }
             },
         }
-        rendered = render_auth_conf(matrix, {"ingress": "UDETINGRESS"})
-        assert "subscribe: { deny: [\">\"] }" in rendered
+        pubkey = f"UDET{name.upper().replace('-', '')}"
+        rendered = render_auth_conf(matrix, {name: pubkey})
+        parsed = parse_auth_conf(rendered)
+
+        assert deny_fragment in rendered
         assert "allow: []" not in rendered
+        user = parsed.users[0]
+        if empty_direction == "publish":
+            assert user.publish_allow == frozenset()
+            assert user.subscribe_allow
+        else:
+            assert user.subscribe_allow == frozenset()
+            assert user.publish_allow
 
 
 class TestInboxGrantFromFlow:

--- a/tests/scripts/test_renderer.py
+++ b/tests/scripts/test_renderer.py
@@ -88,6 +88,29 @@ class TestAllowResponsesHonored:
         assert "allow_responses: false" in rendered
 
 
+class TestEmptyGrantDenyAll:
+    def test_empty_allow_list_renders_deny_all(self) -> None:
+        """Empty matrix grant must emit deny: [\">\"], not allow: [] (#2267)."""
+        matrix: LoadedMatrix = {
+            "version": "2",
+            "request_reply_flows": [],
+            "identities": {
+                "ingress": {
+                    "status": "active",
+                    "created_at": "2026-04-21",
+                    "owner": "factory",
+                    "description": "ingress",
+                    "allow_responses": False,
+                    "publish": ["factory.event.github.>"],
+                    "subscribe": [],
+                }
+            },
+        }
+        rendered = render_auth_conf(matrix, {"ingress": "UDETINGRESS"})
+        assert "subscribe: { deny: [\">\"] }" in rendered
+        assert "allow: []" not in rendered
+
+
 class TestInboxGrantFromFlow:
     def test_inbox_grant_from_flow(self) -> None:
         """Responder's publish allow contains _inbox.<requester>.> from flows.

--- a/tests/test_monitoring_checks_log.py
+++ b/tests/test_monitoring_checks_log.py
@@ -507,7 +507,7 @@ class TestLokiLogFetcher:
         mock_get.assert_called_once()
         _, kwargs = mock_get.call_args
         query = kwargs["params"]["query"]
-        escaped = re.escape("permissions violation")
+        escaped = re.escape("permissions violation").replace(r"\ ", " ")
         assert f'|~ "(?i){escaped}"' in query
 
     def test_fetch_returns_empty_string_on_zero_matching_streams(

--- a/tests/test_monitoring_checks_log.py
+++ b/tests/test_monitoring_checks_log.py
@@ -488,8 +488,15 @@ class TestLokiLogFetcher:
         with pytest.raises(LogFetchError):
             LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
 
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "permissions violation",
+            "_dict_stream_gen timeout",
+        ],
+    )
     def test_fetch_query_param_includes_case_insensitive_regex_filter(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, pattern: str
     ) -> None:
         """Regression guard for the truncation-risk fix: the server-side
         `|~ "(?i)<escaped-pattern>"` LogQL filter must survive future edits.
@@ -502,12 +509,12 @@ class TestLokiLogFetcher:
         mock_get = MagicMock(return_value=mock_response)
         monkeypatch.setattr("factory.monitoring.checks_log.httpx.get", mock_get)
 
-        LokiLogFetcher().fetch("factory-nats", 10, pattern="permissions violation")
+        LokiLogFetcher().fetch("factory-nats", 10, pattern=pattern)
 
         mock_get.assert_called_once()
         _, kwargs = mock_get.call_args
         query = kwargs["params"]["query"]
-        escaped = re.escape("permissions violation").replace(r"\ ", " ")
+        escaped = re.escape(pattern).replace(r"\ ", " ")
         assert f'|~ "(?i){escaped}"' in query
 
     def test_fetch_returns_empty_string_on_zero_matching_streams(


### PR DESCRIPTION
## Summary
- Fix `scripts/_renderer.py` to emit `deny: [">"]` when a matrix grant list is empty, instead of `allow: []` which nats-server 2.10.22 treats as unrestricted (#2267). Affects `dashboard-reader` (publish), `gh-helper` and `ingress` (subscribe).
- Regenerate `deploy/nats/auth.conf` and remove `xfail(strict)` tripwires in `test_parity_e2e.py` — deny-probe tests now pass live.
- Fix `LokiLogFetcher` LogQL regex: `re.escape` was turning spaces into `\ `, invalid in RE2 → HTTP 400 on every `factory-log-monitor` poll (false Telegram alerts every 5 min).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2267: renderer empty-allow ACL gap | Open |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `fix/2267-renderer-empty-allow-deny` | Complete |
| Verification | Lint ✅ Tests ✅ (renderer, checks_log, parity e2e, shell ACL) | Passed |

## Test Plan
- [x] `pytest tests/scripts/test_renderer.py tests/test_monitoring_checks_log.py`
- [x] `pytest tests/scripts/test_parity_e2e.py -k "dashboard-reader or gh-helper or ingress"`
- [x] `bash tests/nats/test_gen_nkeys_acls.sh`
- [ ] M1 post-merge: `make converge` + restart `factory-nats` + `factory-log-monitor`; `factory ops verify` hub deny probe should pass

Fixes #2267

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`