### PR TITLE
docs(runbooks): cortex-memory Quadlet-only + vault import

### DIFF
--- a/docs/runbooks/cortex-memory.md
+++ b/docs/runbooks/cortex-memory.md
@@ -2,6 +2,10 @@
 
 Knowledge capture/search/assemble for factory (ADR-087). Replaces `roxabi-vault` CLI.
 
+**Default branch:** `roxabi-cortex` **`main` only** (no staging).
+**Image:** `ghcr.io/roxabi/cortex-memory:main` (CI publish on push to `main`).
+**Runtime:** **Quadlet only** on M₁ — no long-lived user process unit.
+
 ## Subjects
 
 | Subject | Direction |
@@ -11,54 +15,107 @@ Knowledge capture/search/assemble for factory (ADR-087). Replaces `roxabi-vault`
 | `roxabi.memory.query.assemble` | hub → cortex (agent system-prompt inject) |
 | `roxabi.memory.heartbeat` | cortex → hub |
 
-Identity: **`cortex-memory`** · secret: **`factory-nats-cortex-memory`**.
+Identity: **`cortex-memory`** (ACL external) · secret: **`factory-nats-cortex-memory`**.
+
+## Data migration (legacy vault)
+
+One-shot import from `~/.roxabi-vault/vault.db` into `~/.cortex/memory.db`:
+
+```bash
+cd ~/projects/roxabi-cortex/packages/memory
+uv sync
+uv run cortex-memory import-vault \
+  --vault-db ~/.roxabi-vault/vault.db \
+  --db ~/.cortex/memory.db
+uv run cortex-memory stats --db ~/.cortex/memory.db
+```
+
+M₁ status (2026-07-22): **829 entries** imported (matches vault row count). Source DB left in place; folder may live under `~/projects/archived/roxabi-vault`.
 
 ## One-time provision (M₁)
 
 ```bash
-# 1. ACL already in deploy/nats/acl-matrix.json — regenerate auth.conf
+# 1. Nkey (no rotate others)
 cd ~/projects/roxabi-factory
-make nats-regen-authconf   # or: factory-genkeys (regen authconf from seeds)
+factory-genkeys --add-identity cortex-memory   # → ~/.roxabi/factory/nkeys/cortex-memory.seed
 
-# 2. Add nkey for the new identity (does not rotate other seeds)
-factory-genkeys --add-identity cortex-memory
+# 2. Regen NATS auth.conf + restart stack
+make nats-regen-authconf
 
-# 3. Fan-out seed to M₁ (external identity — not a factory Quadlet secret)
-# On M₁: place seed at ~/.roxabi/factory/nkeys/cortex-memory.seed (0600)
-# and set NATS_NKEY_SEED_PATH when running cortex-memory.
+# 3. Podman secret for Quadlet
+podman secret create factory-nats-cortex-memory \
+  ~/.roxabi/factory/nkeys/cortex-memory.seed
 
-# 4. Import legacy vault data (optional, once)
-cd ~/projects/roxabi-cortex/packages/memory
-uv run cortex-memory import-vault   # → ~/.cortex/memory.db
+# 4. Import vault data (once)
+mkdir -p ~/.cortex
+cd ~/projects/roxabi-cortex && git pull --ff-only origin main
+cd packages/memory && uv sync
+uv run cortex-memory import-vault --db ~/.cortex/memory.db
 
-# 5. Install Quadlet unit
+# 5. Quadlet unit
 mkdir -p ~/.config/containers/systemd
 ln -sfn ~/projects/roxabi-cortex/packages/memory/deploy/quadlet/cortex-memory.container \
   ~/.config/containers/systemd/cortex-memory.container
 systemctl --user daemon-reload
-systemctl --user start cortex-memory.service
+systemctl --user enable --now cortex-memory.service
 systemctl --user status cortex-memory.service
 ```
 
-## Local dev (no Quadlet)
+Image pull (after CI publish):
 
 ```bash
-export NATS_URL=nats://127.0.0.1:4222   # unauthenticated local NATS, or seed path set
-cd ~/projects/roxabi-cortex/packages/memory
-uv run cortex-memory import-vault --limit 0
-uv run cortex-memory serve
+podman pull ghcr.io/roxabi/cortex-memory:main
+systemctl --user restart cortex-memory.service
 ```
 
-Factory hub uses `CortexVault` always — ensure the same `NATS_URL` and that
-`cortex-memory` is subscribed before `/vault-add` / first-turn assemble.
+Local image build (if GHCR unavailable):
+
+```bash
+cd ~/projects/roxabi-cortex
+podman build -f packages/memory/Dockerfile \
+  --build-context factory=../roxabi-factory \
+  -t ghcr.io/roxabi/cortex-memory:main packages/memory
+# retag for unit if needed: same name as Image= in the .container file
+```
+
+## Dev (process, not Quadlet)
+
+```bash
+export NATS_URL=nats://127.0.0.1:4222
+export NATS_NKEY_SEED_PATH=~/.roxabi/factory/nkeys/cortex-memory.seed
+cd ~/projects/roxabi-cortex/packages/memory
+uv run cortex-memory serve --db ~/.cortex/memory.db
+```
 
 ## Smoke
 
 ```bash
-# from host with nats CLI + hub nkey (or open local NATS)
-nats req roxabi.memory.query.search \
-  "$(python -c 'from roxabi_contracts.memory import build_search_request; print(build_search_request(query=\"claude\").model_dump_json())')"
+# hub nkey + contracts from factory checkout
+export NATS_URL=nats://127.0.0.1:4222
+export NATS_NKEY_SEED_PATH=~/.roxabi/factory/nkeys/hub.seed
+cd ~/projects/roxabi-cortex/packages/memory
+uv run python - <<'PY'
+import asyncio, os
+from roxabi_contracts.memory import build_search_request, SearchResponse, SUBJECTS
+from roxabi_nats.connect import nats_connect
+
+async def main():
+    nc = await nats_connect(os.environ["NATS_URL"], identity_name="hub")
+    try:
+        req = build_search_request(query="claude", limit=3)
+        msg = await nc.request(SUBJECTS.query_search, req.model_dump_json().encode(), timeout=5)
+        r = SearchResponse.model_validate_json(msg.data)
+        print("ok", r.ok, "hits", len(r.hits))
+        for h in r.hits:
+            print("-", h.title[:80])
+    finally:
+        await nc.drain()
+
+asyncio.run(main())
+PY
 ```
+
+Product path: Telegram/Discord bare URL or `/vault-add` → hub `CortexVault` → NATS → this satellite.
 
 ## Fail-open
 


### PR DESCRIPTION
## Summary
- Update cortex-memory runbook: Quadlet-only, image `:main`, vault import (829 rows on M1).

## Test plan
- [x] Markdown only