### PR TITLE
fix(hub): keep session_token on public auth session.resolve

### DIFF
--- a/src/factory/bootstrap/factory/dashboard/rpc_wrap.py
+++ b/src/factory/bootstrap/factory/dashboard/rpc_wrap.py
@@ -50,6 +50,7 @@ def wrap_dashboard_handler(
             parse_principal_from_payload,
             set_request_principal,
             strip_principal_payload,
+            strip_proof_payload,
         )
 
         try:
@@ -82,7 +83,11 @@ def wrap_dashboard_handler(
                 # Public path may still carry stamp — do not trust roles.
                 set_request_principal(wire)
             try:
+                # Public auth handlers (session.resolve / api_key.resolve) need
+                # proof fields; protected handlers get them stripped after rehydrate.
                 business = strip_principal_payload(payload)
+                if need_principal:
+                    business = strip_proof_payload(business)
                 result = await handler(hub, nc, business)
                 await msg.respond(json.dumps(result).encode())
             finally:

--- a/src/factory/core/auth/control_plane_wire.py
+++ b/src/factory/core/auth/control_plane_wire.py
@@ -19,6 +19,7 @@ __all__ = [
     "set_request_session_token",
     "stamp_principal_payload",
     "strip_principal_payload",
+    "strip_proof_payload",
 ]
 
 ORG_HEADER = "X-Factory-Org-Id"
@@ -33,6 +34,8 @@ _request_api_key: ContextVar[str | None] = ContextVar(
     "control_plane_api_key", default=None
 )
 
+# Wire stamp only — proof fields are NOT stripped here. Protected handlers drop
+# proofs after rehydrate in rpc_wrap (public auth RPCs need session_token/api_key).
 _PRINCIPAL_KEYS = frozenset(
     {
         "principal_user_id",
@@ -40,10 +43,9 @@ _PRINCIPAL_KEYS = frozenset(
         "principal_org_ids",
         "principal_active_org_id",
         "principal_via",
-        "session_token",
-        "api_key",
     }
 )
+_PROOF_KEYS = frozenset({"session_token", "api_key"})
 
 
 def set_request_principal(principal: ControlPlanePrincipal | None) -> None:
@@ -103,6 +105,11 @@ def stamp_principal_payload(
 
 def strip_principal_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in payload.items() if k not in _PRINCIPAL_KEYS}
+
+
+def strip_proof_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop session_token / api_key after rehydrate (business handlers)."""
+    return {k: v for k, v in payload.items() if k not in _PROOF_KEYS}
 
 
 def parse_principal_from_payload(

--- a/tests/bootstrap/test_session_resolve_keeps_token.py
+++ b/tests/bootstrap/test_session_resolve_keeps_token.py
@@ -1,0 +1,44 @@
+"""Public session.resolve must receive session_token (not stripped by wrap)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from factory.bootstrap.factory.dashboard.auth_rpc import (
+    handle_auth_login,
+    handle_auth_session_resolve,
+)
+from factory.bootstrap.factory.dashboard.rpc_wrap import wrap_dashboard_handler
+from factory.infrastructure.stores.identity.control_plane_store import ControlPlaneStore
+from roxabi_contracts.dashboard import SUBJECTS
+
+
+@pytest.mark.asyncio
+async def test_wrap_session_resolve_keeps_token(tmp_path: Path) -> None:
+    store = ControlPlaneStore(tmp_path / "auth.db")
+    await store.connect()
+    try:
+        await store.bootstrap_admin_if_empty(
+            email="a@test.local", password="admin-secret-99", display_name="A"
+        )
+        hub = MagicMock()
+        hub._control_plane = store
+        login = await handle_auth_login(
+            hub, MagicMock(), {"email": "a@test.local", "password": "admin-secret-99"}
+        )
+        token = login["session_token"]
+        cb = wrap_dashboard_handler(hub, MagicMock(), handle_auth_session_resolve)
+        msg = MagicMock()
+        msg.subject = SUBJECTS.auth_session_resolve
+        msg.data = json.dumps({"session_token": token}).encode()
+        msg.respond = AsyncMock()
+        await cb(msg)
+        raw = json.loads(msg.respond.await_args.args[0].decode())
+        assert raw.get("ok") is True, raw
+        assert raw["principal"]["user_id"] == login["principal"]["user_id"]
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary
Public `factory.dashboard.auth.session.resolve` was receiving empty payloads because `session_token` was stripped as a principal key before the handler. Login 200 + me 401 on M₁.

## Test plan
- [x] `tests/bootstrap/test_session_resolve_keeps_token.py`
- [x] existing dashboard auth RPC tests
- [x] M₁ hot-patch smoke login + me 200