### PR TITLE
chore(deploy): disable socialmedia-adapter until Postiz WIP ready

### DIFF
--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -54,10 +54,12 @@ container = "factory-omp.container"
 host_roles = ["factory-hub"]
 required_secrets = ["factory-nats-omp", "factory-litellm-key", "factory_otel_token"]
 
+# socialmedia-adapter — WIP (#1713): disabled until config.toml mount + Postiz path ready.
 [component.socialmedia-adapter]
 container = "factory-socialmedia-adapter.container"
 host_roles = ["factory-hub"]
 required_secrets = ["factory-nats-socialmedia", "factory-socialmedia-api-key", "factory_blobstore_token"]
+disabled = true
 
 [component.ingress]
 container = "factory-ingress.container"

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -29,7 +29,7 @@ EXPECTED_CONTAINERS = [
     "factory-turn-writer",
     "factory-blobstore",
     "factory-omp",
-    "factory-socialmedia-adapter",
+    # factory-socialmedia-adapter — disabled in quadlet.toml until #1713 ready.
     "factory-ingress",
     "factory-cloudflared",
     "factory-loki",
@@ -55,12 +55,14 @@ def _source_and_run(helper: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_emits_exactly_20_containers() -> None:
+def test_emits_enabled_container_count() -> None:
     """Real helper against the real quadlet.toml → returncode 0, enabled names only."""
     result = _source_and_run(HELPER)
     assert result.returncode == 0, result.stderr
     lines = [line for line in result.stdout.splitlines() if line]
-    assert len(lines) == 20, f"expected 20 containers, got {len(lines)}: {lines}"
+    assert len(lines) == len(EXPECTED_CONTAINERS), (
+        f"expected {len(EXPECTED_CONTAINERS)} containers, got {len(lines)}: {lines}"
+    )
 
 
 def test_declaration_order() -> None:


### PR DESCRIPTION
## Summary

- Set `disabled = true` on `[component.socialmedia-adapter]` in `deploy/quadlet.toml`
- Skips unit install/restart on `make quadlet-install` / `make converge` until #1713 is ready

## Motivation

M1 `factory-socialmedia-adapter` was running but permanently unhealthy (`factory config validate` — `config.toml` not mounted), causing `is-system-running = degraded`.

## Test plan

- [x] M1: service stopped + disabled manually
- [ ] After merge: `make converge` on M1 does not recreate the unit