### PR TITLE
chore(semctx): enable change-impact gate and factory semantic model

### DIFF
--- a/.claude/semctx.md
+++ b/.claude/semctx.md
@@ -1,0 +1,15 @@
+# semctx — change verification
+
+Before finishing a non-trivial change, and before committing:
+
+1. Run `semctx verify diff` (or the MCP tool `semctx_verify_change`).
+2. PASS → proceed. WARN → consider a test (not a failure). BLOCK → resolve before finishing.
+3. Run the recommended tests.
+4. Never declare the work done while a BLOCK is unresolved. Never cite evidence not in the report.
+
+semctx maps a diff to affected symbols, contracts, invariants and tests. It is **not** a
+code-search tool and does not "understand the whole repository".
+
+Optional guarded mode (opt-in): create `.semctx/guard.json` with `{ "enabled": true }` to block
+`git commit`/`git push` until `semctx verify diff --record` has verified the current diff.
+Disable strictly with `SEMCTX_GUARD=off`.

--- a/.github/workflows/semctx.yml
+++ b/.github/workflows/semctx.yml
@@ -1,0 +1,23 @@
+# semctx PR gate: BLOCK fails the check, WARN does not. Read-only, no secrets.
+# Uses the semctx GitHub Action from hoklims/semctx, pinned at v0.1.0.
+name: Semctx
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  semctx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: hoklims/semctx/packages/github-action@v0.1.0
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.sha }}
+          fail-on: block

--- a/.semctx/semantic/assumptions.sem
+++ b/.semctx/semantic/assumptions.sem
@@ -1,0 +1,5 @@
+# Assumptions — believed-but-unproven premises. Kept distinct from established facts.
+
+assumption assumption.factory.ts-surface-is-secondary
+  statement: TypeScript under packages/ and apps/dashboard-v2 is a secondary surface; the load-bearing runtime path is Python (src/factory) + NATS + Quadlet.
+  status: declared

--- a/.semctx/semantic/decisions.sem
+++ b/.semctx/semantic/decisions.sem
@@ -1,0 +1,25 @@
+# Decisions — recorded choices (why the system is shaped as it is).
+
+decision decision.factory.stage-over-platform
+  statement: Primary axis of decomposition is stage/pipeline (ADR-073), not platform/adapter — prevents N×M drift across adapters.
+  status: declared
+  justifies: invariant.factory.stage-axis-primary
+  justifies: invariant.factory.helpers-per-part
+  link: file:docs/architecture/engineering-standards.md
+  link: file:AGENTS.md
+
+decision decision.factory.hexagonal-composition-root
+  statement: Hexagonal/Clean Architecture with a single composition root (ADR-059) — ports in domain, wiring only in bootstrap.
+  status: declared
+  justifies: invariant.factory.ports-and-composition-root
+  justifies: invariant.factory.layer-imports-inward
+  link: file:docs/architecture/engineering-standards.md
+  link: file:src/factory/bootstrap/AGENTS.md
+
+decision decision.factory.importlinter-enforcement
+  statement: Layer and stage-axis contracts are machine-enforced via .importlinter; new modules join contracts, they are not exempted.
+  status: declared
+  justifies: invariant.factory.stage-axis-primary
+  justifies: invariant.factory.layer-imports-inward
+  link: file:docs/architecture/engineering-standards.md
+  link: file:AGENTS.md

--- a/.semctx/semantic/evidence.sem
+++ b/.semctx/semantic/evidence.sem
@@ -1,0 +1,12 @@
+# Evidence — proofs (tests, static checks, runtime observations) that back a claim.
+
+evidence proof.factory.importlinter
+  statement: .importlinter stage-axis and clean-architecture contracts fail qg/CI when layer or stage purity is violated.
+  status: declared
+  link: file:docs/architecture/engineering-standards.md
+  link: file:AGENTS.md
+
+evidence proof.factory.qg
+  statement: scripts/qg (and CI quality gates from .claude/stack.yml) run the declared static and test gates before merge.
+  status: declared
+  link: file:docs/architecture/engineering-standards.md

--- a/.semctx/semantic/goals.sem
+++ b/.semctx/semantic/goals.sem
@@ -1,0 +1,22 @@
+# Goals — what the system must achieve. Versioned in Git; edit freely.
+# Plane A (ts-analyzer) only indexes TypeScript today; Python core is authored here
+# as intent + links to docs/importlinter, not as resolved sym: graph nodes.
+
+goal goal.factory.stage-axis-decomposition
+  statement: System variation is decomposed along the stage/pipeline axis, not per platform/adapter.
+  status: declared
+  tag: critical
+
+goal goal.factory.clean-architecture
+  statement: Dependencies point inward; ports are domain-owned; concretions only at the composition root.
+  status: declared
+  tag: critical
+
+goal goal.factory.safe-routing
+  statement: Outbound delivery never reaches the wrong bot or channel; routing is verified at the adapter edge.
+  status: declared
+  tag: security
+
+goal goal.factory.observable-jobs
+  statement: Every user message is one job_id run with event-driven terminal close and durable routing.
+  status: declared

--- a/.semctx/semantic/invariants.sem
+++ b/.semctx/semantic/invariants.sem
@@ -1,0 +1,50 @@
+# Invariants — business/architecture rules a change must preserve.
+# Enforced in code primarily by .importlinter (stage-axis contracts) + qg/CI.
+# Plane A is TypeScript-only today; links target indexed docs (not .importlinter itself).
+
+invariant invariant.factory.stage-axis-primary
+  statement: New concern lands in one stage module plus compose primitives; adapters stay thin config only — never duplicate parse/sanitize/route/emit per platform. Machine-enforced by .importlinter stage-axis contracts.
+  status: declared
+  serves: goal.factory.stage-axis-decomposition
+  tag: critical
+  link: file:AGENTS.md
+  link: file:docs/architecture/job-model.md
+  link: file:docs/architecture/engineering-standards.md
+
+invariant invariant.factory.helpers-per-part
+  statement: HELPERS are focused extracts inside a part (inbound/, streaming/, …); no god modules and no cross-part duplication of stage logic.
+  status: declared
+  serves: goal.factory.stage-axis-decomposition
+  tag: critical
+  link: file:AGENTS.md
+  link: file:docs/architecture/engineering-standards.md
+
+invariant invariant.factory.ports-and-composition-root
+  statement: Ports are domain-owned; adapters implement them; concretions are instantiated only in factory.bootstrap — never in domain or application.
+  status: declared
+  serves: goal.factory.clean-architecture
+  tag: critical
+  link: file:docs/architecture/engineering-standards.md
+  link: file:src/factory/bootstrap/AGENTS.md
+
+invariant invariant.factory.layer-imports-inward
+  statement: Domain imports nothing outer; application imports domain only; infrastructure implements domain ports; adapters are outer ring and are never imported by inner layers. Enforced via .importlinter.
+  status: declared
+  serves: goal.factory.clean-architecture
+  tag: critical
+  link: file:docs/architecture/engineering-standards.md
+  link: file:src/factory/core/AGENTS.md
+
+invariant invariant.factory.routing-channel-bot-match
+  statement: Adapters must verify channel and bot_id from RoutingContext before any outbound delivery.
+  status: declared
+  serves: goal.factory.safe-routing
+  tag: security
+  link: file:docs/architecture/security-routing.md
+  link: file:src/factory/adapters/AGENTS.md
+
+invariant invariant.factory.job-id-is-run
+  statement: job_id equals one run (user message → full processing → terminal JobResult); not a turn, not an internal LLM hop.
+  status: declared
+  serves: goal.factory.observable-jobs
+  link: file:docs/architecture/job-model.md

--- a/.semctx/semantic/unknowns.sem
+++ b/.semctx/semantic/unknowns.sem
@@ -1,0 +1,9 @@
+# Unknowns — open questions that must survive while the system is changed.
+
+unknown unknown.factory.semctx-python-coverage
+  statement: semctx Plane A (ts-analyzer) does not index Python; factory core under src/factory/** is not in the symbol graph — impact on pure-Python diffs is incomplete until a Python analyzer exists.
+  status: declared
+
+unknown unknown.factory.graph-link-resolution
+  statement: Authored invariant links use file: targets (docs, .importlinter) rather than resolved inv:/sym: ids; automated prove-by-test for stage-axis rules still relies on importlinter + qg, not semctx alone.
+  status: declared


### PR DESCRIPTION
## Summary
- Add semctx GitHub Action PR gate (`.github/workflows/semctx.yml`)
- Add Claude note for verify-before-finish (`.claude/semctx.md`)
- Author factory semantic model: stage-axis, clean architecture, routing, job_id goals/invariants

## Notes
- `.semctx/config.json` + index stay local-only (gitignore)
- Plane A is TypeScript-only today; Python core intent is in Plane B docs links

## Test plan
- [ ] `semctx doctor` healthy after `semctx setup`
- [ ] CI Semctx workflow runs on this PR
- [ ] Semantic files only under `.semctx/semantic/`