### PR TITLE
ci(semctx): pin bundled CLI v0.1.16 and wire root semctx shim

### DIFF
--- a/.github/workflows/semctx.yml
+++ b/.github/workflows/semctx.yml
@@ -1,13 +1,30 @@
 # semctx PR gate: BLOCK fails the check, WARN does not. Read-only, no secrets.
-# Uses the semctx GitHub Action from hoklims/semctx, pinned at v0.1.0.
+#
+# Does NOT use hoklims/semctx/packages/github-action: that action runs
+# `bun install --frozen-lockfile` and then executes the CLI from TS sources
+# (`apps/cli/src/index.ts`) — true at v0.1.0 as well as at v0.1.16. We fetch the
+# **bundled** CLI instead (`plugins/claude-code/dist/semctx.js`, self-contained,
+# `#!/usr/bin/env bun`) — the same artifact the local Claude Code plugin ships.
+# `--format github` emits the same annotations the action's adapter produced.
+#
+# Version: v0.1.16. The previous pin, v0.1.0, dates from 2026-07-04 and predates the
+# bundle entirely: CI was judging with an engine a month older than the dev machine.
+#
+# The bundle is downloaded into RUNNER_TEMP, outside the workspace — otherwise `index`
+# would swallow it (the default `exclude` does not cover a directory added at the root).
 name: Semctx
+
+permissions:
+  contents: read
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
+env:
+  # Pinned by commit SHA (immutable content) + verified checksum.
+  SEMCTX_REF: 6716f3db2d3f5959370d93bd4278d90c1ad9e23d # v0.1.16
+  SEMCTX_SHA256: 03d4ad5ca8bbab04d26d8cbe59574da9e4f1fd2f508d8139c5b0804888b3be3c
 
 jobs:
   semctx:
@@ -15,9 +32,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Full history: the verdict needs the real merge-base.
           fetch-depth: 0
-      - uses: hoklims/semctx/packages/github-action@v0.1.0
+
+      # Runtime for the bundle only — unrelated to this repo's package manager.
+      - uses: oven-sh/setup-bun@v2
         with:
-          base: ${{ github.event.pull_request.base.sha }}
-          head: ${{ github.sha }}
-          fail-on: block
+          bun-version: "1.3.14"
+
+      - name: Fetch semctx CLI (self-contained bundle, no install)
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/semctx.js" \
+            "https://raw.githubusercontent.com/hoklims/semctx/$SEMCTX_REF/plugins/claude-code/dist/semctx.js"
+          echo "$SEMCTX_SHA256  $RUNNER_TEMP/semctx.js" | sha256sum -c -
+
+      - name: Verify change impact
+        env:
+          SEMCTX_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          bun "$RUNNER_TEMP/semctx.js" init  --root .
+          bun "$RUNNER_TEMP/semctx.js" index --root .
+          bun "$RUNNER_TEMP/semctx.js" verify diff --root . \
+            --base "$SEMCTX_BASE" --head "$GITHUB_SHA" \
+            --format github --fail-on block

--- a/.github/workflows/semctx.yml
+++ b/.github/workflows/semctx.yml
@@ -29,14 +29,16 @@ env:
 jobs:
   semctx:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      # Full SHAs match ci.yml fleet pin (mutable @vN tags retarget without a workflow diff).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Full history: the verdict needs the real merge-base.
           fetch-depth: 0
 
       # Runtime for the bundle only — unrelated to this repo's package manager.
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
 @.claude/stack.yml
+@.claude/semctx.md
 @AGENTS.md

--- a/docs/claude-md-registry.md
+++ b/docs/claude-md-registry.md
@@ -1,6 +1,6 @@
 # CLAUDE.md / AGENTS.md Registry
 
-Instruction content lives in `AGENTS.md`. Each `CLAUDE.md` is a thin shim (`@AGENTS.md`; root also `@.claude/stack.yml`). Update here on add/rename/delete.
+Instruction content lives in `AGENTS.md`. Each `CLAUDE.md` is a thin shim (`@AGENTS.md`; root also `@.claude/stack.yml` + `@.claude/semctx.md`). Update here on add/rename/delete.
 
 | P (shim) | AGENTS.md | Scope |
 |---|---|---|


### PR DESCRIPTION
## Summary
- **Semctx CI gate**: stop using `hoklims/semctx/packages/github-action@v0.1.0` (runs `bun install` + TS sources; pin predates the bundle and was a month behind local).
- Fetch **bundled** CLI `plugins/claude-code/dist/semctx.js` at commit `6716f3db…` (v0.1.16), verify **SHA-256**, run under Bun 1.3.14 from `RUNNER_TEMP`.
- Full `fetch-depth: 0` so merge-base is real; `--fail-on block` + `--format github` unchanged in intent.
- Root `CLAUDE.md` imports `@.claude/semctx.md`; `docs/claude-md-registry.md` documents the shim.

## Test plan
- [ ] CI `Semctx` job green on this PR
- [ ] Confirm annotations still appear on BLOCK findings
- [ ] Local: root agent still picks up `.claude/semctx.md` via CLAUDE.md