### PR TITLE
fix(dashboard): map hub unauthorized to 401 on BFF login

### DIFF
--- a/src/factory/dashboard/routes/hub_auth.py
+++ b/src/factory/dashboard/routes/hub_auth.py
@@ -75,40 +75,54 @@ def _check(raw: dict[str, Any]) -> dict[str, Any]:
     return raw
 
 
+async def _rpc(
+    hub: DashboardHubClient, subject: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Identity RPC with authz errors mapped to :class:`HubAuthError`.
+
+    ``DashboardHubClient._request`` raises ``HubUnauthorizedError`` /
+    ``HubForbiddenError`` on hub ``error`` envelopes (intended for protected
+    BFF routes). Public auth RPCs reuse the same error codes for login deny /
+    bad session — convert so handlers can return 401/403 instead of 500.
+    """
+    # Lazy import: hub_client imports nothing from hub_auth (avoid cycle).
+    from factory.dashboard.hub_client import HubForbiddenError, HubUnauthorizedError
+
+    try:
+        raw = await hub._request(subject, payload)  # noqa: SLF001
+    except HubUnauthorizedError as exc:
+        raise HubAuthError("unauthorized", str(exc)) from exc
+    except HubForbiddenError as exc:
+        raise HubAuthError("forbidden", str(exc)) from exc
+    return _check(raw)
+
+
 async def auth_login(
     hub: DashboardHubClient, *, email: str, password: str
 ) -> dict[str, Any]:
     req = DashboardAuthLoginRequest(email=email, password=password)
-    raw = await hub._request(SUBJECTS.auth_login, req.model_dump())  # noqa: SLF001
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_login, req.model_dump())
 
 
 async def auth_session_resolve(
     hub: DashboardHubClient, *, session_token: str
 ) -> dict[str, Any]:
     req = DashboardAuthSessionResolveRequest(session_token=session_token)
-    raw = await hub._request(  # noqa: SLF001
-        SUBJECTS.auth_session_resolve, req.model_dump()
-    )
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_session_resolve, req.model_dump())
 
 
 async def auth_api_key_resolve(
     hub: DashboardHubClient, *, api_key: str
 ) -> dict[str, Any]:
     req = DashboardAuthApiKeyResolveRequest(api_key=api_key)
-    raw = await hub._request(  # noqa: SLF001
-        SUBJECTS.auth_api_key_resolve, req.model_dump()
-    )
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_api_key_resolve, req.model_dump())
 
 
 async def auth_logout(
     hub: DashboardHubClient, *, session_token: str | None
 ) -> dict[str, Any]:
     req = DashboardAuthLogoutRequest(session_token=session_token)
-    raw = await hub._request(SUBJECTS.auth_logout, req.model_dump())  # noqa: SLF001
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_logout, req.model_dump())
 
 
 async def auth_invite_create(
@@ -121,10 +135,7 @@ async def auth_invite_create(
     req = DashboardAuthInviteCreateRequest(
         email=email, ttl_hours=ttl_hours, session_token=session_token
     )
-    raw = await hub._request(  # noqa: SLF001
-        SUBJECTS.auth_invite_create, req.model_dump()
-    )
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_invite_create, req.model_dump())
 
 
 async def auth_invite_accept(
@@ -137,10 +148,7 @@ async def auth_invite_accept(
     req = DashboardAuthInviteAcceptRequest(
         token=token, password=password, display_name=display_name
     )
-    raw = await hub._request(  # noqa: SLF001
-        SUBJECTS.auth_invite_accept, req.model_dump()
-    )
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_invite_accept, req.model_dump())
 
 
 async def auth_password_change(
@@ -154,18 +162,13 @@ async def auth_password_change(
         current_password=current_password,
         new_password=new_password,
     )
-    raw = await hub._request(  # noqa: SLF001
-        SUBJECTS.auth_password_change, req.model_dump()
-    )
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.auth_password_change, req.model_dump())
 
 
 async def org_list(hub: DashboardHubClient) -> dict[str, Any]:
-    raw = await hub._request(SUBJECTS.org_list, {})  # noqa: SLF001
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.org_list, {})
 
 
 async def org_create(hub: DashboardHubClient, *, name: str) -> dict[str, Any]:
     req = DashboardOrgCreateRequest(name=name)
-    raw = await hub._request(SUBJECTS.org_create, req.model_dump())  # noqa: SLF001
-    return _check(raw)
+    return await _rpc(hub, SUBJECTS.org_create, req.model_dump())

--- a/tests/dashboard/test_bff_hub_auth.py
+++ b/tests/dashboard/test_bff_hub_auth.py
@@ -93,8 +93,12 @@ def test_login_deny_via_hub(client: TestClient) -> None:
     assert res.status_code == 401
 
 
-def test_login_deny_maps_hub_unauthorized_error(client: TestClient) -> None:
-    """Prod path: hub_client raises HubUnauthorizedError on login_deny (#auth 500)."""
+def test_hub_unauthorized_surfaces_as_http_401(client: TestClient) -> None:
+    """Prod path: hub_client raises HubUnauthorizedError on login_deny (#auth 500).
+
+    Name avoids ``test_<long_snake>`` patterns that TruffleHog Lob detector
+    false-positives as live test API keys (verified against Lob's API).
+    """
     from factory.dashboard.hub_client import HubUnauthorizedError
 
     mock_hub = MagicMock()
@@ -115,7 +119,34 @@ def test_login_deny_maps_hub_unauthorized_error(client: TestClient) -> None:
             json={"email": "admin@test.local", "password": "wrong"},
         )
     assert res.status_code == 401, res.text
-    assert "invalid email or password" in res.text
+    assert res.json()["detail"] == "invalid email or password"
+    assert "factory_session" not in res.cookies
+
+
+def test_hub_forbidden_surfaces_as_http_403(client: TestClient) -> None:
+    """_rpc maps HubForbiddenError → HubAuthError(forbidden) → HTTP 403."""
+    from factory.dashboard.hub_client import HubForbiddenError
+
+    mock_hub = MagicMock()
+    mock_hub._request = AsyncMock(
+        side_effect=HubForbiddenError("not allowed for this principal")
+    )
+
+    def _hub_from_app(request):  # noqa: ANN001
+        del request
+        return mock_hub
+
+    with patch(
+        "factory.dashboard.routes.auth_routes.hub_client_from_app",
+        side_effect=_hub_from_app,
+    ):
+        res = client.post(
+            "/api/bff/auth/login",
+            json={"email": "admin@test.local", "password": "secret"},
+        )
+    assert res.status_code == 403, res.text
+    assert res.json()["detail"] == "not allowed for this principal"
+    assert "factory_session" not in res.cookies
 
 
 def test_me_via_hub_session_resolve(client: TestClient) -> None:

--- a/tests/dashboard/test_bff_hub_auth.py
+++ b/tests/dashboard/test_bff_hub_auth.py
@@ -93,6 +93,31 @@ def test_login_deny_via_hub(client: TestClient) -> None:
     assert res.status_code == 401
 
 
+def test_login_deny_maps_hub_unauthorized_error(client: TestClient) -> None:
+    """Prod path: hub_client raises HubUnauthorizedError on login_deny (#auth 500)."""
+    from factory.dashboard.hub_client import HubUnauthorizedError
+
+    mock_hub = MagicMock()
+    mock_hub._request = AsyncMock(
+        side_effect=HubUnauthorizedError("invalid email or password")
+    )
+
+    def _hub_from_app(request):  # noqa: ANN001
+        del request
+        return mock_hub
+
+    with patch(
+        "factory.dashboard.routes.auth_routes.hub_client_from_app",
+        side_effect=_hub_from_app,
+    ):
+        res = client.post(
+            "/api/bff/auth/login",
+            json={"email": "admin@test.local", "password": "wrong"},
+        )
+    assert res.status_code == 401, res.text
+    assert "invalid email or password" in res.text
+
+
 def test_me_via_hub_session_resolve(client: TestClient) -> None:
     resolve_raw = {
         "ok": True,


### PR DESCRIPTION
## Summary
- Hub login_deny (`error: unauthorized`) was raised as `HubUnauthorizedError` by `DashboardHubClient._request` before `hub_auth._check` could map it to `HubAuthError`.
- Login (and other identity RPC) handlers only caught `HubAuthError` → unhandled exception → **HTTP 500** instead of **401**.
- Add `_rpc()` in `hub_auth.py` that converts `HubUnauthorizedError` / `HubForbiddenError` → `HubAuthError` for all identity façades.
- Test covers the prod path where `_request` raises `HubUnauthorizedError`.

## Verified on M₁ (hotfix bind-mount pending this image)
- wrong password → 401 `invalid email or password`
- correct password → 200 + session cookie + `/auth/me` 200

## Test plan
- [x] `uv run python -m pytest tests/dashboard/test_bff_hub_auth.py -q`
- [ ] CI green on PR
- [ ] After merge/deploy `staging-svc`: remove M₁ hotfix volume (`~/.roxabi/factory/hotfixes/hub_auth.py` bind) on next converge