### PR TITLE
ci(tests): split infra pytest job from unit coverage (slice 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,8 @@ on:
   merge_group: {}
   workflow_dispatch: {}  # dispatch resolves from default branch — per-branch re-triggers require the branch to contain a compatible ci.yml
 
-# Single declaration site: the installer step is duplicated in the tests and
-# package-coverage jobs — a per-step env would let the two copies drift on a
-# version bump (coverage floors would then measure against different servers).
+# Single declaration site: nats-server install is duplicated in infra (and was
+# formerly in tests/package-coverage) — keep NATS_VERSION in sync on bumps.
 env:
   NATS_VERSION: "2.10.22"
 
@@ -30,9 +29,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'merge_group' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/staging' }}
 
 jobs:
-  # 3-way split of the former monolithic `ci` job (~4m50 serial → ~2m45 wall):
-  # gates / tests / package-coverage run in parallel; the aggregate `ci` job
-  # below keeps the required-check context stable.
+  # 4-way split: gates / tests / infra / package-coverage run in parallel; the
+  # aggregate `ci` job below keeps the required-check context stable. Infra
+  # isolates live-nats + deploy-contract suites from the bulk unit/coverage job.
 
   # No nats-server/nk here: no ci-stage gate shells out to either binary —
   # acl_authconf_drift runs `factory-acl genkeys --template-only`, which
@@ -129,48 +128,14 @@ jobs:
       - name: Test qg runner
         run: bash tests/scripts/test_qg.sh
 
-  # Dashboard e2e + factory unit coverage. Default-depth checkout: these
-  # pytest suites stub git (tests/deploy/test_converge_nats_restart.py) —
-  # only check_debt_expiry (gates job) needs full history.
+  # Dashboard e2e + in-process factory unit coverage (no live nats-server/nk).
+  # Live-infra suites run in the `infra` job. Default-depth checkout: these
+  # pytest suites stub git — only check_debt_expiry (gates job) needs full history.
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      # tests/nats + tests/bootstrap/test_embedded_nats.py spawn a real
-      # nats-server subprocess (tests/factories/nats_server.py).
-      - name: Install nats-server
-        run: |
-          ARCH=$(dpkg --print-architecture)
-          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
-          TMPDIR=$(mktemp -d)
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
-            -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
-            -o "${TMPDIR}/SHA256SUMS"
-          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
-          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
-          nats-server --version
-
-      # tests/scripts/test_nk.py + test_genkeys_modes.py exercise the real
-      # nk binary.
-      - name: Install nk
-        env:
-          NK_VERSION: "0.4.15"
-        run: |
-          ARCH=$(dpkg --print-architecture)
-          ZIPFILE="nkeys-v${NK_VERSION}-linux-${ARCH}.zip"
-          TMPDIR=$(mktemp -d)
-          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/${ZIPFILE}" \
-            -o "${TMPDIR}/${ZIPFILE}"
-          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/nkeys-v${NK_VERSION}-checksums.txt" \
-            -o "${TMPDIR}/checksums.txt"
-          cd "${TMPDIR}" && grep -F "${ZIPFILE}" checksums.txt | sha256sum --check
-          unzip -q "${TMPDIR}/${ZIPFILE}" -d "${TMPDIR}"
-          sudo install -m 755 "${TMPDIR}/nkeys-v${NK_VERSION}-linux-${ARCH}/nk" /usr/local/bin/nk
-          nk -v
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -222,10 +187,16 @@ jobs:
 
       # tests/integration runs in the dedicated integration job (against real
       # docker NATS) and tests/e2e in the step above — excluded here so each
-      # suite executes exactly once per run. No --reruns here: unit/coverage
-      # failures must surface on first occurrence.
+      # suite executes exactly once per run. Infra-marked suites (subprocess
+      # NATS, live ACL, deploy shell, nk tooling) run in the `infra` job.
+      # No --reruns: unit/coverage failures must surface on first occurrence.
       - name: Coverage — factory
-        run: uv run pytest tests/ --ignore=tests/integration --ignore=tests/e2e --cov=factory --cov-branch --cov-report=term-missing --cov-fail-under=50 --junitxml=reports/pytest-unit.xml
+        run: >-
+          uv run pytest tests/
+          --ignore=tests/integration --ignore=tests/e2e
+          -m "not live_acl and not subprocess_nats and not deploy_contract and not nk_tooling"
+          --cov=factory --cov-branch --cov-report=term-missing --cov-fail-under=50
+          --junitxml=reports/pytest-unit.xml
 
       # always(): junit XML is most valuable when a rerun turned the job green —
       # flake-recurrence observability. run_attempt suffix: v4 artifact names
@@ -239,29 +210,13 @@ jobs:
           retention-days: 5
           if-no-files-found: ignore
 
-  # Workspace package suites. roxabi-nats tests spawn a real nats-server
-  # subprocess and auto-skip without the binary — install it so the 70%
-  # floor keeps measuring real-server coverage. No nk (zero references in
-  # packages/*/tests), no bun.
+  # Live subprocess-nats suites for roxabi-nats run in `infra`; this job keeps
+  # in-process package coverage only. No nats-server/nk/bun.
   package-coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install nats-server
-        run: |
-          ARCH=$(dpkg --print-architecture)
-          TARBALL="nats-server-v${NATS_VERSION}-linux-${ARCH}.tar.gz"
-          TMPDIR=$(mktemp -d)
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/${TARBALL}" \
-            -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/SHA256SUMS" \
-            -o "${TMPDIR}/SHA256SUMS"
-          cd "${TMPDIR}" && grep -F "${TARBALL}" SHA256SUMS | sha256sum --check
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
-          sudo install -m 755 "${TMPDIR}/nats-server-v${NATS_VERSION}-linux-${ARCH}/nats-server" /usr/local/bin/nats-server
-          nats-server --version
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -270,7 +225,9 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Coverage — roxabi_nats
-        run: uv run pytest packages/roxabi-nats/tests --cov=roxabi_nats --cov-branch --cov-report=term-missing --cov-fail-under=70
+        run: >-
+          uv run pytest packages/roxabi-nats/tests -m "not subprocess_nats"
+          --cov=roxabi_nats --cov-branch --cov-report=term-missing --cov-fail-under=70
 
       - name: Coverage — roxabi_contracts
         run: uv run pytest packages/roxabi-contracts/tests --cov=roxabi_contracts --cov-branch --cov-report=term-missing --cov-fail-under=80
@@ -278,13 +235,65 @@ jobs:
       - name: Coverage — roxabi_obs
         run: uv run pytest packages/roxabi-obs/tests --cov=roxabi_obs --cov-branch --cov-report=term-missing --cov-fail-under=69
 
+  # Subprocess NATS, live ACL matrix, deploy shell contracts, nk tooling.
+  # Isolated from bulk unit/coverage so timing flakes don't block cov floors.
+  # No --reruns — structural fixes, not retry masking.
+  infra:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install nats-server
+        uses: ./.github/actions/install-nats-server
+        with:
+          nats-version: ${{ env.NATS_VERSION }}
+
+      - name: Install nk
+        env:
+          NK_VERSION: "0.4.15"
+        run: |
+          ARCH=$(dpkg --print-architecture)
+          ZIPFILE="nkeys-v${NK_VERSION}-linux-${ARCH}.zip"
+          TMPDIR=$(mktemp -d)
+          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/${ZIPFILE}" \
+            -o "${TMPDIR}/${ZIPFILE}"
+          curl -fsSL "https://github.com/nats-io/nkeys/releases/download/v${NK_VERSION}/nkeys-v${NK_VERSION}-checksums.txt" \
+            -o "${TMPDIR}/checksums.txt"
+          cd "${TMPDIR}" && grep -F "${ZIPFILE}" checksums.txt | sha256sum --check
+          unzip -q "${TMPDIR}/${ZIPFILE}" -d "${TMPDIR}"
+          sudo install -m 755 "${TMPDIR}/nkeys-v${NK_VERSION}-linux-${ARCH}/nk" /usr/local/bin/nk
+          nk -v
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Infra pytest (live NATS + deploy + nk)
+        run: >-
+          uv run pytest tests/ packages/roxabi-nats/tests
+          --ignore=tests/integration --ignore=tests/e2e
+          -m "live_acl or subprocess_nats or deploy_contract or nk_tooling"
+          -v --junitxml=reports/pytest-infra.xml
+
+      - name: Upload infra test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: infra-failure-artifacts-${{ github.run_attempt }}
+          path: reports/
+          retention-days: 5
+          if-no-files-found: ignore
+
   # Aggregate gate — staging branch protection requires the check context
-  # "ci" (strict). Keeping this job id `ci` means the 3-way split needs ZERO
+  # "ci" (strict). Keeping this job id `ci` means the split needs ZERO
   # branch-protection changes. `if: always()` is mandatory: without it, a
   # failed needed job leaves this job skipped, and a skipped required check
   # deadlocks merges exactly like a missing one.
   ci:
-    needs: [gates, tests, package-coverage]
+    needs: [gates, tests, infra, package-coverage]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,8 @@ jobs:
           retention-days: 5
           if-no-files-found: ignore
 
-  # Live subprocess-nats suites for roxabi-nats run in `infra`; this job keeps
-  # in-process package coverage only. No nats-server/nk/bun.
+  # In-process workspace packages only. roxabi-nats coverage runs in `infra`
+  # (full suite needs nats-server for readiness/testing modules). No nats-server/nk/bun.
   package-coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -223,11 +223,6 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --frozen --group dev
-
-      - name: Coverage — roxabi_nats
-        run: >-
-          uv run pytest packages/roxabi-nats/tests -m "not subprocess_nats"
-          --cov=roxabi_nats --cov-branch --cov-report=term-missing --cov-fail-under=70
 
       - name: Coverage — roxabi_contracts
         run: uv run pytest packages/roxabi-contracts/tests --cov=roxabi_contracts --cov-branch --cov-report=term-missing --cov-fail-under=80
@@ -271,9 +266,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --group dev
 
+      # Full roxabi-nats suite (in-process + subprocess_nats). Coverage floor
+      # applies here — splitting subprocess tests to this job dropped in-process-only
+      # coverage below 70% (readiness + testing/* need a live nats-server).
+      - name: Coverage — roxabi_nats
+        run: >-
+          uv run pytest packages/roxabi-nats/tests -n 1
+          --cov=roxabi_nats --cov-branch --cov-report=term-missing --cov-fail-under=70
+
       - name: Infra pytest (live NATS + deploy + nk)
         run: >-
-          uv run pytest tests/ packages/roxabi-nats/tests
+          uv run pytest tests/
           --ignore=tests/integration --ignore=tests/e2e
           -m "live_acl or subprocess_nats or deploy_contract or nk_tooling"
           -v --junitxml=reports/pytest-infra.xml

--- a/packages/roxabi-nats/pyproject.toml
+++ b/packages/roxabi-nats/pyproject.toml
@@ -39,3 +39,6 @@ packages = ["src/roxabi_nats"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "subprocess_nats: tests spawning a local nats-server subprocess (no auth.conf)",
+]

--- a/packages/roxabi-nats/tests/conftest.py
+++ b/packages/roxabi-nats/tests/conftest.py
@@ -45,8 +45,8 @@ def _register_stub_fixture() -> None:
 
 _register_stub_fixture()
 
-# Live-server modules only — mock-only suites (e.g. test_driver_base) stay in
-# package-coverage. xdist_group applied in modifyitems for subprocess modules.
+# Live-server modules only — mock-only suites (e.g. test_driver_base) run in the
+# same job but outside this marker. xdist_group applied in modifyitems below.
 _SUBPROCESS_NAT_MODULES = frozenset({
     "test_readiness.py",
     "test_image_testing_doubles.py",

--- a/packages/roxabi-nats/tests/conftest.py
+++ b/packages/roxabi-nats/tests/conftest.py
@@ -45,13 +45,10 @@ def _register_stub_fixture() -> None:
 
 _register_stub_fixture()
 
-# Serialize live-server tests on one xdist worker (see tests/nats/conftest.py).
-pytestmark = pytest.mark.xdist_group(name="nats_server")
-
-
+# Live-server modules only — mock-only suites (e.g. test_driver_base) stay in
+# package-coverage. xdist_group applied in modifyitems for subprocess modules.
 _SUBPROCESS_NAT_MODULES = frozenset({
     "test_readiness.py",
-    "test_driver_base.py",
     "test_image_testing_doubles.py",
     "test_voice_testing_doubles.py",
 })

--- a/packages/roxabi-nats/tests/conftest.py
+++ b/packages/roxabi-nats/tests/conftest.py
@@ -49,9 +49,19 @@ _register_stub_fixture()
 pytestmark = pytest.mark.xdist_group(name="nats_server")
 
 
+_SUBPROCESS_NAT_MODULES = frozenset({
+    "test_readiness.py",
+    "test_driver_base.py",
+    "test_image_testing_doubles.py",
+    "test_voice_testing_doubles.py",
+})
+
+
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         if "/packages/roxabi-nats/tests/" not in str(item.fspath):
+            continue
+        if Path(item.fspath).name not in _SUBPROCESS_NAT_MODULES:
             continue
         item.add_marker(pytest.mark.subprocess_nats)
         item.add_marker(pytest.mark.xdist_group(name="nats_server"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ markers = [
     "subprocess_nats: tests spawning a local nats-server subprocess (no auth.conf)",
     "live_acl: live nats-server with rendered auth.conf and nk seeds",
     "deploy_contract: deploy/install/converge/quadlet bash contract tests",
+    "nk_tooling: tests requiring the nk binary on PATH (no live nats-server)",
     "audio_consumer_live: test exercises audio consumer directly; skip the autouse no-op neutralizer",
     "bot_store_live: test exercises real BotStore roster loading; skip autouse roster mocks",
     "smoke: fast in-process smoke tests for critical user-facing paths",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ markers = [
     "subprocess_nats: tests spawning a local nats-server subprocess (no auth.conf)",
     "live_acl: live nats-server with rendered auth.conf and nk seeds",
     "deploy_contract: deploy/install/converge/quadlet bash contract tests",
-    "nk_tooling: tests requiring the nk binary on PATH (no live nats-server)",
+    "nk_tooling: tests shelling out to the nk binary on PATH (no live nats-server)",
     "audio_consumer_live: test exercises audio consumer directly; skip the autouse no-op neutralizer",
     "bot_store_live: test exercises real BotStore roster loading; skip autouse roster mocks",
     "smoke: fast in-process smoke tests for critical user-facing paths",

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -20,11 +20,8 @@ _V1_LEGACY_JSON = FIXTURES_DIR / "v1-legacy.json"
 _V2_WITH_RETIRED_JSON = FIXTURES_DIR / "v2-with-retired.json"
 _REAL_MATRIX_JSON = REPO / "deploy" / "nats" / "acl-matrix.json"
 
-_NK_TOOL_MODULES = frozenset({
-    "test_nk.py",
-    "test_genkeys_modes.py",
-    "test_genkeys_modes_add_identity.py",
-})
+# Only suites that shell out to the nk binary — genkeys_modes* use FakeNkeyProvider.
+_NK_TOOL_MODULES = frozenset({"test_nk.py"})
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -20,6 +20,21 @@ _V1_LEGACY_JSON = FIXTURES_DIR / "v1-legacy.json"
 _V2_WITH_RETIRED_JSON = FIXTURES_DIR / "v2-with-retired.json"
 _REAL_MATRIX_JSON = REPO / "deploy" / "nats" / "acl-matrix.json"
 
+_NK_TOOL_MODULES = frozenset({
+    "test_nk.py",
+    "test_genkeys_modes.py",
+    "test_genkeys_modes_add_identity.py",
+})
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if "/tests/scripts/" not in str(item.fspath):
+            continue
+        if Path(item.fspath).name not in _NK_TOOL_MODULES:
+            continue
+        item.add_marker(pytest.mark.nk_tooling)
+
 
 # ── Path fixtures (copies to tmp_path for isolation) ─────────────────────────
 

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -31,6 +32,42 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         if Path(item.fspath).name not in _NK_TOOL_MODULES:
             continue
         item.add_marker(pytest.mark.nk_tooling)
+
+
+_live_acl_ci_guard_checked = False
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Hard-fail before the first live_acl test when CI infra deps are absent.
+
+    Runs only for tests that survive the active ``-m`` filter, so the ``tests``
+    job (``not live_acl``) imports ``test_parity_e2e`` without nats-server/nk
+    while the ``infra`` job still fails loudly on a broken runner (#2247).
+    """
+    global _live_acl_ci_guard_checked
+    if _live_acl_ci_guard_checked or item.get_closest_marker("live_acl") is None:
+        return
+    _live_acl_ci_guard_checked = True
+
+    from tests.scripts.test_parity_e2e import (
+        NATS_AVAILABLE,
+        NATS_PY_AVAILABLE,
+        NK_AVAILABLE,
+        _ci_hardfail_missing_deps,
+    )
+
+    missing = _ci_hardfail_missing_deps(
+        github_actions=os.getenv("GITHUB_ACTIONS") == "true",
+        nats_available=NATS_AVAILABLE,
+        nk_available=NK_AVAILABLE,
+        nats_py_available=NATS_PY_AVAILABLE,
+    )
+    if missing:
+        pytest.fail(
+            f"GITHUB_ACTIONS=true but missing: {', '.join(missing)} — "
+            "CI must install nats-server + nk and have nats-py importable; a "
+            "silent skip here would mask a broken CI environment (#2247)."
+        )
 
 
 # ── Path fixtures (copies to tmp_path for isolation) ─────────────────────────

--- a/tests/scripts/test_parity_e2e.py
+++ b/tests/scripts/test_parity_e2e.py
@@ -66,10 +66,9 @@ NATS_PY_AVAILABLE: bool = _nats_py_available
 #
 # The decision itself (not just the missing-deps list) is factored into a
 # pure function so it can be unit-tested directly below
-# (test_ci_hardfail_guard_*) — the guard fires once at module-import time
-# and can't be re-triggered in-process, so without this extraction neither
-# a deleted guard nor a silently-inverted `== "true"` condition would have
-# any automated regression coverage (#2251 review, N6 finding).
+# (test_ci_hardfail_guard_*). Enforcement lives in tests/scripts/conftest.py
+# (pytest_runtest_setup on the first live_acl test) — the tests job excludes
+# live_acl (no nats-server/nk), so import must not hard-fail there (#2251, N6).
 def _ci_hardfail_missing_deps(
     *,
     github_actions: bool,
@@ -95,19 +94,6 @@ def _ci_hardfail_missing_deps(
         if not available
     ]
 
-
-_ci_hardfail_missing = _ci_hardfail_missing_deps(
-    github_actions=os.getenv("GITHUB_ACTIONS") == "true",
-    nats_available=NATS_AVAILABLE,
-    nk_available=NK_AVAILABLE,
-    nats_py_available=NATS_PY_AVAILABLE,
-)
-if _ci_hardfail_missing:
-    pytest.fail(
-        f"GITHUB_ACTIONS=true but missing: {', '.join(_ci_hardfail_missing)} — "
-        "CI must install nats-server + nk and have nats-py importable; a "
-        "silent skip here would mask a broken CI environment (#2247)."
-    )
 
 # ── Matrix-driven parametrization (#2247) ───────────────────────────────────
 # Sourced directly from the SSoT (deploy/nats/acl-matrix.json), not from the
@@ -266,10 +252,17 @@ async def _request_when_responders_ready(
     raise last
 
 
+def _skip_without_nats_binaries() -> bool:
+    """Skip locally when binaries are absent; on GHA conftest guard fails instead."""
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        return False
+    return not (NATS_AVAILABLE and NK_AVAILABLE)
+
+
 pytestmark = [
     pytest.mark.live_acl,
     pytest.mark.skipif(
-        not (NATS_AVAILABLE and NK_AVAILABLE),
+        _skip_without_nats_binaries(),
         reason="nats-server and nk must be on PATH — CI installs both",
     ),
     # Keep all tests in this file on a single pytest-xdist worker. Each test
@@ -687,12 +680,11 @@ def test_ci_hardfail_guard_noop_outside_github_actions() -> None:
 def test_ci_hardfail_guard_fires_in_github_actions_with_missing_deps() -> None:
     """N6 guard: `github_actions=True` reports every missing dep by name.
 
-    Regression coverage for the guard itself (module-level `pytest.fail`
-    fires once at import time and can't be re-triggered in-process) — a
-    future edit that deletes the guard, drops a dep from the check, or
-    silently inverts the `== "true"` condition it's built from now fails
-    this always-collected unit test instead of only a scenario nobody runs
-    by default (`GITHUB_ACTIONS=true PATH=/usr/bin`, per the PR Test Plan).
+    Regression coverage for the guard decision function — a future edit that
+    deletes the guard, drops a dep from the check, or silently inverts the
+    `== "true"` condition it's built from now fails this always-collected
+    unit test instead of only a scenario nobody runs by default
+    (`GITHUB_ACTIONS=true PATH=/usr/bin`, per the PR Test Plan).
     """
     assert _ci_hardfail_missing_deps(
         github_actions=True,


### PR DESCRIPTION
## Summary

Slice 3 — CI boundary split:

- New `infra` job (nats-server + nk, 15 min): `-m "live_acl or subprocess_nats or deploy_contract or nk_tooling"`
- `tests` + `package-coverage` jobs exclude infra markers
- Add `nk_tooling` marker; scope `subprocess_nats` in roxabi-nats to live-server modules only
- Aggregate `ci` job: `needs: [gates, tests, infra, package-coverage]`

## Stack

**PR 3/4** — base: #2279

| # | PR | Files |
|---|-----|-------|
| 1 | #2278 | 1 |
| 2 | #2279 markers | 9 |
| **3** | **this PR** | 4 |
| 4 | #2281 | 6 |

## Test Plan

- [ ] CI `infra` job collects 608 tests
- [ ] CI `tests` job no longer installs nats-server/nk

---
Depends on #2279. Replaces #2277.