### PR TITLE
fix(discord): single-message tool recap + BotStore auto_thread default

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -148,7 +148,7 @@ Credentials (token, webhook_secret) are read from Podman secrets at bootstrap â€
 ```toml
 [[discord.bots]]
 bot_id = "lyra"
-auto_thread = true             # create thread per conversation (default: true)
+auto_thread = true             # create thread per conversation (default: false; opt-in via BotStore)
 agent = "lyra_default"         # fallback if DB has no botâ†’agent mapping
 thread_hot_hours = 36          # hours before thread is considered cold (default: 36)
 ```

--- a/src/factory/adapters/discord/adapter.py
+++ b/src/factory/adapters/discord/adapter.py
@@ -93,7 +93,7 @@ class DiscordAdapter(discord.Client, OutboundAdapterBase):
         intents: discord.Intents | None = None,
         circuit_registry: CircuitRegistry | None = None,
         msg_manager: MessageManager | None = None,
-        auto_thread: bool = True,
+        auto_thread: bool = False,
         thread_hot_hours: int = 36,
         thread_store: ThreadStoreProtocol | None = None,
         watch_channels: frozenset[int] = frozenset(),

--- a/src/factory/adapters/discord/discord_formatter.py
+++ b/src/factory/adapters/discord/discord_formatter.py
@@ -47,8 +47,10 @@ class DiscordFormatter(BaseFormatter):
       cast to ``_PartialMessageable``).
     - ``send_fallback``: delegates to ``discord_outbound.send`` so the full
       non-streaming send path (reply-to, metadata, typing) is reused.
-    - ``edit_tool_recap``: uses ``discord.Embed`` with green/blue colour logic
-      instead of plain text (Telegram uses plain MarkdownV2 text).
+    - **Single message**: tool recap + answer share one Discord message.
+      ``send_trace_placeholder`` reuses the answer placeholder; recap sits in
+      an embed (title on top), answer in the embed description below it.
+      Overflow answer chunks still go as follow-up messages via ``send_message``.
     """
 
     def __init__(  # noqa: PLR0913 — send-mechanics absorb added reply context args
@@ -69,6 +71,12 @@ class DiscordFormatter(BaseFormatter):
         self._should_reply = should_reply
         self._original_msg = original_msg
         self._reasoning = ReasoningAccumulator()
+        # Single-message composition state (recap + answer on one bubble).
+        self._placeholder_msg: Any | None = None
+        self._answer_text: str = ""
+        self._recap_lines: list[str] = []
+        self._recap_done: bool = False
+        self._reasoning_display: str | None = None
 
     # ── Pure-formatting axis implementations ──────────────────────────────────
 
@@ -97,6 +105,7 @@ class DiscordFormatter(BaseFormatter):
 
         Reply-vs-thread: skip reply in threads (thread context makes it redundant).
         Cast to _PartialMessageable is required for get_partial_message().
+        Cached for ``send_trace_placeholder`` reuse (single-message recap).
         """
         messageable = await self._adapter._resolve_channel(self._send_to_id)
         if self._should_reply and self._reply_msg_id is not None:
@@ -105,21 +114,30 @@ class DiscordFormatter(BaseFormatter):
             placeholder = await msg_obj.reply(self._placeholder_text)
         else:
             placeholder = await messageable.send(self._placeholder_text)
+        self._placeholder_msg = placeholder
+        self._answer_text = self._placeholder_text
         return placeholder, placeholder.id
 
     async def edit_placeholder_text(
         self, ph: Any, text: str, *, finalize: bool = False
     ) -> None:
         del finalize
-        display = text[-DISCORD_MAX_LENGTH:]
-        await send_with_retry(
-            lambda d=display: ph.edit(content=d, embed=None),
-            label="Intermediate text edit",
-        )
+        self._answer_text = text
+        await self._render_combined(ph)
 
     async def send_trace_placeholder(self) -> tuple[Any, int | None]:
+        """Reuse the answer placeholder — one Discord message for recap + reply.
+
+        Emitter always sends the answer placeholder first; tools arrive later.
+        Returning the same message object makes ``edit_tool_recap`` and
+        ``edit_placeholder_text`` compose into a single bubble.
+        """
+        if self._placeholder_msg is not None:
+            return self._placeholder_msg, self._placeholder_msg.id
+        # Fallback (should not happen in normal streaming order).
         messageable = await self._adapter._resolve_channel(self._send_to_id)
-        msg = await messageable.send("🔧 …")
+        msg = await messageable.send(self._placeholder_text)
+        self._placeholder_msg = msg
         return msg, msg.id
 
     async def send_message(self, text: str) -> int | None:
@@ -169,7 +187,7 @@ class DiscordFormatter(BaseFormatter):
         | ReasoningDeltaRenderEvent
         | ReasoningEndRenderEvent,
     ) -> None:
-        """Render reasoning events as dim italic text in the trace placeholder.
+        """Fold reasoning into the single combined message (dim italic).
 
         trace_obj=None means placeholder send failed — bail silently.
         Delta edits are throttled by ReasoningAccumulator.
@@ -178,11 +196,8 @@ class DiscordFormatter(BaseFormatter):
             return
         text, should_edit = self._reasoning.process(event)
         if should_edit and text is not None:
-            display = self.dim_italic(text)[-DISCORD_MAX_LENGTH:]
-            await send_with_retry(
-                lambda d=display: trace_obj.edit(content=d, embed=None),
-                label="Reasoning trace edit",
-            )
+            self._reasoning_display = self.dim_italic(text)
+            await self._render_combined(trace_obj)
 
     async def edit_tool_recap(
         self,
@@ -190,21 +205,62 @@ class DiscordFormatter(BaseFormatter):
         lines: list[str],
         done: bool,
     ) -> None:
-        """Render tool recap card lines into the trace placeholder embed.
+        """Render tool recap at the top of the single combined message.
 
-        Uses discord.Embed with green (done) or blue (in-progress) colour.
-        Telegram uses plain MarkdownV2 text; Discord-specific divergence kept here.
+        Recap is the embed title + leading description lines (green when done,
+        blue while working). Answer text (if any) follows in the same embed.
         """
         if not lines:
             return
-        # Discord embed limits: title ≤256, description ≤4096 (per discord API).
-        title = lines[0][:256]
-        description = ("\n".join(lines[1:]) or "​")[
-            :4096
-        ]  # zero-width space placeholder
-        color = discord.Color.green() if done else discord.Color.blue()
+        self._recap_lines = lines
+        self._recap_done = done
+        await self._render_combined(trace_obj)
+
+    async def _render_combined(self, msg: Any) -> None:
+        """Edit *msg* with recap (top) + optional reasoning + answer (bottom).
+
+        Layout when tools ran:
+          embed.title = recap header (🔧 Working… / Done ✅)
+          embed.description = tool lines, then reasoning, then answer
+          content cleared so the bubble is one visual card (recap first).
+
+        Layout without tools: plain content = answer (or reasoning).
+        """
+        answer = self._answer_text
+        # Hide the bare "…" placeholder once we have real body content.
+        show_answer = bool(answer) and answer != self._placeholder_text
+
+        if not self._recap_lines:
+            body_parts: list[str] = []
+            if self._reasoning_display:
+                body_parts.append(self._reasoning_display)
+            if show_answer:
+                body_parts.append(answer)
+            display = ("\n\n".join(body_parts) if body_parts else self._placeholder_text)[
+                -DISCORD_MAX_LENGTH:
+            ]
+            await send_with_retry(
+                lambda d=display: msg.edit(content=d, embed=None),
+                label="Combined text edit",
+            )
+            return
+
+        # Discord embed limits: title ≤256, description ≤4096.
+        title = self._recap_lines[0][:256]
+        desc_parts: list[str] = []
+        recap_body = "\n".join(self._recap_lines[1:])
+        if recap_body:
+            desc_parts.append(recap_body)
+        if self._reasoning_display:
+            desc_parts.append(self._reasoning_display)
+        if show_answer:
+            desc_parts.append(answer)
+        # Zero-width space keeps an empty embed description valid mid-flight.
+        description = ("\n\n".join(desc_parts) or "​")[:4096]
+        color = discord.Color.green() if self._recap_done else discord.Color.blue()
         embed = discord.Embed(title=title, description=description, color=color)
         try:
-            await trace_obj.edit(embed=embed)
+            # content="" drops the old "…" so only the embed card shows.
+            await msg.edit(content="", embed=embed)
         except discord.DiscordException as exc:
-            log.debug("Tool recap edit skipped: type=%s", type(exc).__name__)
+            log.debug("Combined recap edit skipped: type=%s", type(exc).__name__)

--- a/src/factory/adapters/discord/discord_formatter.py
+++ b/src/factory/adapters/discord/discord_formatter.py
@@ -216,57 +216,36 @@ class DiscordFormatter(BaseFormatter):
         self._recap_done = done
         await self._render_combined(trace_obj)
 
-    async def _render_combined(self, msg: Any) -> None:
-        """Edit *msg* with recap (top) + optional reasoning + answer (bottom).
-
-        Layout when tools ran:
-          embed.title = recap header (🔧 Working… / Done ✅)
-          embed.description = tool lines, then reasoning, then answer
-          content cleared so the bubble is one visual card (recap first).
-
-        Layout without tools: plain content = answer (or reasoning).
-
-        Budget: embed description ≤4096. Answer is reserved first (emitter already
-        head-chunks at DISCORD_MAX_LENGTH); recap/reasoning shrink if needed so
-        the priced answer is never silently mid-cut by a fat recap.
-        """
+    def _compose_no_recap_display(self) -> str:
+        """Plain-content body when no tool recap is active (head-sliced)."""
         answer = self._answer_text
-        # Hide the bare "…" placeholder once we have real body content.
         show_answer = bool(answer) and answer != self._placeholder_text
+        body_parts: list[str] = []
+        if self._reasoning_display:
+            body_parts.append(self._reasoning_display)
+        if show_answer:
+            body_parts.append(answer)
+        joined = "\n\n".join(body_parts) if body_parts else self._placeholder_text
+        return joined[:DISCORD_MAX_LENGTH]
 
-        if not self._recap_lines:
-            body_parts: list[str] = []
-            if self._reasoning_display:
-                body_parts.append(self._reasoning_display)
-            if show_answer:
-                body_parts.append(answer)
-            # Head-slice matches final chunk() policy (not tail).
-            display = ("\n\n".join(body_parts) if body_parts else self._placeholder_text)[
-                :DISCORD_MAX_LENGTH
-            ]
-            await send_with_retry(
-                lambda d=display: msg.edit(content=d, embed=None),
-                label="Combined text edit",
-            )
-            return
-
-        # Discord embed limits: title ≤256, description ≤4096.
-        _EMBED_DESC_MAX = 4096
+    def _compose_recap_embed(self) -> discord.Embed:
+        """Build recap-on-top embed; answer reserved first in description budget."""
+        _embed_desc_max = 4096
+        sep = "\n\n"
+        answer = self._answer_text
+        show_answer = bool(answer) and answer != self._placeholder_text
         title = self._recap_lines[0][:256]
         recap_body = "\n".join(self._recap_lines[1:])
         reasoning = self._reasoning_display or ""
         answer_part = answer if show_answer else ""
 
-        # Prefer full answer; shrink recap then reasoning if over budget.
-        sep = "\n\n"
-        budget = _EMBED_DESC_MAX
+        budget = _embed_desc_max
         if answer_part:
             budget -= len(answer_part)
             if recap_body or reasoning:
                 budget -= len(sep)
         if recap_body and reasoning:
             budget -= len(sep)
-        if recap_body and reasoning:
             r_budget = min(len(reasoning), max(0, budget // 4))
             c_budget = max(0, budget - r_budget)
             recap_body = recap_body[:c_budget]
@@ -284,9 +263,33 @@ class DiscordFormatter(BaseFormatter):
         if answer_part:
             desc_parts.append(answer_part)
         # Zero-width space keeps an empty embed description valid mid-flight.
-        description = (sep.join(desc_parts) or "​")[:_EMBED_DESC_MAX]
+        description = (sep.join(desc_parts) or "​")[:_embed_desc_max]
         color = discord.Color.green() if self._recap_done else discord.Color.blue()
-        embed = discord.Embed(title=title, description=description, color=color)
+        return discord.Embed(title=title, description=description, color=color)
+
+    async def _render_combined(self, msg: Any) -> None:
+        """Edit *msg* with recap (top) + optional reasoning + answer (bottom).
+
+        Layout when tools ran:
+          embed.title = recap header (🔧 Working… / Done ✅)
+          embed.description = tool lines, then reasoning, then answer
+          content cleared so the bubble is one visual card (recap first).
+
+        Layout without tools: plain content = answer (or reasoning).
+
+        Budget: embed description ≤4096. Answer is reserved first (emitter already
+        head-chunks at DISCORD_MAX_LENGTH); recap/reasoning shrink if needed so
+        the priced answer is never silently mid-cut by a fat recap.
+        """
+        if not self._recap_lines:
+            display = self._compose_no_recap_display()
+            await send_with_retry(
+                lambda d=display: msg.edit(content=d, embed=None),
+                label="Combined text edit",
+            )
+            return
+
+        embed = self._compose_recap_embed()
         # content="" drops the old "…" so only the embed card shows.
         await send_with_retry(
             lambda e=embed: msg.edit(content="", embed=e),

--- a/src/factory/adapters/discord/discord_formatter.py
+++ b/src/factory/adapters/discord/discord_formatter.py
@@ -225,6 +225,10 @@ class DiscordFormatter(BaseFormatter):
           content cleared so the bubble is one visual card (recap first).
 
         Layout without tools: plain content = answer (or reasoning).
+
+        Budget: embed description ≤4096. Answer is reserved first (emitter already
+        head-chunks at DISCORD_MAX_LENGTH); recap/reasoning shrink if needed so
+        the priced answer is never silently mid-cut by a fat recap.
         """
         answer = self._answer_text
         # Hide the bare "…" placeholder once we have real body content.
@@ -236,8 +240,9 @@ class DiscordFormatter(BaseFormatter):
                 body_parts.append(self._reasoning_display)
             if show_answer:
                 body_parts.append(answer)
+            # Head-slice matches final chunk() policy (not tail).
             display = ("\n\n".join(body_parts) if body_parts else self._placeholder_text)[
-                -DISCORD_MAX_LENGTH:
+                :DISCORD_MAX_LENGTH
             ]
             await send_with_retry(
                 lambda d=display: msg.edit(content=d, embed=None),
@@ -246,21 +251,44 @@ class DiscordFormatter(BaseFormatter):
             return
 
         # Discord embed limits: title ≤256, description ≤4096.
+        _EMBED_DESC_MAX = 4096
         title = self._recap_lines[0][:256]
-        desc_parts: list[str] = []
         recap_body = "\n".join(self._recap_lines[1:])
+        reasoning = self._reasoning_display or ""
+        answer_part = answer if show_answer else ""
+
+        # Prefer full answer; shrink recap then reasoning if over budget.
+        sep = "\n\n"
+        budget = _EMBED_DESC_MAX
+        if answer_part:
+            budget -= len(answer_part)
+            if recap_body or reasoning:
+                budget -= len(sep)
+        if recap_body and reasoning:
+            budget -= len(sep)
+        if recap_body and reasoning:
+            r_budget = min(len(reasoning), max(0, budget // 4))
+            c_budget = max(0, budget - r_budget)
+            recap_body = recap_body[:c_budget]
+            reasoning = reasoning[:r_budget]
+        elif recap_body:
+            recap_body = recap_body[: max(0, budget)]
+        elif reasoning:
+            reasoning = reasoning[: max(0, budget)]
+
+        desc_parts: list[str] = []
         if recap_body:
             desc_parts.append(recap_body)
-        if self._reasoning_display:
-            desc_parts.append(self._reasoning_display)
-        if show_answer:
-            desc_parts.append(answer)
+        if reasoning:
+            desc_parts.append(reasoning)
+        if answer_part:
+            desc_parts.append(answer_part)
         # Zero-width space keeps an empty embed description valid mid-flight.
-        description = ("\n\n".join(desc_parts) or "​")[:4096]
+        description = (sep.join(desc_parts) or "​")[:_EMBED_DESC_MAX]
         color = discord.Color.green() if self._recap_done else discord.Color.blue()
         embed = discord.Embed(title=title, description=description, color=color)
-        try:
-            # content="" drops the old "…" so only the embed card shows.
-            await msg.edit(content="", embed=embed)
-        except discord.DiscordException as exc:
-            log.debug("Combined recap edit skipped: type=%s", type(exc).__name__)
+        # content="" drops the old "…" so only the embed card shows.
+        await send_with_retry(
+            lambda e=embed: msg.edit(content="", embed=e),
+            label="Combined recap edit",
+        )

--- a/src/factory/bootstrap/wiring/kv_bot_roster.py
+++ b/src/factory/bootstrap/wiring/kv_bot_roster.py
@@ -18,13 +18,13 @@ from typing import Literal, NoReturn, overload
 from pydantic import ValidationError
 
 from factory.config import (
-    DISCORD_DEFAULT_AUTO_THREAD,
     DISCORD_DEFAULT_THREAD_HOT_HOURS,
     DiscordBotConfig,
     DiscordMultiConfig,
     TelegramBotConfig,
     TelegramMultiConfig,
 )
+from factory.core.agent.bot_models import DEFAULT_AUTO_THREAD
 from factory.infrastructure.kv.bot_roster import publish_bot_roster
 from factory.infrastructure.kv.factory_state import FACTORY_STATE_BUCKET
 from roxabi_contracts.state.bot_roster import (
@@ -60,9 +60,7 @@ def _entry_to_discord_bot(entry: RosterBotEntry) -> DiscordBotConfig:
         agent=entry.agent,
         public_bot=entry.public_bot,
         auto_thread=(
-            entry.auto_thread
-            if entry.auto_thread is not None
-            else DISCORD_DEFAULT_AUTO_THREAD
+            entry.auto_thread if entry.auto_thread is not None else DEFAULT_AUTO_THREAD
         ),
         thread_hot_hours=(
             entry.thread_hot_hours

--- a/src/factory/config.py
+++ b/src/factory/config.py
@@ -51,8 +51,10 @@ __all__ = [
     "DiscordMultiConfig",
     "load_multibot_config",
     "multibot_config_from_store",
-    # Discord-specific defaults (#1514)
-    "DISCORD_DEFAULT_AUTO_THREAD",
+    # Discord-specific default for thread hot set window (#1514).
+    # auto_thread has no Discord-only override: BotStore / bot_models
+    # DEFAULT_AUTO_THREAD (False) is the SSoT; enable per-bot via
+    # `factory agent discord patch <id> --auto-thread`.
     "DISCORD_DEFAULT_THREAD_HOT_HOURS",
 ]
 
@@ -61,11 +63,8 @@ log = logging.getLogger(__name__)
 _ENV_PREFIX = "env:"
 _AUTO_THREAD_TRUE = frozenset({"1", "true", "yes", "on"})
 
-# Discord-specific defaults — intentionally diverge from the generic bot_models defaults
-# (DEFAULT_AUTO_THREAD=False / DEFAULT_THREAD_HOT_HOURS=24).
-# Discord threads conversations by default; the generic store default is False for
-# non-threading platforms (e.g. Telegram). See #1514. Keep the divergence deliberate.
-DISCORD_DEFAULT_AUTO_THREAD: bool = True
+# Discord-only default for the hot-thread restore window (generic store = 24 h).
+# auto_thread deliberately uses the generic store default (False) — BotStore is SSoT.
 DISCORD_DEFAULT_THREAD_HOT_HOURS: int = 36
 
 
@@ -110,7 +109,8 @@ class DiscordBotConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     bot_id: str
-    auto_thread: bool = DISCORD_DEFAULT_AUTO_THREAD
+    # SSoT for the default is BotStore (DEFAULT_AUTO_THREAD=False). Opt in per bot.
+    auto_thread: bool = False
     agent: str = "lyra_default"
     thread_hot_hours: int = DISCORD_DEFAULT_THREAD_HOT_HOURS
     # Handle of the dedicated public bot for ADR-090 §5 deny refusals; None →
@@ -171,7 +171,7 @@ def _parse_discord_bots(raw: dict[str, Any]) -> list[DiscordBotConfig]:
     """Parse [[discord.bots]] array from raw config.
 
     Each entry requires: bot_id.
-    Optional: auto_thread (default DISCORD_DEFAULT_AUTO_THREAD),
+    Optional: auto_thread (default False — same as BotStore),
     agent (default "lyra_default").
 
     Credentials (token) are resolved at bootstrap time from
@@ -183,7 +183,7 @@ def _parse_discord_bots(raw: dict[str, Any]) -> list[DiscordBotConfig]:
     bots: list[DiscordBotConfig] = []
     for entry in bots_raw:
         bot_id: str = entry.get("bot_id", "main")
-        auto_thread: bool = entry.get("auto_thread", DISCORD_DEFAULT_AUTO_THREAD)
+        auto_thread: bool = entry.get("auto_thread", False)
         agent: str = entry.get("agent", "lyra_default")
         thread_hot_hours: int = int(
             entry.get("thread_hot_hours", DISCORD_DEFAULT_THREAD_HOT_HOURS)
@@ -241,11 +241,8 @@ def load_multibot_config(
     dc_has_bots_key = "bots" in raw.get("discord", {})
     if not dc_bots and not dc_has_bots_key and raw.get("auth", {}).get("discord"):
         auto_thread_str = os.environ.get("DISCORD_AUTO_THREAD", "").strip().lower()
-        auto_thread = (
-            auto_thread_str in _AUTO_THREAD_TRUE
-            if auto_thread_str
-            else DISCORD_DEFAULT_AUTO_THREAD
-        )
+        # Env opt-in only; unset → False (aligned with BotStore DEFAULT_AUTO_THREAD).
+        auto_thread = auto_thread_str in _AUTO_THREAD_TRUE if auto_thread_str else False
         log.info(
             "discord: no [[discord.bots]] found; "
             "falling back to legacy single-bot path (bot_id='main')"

--- a/src/factory/core/config/__init__.py
+++ b/src/factory/core/config/__init__.py
@@ -128,7 +128,8 @@ class DiscordConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     token: str = Field(repr=False)
-    auto_thread: bool = True
+    # Aligned with BotStore DEFAULT_AUTO_THREAD (False) — opt in via env / BotStore.
+    auto_thread: bool = False
 
 
 def load_discord_config() -> DiscordConfig:
@@ -140,7 +141,8 @@ def load_discord_config() -> DiscordConfig:
     if not token:
         raise SystemExit("Missing required env var: DISCORD_TOKEN")
     auto_thread_str = os.environ.get("DISCORD_AUTO_THREAD", "").strip().lower()
-    auto_thread = auto_thread_str in _AUTO_THREAD_TRUE if auto_thread_str else True
+    # Env opt-in only; unset → False (BotStore SSoT).
+    auto_thread = auto_thread_str in _AUTO_THREAD_TRUE if auto_thread_str else False
     return DiscordConfig(token=token, auto_thread=auto_thread)
 
 

--- a/tests/adapters/test_discord_snapshots.py
+++ b/tests/adapters/test_discord_snapshots.py
@@ -73,6 +73,22 @@ def _last_edit_content(placeholder: AsyncMock) -> str:
     return call.kwargs.get("content", "")
 
 
+def _last_edit_visible_text(placeholder: AsyncMock) -> str:
+    """User-visible text: plain content, or embed description when content is empty.
+
+    Single-message recap path puts answer in embed.description with content=\"\".
+    """
+    call = placeholder.edit.call_args
+    assert call is not None, "placeholder.edit was never called"
+    content = call.kwargs.get("content") or ""
+    embed = call.kwargs.get("embed")
+    if embed is not None:
+        desc = getattr(embed, "description", None) or ""
+        title = getattr(embed, "title", None) or ""
+        return f"{title}\n{desc}\n{content}".strip()
+    return content
+
+
 # ---------------------------------------------------------------------------
 # Snapshot tests — v2 events (re-recorded Slice 5 / #1192)
 # ---------------------------------------------------------------------------
@@ -119,8 +135,8 @@ class TestDiscordSnapshots:
           RunStarted, ToolCallStart, ToolCallEnd, TextStart,
           TextDelta("Tests passed."), TextEnd, RunFinished
 
-        No ToolSummaryRenderEvent in stream (removed in Slice 5).
-        No embed edit expected. Final text delivered via placeholder.edit content.
+        Single-message recap: answer lives in embed description (content=\"\").
+        Visible text still includes the final answer.
         """
         adapter = _make_discord_adapter()
         _, placeholder = _attach_channel(adapter)
@@ -138,11 +154,15 @@ class TestDiscordSnapshots:
 
         await adapter.send_streaming(msg, _events())
 
-        # Final text snapshot: response placeholder edited with text content
-        final_content = _last_edit_content(placeholder)
-        assert "Tests passed" in final_content, (
-            f"Expected 'Tests passed' in final content, got: {final_content!r}"
+        visible = _last_edit_visible_text(placeholder)
+        assert "Tests passed" in visible, (
+            f"Expected 'Tests passed' in visible text, got: {visible!r}"
         )
+        # Single-message card: content cleared; answer is in the embed.
+        last = placeholder.edit.call_args
+        assert last.kwargs.get("content") == ""
+        assert last.kwargs.get("embed") is not None
+
 
     @pytest.mark.asyncio
     async def test_error_snapshot(self) -> None:

--- a/tests/adapters/test_discord_threads.py
+++ b/tests/adapters/test_discord_threads.py
@@ -257,15 +257,15 @@ class TestDiscordAutoThread:
         assert hub_msg.platform_meta.thread_id == 8888
         assert 8888 in adapter._owned_threads
 
-    def test_discord_config_auto_thread_default_true(self) -> None:
-        """DiscordConfig() has auto_thread=True by default (S5-5)."""
+    def test_discord_config_auto_thread_default_false(self) -> None:
+        """DiscordConfig() has auto_thread=False by default (BotStore SSoT)."""
         from factory.adapters.discord.discord_config import DiscordConfig
 
         # Arrange / Act
         config = DiscordConfig(token="dummy-token")
 
         # Assert
-        assert config.auto_thread is True
+        assert config.auto_thread is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_discord_tool_recap.py
+++ b/tests/adapters/test_discord_tool_recap.py
@@ -1,13 +1,8 @@
 # pyright: reportFunctionMemberAccess=false, reportAttributeAccessIssue=false, reportCallIssue=false, reportGeneralTypeIssues=false
-"""RED tests for Discord adapter tool recap card rendering (#1214 T11).
+"""Discord adapter tool recap — single combined message (#1214 / recap-on-top).
 
-These tests expose the gap: ``build_streaming_callbacks`` in ``discord_outbound.py``
-does NOT yet pass ``edit_tool_recap=...`` to ``PlatformCallbacks``.  The default
-no-op is used, so ``trace_obj.edit`` is never called with ``embed=...`` kwargs.
-
-Tests SC8 (multi-tool embed parity) and the intermediate-color smoke MUST FAIL
-on the unmodified codebase.  Test SC9 (text-only regression guard) will PASS
-even at RED state — that is intentional.
+Recap + answer share the answer placeholder: no second ``🔧 …`` send.
+Embed title/description hold recap (top); answer follows in description.
 """
 
 from __future__ import annotations
@@ -35,8 +30,6 @@ from tests.adapters.conftest import make_dc_inbound_msg
 # Helpers
 # ---------------------------------------------------------------------------
 
-_TRACE_MSG_ID = 999
-
 
 def _make_discord_adapter():
     """Build a DiscordAdapter with mocked internals."""
@@ -49,26 +42,13 @@ def _make_discord_adapter():
     )
 
 
-def _make_trace_obj() -> MagicMock:
-    """Return a fake trace placeholder object (simulates a discord.Message)."""
-    trace_obj = MagicMock()
-    trace_obj.edit = AsyncMock(return_value=None)
-    trace_obj.id = _TRACE_MSG_ID
-    return trace_obj
-
-
-def _make_channel(trace_obj: MagicMock) -> tuple[MagicMock, MagicMock]:
+def _make_channel() -> tuple[MagicMock, MagicMock]:
     """Return (placeholder_msg, channel) mocked for streaming tests.
 
-    build_streaming_callbacks uses ``msg_obj.reply()`` (via get_partial_message)
-    for the response placeholder (because message_id=555, should_reply=True),
-    and ``messageable.send("🔧 …")`` for the trace placeholder.
-
-    Call order:
-    1. _send_placeholder() → channel.get_partial_message(555).reply(...) → placeholder
-    2. _send_trace_placeholder() → channel.send("🔧 …") → trace_obj
-    3. _deliver_final / edit_placeholder_text → placeholder.edit(content=...,
-       embed=None)
+    Single-message path:
+    1. send_placeholder → reply() → placeholder
+    2. send_trace_placeholder → reuses placeholder (no channel.send)
+    3. edits (recap + answer) → placeholder.edit(content=..., embed=...)
     """
     placeholder_msg = MagicMock()
     placeholder_msg.id = 42
@@ -78,12 +58,10 @@ def _make_channel(trace_obj: MagicMock) -> tuple[MagicMock, MagicMock]:
     trigger_msg.reply = AsyncMock(return_value=placeholder_msg)
 
     channel = AsyncMock()
-    # channel.send is used only for the trace placeholder
-    channel.send = AsyncMock(return_value=trace_obj)
-    # get_partial_message returns the trigger msg whose reply() returns the placeholder
+    # Must not be used for a second recap bubble on tool turns.
+    channel.send = AsyncMock(return_value=None)
     channel.get_partial_message = MagicMock(return_value=trigger_msg)
 
-    # typing() must be an async context manager
     typing_cm = AsyncMock()
     typing_cm.__aenter__ = AsyncMock(return_value=None)
     typing_cm.__aexit__ = AsyncMock(return_value=False)
@@ -103,41 +81,33 @@ async def _gen(*items: RenderEvent) -> AsyncIterator[RenderEvent]:
 
 
 async def test_multi_tool_turn_renders_recap_card_via_embed() -> None:
-    """SC8: a turn with edit + bash tool calls must call trace_obj.edit at least
-    once with an embed= kwarg whose title is '🔧 Done ✅', color is green,
-    and description contains both '✏️' and '💻'.
+    """SC8: edit+bash tools → one message; embed title Done ✅, green, both icons.
 
-    This test FAILS on the unmodified codebase because ``edit_tool_recap`` is
-    the default no-op, so trace_obj.edit is never called with embed= kwargs.
+    Answer text lands in the same embed description below the recap lines.
+    No second channel.send for a separate recap bubble.
     """
-    # Arrange
     adapter = _make_discord_adapter()
-    trace_obj = _make_trace_obj()
-    _placeholder_msg, channel = _make_channel(trace_obj)
+    placeholder_msg, channel = _make_channel()
     adapter._resolve_channel = AsyncMock(return_value=channel)
 
     original_msg = make_dc_inbound_msg()
 
-    # Act — drive a streaming session with edit + bash tool calls
     await adapter.send_streaming(
         original_msg,
         _gen(
             RunStartedRenderEvent(run_id="r1"),
-            # Tool 1: edit call
             ToolCallStartRenderEvent(tool_call_id="t1", tool_name="edit"),
             ToolCallArgsRenderEvent(
                 tool_call_id="t1",
                 delta=json.dumps({"path": "src/x.py"}),
             ),
             ToolCallEndRenderEvent(tool_call_id="t1"),
-            # Tool 2: bash call
             ToolCallStartRenderEvent(tool_call_id="t2", tool_name="bash"),
             ToolCallArgsRenderEvent(
                 tool_call_id="t2",
                 delta=json.dumps({"command": "ls"}),
             ),
             ToolCallEndRenderEvent(tool_call_id="t2"),
-            # Text response
             TextStartRenderEvent(message_id="msg-1"),
             TextDeltaRenderEvent(message_id="msg-1", delta="ok"),
             TextEndRenderEvent(message_id="msg-1"),
@@ -146,16 +116,19 @@ async def test_multi_tool_turn_renders_recap_card_via_embed() -> None:
         outbound=None,
     )
 
-    # Assert — trace_obj.edit was called at least once with embed= kwarg
-    all_calls = trace_obj.edit.call_args_list
+    # No second bubble for recap
+    assert channel.send.await_count == 0, (
+        f"expected no separate recap send, got {channel.send.call_args_list}"
+    )
+
+    all_calls = placeholder_msg.edit.call_args_list
     embed_calls = [c for c in all_calls if c.kwargs.get("embed") is not None]
 
     assert len(embed_calls) >= 1, (
-        f"trace_obj.edit must be called at least once with embed= kwarg. "
+        f"placeholder.edit must be called with embed= at least once. "
         f"All calls: {all_calls}"
     )
 
-    # At least one call must have title='🔧 Done ✅' and color=green
     done_header = "\U0001f527 Done ✅"  # 🔧 Done ✅
     done_calls = [
         c
@@ -169,8 +142,7 @@ async def test_multi_tool_turn_renders_recap_card_via_embed() -> None:
         f"Embed titles: {embed_titles}"
     )
 
-    # The description of the done embed must contain both tool icons
-    edit_icon = "✏️"  # ✏️
+    edit_icon = "✏️"
     bash_icon = "\U0001f4bb"  # 💻
     matching = [
         c
@@ -181,6 +153,17 @@ async def test_multi_tool_turn_renders_recap_card_via_embed() -> None:
     descriptions = [getattr(c.kwargs["embed"], "description", None) for c in done_calls]
     assert len(matching) >= 1, (
         f"Done embed description must contain both '✏️' and '💻'. "
+        f"Descriptions: {descriptions}"
+    )
+
+    # Answer is in the same embed (recap on top, answer below)
+    with_answer = [
+        c
+        for c in done_calls
+        if "ok" in (getattr(c.kwargs["embed"], "description", "") or "")
+    ]
+    assert len(with_answer) >= 1, (
+        f"Done embed description must include answer text 'ok'. "
         f"Descriptions: {descriptions}"
     )
 
@@ -261,36 +244,21 @@ async def test_text_only_turn_does_not_send_discord_trace_placeholder() -> None:
 
 
 async def test_intermediate_edit_uses_blue_color_and_working_title() -> None:
-    """Smoke: at least one intermediate recap edit (done=False) fires with
-    embed.color == discord.Color.blue() and embed.title == '🔧 Working…'.
-
-    Time is monkeypatched so the first ToolCallEnd always passes the debounce
-    threshold, guaranteeing an intermediate edit before the final done=True.
-
-    This test FAILS on the unmodified codebase because edit_tool_recap is a
-    no-op and trace_obj.edit is never called with embed= kwargs.
-    """
-    # Arrange
+    """Smoke: intermediate recap (done=False) → blue embed '🔧 Working…' on placeholder."""
     adapter = _make_discord_adapter()
-    trace_obj = _make_trace_obj()
-    _placeholder_msg, channel = _make_channel(trace_obj)
+    placeholder_msg, channel = _make_channel()
     adapter._resolve_channel = AsyncMock(return_value=channel)
     original_msg = make_dc_inbound_msg()
 
-    # Patch time.monotonic so that the debounce always fires:
-    # first call returns 0.0 (last_recap_edit is None → always fires on first event),
-    # subsequent calls return large values to guarantee the interval is exceeded.
     _call_count = 0
 
     def _fake_monotonic() -> float:
         nonlocal _call_count
         _call_count += 1
-        # 10s gap between each call → always past debounce interval
         return float(_call_count * 10)
 
     _patch_target = "factory.outbound.emitter.time.monotonic"
     with patch(_patch_target, _fake_monotonic):
-        # Act — drive tool events; debounce is bypassed by time patch
         await adapter.send_streaming(
             original_msg,
             _gen(
@@ -309,12 +277,11 @@ async def test_intermediate_edit_uses_blue_color_and_working_title() -> None:
             outbound=None,
         )
 
-    # Assert — at least one embed call with blue color and "Working…" title
-    all_calls = trace_obj.edit.call_args_list
+    all_calls = placeholder_msg.edit.call_args_list
     embed_calls = [c for c in all_calls if c.kwargs.get("embed") is not None]
 
     assert len(embed_calls) >= 1, (
-        f"trace_obj.edit must be called at least once with embed= kwarg. "
+        f"placeholder.edit must be called with embed= at least once. "
         f"All calls: {all_calls}"
     )
 

--- a/tests/adapters/test_discord_tool_recap.py
+++ b/tests/adapters/test_discord_tool_recap.py
@@ -244,7 +244,7 @@ async def test_text_only_turn_does_not_send_discord_trace_placeholder() -> None:
 
 
 async def test_intermediate_edit_uses_blue_color_and_working_title() -> None:
-    """Smoke: intermediate recap (done=False) → blue embed '🔧 Working…' on placeholder."""
+    """Smoke: intermediate recap (done=False) → blue Working… embed."""
     adapter = _make_discord_adapter()
     placeholder_msg, channel = _make_channel()
     adapter._resolve_channel = AsyncMock(return_value=channel)
@@ -373,7 +373,8 @@ async def test_fat_recap_preserves_full_answer_in_embed() -> None:
         should_reply=False,
     )
     await fmt.send_placeholder()
-    fat_recap = ["\U0001f527 Done ✅"] + [f"\U0001f310 `https://example.com/{i}`" for i in range(200)]
+    urls = [f"\U0001f310 `https://example.com/{i}`" for i in range(200)]
+    fat_recap = ["\U0001f527 Done ✅"] + urls
     answer = "A" * DISCORD_MAX_LENGTH  # first emitter chunk size
     await fmt.edit_tool_recap(ph, fat_recap, done=True)
     await fmt.edit_placeholder_text(ph, answer)

--- a/tests/adapters/test_discord_tool_recap.py
+++ b/tests/adapters/test_discord_tool_recap.py
@@ -298,3 +298,88 @@ async def test_intermediate_edit_uses_blue_color_and_working_title() -> None:
         f"Expected at least one embed call with title={working_header!r} and "
         f"color=blue. Titles: {titles}, Colors: {colors}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Unit: DiscordFormatter combined composition edges
+# ---------------------------------------------------------------------------
+
+
+async def test_mid_tools_placeholder_not_in_embed_description() -> None:
+    """Tools-only recap must not leak the bare placeholder into embed description."""
+    from factory.adapters.discord import DiscordAdapter
+    from factory.adapters.discord.discord_formatter import DiscordFormatter
+
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        intents=discord.Intents.none(),
+    )
+    ph = MagicMock()
+    ph.id = 42
+    ph.edit = AsyncMock(return_value=None)
+
+    channel = AsyncMock()
+    channel.send = AsyncMock(return_value=ph)
+    adapter._resolve_channel = AsyncMock(return_value=channel)
+
+    fmt = DiscordFormatter(
+        adapter,
+        send_to_id=1,
+        get_msg=lambda k, fb: fb,
+        placeholder_text="…",
+        should_reply=False,
+    )
+    await fmt.send_placeholder()
+    await fmt.edit_tool_recap(
+        ph,
+        ["\U0001f527 Working…", "\U0001f4bb `ls`"],
+        done=False,
+    )
+
+    assert ph.edit.await_count >= 1
+    last = ph.edit.call_args_list[-1]
+    embed = last.kwargs.get("embed")
+    assert embed is not None
+    desc = embed.description or ""
+    assert "…" not in desc
+    assert "\U0001f4bb" in desc
+
+
+async def test_fat_recap_preserves_full_answer_in_embed() -> None:
+    """Answer is reserved in embed budget; fat recap must not mid-cut answer."""
+    from factory.adapters.discord import DiscordAdapter
+    from factory.adapters.discord.discord_formatter import DiscordFormatter
+    from factory.adapters.shared._shared import DISCORD_MAX_LENGTH
+
+    adapter = DiscordAdapter(
+        bot_id="main",
+        inbound_bus=MagicMock(),
+        intents=discord.Intents.none(),
+    )
+    ph = MagicMock()
+    ph.id = 42
+    ph.edit = AsyncMock(return_value=None)
+
+    channel = AsyncMock()
+    channel.send = AsyncMock(return_value=ph)
+    adapter._resolve_channel = AsyncMock(return_value=channel)
+
+    fmt = DiscordFormatter(
+        adapter,
+        send_to_id=1,
+        get_msg=lambda k, fb: fb,
+        placeholder_text="…",
+        should_reply=False,
+    )
+    await fmt.send_placeholder()
+    fat_recap = ["\U0001f527 Done ✅"] + [f"\U0001f310 `https://example.com/{i}`" for i in range(200)]
+    answer = "A" * DISCORD_MAX_LENGTH  # first emitter chunk size
+    await fmt.edit_tool_recap(ph, fat_recap, done=True)
+    await fmt.edit_placeholder_text(ph, answer)
+
+    last = ph.edit.call_args_list[-1]
+    embed = last.kwargs["embed"]
+    desc = embed.description or ""
+    assert desc.endswith(answer), "full answer must be present (not mid-truncated)"
+    assert last.kwargs.get("content") == ""

--- a/tests/bootstrap/test_kv_bot_roster.py
+++ b/tests/bootstrap/test_kv_bot_roster.py
@@ -11,11 +11,11 @@ from nats.js.errors import BucketNotFoundError, KeyNotFoundError
 
 from factory.bootstrap.wiring.kv_bot_roster import seed_bot_roster
 from factory.config import (
-    DISCORD_DEFAULT_AUTO_THREAD,
     DISCORD_DEFAULT_THREAD_HOT_HOURS,
     DiscordMultiConfig,
     TelegramMultiConfig,
 )
+from factory.core.agent.bot_models import DEFAULT_AUTO_THREAD
 from factory.infrastructure.kv.bot_roster import publish_bot_roster
 from roxabi_contracts.state.bot_roster import (
     PlatformRosterDocument,
@@ -178,7 +178,8 @@ async def test_seed_bot_roster_discord_applies_defaults() -> None:
 
     assert isinstance(result, DiscordMultiConfig)
     assert result.bots[0].bot_id == "aryl"
-    assert result.bots[0].auto_thread is DISCORD_DEFAULT_AUTO_THREAD
+    assert result.bots[0].auto_thread is DEFAULT_AUTO_THREAD
+    assert result.bots[0].auto_thread is False
     assert result.bots[0].thread_hot_hours == DISCORD_DEFAULT_THREAD_HOT_HOURS
 
 

--- a/tests/helpers/standalone_bot_store.py
+++ b/tests/helpers/standalone_bot_store.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 import pytest
 
 from factory.config import (
-    DISCORD_DEFAULT_AUTO_THREAD,
     DISCORD_DEFAULT_THREAD_HOT_HOURS,
     DiscordBotConfig,
     DiscordMultiConfig,
@@ -31,7 +30,7 @@ def telegram_roster(bot_ids: list[str], **bot_kwargs: object) -> TelegramMultiCo
 def discord_roster(
     bot_ids: list[str],
     *,
-    auto_thread: bool = DISCORD_DEFAULT_AUTO_THREAD,
+    auto_thread: bool = False,
     thread_hot_hours: int = DISCORD_DEFAULT_THREAD_HOT_HOURS,
 ) -> DiscordMultiConfig:
     return DiscordMultiConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,6 @@ import pytest
 
 import factory.core.agent.bot_models as bot_models
 from factory.config import (
-    DISCORD_DEFAULT_AUTO_THREAD,
     DISCORD_DEFAULT_THREAD_HOT_HOURS,
     DiscordBotConfig,
     DiscordMultiConfig,
@@ -137,7 +136,7 @@ class TestParseDiscordBots:
         bot = bots[0]
         assert isinstance(bot, DiscordBotConfig)
         assert bot.bot_id == "lyra"
-        assert bot.auto_thread is True  # default
+        assert bot.auto_thread is False  # BotStore / DEFAULT_AUTO_THREAD SSoT
 
     def test_auto_thread_false(self) -> None:
         # Arrange
@@ -208,19 +207,19 @@ class TestLoadMultibotConfig:
         assert len(dc.bots) == 1
         bot = dc.bots[0]
         assert bot.bot_id == "main"
-        assert bot.auto_thread is True  # default when env var not set
+        assert bot.auto_thread is False  # default when env var not set
 
     def test_legacy_discord_auto_thread_parsing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Arrange — DISCORD_AUTO_THREAD=false disables threading
-        monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+        # Arrange — DISCORD_AUTO_THREAD=true opts in (env is the only opt-in)
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
         raw = {"auth": {"discord": {"default": "blocked"}}}
         # Act
         _, dc = load_multibot_config(raw)
         # Assert
         assert len(dc.bots) == 1
-        assert dc.bots[0].auto_thread is False
+        assert dc.bots[0].auto_thread is True
 
     def test_new_style_wins_over_legacy(self) -> None:
         # Arrange — both [[telegram.bots]] AND [auth.telegram] present
@@ -388,38 +387,21 @@ class TestMultibotConfigFromStore:
 
 
 class TestDiscordDefaultConstants:
-    """Guard that the Discord-specific defaults are named, valued, and deliberately
-    diverge from the generic platform-agnostic defaults in bot_models.
+    """Discord defaults: auto_thread follows BotStore; thread_hot_hours stays Discord-specific."""
 
-    If a future "alignment" refactor changes these values, this test will trip and
-    force re-reading the decision documented in #1514 before proceeding.
-    """
-
-    def test_discord_default_auto_thread_is_true(self) -> None:
-        # Discord threads every conversation by default.
-        assert DISCORD_DEFAULT_AUTO_THREAD is True
+    def test_discord_bot_config_default_auto_thread_matches_store(self) -> None:
+        # BotStore is SSoT — no Discord-only True override.
+        cfg = DiscordBotConfig(bot_id="test")
+        assert cfg.auto_thread is bot_models.DEFAULT_AUTO_THREAD
+        assert cfg.auto_thread is False
 
     def test_discord_default_thread_hot_hours_is_36(self) -> None:
         assert DISCORD_DEFAULT_THREAD_HOT_HOURS == 36
 
-    def test_discord_bot_config_default_auto_thread(self) -> None:
-        # DiscordBotConfig() with no explicit auto_thread must use the named constant.
-        cfg = DiscordBotConfig(bot_id="test")
-        assert cfg.auto_thread is DISCORD_DEFAULT_AUTO_THREAD
-        assert cfg.auto_thread is True
-
     def test_discord_bot_config_default_thread_hot_hours(self) -> None:
-        # DiscordBotConfig() with no explicit thread_hot_hours must use the constant.
         cfg = DiscordBotConfig(bot_id="test")
         assert cfg.thread_hot_hours == DISCORD_DEFAULT_THREAD_HOT_HOURS
         assert cfg.thread_hot_hours == 36
-
-    def test_intentional_divergence_from_generic_auto_thread(self) -> None:
-        # DELIBERATE: Discord default (True) != generic default (False).
-        # bot_models.DEFAULT_AUTO_THREAD is False for non-threading platforms
-        # (e.g. Telegram). Discord is the exception.
-        # See #1514. Do NOT "fix" this divergence without re-reading that decision.
-        assert DISCORD_DEFAULT_AUTO_THREAD != bot_models.DEFAULT_AUTO_THREAD
 
     def test_intentional_divergence_from_generic_thread_hot_hours(self) -> None:
         # DELIBERATE: Discord default (36 h) != generic default (24 h). See #1514.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -387,7 +387,7 @@ class TestMultibotConfigFromStore:
 
 
 class TestDiscordDefaultConstants:
-    """Discord defaults: auto_thread follows BotStore; thread_hot_hours stays Discord-specific."""
+    """Discord defaults: auto_thread → BotStore; thread_hot_hours stays Discord-only."""
 
     def test_discord_bot_config_default_auto_thread_matches_store(self) -> None:
         # BotStore is SSoT — no Discord-only True override.


### PR DESCRIPTION
## Summary
- Discord streaming now posts **one** message: tool recap embed on top, answer in the same embed description (no second `🔧 …` bubble).
- Remove `DISCORD_DEFAULT_AUTO_THREAD=True` — auto_thread defaults to BotStore `False`; opt in with `factory agent discord patch <id> --auto-thread`.
- Docs: CONFIGURATION default note updated.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | ad-hoc (ops + UX) | n/a |
| Implementation | 1 commit on `fix/discord-single-message-recap` | Complete |
| Verification | unit tests config + discord tool recap | Passed locally |

## Test Plan
- [ ] Unit: `pytest tests/test_config.py tests/adapters/test_discord_tool_recap.py tests/bootstrap/test_kv_bot_roster.py`
- [ ] Prod smoke after deploy: post in Discord `#links` → thread created (auto_thread already patched on M1) + single reply bubble with recap above answer

## Notes
- M1 already has `discord/lyra auto_thread=1` and hub path symlink fixed (ops, not in this PR).
- Thin adapter change only (`DiscordFormatter`); emitter stage unchanged.

---
Generated with [Roxabi dev-core](https://github.com/Roxabi/roxabi-plugins) via `/ship`