### PR TITLE
feat(ci): pytest partition SSoT + make pre-pr

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -274,8 +274,8 @@ quality_gates:
     enabled: true
     script: PYTHONPATH=src uv run python tools/check_pytest_partition.py
     stages: [ci]
-    files: ^(tests/|packages/roxabi-nats/tests/|pyproject\.toml$|\.github/workflows/ci\.yml$|tools/check_pytest_partition\.py$)
-    description: CI pytest job partitions are disjoint and cover each pool (collect-only; mirrors ci.yml -m expressions)
+    files: ^(tests/|packages/roxabi-nats/tests/|pyproject\.toml$|\.github/workflows/ci\.yml$|scripts/ci-pytest\.sh$|tools/(check_pytest_partition|pytest_partitions)\.py$)
+    description: CI pytest job partitions are disjoint and cover each pool (collect-only; SSoT tools/pytest_partitions.py)
 
   secrets_drift:
     enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,7 @@ jobs:
       # first occurrence.
       - name: Coverage — factory
         run: >-
-          uv run pytest tests/
-          --ignore=tests/e2e
-          -m "not live_acl and not subprocess_nats and not deploy_contract and not nk_tooling and not nats_integration"
+          bash scripts/ci-pytest.sh factory_unit
           --cov=factory --cov-branch --cov-report=term-missing --cov-fail-under=50
           --junitxml=reports/pytest-unit.xml
 
@@ -218,10 +216,14 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Coverage — roxabi_contracts
-        run: uv run pytest packages/roxabi-contracts/tests --cov=roxabi_contracts --cov-branch --cov-report=term-missing --cov-fail-under=80
+        run: >-
+          bash scripts/ci-pytest.sh roxabi_contracts
+          --cov=roxabi_contracts --cov-branch --cov-report=term-missing --cov-fail-under=80
 
       - name: Coverage — roxabi_obs
-        run: uv run pytest packages/roxabi-obs/tests --cov=roxabi_obs --cov-branch --cov-report=term-missing --cov-fail-under=69
+        run: >-
+          bash scripts/ci-pytest.sh roxabi_obs
+          --cov=roxabi_obs --cov-branch --cov-report=term-missing --cov-fail-under=69
 
   # Subprocess NATS, live ACL matrix, deploy shell contracts, nk tooling.
   # Isolated from bulk unit/coverage so timing flakes don't block cov floors.
@@ -264,14 +266,12 @@ jobs:
       # coverage below 70% (readiness + testing/* need a live nats-server).
       - name: Coverage — roxabi_nats
         run: >-
-          uv run pytest packages/roxabi-nats/tests -n 1
+          bash scripts/ci-pytest.sh roxabi_nats -n 1
           --cov=roxabi_nats --cov-branch --cov-report=term-missing --cov-fail-under=70
 
       - name: Infra pytest (live NATS + deploy + nk)
         run: >-
-          uv run pytest tests/
-          --ignore=tests/integration --ignore=tests/e2e
-          -m "live_acl or subprocess_nats or deploy_contract or nk_tooling"
+          bash scripts/ci-pytest.sh factory_infra
           -v --junitxml=reports/pytest-infra.xml
 
       - name: Upload infra test reports
@@ -340,8 +340,7 @@ jobs:
         env:
           NATS_URL: nats://localhost:4222
         run: >-
-          uv run pytest tests/integration/
-          -m nats_integration
+          bash scripts/ci-pytest.sh factory_integration
           -v --reruns 1 --reruns-delay 5 --junitxml=reports/pytest-integration.xml
 
       - name: Tear down Docker environment

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ define require_machine1
 	@case "$(DEPLOY_DIR)" in *[\'\"\$$\\\;\&\|\`]*) echo "Error: DEPLOY_DIR contains shell metacharacters"; exit 1 ;; esac
 endef
 
-.PHONY: build push factory telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy converge remote nats-setup nats-regen-authconf nats-add-identity check-seed-age test test-integration voice-smoke lint typecheck format dev-setup hooks-install quality-debt-report quality-debt-classify qg fleet-obs-evidence build-dashboard lint-js
+.PHONY: build push factory telegram discord nats clipool monitor quadlet-preflight quadlet-install quadlet-sync-install quadlet-secrets-install quadlet-authconf-merged quadlet-lint deploy full-deploy converge remote nats-setup nats-regen-authconf nats-add-identity check-seed-age test test-integration voice-smoke lint typecheck format dev-setup hooks-install quality-debt-report quality-debt-classify qg pre-pr fleet-obs-evidence build-dashboard lint-js
 
 # ── Container image build + transfer ─────────────────────────────────────────
 
@@ -393,6 +393,11 @@ lint-js:               ## lint JS/TS workspaces (biome)
 # Capture with: make qg 2>&1 | tee "${GOAL_1771_SCRATCH:-/tmp}/b3-qg.log"
 fleet-obs-evidence:  ## run scripts/goal-fleet-obs-evidence.sh (fleet goal verification plan steps 1–8)
 	bash scripts/goal-fleet-obs-evidence.sh
+
+pre-pr:  ## lightweight pre-PR check (pre-push gates + qg plan + pytest partitions)
+	scripts/qg run --stage pre-push
+	QG_DIFF_RANGE="$${QG_DIFF_RANGE:-origin/staging...HEAD}" scripts/qg plan --stage ci --format github
+	PYTHONPATH=src uv run python tools/check_pytest_partition.py
 
 qg:  ## local QG bundle (stack.yml qg.profiles.local + factory flows/tests)
 	scripts/qg run --profile local

--- a/artifacts/handoffs/2026-07-11-ci-pytest-tier1-passation.mdx
+++ b/artifacts/handoffs/2026-07-11-ci-pytest-tier1-passation.mdx
@@ -1,0 +1,219 @@
+---
+title: "Passation — CI pytest Tier 1 + follow-ups axial"
+date: 2026-07-11
+branch: staging
+commit: 9ef2dcf3a3ffcb9bbcf9e868781ab6dfd24eec4d
+status: tier1-code-local — PR non ouverte (à vérifier git status)
+---
+
+# Passation session — infra-test-debt / Tier 1
+
+## Contexte
+
+Stack **infra-test-debt** (#2278–#2281) **MERGED** sur `staging` (2026-07-11). CI verte post-merge.
+
+Panel (devops + architect + axial) a recommandé :
+
+1. **Tier 1 d'abord** — SSoT partitions, `qg plan`, `make pre-pr`, doc merge queue
+2. **Axial ensuite** — via #2285 + nouvelles issues
+
+**Tier 1 est implémenté localement** dans cette session. Les issues axial ont été créées manuellement par l'utilisateur (shell agent cassé pendant toute la session).
+
+---
+
+## Issues GitHub
+
+| Issue | Titre | État | Notes |
+|-------|-------|------|-------|
+| [#2285](https://github.com/Roxabi/roxabi-factory/issues/2285) | per-class `subprocess_nats` roxabi-nats | OPEN | Ancre axial ; commentaire Tier 1 ajouté |
+| [#2287](https://github.com/Roxabi/roxabi-factory/issues/2287) | directory↔marker gate | OPEN | blocked-by #2285 |
+| [#2288](https://github.com/Roxabi/roxabi-factory/issues/2288) | split `tests/nats/` | OPEN | blocked-by #2285 |
+
+Issues **fermées / livrées** (ne pas refaire) :
+
+- #2249 phase 0–1 (`qg plan`) — CLOSED
+- #2278–#2281 infra-test-debt — MERGED
+
+**Gaps sans issue** (hors scope Tier 1 actuel) :
+
+- #2249 phase 2 — jobs `tests`/`package-coverage` conditionnels selon `qg plan`
+
+---
+
+## Tier 1 — ce qui a été fait
+
+### SSoT partitions
+
+- **`tools/pytest_partitions.py`** — expressions `-m` / `--ignore`, partitions nommées, tripwire `verify_ci_yml_sync()`
+- **`scripts/ci-pytest.sh`** — `bash scripts/ci-pytest.sh <partition> [args pytest…]`
+- **`tools/check_pytest_partition.py`** — collect-only disjoint/cover + vérifie que `ci.yml` référence `ci-pytest.sh`
+
+### CI
+
+`.github/workflows/ci.yml` délègue les 6 invocations pytest :
+
+| Job | Partition | Extra args typiques |
+|-----|-----------|---------------------|
+| `tests` | `factory_unit` | `--cov=factory … --cov-fail-under=50` |
+| `infra` | `factory_infra` | `-v --junitxml=…` |
+| `infra` | `roxabi_nats` | `-n 1 --cov=roxabi_nats … --cov-fail-under=70` |
+| `integration` | `factory_integration` | `--reruns 1 …` |
+| `package-coverage` | `roxabi_contracts` / `roxabi_obs` | cov floors |
+
+### Ergonomie locale
+
+- **`make pre-pr`** — `pre-push` + `qg plan --stage ci` (`QG_DIFF_RANGE=origin/staging...HEAD`) + `check_pytest_partition`
+- Docs : `docs/runbooks/quality-gates.md` (§ Pre-PR ritual), `docs/runbooks/pr-automation.md` (checklist avant `reviewed`)
+- **`.claude/stack.yml`** — gate `pytest_partition` : `files:` étendu à `scripts/ci-pytest.sh` + `pytest_partitions.py`
+
+### Fichiers modifiés / créés
+
+```
+tools/pytest_partitions.py          # NEW — SSoT
+scripts/ci-pytest.sh                # NEW
+tools/check_pytest_partition.py     # refacto → import SSoT
+.github/workflows/ci.yml            # bash scripts/ci-pytest.sh …
+.claude/stack.yml                   # pytest_partition files:
+Makefile                            # target pre-pr
+docs/runbooks/quality-gates.md
+docs/runbooks/pr-automation.md
+```
+
+**À supprimer** (temporaire, déjà exécuté) :
+
+```
+.tmp-create-infra-followup-issues.sh
+```
+
+---
+
+## État git (à confirmer en nouvelle session)
+
+- Branche lue statiquement : **`staging`** @ `9ef2dcf3`
+- `origin/staging` même SHA au moment de la passation
+- **Statut working tree inconnu** — Tier 1 peut être **non commité**
+
+Première action nouvelle session :
+
+```bash
+cd /home/mickael/projects/roxabi-factory
+git status -sb
+git diff --stat
+```
+
+---
+
+## Checklist démarrage nouvelle session
+
+### 1. Vérifier que le shell agent fonctionne
+
+```bash
+echo ok && pwd
+```
+
+Si `failed to spawn` → problème harness Grok, pas le repo. L'utilisateur peut toujours exécuter en local.
+
+### 2. Valider Tier 1
+
+```bash
+cd /home/mickael/projects/roxabi-factory
+git fetch origin staging
+
+bash tests/tools/test_check_pytest_partition.sh
+PYTHONPATH=src uv run python tools/check_pytest_partition.py
+
+# optionnel — long (~pre-push)
+make pre-pr
+```
+
+Attendu : `check_pytest_partition: OK` + counts factory/nats cohérents.
+
+### 3. Commit + PR (si pas déjà fait)
+
+```bash
+git checkout -b feat/ci-pytest-partitions-tier1
+
+git add \
+  tools/pytest_partitions.py \
+  scripts/ci-pytest.sh \
+  tools/check_pytest_partition.py \
+  .github/workflows/ci.yml \
+  .claude/stack.yml \
+  Makefile \
+  docs/runbooks/quality-gates.md \
+  docs/runbooks/pr-automation.md \
+  artifacts/handoffs/2026-07-11-ci-pytest-tier1-passation.mdx
+
+git commit -m "feat(ci): pytest partition SSoT + make pre-pr"
+
+git push -u origin feat/ci-pytest-partitions-tier1
+```
+
+**PR** → base `staging`. Corps suggéré :
+
+- SSoT `tools/pytest_partitions.py` + `scripts/ci-pytest.sh`
+- Gate `check_pytest_partition` vérifie disjoint/cover + sync `ci.yml`
+- `make pre-pr` + doc rituel avant `reviewed`
+- Follow-ups : #2285, #2287, #2288 (hors scope PR)
+
+### 4. Après merge Tier 1
+
+Ordre recommandé axial :
+
+1. **#2285** — markers per-class roxabi-nats
+2. **#2287** — gate directory↔marker
+3. **#2288** — split `tests/nats/`
+
+---
+
+## Référence CI partitions (post #2281)
+
+| Job | Sélection |
+|-----|-----------|
+| `tests` | `factory_unit` — exclut infra markers + `nats_integration` |
+| `infra` | `factory_infra` + `roxabi_nats` full suite |
+| `integration` | `factory_integration` — `tests/integration/` `-m nats_integration` |
+| `package-coverage` | `roxabi_contracts`, `roxabi_obs` (pas roxabi-nats) |
+
+Aggregate `ci` : `needs: [gates, tests, infra, package-coverage]`.
+
+Required checks `staging` : **`ci`**, **`trufflehog`**, **`docker-build`** (`infra` pas required nommé, bloque via aggregate `ci`).
+
+---
+
+## Rejets panel (ne pas réintroduire)
+
+- `pytest_partition` sur chaque pre-push (trop lourd)
+- Makefile dupliquant les `-m` en dur
+- Rituel humain lourd obligatoire avant `reviewed` (doc légère OK, pas de cérémonie)
+
+---
+
+## SECRET_POLICY / secrets-policy.toml
+
+Chaîne compile, pas doublon SSoT :
+
+`deploy/secrets-policy.toml` → `emit_secrets_manifest.py` → `deploy/generated/secrets-manifest.sh` → `install.sh`
+
+Gate existant : `check_secrets_drift`. Pas de gate manifest↔TOML supplémentaire recommandé.
+
+---
+
+## Prompt suggéré pour la nouvelle session
+
+```
+Lis artifacts/handoffs/2026-07-11-ci-pytest-tier1-passation.mdx
+
+1. Vérifie git status — Tier 1 commité ou pas ?
+2. Lance bash tests/tools/test_check_pytest_partition.sh + make pre-pr si shell OK
+3. Si pas de PR : commit, push, ouvre PR feat/ci-pytest-partitions-tier1 → staging
+4. Supprime .tmp-create-infra-followup-issues.sh si présent
+```
+
+---
+
+## Historique session précédente
+
+- Shell agent : **cassé** (`failed to spawn`) pendant toute la session — tests/PR non exécutés par l'agent
+- Issues #2287/#2288 + commentaire #2285 : créés par l'utilisateur via `.tmp-create-infra-followup-issues.sh`
+- Conversation summary : overlap Tier 1 / issues analysé ; Tier 1 recommandé avant axial

--- a/docs/runbooks/pr-automation.md
+++ b/docs/runbooks/pr-automation.md
@@ -86,6 +86,16 @@ PRs labelled `roxabi-sdk` (grouped `git-refs` bumps for `roxabi-contracts` / `ro
 - CI (+ `docker-build` on factory) is the actual safety gate, not the label: a labelled PR with
   a breaking bump still needs green required checks to merge.
 
+## Pre-`reviewed` checklist
+
+Before adding `reviewed` on a human-authored PR:
+
+1. **`make pre-pr`** — pre-push gates, `qg plan --stage ci` on `origin/staging...HEAD`, and the
+   pytest-partition collect-only gate (`docs/runbooks/quality-gates.md` § Pre-PR ritual).
+2. Confirm PR-level required checks (`ci`, `trufflehog`, `docker-build`) are green.
+3. Apply `reviewed` only after both — the label arms merge-when-ready; the merge queue then runs
+   the **full** suite on a temporary queue ref (fail-open: empty `QG_DIFF_RANGE`).
+
 ## Troubleshooting
 
 If a human-authored PR "won't merge" despite green CI: check for the `reviewed` label — that's

--- a/docs/runbooks/quality-gates.md
+++ b/docs/runbooks/quality-gates.md
@@ -38,10 +38,25 @@ scripts/qg run --stage pre-commit           # commit hooks parity
 scripts/qg run --stage pre-push             # push hooks parity (incl. deploy gates)
 scripts/qg run --stage ci                   # CI gate bundle
 scripts/qg run lint_js                      # single gate
+make pre-pr                                 # pre-PR ritual (see below)
 make qg                                     # profile local + extra factory tests
 pre-commit run --all-files                  # upstream + pre-commit stage
 pre-commit run --hook-stage pre-push --all-files
 ```
+
+### Pre-PR ritual (`make pre-pr`)
+
+Before applying the `reviewed` label on a feature PR:
+
+1. **`scripts/qg run --stage pre-push`** — typecheck, smoke pytest, deploy gates, doc drift.
+2. **`scripts/qg plan --stage ci`** — diff-scoped gate/job plan (same contract CI logs on PRs).
+   Default diff for `make pre-pr`: `origin/staging...HEAD` (run `git fetch origin staging` first if
+   the ref is missing). Override with `QG_DIFF_RANGE=...`.
+3. **`tools/check_pytest_partition.py`** — collect-only check that CI pytest partitions stay
+   disjoint and that `ci.yml` still calls `scripts/ci-pytest.sh` for each runtime partition.
+
+Partition expressions live in **`tools/pytest_partitions.py`** (SSoT). CI invokes
+`scripts/ci-pytest.sh <partition>`; do not duplicate `-m` / `--ignore` strings in `ci.yml`.
 
 ---
 
@@ -93,6 +108,7 @@ Explicit steps in `.github/workflows/ci.yml` after the QG bundle:
 - `uv lock --check` in the `gates` job (pyproject.toml ↔ `uv.lock` desync tripwire; #2173)
 - Gate self-tests (`tests/tools/test_check_*.sh`, `tests/scripts/test_qg.sh`)
 - Dashboard Playwright e2e, package coverage thresholds
+- Pytest jobs via `scripts/ci-pytest.sh` (partitions from `tools/pytest_partitions.py`)
 - Jobs `integration`, `docker-build` (`docker-build` is a required check on `staging`)
 
 ACL scanners (`acl_matrix_retired`, `request_reply_flows`, `acl_grants`, `inbox_prefix`, `subject_literals`) are declared in `stack.yml` and run inside `qg run --stage ci`.

--- a/scripts/ci-pytest.sh
+++ b/scripts/ci-pytest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ci-pytest.sh — run a named CI pytest partition (SSoT: tools/pytest_partitions.py).
+#
+# Usage:
+#   scripts/ci-pytest.sh <partition> [extra pytest args...]
+#
+# Partitions: factory_unit, factory_infra, factory_integration,
+#             roxabi_nats, roxabi_contracts, roxabi_obs
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+partition="${1:?usage: ci-pytest.sh <partition> [extra pytest args...]}"
+shift
+
+mapfile -t BASE_ARGS < <(PYTHONPATH=src uv run python tools/pytest_partitions.py emit "$partition")
+
+exec uv run pytest "${BASE_ARGS[@]}" "$@"

--- a/scripts/ci-pytest.sh
+++ b/scripts/ci-pytest.sh
@@ -14,6 +14,22 @@ cd "$REPO_ROOT"
 partition="${1:?usage: ci-pytest.sh <partition> [extra pytest args...]}"
 shift
 
-mapfile -t BASE_ARGS < <(PYTHONPATH=src uv run python tools/pytest_partitions.py emit "$partition")
+# Process substitution does not surface the child's exit under set -e.
+# Write emit output to a temp file so a non-zero emit status aborts before pytest.
+# Capture emit_rc explicitly: after `if ! cmd`, $? is 0 (the if test succeeded).
+emit_tmp="$(mktemp)"
+trap 'rm -f "$emit_tmp"' EXIT
+set +e
+PYTHONPATH=src uv run python tools/pytest_partitions.py emit "$partition" >"$emit_tmp"
+emit_rc=$?
+set -e
+if [ "$emit_rc" -ne 0 ]; then
+  exit "$emit_rc"
+fi
+mapfile -t BASE_ARGS <"$emit_tmp"
+if [ "${#BASE_ARGS[@]}" -eq 0 ]; then
+  echo "ERROR: emit produced no pytest args for partition '$partition'" >&2
+  exit 2
+fi
 
 exec uv run pytest "${BASE_ARGS[@]}" "$@"

--- a/tests/tools/test_check_pytest_partition.sh
+++ b/tests/tools/test_check_pytest_partition.sh
@@ -35,21 +35,26 @@ rc=0
 bash "$WRAPPER" >/dev/null 2>&1 || rc=$?
 [ "$rc" -ne 0 ] || fail "ci-pytest.sh with no args should fail"
 
-# 5. Wrapper: unknown partition → non-zero, fail-closed (must not start full suite).
+# 5. Wrapper: unknown partition → exit 2, fail-closed (must not start full suite).
 #    Bound wall time so a regression that runs default testpaths fails this case.
+tmp_out="$(mktemp)"
+tmp_err="$(mktemp)"
+trap 'rm -f "$tmp_out" "$tmp_err"' EXIT
 rc=0
 if command -v timeout >/dev/null 2>&1; then
   timeout 30s bash "$WRAPPER" not_a_real_partition --collect-only -q \
-    >/tmp/ci-pytest-bad.out 2>/tmp/ci-pytest-bad.err || rc=$?
+    >"$tmp_out" 2>"$tmp_err" || rc=$?
 else
   bash "$WRAPPER" not_a_real_partition --collect-only -q \
-    >/tmp/ci-pytest-bad.out 2>/tmp/ci-pytest-bad.err || rc=$?
+    >"$tmp_out" 2>"$tmp_err" || rc=$?
 fi
-[ "$rc" -ne 0 ] || fail "ci-pytest.sh unknown partition should exit non-zero"
-if grep -qE '::test_|collected [1-9]' /tmp/ci-pytest-bad.out 2>/dev/null; then
+# timeout returns 124 — treat as fail (should never need 30s for emit fail-closed)
+[ "$rc" -eq 124 ] && fail "ci-pytest.sh unknown partition timed out (likely full suite)"
+[ "$rc" -eq 2 ] || fail "ci-pytest.sh unknown partition should exit 2 (got $rc)"
+if grep -qE '::test_|collected [1-9]' "$tmp_out" 2>/dev/null; then
   fail "ci-pytest.sh unknown partition must not collect real tests"
 fi
-grep -q 'unknown partition\|ERROR' /tmp/ci-pytest-bad.err \
+grep -q 'unknown partition\|ERROR' "$tmp_err" \
   || fail "ci-pytest.sh unknown partition should report ERROR on stderr"
 
 echo "check_pytest_partition: all cases pass"

--- a/tests/tools/test_check_pytest_partition.sh
+++ b/tests/tools/test_check_pytest_partition.sh
@@ -1,17 +1,55 @@
 #!/usr/bin/env bash
-# test_check_pytest_partition.sh — smoke-test the CI partition gate on HEAD.
-# Exit 0 = gate passes on the in-lockstep repo tree.
+# test_check_pytest_partition.sh — partition gate + ci-pytest wrapper contracts.
+# Exit 0 = all cases pass.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 GATE="$REPO/tools/check_pytest_partition.py"
+WRAPPER="$REPO/scripts/ci-pytest.sh"
+EMIT=(env PYTHONPATH=src uv run python "$REPO/tools/pytest_partitions.py")
 
 fail() { echo "TEST FAIL: $1" >&2; exit 1; }
 
 [ -f "$GATE" ] || fail "missing gate script: $GATE"
+[ -f "$WRAPPER" ] || fail "missing wrapper: $WRAPPER"
 
+# 1. Gate passes on the in-lockstep repo tree.
 rc=0
 PYTHONPATH=src uv run python "$GATE" >/dev/null || rc=$?
 [ "$rc" -eq 0 ] || fail "gate should pass on the in-lockstep repo tree (exit $rc)"
+
+# 2. emit unknown partition → exit 2 (does not print args).
+rc=0
+out="$("${EMIT[@]}" emit not_a_real_partition 2>/dev/null)" || rc=$?
+[ "$rc" -eq 2 ] || fail "emit unknown should exit 2 (got $rc)"
+[ -z "$out" ] || fail "emit unknown should produce no stdout"
+
+# 3. emit known partition → non-empty argv starting with a path.
+out="$("${EMIT[@]}" emit factory_unit)"
+[ -n "$out" ] || fail "emit factory_unit should produce args"
+first="$(printf '%s\n' "$out" | head -1)"
+[ "$first" = "tests/" ] || fail "emit factory_unit first arg should be tests/ (got $first)"
+
+# 4. Wrapper: missing partition arg → non-zero.
+rc=0
+bash "$WRAPPER" >/dev/null 2>&1 || rc=$?
+[ "$rc" -ne 0 ] || fail "ci-pytest.sh with no args should fail"
+
+# 5. Wrapper: unknown partition → non-zero, fail-closed (must not start full suite).
+#    Bound wall time so a regression that runs default testpaths fails this case.
+rc=0
+if command -v timeout >/dev/null 2>&1; then
+  timeout 30s bash "$WRAPPER" not_a_real_partition --collect-only -q \
+    >/tmp/ci-pytest-bad.out 2>/tmp/ci-pytest-bad.err || rc=$?
+else
+  bash "$WRAPPER" not_a_real_partition --collect-only -q \
+    >/tmp/ci-pytest-bad.out 2>/tmp/ci-pytest-bad.err || rc=$?
+fi
+[ "$rc" -ne 0 ] || fail "ci-pytest.sh unknown partition should exit non-zero"
+if grep -qE '::test_|collected [1-9]' /tmp/ci-pytest-bad.out 2>/dev/null; then
+  fail "ci-pytest.sh unknown partition must not collect real tests"
+fi
+grep -q 'unknown partition\|ERROR' /tmp/ci-pytest-bad.err \
+  || fail "ci-pytest.sh unknown partition should report ERROR on stderr"
 
 echo "check_pytest_partition: all cases pass"

--- a/tests/tools/test_pytest_partitions.py
+++ b/tests/tools/test_pytest_partitions.py
@@ -1,0 +1,114 @@
+"""Unit tests for tools/pytest_partitions.py + pure gate helpers.
+
+Negative coverage for the SSoT contracts that the collect-only smoke
+(test_check_pytest_partition.sh) cannot falsify alone.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import pytest
+from tools.check_pytest_partition import (
+    Partition,
+    _check_cover,
+    _check_disjoint,
+)
+from tools.pytest_partitions import (
+    CI_PARTITIONS,
+    CI_YML_PARTITION_CALLS,
+    main,
+    verify_ci_yml_sync,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_ci_yml_tripwire_covers_all_runtime_partitions() -> None:
+    """Tripwire list is derived from CI_PARTITIONS — no silent subset."""
+    call_names = {name for name, _ in CI_YML_PARTITION_CALLS}
+    assert call_names == set(CI_PARTITIONS), (
+        f"CI_YML_PARTITION_CALLS {sorted(call_names)} "
+        f"!= CI_PARTITIONS {sorted(CI_PARTITIONS)}"
+    )
+    for name, needle in CI_YML_PARTITION_CALLS:
+        assert needle == f"ci-pytest.sh {name}"
+
+
+def test_verify_ci_yml_sync_ok_on_repo() -> None:
+    assert verify_ci_yml_sync(REPO / ".github/workflows/ci.yml") == []
+
+
+def test_verify_ci_yml_sync_fails_when_needle_missing(tmp_path: Path) -> None:
+    drifted = tmp_path / "ci.yml"
+    drifted.write_text(
+        "# incomplete\nbash scripts/ci-pytest.sh factory_unit\n",
+        encoding="utf-8",
+    )
+    errors = verify_ci_yml_sync(drifted)
+    assert errors, "expected tripwire errors on incomplete ci.yml"
+    assert any("roxabi_contracts" in e or "roxabi_obs" in e for e in errors)
+
+
+def test_emit_unknown_partition_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["emit", "not_a_real_partition"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown partition" in err
+    assert "factory_unit" in err
+
+
+def test_emit_known_partitions_match_ssot(capsys: pytest.CaptureFixture[str]) -> None:
+    for name, partition in CI_PARTITIONS.items():
+        capsys.readouterr()  # clear
+        rc = main(["emit", name])
+        assert rc == 0, name
+        out = capsys.readouterr().out
+        emitted = out.splitlines()
+        assert emitted == partition.pytest_args(), name
+
+
+def test_emit_usage_without_args(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main([]) == 2
+    assert "usage:" in capsys.readouterr().err
+
+
+def test_check_disjoint_overlap() -> None:
+    a = Partition("a", ("tests/",))
+    b = Partition("b", ("tests/",))
+    ok = _check_disjoint(a, {"tests/x.py::t1"}, b, {"tests/x.py::t1", "tests/y.py::t2"})
+    assert ok is False
+
+
+def test_check_disjoint_clean() -> None:
+    a = Partition("a", ("tests/",))
+    b = Partition("b", ("tests/",))
+    ok = _check_disjoint(a, {"tests/x.py::t1"}, b, {"tests/y.py::t2"})
+    assert ok is True
+
+
+def test_check_cover_gap_and_extra() -> None:
+    total = {"tests/a.py::t1", "tests/b.py::t2"}
+    parts = [
+        (Partition("p1", ()), {"tests/a.py::t1"}),
+        (Partition("p2", ()), {"tests/c.py::t3"}),
+    ]
+    # capture stderr noise
+    old = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        ok = _check_cover("total", total, parts)
+    finally:
+        sys.stderr = old
+    assert ok is False
+
+
+def test_check_cover_ok() -> None:
+    total = {"tests/a.py::t1", "tests/b.py::t2"}
+    parts = [
+        (Partition("p1", ()), {"tests/a.py::t1"}),
+        (Partition("p2", ()), {"tests/b.py::t2"}),
+    ]
+    assert _check_cover("total", total, parts) is True

--- a/tests/tools/test_pytest_partitions.py
+++ b/tests/tools/test_pytest_partitions.py
@@ -23,7 +23,15 @@ from tools.pytest_partitions import (
     verify_ci_yml_sync,
 )
 
+from tools import check_pytest_partition as gate
+
 REPO = Path(__file__).resolve().parents[2]
+
+
+def _silence_stderr():
+    old = sys.stderr
+    sys.stderr = io.StringIO()
+    return old
 
 
 def test_ci_yml_tripwire_covers_all_runtime_partitions() -> None:
@@ -89,15 +97,27 @@ def test_check_disjoint_clean() -> None:
     assert ok is True
 
 
-def test_check_cover_gap_and_extra() -> None:
+def test_check_cover_missing_only() -> None:
     total = {"tests/a.py::t1", "tests/b.py::t2"}
+    parts = [
+        (Partition("p1", ()), {"tests/a.py::t1"}),
+        (Partition("p2", ()), set()),
+    ]
+    old = _silence_stderr()
+    try:
+        ok = _check_cover("total", total, parts)
+    finally:
+        sys.stderr = old
+    assert ok is False
+
+
+def test_check_cover_extra_only() -> None:
+    total = {"tests/a.py::t1"}
     parts = [
         (Partition("p1", ()), {"tests/a.py::t1"}),
         (Partition("p2", ()), {"tests/c.py::t3"}),
     ]
-    # capture stderr noise
-    old = sys.stderr
-    sys.stderr = io.StringIO()
+    old = _silence_stderr()
     try:
         ok = _check_cover("total", total, parts)
     finally:
@@ -112,3 +132,42 @@ def test_check_cover_ok() -> None:
         (Partition("p2", ()), {"tests/b.py::t2"}),
     ]
     assert _check_cover("total", total, parts) is True
+
+
+def test_gate_main_collect_failure_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collect RuntimeError must map to exit 2 (not partition-math exit 1)."""
+
+    def boom(_partition: Partition) -> set[str]:
+        raise RuntimeError("collect failed: synthetic")
+
+    monkeypatch.setattr(gate, "_collect_ids", boom)
+    # Avoid live ci.yml noise if sync were to fail independently
+    monkeypatch.setattr(gate, "verify_ci_yml_sync", lambda: [])
+    old = _silence_stderr()
+    try:
+        rc = gate.main()
+    finally:
+        sys.stderr = old
+    assert rc == 2
+
+
+def test_gate_main_ci_drift_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ci.yml tripwire errors alone must yield exit 1 when collect is skipped."""
+
+    monkeypatch.setattr(
+        gate,
+        "verify_ci_yml_sync",
+        lambda: ["ci.yml missing partition invocation: ci-pytest.sh factory_unit"],
+    )
+
+    def empty(_partition: Partition) -> set[str]:
+        return set()
+
+    # Still need collect to succeed with empty ids so we exercise drift path only
+    monkeypatch.setattr(gate, "_collect_ids", empty)
+    old = _silence_stderr()
+    try:
+        rc = gate.main()
+    finally:
+        sys.stderr = old
+    assert rc == 1

--- a/tools/check_pytest_partition.py
+++ b/tools/check_pytest_partition.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Verify CI pytest partitions are disjoint and cover each pool (collect-only).
 
-Mirrors the -m / --ignore expressions in .github/workflows/ci.yml:
-  tests job, infra job, integration job, package-coverage roxabi-nats step.
+Partition shapes come from tools/pytest_partitions.py (SSoT). Also verifies
+.github/workflows/ci.yml invokes scripts/ci-pytest.sh for each runtime partition.
 
-Exit 0 = partitions OK. Exit 1 = overlap or coverage gap. Exit 2 = pytest error.
+Exit 0 = partitions OK.
+Exit 1 = overlap, coverage gap, or ci.yml drift.
+Exit 2 = pytest error.
 
 Usage:
     PYTHONPATH=src uv run python tools/check_pytest_partition.py
@@ -12,6 +14,7 @@ Usage:
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -20,18 +23,33 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# Keep in sync with .github/workflows/ci.yml pytest invocations.
-_FACTORY_UNIT_MARKERS = (
-    "not live_acl and not subprocess_nats and not deploy_contract "
-    "and not nk_tooling and not nats_integration"
-)
-_FACTORY_INFRA_MARKERS = "live_acl or subprocess_nats or deploy_contract or nk_tooling"
+
+def _load_partitions():
+    path = REPO_ROOT / "tools" / "pytest_partitions.py"
+    spec = importlib.util.spec_from_file_location("pytest_partitions", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load partition SSoT: {path}")
+    mod = importlib.util.module_from_spec(spec)
+    # dataclasses look up the module in sys.modules during class body processing
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_partitions = _load_partitions()
+PytestPartition = _partitions.PytestPartition
+gate_partition_groups = _partitions.gate_partition_groups
+verify_ci_yml_sync = _partitions.verify_ci_yml_sync
 
 
 @dataclass(frozen=True)
 class Partition:
     name: str
     args: tuple[str, ...]
+
+
+def _partition_args(spec: PytestPartition) -> tuple[str, ...]:
+    return tuple(spec.pytest_args())
 
 
 def _collect_ids(partition: Partition) -> set[str]:
@@ -121,91 +139,60 @@ def _check_cover(
     return ok
 
 
-def main() -> int:
-    factory_total = Partition(
-        "factory_total",
-        ("tests/", "--ignore=tests/e2e"),
-    )
-    factory_unit = Partition(
-        "factory_unit",
-        (
-            "tests/",
-            "--ignore=tests/e2e",
-            "-m",
-            _FACTORY_UNIT_MARKERS,
-        ),
-    )
-    factory_infra = Partition(
-        "factory_infra",
-        (
-            "tests/",
-            "--ignore=tests/integration",
-            "--ignore=tests/e2e",
-            "-m",
-            _FACTORY_INFRA_MARKERS,
-        ),
-    )
-    factory_integration = Partition(
-        "factory_integration",
-        ("tests/integration/", "-m", "nats_integration"),
-    )
+def _validate_group(
+    total_name: str,
+    specs: list[tuple[PytestPartition, str]],
+) -> tuple[bool, dict[str, int]]:
+    total_spec = specs[0][0]
+    part_specs = specs[1:]
 
-    nats_total = Partition("roxabi_nats_total", ("packages/roxabi-nats/tests",))
-    nats_coverage = Partition(
-        "roxabi_nats_coverage",
-        ("packages/roxabi-nats/tests", "-m", "not subprocess_nats"),
-    )
-    nats_subprocess = Partition(
-        "roxabi_nats_subprocess",
-        ("packages/roxabi-nats/tests", "-m", "subprocess_nats"),
-    )
+    total = Partition(total_name, _partition_args(total_spec))
+    parts = [
+        (Partition(label, _partition_args(spec)), label) for spec, label in part_specs
+    ]
 
     try:
-        factory_total_ids = _collect_ids(factory_total)
-        factory_unit_ids = _collect_ids(factory_unit)
-        factory_infra_ids = _collect_ids(factory_infra)
-        factory_integration_ids = _collect_ids(factory_integration)
-        nats_total_ids = _collect_ids(nats_total)
-        nats_coverage_ids = _collect_ids(nats_coverage)
-        nats_subprocess_ids = _collect_ids(nats_subprocess)
+        total_ids = _collect_ids(total)
+        part_ids = [(p, _collect_ids(p)) for p, _ in parts]
     except RuntimeError:
-        return 2
+        return False, {}
 
     ok = True
-    factory_parts = [
-        (factory_unit, factory_unit_ids),
-        (factory_infra, factory_infra_ids),
-        (factory_integration, factory_integration_ids),
-    ]
-    for i, (a_part, a_ids) in enumerate(factory_parts):
-        for b_part, b_ids in factory_parts[i + 1 :]:
+    for i, (a_part, a_ids) in enumerate(part_ids):
+        for b_part, b_ids in part_ids[i + 1 :]:
             ok = _check_disjoint(a_part, a_ids, b_part, b_ids) and ok
-    ok = _check_cover("factory_total", factory_total_ids, factory_parts) and ok
+    ok = _check_cover(total_name, total_ids, part_ids) and ok
 
-    nats_parts = [
-        (nats_coverage, nats_coverage_ids),
-        (nats_subprocess, nats_subprocess_ids),
-    ]
-    ok = (
-        _check_disjoint(
-            nats_coverage,
-            nats_coverage_ids,
-            nats_subprocess,
-            nats_subprocess_ids,
-        )
-        and ok
-    )
-    ok = _check_cover("roxabi_nats_total", nats_total_ids, nats_parts) and ok
+    counts = {total_name: len(total_ids)}
+    for label, ids in zip((lbl for _, lbl in parts), (ids for _, ids in part_ids)):
+        counts[label] = len(ids)
+    return ok, counts
+
+
+def main() -> int:
+    ci_errors = verify_ci_yml_sync()
+    if ci_errors:
+        for err in ci_errors:
+            print(f"FAIL: {err}", file=sys.stderr)
+
+    factory_group, nats_group = gate_partition_groups()
+    ok = not ci_errors
+    counts: dict[str, int] = {}
+
+    for total_name, specs in (factory_group, nats_group):
+        group_ok, group_counts = _validate_group(total_name, list(specs))
+        ok = group_ok and ok
+        counts.update(group_counts)
 
     print(
         "check_pytest_partition:",
-        f"factory unit={len(factory_unit_ids)}",
-        f"infra={len(factory_infra_ids)}",
-        f"integration={len(factory_integration_ids)}",
-        f"total={len(factory_total_ids)};",
-        f"roxabi-nats coverage={len(nats_coverage_ids)}",
-        f"subprocess={len(nats_subprocess_ids)}",
-        f"total={len(nats_total_ids)}",
+        f"factory unit={counts.get('factory_unit', 0)}",
+        f"infra={counts.get('factory_infra', 0)}",
+        f"integration={counts.get('factory_integration', 0)}",
+        f"total={counts.get('factory_total', 0)};",
+        f"roxabi-nats coverage={counts.get('roxabi_nats_coverage', 0)}",
+        f"subprocess={counts.get('roxabi_nats_subprocess', 0)}",
+        f"total={counts.get('roxabi_nats_total', 0)}",
     )
 
     if ok:

--- a/tools/check_pytest_partition.py
+++ b/tools/check_pytest_partition.py
@@ -142,7 +142,14 @@ def _check_cover(
 def _validate_group(
     total_name: str,
     specs: list[tuple[PytestPartition, str]],
-) -> tuple[bool, dict[str, int]]:
+) -> tuple[bool | None, dict[str, int]]:
+    """Validate one partition group.
+
+    Returns:
+        (True, counts) — disjoint/cover OK
+        (False, counts) — partition math violation
+        (None, {}) — pytest collect failed (caller should exit 2)
+    """
     total_spec = specs[0][0]
     part_specs = specs[1:]
 
@@ -155,7 +162,7 @@ def _validate_group(
         total_ids = _collect_ids(total)
         part_ids = [(p, _collect_ids(p)) for p, _ in parts]
     except RuntimeError:
-        return False, {}
+        return None, {}
 
     ok = True
     for i, (a_part, a_ids) in enumerate(part_ids):
@@ -177,10 +184,14 @@ def main() -> int:
 
     factory_group, nats_group = gate_partition_groups()
     ok = not ci_errors
+    collect_failed = False
     counts: dict[str, int] = {}
 
     for total_name, specs in (factory_group, nats_group):
         group_ok, group_counts = _validate_group(total_name, list(specs))
+        if group_ok is None:
+            collect_failed = True
+            continue
         ok = group_ok and ok
         counts.update(group_counts)
 
@@ -195,6 +206,8 @@ def main() -> int:
         f"total={counts.get('roxabi_nats_total', 0)}",
     )
 
+    if collect_failed:
+        return 2
     if ok:
         print("check_pytest_partition: OK")
         return 0

--- a/tools/pytest_partitions.py
+++ b/tools/pytest_partitions.py
@@ -22,14 +22,6 @@ NAT_COVERAGE_MARKERS = "not subprocess_nats"
 NAT_SUBPROCESS_MARKERS = "subprocess_nats"
 INTEGRATION_MARKERS = "nats_integration"
 
-# ci.yml must invoke scripts/ci-pytest.sh for these partitions (sync tripwire).
-CI_YML_PARTITION_CALLS: tuple[tuple[str, str], ...] = (
-    ("factory_unit", "ci-pytest.sh factory_unit"),
-    ("factory_infra", "ci-pytest.sh factory_infra"),
-    ("factory_integration", "ci-pytest.sh factory_integration"),
-    ("roxabi_nats", "ci-pytest.sh roxabi_nats"),
-)
-
 
 @dataclass(frozen=True)
 class PytestPartition:
@@ -80,6 +72,12 @@ CI_PARTITIONS: dict[str, PytestPartition] = {
         ("packages/roxabi-obs/tests",),
     ),
 }
+
+# Derived from CI_PARTITIONS so tripwire stays complete by construction.
+# ci.yml must invoke scripts/ci-pytest.sh for every runtime partition.
+CI_YML_PARTITION_CALLS: tuple[tuple[str, str], ...] = tuple(
+    (name, f"ci-pytest.sh {name}") for name in CI_PARTITIONS
+)
 
 
 def gate_partition_groups() -> tuple[

--- a/tools/pytest_partitions.py
+++ b/tools/pytest_partitions.py
@@ -1,0 +1,160 @@
+"""SSoT for CI pytest job partitions.
+
+Consumed by:
+  - scripts/ci-pytest.sh (runtime invocations in .github/workflows/ci.yml)
+  - tools/check_pytest_partition.py (collect-only disjoint/cover checks)
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+FACTORY_UNIT_MARKERS = (
+    "not live_acl and not subprocess_nats and not deploy_contract "
+    "and not nk_tooling and not nats_integration"
+)
+FACTORY_INFRA_MARKERS = "live_acl or subprocess_nats or deploy_contract or nk_tooling"
+NAT_COVERAGE_MARKERS = "not subprocess_nats"
+NAT_SUBPROCESS_MARKERS = "subprocess_nats"
+INTEGRATION_MARKERS = "nats_integration"
+
+# ci.yml must invoke scripts/ci-pytest.sh for these partitions (sync tripwire).
+CI_YML_PARTITION_CALLS: tuple[tuple[str, str], ...] = (
+    ("factory_unit", "ci-pytest.sh factory_unit"),
+    ("factory_infra", "ci-pytest.sh factory_infra"),
+    ("factory_integration", "ci-pytest.sh factory_integration"),
+    ("roxabi_nats", "ci-pytest.sh roxabi_nats"),
+)
+
+
+@dataclass(frozen=True)
+class PytestPartition:
+    """A named pytest invocation shape used in CI."""
+
+    name: str
+    paths: tuple[str, ...]
+    ignores: tuple[str, ...] = ()
+    markers: str | None = None
+
+    def pytest_args(self) -> list[str]:
+        args: list[str] = list(self.paths)
+        for ign in self.ignores:
+            args.extend(["--ignore", ign])
+        if self.markers is not None:
+            args.extend(["-m", self.markers])
+        return args
+
+
+CI_PARTITIONS: dict[str, PytestPartition] = {
+    "factory_unit": PytestPartition(
+        "factory_unit",
+        ("tests/",),
+        ignores=("tests/e2e",),
+        markers=FACTORY_UNIT_MARKERS,
+    ),
+    "factory_infra": PytestPartition(
+        "factory_infra",
+        ("tests/",),
+        ignores=("tests/integration", "tests/e2e"),
+        markers=FACTORY_INFRA_MARKERS,
+    ),
+    "factory_integration": PytestPartition(
+        "factory_integration",
+        ("tests/integration/",),
+        markers=INTEGRATION_MARKERS,
+    ),
+    "roxabi_nats": PytestPartition(
+        "roxabi_nats",
+        ("packages/roxabi-nats/tests",),
+    ),
+    "roxabi_contracts": PytestPartition(
+        "roxabi_contracts",
+        ("packages/roxabi-contracts/tests",),
+    ),
+    "roxabi_obs": PytestPartition(
+        "roxabi_obs",
+        ("packages/roxabi-obs/tests",),
+    ),
+}
+
+
+def gate_partition_groups() -> tuple[
+    tuple[str, list[tuple[PytestPartition, str]]],
+    tuple[str, list[tuple[PytestPartition, str]]],
+]:
+    """Return (factory_group, nats_group) for disjoint/cover validation."""
+    factory_total = PytestPartition(
+        "factory_total",
+        ("tests/",),
+        ignores=("tests/e2e",),
+    )
+    factory_parts = [
+        (CI_PARTITIONS["factory_unit"], "factory_unit"),
+        (CI_PARTITIONS["factory_infra"], "factory_infra"),
+        (CI_PARTITIONS["factory_integration"], "factory_integration"),
+    ]
+    nats_total = PytestPartition("roxabi_nats_total", ("packages/roxabi-nats/tests",))
+    nats_parts = [
+        (
+            PytestPartition(
+                "roxabi_nats_coverage",
+                ("packages/roxabi-nats/tests",),
+                markers=NAT_COVERAGE_MARKERS,
+            ),
+            "roxabi_nats_coverage",
+        ),
+        (
+            PytestPartition(
+                "roxabi_nats_subprocess",
+                ("packages/roxabi-nats/tests",),
+                markers=NAT_SUBPROCESS_MARKERS,
+            ),
+            "roxabi_nats_subprocess",
+        ),
+    ]
+    return (
+        ("factory_total", [(factory_total, "factory_total"), *factory_parts]),
+        ("roxabi_nats_total", [(nats_total, "roxabi_nats_total"), *nats_parts]),
+    )
+
+
+def verify_ci_yml_sync(ci_yml: Path | None = None) -> list[str]:
+    """Return error messages when ci.yml drifts from partition SSoT."""
+    path = ci_yml or (REPO_ROOT / ".github/workflows/ci.yml")
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    for _name, needle in CI_YML_PARTITION_CALLS:
+        if needle not in text:
+            errors.append(f"ci.yml missing partition invocation: {needle}")
+    return errors
+
+
+def _cmd_emit(partition_name: str) -> int:
+    try:
+        partition = CI_PARTITIONS[partition_name]
+    except KeyError:
+        known = ", ".join(sorted(CI_PARTITIONS))
+        print(
+            f"ERROR: unknown partition {partition_name!r} (known: {known})",
+            file=sys.stderr,
+        )
+        return 2
+    for arg in partition.pytest_args():
+        print(arg)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if len(args) >= 2 and args[0] == "emit":
+        return _cmd_emit(args[1])
+    print("usage: pytest_partitions.py emit <partition>", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **SSoT** `tools/pytest_partitions.py` + runtime wrapper `scripts/ci-pytest.sh` for all CI pytest job shapes
- **Gate** `check_pytest_partition` — collect-only disjoint/cover + `ci.yml` sync tripwire (`ci-pytest.sh <partition>`)
- **`make pre-pr`** — pre-push + `qg plan --stage ci` + partition check; docs in quality-gates / pr-automation runbooks
- Importlib load registers module in `sys.modules` so `@dataclass` works under dynamic load

## Test plan

- [x] `bash tests/tools/test_check_pytest_partition.sh`
- [x] `PYTHONPATH=src uv run python tools/check_pytest_partition.py` → OK (factory unit=5243 / infra=441 / integration=5; nats 365)
- [x] `make pre-pr` green

## Out of scope (follow-ups)

- #2285 per-class `subprocess_nats` roxabi-nats
- #2287 directory↔marker gate
- #2288 split `tests/nats/`
- #2249 phase 2 — conditional `tests`/`package-coverage` jobs from `qg plan`