### PR TITLE
deploy(llmcli): track :staging with registry autoupdate on M₁

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -56,7 +56,7 @@ Rollback: edit `Image=` to previous semver tag → `systemctl --user daemon-relo
 
 The M₁ always-on cloud LLM gateway — **`factory-litellm`** (LiteLLM proxy :18091), **`llmcli-xai-forwarder`** (:18645, xAI/Grok OAuth relay), **`llmcli-fw-forwarder`** (:18646, Fireworks) — is deployed from this repo (`deploy/quadlet/{factory-litellm,llmcli-xai-forwarder,llmcli-fw-forwarder}.container` + `[component.litellm-proxy|xai-forwarder|fw-forwarder]`, `host_roles=["factory-hub"]`). The proxy container was renamed `llmcli`→`factory-litellm` (factory-`<component>` convention) to avoid a filename collision with llmCLI's own M₂ `llmcli.container` — `cluster_plan` matches by filename, so a shared name leaked llmCLI's M₂ proxy into M₁'s install-plan. Rationale: HA requires M₁ to answer LLM 24/7 (LiteLLM→cloud), so the always-on gateway belongs with the always-on hub.
 
-**Boundary** — factory owns *deployment* (host placement, converge lifecycle, digest pin, secret wiring); Roxabi/llmCLI owns *code + image* (`ghcr.io/roxabi/llmcli`, built + published by its CI) and the **M₂ local GPU worker** (`llmcli-nats-worker` + engines, `host_roles=["llm-worker"]`, unchanged — deferred). The units are byte-vendored from llmCLI; do not diverge them beyond the digest pin.
+**Boundary** — factory owns *deployment* (host placement, converge lifecycle, autoupdate wiring, secret wiring); Roxabi/llmCLI owns *code + image* (`ghcr.io/roxabi/llmcli`, built + published by its CI) and the **M₂ local GPU worker** (`llmcli-nats-worker` + engines, `host_roles=["llm-worker"]`, unchanged — deferred). The units are byte-vendored from llmCLI; M₁ gateway images track `:staging` via `io.containers.autoupdate=registry`.
 
 **Carve-outs from § Hardening invariants** (intentional — do not "normalize"):
 - `UserNS=keep-id:uid=1502,gid=1502` — the llmCLI image runs as uid 1502 (distinct from factory 1500 / voicecli 1501). The `NoNewPrivileges`/`ReadOnly`/`DropCapability=all` trio is present.
@@ -67,15 +67,10 @@ The M₁ always-on cloud LLM gateway — **`factory-litellm`** (LiteLLM proxy :1
 
 ### llmCLI cloud-gateway image
 
-Pinned by digest (¬autoupdate) so factory controls gateway bumps. To bump:
-
-```bash
-# 1. resolve the desired digest (current good staging on M₁, or a release tag)
-skopeo inspect docker://ghcr.io/roxabi/llmcli:staging --format '{{.Digest}}'
-# 2. set Image=ghcr.io/roxabi/llmcli@sha256:<digest> in all 3 deploy/quadlet/{factory-litellm,llmcli-xai-forwarder,llmcli-fw-forwarder}.container
-# 3. commit → merge staging → M₁ converge picks it up
-#    (or manual: systemctl --user restart factory-litellm llmcli-xai-forwarder llmcli-fw-forwarder)
-```
+`ghcr.io/roxabi/llmcli:staging` with `Label=io.containers.autoupdate=registry` in all three
+`deploy/quadlet/{factory-litellm,llmcli-xai-forwarder,llmcli-fw-forwarder}.container` files.
+`podman-auto-update.timer` pulls new staging builds and restarts the units (same as voiceCLI).
+Manual catch-up: `podman auto-update && systemctl --user restart factory-litellm llmcli-xai-forwarder llmcli-fw-forwarder`.
 
 ---
 

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -143,8 +143,8 @@ host_roles = ["factory-hub"]
 # --- llmCLI cloud gateway (vendored from Roxabi/llmCLI) ----------------------
 # LiteLLM proxy (:18091) + xAI/Grok forwarder (:18645) + Fireworks forwarder
 # (:18646). Deployment owned here — M₁ always-on cloud LLM gateway (HA: M₁ must
-# answer LLM 24/7). Image is built + published by llmCLI CI, pinned by digest in
-# the .container files (¬autoupdate). Local GPU inference (llmcli-nats-worker,
+# answer LLM 24/7). Image is built + published by llmCLI CI; M₁ units use
+# ghcr.io/roxabi/llmcli:staging + autoupdate=registry. Local GPU inference (llmcli-nats-worker,
 # M₂) stays in Roxabi/llmCLI. required_secrets=[]: the proxy master key is read
 # from ~/.roxabi/llmcli/env/proxy.env (grandfathered llmcli data dir), not a
 # Podman secret — hardening to a type=mount _FILE secret is a tracked follow-up.

--- a/deploy/quadlet/factory-litellm.container
+++ b/deploy/quadlet/factory-litellm.container
@@ -6,9 +6,9 @@ StartLimitBurst=5
 [Container]
 # Vendored from Roxabi/llmCLI (deploy/quadlet/). Deployment owned by roxabi-factory
 # (M₁ 24/7 cloud gateway, factory-hub role); the image is still built + published by
-# llmCLI CI. Pinned by digest so factory controls gateway bumps — ¬autoupdate label.
-# Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
-Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
+# llmCLI CI. :staging + autoupdate (same pattern as voiceCLI on M₁).
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
 ContainerName=factory-litellm
 # Renamed llmcli → factory-litellm: factory-<component> convention + avoids a filename
 # collision with llmCLI's own M₂ llmcli.container (cluster_plan matches by filename, so

--- a/deploy/quadlet/llmcli-fw-forwarder.container
+++ b/deploy/quadlet/llmcli-fw-forwarder.container
@@ -5,9 +5,9 @@ StartLimitBurst=5
 
 [Container]
 # Vendored from Roxabi/llmCLI — deployment owned by roxabi-factory (M₁ cloud gateway).
-# Image built + published by llmCLI CI; pinned by digest here (¬autoupdate) so factory
-# controls bumps. Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
-Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
+# Image built + published by llmCLI CI; :staging + autoupdate (same pattern as voiceCLI).
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
 ContainerName=llmcli-fw-forwarder
 # No PublishPort — internal to roxabi.network only (reachable as
 # http://llmcli-fw-forwarder:18646 from other containers on roxabi.network)

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -5,9 +5,9 @@ StartLimitBurst=5
 
 [Container]
 # Vendored from Roxabi/llmCLI — deployment owned by roxabi-factory (M₁ cloud gateway).
-# Image built + published by llmCLI CI; pinned by digest here (¬autoupdate) so factory
-# controls bumps. Bump recipe → deploy/AGENTS.md § llmCLI cloud-gateway image.
-Image=ghcr.io/roxabi/llmcli@sha256:3d52ccf3397b7b6e487833869eeb3b6a9c01d68426b4a3aaf0452b2a706f8217
+# Image built + published by llmCLI CI; :staging + autoupdate (same pattern as voiceCLI).
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
 ContainerName=llmcli-xai-forwarder
 # Reachable two ways:
 #  - container-to-container via roxabi.network DNS (http://llmcli-xai-forwarder:18645)


### PR DESCRIPTION
Replace digest-pinned `ghcr.io/roxabi/llmcli@sha256:3d52ccf3…` with floating `:staging` + `io.containers.autoupdate=registry` on the three M₁ cloud-gateway units (factory-litellm, xai-forwarder, fw-forwarder).

Aligns llmCLI M₁ deploy with voiceCLI — podman-auto-update pulls new staging builds without manual digest bump PRs.