### PR TITLE
fix(jobs): key chat-path active-jobs by wire job_id

### DIFF
--- a/src/factory/core/pool/pool_active_jobs.py
+++ b/src/factory/core/pool/pool_active_jobs.py
@@ -1,0 +1,110 @@
+"""Pool → active-jobs registry side-channel (#1772, #2147).
+
+Open/close helpers live here so ``pool_processor`` and ``pool_processor_exec``
+can share them without a circular import.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from factory.core.ports.active_jobs import (
+    ActiveJobEntry,
+    RegistryConflictError,
+    concurrency_mode_for_backend,
+)
+from roxabi_contracts import new_job_id
+from roxabi_contracts.jobs.subjects import jobs_steer
+
+if TYPE_CHECKING:
+    from factory.core.pool.pool import Pool
+    from factory.core.ports.active_jobs import ActiveJobsRecorder
+
+log = logging.getLogger(__name__)
+
+
+def _active_jobs_recorder(pool: Pool) -> ActiveJobsRecorder | None:
+    """The hub's active-jobs recorder (``None`` until wired), via ``PoolContext``."""
+    return pool._ctx.active_jobs_recorder()
+
+
+def _pool_backend(pool: Pool) -> str | None:
+    """Best-effort agent backend for concurrency_mode (#2130)."""
+    try:
+        agent = pool._ctx.get_agent(pool.agent_name)
+    except Exception:  # noqa: BLE001 — side-channel
+        return None
+    if agent is None:
+        return None
+    cfg = getattr(agent, "llm_config", None) or getattr(agent, "config", None)
+    return getattr(cfg, "backend", None) if cfg is not None else None
+
+
+async def open_active_job(pool: Pool, *, job_id: str | None = None) -> str | None:
+    """Register this turn in the active-jobs registry; return its job_id.
+
+    *job_id* must be the wire envelope id (TraceContext root / new_job_id) so
+    steer/cancel and ResultCloseListener match the worker (#2147).
+    """
+    try:
+        recorder = _active_jobs_recorder(pool)
+        if recorder is None:
+            return None
+        resolved = job_id or new_job_id()
+        mode = concurrency_mode_for_backend(_pool_backend(pool))
+        entry = ActiveJobEntry(
+            job_id=resolved,
+            pool_id=pool.pool_id,
+            status="open",
+            started_at=datetime.now(UTC),
+            steer_subject=jobs_steer(resolved),
+            concurrency_mode=mode,
+        )
+        await recorder.open(entry)
+    except RegistryConflictError:
+        log.info(
+            "[pool:%s] active-jobs: pool already has an open job — "
+            "run not registered (TTL will heal)",
+            pool.pool_id,
+        )
+        return None
+    except Exception:  # noqa: BLE001 — side-channel: never break the turn
+        log.warning(
+            "[pool:%s] active-jobs: open failed — run not registered",
+            pool.pool_id,
+            exc_info=True,
+        )
+        return None
+    return resolved
+
+
+async def close_active_job(pool: Pool, job_id: str | None) -> None:
+    """Remove this turn from the registry; best-effort (TTL heals a miss)."""
+    if job_id is None:
+        return
+    try:
+        recorder = _active_jobs_recorder(pool)
+        if recorder is None:
+            return
+        await recorder.close(job_id)
+    except Exception:  # noqa: BLE001 — side-channel: never break the turn
+        log.warning(
+            "[pool:%s] active-jobs: close failed for %r",
+            pool.pool_id,
+            job_id,
+            exc_info=True,
+        )
+
+
+# Back-compat aliases used by tests that import private names.
+_open_active_job = open_active_job
+_close_active_job = close_active_job
+
+__all__ = [
+    "close_active_job",
+    "open_active_job",
+    "_close_active_job",
+    "_open_active_job",
+]

--- a/src/factory/core/pool/pool_processor.py
+++ b/src/factory/core/pool/pool_processor.py
@@ -9,119 +9,19 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import uuid
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..agent import AgentBase
     from ..messaging.message import InboundMessage
-    from ..ports.active_jobs import ActiveJobsRecorder
     from .pool import Pool
 
-from roxabi_contracts.jobs.subjects import jobs_steer
-
 from ..messaging.message import Response
-from ..ports.active_jobs import (
-    ActiveJobEntry,
-    RegistryConflictError,
-    concurrency_mode_for_backend,
-)
 from .pool_observer import _TURN_PERSIST_ERRORS
 from .pool_processor_dispatch import safe_dispatch
 from .pool_processor_exec import guarded_process_one
 
 log = logging.getLogger(__name__)
-
-
-def _active_jobs_recorder(pool: Pool) -> ActiveJobsRecorder | None:
-    """The hub's active-jobs recorder (``None`` until wired), via ``PoolContext``.
-
-    Resolved in one place so open/close agree; callers wrap this in the
-    best-effort try/except that guards the whole registry side-channel, so a
-    context that raises here cannot break the turn either.
-    """
-    return pool._ctx.active_jobs_recorder()
-
-
-def _pool_backend(pool: Pool) -> str | None:
-    """Best-effort agent backend for concurrency_mode (#2130)."""
-    try:
-        agent = pool._ctx.get_agent(pool.agent_name)
-    except Exception:  # noqa: BLE001 — side-channel
-        return None
-    if agent is None:
-        return None
-    cfg = getattr(agent, "llm_config", None) or getattr(agent, "config", None)
-    return getattr(cfg, "backend", None) if cfg is not None else None
-
-
-async def _open_active_job(pool: Pool) -> str | None:
-    """Register this run in the active-jobs registry; return its job_id.
-
-    Best-effort side-channel: the registry is observability + routing support,
-    never on the turn's critical path.  The ENTIRE body — recorder resolution,
-    entry construction and ``open()`` — is guarded so no registry or context
-    failure can ever propagate into message processing.
-
-    Note: the registry ``job_id`` is still a local uuid4 on the chat/pool path
-    (#2147 tracks aligning it with the wire envelope job_id).  Dashboard
-    launch (#2142) keys by envelope id so ResultCloseListener can close it.
-    """
-    try:
-        recorder = _active_jobs_recorder(pool)
-        if recorder is None:
-            return None
-        job_id = uuid.uuid4().hex
-        mode = concurrency_mode_for_backend(_pool_backend(pool))
-        entry = ActiveJobEntry(
-            job_id=job_id,
-            pool_id=pool.pool_id,
-            status="open",
-            started_at=datetime.now(UTC),
-            steer_subject=jobs_steer(job_id),
-            concurrency_mode=mode,
-        )
-        await recorder.open(entry)
-    except RegistryConflictError:
-        # Benign + self-healing: a prior run's entry for this pool lingers
-        # until its TTL expires; this run is simply not registered meanwhile.
-        log.info(
-            "[pool:%s] active-jobs: pool already has an open job — "
-            "run not registered (TTL will heal)",
-            pool.pool_id,
-        )
-        return None
-    except Exception:  # noqa: BLE001 — side-channel: never break the turn
-        log.warning(
-            "[pool:%s] active-jobs: open failed — run not registered",
-            pool.pool_id,
-            exc_info=True,
-        )
-        return None
-    return job_id
-
-
-async def _close_active_job(pool: Pool, job_id: str | None) -> None:
-    """Remove this run from the registry; best-effort (TTL heals a miss).
-
-    Whole body guarded — a registry/context failure on the teardown path
-    (incl. during ``asyncio.CancelledError`` unwind) must never propagate.
-    """
-    if job_id is None:
-        return
-    try:
-        recorder = _active_jobs_recorder(pool)
-        if recorder is None:
-            return
-        await recorder.close(job_id)
-    except Exception:  # noqa: BLE001 — side-channel: never break the turn
-        log.warning(
-            "[pool:%s] active-jobs: close failed for %r",
-            pool.pool_id,
-            job_id,
-            exc_info=True,
-        )
 
 
 class PoolProcessor:
@@ -136,12 +36,15 @@ class PoolProcessor:
         self._pool = pool
 
     async def process_loop(self) -> None:  # noqa: C901 — DEBT:wiring-bootstrap-deps — debounce + cancel-in-flight adds inherent branches
-        """Consume inbox with debounce aggregation and cancel-in-flight."""
+        """Consume inbox with debounce aggregation and cancel-in-flight.
+
+        Active-jobs registry open/close is per-turn (see
+        ``guarded_process_one``) so the registry id matches the wire
+        envelope job_id drivers mint via TraceContext (#2147).
+        """
         pool = self._pool
         _last_msg: InboundMessage | None = None
-        _job_id: str | None = None
         try:
-            _job_id = await _open_active_job(pool)
             while True:
                 if pool._inbox.empty():
                     break
@@ -197,7 +100,6 @@ class PoolProcessor:
             raise
         finally:
             pool._current_task = None
-            await _close_active_job(pool, _job_id)
 
     async def _process_with_cancel(
         self,

--- a/src/factory/core/pool/pool_processor_exec.py
+++ b/src/factory/core/pool/pool_processor_exec.py
@@ -20,6 +20,8 @@ from factory.transport.typing_publisher import is_typing_enabled
 from factory.transport.work_scope import WorkScope
 
 from ..messaging.message import GENERIC_ERROR_REPLY, Response
+from ..trace import TraceContext
+from .pool_active_jobs import _close_active_job, _open_active_job
 from .pool_processor_dispatch import (
     is_pool_turn_error,
     process_non_streaming,
@@ -36,10 +38,17 @@ log = logging.getLogger(__name__)
 async def guarded_process_one(  # noqa: PLR0915, C901 — DEBT:complexity-residual
     msg: InboundMessage, agent: AgentBase, pool: Pool
 ) -> None:
-    """Wrap process_one with timeout and error handling."""
+    """Wrap process_one with timeout and error handling.
+
+    Per-turn active-jobs open/close uses TraceContext ``root_job_id`` so the
+    registry id equals the wire envelope job_id drivers mint (#2147).
+    """
     with pool_turn_trace_context(
         msg, pool_id=pool.pool_id, agent_name=pool.agent_name
     ) as trace_id:
+        # Same id drivers will stamp via mint_work_envelope_fields.
+        wire_job_id = TraceContext.get_root_job_id()
+        reg_job_id = await _open_active_job(pool, job_id=wire_job_id)
         _start = time.monotonic()
         _cancelled = False
         log.info(
@@ -117,6 +126,7 @@ async def guarded_process_one(  # noqa: PLR0915, C901 — DEBT:complexity-residu
                 str(exc)[:200],
             )
         finally:
+            await _close_active_job(pool, reg_job_id)
             if not _cancelled:
                 log.info(
                     "agent idle: agent=%s pool=%s",

--- a/src/factory/core/pool/pool_trace_context.py
+++ b/src/factory/core/pool/pool_trace_context.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from factory.core.messaging.message import InboundMessage
 from factory.core.trace import TraceContext
+from roxabi_contracts import new_job_id
 
 
 @contextmanager
@@ -18,16 +19,24 @@ def turn_trace_context(
     pool_id: str | None = None,
     agent_name: str | None = None,
 ) -> Generator[str, None, None]:
-    """Re-hydrate trace correlation vars from a stamped InboundMessage."""
+    """Re-hydrate trace correlation vars from a stamped InboundMessage.
+
+    Always stamps ``root_job_id`` (msg → ambient → mint) so hub drivers
+    pick the same id via ``mint_work_envelope_fields`` (#2147).
+    """
     stamped_trace = msg.trace_id if isinstance(msg.trace_id, str) else None
     trace_id = stamped_trace or TraceContext.get_trace_id() or uuid4().hex
     token_t = TraceContext.set_trace_id(trace_id)
     token_p: Token[str] | None = None
     if pool_id is not None:
         token_p = TraceContext.set_pool_id(pool_id)
-    token_j: Token[str] | None = None
-    if isinstance(msg.root_job_id, str) and msg.root_job_id:
-        token_j = TraceContext.set_root_job_id(msg.root_job_id)
+    stamped_job = (
+        msg.root_job_id
+        if isinstance(msg.root_job_id, str) and msg.root_job_id
+        else None
+    )
+    job_id = stamped_job or TraceContext.get_root_job_id() or new_job_id()
+    token_j = TraceContext.set_root_job_id(job_id)
     token_an: Token[str] | None = None
     if agent_name is not None:
         token_an = TraceContext.set_agent_name(agent_name)
@@ -36,8 +45,7 @@ def turn_trace_context(
     finally:
         if token_an is not None:
             TraceContext.reset_agent_name(token_an)
-        if token_j is not None:
-            TraceContext.reset_root_job_id(token_j)
+        TraceContext.reset_root_job_id(token_j)
         if token_p is not None:
             TraceContext.reset_pool_id(token_p)
         TraceContext.reset_trace_id(token_t)

--- a/src/factory/infrastructure/stores/jobs/active_jobs_result_listener.py
+++ b/src/factory/infrastructure/stores/jobs/active_jobs_result_listener.py
@@ -7,11 +7,10 @@ the payload is never deserialized, so a malformed ``JobResult`` still closes
 the entry.
 
 This is the authoritative close of ``docs/architecture/job-model.md``.
-Dashboard-launched jobs (#2142) register under the envelope job_id, so a
-terminal ``.result`` closes them here.  Pool/chat runs still key the
-registry with a local uuid4 (``pool_processor._open_active_job``) that does
-not match the wire id — ``close(wire_id)`` no-ops for those until #2147;
-the pool-loop ``finally`` close stays load-bearing for that path.
+Dashboard launches (#2142) and pool turns (#2147) register under the
+envelope / TraceContext ``root_job_id``, so a terminal ``.result`` closes
+the matching entry.  Pool still closes in ``guarded_process_one`` finally
+as a safety net (cancel / no result path).
 
 Trust boundary: the publish ACL on ``factory.job.*.result`` (clipool/omp
 workers) is the only authorization — any grant holder can name any job_id

--- a/tests/core/pool/test_active_jobs_writeback.py
+++ b/tests/core/pool/test_active_jobs_writeback.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from factory.core.pool.pool_processor import _close_active_job, _open_active_job
+from factory.core.pool.pool_active_jobs import _close_active_job, _open_active_job
 from factory.core.ports.active_jobs import RegistryConflictError
 
 
@@ -63,6 +63,20 @@ async def test_open_registers_entry_and_returns_job_id() -> None:
     assert entry.status == "open"
     assert entry.concurrency_mode == "steer"
     assert entry.steer_subject == f"factory.job.{job_id}.steer"
+
+
+@pytest.mark.asyncio
+async def test_open_uses_explicit_wire_job_id() -> None:
+    """Registry key must be the envelope/wire id (#2147)."""
+    rec = _Recorder()
+    pool = _pool_with(rec, backend="omp-rpc")
+    wire = "wire-job-id-abc123"
+
+    job_id = await _open_active_job(pool, job_id=wire)
+
+    assert job_id == wire
+    assert rec.opened[0].job_id == wire
+    assert rec.opened[0].steer_subject == f"factory.job.{wire}.steer"
 
 
 @pytest.mark.asyncio

--- a/tests/core/pool/test_pool_trace_root_job.py
+++ b/tests/core/pool/test_pool_trace_root_job.py
@@ -1,0 +1,27 @@
+"""TraceContext root_job_id always stamped for pool turns (#2147)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from factory.core.envelope_fields import mint_work_envelope_fields
+from factory.core.pool.pool_trace_context import turn_trace_context
+from factory.core.trace import TraceContext
+
+
+def test_turn_trace_mints_root_job_id_when_msg_lacks_one() -> None:
+    msg = SimpleNamespace(trace_id=None, root_job_id=None)
+    with turn_trace_context(cast(Any, msg), pool_id="web:smoke:a", agent_name="lyra"):
+        jid = TraceContext.get_root_job_id()
+        assert jid
+        # Drivers mint envelopes from ambient root — must match registry key.
+        fields = mint_work_envelope_fields(trace_id=TraceContext.get_trace_id())
+        assert fields.job_id == jid
+    assert TraceContext.get_root_job_id() is None
+
+
+def test_turn_trace_preserves_msg_root_job_id() -> None:
+    msg = SimpleNamespace(trace_id="t" * 32, root_job_id="explicit-wire-id")
+    with turn_trace_context(cast(Any, msg), pool_id="p", agent_name="a"):
+        assert TraceContext.get_root_job_id() == "explicit-wire-id"


### PR DESCRIPTION
## Summary
- Per-turn registry open/close keyed by TraceContext ``root_job_id`` (same id drivers mint via ``mint_work_envelope_fields``)
- ``turn_trace_context`` always stamps ``root_job_id`` (msg → ambient → ``new_job_id()``)
- Extract ``pool_active_jobs`` helpers to avoid circular imports
- Chat steer/cancel and ResultCloseListener can match worker subjects (#2147)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2147 | OPEN |
| Implementation | `feat/2147-jobs-chat-registry-wire-id` | Complete |
| Verification | pre-push qg ✅ unit tests ✅ | Passed |

## Design choice
One registry entry **per turn** (not whole `process_loop`), so each wire job_id stays aligned and ResultClose can reclaim after each result without blocking the next turn.

## Test Plan
- [x] open with explicit wire job_id
- [x] turn_trace mints root_job_id; envelope fields match
- [x] existing writeback / concurrency tests

Closes #2147