### PR TITLE
feat(scrape): pin factory-scrape to intel-scrape image (#2338)

### DIFF
--- a/deploy/quadlet/factory-scrape.container
+++ b/deploy/quadlet/factory-scrape.container
@@ -1,36 +1,41 @@
 [Unit]
-Description=Factory scrape HTTP service — URL → text (#2327)
+Description=Factory scrape HTTP service — web-intel engine (roxabi-intel image) (#2338)
 After=factory-nats.service
 Wants=factory-nats.service
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Container]
-StopTimeout=60
-# Same svc image as hub for now — extractor is httpx + stdlib HTML (no browser
-# download required). Playwright-heavy path can move to a dedicated image later.
-Image=ghcr.io/roxabi/factory:staging-svc
+StopTimeout=90
+# Engine + image owned by Roxabi/roxabi-intel (services/scrape).
+# Factory keeps client (HttpScrapeProvider) + this pin only.
+Image=ghcr.io/roxabi/intel-scrape:staging
 Label=io.containers.autoupdate=registry
 ContainerName=factory-scrape
 Environment=CONTAINER_NAME=factory-scrape
-Environment=IMAGE_REF=ghcr.io/roxabi/factory:staging-svc
+Environment=IMAGE_REF=ghcr.io/roxabi/intel-scrape:staging
 Network=roxabi.network
 NoNewPrivileges=true
+# Chromium needs writable /tmp (profiles + crash dumps). Root FS read-only.
 ReadOnly=true
+Tmpfs=/tmp:rw,size=1G,mode=1777
 DropCapability=all
 UserNS=keep-id:uid=1500,gid=1500
-# No secrets required for public HTTPS scrape; SSRF enforced in-process.
-Exec=factory scrape serve --host 0.0.0.0 --port 8455
+# Optional bearer — set FACTORY_SCRAPE_TOKEN on hub + here if enabled.
+# Environment=SCRAPE_TOKEN=...  (or Secret)
+# Image entrypoint: python -m intel_scrape serve
+Exec=python -m intel_scrape serve --host 0.0.0.0 --port 8455
 # Internal only — hub reaches factory-scrape:8455 on roxabi network.
 # Host publish optional for debug (commented):
 # PublishPort=127.0.0.1:8455:8455
 # Single-quoted python3 -c (no ") — Quadlet HealthCmd quote rule #1370.
-HealthCmd=python3 -c 'import urllib.request,sys; r=urllib.request.urlopen("http://127.0.0.1:8455/ready",timeout=3); sys.exit(0 if r.status==200 else 1)'
+HealthCmd=python3 -c 'import urllib.request,sys; r=urllib.request.urlopen("http://127.0.0.1:8455/ready",timeout=5); sys.exit(0 if r.status==200 else 1)'
 HealthInterval=30s
+HealthStartPeriod=60s
 
 [Service]
 Restart=on-failure
-TimeoutStopSec=70
+TimeoutStopSec=100
 RestartSec=10
 
 [Install]

--- a/docs/architecture/scrape-placement.md
+++ b/docs/architecture/scrape-placement.md
@@ -5,8 +5,18 @@ description: Current scrape path, why hub subprocess fails in prod, and the targ
 
 # Scrape placement
 
-> Status: LIVING design note (2026-08-01). Complements `workers-tooling.md` (tool taxonomy) and `integrations/web_intel.py` (current impl).
+> Status: LIVING design note (2026-08-10). Complements `workers-tooling.md` (tool taxonomy) and `integrations/web_intel.py` / `http_scrape.py`.
 > Not an ADR — placement decision for web scrape only. Vault product path is **deleted** (no `/vault-add`).
+
+## Ownership (locked — option 2)
+
+| Piece | Owner |
+|-------|--------|
+| Scrape **service + image + web-intel engine** | **roxabi-intel** (`services/scrape`, `plugins/web-intel`) → `ghcr.io/roxabi/intel-scrape` |
+| `HttpScrapeProvider` + `FACTORY_SCRAPE_URL` + Quadlet **pin** | **roxabi-factory** |
+| Hub / Discord / agents | consumers only |
+
+Factory in-tree `scrape_service/` (httpx extract) is **transitional** for local/dev; prod Quadlet runs the **intel** image.
 
 ## Current state (what ships today)
 
@@ -17,10 +27,10 @@ User: /explain | /summarize <url>   (bare URL → /explain when patterns.bare_ur
 Hub  ScrapingProcessor.pre()     HTTPS-only + SSRF guard (private IP reject)
         │
         ▼
-WebIntelScraper  (in-process in hub)
-        │  subprocess: uv run python …/roxabi-plugins/plugins/web-intel/scripts/scraper.py
+HttpScrapeProvider  (FACTORY_SCRAPE_URL=http://factory-scrape:8455)
+        │  POST /scrape
         ▼
-playwright + trafilatura  (plugin venv under ~/projects/…)
+factory-scrape Quadlet  →  ghcr.io/roxabi/intel-scrape  (web-intel + Playwright)
         │
         ▼
 text injected into LLM prompt   — or "[scraping unavailable]" on failure
@@ -29,11 +39,12 @@ text injected into LLM prompt   — or "[scraping unavailable]" on failure
 | Piece | Location |
 |---|---|
 | Protocol | `ScrapeProvider` — `factory.integrations.base` |
-| Impl | `WebIntelScraper` — `factory.integrations.web_intel` |
+| Prod impl | `HttpScrapeProvider` — `factory.integrations.http_scrape` |
+| Host-dev fallback | `WebIntelScraper` — `factory.integrations.web_intel` (when `FACTORY_SCRAPE_URL` unset) |
 | Consumers | `ExplainProcessor`, `SummarizeProcessor` via `_scraping.ScrapingProcessor` |
-| Plugin | `~/projects/roxabi-plugins/plugins/web-intel` (override: `FACTORY_WEB_INTEL_PATH`) |
+| Engine | Roxabi/roxabi-intel `plugins/web-intel` (image: `ghcr.io/roxabi/intel-scrape`) |
 
-**Prod failure mode:** `factory-hub` container has no `~/projects` mount and no web-intel image layer → `ScrapeFailed("not_available")` → user sees `[scraping unavailable]`. Fix is **placement**, not a volume hack on the hub monolithe.
+**Prod failure mode (historical):** hub subprocess to host `~/projects` → missing in container. Fixed by HTTP service + intel image (#2327 pipe, #2338 engine).
 
 **Out of scope / removed:** `/vault-add`, `/add-vault`, bare-URL→vault. Memory writes = cortex (ADR-087), not hub scrape side-effects.
 
@@ -66,8 +77,9 @@ agent tool / MCP           ──POST /scrape──▶  (same)
 | Transport | HTTPS (or localhost HTTP on pod network) |
 | Health | `GET /ready` — process up **and** scraper importable; hub/client circuit-breaker on call failures |
 | SSRF | **Dual-check required**: hub cheap pre-check **and** service enforces HTTPS-only + non-global IP + redirect revalidation |
-| Deploy | Quadlet unit on M₁ (or M₂ if browser-heavy); image embeds web-intel/playwright |
+| Deploy | Quadlet `factory-scrape` on M₁ pins **intel** image (`ghcr.io/roxabi/intel-scrape`) |
 | Hub change | HTTP-backed `ScrapeProvider` impl; drop subprocess from hub image |
+| Engine home | **roxabi-intel** — factory never embeds Chromium |
 | Agent | Skill/CLI optional wrapper calling same HTTP API — **one** scrape engine |
 
 **Why not NATS satellite first?** No GPU multi-worker routing need; request/response + health is enough. Revisit NATS only if multi-instance queue + fleet registry become real requirements.
@@ -107,15 +119,16 @@ Heartbeat push is optional candy; pull `/ready` + CB is enough.
 ## Migration slices (suggested)
 
 1. **Done** — remove vault-add product path; bare URL → `/explain`.
-2. **Done (#2327)** — scrape HTTP service: `factory scrape serve`, Quadlet
-   `factory-scrape.container` (`POST /scrape`, `GET /ready` / `/health`).
-   Extractor: httpx + HTML text (no host plugin). Playwright-heavy image optional later.
-3. **Done (#2327)** — `HttpScrapeProvider` + `build_scrape_provider()`; hub injects
-   when `FACTORY_SCRAPE_URL` is set (hub unit sets `http://factory-scrape:8455`).
-4. **Done (#2327)** — container deploy path does not require `FACTORY_WEB_INTEL_PATH`
-   / host `~/projects` for hub scrape. Host-dev still falls back to `WebIntelScraper`.
-5. Optional: MCP or skill façade for agent runtime → same HTTP API.
-6. Optional later: retire hub `/explain`/`/summarize` if product prefers pure agent tools.
+2. **Done (#2327)** — scrape HTTP placement: contract + `HttpScrapeProvider` + Quadlet unit
+   + transitional in-tree extract (`factory scrape serve` / staging-svc).
+3. **Done (#2327)** — hub injects HTTP client when `FACTORY_SCRAPE_URL` is set
+   (`http://factory-scrape:8455`); fail-closed in container without it.
+4. **Done (#2338 / intel#27)** — engine ownership: **roxabi-intel** publishes
+   `ghcr.io/roxabi/intel-scrape` (web-intel + Playwright); factory Quadlet **pins**
+   that image (not factory Chromium layer).
+5. Optional: drop in-tree `scrape_service` extract once intel image is sole backend.
+6. Optional: MCP or skill façade for agent runtime → same HTTP API.
+7. Optional later: retire hub `/explain`/`/summarize` if product prefers pure agent tools.
 
 ---
 

--- a/src/factory/integrations/web_intel.py
+++ b/src/factory/integrations/web_intel.py
@@ -1,10 +1,13 @@
-"""WebIntelScraper — ScrapeProvider backed by the roxabi web-intel plugin (issue #360).
+"""WebIntelScraper — host-dev ScrapeProvider via roxabi-intel web-intel (issue #360).
 
 Invokes: uv run python scripts/scraper.py <url>
 inside the web-intel plugin directory (separate venv: playwright, trafilatura).
 
+Prod uses HttpScrapeProvider → intel-scrape image (factory#2338 / intel#27).
+This path is host-dev fallback only (when FACTORY_SCRAPE_URL is unset).
+
 Override plugin root with FACTORY_WEB_INTEL_PATH env var.
-Default: ~/projects/roxabi-plugins/plugins/web-intel
+Default: ~/projects/roxabi/roxabi-intel/plugins/web-intel
 """
 
 from __future__ import annotations
@@ -38,7 +41,12 @@ class WebIntelScraper:
             self._root = resolved
         else:
             self._root = plugin_root or (
-                Path.home() / "projects" / "roxabi-plugins" / "plugins" / "web-intel"
+                Path.home()
+                / "projects"
+                / "roxabi"
+                / "roxabi-intel"
+                / "plugins"
+                / "web-intel"
             )
 
     async def scrape(self, url: str, timeout: float = 30.0) -> str:

--- a/src/factory/scrape_service/extract.py
+++ b/src/factory/scrape_service/extract.py
@@ -1,4 +1,8 @@
-"""Fetch URL with redirect revalidation and extract plain text."""
+"""Fetch URL with redirect revalidation and extract plain text.
+
+Transitional (#2327): prod Quadlet pins ghcr.io/roxabi/intel-scrape (#2338).
+Do not grow this into a second long-term engine.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Quadlet `factory-scrape` pins **`ghcr.io/roxabi/intel-scrape:staging`** (engine owned by roxabi-intel)
- Exec → `python -m intel_scrape serve` (factory contract unchanged: `:8455`)
- Docs: ownership option 2; migration slice #2338
- Host-dev `WebIntelScraper` default path → `~/projects/roxabi/roxabi-intel/plugins/web-intel`
- In-tree httpx extract marked transitional

Closes #2338

### Depends on

- [Roxabi/roxabi-intel#28](https://github.com/Roxabi/roxabi-intel/pull/28) merged + image published to GHCR before M1 converge (or unit will fail to pull).

## Test plan

- [ ] intel PR CI green + image push on merge to staging
- [ ] `podman pull ghcr.io/roxabi/intel-scrape:staging`
- [ ] M1: unit starts, `/ready` 200
- [ ] Hub `/explain` or Discord bare URL smoke on non-trivial page