### PR TITLE
fix(commands): mitigate bare-URL scrape pain + vault-add migration

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -222,13 +222,15 @@ Pipeline: **scrape** → **LLM 3-5 bullet points**.
 
 ### Bare URL auto-rewrite
 
-Sending a bare URL (no slash command prefix) is automatically rewritten to `/explain <url>`:
+Sending a bare HTTPS URL (no slash command prefix) is rewritten to `/explain <url>` **when** the agent has `patterns.bare_url = true` (default **off**):
 
 ```
 https://example.com/article   →   /explain https://example.com/article
 ```
 
-The detection uses `CommandRouter._BARE_URL_RE` (`^https?://\S+$`). The target command is read from `src/factory/data/patterns.toml` `[bare_url].command` — change it there to reroute bare URLs to a different command without touching Python.
+- Detection: `command_patterns.BARE_URL_RE` — **HTTPS only** (`http://` is not rewritten).
+- Target command: `src/factory/data/patterns.toml` `[bare_url].command`.
+- Leave `bare_url` off in production until HTTP scrape is deployed (`scrape-placement.md`).
 
 ### `/search <query>` — Cortex memory search
 

--- a/docs/architecture/scrape-placement.md
+++ b/docs/architecture/scrape-placement.md
@@ -65,7 +65,7 @@ agent tool / MCP           ──POST /scrape──▶  (same)
 |---|---|
 | Transport | HTTPS (or localhost HTTP on pod network) |
 | Health | `GET /ready` — process up **and** scraper importable; hub/client circuit-breaker on call failures |
-| SSRF | Keep HTTPS-only + private-IP reject (move from hub `_scraping` into service **or** dual-check) |
+| SSRF | **Dual-check required**: hub cheap pre-check **and** service enforces HTTPS-only + non-global IP + redirect revalidation |
 | Deploy | Quadlet unit on M₁ (or M₂ if browser-heavy); image embeds web-intel/playwright |
 | Hub change | HTTP-backed `ScrapeProvider` impl; drop subprocess from hub image |
 | Agent | Skill/CLI optional wrapper calling same HTTP API — **one** scrape engine |

--- a/src/factory/core/commands/command_patterns.py
+++ b/src/factory/core/commands/command_patterns.py
@@ -21,10 +21,24 @@ BUNDLED_PATTERNS_CONFIG = (
     Path(__file__).resolve().parent.parent.parent / "data" / "patterns.toml"
 )
 
-BARE_URL_RE: re.Pattern[str] = re.compile(r"^https?://\S+$")
+# HTTPS only — scrape processors reject http://; keep rewrite aligned.
+BARE_URL_RE: re.Pattern[str] = re.compile(r"^https://\S+$")
 
 # Default command for bare URL rewriting
 DEFAULT_BARE_URL_COMMAND = "explain"
+
+# Retired product commands → migration copy (no LLM, no side effect).
+_RETIRED_COMMAND_MESSAGES: dict[str, str] = {
+    "vault-add": (
+        "Command /vault-add was removed. URL capture is no longer a hub slash "
+        "command (cortex owns long-term memory). Use /explain or /summarize "
+        "to read a page, or /search to query memory. Type /help for commands."
+    ),
+    "add-vault": (
+        "Command /add-vault was removed. Notes are no longer saved via this "
+        "hub command. Use /search for memory search. Type /help for commands."
+    ),
+}
 
 
 def load_pattern_configs(path: Path | None = None) -> dict[str, dict]:
@@ -85,5 +99,13 @@ def check_command_conflicts(
 
 
 def format_unknown_command(command_name: str) -> str:
-    """Format a standardized unknown command error message."""
+    """Format a standardized unknown command error message.
+
+    Retired product commands get an explicit migration string instead of a
+    generic unknown-command line.
+    """
+    bare = command_name.lstrip("/!")
+    retired = _RETIRED_COMMAND_MESSAGES.get(bare)
+    if retired is not None:
+        return retired
     return f"Unknown command: {command_name}. Type /help for available commands."

--- a/src/factory/core/commands/command_router.py
+++ b/src/factory/core/commands/command_router.py
@@ -299,11 +299,12 @@ class CommandRouter:
         if handler is None:
             if msg.command.prefix == "!" or command_name in self._passthroughs:
                 return None
-            reply = (
-                self._msg_manager.get("unknown_command", command_name=command_name)
-                if self._msg_manager
-                else format_unknown_command(command_name)
-            )
+            # Retired product cmds always use migration copy (skip i18n generic).
+            reply = format_unknown_command(command_name)
+            if reply.startswith("Unknown command:") and self._msg_manager:
+                reply = self._msg_manager.get(
+                    "unknown_command", command_name=command_name
+                )
             return Response(content=reply)
         if pool is None:
             raise TypeError(

--- a/src/factory/core/processors/_scraping.py
+++ b/src/factory/core/processors/_scraping.py
@@ -95,15 +95,27 @@ async def _scrape_with_fallback(scraper, url: str, timeout: float) -> str:
     """Scrape *url* via scraper; return fallback string on any ScrapeFailed.
 
     B7: single shared implementation — no more copy-paste across 3 files.
+    Fallback text is user-facing (may still pass through the LLM turn).
     """
     try:
         return await scraper.scrape(url, timeout=timeout)
     except ScrapeFailed as exc:
         if exc.reason == "not_available":
-            return f"[scraping unavailable] {url}"
+            return (
+                f"Web scraping is not available in this deployment for {url}. "
+                "The scrape plugin/service is missing (common in production "
+                "containers). Paste the page text instead, or try again after "
+                "scrape is restored. See docs/architecture/scrape-placement.md."
+            )
         if exc.reason == "timeout":
-            return f"[scrape timed out] {url}"
-        return f"[scrape failed] {url}"
+            return (
+                f"Web scrape timed out for {url}. "
+                "Try again later or paste the page text."
+            )
+        return (
+            f"Web scrape failed for {url}. "
+            "The page may be blocked or unreachable; paste the text instead."
+        )
 
 
 class ScrapingProcessor(BaseProcessor):

--- a/src/factory/data/patterns.toml
+++ b/src/factory/data/patterns.toml
@@ -1,8 +1,12 @@
 # Pattern rules — defines what each rewrite pattern does.
 # Agents activate patterns via [patterns] in their TOML (bare_url = true/false).
 # This file controls the behaviour of each pattern.
+#
+# bare_url defaults OFF (CommandRouter: patterns.get("bare_url", False)).
+# Leave OFF in production until HTTP scrape is deployed — otherwise paste-URL
+# hits a broken hub WebIntel subprocess. See scrape-placement.md.
 
 [bare_url]
-# Command dispatched when a message is a bare URL and bare_url pattern is enabled.
-# vault-add product path removed 2026-08-01 — bare URLs route to explain (scrape + LLM).
+# Command when bare_url pattern is enabled (HTTPS URLs only).
+# vault-add product path removed 2026-08-01 — bare URLs route to explain.
 command = "explain"

--- a/tests/core/processors/test_scraping.py
+++ b/tests/core/processors/test_scraping.py
@@ -208,8 +208,9 @@ class TestScrapeWithFallback:
             scraper, "https://example.com", timeout=30.0
         )
 
-        # Assert
-        assert "[scraping unavailable]" in result
+        # Assert — actionable copy (prod hub often hits not_available)
+        assert "not available" in result.lower()
+        assert "https://example.com" in result
 
     async def test_timeout_returns_timeout_fallback(self) -> None:
         # Arrange
@@ -222,7 +223,8 @@ class TestScrapeWithFallback:
         )
 
         # Assert
-        assert "[scrape timed out]" in result
+        assert "timed out" in result.lower()
+        assert "https://example.com" in result
 
     async def test_subprocess_error_returns_generic_fallback(self) -> None:
         # Arrange
@@ -235,7 +237,8 @@ class TestScrapeWithFallback:
         )
 
         # Assert
-        assert "[scrape failed]" in result
+        assert "scrape failed" in result.lower()
+        assert "https://example.com" in result
 
     async def test_url_included_in_fallback_message(self) -> None:
         # Arrange

--- a/tests/core/test_command_router_special.py
+++ b/tests/core/test_command_router_special.py
@@ -186,13 +186,14 @@ class TestBareUrlDetection:
             is True
         )  # noqa: E501
 
-    def test_http_url_is_detected(self, tmp_path: Path) -> None:
+    def test_http_url_is_not_detected(self, tmp_path: Path) -> None:
+        """http:// is rejected — scrape is HTTPS-only; bare rewrite stays aligned."""
         assert (
             make_router(tmp_path).is_command(make_message(content="http://example.com"))
-            is True
-        )  # noqa: E501
+            is False
+        )
 
-    def test_prepare_returns_add_command(self, tmp_path: Path) -> None:
+    def test_prepare_returns_explain_command(self, tmp_path: Path) -> None:
         prepared = make_router(tmp_path).prepare(
             make_message(content="https://example.com/page")
         )
@@ -225,7 +226,9 @@ class TestBareUrlDetection:
         assert prepared.command is not None
         assert prepared.command.name == "help"
 
-    def test_get_command_name_returns_add_for_bare_url(self, tmp_path: Path) -> None:
+    def test_get_command_name_returns_explain_for_bare_url(
+        self, tmp_path: Path
+    ) -> None:
         router = make_router(tmp_path)
         prepared = router.prepare(make_message(content="https://example.com"))
         assert router.get_command_name(prepared) == "/explain"
@@ -237,7 +240,7 @@ class TestBareUrlDetection:
         )  # noqa: E501
 
     @pytest.mark.asyncio
-    async def test_dispatch_bare_url_routes_to_add_session(
+    async def test_dispatch_bare_url_routes_to_explain_session(
         self, tmp_path: Path
     ) -> None:
         """dispatch() with a bare URL calls the /explain session handler."""
@@ -247,7 +250,7 @@ class TestBareUrlDetection:
         from factory.integrations.base import SessionTools
 
         router = make_router(tmp_path)
-        handler = AsyncMock(return_value=Response(content="added"))
+        handler = AsyncMock(return_value=Response(content="explained"))
         tools = SessionTools(scraper=MM(), vault=MM())
         router.register_session_command("explain", handler, tools=tools)
         router._session_driver = MM()
@@ -256,8 +259,22 @@ class TestBareUrlDetection:
         pool = MagicMock(spec=Pool)
         response = await router.dispatch(msg, pool=pool)
         assert response is not None
-        assert response.content == "added"
+        assert response.content == "explained"
         handler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retired_vault_add_returns_migration_message(
+        self, tmp_path: Path
+    ) -> None:
+        router = make_router(tmp_path)
+        pool = MagicMock(spec=Pool)
+        response = await router.dispatch(
+            make_message_with_command("/vault-add https://example.com"),
+            pool=pool,
+        )
+        assert response is not None
+        assert "removed" in response.content.lower()
+        assert "vault-add" in response.content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bare URL rewrite matches **HTTPS only** (aligned with scrape validators; `http://` no longer rewrites).
- Actionable scrape failure copy when plugin/service is missing (prod hub common case).
- Migration messages for retired `/vault-add` and `/add-vault` instead of generic unknown-command.
- Document `bare_url` opt-in + leave off in prod until HTTP scrape (`scrape-placement.md`); dual-check SSRF wording.

## Test Plan
- [x] `tests/core/test_command_router_special.py` (http not bare; retired vault-add)
- [x] `tests/core/processors/test_scraping.py` (fallback copy)
- [ ] CI green

Follow-up: capability admission SSoT in workers-tooling (PR B).