### PR TITLE
fix(dashboard): orgs hub RPC (no 503) + Base UI #31 nav composition

### DIFF
--- a/apps/dashboard-v2/src/components/app-shell/app-sidebar.tsx
+++ b/apps/dashboard-v2/src/components/app-shell/app-sidebar.tsx
@@ -55,13 +55,7 @@ function NavSection({ titleKey, items }: { titleKey: string; items: AppNavItem[]
 
             return (
               <SidebarMenuItem key={item.to}>
-                <SidebarMenuButton
-                  isActive={active}
-                  tooltip={label}
-                  // Link renders <a>; Base UI error #31 if nativeButton stays true.
-                  nativeButton={false}
-                  render={<Link to={item.to} />}
-                >
+                <SidebarMenuButton isActive={active} tooltip={label} render={<Link to={item.to} />}>
                   <Icon />
                   <span>{label}</span>
                 </SidebarMenuButton>
@@ -82,7 +76,7 @@ export function AppSidebar() {
       <SidebarHeader className="border-b border-sidebar-border">
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton size="lg" nativeButton={false} render={<Link to="/" />}>
+            <SidebarMenuButton size="lg" render={<Link to="/" />}>
               <img src="/factory-mark.svg" alt="" className="size-8" aria-hidden />
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-semibold">{t("appName")}</span>

--- a/apps/dashboard-v2/src/components/app-shell/nav-user.tsx
+++ b/apps/dashboard-v2/src/components/app-shell/nav-user.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import {
   Building2,
   ChevronsUpDown,
@@ -66,6 +66,7 @@ export function NavUser() {
   const { t } = useTranslation("common");
   const { t: ta } = useTranslation("auth");
   const { isMobile } = useSidebar();
+  const navigate = useNavigate();
   const { status, session, logout, activeOrgId, setOrg } = useAuth();
   const { theme, setTheme } = useTheme();
   const qc = useQueryClient();
@@ -76,6 +77,8 @@ export function NavUser() {
     queryKey: ["auth", "orgs"],
     queryFn: fetchOrgs,
     enabled: status === "authenticated",
+    // Soft-fail: empty org list if hub/BFF briefly unavailable (no toast storm).
+    retry: 1,
   });
   const create = useMutation({
     mutationFn: () => createOrg(orgName.trim()),
@@ -95,8 +98,6 @@ export function NavUser() {
           <SidebarMenuButton
             size="lg"
             tooltip={ta("login.submit")}
-            // Link is <a> — Base UI requires nativeButton=false (error #31).
-            nativeButton={false}
             render={<Link to="/login" search={{ redirect: undefined }} />}
           >
             <UserRound />
@@ -120,12 +121,14 @@ export function NavUser() {
         <SidebarMenuItem>
           <DropdownMenu>
             <DropdownMenuTrigger
-              // Trigger expects native <button>; SidebarMenuButton is a <button>.
+              // Menu.Trigger is nativeButton=true. Do NOT pass tooltip on the
+              // rendered SidebarMenuButton — tooltip wraps TooltipTrigger (non-
+              // <button>) and triggers Base UI production error #31.
+              aria-label={t("userMenu.open", { name: primary })}
               render={
                 <SidebarMenuButton
                   size="lg"
                   className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
-                  tooltip={t("userMenu.open", { name: primary })}
                 />
               }
             >
@@ -220,9 +223,9 @@ export function NavUser() {
 
               <DropdownMenuGroup>
                 <DropdownMenuItem
-                  // Close menu then navigate — Item is non-native (div).
-                  render={<Link to="/account/links" />}
-                  nativeButton={false}
+                  onClick={() => {
+                    void navigate({ to: "/account/links" });
+                  }}
                 >
                   <Link2 />
                   {ta("session.linkAccounts")}

--- a/apps/dashboard-v2/src/components/ui/button.tsx
+++ b/apps/dashboard-v2/src/components/ui/button.tsx
@@ -44,12 +44,19 @@ function Button({
   className,
   variant = "default",
   size = "default",
+  render,
+  nativeButton,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  // Base UI defaults nativeButton=true. Composition with <Link>/<a>/etc. must
+  // opt out or production throws error #31.
+  const resolvedNativeButton = nativeButton ?? (render != null ? false : undefined);
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      render={render}
+      {...(resolvedNativeButton === undefined ? {} : { nativeButton: resolvedNativeButton })}
       {...props}
     />
   );

--- a/apps/dashboard-v2/src/components/ui/sidebar.tsx
+++ b/apps/dashboard-v2/src/components/ui/sidebar.tsx
@@ -481,27 +481,33 @@ function SidebarMenuButton({
   size = "default",
   tooltip,
   className,
-  nativeButton,
   ...props
 }: useRender.ComponentProps<"button"> &
   React.ComponentProps<"button"> & {
     isActive?: boolean;
     tooltip?: string | React.ComponentProps<typeof TooltipContent>;
-    /** When render is non-<button> (e.g. Link), set false — Base UI error #31. */
-    nativeButton?: boolean;
   } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const { isMobile, state } = useSidebar();
+  // TooltipTrigger is a native-button host. Wrapping a Link (or other non-button
+  // `render`) causes Base UI production error #31. For composition renders we
+  // fall back to the HTML title attribute when collapsed tooltips are needed.
+  const tooltipLabel = typeof tooltip === "string" ? tooltip : undefined;
+  const useRichTooltip = Boolean(tooltip) && render == null;
+  const titleFallback =
+    !useRichTooltip && tooltipLabel && (state === "collapsed" || isMobile)
+      ? tooltipLabel
+      : undefined;
+
   const comp = useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(
       {
         className: cn(sidebarMenuButtonVariants({ variant, size }), className),
-        // useRender/useButton read nativeButton from props.
-        ...(nativeButton === undefined ? {} : { nativeButton }),
-      } as React.ComponentProps<"button">,
+        ...(titleFallback ? { title: titleFallback } : {}),
+      },
       props,
     ),
-    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    render: useRichTooltip ? <TooltipTrigger /> : render,
     state: {
       slot: "sidebar-menu-button",
       sidebar: "menu-button",
@@ -510,7 +516,7 @@ function SidebarMenuButton({
     },
   });
 
-  if (!tooltip) {
+  if (!useRichTooltip) {
     return comp;
   }
 

--- a/packages/roxabi-contracts/src/roxabi_contracts/dashboard/auth_models.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/dashboard/auth_models.py
@@ -138,3 +138,33 @@ class DashboardAuthPasswordChangeResponse(BaseModel):
     ok: bool = True
     error: str | None = None
     message: str | None = None
+
+
+class DashboardOrgRow(BaseModel):
+    id: str
+    name: str
+    created_by: str
+    created_at: str
+
+
+class DashboardOrgListRequest(BaseModel):
+    """Principal from session rehydrate (empty body OK)."""
+
+
+class DashboardOrgListResponse(BaseModel):
+    ok: bool = True
+    error: str | None = None
+    message: str | None = None
+    orgs: list[DashboardOrgRow] = Field(default_factory=list)
+    active_org_id: str | None = None
+
+
+class DashboardOrgCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+
+
+class DashboardOrgCreateResponse(BaseModel):
+    ok: bool = True
+    error: str | None = None
+    message: str | None = None
+    org: DashboardOrgRow | None = None

--- a/packages/roxabi-contracts/src/roxabi_contracts/dashboard/subjects.py
+++ b/packages/roxabi-contracts/src/roxabi_contracts/dashboard/subjects.py
@@ -97,6 +97,11 @@ class DashboardSubjects(BaseModel):
     auth_password_change: Literal["factory.dashboard.auth.password.change"] = (
         "factory.dashboard.auth.password.change"
     )
+    # Orgs live on hub ControlPlaneStore (thin BFF must not open auth.db)
+    org_list: Literal["factory.dashboard.org.list"] = "factory.dashboard.org.list"
+    org_create: Literal["factory.dashboard.org.create"] = (
+        "factory.dashboard.org.create"
+    )
 
 
 SUBJECTS = DashboardSubjects()

--- a/src/factory/bootstrap/factory/dashboard/org_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard/org_rpc.py
@@ -1,0 +1,90 @@
+"""Hub org directory RPC — factory.dashboard.org.* (thin BFF, hub sole IdP)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from factory.core.auth.control_plane_authz import authorize
+from factory.core.auth.control_plane_wire import get_request_principal
+from roxabi_contracts.dashboard.auth_models import (
+    DashboardOrgCreateRequest,
+    DashboardOrgCreateResponse,
+    DashboardOrgListResponse,
+    DashboardOrgRow,
+)
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+
+    from factory.core.hub import Hub
+    from factory.core.stores.control_plane_protocol import ControlPlaneDirectory
+
+log = logging.getLogger(__name__)
+
+
+def _cp(hub: Hub) -> ControlPlaneDirectory | None:
+    return getattr(hub, "_control_plane", None)
+
+
+def _org_row(org: Any) -> DashboardOrgRow:
+    return DashboardOrgRow(
+        id=org.id,
+        name=org.name,
+        created_by=org.created_by,
+        created_at=org.created_at.isoformat(),
+    )
+
+
+async def handle_org_list(
+    hub: Hub, _nc: NATS, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """List orgs for the rehydrated principal (self memberships)."""
+    del payload
+    cp = _cp(hub)
+    if cp is None:
+        return DashboardOrgListResponse(
+            ok=False, error="unavailable", message="control-plane not configured"
+        ).model_dump()
+    principal = get_request_principal()
+    if principal is None:
+        return DashboardOrgListResponse(
+            ok=False, error="unauthorized", message="principal required"
+        ).model_dump()
+    orgs = await cp.list_orgs_for_user(principal.user_id)
+    return DashboardOrgListResponse(
+        ok=True,
+        orgs=[_org_row(o) for o in orgs],
+        active_org_id=principal.active_org_id,
+    ).model_dump()
+
+
+async def handle_org_create(
+    hub: Hub, _nc: NATS, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Create org as rehydrated principal (authz orgs.create)."""
+    cp = _cp(hub)
+    if cp is None:
+        return DashboardOrgCreateResponse(
+            ok=False, error="unavailable", message="control-plane not configured"
+        ).model_dump()
+    principal = get_request_principal()
+    if principal is None:
+        return DashboardOrgCreateResponse(
+            ok=False, error="unauthorized", message="principal required"
+        ).model_dump()
+    decision = authorize(principal, "orgs.create")
+    if not decision.allowed:
+        return DashboardOrgCreateResponse(
+            ok=False, error="forbidden", message=decision.reason or "forbidden"
+        ).model_dump()
+    req = DashboardOrgCreateRequest.model_validate(payload)
+    try:
+        org = await cp.create_org(name=req.name, created_by=principal.user_id)
+    except ValueError as exc:
+        log.info("org_rpc create_fail reason=%s", str(exc)[:80])
+        return DashboardOrgCreateResponse(
+            ok=False, error="bad_request", message=str(exc)[:120]
+        ).model_dump()
+    log.info("org_rpc create_ok org_id=%s user_id=%s", org.id, principal.user_id)
+    return DashboardOrgCreateResponse(ok=True, org=_org_row(org)).model_dump()

--- a/src/factory/bootstrap/factory/dashboard_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_rpc.py
@@ -31,6 +31,10 @@ from factory.bootstrap.factory.dashboard.fleet_rpc import handle_fleet_list
 from factory.bootstrap.factory.dashboard.identity_rpc import (
     handle_identity_cache_rewarm,
 )
+from factory.bootstrap.factory.dashboard.org_rpc import (
+    handle_org_create,
+    handle_org_list,
+)
 from factory.bootstrap.factory.dashboard.pipeline_rpc import handle_pipeline_list
 from factory.bootstrap.factory.dashboard.rpc_wrap import wrap_dashboard_handler
 from factory.bootstrap.factory.dashboard.voice_rpc import handle_voice_capabilities
@@ -130,6 +134,8 @@ async def start_dashboard_rpc(hub: Hub, nc: NATS) -> list[Any]:
         (SUBJECTS.auth_invite_accept, handle_auth_invite_accept),
         (SUBJECTS.auth_api_key_resolve, handle_auth_api_key_resolve),
         (SUBJECTS.auth_password_change, handle_auth_password_change),
+        (SUBJECTS.org_list, handle_org_list),
+        (SUBJECTS.org_create, handle_org_create),
     ):
         sub = await nc.subscribe(subject, cb=wrap_dashboard_handler(hub, nc, handler))
         subs.append(sub)

--- a/src/factory/dashboard/routes/hub_auth.py
+++ b/src/factory/dashboard/routes/hub_auth.py
@@ -19,6 +19,7 @@ from roxabi_contracts.dashboard.auth_models import (
     DashboardAuthPasswordChangeRequest,
     DashboardAuthPrincipal,
     DashboardAuthSessionResolveRequest,
+    DashboardOrgCreateRequest,
 )
 
 if TYPE_CHECKING:
@@ -33,6 +34,8 @@ __all__ = [
     "auth_logout",
     "auth_password_change",
     "auth_session_resolve",
+    "org_create",
+    "org_list",
     "principal_from_wire",
 ]
 
@@ -154,4 +157,15 @@ async def auth_password_change(
     raw = await hub._request(  # noqa: SLF001
         SUBJECTS.auth_password_change, req.model_dump()
     )
+    return _check(raw)
+
+
+async def org_list(hub: DashboardHubClient) -> dict[str, Any]:
+    raw = await hub._request(SUBJECTS.org_list, {})  # noqa: SLF001
+    return _check(raw)
+
+
+async def org_create(hub: DashboardHubClient, *, name: str) -> dict[str, Any]:
+    req = DashboardOrgCreateRequest(name=name)
+    raw = await hub._request(SUBJECTS.org_create, req.model_dump())  # noqa: SLF001
     return _check(raw)

--- a/src/factory/dashboard/routes/org_routes.py
+++ b/src/factory/dashboard/routes/org_routes.py
@@ -1,4 +1,4 @@
-"""Organization BFF routes (ADR-103 Block 4)."""
+"""Organization BFF routes — local CP (tests) or hub RPC (thin BFF / ADR-103)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,13 @@ from pydantic import BaseModel, Field
 from factory.core.auth.control_plane import ControlPlanePrincipal
 from factory.core.auth.control_plane_authz import authorize
 from factory.core.auth.control_plane_org import OrgRole
-from factory.dashboard.auth import control_plane_from_app, require_principal
+from factory.dashboard.auth import (
+    control_plane_from_app,
+    hub_client_from_app,
+    require_principal,
+)
+from factory.dashboard.routes.auth_common import http_from_hub_error
+from factory.dashboard.routes.hub_auth import HubAuthError, org_create, org_list
 
 __all__ = ["register_org_routes"]
 
@@ -41,6 +47,16 @@ async def _create_org(
     decision = authorize(principal, "orgs.create")
     if not decision.allowed:
         raise HTTPException(status_code=403, detail=decision.reason)
+    hub = hub_client_from_app(request)
+    cp = control_plane_from_app(request)
+    if hub is not None and cp is None:
+        try:
+            raw = await org_create(hub, name=body.name)
+        except HubAuthError as exc:
+            raise http_from_hub_error(exc) from exc
+        org = raw.get("org") or {}
+        return {"org": org}
+
     cp = _cp_or_503(request)
     try:
         org = await cp.create_org(name=body.name, created_by=principal.user_id)
@@ -60,6 +76,18 @@ async def _list_orgs(
     request: Request,
     principal: ControlPlanePrincipal = Depends(require_principal),
 ) -> dict[str, Any]:
+    hub = hub_client_from_app(request)
+    cp = control_plane_from_app(request)
+    if hub is not None and cp is None:
+        try:
+            raw = await org_list(hub)
+        except HubAuthError as exc:
+            raise http_from_hub_error(exc) from exc
+        return {
+            "orgs": raw.get("orgs") or [],
+            "active_org_id": raw.get("active_org_id") or principal.active_org_id,
+        }
+
     cp = _cp_or_503(request)
     # V1: list memberships of self (admin expansion deferred).
     orgs = await cp.list_orgs_for_user(principal.user_id)

--- a/tests/dashboard/test_org_hub_rpc.py
+++ b/tests/dashboard/test_org_hub_rpc.py
@@ -1,0 +1,138 @@
+"""Hub org list/create RPC + thin BFF orgs path."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from factory.adapters.web.web_adapter import WebAdapter
+from factory.adapters.web.web_server import create_app
+from factory.bootstrap.factory.dashboard.org_rpc import (
+    handle_org_create,
+    handle_org_list,
+)
+from factory.core.auth.control_plane import (
+    ControlPlanePrincipal,
+    GlobalRole,
+)
+from factory.core.auth.control_plane_wire import (
+    clear_request_principal,
+    set_request_principal,
+)
+
+
+def _principal() -> ControlPlanePrincipal:
+    return ControlPlanePrincipal(
+        user_id="rx:u1",
+        roles=frozenset({GlobalRole.ADMIN.value}),
+        org_ids=frozenset(),
+        active_org_id=None,
+        via="session",
+    )
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FACTORY_DASHBOARD_COOKIE_INSECURE", "1")
+    monkeypatch.delenv("FACTORY_DASHBOARD_E2E", raising=False)
+    bus = MagicMock()
+    bus.put = AsyncMock()
+    ad = WebAdapter(inbound_bus=bus, agent_names=["alpha"], port=19998)
+    ad._outbound_listener = MagicMock()
+    app = create_app(ad, control_plane=None)
+    return TestClient(app)
+
+
+@pytest.mark.asyncio
+async def test_org_list_rpc_ok() -> None:
+    org = MagicMock()
+    org.id = "org:1"
+    org.name = "Acme"
+    org.created_by = "rx:u1"
+    org.created_at = datetime.now(timezone.utc)
+    hub = MagicMock()
+    cp = AsyncMock()
+    cp.list_orgs_for_user = AsyncMock(return_value=[org])
+    hub._control_plane = cp
+    set_request_principal(_principal())
+    try:
+        raw = await handle_org_list(hub, MagicMock(), {})
+        assert raw["ok"] is True
+        assert raw["orgs"][0]["name"] == "Acme"
+    finally:
+        clear_request_principal()
+
+
+@pytest.mark.asyncio
+async def test_org_create_rpc_ok() -> None:
+    org = MagicMock()
+    org.id = "org:2"
+    org.name = "NewCo"
+    org.created_by = "rx:u1"
+    org.created_at = datetime.now(timezone.utc)
+    hub = MagicMock()
+    cp = AsyncMock()
+    cp.create_org = AsyncMock(return_value=org)
+    hub._control_plane = cp
+    set_request_principal(_principal())
+    try:
+        raw = await handle_org_create(hub, MagicMock(), {"name": "NewCo"})
+        assert raw["ok"] is True
+        assert raw["org"]["id"] == "org:2"
+        cp.create_org.assert_awaited_once()
+    finally:
+        clear_request_principal()
+
+
+def test_bff_list_orgs_via_hub(client: TestClient) -> None:
+    resolve_raw = {
+        "ok": True,
+        "principal": {
+            "user_id": "rx:u1",
+            "roles": [GlobalRole.ADMIN.value],
+            "org_ids": [],
+            "active_org_id": None,
+            "via": "session",
+        },
+        "user": {
+            "id": "rx:u1",
+            "email": "a@b.c",
+            "global_role": "admin",
+            "status": "active",
+        },
+    }
+    org_raw = {
+        "ok": True,
+        "orgs": [
+            {
+                "id": "org:1",
+                "name": "Acme",
+                "created_by": "rx:u1",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+        "active_org_id": None,
+    }
+    with (
+        patch(
+            "factory.dashboard.routes.hub_auth.auth_session_resolve",
+            new=AsyncMock(return_value=resolve_raw),
+        ),
+        patch(
+            "factory.dashboard.routes.org_routes.org_list",
+            new=AsyncMock(return_value=org_raw),
+        ),
+    ):
+        client.cookies.set("factory_session", "tok")
+        res = client.get("/api/bff/orgs")
+    assert res.status_code == 200, res.text
+    assert res.json()["orgs"][0]["name"] == "Acme"
+
+
+def test_bff_list_orgs_no_cp_no_hub_503(client: TestClient) -> None:
+    # Without session → 401; with session but hub path fails differently.
+    res = client.get("/api/bff/orgs")
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- **503 on `/api/bff/orgs`**: thin BFF had no local CP; list/create now go via hub `factory.dashboard.org.list|create`
- **Base UI #31**: `SidebarMenuButton` no longer wraps `Link` with `TooltipTrigger`; `Button` defaults `nativeButton={false}` when `render` is set
- Local verify: vite mock — open user menu, **0× #31**, orgs **200**; pytest org hub path green

## Test plan
- [x] `tests/dashboard/test_org_hub_rpc.py` + typecheck + vitest
- [x] Local puppeteer on `http://127.0.0.1:5179` (mock)
- [ ] After deploy: open sidebar user menu on M1 — no 503 on orgs, no Base UI #31