### PR TITLE
feat(ci): directory↔marker gate for pytest layout

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -277,6 +277,13 @@ quality_gates:
     files: ^(tests/|packages/roxabi-nats/tests/|pyproject\.toml$|\.github/workflows/ci\.yml$|scripts/ci-pytest\.sh$|tools/(check_pytest_partition|pytest_partitions)\.py$)
     description: CI pytest job partitions are disjoint and cover each pool (collect-only; SSoT tools/pytest_partitions.py)
 
+  pytest_dir_markers:
+    enabled: true
+    script: PYTHONPATH=src uv run python tools/check_pytest_dir_markers.py
+    stages: [ci]
+    files: ^(tests/|packages/roxabi-nats/tests/|tools/(check_pytest_dir_markers|pytest_partitions)\.py$)
+    description: Infra/integration markers only under allowed directory prefixes (SSoT MARKER_DIR_ALLOWLIST)
+
   secrets_drift:
     enabled: true
     script: tools/check_secrets_drift.sh
@@ -405,6 +412,7 @@ qg:
       - qg_conf_drift
       - duplicate_test_basenames
       - pytest_partition
+      - pytest_dir_markers
       - folder_size
       - no_runtime_toml_bots
       - doc_drift_bundle

--- a/docs/runbooks/quality-gates.md
+++ b/docs/runbooks/quality-gates.md
@@ -109,6 +109,8 @@ Explicit steps in `.github/workflows/ci.yml` after the QG bundle:
 - Gate self-tests (`tests/tools/test_check_*.sh`, `tests/scripts/test_qg.sh`)
 - Dashboard Playwright e2e, package coverage thresholds
 - Pytest jobs via `scripts/ci-pytest.sh` (partitions from `tools/pytest_partitions.py`)
+- Directory↔marker layout (`tools/check_pytest_dir_markers.py` — markers only under
+  `MARKER_DIR_ALLOWLIST` prefixes in `tools/pytest_partitions.py`; see #2287)
 - Jobs `integration`, `docker-build` (`docker-build` is a required check on `staging`)
 
 ACL scanners (`acl_matrix_retired`, `request_reply_flows`, `acl_grants`, `inbox_prefix`, `subject_literals`) are declared in `stack.yml` and run inside `qg run --stage ci`.

--- a/tests/tools/test_check_pytest_dir_markers.sh
+++ b/tests/tools/test_check_pytest_dir_markers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# test_check_pytest_dir_markers.sh — smoke the directory↔marker gate on HEAD.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$REPO/tools/check_pytest_dir_markers.py"
+
+fail() { echo "TEST FAIL: $1" >&2; exit 1; }
+
+[ -f "$GATE" ] || fail "missing gate: $GATE"
+
+rc=0
+PYTHONPATH=src uv run python "$GATE" >/dev/null || rc=$?
+[ "$rc" -eq 0 ] || fail "gate should pass on the in-lockstep repo tree (exit $rc)"
+
+echo "check_pytest_dir_markers: all cases pass"

--- a/tests/tools/test_pytest_dir_markers.py
+++ b/tests/tools/test_pytest_dir_markers.py
@@ -1,0 +1,31 @@
+"""Unit tests for directory↔marker allowlist helpers."""
+
+from __future__ import annotations
+
+from tools.check_pytest_dir_markers import _check_allowlist
+from tools.pytest_partitions import MARKER_DIR_ALLOWLIST
+
+
+def test_allowlist_covers_expected_markers() -> None:
+    assert "nats_integration" in MARKER_DIR_ALLOWLIST
+    assert "subprocess_nats" in MARKER_DIR_ALLOWLIST
+    assert "deploy_contract" in MARKER_DIR_ALLOWLIST
+
+
+def test_check_allowlist_ok() -> None:
+    errs = _check_allowlist(
+        "nats_integration",
+        ["tests/integration/test_voice_routing.py"],
+        MARKER_DIR_ALLOWLIST["nats_integration"],
+    )
+    assert errs == []
+
+
+def test_check_allowlist_rejects_wrong_tree() -> None:
+    errs = _check_allowlist(
+        "nats_integration",
+        ["tests/nats/test_nats_bus.py"],
+        MARKER_DIR_ALLOWLIST["nats_integration"],
+    )
+    assert len(errs) == 1
+    assert "tests/nats/test_nats_bus.py" in errs[0]

--- a/tools/check_pytest_dir_markers.py
+++ b/tools/check_pytest_dir_markers.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Directory↔marker layout gate for CI pytest partitions.
+
+Ensures infra / integration markers only appear under their allowed directory
+prefixes (SSoT: tools/pytest_partitions.py ``MARKER_DIR_ALLOWLIST``).
+
+Exit 0 = OK. Exit 1 = layout drift. Exit 2 = collection error.
+
+Usage:
+    PYTHONPATH=src uv run python tools/check_pytest_dir_markers.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_partitions():
+    path = REPO_ROOT / "tools" / "pytest_partitions.py"
+    spec = importlib.util.spec_from_file_location("pytest_partitions", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load partition SSoT: {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_partitions = _load_partitions()
+MARKER_DIR_ALLOWLIST = _partitions.MARKER_DIR_ALLOWLIST
+DIR_MARKER_COLLECT_PATHS = _partitions.DIR_MARKER_COLLECT_PATHS
+
+
+def _rel_path(item_path: Path) -> str:
+    try:
+        return item_path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return item_path.as_posix()
+
+
+def _collect_marked_paths() -> dict[str, list[str]]:
+    """Collect tests and map each allowlisted marker → relative file paths."""
+    import pytest
+
+    class _Collector:
+        def __init__(self) -> None:
+            self.by_marker: dict[str, list[str]] = {
+                m: [] for m in MARKER_DIR_ALLOWLIST
+            }
+
+        def pytest_collection_modifyitems(
+            self,
+            items: list[pytest.Item],
+        ) -> None:
+            for item in items:
+                path = getattr(item, "path", None)
+                if path is None:
+                    # pytest < 7 fallback
+                    path = Path(str(item.fspath))
+                rel = _rel_path(Path(path))
+                names = {m.name for m in item.iter_markers()}
+                for marker in MARKER_DIR_ALLOWLIST:
+                    if marker in names:
+                        self.by_marker[marker].append(rel)
+
+    plugin = _Collector()
+    args = [
+        "--collect-only",
+        "-q",
+        "--disable-warnings",
+        *DIR_MARKER_COLLECT_PATHS,
+    ]
+    # Suppress collect-only nodeid dump; keep markers via the plugin.
+    sink = io.StringIO()
+    with redirect_stdout(sink), redirect_stderr(sink):
+        code = pytest.main(args, plugins=[plugin])
+    if code not in (0, 5):  # 5 = no tests collected
+        detail = sink.getvalue().strip()
+        raise RuntimeError(
+            f"pytest collect failed (exit {code})"
+            + (f":\n{detail[-2000:]}" if detail else "")
+        )
+    # dedupe paths per marker
+    return {
+        m: sorted(set(paths)) for m, paths in plugin.by_marker.items()
+    }
+
+
+def _check_allowlist(
+    marker: str,
+    paths: list[str],
+    prefixes: tuple[str, ...],
+) -> list[str]:
+    errors: list[str] = []
+    for path in paths:
+        if not any(path.startswith(p) for p in prefixes):
+            errors.append(
+                f"{marker}: {path} not under allowed prefixes {list(prefixes)}"
+            )
+    return errors
+
+
+def main() -> int:
+    try:
+        by_marker = _collect_marked_paths()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    counts: list[str] = []
+    for marker, prefixes in MARKER_DIR_ALLOWLIST.items():
+        paths = by_marker.get(marker, [])
+        counts.append(f"{marker}={len(paths)}")
+        errors.extend(_check_allowlist(marker, paths, prefixes))
+
+    print("check_pytest_dir_markers:", ", ".join(counts))
+    if errors:
+        for err in errors:
+            print(f"FAIL: {err}", file=sys.stderr)
+        return 1
+    print("check_pytest_dir_markers: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pytest_partitions.py
+++ b/tools/pytest_partitions.py
@@ -79,6 +79,36 @@ CI_YML_PARTITION_CALLS: tuple[tuple[str, str], ...] = tuple(
     (name, f"ci-pytest.sh {name}") for name in CI_PARTITIONS
 )
 
+# Directory↔marker layout (#2287). Each marker may only appear on tests whose
+# file path starts with one of the allowed prefixes (posix, relative to repo).
+# Keep in lockstep with where conftest / pytestmark apply these markers.
+MARKER_DIR_ALLOWLIST: dict[str, tuple[str, ...]] = {
+    "nats_integration": (
+        "tests/integration/",
+    ),
+    "subprocess_nats": (
+        "packages/roxabi-nats/tests/",
+        "tests/nats/",
+        "tests/bootstrap/",
+        "tests/typing/",
+    ),
+    "deploy_contract": (
+        "tests/deploy/",
+    ),
+    "nk_tooling": (
+        "tests/scripts/",
+    ),
+    "live_acl": (
+        "tests/scripts/",
+    ),
+}
+
+# Collect roots for the directory↔marker gate (factory + roxabi-nats tests).
+DIR_MARKER_COLLECT_PATHS: tuple[str, ...] = (
+    "tests/",
+    "packages/roxabi-nats/tests",
+)
+
 
 def gate_partition_groups() -> tuple[
     tuple[str, list[tuple[PytestPartition, str]]],


### PR DESCRIPTION
## Summary

- SSoT `MARKER_DIR_ALLOWLIST` in `tools/pytest_partitions.py`
- Gate `tools/check_pytest_dir_markers.py` — collect-only, fails if infra markers leave allowed trees
- `qg` stage `ci` + docs in quality-gates runbook
- Unit + shell smoke tests

Closes #2287

## Allowlist (current tree)

| Marker | Allowed prefixes |
|--------|------------------|
| nats_integration | `tests/integration/` |
| subprocess_nats | `packages/roxabi-nats/tests/`, `tests/nats/`, `tests/bootstrap/`, `tests/typing/` |
| deploy_contract | `tests/deploy/` |
| nk_tooling / live_acl | `tests/scripts/` |

## Test plan

- [x] `check_pytest_dir_markers` → OK on HEAD
- [x] `pytest tests/tools/test_pytest_dir_markers.py` (3)
- [x] shell smoke