### PR TITLE
docs(adr-103): hub sole IdP + disable dashboard until thin-BFF

### DIFF
--- a/artifacts/goal/dashboard-auth-hub-idp-migration.md
+++ b/artifacts/goal/dashboard-auth-hub-idp-migration.md
@@ -1,0 +1,162 @@
+# Migration — Hub IdP + thin BFF (ADR-103 amended)
+
+**Status:** planned
+**Target:** ADR-103 Accepted 2026-07-12 (store owner = hub)
+**Interim ops:** `[component.dashboard] disabled = true` on factory-hub until Slice 3+ green
+**Forbidden bandage:** do **not** mount `factory-data` RW on `factory-dashboard`
+
+---
+
+## North star
+
+```text
+Browser → dashboard (thin BFF + SPA + chat) → NATS → hub sole ControlPlaneStore
+                no auth.db open on dashboard
+```
+
+| Layer | Owner |
+|-------|--------|
+| Durable identity (users, sessions, invites, keys, orgs, links) | **Hub only** |
+| HTTP cookie / login UX | **Dashboard BFF** (façade) |
+| Authz (`authorize`, jobs/agents/admin) | **Hub** (rehydrate principal) |
+| Chat grants / dual-link gate | **Hub** (unchanged plane) |
+
+---
+
+## PR slices (ordered, each mergeable)
+
+### Slice 0 — Ops quarantine (this change set)
+
+| Item | Done when |
+|------|-----------|
+| ADR-103 amended (hub store owner) | ✓ |
+| This migration doc | ✓ |
+| `security-routing.md` target updated | ✓ |
+| `quadlet.toml` `component.dashboard` **disabled** | ✓ |
+| M₁: stop + disable unit; confirm hub/NATS green | ✓ |
+
+**Out of scope:** volume mount, partial dual-open “fix”.
+
+---
+
+### Slice 1 — Hub identity RPC surface (no SPA change)
+
+**Goal:** Hub can serve full identity lifecycle over NATS; dashboard code still dual-open until Slice 2.
+
+| Work | Notes |
+|------|--------|
+| Contracts | `factory.dashboard.auth.*` (or `identity.*`) subjects: login, logout, session.resolve, session.revoke, invite.create/list/revoke/accept, apikey.*, org.* as needed for parity |
+| Hub handlers | Use **existing** hub `_control_plane` only; fail-closed; audit events |
+| Bootstrap admin | Env on **hub** process (`hub.env` / bootstrap_stores path) — document |
+| Principal wire | Spec: BFF will send `user_id` + proof; hub rehydrates roles/orgs (**implement rehydrate in `_wrap` or resolve handler**) |
+| Tests | Unit hub RPC: login happy/deny, resolve session, member cannot invite |
+
+**Exit:** hub RPC green in CI; dual-open still present but unused by new path.
+
+**Depends:** Slice 0.
+
+---
+
+### Slice 2 — Thin BFF: stop local store open
+
+| Work | Notes |
+|------|--------|
+| Remove `open_control_plane_store()` from `WebAdapter.astart` | Inject nothing or a **RPC-backed** directory port |
+| `require_principal` / auth routes | Call hub RPC for resolve/login/logout/invite |
+| Cookie | Set/clear from hub-minted opaque token or session id |
+| Optional edge cache | TTL cache `session_token → user_id` only (not roles) |
+| Delete dual-open code paths | No ControlPlaneStore in dashboard process |
+| Tests | BFF TestClient with mocked hub RPC; no real auth.db in web adapter |
+
+**Exit:** dashboard process has **zero** SQLite identity open; still works against hub in integration tests.
+
+**Depends:** Slice 1.
+
+---
+
+### Slice 3 — Wire security: rehydrate + health
+
+| Work | Notes |
+|------|--------|
+| Hub `_wrap` | Rehydrate principal from store by `user_id` (+ validate proof); **ignore** client roles |
+| HealthCmd dashboard | Public `/healthz` (or cmdline probe); **never** `/api/agents` 200 |
+| Public routes | login, accept-invite, health, static login shell only |
+| Runbooks | Bootstrap on hub; dashboard has no BOOTSTRAP_* store open |
+
+**Exit:** forgery class (trusted wire roles) closed; healthchecks auth-safe.
+
+**Depends:** Slice 2 (or parallel if hub rehydrate independent).
+
+---
+
+### Slice 4 — Re-enable dashboard on M₁
+
+| Work | Notes |
+|------|--------|
+| `disabled = false` on `component.dashboard` | After Slice 2–3 on staging image |
+| Converge M₁ | Observe post-autoupdate; **no** factory-data on dashboard unit |
+| Smoke | `auth/me` → 401 unauth; login → 200; hub still sole `auth.db` open |
+| SPA | Full login / invite / link against thin BFF |
+
+**Exit:** operator console live; crash-loop gone without volume bandage.
+
+**Depends:** Slice 2 + 3 shipped in `staging-svc`.
+
+---
+
+### Slice 5 — Cleanup debt (optional same train)
+
+| Work | Notes |
+|------|--------|
+| Remove `identity_cache_rewarm` if link writes only on hub | Or keep as no-op safety |
+| Org routes: no local authorize fork | Prefer hub RPC for mutations |
+| Docs | deployment.md volumes table stays hub-only for identity |
+| ADR-094 soft note | One Tailnet surface; IdP DB on hub |
+
+---
+
+### Slice 6 — C-lite (optional, not committed)
+
+Only if measured: move BFF route modules into hub process; dashboard reverse-proxies `/api/bff`.
+SPA + chat stay edge. **Not** required for IdP uniqueness.
+
+---
+
+## Explicit non-goals
+
+| Non-goal | Why |
+|----------|-----|
+| Mount `factory-data` on dashboard | #1721 / dual-writer / blast radius |
+| SPA inside hub container | Blast radius + release cadence |
+| External OIDC V1 | Deferred multi-product |
+| Per-platform auth policy | Axial trap |
+
+---
+
+## Gate checklist (every slice)
+
+- [ ] `qg` / pre-push green
+- [ ] No new dual open of ControlPlaneStore
+- [ ] importlinter `dashboard-no-infrastructure`
+- [ ] Hub fail-closed without principal / invalid proof
+- [ ] Health public
+- [ ] M₁ hub/NATS/adapters healthy when dashboard still disabled (Slices 0–3)
+
+---
+
+## Rollback
+
+| Slice | Rollback |
+|-------|----------|
+| 0 | Re-enable component only after Slice 4 criteria |
+| 1–3 | Feature flag hub RPC vs legacy dual-open **only in non-prod**; prod stays dashboard-disabled until 4 |
+| 4 | `disabled = true` again |
+
+---
+
+## Success metric
+
+- One process opens durable CP identity: **hub**
+- Dashboard container RO, **no** identity volume
+- Unauth `/api/bff/auth/me` → **401** (not 404, not crash)
+- Operator login works end-to-end on Tailnet

--- a/artifacts/goal/dashboard-auth-hub-idp-migration.md
+++ b/artifacts/goal/dashboard-auth-hub-idp-migration.md
@@ -2,8 +2,20 @@
 
 **Status:** planned
 **Target:** ADR-103 Accepted 2026-07-12 (store owner = hub)
-**Interim ops:** `[component.dashboard] disabled = true` on factory-hub until Slice 3+ green
+**Interim ops:** prod stays `disabled = true` until **Slice 4 exit** (Slice 3 green is necessary but not sufficient)
 **Forbidden bandage:** do **not** mount `factory-data` RW on `factory-dashboard`
+**Predecessor:** [`dashboard-auth-identity-org-goal.md`](dashboard-auth-identity-org-goal.md) (Blocks 0–14 dual-open debt)
+
+### V1 identity RPC defaults (lock for Slice 1)
+
+| Choice | V1 default |
+|--------|------------|
+| Session durability | Opaque server session rows in hub `sessions` table |
+| Edge cookie | Session id / opaque token only (**no roles**) |
+| RPC stamp | `user_id` + `session_id` (or api_key id); hub validates + **rehydrates** roles/orgs |
+| Subject namespace | `factory.dashboard.auth.*` (reuse `factory.dashboard.>` ACL) |
+| Edge cache | Optional TTL `session→user_id` only |
+| Signed JWT/HMAC | Deferred (not parallel V1) |
 
 ---
 
@@ -27,15 +39,20 @@ Browser → dashboard (thin BFF + SPA + chat) → NATS → hub sole ControlPlane
 
 ### Slice 0 — Ops quarantine (this change set)
 
-| Item | Done when |
-|------|-----------|
-| ADR-103 amended (hub store owner) | ✓ |
-| This migration doc | ✓ |
-| `security-routing.md` target updated | ✓ |
-| `quadlet.toml` `component.dashboard` **disabled** | ✓ |
-| M₁: stop + disable unit; confirm hub/NATS green | ✓ |
+| Item | Scope | Done when |
+|------|--------|-----------|
+| ADR-103 amended (hub store owner) | git | ✓ |
+| This migration doc | git | ✓ |
+| `security-routing.md` target updated | git | ✓ |
+| `quadlet.toml` `component.dashboard` **disabled** | git SSoT | ✓ this PR |
+| M₁ host: stop/mask unit; hub/NATS green | **ops host** (not git) | ✓ one-time ops |
+| Post-merge: converge does not re-enable dashboard | gate | after merge |
+
+**Slice 0 CI exit:** docs + `disabled` flag only — no identity RPC expected green.
 
 **Out of scope:** volume mount, partial dual-open “fix”.
+
+**Gate (until Slice 4):** no new dual-open surface; existing dual-open code = known debt until Slice 2.
 
 ---
 
@@ -45,13 +62,14 @@ Browser → dashboard (thin BFF + SPA + chat) → NATS → hub sole ControlPlane
 
 | Work | Notes |
 |------|--------|
-| Contracts | `factory.dashboard.auth.*` (or `identity.*`) subjects: login, logout, session.resolve, session.revoke, invite.create/list/revoke/accept, apikey.*, org.* as needed for parity |
+| Contracts | Subjects under **`factory.dashboard.auth.*`** (+ request/response types in roxabi-contracts) |
 | Hub handlers | Use **existing** hub `_control_plane` only; fail-closed; audit events |
-| Bootstrap admin | Env on **hub** process (`hub.env` / bootstrap_stores path) — document |
-| Principal wire | Spec: BFF will send `user_id` + proof; hub rehydrates roles/orgs (**implement rehydrate in `_wrap` or resolve handler**) |
+| Bootstrap admin | Env on **hub** process; document rename plan (`FACTORY_CP_BOOTSTRAP_*` alias later) |
+| Principal wire (design) | `user_id` + `session_id`/api_key id; **rehydrate design** documented (implement fail-closed on all business RPCs in Slice 3) |
+| Data | Same `auth.db` path hub already uses — no bulk data migration if path identical |
 | Tests | Unit hub RPC: login happy/deny, resolve session, member cannot invite |
 
-**Exit:** hub RPC green in CI; dual-open still present but unused by new path.
+**Exit:** hub identity RPC green in CI; dual-open code may still exist but new path does not depend on dashboard store open.
 
 **Depends:** Slice 0.
 
@@ -93,14 +111,15 @@ Browser → dashboard (thin BFF + SPA + chat) → NATS → hub sole ControlPlane
 
 | Work | Notes |
 |------|--------|
-| `disabled = false` on `component.dashboard` | After Slice 2–3 on staging image |
-| Converge M₁ | Observe post-autoupdate; **no** factory-data on dashboard unit |
-| Smoke | `auth/me` → 401 unauth; login → 200; hub still sole `auth.db` open |
+| `disabled = false` on `component.dashboard` | After Slice 2–3 on `staging-svc` image |
+| If host was masked | `systemctl --user unmask factory-dashboard.service` **before** converge |
+| Converge M₁ | `make converge`; confirm unit file reinstalled; **no** factory-data on dashboard unit |
+| Smoke | unauth `auth/me` → 401; login → 200; hub sole `auth.db` open; HealthCmd public |
 | SPA | Full login / invite / link against thin BFF |
 
 **Exit:** operator console live; crash-loop gone without volume bandage.
 
-**Depends:** Slice 2 + 3 shipped in `staging-svc`.
+**Depends:** Slice 2 + 3 shipped in `staging-svc` (Slice 3 green necessary, not sufficient alone).
 
 ---
 

--- a/artifacts/goal/dashboard-auth-identity-org-goal.md
+++ b/artifacts/goal/dashboard-auth-identity-org-goal.md
@@ -1,9 +1,15 @@
 # /goal — Dashboard auth + identité unifiée + orgs + link TG/DC
 
+> **2026-07-12 supersession (store ownership):** Blocks 0–14 dual-open path = **shipped debt**.
+> Execution SSoT for **hub sole IdP + thin BFF** =
+> [`dashboard-auth-hub-idp-migration.md`](dashboard-auth-hub-idp-migration.md).
+> [ADR-103](../../docs/architecture/adr/103-dashboard-auth-user-org-platform-link.mdx) = **Accepted** (amended).
+> This file = historical product ACs + journal; **do not** re-open dual-open as target.
+>
 > **Issue (à ouvrir / lier) :** epic control-plane auth — suite #2262 · #1992
-> **ADR cibles :** [ADR-103](../../docs/architecture/adr/103-dashboard-auth-user-org-platform-link.mdx) (Proposed) · living [security-routing.md](../../docs/architecture/security-routing.md) § control-plane · companion [phase0 schema/threat](../specs/dashboard-auth-phase0-schema-threat.md)
-> **Références panel :** audit L2 `artifacts/analyses/2026-07-11-deep-audit-L2.md` · décisions session 2026-07-11 (full auth, Python-in-BFF, invite-only, no default org, link requis TG+DC)
-> **Statut global :** `phase_5_done` — Blocks 0–14 on `feat/dashboard-auth-identity-org` ; ready for PR → staging
+> **ADR cibles :** ADR-103 (Accepted) · living [security-routing.md](../../docs/architecture/security-routing.md) § control-plane · companion [phase0 schema/threat](../specs/dashboard-auth-phase0-schema-threat.md)
+> **Références panel :** audit L2 · décisions 2026-07-11 (product) + 2026-07-12 (hub IdP)
+> **Statut global :** product Blocks 0–14 merged; store placement **amended** → hub-idp migration
 
 ---
 

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -28,6 +28,10 @@ template = true
 container = "factory-dashboard.container"
 required_secrets = ["factory-nats-web", "factory_otel_token"]
 host_roles = ["factory-hub"]
+# ADR-103 amended (hub sole IdP): dual-open dashboard crashes RO without factory-data.
+# Disabled until thin-BFF migration Slice 4 — do NOT bandage with factory-data mount.
+# See artifacts/goal/dashboard-auth-hub-idp-migration.md
+disabled = true
 
 [component.clipool]
 container = "factory-clipool.container"

--- a/docs/architecture/adr/103-dashboard-auth-user-org-platform-link.mdx
+++ b/docs/architecture/adr/103-dashboard-auth-user-org-platform-link.mdx
@@ -1,352 +1,242 @@
 ---
-title: "ADR-103: Dashboard auth (Python BFF) — User, Org, invite-only, platform link"
-description: "Full-auth control plane: Python session/API-key auth in factory-dashboard process; invite-only users; organizations without default; TG/DC chat only after dual platform link; hub-authoritative principal on dashboard RPC"
-status: proposed
+title: "ADR-103: Dashboard auth — hub IdP + thin BFF edge"
+description: "Unique control-plane IdP on hub (sole ControlPlaneStore/auth.db); invite-only users/orgs; dual TG/DC link; thin HTTP BFF at Tailnet edge stamps principal; hub rehydrates + authz; SPA stays on dashboard process (not hub)"
+status: accepted
 date: 2026-07-11
+accepted: 2026-07-12
 deciders: [Mickael]
-related: [049, 059, 073, 090, 094, 1992, 2262]
+related: [049, 059, 068, 073, 090, 094, 1992, 2262]
 ---
 
-> **Current truth (until Accepted + shipped)** → this ADR (Proposed) + goal
-> [`artifacts/goal/dashboard-auth-identity-org-goal.md`](../../../artifacts/goal/dashboard-auth-identity-org-goal.md).
-> Living domain page: [`security-routing.md`](../security-routing.md) § control-plane (target).
+> **Living domain page:** [`security-routing.md`](../security-routing.md) § control-plane.
+> **Migration slices:** [`artifacts/goal/dashboard-auth-hub-idp-migration.md`](../../../artifacts/goal/dashboard-auth-hub-idp-migration.md).
+> **Ops (interim):** `factory-dashboard` **disabled** on M₁ until migration B lands (no shared-volume bandage).
 
 ## Status
 
-**Proposed** — 2026-07-11. Phase 0 design for goal *dashboard-auth-identity-org*.
-**No production code** until this ADR is Accepted.
+**Accepted** — 2026-07-12 (amended).
+
+| Phase | Truth |
+|-------|--------|
+| Product (invite-only, orgs, dual link, hub authz) | Unchanged |
+| **Store ownership** | **Amended:** sole IdP writer = **hub** (not dashboard process) |
+| Code on `staging` (pre-amend implementation) | Dual open `ControlPlaneStore` (hub + web adapter) — **debt**, must migrate to B |
+| Production dashboard | **Stopped** until thin-BFF / hub IdP path is shippable |
+
+Phase 0–14 code that opens `auth.db` in the dashboard process is **not** the durable design. Do **not** “fix” it by mounting `factory-data` on `factory-dashboard` (violates hub-only volume policy #1721 / ADR-068 spirit).
 
 ## Context
 
 ### Problem
 
-1. Dashboard BFF trust is **Tailnet membership** plus an optional shared
-   `FACTORY_DASHBOARD_OPERATOR_TOKEN` that **fails open** when unset
-   (`src/factory/dashboard/auth.py`). Only connectors use `Depends(require_operator)`.
-2. Hub handlers for `factory.dashboard.*` accept any payload from NATS identity
-   `web-adapter` with **no human principal** — the process seed is effectively
-   super-admin on the control plane.
-3. Product needs **multi-user** console: invite-only signup, **organizations**
-   (no default org), **API keys**, and **Telegram/Discord** only after the user
-   is invited **and** has linked both platform accounts.
-4. Better Auth (TypeScript) is attractive for orgs/API keys but the control-plane
-   BFF is **Python FastAPI** in the same process as the web adapter (**ADR-094**).
-   A TS auth sidecar is an extra runtime without a shared contracts package for HTTP.
+1. Network / optional operator token is not multi-user control-plane auth.
+2. Hub `factory.dashboard.*` must not treat NKey `web-adapter` as human super-admin.
+3. Product: invite-only, orgs (no default), API keys, TG/DC only after dual platform link.
+4. **2026-07-12 post-merge learnings:**
+   - Dual open of `ControlPlaneStore` (hub + dashboard) on `auth.db` is a **composition / SSoT** smell (dual writer, rewarm hacks, deploy RO crash).
+   - `factory-data.volume` is **hub-only** by design; dashboard is `ReadOnly` without that mount → crash-loop when web opens the store.
+   - Panel review (architect / devops / axial / adversarial): **not** axial N×M drift; **is** dual-process identity ownership debt. Target = **hub sole IdP store**, thin HTTP edge.
 
 ### Constraints inherited
 
 | Source | Constraint |
 |--------|------------|
-| ADR-094 | One HTTP process: chat axis + BFF axis; not a second NATS platform adapter |
-| ADR-090 / C3 | Adapters untrusted normalizers; hub authoritative for chat authz (`agent_grants`) |
-| ADR-059 | Ports in `core`, stores in `infrastructure`, CR in bootstrap |
-| ADR-073 | Authz once per plane (stage composition); no per-worker / per-adapter policy copies |
-| ADR-049 | Security-bearing wire fields are major; not additive on global `ContractEnvelope` |
+| ADR-094 | One **Tailnet human HTTP surface** process may host SPA + chat axis + **thin** BFF; not a second NATS platform adapter. Identity **DB** need not live in that process. |
+| ADR-090 / C3 | Adapters untrusted; hub authoritative for chat authz |
+| ADR-059 | Ports in core; stores in infrastructure; CR in bootstrap |
+| ADR-073 | Authz once per plane (stage); no per-adapter policy copies |
+| ADR-068 / #1721 | Shared durable state not dual-mounted across adapters; hub owns `factory-data` |
+| ADR-049 | Security-bearing wire fields on dashboard contracts, not global envelope |
 | importlinter | `factory.dashboard` ↛ `factory.infrastructure.stores` |
 
-### Product decisions (session 2026-07-11)
+### Product decisions (session 2026-07-11) — unchanged
 
 | Decision | Choice |
 |----------|--------|
-| Network as auth | **Rejected** — full auth regardless of origin |
-| Auth stack | **Python minimal “BetterAuth-like”** in dashboard process |
+| Network as auth | **Rejected** |
 | Signup | **Invite-only** |
 | Default org | **None** |
-| Org visibility | Resource with `org_id` → **all org members** (+ global admin) |
-| Private visibility | Resource without org → **owner + admin** |
-| Ops identity | **Dropped** — roles/permissions on **User** |
-| TG/DC availability | Invite **and** link **both** TG and DC |
-| Console without link | **Allowed** (session only) |
-| Admin + chat | Admin **must link** to use TG/DC |
+| Org visibility | own ∪ org members ∪ admin |
+| Ops identity | Dropped — roles on User |
+| TG/DC | Invite **and** dual link |
+| Console without link | Allowed |
+| Admin chat | Must link |
 | Workers | No user/org re-auth |
+
+### Topology decisions (session 2026-07-12) — amended
+
+| Decision | Choice |
+|----------|--------|
+| Unique IdP | **Hub** sole writer of durable control-plane identity (`auth.db` / ControlPlaneStore) |
+| Authn HTTP presentation | **Thin BFF** at Tailnet edge (dashboard process) — credentials → hub RPC; cookie set at edge |
+| Authz | **Hub** only (rehydrate principal from store; never trust wire `roles`) |
+| Shared `auth.db` volume on dashboard | **Rejected** as durable design |
+| SPA in hub container | **Rejected** |
+| BFF process = hub (all HTTP on hub) | **Not required**; optional later “C-lite” behind reverse-proxy only if measured need |
+| Frontend | Remains with dashboard process (SPA + chat SSE); **not** hub |
 
 ## Options considered
 
-### Option A — Tailnet + optional shared bearer (status quo)
+### Option A — Dual open (BFF + hub both open ControlPlaneStore)
 
-- **Pros:** Simple; already partial.
-- **Cons:** Not multi-user; fail-open; hub RPC anonymous; rejected by product.
+- **Pros:** Fast V1; local session verify.
+- **Cons:** Dual writer SQLite; volume policy break if mounted; RO crash without mount; rewarm debt; rejected as **end state**.
 
-### Option B — Better Auth (TypeScript) sidecar
+### Option B — Hub-centric IdP + thin BFF (chosen)
 
-- **Pros:** Orgs, invites, API keys mature; good SPA DX.
-- **Cons:** Second runtime in deploy path; session bridge to Python BFF; no shared TS↔Python wire package; dual source of user truth unless carefully synced.
+- **Pros:** Unique IdP process; hub-only `factory-data`; dashboard stays data-free RO; aligns chat + control identity ownership on hub; importlinter stays clean.
+- **Cons:** NATS RTT for login/resolve (mitigate with short TTL edge cache of session→user_id only).
 
-### Option C — Python auth module in dashboard process (chosen)
+### Option C — BFF HTTP implementation inside hub process
 
-- **Pros:** One process (ADR-094); principal stamp natural on NATS client; aligns with hub Python stores/ports; axis-clear (BFF authn, hub authz).
-- **Cons:** Build invite/session/org/API-key/link ourselves (V1 subset only); no Better Auth UI widgets.
+- **Pros:** One Python process for identity + RPC.
+- **Cons:** Expands hub HTTP/Tailnet surface or requires reverse-proxy; larger blast radius; optional later (C-lite), not V1 requirement.
 
-### Option D — Full IdP (Keycloak / OIDC SaaS)
+### Option D — SPA + BFF + hub one container
 
-- **Pros:** Enterprise SSO.
-- **Cons:** Overkill for single-factory self-host V1; ops weight.
+- **Pros:** Unit count.
+- **Cons:** God hub; UI restart kills bots — **rejected**.
+
+### Option E — External OIDC IdP
+
+- **Pros:** Multi-product SSO.
+- **Cons:** Overkill V1; still need local grants/links.
 
 ## Decision
 
-### 1. Auth runtime = Python in `factory-dashboard` process
+### 1. IdP ownership = hub (sole ControlPlaneStore)
 
-Implement a **minimal** control-plane auth subsystem (session cookie, API keys,
-invites, users, orgs, platform links) as:
+- **Only the hub process** opens and mutates durable control-plane identity:
+  users, password hashes, invites, sessions (or session jti denylist), API key hashes,
+  orgs/memberships, platform link rows used as SSoT for chat_ready.
+- Bootstrap admin env is **hub-scoped** (not dashboard-only).
+- Dashboard / web adapter **must not** call `open_control_plane_store()`.
 
-- **Edge (authn):** `factory.dashboard` routes + dependencies (`require_principal`).
-- **Ports (pure):** `factory.core.auth` (or dedicated subpackage) — `Principal`,
-  resource authorize helpers; **do not** overload `agent_grants` / `Capability` for ops.
-- **Stores:** `factory.infrastructure.stores.identity` (extend auth.db or sibling DB).
-- **Control-plane gate (authz + principal bind):** hub `dashboard_rpc._wrap` —
-  **single** fan-in; handlers stay business-only.
-- **SPA:** login / accept-invite / link accounts / org UI in `apps/dashboard-v2`.
+### 2. Thin BFF at Tailnet edge (dashboard process)
 
-**Reject** Better Auth sidecar for V1. Revisit only if multi-product Roxabi SSO is required.
+Implement HTTP presentation of the IdP as:
 
-### 2. Principal model
+| Layer | Responsibility |
+|-------|----------------|
+| **Edge BFF** | Public login / accept-invite; set/clear HttpOnly cookie; `require_principal` = resolve session/API key **via hub RPC** (or verify hub-minted signed token); stamp dashboard RPC with `principal_user_id` + **proof** (session id / jti / HMAC — **not** trusted roles from body) |
+| **Hub IdP RPC** | login, logout, session resolve/create/revoke, invite CRUD, API keys, org/membership, link code mint (consume may stay chat `/link` on hub) |
+| **Hub `_wrap`** | Fail-closed without proof; **rehydrate** roles/orgs from store; `authorize(action, resource)`; handlers business-only |
+| **SPA** | login / invite / org / link UX in `apps/dashboard-v2` |
+| **Chat axis** | Unchanged process placement (ADR-094); auth when required uses same edge principal path |
+
+**Reject** Better Auth sidecar for V1.
+**Reject** mounting `factory-data` on `factory-dashboard` as permanent fix.
+
+### 3. Principal model
 
 ```text
 Principal:
-  user_id: str          # dash:user:<uuid> or sys:hub | sys:scheduler
-  roles: frozenset      # global: admin | member | …
-  org_ids: frozenset    # memberships
+  user_id: str
+  roles: frozenset      # authoritative only after hub rehydrate
+  org_ids: frozenset
   active_org_id: str | None
   via: session | api_key | platform_link | sys
 ```
 
-- **Global `admin`:** sees and mutates **all** control-plane resources (subject to
-  audit). Does **not** skip TG/DC link requirement for **chat**.
-- **Member:** sees `owner_user_id == me` ∪ `org_id ∈ my_orgs`.
-- **Ops is not an identity kind** — only roles/permissions on User.
+Wire from BFF → hub: prefer **`user_id` + session/api_key proof**.
+Hub **must not** treat client/BFF-supplied `roles` as authoritative.
 
-### 3. Organizations
+### 4–11. Unchanged product rules
 
-- No org created at invite/bootstrap by default.
-- User may create orgs; members added explicitly.
-- Actions may set `org_id` when initiator is a member; resource then **org-visible**.
-- Migrate connectors’ `factory_tenant` toward `org_id` (compat window documented in impl).
+Organizations, invite-only, bootstrap admin (on **hub**), dual platform link,
+chat_ready, jobs visibility, public vs protected HTTP (health unauthenticated),
+secrets (session/HMAC keys as Podman secrets on hub + edge as needed) — as in prior
+ADR body; see data model below.
 
-### 4. Invite-only lifecycle
+### 12. Deploy interim
 
-```text
-pending → accepted → (optional) revoked
-```
+Until migration B is shippable:
 
-- Only `admin` (or future `users.invite` cap) creates invites.
-- Accept creates/activates User; no open registration endpoint.
-
-### 5. Bootstrap admin
-
-- First install / setup creates **one** admin user (seed credentials rotated in prod).
-- Optional: seed from config once; never fail-open anonymous console.
-
-### 6. Platform link (Telegram + Discord)
-
-```text
-chat_ready ⇔ invite accepted ∧ linked(telegram) ∧ linked(discord)
-```
-
-| Surface | Without dual link | With dual link |
-|---------|-------------------|----------------|
-| Dashboard console | Allowed (session) | Allowed |
-| TG/DC agent turns | **Refuse** (pull onboarding) | Allowed if `agent_grants` USE |
-
-**Link mechanism (V1 recommendation):** bot-mediated **pairing code** (user starts
-`/link` or dashboard shows code; bot confirms) — avoids OAuth app review for V1.
-OAuth can replace later without changing the data model.
-
-### 7. Chat principal SSoT after link (alias table)
-
-**Chosen:** keep inbound wire `user_id` as **platform-prefixed** ids
-(`tg:user:…`, `dc:user:…`) for adapter simplicity; maintain
-`platform_links(platform, platform_user_id) → dash_user_id`.
-
-- Hub resolve: platform id → dash user (if linked) for grants/audit display.
-- `agent_grants` subjects remain platform principals **or** are issued for all
-  linked platform ids of a dash user when granting “this human” (impl detail in
-  Block 10 of the goal — must be one consistent write path).
-- **Unlinked** platform id → no agent pipeline (drop/refuse before authorize).
-
-### 8. Control-plane wire (dashboard RPC)
-
-- Dashboard request contracts carry **security-bearing** principal fields
-  (dashboard mixin / base request type) — **not** `ContractEnvelope` global.
-- BFF stamps principal from **server-side** session/API key (never trust client
-  body for identity).
-- Hub `_wrap` **rejects** missing/invalid principal (fail-closed in prod).
-- NKey `web-adapter` remains transport ACL only.
-
-### 9. Jobs
-
-- Launch records `launched_by` (+ optional `org_id`).
-- List/steer/cancel use same visibility rules (own ∪ org ∪ admin).
-- Workers remain actuators (no org checks).
-
-### 10. Public vs protected HTTP
-
-| Public | Protected |
-|--------|-----------|
-| Health / liveness (HealthCmd) | All `/api/bff/*` except explicit public |
-| Login, accept-invite | Sessions, jobs, agents, admin, connectors, … |
-| Static assets needed for login shell | |
-
-E2E: **explicit** bypass flag — never “unset secret = open”.
-
-### 11. Secrets (design)
-
-| Secret | Purpose |
-|--------|---------|
-| Session signing / cookie key | HMAC or encrypted session blob |
-| Password hashing | argon2/bcrypt at rest |
-| API keys | Store **hash only**; show secret once at create |
-| Bootstrap admin password | One-time / force rotate |
-
-Prefer Podman secret for session key (align secrets-policy) over wipeable `web.env`.
+- **`[component.dashboard] disabled = true`** on M₁ / factory-hub role.
+- No production reliance on dual-open dashboard image.
+- Hub and messaging stack remain up.
 
 ## Data model (logical schema)
 
-```text
-users
-  id              TEXT PK     -- dash:user:<uuid>
-  email           TEXT UNIQUE NULL
-  password_hash   TEXT NULL   -- null if magic-link only later
-  global_role     TEXT        -- admin | member
-  status          TEXT        -- active | disabled
-  created_at      TEXT
-
-invites
-  id              TEXT PK
-  email           TEXT
-  token_hash      TEXT
-  invited_by      TEXT FK users
-  status          TEXT        -- pending | accepted | revoked | expired
-  expires_at      TEXT
-  created_at      TEXT
-
-sessions
-  id              TEXT PK
-  user_id         TEXT FK
-  token_hash      TEXT
-  expires_at      TEXT
-  created_at      TEXT
-
-api_keys
-  id              TEXT PK
-  user_id         TEXT FK
-  name            TEXT
-  key_hash        TEXT
-  prefix          TEXT        -- display hint
-  scopes          TEXT NULL   -- optional subset JSON
-  created_at      TEXT
-  revoked_at      TEXT NULL
-
-organizations
-  id              TEXT PK     -- org:<uuid>
-  name            TEXT
-  created_by      TEXT FK
-  created_at      TEXT
-
-org_members
-  org_id          TEXT FK
-  user_id         TEXT FK
-  org_role        TEXT        -- owner | member | …
-  PRIMARY KEY (org_id, user_id)
-
-platform_links
-  user_id         TEXT FK
-  platform        TEXT        -- telegram | discord
-  platform_user_id TEXT       -- tg:user:… / dc:user:…
-  linked_at       TEXT
-  UNIQUE (platform, platform_user_id)
-  UNIQUE (user_id, platform)  -- one link per platform per user V1
-
--- resource tagging (examples; actual tables may add columns)
--- jobs catalog / active jobs: launched_by, org_id NULL
--- connectors: org_id replaces/aliases factory_tenant
-```
-
-**Chat-ready predicate (app layer):**
-
-```text
-chat_ready(user) =
-  user.status == active
-  ∧ ∃ link telegram
-  ∧ ∃ link discord
-```
+Unchanged tables (`users`, `invites`, `sessions`, `api_keys`, `organizations`,
+`org_members`, `platform_links` / `platform_identities`). Physical open = **hub only**.
 
 ## Architecture diagrams
 
-### Authn / authz split
+### Target (hub IdP + thin edge)
 
 ```text
-SPA / API client
-    │  cookie session | Bearer API key
+SPA / browser  (Tailnet :8765)
+    │  cookie | Bearer
     ▼
-┌─────────────────────────────────────┐
-│ factory-dashboard (Python)          │
-│  require_principal → Principal      │
-│  hub_client stamps RPC (server)     │
-└──────────────┬──────────────────────┘
-               │ NATS (NKey web-adapter)
+┌──────────────────────────────────────┐
+│ factory-dashboard (edge)             │
+│  thin BFF → hub identity RPC         │
+│  SPA + chat axis                     │
+│  NO auth.db / NO factory-data mount  │
+└──────────────┬───────────────────────┘
+               │ NATS  user_id + proof
                ▼
-┌─────────────────────────────────────┐
-│ hub dashboard_rpc._wrap             │
-│  1) reject if no principal          │
-│  2) authorize(action, resource)     │
-│  3) handler                         │
-└─────────────────────────────────────┘
+┌──────────────────────────────────────┐
+│ factory-hub = sole IdP               │
+│  ControlPlaneStore (auth.db)         │
+│  rehydrate Principal → authorize     │
+│  dashboard business handlers         │
+│  PlatformLink + UserStore + grants   │
+└──────────────────────────────────────┘
 ```
 
-### TG/DC path
+### TG/DC path (unchanged intent)
 
 ```text
-Platform message
-    → adapter normalize (platform user_id)
-    → link lookup
-         ├─ missing → refuse / onboarding (no agent)
-         └─ linked  → inbound pipeline
-                        → ResolveIdentity / AuthorizeAgent (ADR-090)
+Platform message → adapter normalize → hub link / chat_ready
+  → refuse if unlinked → else ADR-090 authorize
 ```
 
 ## Consequences
 
 ### Positive
 
-- Real multi-user console with clear ownership and org share.
-- Hub no longer treats web-adapter seed as anonymous superuser for business actions.
-- Aligns authn placement with ADR-094 single process.
-- Chat and control-plane planes stay separated; link unifies humans without collapsing grant matrices.
+- Unique IdP process; hub-only data volume invariant preserved.
+- Hub no longer trusts anonymous web seed for business actions; roles rehydrated.
+- Axial stage composition preserved (not per-platform auth).
+- Dashboard RO rootfs remains valid without identity volume.
 
 ### Negative
 
-- Implementation cost of invite/session/org/API-key/link (no Better Auth free lunch).
-- Dual-link requirement adds onboarding friction (accepted).
-- Migration from open Tailnet console is breaking for current operators (runbook required).
+- Migration cost: move session/invite/login I/O from BFF local store to hub RPC.
+- Identity path depends on hub + NATS (acceptable: console already depends on hub RPC).
+- Interim: no operator SPA on M₁ until B lands.
 
 ### Neutral
 
-- `factory_tenant` → `org_id` compat period.
-- `[admin].user_ids` chat bypass may later bind to linked dash admin (follow-up).
-- NATS TLS (#2264) remains orthogonal.
+- Optional C-lite later (BFF routes in hub process, reverse-proxy from dashboard).
+- External OIDC (E) only for multi-product SSO.
 
-## Acceptance criteria (product)
+## Acceptance criteria (product) — unchanged intent
 
-1. Unauthenticated clients cannot use sensitive BFF or dashboard RPC (any network).
+1. Unauthenticated clients cannot use sensitive BFF or dashboard RPC.
 2. Invite-only; no open signup.
-3. Admin sees all; member sees own + org-shared only.
+3. Admin sees all; member own + org.
 4. No default org at invite.
-5. Org-tagged resources visible to all members of that org.
-6. API keys act as that user (or scoped subset).
-7. Unlinked TG/DC cannot complete agent turns.
-8. Linked + USE grant → chat works.
-9. Admin console works without link; admin chat requires link.
-10. Health endpoint remains unauthenticated for Quadlet.
-11. Workers have no user/org authz logic.
+5. Org-tagged resources visible to org members.
+6. API keys as that user (or scoped).
+7. Unlinked TG/DC no agent turns.
+8. Dual link + USE → chat.
+9. Admin console without link; admin chat needs link.
+10. Health unauthenticated for Quadlet.
+11. Workers no user/org authz.
+12. **NEW:** Only hub opens durable control-plane identity store; dashboard has zero `auth.db` open.
+13. **NEW:** Hub rehydrates principal; wire roles not authoritative.
 
-## Implementation plan pointer
+## Implementation plan
 
-Ordered blocks, PR slices, and gates:
-[`artifacts/goal/dashboard-auth-identity-org-goal.md`](../../../artifacts/goal/dashboard-auth-identity-org-goal.md).
+Ordered PR slices:
+[`artifacts/goal/dashboard-auth-hub-idp-migration.md`](../../../artifacts/goal/dashboard-auth-hub-idp-migration.md).
 
 ## References
 
-- Goal SSoT (execution)
-- Audit L2: `artifacts/analyses/2026-07-11-deep-audit-L2.md`
-- Issues: #2262, #1992
-- ADR-090, ADR-094, ADR-049, ADR-073, ADR-059
+- Goal / migration SSoT (execution)
+- Panel 2026-07-12: architect + devops + axial + adversarial (PR #2293 follow-up)
+- Issues: #2262, #1992, #1721
+- ADR-090, ADR-094, ADR-068, ADR-073, ADR-059, ADR-049

--- a/docs/architecture/security-routing.md
+++ b/docs/architecture/security-routing.md
@@ -1,8 +1,10 @@
 # factory — — Security, Routing & Memory Isolation
 
-> Reference document. Last updated: 2026-07-01.
+> Reference document. Last updated: 2026-07-12.
 > **Status**: #auth chat (#151 ✅ ADR-090), #routing (#152 ✅), #commands ✅, #memory-isolation — partial.
-> **Control-plane auth**: **target** in [ADR-103](adr/103-dashboard-auth-user-org-platform-link.mdx) (Proposed) — see § control-plane below. Live code still Tailnet + optional fail-open bearer until goal ships.
+> **Control-plane auth:** [ADR-103](adr/103-dashboard-auth-user-org-platform-link.mdx) **Accepted** (hub sole IdP target).
+> Live staging code may still dual-open `ControlPlaneStore` (**debt**). Prod dashboard **disabled** until
+> migration Slice 4 — see § control-plane + [`dashboard-auth-hub-idp-migration.md`](../../artifacts/goal/dashboard-auth-hub-idp-migration.md).
 
 ---
 
@@ -80,8 +82,8 @@ Bot transport config lives in `BotStore` (no auth fields). Pairing `/join` write
 - [x] CLIAdapter (trust = OWNER by default)
 
 > The dashboard HTTP BFF (`/api/bff/*`) is a **separate control plane** from the NATS inbound
-> chat pipeline above. **Live (until ADR-103 ships):** optional shared bearer fail-open +
-> Tailnet bind — see `src/factory/dashboard/auth.py`. **Target:** § control-plane below.
+> chat pipeline above. **Live (debt, pre–thin-BFF):** dual-open ControlPlaneStore and/or prior
+> bearer path where still present — **not** target. **Target:** § control-plane below (hub IdP).
 
 ### Admin access (chat plane — live)
 
@@ -156,10 +158,10 @@ the grant matrix. Planes stay separate (ADR-103).
 
 - [x] Dual-open prototype on staging (debt) — superseded by target B
 - [x] ADR-103 amended; dashboard disabled interim
-- [ ] Slice 1: hub identity RPCs + rehydrate design
+- [ ] Slice 1: hub identity RPCs (`factory.dashboard.auth.*`) + rehydrate **design**
 - [ ] Slice 2: thin BFF — no `open_control_plane_store` on web
-- [ ] Slice 3: wire proof + public HealthCmd/healthz
-- [ ] Slice 4: re-enable dashboard on M₁
+- [ ] Slice 3: `_wrap` rehydrate **enforcement** + public HealthCmd/healthz
+- [ ] Slice 4: re-enable dashboard on M₁ (unmask if needed)
 - [ ] Jobs / dual-link / SPA parity under thin BFF
 
 ---

--- a/docs/architecture/security-routing.md
+++ b/docs/architecture/security-routing.md
@@ -93,27 +93,32 @@ Admin resolution lives in `Authenticator.resolve()` (`src/factory/core/auth/auth
 
 ## #control-plane — dashboard auth, users, orgs, platform link (target — ADR-103)
 
-> **Status:** Proposed design ([ADR-103](adr/103-dashboard-auth-user-org-platform-link.mdx)).
-> Execution: [`artifacts/goal/dashboard-auth-identity-org-goal.md`](../../artifacts/goal/dashboard-auth-identity-org-goal.md).
-> This section is **target truth**; do not assume shipped until the goal blocks land.
+> **Status:** [ADR-103](adr/103-dashboard-auth-user-org-platform-link.mdx) **Accepted** (amended 2026-07-12).
+> **Target:** hub sole IdP store; thin BFF at Tailnet edge.
+> **Migration:** [`artifacts/goal/dashboard-auth-hub-idp-migration.md`](../../artifacts/goal/dashboard-auth-hub-idp-migration.md).
+> **Interim:** `factory-dashboard` disabled on M₁ until migration Slice 4 (no shared-volume bandage).
+> Staging may still contain pre-amend dual-open code — treat as debt, not target truth.
 
 ### Problem
 
 Control-plane BFF and `factory.dashboard.*` hub RPC must not rely on network perimeter
 (Tailnet) or an anonymous process identity (`web-adapter` NKey alone). Multi-user product
 needs invite-only accounts, organizations, API keys, and TG/DC only after dual platform link.
+Dual open of `auth.db` (hub + dashboard) is rejected as durable design.
 
-### Solution — Python authn in dashboard process + hub authz
+### Solution — Hub sole IdP + thin BFF edge + hub authz
 
 | Layer | Responsibility |
 |-------|----------------|
-| **BFF (authn)** | Session cookie + API keys → `Principal(user, roles, orgs)`; invite accept; link pairing |
-| **Hub `_wrap` (gate)** | Reject missing principal; `authorize(action, resource)`; handlers business-only |
+| **Hub (IdP store)** | Sole `ControlPlaneStore` / `auth.db` writer; login/session/invite/org/link RPCs |
+| **BFF edge (authn presentation)** | Cookie/Bearer; resolve via hub RPC; stamp `user_id` + proof (**not** trusted roles) |
+| **Hub `_wrap` (gate)** | Rehydrate principal from store; `authorize`; handlers business-only |
 | **Workers** | No user/org checks (actuators) |
-| **TG/DC adapters** | Thin: resolve platform id → `platform_links`; unlinked → refuse chat turn |
+| **TG/DC adapters** | Thin: platform id → links; unlinked → refuse chat turn |
 
 **Rejected for V1:** Better Auth TS sidecar; Tailnet-as-auth; “ops” as identity kind;
-default organization; open signup.
+default organization; open signup; **shared `factory-data` on dashboard**; SPA-in-hub.
+
 
 ### Visibility
 
@@ -136,9 +141,9 @@ Inbound unlinked platform ids never reach agent authorize (onboarding refusal).
 
 ### Principal on the bus
 
-- Dashboard RPC: BFF stamps principal server-side (security-bearing dashboard contracts —
-  not global `ContractEnvelope`).
-- Hub fails closed without principal.
+- Dashboard RPC: BFF stamps **user_id + proof** server-side (dashboard contracts —
+  not global `ContractEnvelope`). Roles on the wire are **not** authoritative.
+- Hub fails closed without principal; **rehydrates** roles/orgs from store.
 - NKey = process ACL only.
 
 ### Relation to #auth (ADR-090)
@@ -147,15 +152,15 @@ Chat `agent_grants` USE matrix stays the SSoT for **agent access**. Platform lin
 `tg:user:` / `dc:user:` → dashboard user for product identity; it does **not** replace
 the grant matrix. Planes stay separate (ADR-103).
 
-### Implementation checklist (goal blocks — not live yet)
+### Implementation checklist (hub IdP migration)
 
-- [ ] User / invite / session / API key / org / platform_link stores + ports
-- [ ] `require_principal` fail-closed on BFF
-- [ ] Hub `_wrap` principal + resource authorize
-- [ ] Jobs `launched_by` + optional `org_id`
-- [ ] Dual platform link + inbound refuse if unlinked
-- [ ] SPA login / invite / org / link UX
-- [ ] Secrets-policy session key; HealthCmd still public
+- [x] Dual-open prototype on staging (debt) — superseded by target B
+- [x] ADR-103 amended; dashboard disabled interim
+- [ ] Slice 1: hub identity RPCs + rehydrate design
+- [ ] Slice 2: thin BFF — no `open_control_plane_store` on web
+- [ ] Slice 3: wire proof + public HealthCmd/healthz
+- [ ] Slice 4: re-enable dashboard on M₁
+- [ ] Jobs / dual-link / SPA parity under thin BFF
 
 ---
 

--- a/docs/runbooks/dashboard-auth-bootstrap.md
+++ b/docs/runbooks/dashboard-auth-bootstrap.md
@@ -2,27 +2,68 @@
 
 > **2026-07-12 interim:** `factory-dashboard` is **disabled** on M₁ until hub-IdP
 > migration ([`dashboard-auth-hub-idp-migration.md`](../../artifacts/goal/dashboard-auth-hub-idp-migration.md)).
-> Do **not** mount `factory-data` on the dashboard unit. Bootstrap admin will move to
-> **hub** env when Slice 1 lands; the dual-open dashboard path is debt.
+> Do **not** mount `factory-data` on the dashboard unit.
 
-## First install
+## Disable / re-enable (ops)
 
-1. Ensure `auth.db` path is writable (`~/.roxabi/factory/auth.db` or `FACTORY_AUTH_DB`).
-2. Set env on the web/dashboard process (password **required** when email is
-   set — never auto-generated, never written to logs):
+### Disable (Slice 0 — durable control is git)
+
+```bash
+# Host one-time (M₁) — stop crash-loop immediately
+systemctl --user stop factory-dashboard.service || true
+systemctl --user reset-failed factory-dashboard.service 2>/dev/null || true
+# Optional emergency pin (if used, MUST unmask on re-enable):
+# systemctl --user mask factory-dashboard.service
+
+# After merge of disabled=true in quadlet.toml:
+make converge
+# Verify unit file pruned / not in restart set:
+test ! -f ~/.config/containers/systemd/factory-dashboard.container || true
+podman ps -a --filter name=factory-dashboard
+# Hub/NATS still green:
+curl -sS http://127.0.0.1:8443/health
+```
+
+| Control | Scope |
+|---------|--------|
+| `quadlet.toml` `disabled = true` | **Git SSoT** — converge/prune skips unit |
+| `systemctl mask` | **Host-local** only; not durable across clean hosts |
+
+### Re-enable (Slice 4 only)
+
+```bash
+# 1. PR: disabled = false (or remove key) after Slices 2–3 on staging-svc
+# 2. If ever masked:
+systemctl --user unmask factory-dashboard.service
+# 3.
+make converge
+systemctl --user is-active factory-dashboard
+# 4. Smoke: Tailnet :8765 — unauth /api/bff/auth/me → 401; /healthz public
+```
+
+## Target install (post Slice 1–4 — hub IdP)
+
+1. Ensure hub can write `auth.db` (`factory-data.volume` / `FACTORY_AUTH_DB`).
+2. Bootstrap admin env on **hub** (Slice 1 renames may apply — see migration):
 
    ```bash
+   # provisional names until Slice 1 lands
    FACTORY_DASHBOARD_BOOTSTRAP_ADMIN_EMAIL=you@example.com
    FACTORY_DASHBOARD_BOOTSTRAP_ADMIN_PASSWORD='…strong…'
    ```
 
-3. Start `factory adapter web` (or unified `factory start`). On first connect,
-   ControlPlaneStore creates the admin if none exists. Missing password with
-   email set fails startup with a clear error.
-4. Open the SPA → **Sign in** with that email/password.
-5. **Invite** users: `POST /api/bff/auth/invites` (admin session) or future UI.
-6. Each user: **Link accounts** → `/link <code>` on Telegram **and** Discord.
-7. Admin grants agent USE (CLI or Users page) — grants land on platform ids.
+3. Thin BFF on dashboard resolves sessions via **hub RPC** (no local ControlPlaneStore).
+4. SPA → Sign in; invite; link TG+DC; grants on platform ids.
+
+## Historical dual-open path (debt — local/dev only)
+
+> **Prod M₁:** do **not** run these against factory-dashboard until Slice 4.
+> Dual-open (`open_control_plane_store` in web adapter) is **superseded** as target.
+
+1. Writable `auth.db` path on the host used by the **local** web process.
+2. `FACTORY_DASHBOARD_BOOTSTRAP_*` on that process (password required if email set).
+3. `factory adapter web` — store open at astart (debt path).
+4. SPA login / invite / link as before.
 
 ## Cookies
 
@@ -37,9 +78,9 @@ TG/DC agent turns refuse until dual-linked (`PlatformLinkMiddleware`).
 ## Health
 
 Liveness / HealthCmd remains unauthenticated. Do not put auth on `/healthz`.
+(Slice 3: HealthCmd must not require `/api/agents` 200.)
 
 ## Rollback (emergency)
 
-Unset bootstrap env and stop requiring principal only after a deliberate
-maintenance window — hub `_wrap` fails closed without principal stamps.
-Prefer fixing session secret / admin password over disabling auth.
+Prefer hub/session secret fix over disabling auth. Interim console off =
+`disabled = true` + stop (this Slice 0 posture).

--- a/docs/runbooks/dashboard-auth-bootstrap.md
+++ b/docs/runbooks/dashboard-auth-bootstrap.md
@@ -1,5 +1,10 @@
 # Runbook — Dashboard control-plane auth bootstrap (ADR-103)
 
+> **2026-07-12 interim:** `factory-dashboard` is **disabled** on M₁ until hub-IdP
+> migration ([`dashboard-auth-hub-idp-migration.md`](../../artifacts/goal/dashboard-auth-hub-idp-migration.md)).
+> Do **not** mount `factory-data` on the dashboard unit. Bootstrap admin will move to
+> **hub** env when Slice 1 lands; the dual-open dashboard path is debt.
+
 ## First install
 
 1. Ensure `auth.db` path is writable (`~/.roxabi/factory/auth.db` or `FACTORY_AUTH_DB`).

--- a/tests/deploy/test_converge_nats_restart.py
+++ b/tests/deploy/test_converge_nats_restart.py
@@ -34,12 +34,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent.parent
 CONVERGE_SH = REPO_ROOT / "deploy" / "converge.sh"
 
-# All 7 factory clients restarted on structural drift (per converge.sh lines 86-89)
+# Enabled factory clients restarted on structural drift (quadlet_containers minus
+# factory-nats). factory-dashboard is disabled=true (ADR-103 hub sole IdP) until
+# thin-BFF Slice 4 — converge must NOT restart it.
 STRUCTURAL_CLIENTS = [
     "factory-hub",
     "factory-telegram",
     "factory-discord",
-    "factory-dashboard",
     "factory-clipool",
     "factory-turn-writer",
     "factory-gh-helper",

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -23,7 +23,7 @@ EXPECTED_CONTAINERS = [
     "factory-hub",
     "factory-telegram",
     "factory-discord",
-    "factory-dashboard",
+    # factory-dashboard — disabled (ADR-103 hub sole IdP) until thin-BFF.
     "factory-clipool",
     "factory-gh-helper",
     "factory-turn-writer",


### PR DESCRIPTION
## Summary

- **Accept ADR-103 (amended):** unique control-plane IdP = **hub** sole `ControlPlaneStore` / `auth.db`; thin HTTP BFF at Tailnet edge; **reject** shared `factory-data` on dashboard and SPA-in-hub.
- **Migration plan B** in PR slices: `artifacts/goal/dashboard-auth-hub-idp-migration.md`.
- **Ops interim:** `[component.dashboard] disabled = true` so M₁ does not restart the crash-loop dual-open dashboard.
- Update `security-routing.md` + bootstrap runbook.

M₁ already: `systemctl --user mask factory-dashboard` (hub/NATS/adapters green).

## Test plan

- [x] Docs only + quadlet disable flag
- [x] M₁ hub/nats health after dashboard mask
- [ ] After merge: M₁ quadlet-sync does not re-enable dashboard

Refs: ADR-103, #2262