### PR TITLE
fix(dashboard): multi-slot stream tokens + jobs authz tests + deploy doc

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -238,7 +238,7 @@ carries its own auth — bind tier and auth mechanism are chosen **together**:
 | `factory-nats` 4222 | `0.0.0.0` | LAN + Tailnet | NKey (mandatory, per-identity) |
 | `factory-nats` 8222 (monitoring) | `127.0.0.1` | host only | — |
 | `factory-blobstore` 8449 | `${TAILSCALE_IPV4}` | Tailnet only | bearer token (#1330) |
-| `factory-dashboard` 8765 | `${TAILSCALE_IPV4}` | Tailnet only | control-plane session cookie / API key (`require_principal` on protected BFF); Tailnet bind = defense-in-depth (ADR-103, #2129) |
+| `factory-dashboard` 8765 | `${TAILSCALE_IPV4}` | Tailnet only | control-plane session cookie / API key (`require_principal` on protected BFF); Tailnet bind = defense-in-depth → `docs/architecture/security-routing.md` § control-plane (#2129) |
 | `factory-hub` 8443 | `127.0.0.1` | host only | — |
 | `factory-loki` 3100 | `127.0.0.1` | host only (logcli / #1760) | — |
 | `factory-langfuse-web` 3000 | `127.0.0.1` | host only (trace UI / #1760) | Langfuse login |

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -238,7 +238,7 @@ carries its own auth — bind tier and auth mechanism are chosen **together**:
 | `factory-nats` 4222 | `0.0.0.0` | LAN + Tailnet | NKey (mandatory, per-identity) |
 | `factory-nats` 8222 (monitoring) | `127.0.0.1` | host only | — |
 | `factory-blobstore` 8449 | `${TAILSCALE_IPV4}` | Tailnet only | bearer token (#1330) |
-| `factory-dashboard` 8765 | `${TAILSCALE_IPV4}` | Tailnet only | **none** — Tailnet membership is the boundary (#1992) |
+| `factory-dashboard` 8765 | `${TAILSCALE_IPV4}` | Tailnet only | control-plane session cookie / API key (`require_principal` on protected BFF); Tailnet bind = defense-in-depth (ADR-103, #2129) |
 | `factory-hub` 8443 | `127.0.0.1` | host only | — |
 | `factory-loki` 3100 | `127.0.0.1` | host only (logcli / #1760) | — |
 | `factory-langfuse-web` 3000 | `127.0.0.1` | host only (trace UI / #1760) | Langfuse login |
@@ -291,22 +291,24 @@ Prior to #1368, `[ -n "   " ]` was TRUE in POSIX sh — a whitespace-only value 
 guard and Podman's downstream parse error provided fail-closed behaviour by accident, not
 by design. The guard is now the authoritative rejection point.
 
-### Known residual risk — factory-dashboard has NO auth on the Tailnet (#1992)
+### factory-dashboard auth boundary (ADR-103 — supersedes “no auth” wording)
 
 `factory-dashboard.container` binds PublishPort to `${TAILSCALE_IPV4}:8765:8765` (same pattern +
-fail-closed `ExecStartPre` guard as blobstore above). Unlike blobstore, the web smoke adapter
-has **no application auth** — any Tailnet member who reaches `http://roxabituwer:8765` can pick
-an agent and chat (LLM token spend; session_id is client-supplied → cross-session read, see
-#1992). Tailnet membership is the **sole** access boundary; this is why it is bound to the
-Tailscale IP and never `0.0.0.0` (no LAN exposure). Per-session tokens / real auth are tracked
-in #1992 before any wider exposure.
+fail-closed `ExecStartPre` guard as blobstore above). **Application auth is live:** protected
+BFF routes (including `/api/bff/jobs*`, sessions, agents, admin, pipeline) require
+`require_principal` (session cookie and/or Bearer API key / shared operator token). Hub RPC
+rehydrates principal from proof fields (session_token / api_key) — wire roles alone are not
+enough. Jobs list/steer/cancel are further scoped by ownership/org (ADR-103 Blocks 4–7; #2129).
 
-**Session list API (`/api/bff/sessions*`)** — same Tailnet boundary applies: cross-platform
-`cli_session_id` resume/list is hub-backed (no `turns.db` mount on the dashboard container).
-Dashboard auth is control-plane session/API-key.
+Tailnet-only bind remains **defense-in-depth** (never `0.0.0.0`) — not the sole boundary.
+SSE stream tokens (`stream_token` query param) are an additional gate for EventSource; mint
+endpoints sit behind principal auth; multi-slot registry avoids peer clobber (#2316).
+
+**Session list API (`/api/bff/sessions*`)** — hub-backed (no `turns.db` mount on the dashboard
+container); same principal gate as other protected BFF routes.
 → `docs/runbooks/dashboard-auth-bootstrap.md` · `docs/architecture/security-routing.md`
-Legacy `FACTORY_DASHBOARD_AUTH_REQUIRED` stub was removed.
-lands; `stream_token` on SSE is separate (#1992 phase 1).
+Legacy `FACTORY_DASHBOARD_AUTH_REQUIRED` stub was removed. Remaining #1992 items (if any) are
+phase-2 GA hardening beyond this baseline, not “auth absent”.
 
 ### Known residual risk — clipool `core.hooksPath` override (tracked #1245)
 

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -291,14 +291,14 @@ Prior to #1368, `[ -n "   " ]` was TRUE in POSIX sh — a whitespace-only value 
 guard and Podman's downstream parse error provided fail-closed behaviour by accident, not
 by design. The guard is now the authoritative rejection point.
 
-### factory-dashboard auth boundary (ADR-103 — supersedes “no auth” wording)
+### factory-dashboard auth boundary (supersedes “no auth” wording)
 
 `factory-dashboard.container` binds PublishPort to `${TAILSCALE_IPV4}:8765:8765` (same pattern +
 fail-closed `ExecStartPre` guard as blobstore above). **Application auth is live:** protected
 BFF routes (including `/api/bff/jobs*`, sessions, agents, admin, pipeline) require
 `require_principal` (session cookie and/or Bearer API key / shared operator token). Hub RPC
 rehydrates principal from proof fields (session_token / api_key) — wire roles alone are not
-enough. Jobs list/steer/cancel are further scoped by ownership/org (ADR-103 Blocks 4–7; #2129).
+enough. Jobs list/steer/cancel are further scoped by ownership/org (#2129).
 
 Tailnet-only bind remains **defense-in-depth** (never `0.0.0.0`) — not the sole boundary.
 SSE stream tokens (`stream_token` query param) are an additional gate for EventSource; mint
@@ -306,7 +306,7 @@ endpoints sit behind principal auth; multi-slot registry avoids peer clobber (#2
 
 **Session list API (`/api/bff/sessions*`)** — hub-backed (no `turns.db` mount on the dashboard
 container); same principal gate as other protected BFF routes.
-→ `docs/runbooks/dashboard-auth-bootstrap.md` · `docs/architecture/security-routing.md`
+→ `docs/runbooks/dashboard-auth-bootstrap.md` · `docs/architecture/security-routing.md` § control-plane
 Legacy `FACTORY_DASHBOARD_AUTH_REQUIRED` stub was removed. Remaining #1992 items (if any) are
 phase-2 GA hardening beyond this baseline, not “auth absent”.
 

--- a/src/factory/dashboard/app.py
+++ b/src/factory/dashboard/app.py
@@ -32,6 +32,7 @@ def create_dashboard_app(
     hub = DashboardHubClient(adapter)
     app.state.control_plane = control_plane
     app.state.hub_client = hub
+    app.state.stream_tokens = tokens  # multi-slot registry (#2316); tests + diagnostics
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/src/factory/dashboard/routes/bff.py
+++ b/src/factory/dashboard/routes/bff.py
@@ -198,6 +198,8 @@ def build_bff_router(  # noqa: C901, PLR0915
     ) -> StreamingResponse:
         if not tokens.verify(PIPELINE_STREAM_ID, token):
             raise HTTPException(status_code=403, detail="invalid stream token")
+        # Capture for multi-slot revoke — do not clear peer operators (#2316).
+        stream_token = token
 
         async def _client_connected() -> bool:
             return not await request.is_disconnected()
@@ -212,7 +214,7 @@ def build_bff_router(  # noqa: C901, PLR0915
             except asyncio.CancelledError:
                 return
             finally:
-                tokens.revoke(PIPELINE_STREAM_ID)
+                tokens.revoke_token(stream_token)
 
         return StreamingResponse(event_gen(), media_type="text/event-stream")
 

--- a/src/factory/dashboard/routes/bff_jobs.py
+++ b/src/factory/dashboard/routes/bff_jobs.py
@@ -102,6 +102,8 @@ def register_jobs_routes(  # noqa: C901, PLR0915
     ) -> StreamingResponse:
         if not tokens.verify(JOBS_STREAM_ID, token):
             raise HTTPException(status_code=403, detail="invalid stream token")
+        # Capture for multi-slot revoke — do not clear peer operators (#2316).
+        stream_token = token
 
         async def _client_connected() -> bool:
             return not await request.is_disconnected()
@@ -116,7 +118,7 @@ def register_jobs_routes(  # noqa: C901, PLR0915
             except asyncio.CancelledError:
                 return
             finally:
-                tokens.revoke(JOBS_STREAM_ID)
+                tokens.revoke_token(stream_token)
 
         return StreamingResponse(event_gen(), media_type="text/event-stream")
 

--- a/src/factory/dashboard/stream_tokens.py
+++ b/src/factory/dashboard/stream_tokens.py
@@ -1,4 +1,14 @@
-"""SSE stream token minting — interim #1992 mitigation."""
+"""SSE stream token minting — multi-slot registry (#2316).
+
+Tokens are opaque secrets mapped to a stream key (chat session_id, or a
+kind label like ``jobs`` / ``pipeline``). Multiple concurrent mints for the
+same stream key remain valid until each token is revoked — operators no
+longer clobber each other when opening parallel jobs/pipeline SSE feeds.
+
+Chat still calls :meth:`revoke` with the session_id on stream end (clears
+every token for that session). Jobs/pipeline SSE must call
+:meth:`revoke_token` so peer streams on the same kind stay alive.
+"""
 
 from __future__ import annotations
 
@@ -8,20 +18,46 @@ from dataclasses import dataclass, field
 
 @dataclass
 class StreamTokenRegistry:
-    """Maps session_id → opaque stream token required for SSE subscribe."""
+    """Maps opaque stream tokens → stream key (multi-slot per key)."""
 
-    _tokens: dict[str, str] = field(default_factory=dict)
+    _by_token: dict[str, str] = field(default_factory=dict)
+    _by_stream: dict[str, set[str]] = field(default_factory=dict)
 
     def mint(self, session_id: str) -> str:
+        """Issue a new token bound to *session_id* (does not invalidate peers)."""
         token = secrets.token_urlsafe(32)
-        self._tokens[session_id] = token
+        self._by_token[token] = session_id
+        self._by_stream.setdefault(session_id, set()).add(token)
         return token
 
     def verify(self, session_id: str, token: str | None) -> bool:
         if not token:
             return False
-        expected = self._tokens.get(session_id)
-        return expected is not None and secrets.compare_digest(expected, token)
+        bound = self._by_token.get(token)
+        if bound is None:
+            return False
+        # compare_digest requires equal-length strings; stream keys are short
+        # fixed labels / session hex — length mismatch ⇒ reject without raise.
+        if len(bound) != len(session_id):
+            return False
+        return secrets.compare_digest(bound, session_id)
 
     def revoke(self, session_id: str) -> None:
-        self._tokens.pop(session_id, None)
+        """Revoke every token bound to *session_id* (chat session close)."""
+        tokens = self._by_stream.pop(session_id, set())
+        for tok in tokens:
+            self._by_token.pop(tok, None)
+
+    def revoke_token(self, token: str | None) -> None:
+        """Revoke a single token without affecting peers on the same stream key."""
+        if not token:
+            return
+        stream = self._by_token.pop(token, None)
+        if stream is None:
+            return
+        bucket = self._by_stream.get(stream)
+        if bucket is None:
+            return
+        bucket.discard(token)
+        if not bucket:
+            self._by_stream.pop(stream, None)

--- a/tests/adapters/web/test_dashboard_bff.py
+++ b/tests/adapters/web/test_dashboard_bff.py
@@ -336,6 +336,38 @@ class TestDashboardBffRealPath:
         assert res.status_code == 200
         assert res.json()["accepted"] is True
 
+    def test_jobs_surface_requires_auth(
+        self,
+        wired_client: tuple[TestClient, WebAdapter, AsyncMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unauth matrix on /jobs* (#2316 R3) — principal gate fail-closed."""
+        monkeypatch.delenv("FACTORY_DASHBOARD_E2E", raising=False)
+        monkeypatch.delenv("FACTORY_DASHBOARD_OPERATOR_TOKEN", raising=False)
+        tc, _adapter, _nc = wired_client
+        # Drop wired_client default Authorization header.
+        tc.headers.pop("Authorization", None)
+
+        matrix: list[tuple[str, str, dict | None]] = [
+            ("GET", "/api/bff/jobs", None),
+            (
+                "POST",
+                "/api/bff/jobs/launch",
+                {"agent": "alpha", "prompt": "x", "job_name": "omp"},
+            ),
+            ("POST", "/api/bff/jobs/steer", {"job_id": "j1", "text": "x"}),
+            ("POST", "/api/bff/jobs/cancel", {"job_id": "j1"}),
+            ("POST", "/api/bff/jobs/stream-token", None),
+            ("GET", "/api/bff/jobs/stream", None),
+            ("GET", "/api/bff/jobs/stream?token=bogus", None),
+        ]
+        for method, path, body in matrix:
+            if method == "GET":
+                res = tc.get(path)
+            else:
+                res = tc.post(path, json=body)
+            assert res.status_code == 401, f"{method} {path} → {res.status_code}"
+
     def test_list_agents_config_calls_hub_rpc(
         self,
         wired_client: tuple[TestClient, WebAdapter, AsyncMock],

--- a/tests/adapters/web/test_dashboard_bff.py
+++ b/tests/adapters/web/test_dashboard_bff.py
@@ -390,7 +390,8 @@ class TestDashboardBffRealPath:
         tc, _adapter, _nc = wired_client
         a = tc.post("/api/bff/jobs/stream-token").json()["stream_token"]
         b = tc.post("/api/bff/jobs/stream-token").json()["stream_token"]
-        reg = tc.app.state.stream_tokens
+        # TestClient.app is typed loosely; state set in create_dashboard_app.
+        reg = tc.app.state.stream_tokens  # type: ignore[union-attr]
         assert reg.verify(JOBS_STREAM_ID, a)
         assert reg.verify(JOBS_STREAM_ID, b)
 

--- a/tests/adapters/web/test_dashboard_bff.py
+++ b/tests/adapters/web/test_dashboard_bff.py
@@ -368,6 +368,37 @@ class TestDashboardBffRealPath:
                 res = tc.post(path, json=body)
             assert res.status_code == 401, f"{method} {path} → {res.status_code}"
 
+    def test_jobs_stream_disconnect_revokes_only_own_token(
+        self,
+        wired_client: tuple[TestClient, WebAdapter, AsyncMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """R1 route wiring: SSE finally must not revoke peer tokens (#2316)."""
+        from collections.abc import AsyncIterator
+
+        from factory.dashboard.jobs_stream import JOBS_STREAM_ID
+
+        async def _one_frame(*_a: object, **_k: object) -> AsyncIterator[str]:
+            yield 'data: {"type":"ping"}\n\n'
+
+        # Finite generator so the StreamingResponse finally always runs.
+        monkeypatch.setattr(
+            "factory.dashboard.routes.bff_jobs.jobs_sse_events",
+            _one_frame,
+        )
+        monkeypatch.delenv("FACTORY_DASHBOARD_E2E", raising=False)
+        tc, _adapter, _nc = wired_client
+        a = tc.post("/api/bff/jobs/stream-token").json()["stream_token"]
+        b = tc.post("/api/bff/jobs/stream-token").json()["stream_token"]
+        reg = tc.app.state.stream_tokens
+        assert reg.verify(JOBS_STREAM_ID, a)
+        assert reg.verify(JOBS_STREAM_ID, b)
+
+        res = tc.get(f"/api/bff/jobs/stream?token={a}")
+        assert res.status_code == 200
+        assert not reg.verify(JOBS_STREAM_ID, a)
+        assert reg.verify(JOBS_STREAM_ID, b), "peer token must survive A disconnect"
+
     def test_list_agents_config_calls_hub_rpc(
         self,
         wired_client: tuple[TestClient, WebAdapter, AsyncMock],

--- a/tests/dashboard/test_stream_tokens.py
+++ b/tests/dashboard/test_stream_tokens.py
@@ -1,0 +1,50 @@
+"""Multi-slot stream token registry (#2316)."""
+
+from __future__ import annotations
+
+from factory.dashboard.stream_tokens import StreamTokenRegistry
+
+
+def test_mint_verify_roundtrip() -> None:
+    reg = StreamTokenRegistry()
+    tok = reg.mint("jobs")
+    assert reg.verify("jobs", tok)
+    assert not reg.verify("pipeline", tok)
+    assert not reg.verify("jobs", "bogus")
+    assert not reg.verify("jobs", None)
+
+
+def test_concurrent_mint_does_not_clobber_peer() -> None:
+    reg = StreamTokenRegistry()
+    a = reg.mint("jobs")
+    b = reg.mint("jobs")
+    assert a != b
+    assert reg.verify("jobs", a)
+    assert reg.verify("jobs", b)
+
+
+def test_revoke_token_leaves_peer() -> None:
+    reg = StreamTokenRegistry()
+    a = reg.mint("jobs")
+    b = reg.mint("jobs")
+    reg.revoke_token(a)
+    assert not reg.verify("jobs", a)
+    assert reg.verify("jobs", b)
+
+
+def test_revoke_stream_clears_all_slots() -> None:
+    """Chat session close — revoke(session_id) clears every token for that key."""
+    reg = StreamTokenRegistry()
+    a = reg.mint("sess-1")
+    b = reg.mint("sess-1")
+    other = reg.mint("sess-2")
+    reg.revoke("sess-1")
+    assert not reg.verify("sess-1", a)
+    assert not reg.verify("sess-1", b)
+    assert reg.verify("sess-2", other)
+
+
+def test_revoke_token_noop_on_unknown() -> None:
+    reg = StreamTokenRegistry()
+    reg.revoke_token(None)
+    reg.revoke_token("not-a-token")

--- a/tests/dashboard/test_stream_tokens.py
+++ b/tests/dashboard/test_stream_tokens.py
@@ -46,5 +46,7 @@ def test_revoke_stream_clears_all_slots() -> None:
 
 def test_revoke_token_noop_on_unknown() -> None:
     reg = StreamTokenRegistry()
+    kept = reg.mint("jobs")
     reg.revoke_token(None)
     reg.revoke_token("not-a-token")
+    assert reg.verify("jobs", kept)

--- a/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
+++ b/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
@@ -245,6 +245,7 @@ class TestJobsAuthzDeny:
         hub._control_plane = _cp_with_job_meta("rx:user:b", "org:1")
         result = await handle_jobs_steer(hub, nc, {"job_id": "j1", "text": "peer"})
         assert result["accepted"] is True
+        nc.publish.assert_awaited_once_with(jobs_steer("j1"), b"peer")
 
     @pytest.mark.asyncio
     async def test_cancel_outsider_forbidden(

--- a/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
+++ b/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
@@ -176,3 +176,83 @@ class TestJobsCancel:
             jobs_steer("abc123"),
             JOB_CANCEL_STEER_TOKEN.encode(),
         )
+
+
+def _member(
+    *,
+    user_id: str = "rx:user:a",
+    orgs: frozenset[str] | None = None,
+) -> ControlPlanePrincipal:
+    return ControlPlanePrincipal(
+        user_id=user_id,
+        roles=frozenset({GlobalRole.MEMBER.value}),
+        org_ids=orgs or frozenset(),
+        active_org_id=None,
+        via="session",
+    )
+
+
+def _cp_with_job_meta(launched_by: str | None, org_id: str | None) -> MagicMock:
+    cp = MagicMock()
+    cp.get_job_meta = AsyncMock(return_value=(launched_by, org_id))
+    return cp
+
+
+class TestJobsAuthzDeny:
+    """Non-admin ownership/org checks (#2316 R2)."""
+
+    @pytest.mark.asyncio
+    async def test_steer_without_principal_unauthorized(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        clear_request_principal()
+        result = await handle_jobs_steer(hub, nc, {"job_id": "j1", "text": "x"})
+        assert result["error"] == "unauthorized"
+        nc.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_steer_outsider_forbidden(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        set_request_principal(_member(user_id="rx:user:a"))
+        hub._control_plane = _cp_with_job_meta("rx:user:other", None)
+        result = await handle_jobs_steer(hub, nc, {"job_id": "j1", "text": "hijack"})
+        assert result.get("error") == "forbidden"
+        assert result["accepted"] is False
+        nc.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_steer_no_meta_forbidden_for_member(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        set_request_principal(_member())
+        hub._control_plane = _cp_with_job_meta(None, None)
+        result = await handle_jobs_steer(hub, nc, {"job_id": "orphan", "text": "x"})
+        assert result.get("error") == "forbidden"
+        nc.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_steer_owner_allowed(self, hub: MagicMock, nc: AsyncMock) -> None:
+        set_request_principal(_member(user_id="rx:user:a"))
+        hub._control_plane = _cp_with_job_meta("rx:user:a", None)
+        result = await handle_jobs_steer(hub, nc, {"job_id": "j1", "text": "nudge"})
+        assert result["accepted"] is True
+        nc.publish.assert_awaited_once_with(jobs_steer("j1"), b"nudge")
+
+    @pytest.mark.asyncio
+    async def test_steer_org_peer_allowed(self, hub: MagicMock, nc: AsyncMock) -> None:
+        set_request_principal(_member(user_id="rx:user:a", orgs=frozenset({"org:1"})))
+        hub._control_plane = _cp_with_job_meta("rx:user:b", "org:1")
+        result = await handle_jobs_steer(hub, nc, {"job_id": "j1", "text": "peer"})
+        assert result["accepted"] is True
+
+    @pytest.mark.asyncio
+    async def test_cancel_outsider_forbidden(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        set_request_principal(_member(user_id="rx:user:a"))
+        hub._control_plane = _cp_with_job_meta("rx:user:other", None)
+        result = await handle_jobs_cancel(hub, nc, {"job_id": "j1"})
+        assert result.get("error") == "forbidden"
+        assert result["accepted"] is False
+        nc.publish.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Multi-slot `StreamTokenRegistry`: concurrent jobs/pipeline SSE mints no longer clobber peers; disconnect revokes only the closing token
- Hub jobs authz deny tests (outsider / no-meta / owner / org peer) + BFF unauth 401 matrix on `/jobs*`
- `deploy/AGENTS.md`: document control-plane principal auth as the dashboard boundary (remove stale “NO auth”)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2316: residual jobs auth hardening | OPEN |
| Implementation | commits on `feat/2316-residual-jobs-auth-hardening` | Complete |
| Verification | pre-push qg ✅ targeted pytest ✅ | Passed |

## Test Plan
- [x] `tests/dashboard/test_stream_tokens.py` — multi-slot mint/verify/revoke_token
- [x] `tests/factory/bootstrap/test_dashboard_rpc_jobs.py` — authz deny suite
- [x] `tests/adapters/web/test_dashboard_bff.py::test_jobs_surface_requires_auth`

Closes #2316