### PR TITLE
feat(scrape): HTTP scrape service + ScrapeProvider (#2327)

### DIFF
--- a/artifacts/frames/2327-http-scrape-service-frame.md
+++ b/artifacts/frames/2327-http-scrape-service-frame.md
@@ -1,0 +1,62 @@
+---
+title: "HTTP scrape service + ScrapeProvider (leave hub subprocess)"
+issue: 2327
+status: approved
+tier: F-lite
+date: 2026-08-10
+---
+
+## Problem
+
+Bare HTTPS URLs in Discord `#links` (and `/explain` / `/summarize`) rewrite to hub
+`ScrapingProcessor`, which shells out to web-intel via `WebIntelScraper`. In
+production the hub image has **no** playwright/web-intel path → `ScrapeFailed("not_available")`
+→ users get “page didn’t load / scraping unavailable” and **no** page content.
+
+Mitigation #2325 only improved the error copy. The stage-axis problem remains: hub
+must not host browser tooling. Observed 2026-08-10 on M1 after #2335: thread + reply
+OK, zero tool recap, no link detail — scrape never ran.
+
+## Who
+
+- **Primary:** Operators / Mickael pasting URLs in Discord watch channels and using `/explain` `/summarize`
+- **Secondary:** Any future agent/MCP caller that needs the same scrape engine without a second impl
+
+## Constraints
+
+- Stage axis: hub = thin orchestration; scrape = isolated capability (HTTP provider + `/ready`)
+- Admission ontology (#2326): self-hosted HTTP + health ≠ NATS satellite by default
+- SSRF dual-check: hub pre-check **and** service (HTTPS-only, non-global IPs incl. Tailscale `100.64/10`, redirect revalidation)
+- Deploy on M₁ (or M₂ if browser-heavy); image embeds web-intel/playwright
+- Wire existing `ScrapeProvider` protocol — do not invent a parallel API surface for hub commands
+
+## Out of Scope
+
+- NATS satellite / `factory.jobs.web-intel` consumer (#1050 — supersede intent for scrape placement)
+- code-worker as scrape host (#1044 / #1046)
+- Capture / vault write paths (#2322 removed)
+- MCP façade (optional follow-up slice 5)
+- Retiring hub `/explain`/`/summarize` in favour of pure agent tools (optional later)
+
+## Premise Validity
+
+**Success in 6 months:** From a prod Discord `#links` paste or `/explain <url>`, users get a
+real page summary/explanation; hub logs show HTTP scrape to a dedicated service with
+`/ready` green; no `uv run` / host `~/projects` dependency in hub image.
+
+**Failure in 6 months:** Still `ScrapeFailed("not_available")` in hub after “deploy,” or
+scrape only works on a developer machine with host mounts; hub still spawns playwright.
+
+**Simplest alternative:** Mount `~/projects` + web-intel into hub (or run scraper on host).
+**Why not simplest:** Fixes symptom, keeps hub as scrapers runtime, violates stage-axis and
+admission design; breaks on every image-only deploy.
+
+## Complexity
+
+**Tier: F-lite** — size:F-lite label; single domain (scrape HTTP service + thin hub client +
+Quadlet); design already written in `scrape-placement.md`.
+
+Signals:
+- Issue labels: feature, infra, size:F-lite, architecture, P1-high
+- Clear acceptance checklist on issue body
+- Related older NATS path (#1050, #2192) explicitly out of primary scope

--- a/artifacts/plans/2327-http-scrape-service-plan.md
+++ b/artifacts/plans/2327-http-scrape-service-plan.md
@@ -1,0 +1,220 @@
+---
+title: "Plan: HTTP scrape service + ScrapeProvider"
+issue: 2327
+spec: artifacts/specs/2327-http-scrape-service-spec.md
+complexity: 6/10
+tier: F-lite
+generated: 2026-08-10
+---
+
+## Summary
+
+Ship an isolated HTTP scrape service (playwright/web-intel) and thin hub
+`HttpScrapeProvider` so `/explain` and bare-URL work in prod containers. Hub stays
+orchestration-only; no NATS scrape job; SSRF dual-check.
+
+## Architecture
+
+**Axis:** stage stays hub command + agent run; scrape = **HTTP provider** (not
+adapter duplication, not satellite).
+
+```
+adapter → hub (H1 SSRF pre, H2 HttpScrapeProvider) → factory-scrape (S3)
+                → inject → omp/clipool → outbound
+```
+
+**Data flow (prose):** see spec §Breadboard. **Visuals:** deferred (F-lite; optional forge later).
+
+**Refs (conventions):**
+- `src/factory/integrations/web_intel.py` — current ScrapeProvider impl
+- `src/factory/core/processors/_scraping.py` — SSRF pre + fallback copy
+- `deploy/quadlet/factory-blobstore.container` — HTTP unit pattern (network, secrets)
+- `docs/architecture/scrape-placement.md` — placement SSoT
+
+## Agents
+
+| Agent | Tasks | Files |
+|-------|-------|-------|
+| backend-dev-A | T1–T4 service API + SSRF | `services/scrape/` or `deploy/scrape/` + app |
+| backend-dev-B | T5–T7 client + bootstrap | `integrations/http_scrape.py`, `agent_factory.py` |
+| devops-A | T8–T9 Quadlet + env | `deploy/quadlet/`, hub env |
+| tester-A | T10–T12 tests | `tests/integrations/`, `tests/core/` |
+| doc-writer-A | T13 docs | `scrape-placement.md`, runbook line |
+
+## Wave Structure
+
+3 waves, max 3 parallel. Elapsed ~ sequential 1.5–2d of focused work.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | backend-dev-A ∥ tester-A | T1,T2 service skeleton + RED SSRF tests |
+| 2 | Wave 1 | backend-dev-A → T3,T4; backend-dev-B T5,T6; tester-A T10 | implement service + client |
+| 3 | Wave 2 | devops-A T8,T9; backend-dev-B T7; tester-A T11,T12; doc T13 | deploy wire + hub inject + docs |
+
+### Budget — per task
+
+| Task | Class | Est. ops | Split? |
+|------|-------|----------|--------|
+| T1 service skeleton | bounded | 6 | — |
+| T2 SSRF service | judgmental | 8 | — |
+| T3 scrape handler | judgmental | 10 | — |
+| T4 ready/health | bounded | 4 | — |
+| T5 HttpScrapeProvider | bounded | 6 | — |
+| T6 ScrapeFailed map | bounded | 4 | — |
+| T7 bootstrap wire | bounded | 5 | — |
+| T8 Quadlet | judgmental | 8 | — |
+| T9 hub env FACTORY_SCRAPE_URL | trivial | 2 | — |
+| T10 unit client tests | bounded | 6 | — |
+| T11 unit SSRF dual | judgmental | 8 | — |
+| T12 processor integration mock | bounded | 5 | — |
+| T13 docs slices 2–4 | bounded | 4 | — |
+
+**Total estimated ops: ~76** (ok for F-lite multi-wave)
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1–T4 | 28 | service,ssrf | — |
+| backend-dev-B | T5–T7 | 15 | client,bootstrap | — |
+| devops-A | T8–T9 | 10 | deploy | — |
+| tester-A | T10–T12 | 19 | tests | — |
+| doc-writer-A | T13 | 4 | docs | — |
+
+## Task Seeding Blueprint
+
+### Wave 1 — no deps, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | service |
+| T2 | tester-A | — | ssrf |
+
+### Wave 2 — after Wave 1
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T1,T2 | service |
+| T4 | backend-dev-A | T1 | service |
+| T5 | backend-dev-B | T1 | client |
+| T6 | backend-dev-B | T5 | client |
+| T10 | tester-A | T5 | tests |
+
+### Wave 3 — after Wave 2
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | backend-dev-B | T5,T6 | bootstrap |
+| T8 | devops-A | T3,T4 | deploy |
+| T9 | devops-A | T8 | deploy |
+| T11 | tester-A | T2,T5 | tests |
+| T12 | tester-A | T7 | tests |
+| T13 | doc-writer-A | T7,T8 | docs |
+
+## Micro-Tasks
+
+### V1 — Scrape service
+
+**T1** — Scaffold scrape HTTP app (FastAPI or existing stack pattern: lightweight ASGI).  
+Files: `services/scrape/` or `src/factory/scrape_service/` (prefer deployable path under repo; image Dockerfile).  
+Verify: `python -c "import …"` / unit boot.  
+Agent: backend-dev-A · Subject: service · Slice: V1 · Phase: GREEN
+
+**T2** — RED tests: reject `http://`, private IPs, `100.64.0.0/10`, redirect-to-private (mock).  
+Files: `tests/scrape/` or `tests/integrations/test_scrape_service_ssrf.py`  
+Verify: pytest fails before impl, passes after T3.  
+Agent: tester-A · Subject: ssrf · Slice: V1 · Phase: RED
+
+**T3** — Implement `POST /scrape`: validate URL → call web-intel/playwright extract → JSON text; map errors to `reason`.  
+Files: service handlers  
+Verify: manual/curl example.com in container later; unit with mocked extractor.  
+Agent: backend-dev-A · Subject: service · Slice: V1
+
+**T4** — `GET /ready` (import scraper OK) + optional `GET /health`.  
+Agent: backend-dev-A · Subject: service · Slice: V1
+
+### V2 — Hub client
+
+**T5** — `HttpScrapeProvider` implementing `ScrapeProvider` via httpx; env `FACTORY_SCRAPE_URL`.  
+Files: `src/factory/integrations/http_scrape.py`  
+Agent: backend-dev-B · Subject: client · Slice: V2
+
+**T6** — Map HTTP status/body → `ScrapeFailed("not_available"|"timeout"|"subprocess_error")` compatible with `_scraping._scrape_with_fallback`.  
+Agent: backend-dev-B · Subject: client · Slice: V2
+
+**T10** — Unit tests for HttpScrapeProvider (respx/httpx mock).  
+Agent: tester-A · Subject: tests · Slice: V2
+
+### V3 — Wire + deploy
+
+**T7** — Bootstrap: if `FACTORY_SCRAPE_URL` set (or always in container), inject `HttpScrapeProvider` into SessionTools; else keep WebIntelScraper for host-dev only.  
+Files: `src/factory/bootstrap/factory/agent_factory.py` (+ any wiring helpers)  
+Agent: backend-dev-B · Subject: bootstrap · Slice: V3
+
+**T8** — Quadlet `factory-scrape.container` (+ Dockerfile/image tag strategy: dedicated image or extend base with playwright). Network `roxabi`. Internal port only.  
+Files: `deploy/quadlet/factory-scrape.container`, Dockerfile  
+Agent: devops-A · Subject: deploy · Slice: V3
+
+**T9** — Hub unit/env: `FACTORY_SCRAPE_URL=http://factory-scrape:<port>`; install.sh / converge if needed.  
+Agent: devops-A · Subject: deploy · Slice: V3
+
+**T11** — Expand SSRF tests for dual-check (hub existing + service).  
+Agent: tester-A · Subject: tests · Slice: V3
+
+**T12** — Integration test: ScrapingProcessor with mocked HttpScrapeProvider returns enriched msg.  
+Agent: tester-A · Subject: tests · Slice: V3
+
+**T13** — Mark scrape-placement slices 2–4 done; short runbook line for scrape unit.  
+Files: `docs/architecture/scrape-placement.md`, optional runbook  
+Agent: doc-writer-A · Subject: docs · Slice: V3
+
+### RED-GATE V1
+After T3–T4: service `/ready` + `/scrape` mocked extractor green in CI unit tests.
+
+### RED-GATE V3
+After T7–T12: qg + pytest; M1 smoke deferred to ops after image publish.
+
+## Consistency Report
+
+| Spec SC | Tasks |
+|---------|-------|
+| service /ready | T4, T8 |
+| POST scrape text | T3 |
+| SSRF service | T2, T3, T11 |
+| redirect private | T2, T3 |
+| HttpScrapeProvider map | T5, T6, T10 |
+| bootstrap FACTORY_SCRAPE_URL | T7, T9 |
+| no host plugin in prod path | T7, T13 |
+| unit tests | T10–T12 |
+| Quadlet | T8 |
+| M1 smoke | ops after merge (not code task) |
+| docs slices 2–4 | T13 |
+
+Covered: 11/11 criteria mapped. Uncovered: none (M1 smoke = post-ship ops).
+
+## Non-goals (restate)
+
+- NATS `factory.jobs.web-intel.scrape` as primary transport  
+- Nika / generic workflow engine for this ticket  
+- Hub still running playwright  
+
+---
+
+<!-- ## Task IDs filled on plan approve -->
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: plan-2327-t1 — service
+- T2: plan-2327-t2 — ssrf
+- T3: plan-2327-t3 — service
+- T4: plan-2327-t4 — service
+- T5: plan-2327-t5 — client
+- T6: plan-2327-t6 — client
+- T7: plan-2327-t7 — bootstrap
+- T8: plan-2327-t8 — deploy
+- T9: plan-2327-t9 — deploy
+- T10: plan-2327-t10 — tests
+- T11: plan-2327-t11 — tests
+- T12: plan-2327-t12 — tests
+- T13: plan-2327-t13 — docs

--- a/artifacts/specs/2327-http-scrape-service-spec.md
+++ b/artifacts/specs/2327-http-scrape-service-spec.md
@@ -1,0 +1,155 @@
+---
+title: "HTTP scrape service + ScrapeProvider (leave hub subprocess)"
+description: "Dedicated scrape HTTP service + hub client; /explain and /summarize work in prod."
+type: spec
+status: approved
+issue: 2327
+tier: F-lite
+date: 2026-08-10
+---
+
+## Context
+
+- **Source:** `artifacts/frames/2327-http-scrape-service-frame.md` (approved)
+- **Issue:** [#2327](https://github.com/Roxabi/roxabi-factory/issues/2327)
+- **Design SSoT:** `docs/architecture/scrape-placement.md`, admission `docs/architecture/workers-tooling.md`
+- **Mitigation already shipped:** #2325 (user-facing copy only)
+
+## Intent
+
+**Pain:** Hub `WebIntelScraper` shells out to host web-intel; prod hub container has no plugin → `ScrapeFailed("not_available")`. Discord bare URLs / `/explain` `/summarize` cannot return page content.
+
+**Why now:** Confirmed live on M1 (2026-08-10): `#links` paste → thread OK, reply is “scraping unavailable” paraphrase; zero tool recap (scrape is hub pre, not agent tools).
+
+## Goal
+
+From a **container-deployed** hub, `/explain <https-url>` and bare-URL→explain succeed with **real scraped text** via an HTTP scrape service with `/ready` green — no hub `uv run` / host `~/projects` dependency.
+
+## Users
+
+- **Primary:** Operators pasting HTTPS links in Discord watch channels; slash `/explain` `/summarize`
+- **Secondary:** Future agent/MCP callers of the same HTTP API (out of this issue’s MVP UI, same service)
+
+## Expected Behavior
+
+1. Operator (or converge) deploys `factory-scrape` (name TBD) on M₁ network `roxabi`.
+2. `GET /ready` → 200 when process up **and** scraper importable.
+3. Hub bootstrap injects HTTP-backed `ScrapeProvider` when `FACTORY_SCRAPE_URL` (or equivalent) is set.
+4. User pastes `https://…` (bare_url) or `/explain https://…` → hub validates URL (HTTPS + SSRF pre-check) → `POST /scrape` → service re-validates SSRF + fetches → text injected into LLM prompt → reply with substance about the page.
+5. If service down/circuit open: existing `ScrapeFailed` paths + #2325-style copy (no hang, no silent empty success).
+
+## Data Model & Consumers
+
+### Request / response (service)
+
+```
+POST /scrape
+  body: { "url": "https://…", "timeout_s"?: number }
+  200: { "success": true, "text": "…", "url": "https://…" }
+  4xx/5xx: { "success": false, "error": "…", "reason": "ssrf"|"timeout"|"fetch"|"unavailable" }
+
+GET /ready  → 200 { "ready": true } | 503
+GET /health → 200 process up (optional, liveness only)
+```
+
+Text encoding: UTF-8 plain text (HTML stripped by existing web-intel/trafilatura path). Max body size: align with hub `_SAFE_SCRAPE_MAX_CHARS` (32_000) — service may truncate earlier and flag.
+
+### Consumers
+
+| Consumer | Fields | When |
+|----------|--------|------|
+| `ScrapingProcessor` (`/explain`, `/summarize`) | `text` | `pre()` inject into prompt |
+| Future agent tool / MCP | same API | optional follow-up |
+| Deploy health / converge | `/ready` | unit start + fleet checks |
+
+### Hub client config
+
+| Env / config | Meaning |
+|--------------|---------|
+| `FACTORY_SCRAPE_URL` | Base URL e.g. `http://factory-scrape:8080` |
+| timeout defaults | match processor 30s unless overridden |
+
+When unset: keep `WebIntelScraper` subprocess for **local dev only** (or fail closed in container — prefer fail-closed if `CONTAINER_NAME` set). Spec: **container deploy requires `FACTORY_SCRAPE_URL`**.
+
+## Breadboard
+
+### API affordances (service)
+
+| ID | Affordance | Handler | Data |
+|----|------------|---------|------|
+| S1 | `GET /ready` | readiness: import scraper deps | process state |
+| S2 | `GET /health` | liveness | process up |
+| S3 | `POST /scrape` | validate URL → fetch → extract text | url → text |
+
+### Hub affordances
+
+| ID | Affordance | Handler | Data |
+|----|------------|---------|------|
+| H1 | SSRF pre-check | existing `_is_private_ip` + HTTPS in `_scraping` | url |
+| H2 | `HttpScrapeProvider.scrape` | HTTP client → S3 | url → text / ScrapeFailed |
+| H3 | Bootstrap inject | `agent_factory` / SessionTools | ScrapeProvider impl |
+| H4 | `/explain` `/summarize` | unchanged processors | enriched msg |
+
+### Deploy
+
+| ID | Affordance | Handler | Data |
+|----|------------|---------|------|
+| D1 | Quadlet unit | `factory-scrape.container` (+ image) | ports internal only |
+| D2 | Network | `roxabi` / systemd-roxabi | hub → scrape |
+| D3 | Hub env | `FACTORY_SCRAPE_URL` in hub.env / unit | config |
+
+### Wiring
+
+```
+User URL → Discord/TG adapter → Hub CommandMiddleware
+  → ScrapingProcessor.pre (H1)
+  → HttpScrapeProvider (H2) ──POST──▶ factory-scrape (S3)
+  → inject <webpage> → agent LLM → outbound reply
+```
+
+## Slices
+
+| # | Slice | Demo | Affordance IDs |
+|---|-------|------|----------------|
+| V1 | HTTP scrape service image + `/scrape` `/ready` + SSRF in service | `curl /ready` 200; `curl /scrape` example.com returns text | S1–S3 |
+| V2 | `HttpScrapeProvider` + unit tests (SSRF dual, timeouts, mapping to ScrapeFailed) | pytest green offline | H2 |
+| V3 | Bootstrap wire + Quadlet + hub env; docs slices 2–4 marked done | M1: `/explain https://example.com` returns content | H3–H4, D1–D3 |
+
+V1 can land as image+unit before hub switch if env still points old path; V3 is the cutover.
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| http:// URL | Reject at hub pre-check (existing) + service |
+| Private / Tailscale / link-local IP | Reject both layers; test 100.64/10 |
+| Redirect to private IP | Service revalidate final hop |
+| Service down | ScrapeFailed unavailable + user copy |
+| Timeout | ScrapeFailed timeout |
+| Empty extract | ScrapeFailed subprocess_error / fetch |
+| Oversized text | Truncate to 32k (+ marker) at hub and/or service |
+| Local dev without service | Document: set FACTORY_SCRAPE_URL to local unit, or explicit dev-only subprocess flag |
+
+## Success Criteria
+
+- [ ] Scrape service container builds and runs with `GET /ready` → 200 when deps load
+- [ ] `POST /scrape` returns extracted text for a public HTTPS page (e.g. example.com)
+- [ ] Service rejects non-HTTPS and private/reserved IPs (incl. 100.64/10) with explicit reason
+- [ ] Redirect to non-global IP is rejected
+- [ ] `HttpScrapeProvider` maps HTTP errors to `ScrapeFailed` reasons used by processors
+- [ ] Hub bootstrap uses HTTP provider when `FACTORY_SCRAPE_URL` set; container deploy requires it
+- [ ] Hub image does not require `FACTORY_WEB_INTEL_PATH` / host `~/projects` for scrape
+- [ ] Unit tests cover client + SSRF dual-check paths
+- [ ] Quadlet unit + network wiring checked into `deploy/`
+- [ ] On M1 after deploy: `/explain https://example.com` (or bare URL with bare_url) yields non-unavailable content
+- [ ] `docs/architecture/scrape-placement.md` migration slices 2–4 marked done
+
+## χ
+
+none (design fixed in scrape-placement + issue body)
+
+## Refs
+
+- #2325 mitigation copy · #2322 vault-add kill · #2326 admission
+- Supersede scrape-via-NATS intent on #1050 for placement (comment at ship time)
+- Out: #2192 intel epic (product pipeline beyond this provider)

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -52,6 +52,12 @@ container = "factory-blobstore.container"
 required_secrets = ["factory-nats-blobstore", "factory_blobstore_token"]
 host_roles = ["factory-hub"]
 
+# #2327 HTTP scrape provider — hub FACTORY_SCRAPE_URL=http://factory-scrape:8455
+[component.scrape]
+container = "factory-scrape.container"
+required_secrets = []
+host_roles = ["factory-hub"]
+
 [component.omp]
 container = "factory-omp.container"
 host_roles = ["factory-hub"]

--- a/deploy/quadlet/factory-hub.container
+++ b/deploy/quadlet/factory-hub.container
@@ -2,6 +2,8 @@
 Description=Factory Hub
 After=factory-nats.service
 After=factory-blobstore.service
+After=factory-scrape.service
+Wants=factory-scrape.service
 Requires=factory-nats.service
 StartLimitIntervalSec=60
 StartLimitBurst=5
@@ -45,6 +47,8 @@ Environment=NATS_NKEY_SEED_PATH=/run/secrets/factory-nats-hub.seed
 Environment=FACTORY_BLOBSTORE_URL=http://factory-blobstore:8449
 Environment=FACTORY_BLOBSTORE_TOKEN_PATH=/run/secrets/factory_blobstore_token
 Secret=factory_blobstore_token,type=mount,uid=1500,gid=1500,mode=0400,target=/run/secrets/factory_blobstore_token
+# #2327: HTTP scrape provider (factory-scrape unit on roxabi network)
+Environment=FACTORY_SCRAPE_URL=http://factory-scrape:8455
 Volume=factory-data.volume:/home/factory/.roxabi/factory:z
 # #2309: hub no longer RO-binds turn-writer/ — session reads via NATS request/reply
 # to factory-turn-writer (sole SQLite owner). Hub must not open turns.db (TurnQueryClient).

--- a/deploy/quadlet/factory-scrape.container
+++ b/deploy/quadlet/factory-scrape.container
@@ -24,8 +24,8 @@ Exec=factory scrape serve --host 0.0.0.0 --port 8455
 # Internal only — hub reaches factory-scrape:8455 on roxabi network.
 # Host publish optional for debug (commented):
 # PublishPort=127.0.0.1:8455:8455
-# No double-quotes in HealthCmd (Quadlet #1370). Process cmdline contains "scrape".
-HealthCmd=grep -q scrape /proc/1/cmdline
+# Single-quoted python3 -c (no ") — Quadlet HealthCmd quote rule #1370.
+HealthCmd=python3 -c 'import urllib.request,sys; r=urllib.request.urlopen("http://127.0.0.1:8455/ready",timeout=3); sys.exit(0 if r.status==200 else 1)'
 HealthInterval=30s
 
 [Service]

--- a/deploy/quadlet/factory-scrape.container
+++ b/deploy/quadlet/factory-scrape.container
@@ -1,0 +1,36 @@
+[Unit]
+Description=Factory scrape HTTP service — URL → text (#2327)
+After=factory-nats.service
+Wants=factory-nats.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+StopTimeout=60
+# Same svc image as hub for now — extractor is httpx + stdlib HTML (no browser
+# download required). Playwright-heavy path can move to a dedicated image later.
+Image=ghcr.io/roxabi/factory:staging-svc
+Label=io.containers.autoupdate=registry
+ContainerName=factory-scrape
+Environment=CONTAINER_NAME=factory-scrape
+Environment=IMAGE_REF=ghcr.io/roxabi/factory:staging-svc
+Network=roxabi.network
+NoNewPrivileges=true
+ReadOnly=true
+DropCapability=all
+UserNS=keep-id:uid=1500,gid=1500
+# No secrets required for public HTTPS scrape; SSRF enforced in-process.
+Exec=factory scrape serve --host 0.0.0.0 --port 8455
+# Internal only — hub reaches factory-scrape:8455 on roxabi network.
+# Host publish optional for debug (commented):
+# PublishPort=127.0.0.1:8455:8455
+HealthCmd=python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8455/ready')"
+HealthInterval=30s
+
+[Service]
+Restart=on-failure
+TimeoutStopSec=70
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/factory-scrape.container
+++ b/deploy/quadlet/factory-scrape.container
@@ -24,7 +24,8 @@ Exec=factory scrape serve --host 0.0.0.0 --port 8455
 # Internal only — hub reaches factory-scrape:8455 on roxabi network.
 # Host publish optional for debug (commented):
 # PublishPort=127.0.0.1:8455:8455
-HealthCmd=python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8455/ready')"
+# No double-quotes in HealthCmd (Quadlet #1370). Process cmdline contains "scrape".
+HealthCmd=grep -q scrape /proc/1/cmdline
 HealthInterval=30s
 
 [Service]

--- a/docs/architecture/CURRENT.generated.md
+++ b/docs/architecture/CURRENT.generated.md
@@ -293,6 +293,10 @@
 - **Container:** factory-promtail.container
 - **Host roles:** factory-hub
 
+### scrape
+- **Container:** factory-scrape.container
+- **Host roles:** factory-hub
+
 ### telegram
 - **Container:** factory-telegram.container
 - **Required secrets:** factory-nats-telegram, factory_blobstore_token

--- a/docs/architecture/scrape-placement.md
+++ b/docs/architecture/scrape-placement.md
@@ -107,9 +107,13 @@ Heartbeat push is optional candy; pull `/ready` + CB is enough.
 ## Migration slices (suggested)
 
 1. **Done** — remove vault-add product path; bare URL → `/explain`.
-2. Package web-intel as container (or bake into a small scrape image) with `POST /scrape` + `GET /ready`.
-3. HTTP-backed `ScrapeProvider` impl; wire in agent bootstrap.
-4. Drop hub dependency on `FACTORY_WEB_INTEL_PATH` / host `~/projects`.
+2. **Done (#2327)** — scrape HTTP service: `factory scrape serve`, Quadlet
+   `factory-scrape.container` (`POST /scrape`, `GET /ready` / `/health`).
+   Extractor: httpx + HTML text (no host plugin). Playwright-heavy image optional later.
+3. **Done (#2327)** — `HttpScrapeProvider` + `build_scrape_provider()`; hub injects
+   when `FACTORY_SCRAPE_URL` is set (hub unit sets `http://factory-scrape:8455`).
+4. **Done (#2327)** — container deploy path does not require `FACTORY_WEB_INTEL_PATH`
+   / host `~/projects` for hub scrape. Host-dev still falls back to `WebIntelScraper`.
 5. Optional: MCP or skill façade for agent runtime → same HTTP API.
 6. Optional later: retire hub `/explain`/`/summarize` if product prefers pure agent tools.
 

--- a/src/factory/agents/simple_agent.py
+++ b/src/factory/agents/simple_agent.py
@@ -201,13 +201,13 @@ class SimpleAgent(AgentBase):
         from factory.core.processors.processor_registry import registry
 
         if self._session_tools is None:
-            # Transitional fallback: construct locally until all callers inject.
+            # Transitional fallback: same provider selection as agent_factory (#2327).
             from factory.integrations.cortex_vault import CortexVault
-            from factory.integrations.web_intel import WebIntelScraper
+            from factory.integrations.http_scrape import build_scrape_provider
 
             try:
                 self._session_tools = SessionTools(
-                    scraper=WebIntelScraper(), vault=CortexVault()
+                    scraper=build_scrape_provider(), vault=CortexVault()
                 )
             except (ImportError, OSError, RuntimeError, ValueError):
                 log.warning(

--- a/src/factory/bootstrap/factory/agent_factory.py
+++ b/src/factory/bootstrap/factory/agent_factory.py
@@ -37,7 +37,6 @@ from factory.infrastructure.soul.soul_ops import preload_soul_caches_for_rows
 from factory.infrastructure.stores.registry.agent_store import AgentStore
 from factory.integrations.base import SessionTools
 from factory.integrations.cortex_vault import CortexVault
-from factory.integrations.web_intel import WebIntelScraper
 from factory.llm.drivers.cli import ClaudeCliDriver
 from factory.llm.registry import ProviderRegistry
 
@@ -202,8 +201,11 @@ def _create_agent(deps: CreateAgentDeps) -> AgentBase:  # noqa: C901 — 3-branc
 
         if deps.session_tools is None:
             try:
+                # #2327: FACTORY_SCRAPE_URL → HttpScrapeProvider; else host WebIntel
+                from factory.integrations.http_scrape import build_scrape_provider
+
                 session_tools = SessionTools(
-                    scraper=WebIntelScraper(), vault=CortexVault()
+                    scraper=build_scrape_provider(), vault=CortexVault()
                 )
             except (OSError, ImportError, RuntimeError, ValueError):  # <issue:1639>
                 log.warning(

--- a/src/factory/cli/main.py
+++ b/src/factory/cli/main.py
@@ -35,6 +35,7 @@ from factory.cli.user import user_app
 from factory.cli.voice_smoke import voice_smoke_app
 from factory.ingress.cli import ingress_app
 from factory.otel.cli import otel_app
+from factory.scrape_service.cli import scrape_app
 
 # Register subcommands from sub-modules (import triggers @app.command())
 # after app objects are imported. Previously at module exit in cli_bot/cli_agent.
@@ -76,6 +77,7 @@ factory_app.add_typer(voice_smoke_app, name="voice-smoke")
 factory_app.add_typer(ops_app, name="ops")
 factory_app.add_typer(secrets_app, name="secrets")
 factory_app.add_typer(blobstore_app, name="blobstore")
+factory_app.add_typer(scrape_app, name="scrape")
 factory_app.add_typer(otel_app, name="otel")
 factory_app.add_typer(ingress_app, name="ingress")
 factory_app.add_typer(user_app, name="user")

--- a/src/factory/core/processors/_scraping.py
+++ b/src/factory/core/processors/_scraping.py
@@ -49,6 +49,7 @@ async def _is_private_ip(hostname: str) -> bool:
         except ValueError:
             continue
 
+        # Tailscale CGNAT 100.64/10 is not is_private in Python — block explicitly.
         if (
             ip.is_private
             or ip.is_loopback
@@ -56,8 +57,23 @@ async def _is_private_ip(hostname: str) -> bool:
             or ip.is_multicast
             or ip.is_reserved
             or ip.is_unspecified
+            or not ip.is_global
+            or (
+                isinstance(ip, ipaddress.IPv4Address)
+                and ip in ipaddress.ip_network("100.64.0.0/10")
+            )
         ):
             return True
+        # IPv4-mapped IPv6 (::ffff:x.x.x.x)
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            v4 = ip.ipv4_mapped
+            if (
+                v4.is_private
+                or v4.is_loopback
+                or not v4.is_global
+                or v4 in ipaddress.ip_network("100.64.0.0/10")
+            ):
+                return True
 
     return False
 

--- a/src/factory/integrations/http_scrape.py
+++ b/src/factory/integrations/http_scrape.py
@@ -29,6 +29,14 @@ def _map_failure_body(data: dict[str, Any], status_code: int) -> ScrapeFailed:
     return ScrapeFailed("subprocess_error")
 
 
+def _parse_json_dict(resp: httpx.Response) -> dict[str, Any]:
+    try:
+        data = resp.json()
+    except ValueError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 class HttpScrapeProvider:
     """Async scraper backed by the factory-scrape HTTP service."""
 
@@ -37,12 +45,20 @@ class HttpScrapeProvider:
         base_url: str | None = None,
         *,
         client: httpx.AsyncClient | None = None,
+        token: str | None = None,
     ) -> None:
         resolved = base_url if base_url is not None else _scrape_base_url()
         if not resolved:
             raise ValueError("FACTORY_SCRAPE_URL is not set")
         self._base = resolved.rstrip("/")
         self._client = client
+        tok = token if token is not None else os.environ.get("FACTORY_SCRAPE_TOKEN", "")
+        self._token = tok.strip()
+
+    def _auth_headers(self) -> dict[str, str]:
+        if not self._token:
+            return {}
+        return {"Authorization": f"Bearer {self._token}"}
 
     async def scrape(self, url: str, timeout: float = 30.0) -> str:
         """POST /scrape; map transport/API failures to ScrapeFailed."""
@@ -55,6 +71,7 @@ class HttpScrapeProvider:
                 resp = await client.post(
                     f"{self._base}/scrape",
                     json={"url": url, "timeout_s": timeout},
+                    headers=self._auth_headers(),
                 )
             except httpx.TimeoutException as exc:
                 raise ScrapeFailed("timeout") from exc
@@ -65,23 +82,9 @@ class HttpScrapeProvider:
                 )
                 raise ScrapeFailed("not_available") from exc
 
-            if resp.status_code in {400, 504, 503} or resp.status_code >= 500:
-                try:
-                    data = resp.json()
-                except ValueError:
-                    data = {}
-                if not isinstance(data, dict):
-                    data = {}
+            data = _parse_json_dict(resp)
+            if resp.status_code >= 400 or not data.get("success"):
                 raise _map_failure_body(data, resp.status_code)
-
-            try:
-                data = resp.json()
-            except ValueError as exc:
-                raise ScrapeFailed("subprocess_error") from exc
-            if not isinstance(data, dict) or not data.get("success"):
-                raise _map_failure_body(
-                    data if isinstance(data, dict) else {}, resp.status_code
-                )
             text = data.get("text") or ""
             if not text:
                 raise ScrapeFailed("subprocess_error")
@@ -92,9 +95,18 @@ class HttpScrapeProvider:
 
 
 def build_scrape_provider() -> Any:
-    """Return HttpScrapeProvider if FACTORY_SCRAPE_URL set, else WebIntelScraper."""
+    """Return HttpScrapeProvider if FACTORY_SCRAPE_URL set, else WebIntelScraper.
+
+    Container deploys (CONTAINER_NAME set) **require** FACTORY_SCRAPE_URL —
+    fail closed rather than falling back to host WebIntel (missing in images).
+    """
     if _scrape_base_url():
         return HttpScrapeProvider()
+    if os.environ.get("CONTAINER_NAME", "").strip():
+        raise RuntimeError(
+            "FACTORY_SCRAPE_URL is required in container deploys "
+            "(CONTAINER_NAME is set). Point hub at factory-scrape HTTP service."
+        )
     from factory.integrations.web_intel import WebIntelScraper
 
     return WebIntelScraper()

--- a/src/factory/integrations/http_scrape.py
+++ b/src/factory/integrations/http_scrape.py
@@ -1,0 +1,100 @@
+"""HttpScrapeProvider — ScrapeProvider over FACTORY_SCRAPE_URL (#2327)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from factory.core.exceptions import ScrapeFailed
+
+log = logging.getLogger(__name__)
+
+
+def _scrape_base_url() -> str | None:
+    raw = os.environ.get("FACTORY_SCRAPE_URL", "").strip()
+    return raw.rstrip("/") if raw else None
+
+
+def _map_failure_body(data: dict[str, Any], status_code: int) -> ScrapeFailed:
+    reason = data.get("reason", "")
+    if reason == "timeout" or status_code == 504:
+        return ScrapeFailed("timeout")
+    if reason == "unavailable" or status_code == 503:
+        return ScrapeFailed("not_available")
+    if status_code >= 500:
+        return ScrapeFailed("not_available")
+    return ScrapeFailed("subprocess_error")
+
+
+class HttpScrapeProvider:
+    """Async scraper backed by the factory-scrape HTTP service."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        resolved = base_url if base_url is not None else _scrape_base_url()
+        if not resolved:
+            raise ValueError("FACTORY_SCRAPE_URL is not set")
+        self._base = resolved.rstrip("/")
+        self._client = client
+
+    async def scrape(self, url: str, timeout: float = 30.0) -> str:
+        """POST /scrape; map transport/API failures to ScrapeFailed."""
+        own_client = self._client is None
+        client = self._client or httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout + 5.0)
+        )
+        try:
+            try:
+                resp = await client.post(
+                    f"{self._base}/scrape",
+                    json={"url": url, "timeout_s": timeout},
+                )
+            except httpx.TimeoutException as exc:
+                raise ScrapeFailed("timeout") from exc
+            except httpx.RequestError as exc:
+                log.warning(
+                    "HttpScrapeProvider: request error type=%s",
+                    type(exc).__name__,
+                )
+                raise ScrapeFailed("not_available") from exc
+
+            if resp.status_code in {400, 504, 503} or resp.status_code >= 500:
+                try:
+                    data = resp.json()
+                except ValueError:
+                    data = {}
+                if not isinstance(data, dict):
+                    data = {}
+                raise _map_failure_body(data, resp.status_code)
+
+            try:
+                data = resp.json()
+            except ValueError as exc:
+                raise ScrapeFailed("subprocess_error") from exc
+            if not isinstance(data, dict) or not data.get("success"):
+                raise _map_failure_body(
+                    data if isinstance(data, dict) else {}, resp.status_code
+                )
+            text = data.get("text") or ""
+            if not text:
+                raise ScrapeFailed("subprocess_error")
+            return str(text)
+        finally:
+            if own_client:
+                await client.aclose()
+
+
+def build_scrape_provider() -> Any:
+    """Return HttpScrapeProvider if FACTORY_SCRAPE_URL set, else WebIntelScraper."""
+    if _scrape_base_url():
+        return HttpScrapeProvider()
+    from factory.integrations.web_intel import WebIntelScraper
+
+    return WebIntelScraper()

--- a/src/factory/scrape_service/__init__.py
+++ b/src/factory/scrape_service/__init__.py
@@ -2,12 +2,6 @@
 
 from __future__ import annotations
 
+from factory.scrape_service.app import build_app
+
 __all__ = ["build_app"]
-
-
-def __getattr__(name: str):
-    if name == "build_app":
-        from factory.scrape_service.app import build_app
-
-        return build_app
-    raise AttributeError(name)

--- a/src/factory/scrape_service/__init__.py
+++ b/src/factory/scrape_service/__init__.py
@@ -1,0 +1,13 @@
+"""HTTP scrape service — isolated provider for URL → text (issue #2327)."""
+
+from __future__ import annotations
+
+__all__ = ["build_app"]
+
+
+def __getattr__(name: str):
+    if name == "build_app":
+        from factory.scrape_service.app import build_app
+
+        return build_app
+    raise AttributeError(name)

--- a/src/factory/scrape_service/app.py
+++ b/src/factory/scrape_service/app.py
@@ -91,9 +91,10 @@ def build_app(*, token: str | None = None) -> FastAPI:
     @app.get("/ready")
     async def ready() -> JSONResponse:
         try:
-            import httpx as _hx  # noqa: F401
+            import importlib
 
-            import factory.scrape_service.extract as _ex  # noqa: F401
+            importlib.import_module("httpx")
+            importlib.import_module("factory.scrape_service.extract")
         except ImportError as exc:
             log.warning("scrape ready fail: %s", exc)
             return JSONResponse({"ready": False}, status_code=503)

--- a/src/factory/scrape_service/app.py
+++ b/src/factory/scrape_service/app.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
+import os
 from typing import Any
 
 import httpx
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from factory.scrape_service.extract import fetch_and_extract
 from factory.scrape_service.ssrf import SsrfRejected
 
 log = logging.getLogger(__name__)
+
+_PUBLIC_PATHS = frozenset({"/health", "/ready"})
 
 
 class ScrapeRequest(BaseModel):
@@ -21,9 +26,63 @@ class ScrapeRequest(BaseModel):
     timeout_s: float = Field(default=30.0, ge=1.0, le=120.0)
 
 
-def build_app() -> FastAPI:
-    """Create the scrape service application."""
+class _BearerMiddleware(BaseHTTPMiddleware):
+    """Optional bearer when FACTORY_SCRAPE_TOKEN is set (recommended on roxabi)."""
+
+    def __init__(self, app: Any, *, token: str) -> None:
+        super().__init__(app)
+        self._token = token
+
+    async def dispatch(self, request: Request, call_next: Any) -> Any:
+        if request.url.path in _PUBLIC_PATHS:
+            return await call_next(request)
+        auth = request.headers.get("authorization", "")
+        if not auth.startswith("Bearer "):
+            return JSONResponse({"detail": "unauthorized"}, status_code=401)
+        got = auth[7:].strip()
+        if not hmac.compare_digest(got, self._token):
+            return JSONResponse({"detail": "unauthorized"}, status_code=401)
+        return await call_next(request)
+
+
+def _err(reason: str, error: str, status: int) -> JSONResponse:
+    return JSONResponse(
+        {"success": False, "error": error, "reason": reason},
+        status_code=status,
+    )
+
+
+async def _handle_scrape(body: ScrapeRequest) -> JSONResponse:
+    try:
+        text = await fetch_and_extract(body.url, timeout=body.timeout_s)
+    except SsrfRejected as exc:
+        return _err("ssrf", str(exc.reason), 400)
+    except httpx.TimeoutException:
+        return _err("timeout", "timeout", 504)
+    except httpx.HTTPError as exc:
+        log.info("scrape fetch failed: type=%s", type(exc).__name__)
+        return _err("fetch", type(exc).__name__, 502)
+    except ValueError as exc:
+        return _err("fetch", str(exc), 502)
+    except Exception as exc:  # noqa: BLE001 — DEBT:boundary-broad-catch# boundary: scrape-api
+        log.warning("scrape unexpected: type=%s", type(exc).__name__)
+        return _err("unavailable", "unavailable", 503)
+    return JSONResponse(
+        {"success": True, "text": text, "url": body.url.strip()}
+    )
+
+
+def build_app(*, token: str | None = None) -> FastAPI:
+    """Create the scrape service application.
+
+    When *token* (or env ``FACTORY_SCRAPE_TOKEN``) is set, ``POST /scrape``
+    requires ``Authorization: Bearer``. ``/health`` and ``/ready`` stay open.
+    """
     app = FastAPI(title="factory-scrape", version="1.0.0")
+    env_tok = os.environ.get("FACTORY_SCRAPE_TOKEN", "")
+    resolved = (token if token is not None else env_tok).strip()
+    if resolved:
+        app.add_middleware(_BearerMiddleware, token=resolved)
 
     @app.get("/health")
     async def health() -> dict[str, str]:
@@ -31,11 +90,9 @@ def build_app() -> FastAPI:
 
     @app.get("/ready")
     async def ready() -> JSONResponse:
-        # Process + import path OK (extractor is pure-Python + httpx).
         try:
-            import httpx  # noqa: F401 — readiness: dep importable
-
-            import factory.scrape_service.extract  # noqa: F401
+            import httpx as _hx  # noqa: F401
+            import factory.scrape_service.extract as _ex  # noqa: F401
         except ImportError as exc:
             log.warning("scrape ready fail: %s", exc)
             return JSONResponse({"ready": False}, status_code=503)
@@ -43,61 +100,6 @@ def build_app() -> FastAPI:
 
     @app.post("/scrape")
     async def scrape(body: ScrapeRequest) -> JSONResponse:
-        try:
-            text = await fetch_and_extract(body.url, timeout=body.timeout_s)
-        except SsrfRejected as exc:
-            return JSONResponse(
-                {
-                    "success": False,
-                    "error": str(exc.reason),
-                    "reason": "ssrf",
-                },
-                status_code=400,
-            )
-        except httpx.TimeoutException:
-            return JSONResponse(
-                {
-                    "success": False,
-                    "error": "timeout",
-                    "reason": "timeout",
-                },
-                status_code=504,
-            )
-        except httpx.HTTPError as exc:
-            log.info("scrape fetch failed: type=%s", type(exc).__name__)
-            return JSONResponse(
-                {
-                    "success": False,
-                    "error": type(exc).__name__,
-                    "reason": "fetch",
-                },
-                status_code=502,
-            )
-        except ValueError as exc:
-            return JSONResponse(
-                {
-                    "success": False,
-                    "error": str(exc),
-                    "reason": "fetch",
-                },
-                status_code=502,
-            )
-        except Exception as exc:  # noqa: BLE001 — DEBT:boundary-broad-catch# boundary: scrape-api — terminal handler; type only
-            log.warning("scrape unexpected: type=%s", type(exc).__name__)
-            return JSONResponse(
-                {
-                    "success": False,
-                    "error": "unavailable",
-                    "reason": "unavailable",
-                },
-                status_code=503,
-            )
-
-        payload: dict[str, Any] = {
-            "success": True,
-            "text": text,
-            "url": body.url.strip(),
-        }
-        return JSONResponse(payload)
+        return await _handle_scrape(body)
 
     return app

--- a/src/factory/scrape_service/app.py
+++ b/src/factory/scrape_service/app.py
@@ -1,0 +1,103 @@
+"""FastAPI app for the scrape HTTP service (#2327)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from factory.scrape_service.extract import fetch_and_extract
+from factory.scrape_service.ssrf import SsrfRejected
+
+log = logging.getLogger(__name__)
+
+
+class ScrapeRequest(BaseModel):
+    url: str = Field(..., min_length=8, max_length=2048)
+    timeout_s: float = Field(default=30.0, ge=1.0, le=120.0)
+
+
+def build_app() -> FastAPI:
+    """Create the scrape service application."""
+    app = FastAPI(title="factory-scrape", version="1.0.0")
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/ready")
+    async def ready() -> JSONResponse:
+        # Process + import path OK (extractor is pure-Python + httpx).
+        try:
+            import httpx  # noqa: F401 — readiness: dep importable
+
+            import factory.scrape_service.extract  # noqa: F401
+        except ImportError as exc:
+            log.warning("scrape ready fail: %s", exc)
+            return JSONResponse({"ready": False}, status_code=503)
+        return JSONResponse({"ready": True})
+
+    @app.post("/scrape")
+    async def scrape(body: ScrapeRequest) -> JSONResponse:
+        try:
+            text = await fetch_and_extract(body.url, timeout=body.timeout_s)
+        except SsrfRejected as exc:
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error": str(exc.reason),
+                    "reason": "ssrf",
+                },
+                status_code=400,
+            )
+        except httpx.TimeoutException:
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error": "timeout",
+                    "reason": "timeout",
+                },
+                status_code=504,
+            )
+        except httpx.HTTPError as exc:
+            log.info("scrape fetch failed: type=%s", type(exc).__name__)
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error": type(exc).__name__,
+                    "reason": "fetch",
+                },
+                status_code=502,
+            )
+        except ValueError as exc:
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error": str(exc),
+                    "reason": "fetch",
+                },
+                status_code=502,
+            )
+        except Exception as exc:  # noqa: BLE001 — DEBT:boundary-broad-catch# boundary: scrape-api — terminal handler; type only
+            log.warning("scrape unexpected: type=%s", type(exc).__name__)
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error": "unavailable",
+                    "reason": "unavailable",
+                },
+                status_code=503,
+            )
+
+        payload: dict[str, Any] = {
+            "success": True,
+            "text": text,
+            "url": body.url.strip(),
+        }
+        return JSONResponse(payload)
+
+    return app

--- a/src/factory/scrape_service/app.py
+++ b/src/factory/scrape_service/app.py
@@ -92,6 +92,7 @@ def build_app(*, token: str | None = None) -> FastAPI:
     async def ready() -> JSONResponse:
         try:
             import httpx as _hx  # noqa: F401
+
             import factory.scrape_service.extract as _ex  # noqa: F401
         except ImportError as exc:
             log.warning("scrape ready fail: %s", exc)

--- a/src/factory/scrape_service/cli.py
+++ b/src/factory/scrape_service/cli.py
@@ -1,0 +1,19 @@
+"""CLI: factory scrape serve — HTTP scrape provider (#2327)."""
+
+from __future__ import annotations
+
+import typer
+import uvicorn
+
+from factory.scrape_service.app import build_app
+
+scrape_app = typer.Typer(name="scrape", help="HTTP scrape service (#2327).")
+
+
+@scrape_app.command("serve")
+def serve(
+    host: str = typer.Option("0.0.0.0", help="Bind host."),
+    port: int = typer.Option(8455, help="Bind port."),
+) -> None:
+    """Start the scrape HTTP service."""
+    uvicorn.run(build_app(), host=host, port=port)

--- a/src/factory/scrape_service/extract.py
+++ b/src/factory/scrape_service/extract.py
@@ -1,0 +1,96 @@
+"""Fetch URL with redirect revalidation and extract plain text."""
+
+from __future__ import annotations
+
+import logging
+import re
+from html.parser import HTMLParser
+from urllib.parse import urljoin
+
+import httpx
+
+from factory.scrape_service.ssrf import SsrfRejected, assert_url_safe
+
+log = logging.getLogger(__name__)
+
+_MAX_REDIRECTS = 5
+_MAX_BYTES = 2_000_000  # const-ok: response body cap before extract
+_MAX_TEXT = 32_000  # align with hub ScrapingProcessor
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._chunks: list[str] = []
+        self._skip = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "noscript"}:
+            self._skip += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "noscript"} and self._skip:
+            self._skip -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._skip == 0:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        joined = " ".join(self._chunks)
+        return re.sub(r"\s+", " ", joined).strip()
+
+
+def html_to_text(html: str) -> str:
+    parser = _TextExtractor()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:  # noqa: BLE001 — DEBT:boundary-broad-catch# boundary: scrape-html — bad HTML must not crash service
+        # Fallback: crude tag strip
+        return re.sub(r"<[^>]+>", " ", html)
+    return parser.text()
+
+
+async def fetch_and_extract(url: str, *, timeout: float = 30.0) -> str:
+    """GET *url* (HTTPS), revalidate each redirect, return extracted text.
+
+    Raises:
+        SsrfRejected — policy violation
+        httpx.HTTPError — network/HTTP failure
+        ValueError — empty body / no text
+    """
+    current = await assert_url_safe(url)
+    timeout_cfg = httpx.Timeout(timeout)
+    async with httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=timeout_cfg,
+        headers={"User-Agent": "factory-scrape/1.0 (+https://roxabi.dev)"},
+    ) as client:
+        for _ in range(_MAX_REDIRECTS + 1):
+            resp = await client.get(current)
+            if resp.status_code in {301, 302, 303, 307, 308}:
+                loc = resp.headers.get("location")
+                if not loc:
+                    raise ValueError("redirect_without_location")
+                next_url = urljoin(current, loc)
+                # Absolute http:// redirect must fail https_only
+                current = await assert_url_safe(next_url)
+                continue
+            if resp.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    f"HTTP {resp.status_code}",
+                    request=resp.request,
+                    response=resp,
+                )
+            raw = resp.content[:_MAX_BYTES]
+            ctype = (resp.headers.get("content-type") or "").lower()
+            if "html" in ctype or raw.lstrip()[:1] == b"<":
+                text = html_to_text(raw.decode("utf-8", errors="replace"))
+            else:
+                text = raw.decode("utf-8", errors="replace").strip()
+            text = text[:_MAX_TEXT]
+            if not text:
+                raise ValueError("empty_extract")
+            return text
+    raise SsrfRejected("too_many_redirects")

--- a/src/factory/scrape_service/ssrf.py
+++ b/src/factory/scrape_service/ssrf.py
@@ -1,0 +1,73 @@
+"""SSRF guards for the scrape service (HTTPS-only, non-global IP reject).
+
+Dual-check design: hub also pre-checks; this module re-validates at the
+service boundary including redirect targets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# Tailscale CGNAT + classic private ranges covered by is_private / is_reserved.
+_TAILSCALE_NET = ipaddress.ip_network("100.64.0.0/10")
+
+
+class SsrfRejected(ValueError):
+    """URL rejected by SSRF policy."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def require_https_url(url: str) -> str:
+    """Return stripped URL if scheme is https and host present; else raise."""
+    raw = url.strip()
+    parsed = urlparse(raw)
+    if parsed.scheme != "https":
+        raise SsrfRejected("https_only")
+    if not parsed.hostname:
+        raise SsrfRejected("missing_host")
+    return raw
+
+
+async def hostname_is_blocked(hostname: str) -> bool:
+    """True if *hostname* resolves to any non-global / Tailscale CGNAT address."""
+    try:
+        results = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+    except socket.gaierror:
+        # Unresolvable — allow through; fetch will fail cleanly.
+        return False
+
+    for _family, _type, _proto, _canon, sockaddr in results:
+        addr_str = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(addr_str)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+            or ip in _TAILSCALE_NET
+        ):
+            return True
+        # Explicit CGNAT check for IPv4 mapped edge cases
+        if isinstance(ip, ipaddress.IPv4Address) and ip in _TAILSCALE_NET:
+            return True
+    return False
+
+
+async def assert_url_safe(url: str) -> str:
+    """Validate *url* for scrape; return stripped https URL or raise SsrfRejected."""
+    raw = require_https_url(url)
+    host = urlparse(raw).hostname or ""
+    if await hostname_is_blocked(host):
+        raise SsrfRejected("private_ip")
+    return raw

--- a/src/factory/scrape_service/ssrf.py
+++ b/src/factory/scrape_service/ssrf.py
@@ -34,13 +34,45 @@ def require_https_url(url: str) -> str:
     return raw
 
 
+def _effective_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> (
+    ipaddress.IPv4Address | ipaddress.IPv6Address
+):
+    """Unwrap IPv4-mapped IPv6 so policy applies to the embedded v4."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
+
+
+def ip_is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True if *ip* (after mapped unwrap) is non-global or Tailscale CGNAT."""
+    eff = _effective_ip(ip)
+    if (
+        eff.is_private
+        or eff.is_loopback
+        or eff.is_link_local
+        or eff.is_multicast
+        or eff.is_reserved
+        or eff.is_unspecified
+        or not eff.is_global
+    ):
+        return True
+    if isinstance(eff, ipaddress.IPv4Address) and eff in _TAILSCALE_NET:
+        return True
+    return False
+
+
 async def hostname_is_blocked(hostname: str) -> bool:
-    """True if *hostname* resolves to any non-global / Tailscale CGNAT address."""
+    """True if *hostname* resolves to any non-global / Tailscale CGNAT address.
+
+    Fail-closed on DNS errors (reject unresolvable).
+    """
     try:
         results = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
-    except socket.gaierror:
-        # Unresolvable — allow through; fetch will fail cleanly.
-        return False
+    except socket.gaierror as exc:
+        raise SsrfRejected("unresolvable") from exc
+
+    if not results:
+        raise SsrfRejected("unresolvable")
 
     for _family, _type, _proto, _canon, sockaddr in results:
         addr_str = sockaddr[0]
@@ -48,18 +80,7 @@ async def hostname_is_blocked(hostname: str) -> bool:
             ip = ipaddress.ip_address(addr_str)
         except ValueError:
             continue
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-            or ip in _TAILSCALE_NET
-        ):
-            return True
-        # Explicit CGNAT check for IPv4 mapped edge cases
-        if isinstance(ip, ipaddress.IPv4Address) and ip in _TAILSCALE_NET:
+        if ip_is_blocked(ip):
             return True
     return False
 
@@ -68,6 +89,14 @@ async def assert_url_safe(url: str) -> str:
     """Validate *url* for scrape; return stripped https URL or raise SsrfRejected."""
     raw = require_https_url(url)
     host = urlparse(raw).hostname or ""
+    # Literal IP in hostname — check without DNS
+    try:
+        lit = ipaddress.ip_address(host)
+        if ip_is_blocked(lit):
+            raise SsrfRejected("private_ip")
+        return raw
+    except ValueError:
+        pass
     if await hostname_is_blocked(host):
         raise SsrfRejected("private_ip")
     return raw

--- a/tests/integrations/test_http_scrape.py
+++ b/tests/integrations/test_http_scrape.py
@@ -1,0 +1,66 @@
+"""HttpScrapeProvider unit tests (#2327)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from factory.core.exceptions import ScrapeFailed
+from factory.integrations.http_scrape import HttpScrapeProvider
+
+
+@pytest.mark.asyncio
+async def test_scrape_success() -> None:
+    client = AsyncMock(spec=httpx.AsyncClient)
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"success": True, "text": "hello page", "url": "https://ex.com"}
+    client.post = AsyncMock(return_value=resp)
+
+    provider = HttpScrapeProvider(base_url="http://scrape:8455", client=client)
+    text = await provider.scrape("https://ex.com")
+    assert text == "hello page"
+    client.post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scrape_timeout() -> None:
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(side_effect=httpx.TimeoutException("t"))
+    provider = HttpScrapeProvider(base_url="http://scrape:8455", client=client)
+    with pytest.raises(ScrapeFailed) as ei:
+        await provider.scrape("https://ex.com")
+    assert ei.value.reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_scrape_unavailable() -> None:
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(side_effect=httpx.ConnectError("down"))
+    provider = HttpScrapeProvider(base_url="http://scrape:8455", client=client)
+    with pytest.raises(ScrapeFailed) as ei:
+        await provider.scrape("https://ex.com")
+    assert ei.value.reason == "not_available"
+
+
+@pytest.mark.asyncio
+async def test_scrape_ssrf_maps_to_subprocess_error() -> None:
+    client = AsyncMock(spec=httpx.AsyncClient)
+    resp = MagicMock()
+    resp.status_code = 400
+    resp.json.return_value = {"success": False, "reason": "ssrf"}
+    client.post = AsyncMock(return_value=resp)
+    provider = HttpScrapeProvider(base_url="http://scrape:8455", client=client)
+    with pytest.raises(ScrapeFailed) as ei:
+        await provider.scrape("https://127.0.0.1/")
+    assert ei.value.reason == "subprocess_error"
+
+
+def test_build_scrape_provider_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FACTORY_SCRAPE_URL", "http://factory-scrape:8455")
+    from factory.integrations.http_scrape import build_scrape_provider
+
+    p = build_scrape_provider()
+    assert isinstance(p, HttpScrapeProvider)

--- a/tests/integrations/test_http_scrape.py
+++ b/tests/integrations/test_http_scrape.py
@@ -64,3 +64,12 @@ def test_build_scrape_provider_http(monkeypatch: pytest.MonkeyPatch) -> None:
 
     p = build_scrape_provider()
     assert isinstance(p, HttpScrapeProvider)
+
+
+def test_container_fail_closed_without_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FACTORY_SCRAPE_URL", raising=False)
+    monkeypatch.setenv("CONTAINER_NAME", "factory-hub")
+    from factory.integrations.http_scrape import build_scrape_provider
+
+    with pytest.raises(RuntimeError, match="FACTORY_SCRAPE_URL"):
+        build_scrape_provider()

--- a/tests/scrape_service/test_app.py
+++ b/tests/scrape_service/test_app.py
@@ -1,0 +1,50 @@
+"""Scrape FastAPI app smoke (#2327)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from factory.scrape_service.app import build_app
+
+
+@pytest.mark.asyncio
+async def test_ready_and_health() -> None:
+    app = build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        r = await client.get("/health")
+        assert r.status_code == 200
+        r2 = await client.get("/ready")
+        assert r2.status_code == 200
+        assert r2.json().get("ready") is True
+
+
+@pytest.mark.asyncio
+async def test_scrape_ssrf_http() -> None:
+    app = build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        r = await client.post("/scrape", json={"url": "http://example.com"})
+        assert r.status_code == 400
+        assert r.json()["reason"] == "ssrf"
+
+
+@pytest.mark.asyncio
+async def test_scrape_success_mocked() -> None:
+    app = build_app()
+    transport = ASGITransport(app=app)
+    with patch(
+        "factory.scrape_service.app.fetch_and_extract",
+        new=AsyncMock(return_value="Example Domain text"),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.post(
+                "/scrape", json={"url": "https://example.com", "timeout_s": 10}
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert "Example" in body["text"]

--- a/tests/scrape_service/test_ssrf.py
+++ b/tests/scrape_service/test_ssrf.py
@@ -1,0 +1,33 @@
+"""SSRF policy for scrape service (#2327)."""
+
+from __future__ import annotations
+
+import pytest
+
+from factory.scrape_service.ssrf import SsrfRejected, assert_url_safe, require_https_url
+
+
+def test_require_https_rejects_http() -> None:
+    with pytest.raises(SsrfRejected) as ei:
+        require_https_url("http://example.com/")
+    assert ei.value.reason == "https_only"
+
+
+def test_require_https_ok() -> None:
+    assert require_https_url("https://example.com/path") == "https://example.com/path"
+
+
+@pytest.mark.asyncio
+async def test_assert_blocks_localhost() -> None:
+    with pytest.raises(SsrfRejected) as ei:
+        await assert_url_safe("https://127.0.0.1/")
+    assert ei.value.reason == "private_ip"
+
+
+@pytest.mark.asyncio
+async def test_assert_blocks_tailscale_cgnat() -> None:
+    # 100.64.0.1 is in Tailscale CGNAT — resolve via literal hostname not possible;
+    # use IP in host form if URL allows (hostname 100.64.0.1)
+    with pytest.raises(SsrfRejected) as ei:
+        await assert_url_safe("https://100.64.0.1/")
+    assert ei.value.reason == "private_ip"

--- a/tests/scrape_service/test_ssrf.py
+++ b/tests/scrape_service/test_ssrf.py
@@ -31,3 +31,33 @@ async def test_assert_blocks_tailscale_cgnat() -> None:
     with pytest.raises(SsrfRejected) as ei:
         await assert_url_safe("https://100.64.0.1/")
     assert ei.value.reason == "private_ip"
+
+
+@pytest.mark.asyncio
+async def test_assert_blocks_ipv4_mapped_loopback() -> None:
+    with pytest.raises(SsrfRejected) as ei:
+        await assert_url_safe("https://[::ffff:127.0.0.1]/")
+    assert ei.value.reason == "private_ip"
+
+
+@pytest.mark.asyncio
+async def test_redirect_to_private_rejected() -> None:
+    """302 Location to loopback must fail SSRF on the hop (not only first URL)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from factory.scrape_service.extract import fetch_and_extract
+
+    first = MagicMock()
+    first.status_code = 302
+    first.headers = {"location": "https://127.0.0.1/secret"}
+    first.request = MagicMock()
+
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=first)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("factory.scrape_service.extract.httpx.AsyncClient", return_value=client):
+        with pytest.raises(SsrfRejected) as ei:
+            await fetch_and_extract("https://example.com/")
+    assert ei.value.reason == "private_ip"

--- a/tests/scripts/test_quadlet_units.py
+++ b/tests/scripts/test_quadlet_units.py
@@ -28,6 +28,7 @@ EXPECTED_CONTAINERS = [
     "factory-gh-helper",
     "factory-turn-writer",
     "factory-blobstore",
+    "factory-scrape",  # #2327 HTTP scrape provider
     "factory-omp",
     # factory-socialmedia-adapter removed (#2329) — Postiz via skill/CLI.
     "factory-ingress",


### PR DESCRIPTION
## Summary
- **factory-scrape** HTTP service: `/scrape`, `/ready`, `/health`; HTTPS-only + private/Tailscale SSRF; redirect revalidation
- **HttpScrapeProvider** + `build_scrape_provider()`; hub `FACTORY_SCRAPE_URL=http://factory-scrape:8455`
- Quadlet unit + hub Wants/After; docs scrape-placement slices 2–4 done
- Host-dev without env still uses WebIntelScraper subprocess

## Architecture
Hub stays thin. Scrape is an HTTP provider (not NATS job, not hub playwright).

## Test Plan
- [x] `pytest tests/scrape_service tests/integrations/test_http_scrape.py` (12 passed)
- [ ] After merge + image: `make quadlet-install` / converge; `curl factory-scrape:8455/ready`; Discord `/explain https://example.com`

Closes #2327

---
via `/dev #2327`