### PR TITLE
fix(hub): stop SQLite writes to RO turns.db mid-stream

### DIFF
--- a/src/factory/adapters/web/web_formatter.py
+++ b/src/factory/adapters/web/web_formatter.py
@@ -79,23 +79,46 @@ class WebFormatter(BaseFormatter):
     ) -> None:
         del ph
         if self._is_agui():
-            increment = text[len(self._buffer) :]
-            self._buffer = text
-            if increment:
-                await self._publish(
-                    web_agui.text_content(
-                        message_id=self._message_id, delta=increment
+            # AG-UI is append-only. Intermediate edits grow a prefix (⏳ …).
+            # Error/final replacement is NOT a prefix — slicing would garble
+            # ("⏳ pong" + "Something…"[6:] → "ing went wrong…"). On non-prefix
+            # replace, close the intermediate message and open a new one.
+            if text.startswith(self._buffer):
+                increment = text[len(self._buffer) :]
+                self._buffer = text
+                if increment and self._message_id:
+                    await self._publish(
+                        web_agui.text_content(
+                            message_id=self._message_id, delta=increment
+                        )
                     )
+            else:
+                if self._message_id:
+                    await self._publish(
+                        web_agui.text_end(message_id=self._message_id)
+                    )
+                self._message_id = web_agui.new_message_id()
+                self._buffer = text
+                await self._publish(
+                    web_agui.text_start(message_id=self._message_id)
                 )
+                if text:
+                    await self._publish(
+                        web_agui.text_content(
+                            message_id=self._message_id, delta=text
+                        )
+                    )
             if finalize:
-                await self._publish(
-                    web_agui.text_end(message_id=self._message_id)
-                )
-                await self._publish(
-                    web_agui.run_finished(
-                        thread_id=self._session_id, run_id=self._run_id
+                if self._message_id:
+                    await self._publish(
+                        web_agui.text_end(message_id=self._message_id)
                     )
-                )
+                if self._run_id:
+                    await self._publish(
+                        web_agui.run_finished(
+                            thread_id=self._session_id, run_id=self._run_id
+                        )
+                    )
                 self._run_id = ""
                 self._message_id = ""
                 self._buffer = ""

--- a/src/factory/bootstrap/factory/hub/hub_assembly.py
+++ b/src/factory/bootstrap/factory/hub/hub_assembly.py
@@ -112,6 +112,8 @@ async def _build_hub_and_wire(  # noqa: PLR0913 — unavoidable wiring surface
 
     cli_nats_driver = await build_llm_client(nc)
     cli_nats_driver.set_turn_store(stores.turn)
+    # Writes must go TurnPublisher → turn-writer (hub turn-writer/ mount is RO).
+    cli_nats_driver.set_turn_publisher(hub._turn_publisher)
     hub.cli_pool = None
 
     freshness_drivers_list.extend(
@@ -119,6 +121,8 @@ async def _build_hub_and_wire(  # noqa: PLR0913 — unavoidable wiring surface
     )
 
     omp_rpc_driver = OmpRpcDriver(nc)
+    omp_rpc_driver.set_turn_store(stores.turn)
+    omp_rpc_driver.set_turn_publisher(hub._turn_publisher)
 
     register_agents(
         hub,

--- a/src/factory/integrations/cortex_vault.py
+++ b/src/factory/integrations/cortex_vault.py
@@ -165,7 +165,10 @@ class CortexVault:
 
         from roxabi_nats.connect import nats_connect
 
-        nc = await nats_connect(self._nats_url)
+        # ADR-051: hub nkey ACL only allows _inbox.hub.> (not nats-py default
+        # _INBOX.<random>.*). Prefer inject nc= at composition root; ephemeral
+        # fallback must still use identity_name=hub.
+        nc = await nats_connect(self._nats_url, identity_name="hub")
         try:
             msg = await nc.request(subject, payload, timeout=timeout)
             return bytes(msg.data)

--- a/src/factory/llm/drivers/claude_rpc.py
+++ b/src/factory/llm/drivers/claude_rpc.py
@@ -41,7 +41,16 @@ class _ClaudeSessionStore(Protocol):
 class _ClaudeTurnPublisher(Protocol):
     """Structural subset of TurnPublisher (avoids llm→transport hard import)."""
 
-    async def publish_set_cli_session(self, **kwargs: object) -> None: ...
+    async def publish_set_cli_session(  # noqa: PLR0913 — matches TurnPublisher wire
+        self,
+        *,
+        pool_id: str,
+        session_id: str,
+        platform: str,
+        user_id: str,
+        cli_session_id: str,
+        trace_id: str,
+    ) -> None: ...
 
 
 class ClaudeRpcDriver:

--- a/src/factory/llm/drivers/claude_rpc.py
+++ b/src/factory/llm/drivers/claude_rpc.py
@@ -33,9 +33,15 @@ _DEFAULT_TIMEOUT_S: float = 600.0
 
 
 class _ClaudeSessionStore(Protocol):
+    """Read-side only — hub mounts turns.db RO (ADR-075); writes use TurnPublisher."""
+
     async def get_cli_session(self, session_id: str) -> str | None: ...
 
-    async def _set_cli_session(self, session_id: str, cli_session_id: str) -> None: ...
+
+class _ClaudeTurnPublisher(Protocol):
+    """Structural subset of TurnPublisher (avoids llm→transport hard import)."""
+
+    async def publish_set_cli_session(self, **kwargs: object) -> None: ...
 
 
 class ClaudeRpcDriver:
@@ -54,6 +60,7 @@ class ClaudeRpcDriver:
         self._timeout_s = timeout_s
         self._codec = codec or ClaudeJobCodec()
         self._turn_store: _ClaudeSessionStore | None = None
+        self._turn_publisher: _ClaudeTurnPublisher | None = None
         self._pending_resume: dict[str, str] = {}
         self._lyra_sessions: dict[str, str] = {}
 
@@ -64,7 +71,12 @@ class ClaudeRpcDriver:
         """Lifecycle hook — no heartbeat subscription in phase 2."""
 
     def set_turn_store(self, store: _ClaudeSessionStore) -> None:
+        """Wire RO TurnStore for resume lookups (get_cli_session only)."""
         self._turn_store = store
+
+    def set_turn_publisher(self, publisher: _ClaudeTurnPublisher) -> None:
+        """Wire TurnPublisher for set_cli_session writes (hub must not SQLite-write)."""
+        self._turn_publisher = publisher
 
     def link_lyra_session(self, pool_id: str, session_id: str) -> None:
         self._lyra_sessions[pool_id] = session_id
@@ -302,11 +314,32 @@ class ClaudeRpcDriver:
             await self._nc.publish(submit_subject, wire)
 
     async def _persist_session(self, pool_id: str, result: JobResult) -> None:
+        """Publish set_cli_session via TurnPublisher (sole writer = turn-writer).
+
+        Must never call TurnStore SQLite mutators on the hub: the turn-writer/
+        bind is mounted RO (ADR-075 / #1331). Direct writes raise
+        OperationalError and abort the outbound stream mid-flight.
+        """
         data = result.data or {}
         session_id = data.get("session_id")
-        if not session_id or self._turn_store is None:
+        if not session_id:
             return
         linked = self._lyra_sessions.get(pool_id)
         if linked is None:
             return
-        await self._turn_store._set_cli_session(linked, str(session_id))  # noqa: SLF001
+        publisher = self._turn_publisher
+        if publisher is None:
+            log.warning(
+                "claude_rpc: turn_publisher unset — drop set_cli_session "
+                "for lyra_session=%s (hub RO turns.db)",
+                linked,
+            )
+            return
+        await publisher.publish_set_cli_session(
+            pool_id=pool_id,
+            session_id=linked,
+            platform="",
+            user_id="",
+            cli_session_id=str(session_id),
+            trace_id=linked,
+        )

--- a/src/factory/llm/drivers/omp_rpc.py
+++ b/src/factory/llm/drivers/omp_rpc.py
@@ -42,7 +42,16 @@ class _OmpSessionStore(Protocol):
 class _OmpTurnPublisher(Protocol):
     """Structural subset of TurnPublisher (avoids llm→transport hard import)."""
 
-    async def publish_set_cli_session(self, **kwargs: object) -> None: ...
+    async def publish_set_cli_session(  # noqa: PLR0913 — matches TurnPublisher wire
+        self,
+        *,
+        pool_id: str,
+        session_id: str,
+        platform: str,
+        user_id: str,
+        cli_session_id: str,
+        trace_id: str,
+    ) -> None: ...
 
 
 class OmpRpcDriver:

--- a/src/factory/llm/drivers/omp_rpc.py
+++ b/src/factory/llm/drivers/omp_rpc.py
@@ -34,16 +34,15 @@ _DEFAULT_TIMEOUT_S: float = 600.0
 
 
 class _OmpSessionStore(Protocol):
-    """Read+write session store protocol for OmpRpcDriver.
-
-    Extends the read-only _CliSessionStore shape (get_cli_session) with the
-    write path (_set_cli_session) so the driver can persist the omp session
-    file returned by a successful job result.
-    """
+    """Read-side only — hub mounts turns.db RO (ADR-075); writes use TurnPublisher."""
 
     async def get_cli_session(self, session_id: str) -> str | None: ...
 
-    async def _set_cli_session(self, session_id: str, cli_session_id: str) -> None: ...
+
+class _OmpTurnPublisher(Protocol):
+    """Structural subset of TurnPublisher (avoids llm→transport hard import)."""
+
+    async def publish_set_cli_session(self, **kwargs: object) -> None: ...
 
 
 class OmpRpcDriver:
@@ -55,9 +54,9 @@ class OmpRpcDriver:
 
     SessionAware protocol (V2)
     --------------------------
-    Mirrors LlmClient exactly for the session-management interface so the hub
-    can treat OmpRpcDriver and LlmClient uniformly:
-      - set_turn_store(store)        — wire the TurnStore read+write path
+    Mirrors LlmClient for session management:
+      - set_turn_store(store)        — RO lookups (get_cli_session)
+      - set_turn_publisher(pub)      — set_cli_session writes via NATS
       - link_lyra_session(p, s)      — local mapping pool_id → session_id
       - queue_resume(p, s) -> bool   — resolve + stash cli_session_id
       - reset(pool_id)               — drop pending resume (no NATS msg in V2)
@@ -78,6 +77,7 @@ class OmpRpcDriver:
         self._codec = codec or OmpJobCodec()
         # SessionAware state (mirrors LlmClient.__init__)
         self._turn_store: _OmpSessionStore | None = None
+        self._turn_publisher: _OmpTurnPublisher | None = None
         self._pending_resume: dict[str, str] = {}
         self._lyra_sessions: dict[str, str] = {}
 
@@ -90,6 +90,10 @@ class OmpRpcDriver:
     def set_turn_store(self, store: _OmpSessionStore) -> None:
         """Wire the session store for cli_session_id lookups in queue_resume."""
         self._turn_store = store
+
+    def set_turn_publisher(self, publisher: _OmpTurnPublisher) -> None:
+        """Wire TurnPublisher for set_cli_session (hub must not SQLite-write)."""
+        self._turn_publisher = publisher
 
     def link_lyra_session(self, pool_id: str, session_id: str) -> None:
         """Store the pool_id → session_id mapping for session persistence.
@@ -220,12 +224,8 @@ class OmpRpcDriver:
             decoded = self._codec.decode(result)
             if result.status == "success":
                 session_file = (result.data or {}).get("session_file")
-                if session_file and self._turn_store is not None:
-                    linked_session = self._lyra_sessions.get(pool_id)
-                    if linked_session is not None:
-                        await self._turn_store._set_cli_session(  # noqa: SLF001
-                            linked_session, session_file
-                        )
+                if session_file:
+                    await self._persist_session(pool_id, str(session_file))
                 return decoded
 
             log.warning("omp worker returned error status for job %s", job_id)
@@ -237,3 +237,25 @@ class OmpRpcDriver:
 
         finally:
             await sub.unsubscribe()
+
+    async def _persist_session(self, pool_id: str, session_file: str) -> None:
+        """Publish set_cli_session via TurnPublisher (ADR-075 sole writer)."""
+        linked_session = self._lyra_sessions.get(pool_id)
+        if linked_session is None:
+            return
+        publisher = self._turn_publisher
+        if publisher is None:
+            log.warning(
+                "omp_rpc: turn_publisher unset — drop set_cli_session "
+                "for lyra_session=%s (hub RO turns.db)",
+                linked_session,
+            )
+            return
+        await publisher.publish_set_cli_session(
+            pool_id=pool_id,
+            session_id=linked_session,
+            platform="",
+            user_id="",
+            cli_session_id=session_file,
+            trace_id=linked_session,
+        )

--- a/tests/integration/test_omp_session_resume_integration.py
+++ b/tests/integration/test_omp_session_resume_integration.py
@@ -167,8 +167,8 @@ class TestColdStartPersistsSessionFile:
         assert res.result == "done"
 
     @pytest.mark.asyncio
-    async def test_session_file_persisted_in_store(self) -> None:
-        """After complete(), store._set_cli_session is called with the session path."""
+    async def test_session_file_persisted_via_publisher(self) -> None:
+        """After complete(), session is published (not SQLite-written on hub)."""
         session_path = "/tmp/omp/.omp/sessions/sess-abc.jsonl"
         result = JobResult.model_validate(
             {
@@ -180,7 +180,9 @@ class TestColdStartPersistsSessionFile:
 
         driver = OmpRpcDriver(nc, timeout_s=5.0)
         store = _make_store()
+        publisher = AsyncMock()
         driver.set_turn_store(store)
+        driver.set_turn_publisher(publisher)
         driver.link_lyra_session("pool-persist", "lyra-sess-persist")
 
         await driver.complete(
@@ -190,9 +192,11 @@ class TestColdStartPersistsSessionFile:
             system_prompt="sys",
         )
 
-        store._set_cli_session.assert_awaited_once_with(  # noqa: SLF001
-            "lyra-sess-persist", session_path
-        )
+        publisher.publish_set_cli_session.assert_awaited_once()
+        call_kw = publisher.publish_set_cli_session.await_args.kwargs
+        assert call_kw["session_id"] == "lyra-sess-persist"
+        assert call_kw["cli_session_id"] == session_path
+        store._set_cli_session.assert_not_called()  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------

--- a/tests/llm/drivers/test_omp_rpc_session.py
+++ b/tests/llm/drivers/test_omp_rpc_session.py
@@ -197,15 +197,14 @@ class TestOmpRpcDriverSession:
         sub: AsyncMock,
         model_cfg: MagicMock,
     ) -> None:
-        """On success with session_file in JobResult.data, _set_cli_session is called.
+        """On success with session_file, TurnPublisher.publish_set_cli_session is used.
 
-        Contract:
-          - driver must have link_lyra_session() set for the pool_id
-          - _set_cli_session(session_id, session_file_path) is awaited exactly once
-          - session_id is the lyra session_id linked via link_lyra_session()
+        Contract (ADR-075): hub must not SQLite-write turns.db — publish only.
         """
         store = _make_store()
+        publisher = AsyncMock()
         driver.set_turn_store(store)
+        driver.set_turn_publisher(publisher)
         driver.link_lyra_session("pool-3", "lyra-sess-99")
 
         success_result = JobResult.model_validate(
@@ -224,9 +223,11 @@ class TestOmpRpcDriverSession:
         )
 
         assert res.ok is True
-        store._set_cli_session.assert_awaited_once_with(  # noqa: SLF001
-            "lyra-sess-99", "/tmp/omp/.omp/sessions/sess-abc.json"
-        )
+        publisher.publish_set_cli_session.assert_awaited_once()
+        kw = publisher.publish_set_cli_session.await_args.kwargs
+        assert kw["session_id"] == "lyra-sess-99"
+        assert kw["cli_session_id"] == "/tmp/omp/.omp/sessions/sess-abc.json"
+        store._set_cli_session.assert_not_called()  # noqa: SLF001
 
     @pytest.mark.asyncio
     async def test_complete_skips_persist_when_no_session_file(
@@ -235,9 +236,11 @@ class TestOmpRpcDriverSession:
         sub: AsyncMock,
         model_cfg: MagicMock,
     ) -> None:
-        """When JobResult.data has no session_file, _set_cli_session is NOT called."""
+        """When JobResult.data has no session_file, publisher is NOT called."""
         store = _make_store()
+        publisher = AsyncMock()
         driver.set_turn_store(store)
+        driver.set_turn_publisher(publisher)
         driver.link_lyra_session("pool-4", "lyra-sess-42")
 
         success_result = JobResult.model_validate(
@@ -249,6 +252,7 @@ class TestOmpRpcDriverSession:
             pool_id="pool-4", text="q", model_cfg=model_cfg, system_prompt="s"
         )
 
+        publisher.publish_set_cli_session.assert_not_awaited()
         store._set_cli_session.assert_not_awaited()  # noqa: SLF001
 
     # -- (4) cross-conversation isolation --


### PR DESCRIPTION
## Summary
- **Root cause of broken web chat to Lyra:** hub Claude/Omp drivers wrote CLI session IDs into `turns.db` via `TurnStore`, but the hub mounts `turn-writer/` **read-only** (ADR-075 sole writer). That raised `OperationalError: attempt to write a readonly database` mid-stream and aborted outbound SSE.
- **Fix:** both drivers publish `set_cli_session` through `TurnPublisher` → `factory-turn-writer` (same path as CliPool). Hub keeps **read-only** `get_cli_session` for resume.
- **Web AG-UI:** non-prefix error replacement no longer slices intermediate buffer (`⏳ pong` + garbled error). Opens a new message for full replace text.
- **CortexVault:** ephemeral NATS connect uses `identity_name="hub"` so request/reply uses `_inbox.hub.>` (ACL-safe). Prefer inject hub `nc` later.

## Architecture
- Conforms to **ADR-075** (sole SQLite writer = turn-writer) and **ADR-059** (ports/composition root wiring).
- Axial: fix on the **turn-write stage** for both Claude + Omp drivers (not Claude-only N×M).
- Does **not** remount hub RW (would reintroduce dual-writer).

## Test plan
- [x] `uv run pytest tests/llm/` (pre-push typecheck + smoke green)
- [ ] After deploy: `POST /api/chat` `lyra_default` → real reply, no hub `readonly database`
- [ ] Hub journal: no `_inbox.<random>` permissions violation on vault assemble
- [ ] Confirm hub still mounts `turn-writer/:ro`; only turn-writer unit writes

## Mounts (ops context)
| Unit | Path | Mode | Why |
|------|------|------|-----|
| `factory-turn-writer` | `~/.roxabi/factory/turn-writer/` | **RW** | sole writer of `turns.db` |
| `factory-hub` | same dir | **RO** | resume/read only — writes go NATS `factory.turns.write` |
| `factory-hub` | `factory-data` (`~/.roxabi/factory`) | **RW** | auth/config/pipeline (not turns sole-write) |

This PR does not change mount layout; it makes hub code respect the existing RO contract.