### PR TITLE
fix(dashboard-v2): login layout collapsed to 0px under SidebarProvider

### DIFF
--- a/apps/dashboard-v2/src/app/providers.tsx
+++ b/apps/dashboard-v2/src/app/providers.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { I18nextProvider } from "react-i18next";
 import { createAppQueryClient } from "@/app/query-client";
 import { ThemeProvider } from "@/components/theme-provider";
-import { SidebarProvider } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/features/auth/auth-context";
@@ -11,6 +10,11 @@ import i18n from "@/i18n";
 
 const queryClient = createAppQueryClient();
 
+/**
+ * Global providers only. SidebarProvider lives in AppShell so public routes
+ * (/login, /accept-invite) are not flex children of sidebar-wrapper (that
+ * collapses w-full form columns to 0px — login-05 layout).
+ */
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <I18nextProvider i18n={i18n}>
@@ -18,10 +22,8 @@ export function AppProviders({ children }: { children: ReactNode }) {
         <ThemeProvider defaultTheme="dark" storageKey="dashboard-v2-theme">
           <AuthProvider>
             <TooltipProvider>
-              <SidebarProvider>
-                {children}
-                <Toaster richColors position="bottom-right" />
-              </SidebarProvider>
+              {children}
+              <Toaster richColors position="bottom-right" />
             </TooltipProvider>
           </AuthProvider>
         </ThemeProvider>

--- a/apps/dashboard-v2/src/components/app-shell/app-shell.tsx
+++ b/apps/dashboard-v2/src/components/app-shell/app-shell.tsx
@@ -4,7 +4,7 @@ import { resolveLayoutFlags } from "@/app/nav";
 import { ShellTitleProvider } from "@/app/shell-title";
 import { AppHeader } from "@/components/app-shell/app-header";
 import { AppSidebar } from "@/components/app-shell/app-sidebar";
-import { SidebarInset, useSidebar } from "@/components/ui/sidebar";
+import { SidebarInset, SidebarProvider, useSidebar } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
 
@@ -38,12 +38,12 @@ function ShellLayout() {
 
 export function AppShell() {
   return (
-    <>
+    <SidebarProvider>
       <AppSidebar />
       <SidebarInset className="min-h-dvh">
         <ShellLayout />
       </SidebarInset>
       <Toaster />
-    </>
+    </SidebarProvider>
   );
 }


### PR DESCRIPTION
## Summary
Visual check of `http://roxabituwer:8765/login?redirect=%2F` showed the login-05 form crushed to the left edge (inputs ~22px wide, form width **0px**).

**Root cause:** `SidebarProvider` wrapped all routes in `AppProviders`. Its root is `display: flex` (row). Login is a flex child without `w-full`; inner `w-full max-w-sm` then collapses to 0.

**Fix:** Move `SidebarProvider` into `AppShell` only. Public routes (`/login`, `/accept-invite`) render outside the sidebar flex wrapper.

## Test plan
- [x] typecheck + vitest (53)
- [ ] After deploy: screenshot `/login?redirect=%2F` — centered form ~384px, full-width inputs
- [ ] Authenticated shell still works (sidebar open/collapse)