### PR TITLE
feat(dashboard-v2): login page shadcn login-05 style

### DIFF
--- a/apps/dashboard-v2/src/features/auth/login-page.tsx
+++ b/apps/dashboard-v2/src/features/auth/login-page.tsx
@@ -24,9 +24,10 @@ export function LoginPage() {
 
   const redirectTo = safeRedirectPath(search.redirect);
 
+  // href preserves path+search (e.g. /ops?container=x); `to` is pathname-only.
   useEffect(() => {
     if (status === "authenticated" || status === "legacy") {
-      void navigate({ to: redirectTo });
+      void navigate({ href: redirectTo, replace: true });
     }
   }, [status, navigate, redirectTo]);
 
@@ -36,7 +37,8 @@ export function LoginPage() {
     setPending(true);
     try {
       await login(email.trim(), password);
-      await navigate({ to: redirectTo });
+      // Effect also navigates after status flip; href keeps query from safeRedirect.
+      await navigate({ href: redirectTo, replace: true });
     } catch (err) {
       setError(err instanceof BffApiError ? err.detail : t("login.failed"));
     } finally {

--- a/apps/dashboard-v2/src/features/auth/login-page.tsx
+++ b/apps/dashboard-v2/src/features/auth/login-page.tsx
@@ -1,11 +1,15 @@
+/**
+ * Login page — layout aligned with shadcn block login-05
+ * (centered stack, brand mark, FieldGroup form; password kept for hub IdP).
+ */
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { useAuth } from "@/features/auth/auth-context";
+import { cn } from "@/lib/utils";
 import { BffApiError } from "@/shared/api/client";
 
 export function LoginPage() {
@@ -37,57 +41,73 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle className="font-heading text-2xl">{t("login.title")}</CardTitle>
-          <CardDescription>{t("login.subtitle")}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form className="space-y-4" onSubmit={(e) => void onSubmit(e)}>
-            <div className="space-y-2">
-              <Label htmlFor="email">{t("login.email")}</Label>
-              <Input
-                id="email"
-                type="email"
-                autoComplete="username"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">{t("login.password")}</Label>
-              <Input
-                id="password"
-                type="password"
-                autoComplete="current-password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-            </div>
-            {error ? (
-              <p className="text-sm text-destructive" role="alert">
-                {error}
-              </p>
-            ) : null}
-            <Button type="submit" className="w-full" disabled={pending}>
-              {pending ? t("login.submitting") : t("login.submit")}
-            </Button>
+    <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
+      <div className="w-full max-w-sm">
+        <div className={cn("flex flex-col gap-6")}>
+          <form onSubmit={(e) => void onSubmit(e)}>
+            <FieldGroup>
+              <div className="flex flex-col items-center gap-2 text-center">
+                <div className="flex flex-col items-center gap-2 font-medium">
+                  <div className="flex size-10 items-center justify-center rounded-md">
+                    <img
+                      src="/factory-mark.svg"
+                      alt=""
+                      width={40}
+                      height={40}
+                      className="size-10"
+                    />
+                  </div>
+                  <span className="sr-only">{t("login.brand")}</span>
+                </div>
+                <h1 className="text-xl font-bold">{t("login.welcome")}</h1>
+                <FieldDescription className="text-center">
+                  {t("login.subtitle")}{" "}
+                  <Link
+                    to="/accept-invite"
+                    search={{ token: undefined }}
+                    className="underline underline-offset-4"
+                  >
+                    {t("login.acceptInvite")}
+                  </Link>
+                </FieldDescription>
+              </div>
+
+              <Field>
+                <FieldLabel htmlFor="email">{t("login.email")}</FieldLabel>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder={t("login.emailPlaceholder")}
+                  autoComplete="username"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="password">{t("login.password")}</FieldLabel>
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </Field>
+
+              {error ? <FieldError>{error}</FieldError> : null}
+
+              <Field>
+                <Button type="submit" className="w-full" disabled={pending}>
+                  {pending ? t("login.submitting") : t("login.submit")}
+                </Button>
+              </Field>
+            </FieldGroup>
           </form>
-          <p className="mt-4 text-center text-xs text-muted-foreground">
-            {t("login.inviteHint")}{" "}
-            <Link
-              to="/accept-invite"
-              search={{ token: undefined }}
-              className="underline underline-offset-2"
-            >
-              {t("login.acceptInvite")}
-            </Link>
-          </p>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard-v2/src/features/auth/login-page.tsx
+++ b/apps/dashboard-v2/src/features/auth/login-page.tsx
@@ -3,13 +3,13 @@
  * (centered stack, brand mark, FieldGroup form; password kept for hub IdP).
  */
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/features/auth/auth-context";
-import { cn } from "@/lib/utils";
+import { safeRedirectPath } from "@/features/auth/safe-redirect";
 import { BffApiError } from "@/shared/api/client";
 
 export function LoginPage() {
@@ -22,9 +22,13 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
-  if (status === "authenticated" || status === "legacy") {
-    void navigate({ to: (search.redirect as "/") || "/" });
-  }
+  const redirectTo = safeRedirectPath(search.redirect);
+
+  useEffect(() => {
+    if (status === "authenticated" || status === "legacy") {
+      void navigate({ to: redirectTo });
+    }
+  }, [status, navigate, redirectTo]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -32,7 +36,7 @@ export function LoginPage() {
     setPending(true);
     try {
       await login(email.trim(), password);
-      await navigate({ to: search.redirect || "/" });
+      await navigate({ to: redirectTo });
     } catch (err) {
       setError(err instanceof BffApiError ? err.detail : t("login.failed"));
     } finally {
@@ -43,70 +47,74 @@ export function LoginPage() {
   return (
     <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <div className={cn("flex flex-col gap-6")}>
-          <form onSubmit={(e) => void onSubmit(e)}>
-            <FieldGroup>
-              <div className="flex flex-col items-center gap-2 text-center">
-                <div className="flex flex-col items-center gap-2 font-medium">
-                  <div className="flex size-10 items-center justify-center rounded-md">
-                    <img
-                      src="/factory-mark.svg"
-                      alt=""
-                      width={40}
-                      height={40}
-                      className="size-10"
-                    />
-                  </div>
-                  <span className="sr-only">{t("login.brand")}</span>
+        <form className="flex flex-col gap-6" onSubmit={(e) => void onSubmit(e)}>
+          <FieldGroup>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <div className="flex flex-col items-center gap-2 font-medium">
+                <div className="flex size-10 items-center justify-center rounded-md">
+                  <img
+                    src="/factory-mark.svg"
+                    alt=""
+                    width={40}
+                    height={40}
+                    className="size-10"
+                    aria-hidden
+                  />
                 </div>
-                <h1 className="text-xl font-bold">{t("login.welcome")}</h1>
-                <FieldDescription className="text-center">
-                  {t("login.subtitle")}{" "}
-                  <Link
-                    to="/accept-invite"
-                    search={{ token: undefined }}
-                    className="underline underline-offset-4"
-                  >
-                    {t("login.acceptInvite")}
-                  </Link>
-                </FieldDescription>
+                <span className="sr-only">{t("login.brand")}</span>
               </div>
+              <h1 className="text-xl font-bold">{t("login.welcome")}</h1>
+              <FieldDescription className="text-center">{t("login.subtitle")}</FieldDescription>
+              <FieldDescription className="text-center">
+                {t("login.inviteHint")}{" "}
+                <Link
+                  to="/accept-invite"
+                  search={{ token: undefined }}
+                  className="underline underline-offset-4"
+                >
+                  {t("login.acceptInvite")}
+                </Link>
+              </FieldDescription>
+            </div>
 
-              <Field>
-                <FieldLabel htmlFor="email">{t("login.email")}</FieldLabel>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder={t("login.emailPlaceholder")}
-                  autoComplete="username"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                />
-              </Field>
+            <Field>
+              <FieldLabel htmlFor="email">{t("login.email")}</FieldLabel>
+              <Input
+                id="email"
+                type="email"
+                placeholder={t("login.emailPlaceholder")}
+                autoComplete="username"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "login-error" : undefined}
+              />
+            </Field>
 
-              <Field>
-                <FieldLabel htmlFor="password">{t("login.password")}</FieldLabel>
-                <Input
-                  id="password"
-                  type="password"
-                  autoComplete="current-password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                />
-              </Field>
+            <Field>
+              <FieldLabel htmlFor="password">{t("login.password")}</FieldLabel>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "login-error" : undefined}
+              />
+            </Field>
 
-              {error ? <FieldError>{error}</FieldError> : null}
+            {error ? <FieldError id="login-error">{error}</FieldError> : null}
 
-              <Field>
-                <Button type="submit" className="w-full" disabled={pending}>
-                  {pending ? t("login.submitting") : t("login.submit")}
-                </Button>
-              </Field>
-            </FieldGroup>
-          </form>
-        </div>
+            <Field>
+              <Button type="submit" className="w-full" disabled={pending}>
+                {pending ? t("login.submitting") : t("login.submit")}
+              </Button>
+            </Field>
+          </FieldGroup>
+        </form>
       </div>
     </div>
   );

--- a/apps/dashboard-v2/src/features/auth/safe-redirect.test.ts
+++ b/apps/dashboard-v2/src/features/auth/safe-redirect.test.ts
@@ -8,11 +8,19 @@ describe("safeRedirectPath", () => {
     expect(safeRedirectPath("/agents?x=1")).toBe("/agents?x=1");
   });
 
-  it("rejects open redirects", () => {
+  it("rejects open redirects and junk", () => {
     expect(safeRedirectPath("//evil.example")).toBe("/");
     expect(safeRedirectPath("https://evil.example")).toBe("/");
+    expect(safeRedirectPath("http://evil.example")).toBe("/");
+    expect(safeRedirectPath("javascript:alert(1)")).toBe("/");
+    expect(safeRedirectPath("/\\evil.example")).toBe("/");
     expect(safeRedirectPath("")).toBe("/");
     expect(safeRedirectPath(null)).toBe("/");
     expect(safeRedirectPath(undefined)).toBe("/");
+  });
+
+  it("maps public auth paths to home", () => {
+    expect(safeRedirectPath("/login")).toBe("/");
+    expect(safeRedirectPath("/accept-invite")).toBe("/");
   });
 });

--- a/apps/dashboard-v2/src/features/auth/safe-redirect.test.ts
+++ b/apps/dashboard-v2/src/features/auth/safe-redirect.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { safeRedirectPath } from "./safe-redirect";
+
+describe("safeRedirectPath", () => {
+  it("allows same-origin absolute paths", () => {
+    expect(safeRedirectPath("/")).toBe("/");
+    expect(safeRedirectPath("/chat")).toBe("/chat");
+    expect(safeRedirectPath("/agents?x=1")).toBe("/agents?x=1");
+  });
+
+  it("rejects open redirects", () => {
+    expect(safeRedirectPath("//evil.example")).toBe("/");
+    expect(safeRedirectPath("https://evil.example")).toBe("/");
+    expect(safeRedirectPath("")).toBe("/");
+    expect(safeRedirectPath(null)).toBe("/");
+    expect(safeRedirectPath(undefined)).toBe("/");
+  });
+});

--- a/apps/dashboard-v2/src/features/auth/safe-redirect.ts
+++ b/apps/dashboard-v2/src/features/auth/safe-redirect.ts
@@ -1,0 +1,6 @@
+/** Same-origin path only — blocks open redirects (`//evil`, absolute URLs). */
+export function safeRedirectPath(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) return "/";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw;
+}

--- a/apps/dashboard-v2/src/features/auth/safe-redirect.ts
+++ b/apps/dashboard-v2/src/features/auth/safe-redirect.ts
@@ -1,6 +1,19 @@
-/** Same-origin path only — blocks open redirects (`//evil`, absolute URLs). */
+const PUBLIC_AUTH_PATHS = new Set(["/login", "/accept-invite"]);
+
+function hasControlOrBackslash(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c === 0x5c || c <= 0x1f || c === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Same-origin path (+ optional search) only — blocks open redirects. */
 export function safeRedirectPath(raw: unknown): string {
   if (typeof raw !== "string" || raw.length === 0) return "/";
   if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  if (hasControlOrBackslash(raw)) return "/";
+  const pathOnly = raw.split(/[?#]/, 1)[0] ?? "/";
+  if (PUBLIC_AUTH_PATHS.has(pathOnly)) return "/";
   return raw;
 }

--- a/apps/dashboard-v2/src/i18n/locales/en/auth.json
+++ b/apps/dashboard-v2/src/i18n/locales/en/auth.json
@@ -1,6 +1,5 @@
 {
   "login": {
-    "title": "Sign in",
     "brand": "Roxabi Factory",
     "welcome": "Welcome to Factory",
     "subtitle": "Invite-only operator console.",

--- a/apps/dashboard-v2/src/i18n/locales/en/auth.json
+++ b/apps/dashboard-v2/src/i18n/locales/en/auth.json
@@ -1,10 +1,13 @@
 {
   "login": {
     "title": "Sign in",
-    "subtitle": "Invite-only console — use your factory account.",
+    "brand": "Roxabi Factory",
+    "welcome": "Welcome to Factory",
+    "subtitle": "Invite-only operator console.",
     "email": "Email",
+    "emailPlaceholder": "m@example.com",
     "password": "Password",
-    "submit": "Sign in",
+    "submit": "Login",
     "submitting": "Signing in…",
     "failed": "Invalid email or password",
     "inviteHint": "Have an invite?",

--- a/apps/dashboard-v2/src/i18n/locales/fr/auth.json
+++ b/apps/dashboard-v2/src/i18n/locales/fr/auth.json
@@ -1,6 +1,5 @@
 {
   "login": {
-    "title": "Connexion",
     "brand": "Roxabi Factory",
     "welcome": "Bienvenue sur Factory",
     "subtitle": "Console opérateur sur invitation.",

--- a/apps/dashboard-v2/src/i18n/locales/fr/auth.json
+++ b/apps/dashboard-v2/src/i18n/locales/fr/auth.json
@@ -1,10 +1,13 @@
 {
   "login": {
     "title": "Connexion",
-    "subtitle": "Console sur invitation — compte factory.",
+    "brand": "Roxabi Factory",
+    "welcome": "Bienvenue sur Factory",
+    "subtitle": "Console opérateur sur invitation.",
     "email": "E-mail",
+    "emailPlaceholder": "m@example.com",
     "password": "Mot de passe",
-    "submit": "Se connecter",
+    "submit": "Connexion",
     "submitting": "Connexion…",
     "failed": "E-mail ou mot de passe invalide",
     "inviteHint": "Vous avez une invitation ?",

--- a/apps/dashboard-v2/src/router.tsx
+++ b/apps/dashboard-v2/src/router.tsx
@@ -14,6 +14,7 @@ import { AcceptInvitePage } from "@/features/auth/accept-invite-page";
 import { AccountLinksPage } from "@/features/auth/account-links-page";
 import { fetchMe } from "@/features/auth/api";
 import { LoginPage } from "@/features/auth/login-page";
+import { safeRedirectPath } from "@/features/auth/safe-redirect";
 import { ChatPage } from "@/features/chat/chat-page";
 import { FleetPage } from "@/features/fleet/fleet-page";
 import { IntegrationsPage } from "@/features/integrations/integrations-page";
@@ -43,10 +44,8 @@ const rootRoute = createRootRouteWithContext<RouterContext>()({
   component: RootLayout,
   beforeLoad: async ({ location }) => {
     if (PUBLIC_PATHS.has(location.pathname)) return;
-    const safeRedirect =
-      location.pathname.startsWith("/") && !location.pathname.startsWith("//")
-        ? `${location.pathname}${location.searchStr ?? ""}`
-        : "/";
+    const raw = `${location.pathname}${location.searchStr ?? ""}`;
+    const safeRedirect = safeRedirectPath(raw);
     try {
       const me = await fetchMe();
       if (me === null) {
@@ -76,9 +75,13 @@ const loginRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/login",
   component: LoginPage,
-  validateSearch: (search: Record<string, unknown>) => ({
-    redirect: typeof search.redirect === "string" ? search.redirect : undefined,
-  }),
+  validateSearch: (search: Record<string, unknown>) => {
+    const raw = search.redirect;
+    if (typeof raw !== "string") return { redirect: undefined };
+    // Reject open redirects (`//evil`, absolute URLs); keep only same-origin paths.
+    const safe = safeRedirectPath(raw);
+    return { redirect: safe === raw ? raw : undefined };
+  },
 });
 
 const acceptInviteRoute = createRoute({


### PR DESCRIPTION
## Summary
Restyle `/login` after shadcn block **login-05** (centered layout, mark, Field primitives).

- Keeps **password** (required for hub IdP) — block is email-only by default
- No Apple/Google (not wired)
- Invite link in the description under the title

## Test plan
- [x] biome + typecheck + vitest
- [ ] Visual check on Tailnet `/login`