### PR TITLE
fix(tests): infra markers + ACL readiness + manifest SSoT (slice 1-2)

### DIFF
--- a/packages/roxabi-nats/tests/conftest.py
+++ b/packages/roxabi-nats/tests/conftest.py
@@ -45,6 +45,17 @@ def _register_stub_fixture() -> None:
 
 _register_stub_fixture()
 
+# Serialize live-server tests on one xdist worker (see tests/nats/conftest.py).
+pytestmark = pytest.mark.xdist_group(name="nats_server")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if "/packages/roxabi-nats/tests/" not in str(item.fspath):
+            continue
+        item.add_marker(pytest.mark.subprocess_nats)
+        item.add_marker(pytest.mark.xdist_group(name="nats_server"))
+
 
 @pytest.fixture(autouse=True)
 def _reset_version_check_log_state() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ filterwarnings = [
 markers = [
     "nats_integration: NATS integration tests requiring Docker Compose",
     "integration: cross-host integration tests requiring M1 Tailnet",
+    "subprocess_nats: tests spawning a local nats-server subprocess (no auth.conf)",
+    "live_acl: live nats-server with rendered auth.conf and nk seeds",
+    "deploy_contract: deploy/install/converge/quadlet bash contract tests",
     "audio_consumer_live: test exercises audio consumer directly; skip the autouse no-op neutralizer",
     "bot_store_live: test exercises real BotStore roster loading; skip autouse roster mocks",
     "smoke: fast in-process smoke tests for critical user-facing paths",

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -1,0 +1,12 @@
+"""Shared markers for deploy contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if "/tests/deploy/" not in str(item.fspath):
+            continue
+        item.add_marker(pytest.mark.deploy_contract)

--- a/tests/helpers/secrets_manifest.py
+++ b/tests/helpers/secrets_manifest.py
@@ -1,0 +1,49 @@
+"""Shared parsers for deploy/generated/secrets-manifest.sh — test SSoT."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_SH = REPO_ROOT / "deploy" / "generated" / "secrets-manifest.sh"
+
+
+def parse_manifest_block(
+    block_name: str,
+    manifest: Path = MANIFEST_SH,
+) -> dict[str, str]:
+    """Parse a declare -A block from secrets-manifest.sh."""
+    entries: dict[str, str] = {}
+    in_block = False
+    for line in manifest.read_text().splitlines():
+        if f"{block_name}=(" in line:
+            in_block = True
+            continue
+        if in_block:
+            stripped = line.strip()
+            if stripped == ")":
+                break
+            if stripped.startswith("[") and "]=" in stripped:
+                name = stripped[1 : stripped.index("]=")]
+                val = stripped[stripped.index('="') + 2 : -1]
+                entries[name] = val
+    return entries
+
+
+def parse_manifest_sources(manifest: Path = MANIFEST_SH) -> dict[str, str]:
+    """Parse SECRET_SOURCES block from secrets-manifest.sh."""
+    return parse_manifest_block("SECRET_SOURCES", manifest)
+
+
+def parse_manifest_policy(manifest: Path = MANIFEST_SH) -> dict[str, str]:
+    """Parse SECRET_POLICY block from secrets-manifest.sh (install.sh SSoT)."""
+    return parse_manifest_block("SECRET_POLICY", manifest)
+
+
+def factory_nats_seeds_expected(manifest: Path = MANIFEST_SH) -> set[str]:
+    """All secrets with policy=nats-seed in the committed manifest."""
+    return {
+        name
+        for name, policy in parse_manifest_policy(manifest).items()
+        if policy == "nats-seed"
+    }

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -13,6 +13,16 @@ import pytest
 # Serialize NATS subprocess tests on one xdist worker (see test_parity_e2e.py).
 pytestmark = pytest.mark.xdist_group(name="nats_server")
 
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """conftest pytestmark does not tag child modules — apply at collection."""
+    for item in items:
+        if "/tests/nats/" not in str(item.fspath):
+            continue
+        item.add_marker(pytest.mark.subprocess_nats)
+        item.add_marker(pytest.mark.xdist_group(name="nats_server"))
+
+
 from tests.factories.nats_server import (  # noqa: F401,E402
     nats_server_url,
     nc,

--- a/tests/scripts/test_parity_e2e.py
+++ b/tests/scripts/test_parity_e2e.py
@@ -237,7 +237,37 @@ async def _settle_deny(
     return ok, actual
 
 
+async def _request_when_responders_ready(
+    req_nc: Any,
+    resp_nc: Any,
+    subject: str,
+    payload: bytes,
+    *,
+    request_timeout: float,
+) -> Any:
+    """Retry request() while the responder subscription propagates (#2275 flake).
+
+    NATS Core drops requests with no registered subscriber. flush() round-trips
+    the SUB to the server but cross-connection visibility can lag under CI load.
+    """
+    import asyncio
+
+    from nats.errors import NoRespondersError
+
+    last: NoRespondersError | None = None
+    for attempt in range(5):
+        try:
+            return await req_nc.request(subject, payload, timeout=request_timeout)
+        except NoRespondersError as exc:
+            last = exc
+            await resp_nc.flush(timeout=2)
+            await asyncio.sleep(0.1 * (attempt + 1))  # NATS delivery window
+    assert last is not None
+    raise last
+
+
 pytestmark = [
+    pytest.mark.live_acl,
     pytest.mark.skipif(
         not (NATS_AVAILABLE and NK_AVAILABLE),
         reason="nats-server and nk must be on PATH — CI installs both",
@@ -839,7 +869,16 @@ def test_flow_round_trip_positive(
 
                 await resp_nc.subscribe(concrete_subject, cb=_respond)
                 await resp_nc.flush(timeout=2)
-                reply = await req_nc.request(concrete_subject, b"ping", timeout=2)
+                request_timeout = (
+                    10.0 if os.environ.get("GITHUB_ACTIONS") == "true" else 2.0
+                )
+                reply = await _request_when_responders_ready(
+                    req_nc,
+                    resp_nc,
+                    concrete_subject,
+                    b"ping",
+                    request_timeout=request_timeout,
+                )
                 assert reply.data == b"pong", (
                     f"{requester}->{responder} on {concrete_subject!r}: "
                     f"unexpected reply {reply.data!r}"

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,11 @@
+"""Shared markers for deploy/tools contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if "test_install_dry_run.py" in item.nodeid:
+            item.add_marker(pytest.mark.deploy_contract)

--- a/tests/tools/test_emit_secrets_manifest.py
+++ b/tests/tools/test_emit_secrets_manifest.py
@@ -2,7 +2,7 @@
 
 T14 contract map:
   A — parse_unit_secret_names: name=value.split(",")[0]; {{bot_secrets}} excluded
-  B — manifest contains all 7 factory-nats-* (incl. factory-nats-gh-helper)
+  B — manifest contains all factory-nats-* nats-seed secrets
   C — policy classification correct (nats-seed / nats-auth / generated / optional)
   D — gate happy path: current tree → exit 0
   E — gate drift detection: unit Secret= with no required_secrets entry → exit non-zero
@@ -132,12 +132,12 @@ class TestParseUnitSecretNames:
 
 
 # ---------------------------------------------------------------------------
-# Section B — manifest completeness (all 7 factory-nats-* present)
+# Section B — manifest completeness (all factory-nats-* nats-seed present)
 # ---------------------------------------------------------------------------
 
 
 class TestManifestCompleteness:
-    """Verify the committed manifest covers all 7 factory-nats-* secrets."""
+    """Verify the committed manifest covers all factory-nats-* nats-seed secrets."""
 
     EXPECTED_NATS_SEEDS = {
         "factory-nats-hub",
@@ -147,7 +147,10 @@ class TestManifestCompleteness:
         "factory-nats-clipool",
         "factory-nats-turn-writer",
         "factory-nats-blobstore",
-        "factory-nats-gh-helper",  # the #9 miss this PR fixes
+        "factory-nats-gh-helper",
+        "factory-nats-ingress",
+        "factory-nats-omp",
+        "factory-nats-socialmedia",
     }
 
     def _parse_manifest_keys(self, manifest: Path) -> set[str]:
@@ -160,8 +163,8 @@ class TestManifestCompleteness:
                 keys.add(name)
         return keys
 
-    def test_all_seven_nats_seeds_present(self) -> None:
-        """Manifest must contain all 7 factory-nats-* seeds (incl. gh-helper)."""
+    def test_all_nats_seed_secrets_present(self) -> None:
+        """Manifest must contain every factory-nats-* nats-seed secret."""
         manifest_keys = self._parse_manifest_keys(MANIFEST_SH)
 
         missing = self.EXPECTED_NATS_SEEDS - manifest_keys
@@ -200,17 +203,7 @@ class TestPolicyClassification:
         with POLICY_TOML.open("rb") as f:
             policy = tomllib.load(f)
 
-        seed_names = [
-            "factory-nats-hub",
-            "factory-nats-telegram",
-            "factory-nats-discord",
-            "factory-nats-web",
-            "factory-nats-clipool",
-            "factory-nats-turn-writer",
-            "factory-nats-blobstore",
-            "factory-nats-gh-helper",
-            "factory-nats-ingress",
-        ]
+        seed_names = sorted(TestManifestCompleteness.EXPECTED_NATS_SEEDS)
         for name in seed_names:
             assert name in policy.get("secret", {}), f"{name} missing from policy"
             assert policy["secret"][name]["policy"] == "nats-seed", (

--- a/tests/tools/test_emit_secrets_manifest.py
+++ b/tests/tools/test_emit_secrets_manifest.py
@@ -24,6 +24,8 @@ from pathlib import Path
 import pytest
 from tools.emit_secrets_manifest import parse_unit_secret_names
 
+from tests.helpers.secrets_manifest import MANIFEST_SH, factory_nats_seeds_expected
+
 # ── locate repo root so we can import and shell-out correctly ─────────────────
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,7 +33,6 @@ EMIT_SCRIPT = REPO_ROOT / "tools" / "emit_secrets_manifest.py"
 GATE_SCRIPT = REPO_ROOT / "tools" / "check_secrets_drift.sh"
 QUADLET_TOML = REPO_ROOT / "deploy" / "quadlet.toml"
 POLICY_TOML = REPO_ROOT / "deploy" / "secrets-policy.toml"
-MANIFEST_SH = REPO_ROOT / "deploy" / "generated" / "secrets-manifest.sh"
 ACL_MATRIX = REPO_ROOT / "deploy" / "nats" / "acl-matrix.json"
 QUADLET_DIR = REPO_ROOT / "deploy" / "quadlet"
 
@@ -139,19 +140,9 @@ class TestParseUnitSecretNames:
 class TestManifestCompleteness:
     """Verify the committed manifest covers all factory-nats-* nats-seed secrets."""
 
-    EXPECTED_NATS_SEEDS = {
-        "factory-nats-hub",
-        "factory-nats-telegram",
-        "factory-nats-discord",
-        "factory-nats-web",
-        "factory-nats-clipool",
-        "factory-nats-turn-writer",
-        "factory-nats-blobstore",
-        "factory-nats-gh-helper",
-        "factory-nats-ingress",
-        "factory-nats-omp",
-        "factory-nats-socialmedia",
-    }
+    @staticmethod
+    def _expected_nats_seeds() -> set[str]:
+        return factory_nats_seeds_expected()
 
     def _parse_manifest_keys(self, manifest: Path) -> set[str]:
         """Extract key names from the SECRET_SOURCES declare -A block."""
@@ -167,7 +158,7 @@ class TestManifestCompleteness:
         """Manifest must contain every factory-nats-* nats-seed secret."""
         manifest_keys = self._parse_manifest_keys(MANIFEST_SH)
 
-        missing = self.EXPECTED_NATS_SEEDS - manifest_keys
+        missing = self._expected_nats_seeds() - manifest_keys
         assert not missing, f"factory-nats-* seeds missing from manifest: {missing}"
 
     def test_factory_nats_gh_helper_present(self) -> None:
@@ -203,7 +194,7 @@ class TestPolicyClassification:
         with POLICY_TOML.open("rb") as f:
             policy = tomllib.load(f)
 
-        seed_names = sorted(TestManifestCompleteness.EXPECTED_NATS_SEEDS)
+        seed_names = sorted(factory_nats_seeds_expected())
         for name in seed_names:
             assert name in policy.get("secret", {}), f"{name} missing from policy"
             assert policy["secret"][name]["policy"] == "nats-seed", (

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -29,52 +29,14 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.helpers.secrets_manifest import (
+    factory_nats_seeds_expected,
+    parse_manifest_policy,
+    parse_manifest_sources,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SCRIPT = REPO_ROOT / "deploy" / "install.sh"
-MANIFEST_SH = REPO_ROOT / "deploy" / "generated" / "secrets-manifest.sh"
-
-
-# ---------------------------------------------------------------------------
-# helpers
-# ---------------------------------------------------------------------------
-
-
-def _parse_manifest_block(block_name: str) -> dict[str, str]:
-    """Parse a declare -A block from secrets-manifest.sh."""
-    entries: dict[str, str] = {}
-    in_block = False
-    for line in MANIFEST_SH.read_text().splitlines():
-        if f"{block_name}=(" in line:
-            in_block = True
-            continue
-        if in_block:
-            stripped = line.strip()
-            if stripped == ")":
-                break
-            if stripped.startswith("[") and "]=" in stripped:
-                name = stripped[1 : stripped.index("]=")]
-                val = stripped[stripped.index('="') + 2 : -1]
-                entries[name] = val
-    return entries
-
-
-def _parse_manifest_sources() -> dict[str, str]:
-    """Parse SECRET_SOURCES block from secrets-manifest.sh."""
-    return _parse_manifest_block("SECRET_SOURCES")
-
-
-def _parse_manifest_policy() -> dict[str, str]:
-    """Parse SECRET_POLICY block from secrets-manifest.sh (install.sh SSoT)."""
-    return _parse_manifest_block("SECRET_POLICY")
-
-
-def _factory_nats_seeds_expected() -> set[str]:
-    """All secrets with policy=nats-seed in the committed manifest."""
-    return {
-        name
-        for name, policy in _parse_manifest_policy().items()
-        if policy == "nats-seed"
-    }
 
 
 def _create_stub_seeds(home_tmp: Path) -> None:
@@ -85,8 +47,8 @@ def _create_stub_seeds(home_tmp: Path) -> None:
     Generated-policy secrets are skipped by the loop when DRY_RUN=1.
     Optional secrets are never validated (skipped by policy check).
     """
-    sources = _parse_manifest_sources()
-    policies = _parse_manifest_policy()
+    sources = parse_manifest_sources()
+    policies = parse_manifest_policy()
     factory_data = home_tmp / ".roxabi" / "factory"
 
     for name, rel in sources.items():
@@ -136,7 +98,7 @@ class TestDryRunListsAllNatsSecrets:
     def test_dry_run_mentions_all_nats_seed_secrets(self, tmp_path: Path) -> None:
         """[dry-run] lines must cover all manifest nats-seed secrets."""
         _create_stub_seeds(tmp_path)
-        expected = _factory_nats_seeds_expected()
+        expected = factory_nats_seeds_expected()
 
         result = _run_install_dry_run(tmp_path)
 

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -1,7 +1,7 @@
 """Tests for deploy/install.sh --dry-run — T18.
 
 Contract map:
-  A — dry-run lists all 7 factory-nats-* (incl. factory-nats-gh-helper — the #9 miss)
+  A — dry-run lists all factory-nats-* nats-seed secrets from secrets-manifest.sh
   B — blobstore data dir: dry-run logs mkdir of ~/.roxabi/factory/blobstore;
       pre-existing content never blocks
   D — missing nkeys dir → exits 1 (pre-condition gate)
@@ -27,25 +27,11 @@ from __future__ import annotations
 
 import os
 import subprocess
-import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SCRIPT = REPO_ROOT / "deploy" / "install.sh"
 MANIFEST_SH = REPO_ROOT / "deploy" / "generated" / "secrets-manifest.sh"
-POLICY_TOML = REPO_ROOT / "deploy" / "secrets-policy.toml"
-
-# Secrets that require seed files (non-optional, non-generated, source != 'n/a')
-FACTORY_NATS_SEEDS_EXPECTED = {
-    "factory-nats-hub",
-    "factory-nats-telegram",
-    "factory-nats-discord",
-    "factory-nats-web",
-    "factory-nats-clipool",
-    "factory-nats-turn-writer",
-    "factory-nats-blobstore",
-    "factory-nats-gh-helper",  # the #9 miss fixed by this PR
-}
 
 
 # ---------------------------------------------------------------------------
@@ -53,34 +39,42 @@ FACTORY_NATS_SEEDS_EXPECTED = {
 # ---------------------------------------------------------------------------
 
 
-def _parse_manifest_sources() -> dict[str, str]:
-    """Parse SECRET_SOURCES block from secrets-manifest.sh.
-
-    Returns {name: rel_path} where rel_path may be 'n/a'.
-    Only reads entries from the SECRET_SOURCES block (not SECRET_POLICY).
-    """
-    sources: dict[str, str] = {}
-    in_sources_block = False
+def _parse_manifest_block(block_name: str) -> dict[str, str]:
+    """Parse a declare -A block from secrets-manifest.sh."""
+    entries: dict[str, str] = {}
+    in_block = False
     for line in MANIFEST_SH.read_text().splitlines():
-        if "SECRET_SOURCES=(" in line:
-            in_sources_block = True
+        if f"{block_name}=(" in line:
+            in_block = True
             continue
-        if in_sources_block:
+        if in_block:
             stripped = line.strip()
             if stripped == ")":
-                break  # end of SECRET_SOURCES block
+                break
             if stripped.startswith("[") and "]=" in stripped:
                 name = stripped[1 : stripped.index("]=")]
                 val = stripped[stripped.index('="') + 2 : -1]
-                sources[name] = val
-    return sources
+                entries[name] = val
+    return entries
 
 
-def _parse_policy() -> dict[str, str]:
-    """Return {name: policy} from secrets-policy.toml."""
-    with POLICY_TOML.open("rb") as f:
-        data = tomllib.load(f)
-    return {name: attrs["policy"] for name, attrs in data.get("secret", {}).items()}
+def _parse_manifest_sources() -> dict[str, str]:
+    """Parse SECRET_SOURCES block from secrets-manifest.sh."""
+    return _parse_manifest_block("SECRET_SOURCES")
+
+
+def _parse_manifest_policy() -> dict[str, str]:
+    """Parse SECRET_POLICY block from secrets-manifest.sh (install.sh SSoT)."""
+    return _parse_manifest_block("SECRET_POLICY")
+
+
+def _factory_nats_seeds_expected() -> set[str]:
+    """All secrets with policy=nats-seed in the committed manifest."""
+    return {
+        name
+        for name, policy in _parse_manifest_policy().items()
+        if policy == "nats-seed"
+    }
 
 
 def _create_stub_seeds(home_tmp: Path) -> None:
@@ -92,7 +86,7 @@ def _create_stub_seeds(home_tmp: Path) -> None:
     Optional secrets are never validated (skipped by policy check).
     """
     sources = _parse_manifest_sources()
-    policies = _parse_policy()
+    policies = _parse_manifest_policy()
     factory_data = home_tmp / ".roxabi" / "factory"
 
     for name, rel in sources.items():
@@ -132,16 +126,17 @@ def _run_install_dry_run(
 
 
 # ---------------------------------------------------------------------------
-# Section A — dry-run lists all 7 factory-nats-* secrets including gh-helper
+# Section A — dry-run lists all factory-nats-* nats-seed secrets
 # ---------------------------------------------------------------------------
 
 
 class TestDryRunListsAllNatsSecrets:
-    """dry-run output must reference all 7 factory-nats-* seeds."""
+    """dry-run output must reference every factory-nats-* nats-seed secret."""
 
-    def test_dry_run_mentions_all_seven_nats_seeds(self, tmp_path: Path) -> None:
-        """[dry-run] lines must cover all 7 factory-nats-* seed secrets."""
+    def test_dry_run_mentions_all_nats_seed_secrets(self, tmp_path: Path) -> None:
+        """[dry-run] lines must cover all manifest nats-seed secrets."""
         _create_stub_seeds(tmp_path)
+        expected = _factory_nats_seeds_expected()
 
         result = _run_install_dry_run(tmp_path)
 
@@ -151,7 +146,7 @@ class TestDryRunListsAllNatsSecrets:
         )
 
         combined = result.stdout + result.stderr
-        missing = [name for name in FACTORY_NATS_SEEDS_EXPECTED if name not in combined]
+        missing = [name for name in expected if name not in combined]
         assert not missing, (
             f"install.sh --dry-run did not mention these secrets: {missing}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"

--- a/tests/tools/test_install_dry_run.py
+++ b/tests/tools/test_install_dry_run.py
@@ -12,15 +12,10 @@ We override HOME to a tmp dir so tests don't touch the real ~/.roxabi/factory.
 The script sources deploy/generated/secrets-manifest.sh (SCRIPT_DIR-relative,
 not HOME-relative) so the manifests used are the real committed ones.
 
-Seed file creation: the validation loop in install.sh checks seed file existence
-under --dry-run for non-optional, file-based secrets.  We create stub files for
-all required (non-optional, non-generated, source != 'n/a') secrets.
-
-Generated-policy secrets (factory_blobstore_token) are skipped by the validation
-loop when DRY_RUN=1 (install.sh lines ~135-137), so no stub is needed for them.
-
-Optional secrets (factory-gh-pem, factory-claude-oauth) are resolved via the
-uniform SECRET_SOURCES map in install.sh; their absence is silently skipped.
+Seed file creation: _create_stub_seeds writes every manifest source path plus
+generated token targets (blobstore.tok, otel.tok) so install.sh --dry-run never
+fails on optional/generated entries that install.sh may still warn about before
+policy dispatch.
 """
 
 from __future__ import annotations
@@ -40,12 +35,11 @@ INSTALL_SCRIPT = REPO_ROOT / "deploy" / "install.sh"
 
 
 def _create_stub_seeds(home_tmp: Path) -> None:
-    """Create stub seed files for all non-optional, file-based secrets.
+    """Create stub seed files for every path install.sh may validate under --dry-run.
 
-    The validation loop in install.sh checks seed file existence under --dry-run
-    for non-optional, non-generated secrets with a concrete source path.
-    Generated-policy secrets are skipped by the loop when DRY_RUN=1.
-    Optional secrets are never validated (skipped by policy check).
+    Required nats-seed files are the contract under test.  Optional and generated
+    paths are stubbed too so dry-run never fails on manifest/policy drift between
+    the Python test helpers and install.sh's bash parser (CI runners are strict).
     """
     sources = parse_manifest_sources()
     policies = parse_manifest_policy()
@@ -54,16 +48,29 @@ def _create_stub_seeds(home_tmp: Path) -> None:
     for name, rel in sources.items():
         if rel == "n/a":
             continue
-        policy = policies.get(name, "")
-        if policy in ("optional", "generated"):
-            continue  # optional: never validated; generated: skipped under --dry-run
         dest = factory_data / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(f"stub-seed-for-{name}\n")
 
-    # Ensure the nkeys dir exists (required by the NKEYS_DIR guard).
-    nkeys = factory_data / "nkeys"
-    nkeys.mkdir(parents=True, exist_ok=True)
+    # install.sh wires generated tokens into SEEDS before validation (blobstore.tok,
+    # otel.tok) even when DRY_RUN=1 — pre-create so the loop never sees MISSING.
+    for name, policy in policies.items():
+        if policy != "generated":
+            continue
+        rel = sources.get(name, "n/a")
+        if rel != "n/a":
+            path = factory_data / rel
+        elif name == "factory_blobstore_token":
+            path = factory_data / "blobstore.tok"
+        elif name == "factory_otel_token":
+            path = factory_data / "otel.tok"
+        else:
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"stub-generated-for-{name}\n")
+
+    # Required by the NKEYS_DIR guard in install.sh.
+    (factory_data / "nkeys").mkdir(parents=True, exist_ok=True)
 
 
 def _run_install_dry_run(

--- a/tests/typing/test_integration_nats.py
+++ b/tests/typing/test_integration_nats.py
@@ -13,7 +13,10 @@ from factory.transport.work_scope import WorkScope
 from factory.typing.listener import TypingListener
 from tests.nats.conftest import requires_nats_server
 
-pytestmark = pytest.mark.xdist_group(name="nats_server")
+pytestmark = [
+    pytest.mark.subprocess_nats,
+    pytest.mark.xdist_group(name="nats_server"),
+]
 
 
 @requires_nats_server


### PR DESCRIPTION
## Summary

Slice 1–2 of infra test debt audit:

- Register `subprocess_nats`, `live_acl`, `deploy_contract` markers with scoped collection hooks
- Harden `test_flow_round_trip_positive` subscribe-readiness (fixes `hub-voice-stt` flake)
- Align `test_install_dry_run` seed expectations to `secrets-manifest.sh` SSoT (11 nats-seed entries)

## Stack

**PR 2/4** — base: #2278

| # | PR | Files |
|---|-----|-------|
| 1 | #2278 consensus doc | 1 |
| **2** | **this PR** | 9 |
| 3 | #2280 CI split | 4 |
| 4 | #2281 axial cleanup | 6 |

## Test Plan

- [ ] `uv run pytest tests/scripts/test_parity_e2e.py -k flow_round_trip -v`
- [ ] `uv run pytest tests/tools/test_install_dry_run.py -v`
- [ ] `pytest --collect-only -m live_acl` → 71 nodes

---
Depends on #2278. Replaces #2277.