### PR TITLE
chore(claude): declare dev-core + dev-init via roxabi-marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,14 +10,16 @@
     "roxabi-vault@roxabi-vault-marketplace": true,
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "cocoindex-code@cocoindex-code": true
+    "cocoindex-code@cocoindex-code": true,
+    "dev-init@roxabi-marketplace": true
   },
   "extraKnownMarketplaces": {
     "roxabi-marketplace": {
       "source": {
         "source": "github",
         "repo": "Roxabi/roxabi-plugins"
-      }
+      },
+      "autoUpdate": true
     },
     "roxabi-vault-marketplace": {
       "source": {


### PR DESCRIPTION
Both plugins are enabled at user scope, but `~/.claude/settings.json` is not versioned with this repo. Declaring them in `.claude/settings.json` (plus the marketplace they resolve from) makes the setup travel with the clone.

Part of a workspace-wide rollout across 33 repos. Opened as a PR here because `staging` requires the merge queue (`GH013` on direct push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)