### PR TITLE
fix(ops): skip retired identities in ops verify

### DIFF
--- a/src/factory/cli/ops.py
+++ b/src/factory/cli/ops.py
@@ -13,7 +13,6 @@ import json
 import os
 import stat as _stat
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import AsyncGenerator
 
@@ -21,7 +20,13 @@ import nats.errors
 import typer
 from nats.aio.client import Client as NATS
 
-from factory.cli.ops_audit import emit_drift_report
+from factory.cli.ops_audit import (
+    CheckRow,
+    IdentityResult,
+    active_identities,
+    emit_drift_report,
+    print_verify_report,
+)
 from factory.cli.ops_nats import (
     default_hub_seed,
     default_nats_url,
@@ -67,35 +72,6 @@ def _resolve_matrix_path(path: Path) -> Path:
     raise typer.BadParameter(
         f"matrix file not found: {p} — pass --matrix or set ROXABI_FACTORY_REPO"
     )
-
-
-@dataclass
-class CheckRow:
-    identity: str
-    subject: str
-    kind: str  # "pub" | "deny"
-    expected: str
-    actual: str
-    ok: bool
-
-
-@dataclass
-class IdentityResult:
-    identity: str
-    rows: list[CheckRow] = field(default_factory=list)
-    skipped_reason: str | None = None
-
-    @property
-    def pub_passed(self) -> int:
-        return sum(1 for r in self.rows if r.kind == "pub" and r.ok)
-
-    @property
-    def deny_passed(self) -> int:
-        return sum(1 for r in self.rows if r.kind == "deny" and r.ok)
-
-    @property
-    def first_failure(self) -> CheckRow | None:
-        return next((r for r in self.rows if not r.ok), None)
 
 
 def _load_matrix(path: Path) -> dict[str, dict]:
@@ -284,10 +260,18 @@ def verify(
         if unknown:
             raise typer.BadParameter(f"unknown identity name(s): {', '.join(unknown)}")
         identities = {n: identities[n] for n in only}
+        retired = [n for n in identities if identities[n].get("status") == "retired"]
+        if retired:
+            raise typer.BadParameter(
+                "identity/identities retired, not in live auth.conf: "
+                + ", ".join(retired)
+            )
+
+    identities = active_identities(identities)
 
     drift = emit_drift_report(identities, typer.echo)
     results = asyncio.run(_verify_all(resolved_url, identities, seeds_path))
-    exit_code = _print_report(results)
+    exit_code = print_verify_report(results, typer.echo)
     raise typer.Exit(max(exit_code, 1 if drift else 0))
 
 
@@ -299,32 +283,6 @@ async def _verify_all(
         seed_path = seed_path_for(seeds_dir, name)
         out.append(await _verify_identity(nats_url, name, spec, seed_path))
     return out
-
-
-def _print_report(results: list[IdentityResult]) -> int:
-    total_pub_pass = sum(r.pub_passed for r in results)
-    total_pub = sum(1 for r in results for c in r.rows if c.kind == "pub")
-    total_deny_pass = sum(r.deny_passed for r in results)
-    total_deny = sum(1 for r in results for c in r.rows if c.kind == "deny")
-    skipped = [r for r in results if r.skipped_reason]
-    failed = [r for r in results if r.first_failure]
-
-    for r in skipped:
-        typer.echo(f"SKIP {r.identity}: {r.skipped_reason}")
-
-    if failed and (first := failed[0].first_failure):
-        typer.echo(
-            f"FAIL {first.identity} {first.kind} {first.subject} — "
-            f"expected {first.expected!r}, got {first.actual!r}"
-        )
-
-    typer.echo(
-        f"{len(results)} identities, "
-        f"{total_pub_pass}/{total_pub} pub checks passed, "
-        f"{total_deny_pass}/{total_deny} deny checks passed"
-        + (f", {len(skipped)} skipped" if skipped else "")
-    )
-    return 1 if failed or skipped else 0
 
 
 @ops_app.command("publish-host-event")

--- a/src/factory/cli/ops_audit.py
+++ b/src/factory/cli/ops_audit.py
@@ -7,6 +7,8 @@ helpers remain trivially unit-testable without touching Typer.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 FACTORY_OWNED_IDENTITIES: frozenset[str] = frozenset(
     {
         "hub",
@@ -18,6 +20,48 @@ FACTORY_OWNED_IDENTITIES: frozenset[str] = frozenset(
 )
 
 BARE_INBOX_PATTERNS: frozenset[str] = frozenset({"_INBOX.>", "_inbox.>"})
+
+
+@dataclass
+class CheckRow:
+    identity: str
+    subject: str
+    kind: str  # "pub" | "deny"
+    expected: str
+    actual: str
+    ok: bool
+
+
+@dataclass
+class IdentityResult:
+    identity: str
+    rows: list[CheckRow] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+    @property
+    def pub_passed(self) -> int:
+        return sum(1 for r in self.rows if r.kind == "pub" and r.ok)
+
+    @property
+    def deny_passed(self) -> int:
+        return sum(1 for r in self.rows if r.kind == "deny" and r.ok)
+
+    @property
+    def first_failure(self) -> CheckRow | None:
+        return next((r for r in self.rows if not r.ok), None)
+
+
+def active_identities(identities: dict[str, dict]) -> dict[str, dict]:
+    """Identities rendered in live auth.conf (``status != \"retired\"``).
+
+    Mirrors ``scripts._effective.effective_grants`` retirement filter — retired
+    rows stay in the matrix for history but are not NATS-authenticated.
+    """
+    return {
+        name: spec
+        for name, spec in identities.items()
+        if spec.get("status") != "retired"
+    }
 
 
 def audit_matrix_inbox_drift(
@@ -60,3 +104,30 @@ def emit_drift_report(identities: dict[str, dict], echo) -> bool:
     for finding in drift:
         echo(format_drift_finding(finding), err=True)
     return bool(drift)
+
+
+def print_verify_report(results: list[IdentityResult], echo) -> int:
+    """Summarize verify results; return 0 on full pass, 1 if any fail or skip."""
+    total_pub_pass = sum(r.pub_passed for r in results)
+    total_pub = sum(1 for r in results for c in r.rows if c.kind == "pub")
+    total_deny_pass = sum(r.deny_passed for r in results)
+    total_deny = sum(1 for r in results for c in r.rows if c.kind == "deny")
+    skipped = [r for r in results if r.skipped_reason]
+    failed = [r for r in results if r.first_failure]
+
+    for r in skipped:
+        echo(f"SKIP {r.identity}: {r.skipped_reason}")
+
+    if failed and (first := failed[0].first_failure):
+        echo(
+            f"FAIL {first.identity} {first.kind} {first.subject} — "
+            f"expected {first.expected!r}, got {first.actual!r}"
+        )
+
+    echo(
+        f"{len(results)} identities, "
+        f"{total_pub_pass}/{total_pub} pub checks passed, "
+        f"{total_deny_pass}/{total_deny} deny checks passed"
+        + (f", {len(skipped)} skipped" if skipped else "")
+    )
+    return 1 if failed or skipped else 0

--- a/tests/cli/test_ops_verify.py
+++ b/tests/cli/test_ops_verify.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from factory.cli import factory_app
 from factory.cli.ops import _expand_subject, _is_permission_error, _load_matrix
+from factory.cli.ops_audit import active_identities
 from factory.cli.ops_nats import default_hub_seed, inbox_prefix_for_seed
 
 runner = CliRunner()
@@ -141,6 +142,7 @@ def matrix_two(tmp_path: Path) -> Path:
         p,
         {
             "hub": {
+                "status": "active",
                 "publish": [
                     "factory.outbound.telegram.>",
                     "factory.llm.generate.request",
@@ -148,6 +150,7 @@ def matrix_two(tmp_path: Path) -> Path:
                 "subscribe": [],
             },
             "monitor": {
+                "status": "active",
                 "publish": ["lyra.monitor.>"],
                 "subscribe": [],
             },
@@ -258,6 +261,82 @@ def test_verify_skips_when_seed_missing(tmp_path: Path, matrix_two: Path) -> Non
     assert result.exit_code == 1
     assert "SKIP monitor: seed missing" in result.stdout
     assert "1 skipped" in result.stdout
+
+
+def test_active_identities_excludes_retired() -> None:
+    identities = {
+        "hub": {"status": "active", "publish": []},
+        "monitor": {"status": "retired", "publish": []},
+        "legacy": {"publish": []},
+    }
+    assert list(active_identities(identities)) == ["hub", "legacy"]
+
+
+def test_verify_excludes_retired_identities(tmp_path: Path) -> None:
+    matrix = tmp_path / "matrix.json"
+    _write_matrix(
+        matrix,
+        {
+            "hub": {
+                "status": "active",
+                "publish": ["factory.event.>"],
+                "subscribe": [],
+            },
+            "monitor": {
+                "status": "retired",
+                "publish": ["factory.monitor.>"],
+                "subscribe": [],
+            },
+        },
+    )
+    seeds = _seed_dir(tmp_path, ["hub", "monitor"])
+    deny = [{"factory.verify.deny.hub"}]
+    with patch("factory.cli.ops.nats.connect", _patched_connect(deny)):
+        result = runner.invoke(
+            factory_app,
+            [
+                "ops",
+                "verify",
+                "--matrix",
+                str(matrix),
+                "--seeds-dir",
+                str(seeds),
+            ],
+        )
+    assert result.exit_code == 0, result.stdout
+    assert "1 identities" in result.stdout
+    assert "monitor" not in result.stdout
+    assert "1/1 deny checks passed" in result.stdout
+
+
+def test_verify_only_retired_rejects(tmp_path: Path) -> None:
+    matrix = tmp_path / "matrix.json"
+    _write_matrix(
+        matrix,
+        {
+            "monitor": {
+                "status": "retired",
+                "publish": ["factory.monitor.>"],
+                "subscribe": [],
+            },
+        },
+    )
+    seeds = _seed_dir(tmp_path, ["monitor"])
+    result = runner.invoke(
+        factory_app,
+        [
+            "ops",
+            "verify",
+            "--matrix",
+            str(matrix),
+            "--seeds-dir",
+            str(seeds),
+            "--only",
+            "monitor",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "retired" in result.output
 
 
 def test_verify_only_filter(tmp_path: Path, matrix_two: Path) -> None:


### PR DESCRIPTION
## Summary

- Filter `deploy/nats/acl-matrix.json` identities with `status: retired` before NATS probing in `factory ops verify`, matching live `auth.conf` rendering (`effective_grants` retirement filter).
- Reject `--only` when it names a retired identity (not authenticated on the server).
- Move verify report dataclasses and summary printer to `ops_audit.py` to stay under the file-length gate.

## Motivation

M1 `factory ops verify` reported `SKIP monitor: connect failed` (~109s timeout) because `monitor` is retired in the matrix but still had a seed on disk. Retired rows remain in the matrix for history; they should not be probed.

## Test plan

- [x] `pytest tests/cli/test_ops_verify.py` — 25 passed
- [x] `tools/check_file_length.sh` — `ops.py` under 300 SLOC
- [ ] Post-merge: `git pull` on M1 and confirm `factory ops verify` exits 0 without monitor SKIP