### PR TITLE
docs(architecture): capability admission A/B/C/D and fleet map

### DIFF
--- a/docs/architecture/workers-tooling.md
+++ b/docs/architecture/workers-tooling.md
@@ -6,7 +6,7 @@ description: Living reference for the tool taxonomy and runtime vocabulary (work
 # Workers & Tooling — factory
 
 > Status: LIVING — current truth for the tool model, workers, pools, tool registries, dev tooling.
-> Last updated: 2026-07-02. Absorbed `tool-architecture.md` (taxonomy + runtime vocabulary), 2026-07-02.
+> Last updated: 2026-08-04. Absorbed `tool-architecture.md` (taxonomy + runtime vocabulary), 2026-07-02; admission A/B/C/D 2026-08-04.
 > Source ADRs: 010, 019, 061, 071. Archived to `adr/archive/` (superseded, absorbed here): 004, 005, 006, 007, 026, 030, 031, 038.
 
 ## Scope
@@ -73,12 +73,65 @@ The canonical tool-nature subject shape carries a `tool.` infix — live for the
 
 **Rule 2 — provider ⊋ satellite.** A provider is a *satellite* only when it is a self-hosted process we run on NATS with a heartbeat. Otherwise it is a non-satellite provider:
 
-| Backing | Provider shape | Heartbeat |
+| Backing | Provider shape | Health model |
 |---|---|---|
-| self-hosted process we run (imageCLI, voiceCLI, Postiz-via-adapter) | NATS satellite adapter | ✅ |
-| cloud API we don't host (X, GitHub) · one-shot stdio CLI | in-proc HTTP / stdio | ✗ |
+| self-hosted process we run (imageCLI, voiceCLI, Postiz-via-adapter) | NATS satellite adapter | heartbeat + registry |
+| **self-hosted HTTP we run** (target scrape service; socialmedia→Postiz direct) | HTTP provider (in-proc client or thin side-car) | **`GET /ready` + client circuit-breaker** |
+| cloud API we don't host (X, GitHub) · one-shot stdio CLI | in-proc HTTP / stdio | CB on call failures (no fleet heartbeat) |
 
 Corollary — **three layers, do not conflate**: a **backing service** (e.g. the self-hosted Postiz fork: web+DB+Redis, HTTP) is infra like Postgres. **A running container ≠ a heartbeat** — the heartbeat comes from *our* NATS adapter (the provider), not the HTTP app. backing service ≠ provider ≠ tool. Shipped instance of the pattern (#1713): `src/factory/adapters/socialmedia/` is the satellite adapter bridging `factory.tool.socialmedia.>` to the Postiz Public API.
+
+HTTPS self-hosted is a **first-class provider shape**, not “cloud only”. Prefer it when there is no GPU multi-worker routing need (see admission checklist below).
+
+#### Process families (A / B / C / D)
+
+Do not call every NATS process a “satellite”. Classify first:
+
+| Family | Role | Examples |
+|---|---|---|
+| **A — Capability satellite** | Self-hosted **tool/provider** on NATS + heartbeat; one (or few) clear verbs | `voice-stt`, `voice-tts`, `image-worker`, `llm-worker` (fleet façade), `socialmedia-adapter` (bridge), `cortex-memory` |
+| **B — Runtime worker** | Runs a **workerEngine** / agent or job runner (not a single tool) | `clipool-worker`, `omp-worker`; projected `code-worker` (Shape B jobs — if built) |
+| **C — Plomberie** | Bus, storage, edge, write-side; not tool-nature | hub, channel adapters, `blobstore` (HTTP), `turn-writer`, ingress |
+| **D — Client / ops** | Publishes requests or reads telemetry; not a provider | `voice-client`, `llm-operator`, dashboard-reader |
+
+**Hub** is family **C** (composition root). It must not grow family-A engines (playwright, GPU, scrapers). Hub middleware that execs tools is stage-axis debt — see [scrape-placement.md](scrape-placement.md).
+
+#### Capability admission checklist
+
+Before adding a process, container, or NATS identity, answer **yes/no**:
+
+1. Do **we operate** the process (image, secrets, host M₁/M₂)?
+2. Does **another fleet process** (not only a local agent) need to call it?
+3. Do we need **queue groups / multi-instance routing / nkey ACL / JetStream jobs**?
+4. Is there **no** clean HTTP (or in-proc) API already?
+
+| Score | Form |
+|---|---|
+| **Mostly yes** + single capa + NATS already the fabric | **A** NATS satellite (or keep existing) |
+| **Mostly yes** + engine / multi-handler jobs | **B** runtime worker (`factory worker --role=…` style) |
+| **No** on “we operate” or “multi-caller fleet” | **Provider in-proc / HTTP client** (D or in-hub port) — not a new satellite |
+| Self-hosted HTTP API + health | **HTTP provider** (`/ready` + CB) — **not** a satellite by default |
+| Storage / sole-writer / edge | **C** plomberie (HTTP or JetStream as appropriate) |
+
+**Reject by default:** “everything outside the hub is a satellite”; god-box `code` satellites; mounting `~/projects` on hub to fix scrape.
+
+#### Fleet map (admission applied)
+
+| Identity / process | Family | Form | Verdict |
+|---|---|---|---|
+| voice-stt / voice-tts | A | NATS satellite | keep |
+| image-worker | A | NATS satellite | keep |
+| llm-worker | A | NATS façade (HTTP backends behind) | keep; HTTP transport optional later |
+| socialmedia-adapter | A bridge | NATS → Postiz HTTP | keep while isolation/ACL value; target **HTTPS provider** if thin proxy only |
+| cortex-memory | A | NATS today → **API (MCP optional)** | migrate; not hub vault slash |
+| clipool / omp | B | NATS runtime worker | keep |
+| code-worker (#1044) | B (if built) | job runner, not tool satellite | do **not** use for scrape-only |
+| blobstore | C | HTTP + NATS audit/ready | keep (not a tool satellite) |
+| turn-writer | C | JetStream sole writer | keep |
+| telegram / discord / web / ingress | C | edge adapters | keep |
+| hub | C | dispatch / auth / pool | thin; no playwright |
+| WebIntel scrape (today) | misplaced A-in-C | hub subprocess | **move** to HTTP provider — [scrape-placement.md](scrape-placement.md) |
+| vault-add product | — | hub write side-effect | **removed** 2026-08-01 |
 
 ---
 
@@ -152,7 +205,8 @@ Three observation layers: (1) in-process self-monitoring (circuit breakers, erro
 
 - A worker is **not** a tool; it consumes tools and **runs on** a workerEngine. The harness is **pure agentic** (no workflow logic) and is **called by** the workerEngine — layered, never unified.
 - tool-surface ≠ tool-nature: a plomberie domain exposing a tool stays plomberie.
-- provider ⊋ satellite: self-hosted backing → satellite (heartbeat); cloud / one-shot → non-satellite. A running backing container is not a heartbeat.
+- provider ⊋ satellite: NATS self-hosted + heartbeat → satellite; self-hosted HTTP → `/ready`+CB provider (not satellite by default); cloud/stdio → non-satellite. A running backing container is not a heartbeat.
+- New process → run capability admission (A/B/C/D); hub is C and must not host tool engines (scrape/GPU).
 - The tool dispatcher target is **uniform**: one ACL gate, one result type, transport-agnostic — no per-kind branched pipeline.
 - `_find_project_root()` anchor walk is the only permitted pattern for locating the project root; fixed `.parent` chains are prohibited.
 - `ANTHROPIC_API_KEY` must never appear in `_SAFE_ENV_KEYS`; the unit test `test_anthropic_api_key_not_forwarded` is load-bearing.
@@ -172,6 +226,7 @@ Three observation layers: (1) in-process self-monitoring (circuit breakers, erro
 
 ## Open questions / known gaps
 
+- Hub still runs `WebIntelScraper` subprocess — admitted as debt; target HTTP provider ([scrape-placement.md](scrape-placement.md)).
 - worker→provider rename incomplete: the heartbeat-consuming registry is still `WorkerRegistry` (`src/factory/nats/worker_registry.py`); satellite-flavored naming exists only in newer code and docs.
 - Uniform 5-layer dispatcher: design locked, rollout incremental; the shared tool protocol layer (in-process/remote wrappers, manifest) is not yet built in `packages/roxabi-contracts/`.
 - Voice and image subjects still use pre-infix prefixes (`factory.voice.tts.request`, `factory.image.generate.request`); only socialmedia carries the tool infix on the wire (`factory.tool.socialmedia.>`).


### PR DESCRIPTION
## Summary
- Formalize **process families** A (capability satellite) / B (runtime worker) / C (plomberie) / D (client).
- Extend **Rule 2**: self-hosted HTTPS provider with `/ready` + circuit-breaker is first-class (not “cloud only”).
- **Admission checklist** (4 questions) + applied **fleet map** (voice/image keep; scrape → HTTP; code-worker = B if ever; hub stays thin).
- Cross-link [scrape-placement.md](docs/architecture/scrape-placement.md).

Companion: #2325 (scrape bare-URL mitigation).

## Test Plan
- [ ] Doc-only; pre-push QG green
- [ ] CI green