### PR TITLE
fix(jobs): open active-jobs registry on dashboard launch

### DIFF
--- a/src/factory/bootstrap/factory/dashboard_jobs_rpc.py
+++ b/src/factory/bootstrap/factory/dashboard_jobs_rpc.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from factory.core.auth.control_plane_authz import (
@@ -13,6 +15,11 @@ from factory.core.auth.control_plane_wire import get_request_principal
 from factory.core.hub.hub_protocol import RoutingKey
 from factory.core.hub.job_catalog import list_active_jobs
 from factory.core.messaging.message import Platform
+from factory.core.ports.active_jobs import (
+    ActiveJobEntry,
+    RegistryConflictError,
+    concurrency_mode_for_backend,
+)
 from factory.core.prompt_resolution import resolve_agent_runtime_defaults
 from factory.core.trace import TraceContext
 from factory.nats.envelope_fields import mint_work_envelope_fields
@@ -33,6 +40,8 @@ from roxabi_contracts.jobs.subjects import (
     jobs_steer,
     jobs_submit,
 )
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from nats.aio.client import Client as NATS
@@ -153,11 +162,18 @@ async def handle_jobs_launch(hub: Hub, nc: NATS, payload: dict[str, Any]) -> dic
     ):
         await nc.publish(dispatch_subject, wire)
 
+    # Registry open at dispatch so Jobs view sees the run (#2142).
+    # Key = envelope job_id (wire id) so ResultCloseListener can close it (#1795).
+    await _open_dashboard_active_job(
+        hub,
+        job_id=job_id,
+        pool_id=pool_id,
+        backend=model_cfg.get("backend"),
+    )
+
     cp = _control_plane(hub)
     if cp is not None:
-        await cp.record_job_launch(
-            job_id, launched_by=principal.user_id, org_id=org_id
-        )
+        await cp.record_job_launch(job_id, launched_by=principal.user_id, org_id=org_id)
 
     return DashboardJobsLaunchResponse(
         accepted=True,
@@ -165,6 +181,43 @@ async def handle_jobs_launch(hub: Hub, nc: NATS, payload: dict[str, Any]) -> dic
         message=f"dispatched {req.job_name}",
         dispatch_subject=dispatch_subject,
     ).model_dump()
+
+
+async def _open_dashboard_active_job(
+    hub: "Hub",
+    *,
+    job_id: str,
+    pool_id: str,
+    backend: str | None,
+) -> None:
+    """Best-effort registry open for a dashboard-dispatched job (#2142)."""
+    coord = getattr(hub, "_active_jobs_coord", None)
+    if coord is None or not hasattr(coord, "open"):
+        return
+    mode = concurrency_mode_for_backend(backend)
+    entry = ActiveJobEntry(
+        job_id=job_id,
+        pool_id=pool_id,
+        status="open",
+        started_at=datetime.now(UTC),
+        steer_subject=jobs_steer(job_id),
+        concurrency_mode=mode,
+    )
+    try:
+        await coord.open(entry)
+    except RegistryConflictError:
+        log.info(
+            "dashboard jobs: pool %r already has an open job — "
+            "launch %r not registered (TTL will heal)",
+            pool_id,
+            job_id,
+        )
+    except Exception:  # noqa: BLE001 — side-channel: never fail launch
+        log.warning(
+            "dashboard jobs: active-jobs open failed for %r",
+            job_id,
+            exc_info=True,
+        )
 
 
 async def _authorize_job_action(

--- a/src/factory/core/pool/pool_processor.py
+++ b/src/factory/core/pool/pool_processor.py
@@ -22,7 +22,11 @@ if TYPE_CHECKING:
 from roxabi_contracts.jobs.subjects import jobs_steer
 
 from ..messaging.message import Response
-from ..ports.active_jobs import ActiveJobEntry, RegistryConflictError
+from ..ports.active_jobs import (
+    ActiveJobEntry,
+    RegistryConflictError,
+    concurrency_mode_for_backend,
+)
 from .pool_observer import _TURN_PERSIST_ERRORS
 from .pool_processor_dispatch import safe_dispatch
 from .pool_processor_exec import guarded_process_one
@@ -40,6 +44,18 @@ def _active_jobs_recorder(pool: Pool) -> ActiveJobsRecorder | None:
     return pool._ctx.active_jobs_recorder()
 
 
+def _pool_backend(pool: Pool) -> str | None:
+    """Best-effort agent backend for concurrency_mode (#2130)."""
+    try:
+        agent = pool._ctx.get_agent(pool.agent_name)
+    except Exception:  # noqa: BLE001 — side-channel
+        return None
+    if agent is None:
+        return None
+    cfg = getattr(agent, "llm_config", None) or getattr(agent, "config", None)
+    return getattr(cfg, "backend", None) if cfg is not None else None
+
+
 async def _open_active_job(pool: Pool) -> str | None:
     """Register this run in the active-jobs registry; return its job_id.
 
@@ -47,19 +63,24 @@ async def _open_active_job(pool: Pool) -> str | None:
     never on the turn's critical path.  The ENTIRE body — recorder resolution,
     entry construction and ``open()`` — is guarded so no registry or context
     failure can ever propagate into message processing.
+
+    Note: the registry ``job_id`` is still a local uuid4 on the chat/pool path
+    (#2147 tracks aligning it with the wire envelope job_id).  Dashboard
+    launch (#2142) keys by envelope id so ResultCloseListener can close it.
     """
     try:
         recorder = _active_jobs_recorder(pool)
         if recorder is None:
             return None
         job_id = uuid.uuid4().hex
+        mode = concurrency_mode_for_backend(_pool_backend(pool))
         entry = ActiveJobEntry(
             job_id=job_id,
             pool_id=pool.pool_id,
             status="open",
             started_at=datetime.now(UTC),
             steer_subject=jobs_steer(job_id),
-            concurrency_mode="steer",
+            concurrency_mode=mode,
         )
         await recorder.open(entry)
     except RegistryConflictError:

--- a/src/factory/core/ports/active_jobs.py
+++ b/src/factory/core/ports/active_jobs.py
@@ -10,6 +10,21 @@ import datetime
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
+# Backends with a live ``factory.job.<id>.steer`` bridge today (#2130).
+_STEER_BACKENDS = frozenset({"omp-rpc", "omp"})
+
+
+def concurrency_mode_for_backend(backend: str | None) -> str:
+    """Derive registry ``concurrency_mode`` from driver backend (#2130, #2142).
+
+    OMP steers in-flight; CLI/other backends use ``queue`` until Shape-D.
+    """
+    if backend is None:
+        return "queue"
+    if backend.strip().lower() in _STEER_BACKENDS:
+        return "steer"
+    return "queue"
+
 
 class RegistryConflictError(Exception):
     """Raised when ``open()`` finds a non-expired job already mapped to *pool_id*.

--- a/src/factory/infrastructure/stores/jobs/active_jobs_result_listener.py
+++ b/src/factory/infrastructure/stores/jobs/active_jobs_result_listener.py
@@ -6,12 +6,12 @@ a job's terminal result arrives.  The subject itself is the close signal —
 the payload is never deserialized, so a malformed ``JobResult`` still closes
 the entry.
 
-This is the authoritative close of ``docs/architecture/job-model.md``, but
-it is mostly dormant today: every pool run's registry entry is keyed by a
-locally-minted uuid4 (``pool_processor._open_active_job``) that never equals
-the wire job_id, so ``close(wire_id)`` no-ops until #2142/#2147 key entries
-by the envelope job_id.  The pool-loop ``finally`` close stays load-bearing
-until then.
+This is the authoritative close of ``docs/architecture/job-model.md``.
+Dashboard-launched jobs (#2142) register under the envelope job_id, so a
+terminal ``.result`` closes them here.  Pool/chat runs still key the
+registry with a local uuid4 (``pool_processor._open_active_job``) that does
+not match the wire id — ``close(wire_id)`` no-ops for those until #2147;
+the pool-loop ``finally`` close stays load-bearing for that path.
 
 Trust boundary: the publish ACL on ``factory.job.*.result`` (clipool/omp
 workers) is the only authorization — any grant holder can name any job_id

--- a/tests/core/pool/test_active_jobs_writeback.py
+++ b/tests/core/pool/test_active_jobs_writeback.py
@@ -29,15 +29,29 @@ class _Recorder:
         self.closed.append(job_id)
 
 
-def _pool_with(recorder: object | None) -> Any:
-    ctx = SimpleNamespace(active_jobs_recorder=lambda: recorder)
-    return SimpleNamespace(pool_id="web:smoke:agent:lyra", _ctx=ctx)
+def _pool_with(
+    recorder: object | None,
+    *,
+    backend: str | None = None,
+) -> Any:
+    agent = None
+    if backend is not None:
+        agent = SimpleNamespace(llm_config=SimpleNamespace(backend=backend))
+    ctx = SimpleNamespace(
+        active_jobs_recorder=lambda: recorder,
+        get_agent=lambda _name: agent,
+    )
+    return SimpleNamespace(
+        pool_id="web:smoke:agent:lyra",
+        agent_name="lyra",
+        _ctx=ctx,
+    )
 
 
 @pytest.mark.asyncio
 async def test_open_registers_entry_and_returns_job_id() -> None:
     rec = _Recorder()
-    pool = _pool_with(rec)
+    pool = _pool_with(rec, backend="omp-rpc")
 
     job_id = await _open_active_job(pool)
 
@@ -49,6 +63,17 @@ async def test_open_registers_entry_and_returns_job_id() -> None:
     assert entry.status == "open"
     assert entry.concurrency_mode == "steer"
     assert entry.steer_subject == f"factory.job.{job_id}.steer"
+
+
+@pytest.mark.asyncio
+async def test_open_uses_queue_mode_for_cli_backend() -> None:
+    rec = _Recorder()
+    pool = _pool_with(rec, backend="claude-cli")
+
+    job_id = await _open_active_job(pool)
+
+    assert job_id is not None
+    assert rec.opened[0].concurrency_mode == "queue"
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_concurrency_mode.py
+++ b/tests/core/test_concurrency_mode.py
@@ -1,0 +1,18 @@
+"""Unit tests for concurrency_mode_for_backend (#2130)."""
+
+from __future__ import annotations
+
+from factory.core.ports.active_jobs import concurrency_mode_for_backend
+
+
+def test_omp_backends_are_steer() -> None:
+    assert concurrency_mode_for_backend("omp-rpc") == "steer"
+    assert concurrency_mode_for_backend("omp") == "steer"
+    assert concurrency_mode_for_backend("OMP-RPC") == "steer"
+
+
+def test_cli_and_unknown_are_queue() -> None:
+    assert concurrency_mode_for_backend("claude-cli") == "queue"
+    assert concurrency_mode_for_backend(None) == "queue"
+    assert concurrency_mode_for_backend("") == "queue"
+    assert concurrency_mode_for_backend("  ") == "queue"

--- a/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
+++ b/tests/factory/bootstrap/test_dashboard_rpc_jobs.py
@@ -76,6 +76,57 @@ class TestJobsLaunch:
         assert subject == "factory.jobs.omp"
         assert b"hello operator" in payload
 
+    @pytest.mark.asyncio
+    async def test_launch_opens_registry_with_envelope_job_id(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        """Dashboard dispatch registers so Jobs view + ResultClose see it (#2142)."""
+        coord = AsyncMock()
+        hub._active_jobs_coord = coord
+        result = await handle_jobs_launch(
+            hub,
+            nc,
+            {"agent": "lyra", "prompt": "track me", "job_name": "omp"},
+        )
+        assert result["accepted"] is True
+        job_id = result["job_id"]
+        coord.open.assert_awaited_once()
+        entry = coord.open.await_args.args[0]
+        assert entry.job_id == job_id
+        assert entry.concurrency_mode == "steer"  # omp-rpc backend
+        assert entry.steer_subject == jobs_steer(job_id)
+        assert entry.pool_id  # synthetic web:smoke:agent:lyra
+
+    @pytest.mark.asyncio
+    async def test_launch_registry_open_failure_still_accepts(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        coord = AsyncMock()
+        coord.open = AsyncMock(side_effect=RuntimeError("kv down"))
+        hub._active_jobs_coord = coord
+        result = await handle_jobs_launch(
+            hub,
+            nc,
+            {"agent": "lyra", "prompt": "still ok", "job_name": "omp"},
+        )
+        assert result["accepted"] is True
+        nc.publish.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_launch_claude_registers_queue_mode(
+        self, hub: MagicMock, nc: AsyncMock
+    ) -> None:
+        coord = AsyncMock()
+        hub._active_jobs_coord = coord
+        result = await handle_jobs_launch(
+            hub,
+            nc,
+            {"agent": "lyra", "prompt": "cli job", "job_name": "claude"},
+        )
+        assert result["accepted"] is True
+        entry = coord.open.await_args.args[0]
+        assert entry.concurrency_mode == "queue"
+
     @pytest.mark.no_default_trace
     @pytest.mark.asyncio
     async def test_launch_mints_trace_without_ambient_context(


### PR DESCRIPTION
## Summary
- `handle_jobs_launch` opens the active-jobs registry with the **envelope `job_id`** so the Jobs view and ResultCloseListener see dashboard-dispatched runs
- `concurrency_mode_for_backend`: omp → `steer`, else `queue` — used on dashboard launch **and** pool open (#2130)
- Registry open is best-effort (never fails launch); conflict/TTL messaging preserved

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2142 + #2130 | OPEN |
| Implementation | `feat/2142-jobs-dashboard-registry-open` | Complete |
| Verification | pre-push qg ✅ unit tests ✅ | Passed |

## Out of scope
- #2147 chat-path registry id ≠ wire job_id (pool still mints local uuid4)

## Test Plan
- [x] launch opens registry with envelope job_id + steer for omp
- [x] launch still accepts when registry open fails
- [x] claude launch → queue mode
- [x] pool open derives mode from agent backend
- [x] concurrency_mode unit table

Closes #2142
Closes #2130