### PR TITLE
chore(claude): drop 5 unused plugins from enabledPlugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,6 @@
   "enabledPlugins": {
     "dev-core@roxabi-marketplace": true,
     "compress@roxabi-marketplace": true,
-    "1b1@roxabi-marketplace": true,
-    "cv@roxabi-marketplace": false,
-    "get-invoice-details@roxabi-marketplace": false,
-    "image-prompt-generator@roxabi-marketplace": true,
-    "linkedin-post-generator@roxabi-marketplace": false,
     "roxabi-vault@roxabi-vault-marketplace": true,
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,


### PR DESCRIPTION
Remove `1b1`, `cv`, `get-invoice-details`, `image-prompt-generator` and `linkedin-post-generator` from `.claude/settings.json`. All five were uninstalled at project scope; none were in use (three were already `false`).

`cocoindex-code` was collaterally dropped by `claude plugin uninstall` (it rewrites `enabledPlugins` and discards entries not installed at that scope) and has been restored — it stays the default code-search route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)