### PR TITLE
fix(omp): OMP 17 model selector — drop legacy --provider

### DIFF
--- a/src/factory/adapters/omp/AGENTS.md
+++ b/src/factory/adapters/omp/AGENTS.md
@@ -46,6 +46,11 @@ then publishes per-job lifecycle events back to the bus.
   repo's `models.yml` is layered **read-only on top** (SSoT). The LiteLLM base URL override
   lives in `models.yml` under `providers.litellm.baseUrl` — it is NOT an env var.
 
+- **OMP 17 model selector** — CLI `--provider` is legacy and rejects models.yml providers
+  (`Unknown provider "litellm"`). `OmpPool` / `RpcBridge` start `RpcClient` with
+  `provider=None` and `model=compose_omp_cli_model(id)` → `--model litellm/<id>`.
+  Mid-turn switches still use `set_model(provider, bare_id)`.
+
 - **Writable runtime FS under `ReadOnly=true`** — omp also writes `$HOME/.omp` at boot
   (file-log transport + native modules unpacked & dlopen'd under `natives/`). It is a
   tmpfs at **`mode=1777`**: a root-owned `0755` tmpfs EACCESes for uid 1500, and `noexec`

--- a/src/factory/adapters/omp/_model_catalogue.py
+++ b/src/factory/adapters/omp/_model_catalogue.py
@@ -238,3 +238,29 @@ def resolve_startup_model() -> str:
 
 def first_registry_model() -> str | None:
     return resolve_fallback_model(requested=None)
+
+
+# OMP 17+: CLI `--provider` is legacy and rejects models.yml custom providers
+# ("Unknown provider litellm"). Prefer `--model provider/id` selector at process
+# start. Mid-turn `set_model(provider, model_id)` still uses split args.
+DEFAULT_OMP_PROVIDER = "litellm"
+
+
+def compose_omp_cli_model(
+    model_id: str,
+    *,
+    provider: str = DEFAULT_OMP_PROVIDER,
+) -> str:
+    """Compose the OMP CLI ``--model`` selector (``provider/id``).
+
+    Bare catalogue ids (from LiteLLM ``GET /models``) are prefixed with
+    *provider*. Values that already contain ``/`` are returned unchanged so
+    callers can pass a full selector.
+    """
+    bare = (model_id or "").strip()
+    if not bare:
+        return bare
+    if "/" in bare:
+        return bare
+    prov = (provider or DEFAULT_OMP_PROVIDER).strip() or DEFAULT_OMP_PROVIDER
+    return f"{prov}/{bare}"

--- a/src/factory/adapters/omp/_rpc_bridge.py
+++ b/src/factory/adapters/omp/_rpc_bridge.py
@@ -17,7 +17,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from factory.adapters.omp import _rpc_digest
-from factory.adapters.omp._model_catalogue import resolve_startup_model
+from factory.adapters.omp._model_catalogue import (
+    DEFAULT_OMP_PROVIDER,
+    compose_omp_cli_model,
+    resolve_startup_model,
+)
 from factory.adapters.omp._rpc_bridge_callbacks import RpcBridgeCallbacksMixin
 from factory.adapters.omp._rpc_bridge_steer import (
     RpcBridgeSteerMixin,
@@ -42,7 +46,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _DEFAULT_PROVIDER = (
-    "litellm"  # routes through factory LiteLLM proxy (deploy/omp/models.yml)
+    DEFAULT_OMP_PROVIDER  # models.yml providers.litellm → factory LiteLLM proxy
 )
 _OMP_BIN = _rpc_digest._OMP_BIN
 _PINNED_SHA256 = _rpc_digest._PINNED_SHA256
@@ -109,6 +113,9 @@ class RpcBridge(RpcBridgeCallbacksMixin, RpcBridgeSteerMixin):
             # provider/model are constructor kwargs only — no env axis. The runtime
             # model list comes from deploy/omp/models.yml (via PI_CODING_AGENT_DIR),
             # not from OMP_PROVIDER/OMP_MODEL env vars (#1876).
+            # OMP 17+: do not pass legacy --provider (rejects models.yml providers);
+            # pass --model provider/id selector instead. set_model() still uses
+            # split (provider, bare_id) mid-turn.
             resolved_timeout = (
                 request_timeout
                 if request_timeout is not None
@@ -116,8 +123,10 @@ class RpcBridge(RpcBridgeCallbacksMixin, RpcBridgeSteerMixin):
             )
             self._client = omp_rpc.RpcClient(
                 executable=str(omp_bin),
-                provider=resolved_provider,
-                model=resolved_model,
+                provider=None,
+                model=compose_omp_cli_model(
+                    resolved_model, provider=resolved_provider
+                ),
                 no_session=False,
                 request_timeout=resolved_timeout,
             )

--- a/src/factory/adapters/omp/omp_pool.py
+++ b/src/factory/adapters/omp/omp_pool.py
@@ -38,6 +38,8 @@ log = logging.getLogger(__name__)
 # omp binary path — image-build constant (NEVER from env). The sha256 pin + its
 # verification live in _rpc_bridge (_verify_digest) — reused, not duplicated.
 _OMP_BIN = Path("/opt/omp/omp")
+# Provider id for models.yml / set_model — not passed as OMP CLI --provider (legacy
+# on OMP 17+; see compose_omp_cli_model).
 _DEFAULT_PROVIDER = "litellm"
 
 # max concurrent omp workers — size to available RAM (each worker ≈ one omp subprocess).
@@ -211,7 +213,10 @@ class OmpPool:
         # Deferred import — omp_rpc is a container image dep (absent from pyproject).
         import omp_rpc  # type: ignore[import-not-found]
 
-        from factory.adapters.omp._model_catalogue import resolve_startup_model
+        from factory.adapters.omp._model_catalogue import (
+            compose_omp_cli_model,
+            resolve_startup_model,
+        )
         from factory.adapters.omp._rpc_bridge import (
             RpcBridge,
             _read_request_timeout,
@@ -230,10 +235,16 @@ class OmpPool:
             if self._request_timeout is not None
             else _read_request_timeout()
         )
+        # OMP 17+: legacy --provider rejects models.yml providers ("Unknown
+        # provider litellm"). Start with --model provider/id only; keep
+        # self._provider for mid-turn set_model(provider, bare_id).
         client_kwargs: dict[str, Any] = {
             "executable": str(self._omp_bin),
-            "provider": self._provider,
-            "model": resolved_model,
+            "provider": None,
+            "model": compose_omp_cli_model(
+                resolved_model,
+                provider=self._provider or _DEFAULT_PROVIDER,
+            ),
             "no_session": False,
             "request_timeout": resolved_timeout,
         }

--- a/tests/adapters/omp/test_model_catalogue.py
+++ b/tests/adapters/omp/test_model_catalogue.py
@@ -89,6 +89,20 @@ def mock_gateway(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         catalogue._load_litellm_provider.cache_clear()
 
 
+def test_compose_omp_cli_model_prefixes_bare_id() -> None:
+    assert catalogue.compose_omp_cli_model("grok-4.5") == "litellm/grok-4.5"
+    assert (
+        catalogue.compose_omp_cli_model("grok-4.5", provider="factory-litellm")
+        == "factory-litellm/grok-4.5"
+    )
+
+
+def test_compose_omp_cli_model_keeps_existing_selector() -> None:
+    assert (
+        catalogue.compose_omp_cli_model("litellm/grok-4.5") == "litellm/grok-4.5"
+    )
+
+
 def test_resolve_boot_model_uses_first_catalogue_id(mock_gateway: None) -> None:
     assert catalogue.resolve_boot_model() == "deepseek-v4-pro"
 

--- a/tests/adapters/omp/test_rpc_bridge.py
+++ b/tests/adapters/omp/test_rpc_bridge.py
@@ -796,11 +796,14 @@ class TestStartLifecycle:
         assert received_kwargs.get("no_session") is False, (
             "no_session=False must be passed to RpcClient"
         )
-        assert received_kwargs.get("provider") == "litellm", (
-            f"expected provider='litellm', got: {received_kwargs.get('provider')}"
+        # OMP 17+: no legacy --provider; model is the provider/id selector.
+        assert received_kwargs.get("provider") is None, (
+            f"expected provider=None (OMP 17 selector path), "
+            f"got: {received_kwargs.get('provider')}"
         )
-        assert received_kwargs.get("model") == "grok-test-non-reasoning", (
-            f"expected resolved startup model, got: {received_kwargs.get('model')}"
+        assert received_kwargs.get("model") == "litellm/grok-test-non-reasoning", (
+            "expected litellm/<startup model> selector, "
+            f"got: {received_kwargs.get('model')}"
         )
         assert received_kwargs.get("request_timeout") == _DEFAULT_REQUEST_TIMEOUT, (
             "expected default request_timeout when unset"

--- a/tests/llm/drivers/test_omp_pool.py
+++ b/tests/llm/drivers/test_omp_pool.py
@@ -270,7 +270,9 @@ class TestOmpPool:
         assert captured_kwargs.get("no_session") is False, (
             f"Expected no_session=False, got kwargs={captured_kwargs}"
         )
-        assert captured_kwargs.get("model") == "grok-test-non-reasoning"
+        # OMP 17+: provider=None + litellm/<id> selector (legacy --provider broken)
+        assert captured_kwargs.get("provider") is None
+        assert captured_kwargs.get("model") == "litellm/grok-test-non-reasoning"
         assert captured_kwargs.get("request_timeout") == _DEFAULT_REQUEST_TIMEOUT
 
         await pool.aclose()
@@ -311,7 +313,8 @@ class TestOmpPool:
         finally:
             sys.modules.pop("omp_rpc", None)
 
-        assert captured_kwargs.get("model") == "grok-test-non-reasoning"
+        assert captured_kwargs.get("provider") is None
+        assert captured_kwargs.get("model") == "litellm/grok-test-non-reasoning"
         await pool.aclose()
 
     # -- Bonus: _read_cap falls back to default -----------------------------


### PR DESCRIPTION
## Summary
- OMP 17.2.12 rejects CLI `--provider litellm` for models.yml providers (`Unknown provider "litellm"`), which breaks Aryl / omp-rpc after the 17.2.12 lockstep.
- Proven live: `omp models` lists `litellm` (6 Grok models) with `LITELLM_API_KEY`, but `omp --mode rpc --provider litellm --model <id>` exits; `omp --mode rpc --model litellm/<id>` reaches ready + pong.
- Start `RpcClient` with `provider=None` and `model=compose_omp_cli_model(id)` → `--model litellm/<id>`. Mid-turn `set_model(provider, bare_id)` unchanged (verified).

## Test plan
- [x] `uv run python -m pytest tests/adapters/omp/ -n0` (85 passed)
- [ ] Merge → publish `factory:staging` → restart `factory-omp`
- [ ] Probe JobResult pong / Telegram Aryl reply