### PR TITLE
fix(roxabi-nats): tag subprocess_nats by live fixtures only

### DIFF
--- a/packages/roxabi-nats/tests/conftest.py
+++ b/packages/roxabi-nats/tests/conftest.py
@@ -45,12 +45,15 @@ def _register_stub_fixture() -> None:
 
 _register_stub_fixture()
 
-# Live-server modules only — mock-only suites (e.g. test_driver_base) run in the
-# same job but outside this marker. xdist_group applied in modifyitems below.
-_SUBPROCESS_NAT_MODULES = frozenset({
-    "test_readiness.py",
-    "test_image_testing_doubles.py",
-    "test_voice_testing_doubles.py",
+# Live nats-server fixtures only — mock/in-process tests in mixed modules
+# (e.g. TestReadinessConstants, guard-only image/voice suites) stay untagged
+# so they collect under package-coverage (-m "not subprocess_nats").
+# Mirrors tests/bootstrap/conftest.py (per-suite, not per-module).
+_LIVE_NATS_FIXTURES = frozenset({
+    "nats_server_url",
+    "nats_server_jetstream_url",
+    "nc",
+    "nc_js",
 })
 
 
@@ -58,7 +61,8 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         if "/packages/roxabi-nats/tests/" not in str(item.fspath):
             continue
-        if Path(item.fspath).name not in _SUBPROCESS_NAT_MODULES:
+        fixturenames = set(getattr(item, "fixturenames", ()))
+        if not fixturenames & _LIVE_NATS_FIXTURES:
             continue
         item.add_marker(pytest.mark.subprocess_nats)
         item.add_marker(pytest.mark.xdist_group(name="nats_server"))


### PR DESCRIPTION
## Summary

- Replace module-level `_SUBPROCESS_NAT_MODULES` with fixture-based tagging (`nats_server_url`, `nats_server_jetstream_url`, `nc`, `nc_js`)
- Mock/in-process suites in mixed modules (`TestReadinessConstants`, image/voice guards) no longer carry `subprocess_nats`
- Live-server nodes keep `subprocess_nats` + `xdist_group("nats_server")`

Closes #2285

## Counts (collect-only)

| Pool | Before | After |
|------|-------:|------:|
| subprocess_nats | 82 | 24 |
| not subprocess_nats | 283 | 341 |
| total | 365 | 365 |

## Test plan

- [x] `TestReadinessConstants` → not subprocess_nats
- [x] `TestReadinessReply` → subprocess_nats
- [x] image: 5 live / 20 mock split
- [x] `check_pytest_partition` OK (coverage=341 subprocess=24)