### PR TITLE
chore(omp): upgrade oh-my-pi to v17.2.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN useradd -u 1500 -m factory \
 # sha256 of /opt/omp/omp at startup, so a carrier bump must land together with
 # the _PINNED_SHA256 update. Placed before the builder COPY so code-only builds
 # keep this pinned layer cached.
-COPY --from=ghcr.io/roxabi/factory-omp-base:16.2.12 /opt/omp/omp /opt/omp/omp
+COPY --from=ghcr.io/roxabi/factory-omp-base:17.2.12 /opt/omp/omp /opt/omp/omp
 
 COPY --from=builder --chown=factory:factory /app /app
 
@@ -135,7 +135,7 @@ ENV FACTORY_GH_BIN=/opt/factory-gh/gh
 # ── omp_rpc Python package (#1871) ─────────────────────────────────────────────
 # omp_rpc is deliberately kept OUT of uv.lock (alpha lib, pin-by-SHA pattern —
 # #1807/#1810). Install at image build time from the pinned commit that matches
-# OMP_VERSION=v17.2.12 / factory-omp-base:16.2.12. The commit SHA is locked here;
+# OMP_VERSION=v17.2.12 / factory-omp-base:17.2.12. The commit SHA is locked here;
 # a version bump must update deploy/omp-base/Containerfile OMP_VERSION+OMP_SHA256,
 # src/factory/adapters/omp/_rpc_digest.py _PINNED_SHA256, AND this pin — in lockstep.
 # uv is not present in agent-runtime (only in builder); bring the static binary from
@@ -143,7 +143,7 @@ ENV FACTORY_GH_BIN=/opt/factory-gh/gh
 # the project lockfile.
 COPY --from=ghcr.io/astral-sh/uv:0.11.1 /uv /usr/local/bin/uv
 RUN uv pip install --python /app/.venv/bin/python \
-      "git+https://github.com/can1357/oh-my-pi@f70e4f1570872dc973a3f70f02dd8961969abe57#subdirectory=python/omp-rpc"
+      "git+https://github.com/can1357/oh-my-pi@45e12e5bb758198a920c6070e7e64cb33b21beac#subdirectory=python/omp-rpc"
 # Build-time import smoke — fails the image build if omp_rpc is mis-installed or
 # the subdirectory path changes upstream. Closes the "declared but never importable" gap.
 RUN /app/.venv/bin/python -c "import omp_rpc"

--- a/deploy/omp-base/Containerfile
+++ b/deploy/omp-base/Containerfile
@@ -1,5 +1,5 @@
-ARG OMP_VERSION=v16.2.12
-ARG OMP_SHA256=422650ce81304d4fbabc7b7ea3cc840b718ecc57a9fb00ae71660bec072677b2
+ARG OMP_VERSION=v17.2.12
+ARG OMP_SHA256=6c75331bf09d5a9e9433bd592b3ee993d751a15d5b7450c1a334cc0684996f30
 
 # apt layer isolated from the pin ARGs so a version bump never re-runs apt-get.
 FROM debian:12-slim AS base-tools

--- a/deploy/omp-base/README.md
+++ b/deploy/omp-base/README.md
@@ -12,7 +12,7 @@ contains exactly one file: `/opt/omp/omp` (mode 0755), copied from the official
 The image is built `FROM scratch` — no OS layer, no shell, no entrypoint. It never runs
 directly; consumer images pull the binary out via a `COPY --from=` stage.
 
-The tag is the omp version without the `v` prefix (e.g. `16.2.12`). Tags are **immutable** —
+The tag is the omp version without the `v` prefix (e.g. `17.2.12`). Tags are **immutable** —
 content changes require a version bump (see Immutability guard below).
 
 **Build trigger:** `.github/workflows/omp-base.yml` fires only on path `deploy/omp-base/**`.
@@ -49,7 +49,7 @@ Deep omp_rpc e2e validation on bump is **#1812 CI scope**, not this repo's CI.
 Consumer images (e.g. the OmpWorker stage in #1812) copy the binary out of the carrier:
 
 ```dockerfile
-COPY --from=ghcr.io/roxabi/factory-omp-base:16.2.12 /opt/omp/omp /usr/local/bin/omp
+COPY --from=ghcr.io/roxabi/factory-omp-base:17.2.12 /opt/omp/omp /usr/local/bin/omp
 ```
 
 **Runtime requirement:** the consumer image MUST be glibc-based. The `omp-linux-x64` binary

--- a/src/factory/adapters/omp/_rpc_digest.py
+++ b/src/factory/adapters/omp/_rpc_digest.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from pathlib import Path
 
-_PINNED_SHA256 = "422650ce81304d4fbabc7b7ea3cc840b718ecc57a9fb00ae71660bec072677b2"
+_PINNED_SHA256 = "6c75331bf09d5a9e9433bd592b3ee993d751a15d5b7450c1a334cc0684996f30"
 
 _OMP_BIN = Path("/opt/omp/omp")
 _ENV_REQUEST_TIMEOUT_KEY = "OMP_REQUEST_TIMEOUT"


### PR DESCRIPTION
## Summary
- Bump omp carrier + factory pin lockstep to **v17.2.12**
- `factory-omp-base:17.2.12` pre-published to GHCR (smoke `omp/17.2.12`, sha `6c75331b…`)
- Aligns: `deploy/omp-base/Containerfile`, `Dockerfile` COPY, `_PINNED_SHA256`, `omp_rpc` git `@45e12e5b`

## Why
Ship current oh-my-pi after JobResult fix (PR #2336). Carrier pre-published so PR docker-build can resolve the pin.

## Test plan
- [x] `tools/check_omp_pin_lockstep.sh` OK
- [x] local smoke `omp/17.2.12`
- [ ] CI green
- [ ] merge → publish factory:staging
- [ ] M₁ pull/restart factory-omp → `omp --version` = 17.2.12