### PR TITLE
docs(architecture): add dev-factory design notes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,17 @@
 | [workers-tooling.md](architecture/workers-tooling.md) | Tool taxonomy & runtime vocabulary, CliPool, processor registry, tool integration, importlinter |
 | [scrape-placement.md](architecture/scrape-placement.md) | Web scrape placement — hub subprocess → HTTP service / agent tool; vault-add removed |
 | [job-model.md](architecture/job-model.md) | Job model — `job_id`=run, lifecycle, active-jobs registry, `factory.job.<id>.*` taxonomy, transport tiers, sub-jobs, runtime control |
+| [dev-factory.md](architecture/dev-factory.md) | **Dev Factory** (design) — usine de dev Gosilex/Spark : architecture, flow, Work vs Job, sandboxes ; vocabulaire → [dev-factory-terminology.md](architecture/dev-factory-terminology.md) |
 | [observability.md](architecture/observability.md) | Observability planes, control-plane dashboard, trace + log engines, operator audit, fleet/pipeline read models, ingress |
+
+**Dev Factory — bases de réflexion** (`status: reflection`, non-normative — ¬SSoT runtime) :
+
+| Note | What it explores |
+|---|---|
+| [dev-factory-work-contract.md](architecture/dev-factory-work-contract.md) | Champs & états du Work |
+| [dev-factory-runners.md](architecture/dev-factory-runners.md) | Catalogue runners + StepResult |
+| [dev-factory-spark-ingress.md](architecture/dev-factory-spark-ingress.md) | Ingress Spark + Outbound |
+| [dev-factory-implementation-slices.md](architecture/dev-factory-implementation-slices.md) | Ordre de build / slices |
 | [engineering-standards.md](architecture/engineering-standards.md) | **Cross-repo doctrine** (all Roxabi repos) — Clean/Hexagonal/Kernel layering, error contract, testing conventions, CI quality gates |
 | [CURRENT.generated.md](architecture/CURRENT.generated.md) | **Generated** — machine-generated inventory SSoT: layers, subjects, topology, entry points |
 

--- a/docs/architecture/dev-factory-implementation-slices.md
+++ b/docs/architecture/dev-factory-implementation-slices.md
@@ -1,0 +1,156 @@
+---
+id: dev-factory-implementation-slices
+title: Dev Factory — slices d’implémentation
+status: reflection
+kind: base-de-reflexion
+authority: non-normative
+date: 2026-08-11
+scope: >
+  Découpage proposé des briques en slices livrables (ordre de construction).
+  ¬issues GitHub créées · ¬engagement de dates · ¬scope figé.
+parent: dev-factory.md
+related:
+  - dev-factory.md
+  - dev-factory-terminology.md
+  - dev-factory-work-contract.md
+  - dev-factory-runners.md
+  - dev-factory-spark-ingress.md
+---
+
+# Dev Factory — slices d’implémentation
+
+> **Base de réflexion** — ordre de build pour ne pas commencer par le YAML final.
+> À transformer plus tard en epic / issues GH si on lance le chantier.
+> Parent : [dev-factory.md](./dev-factory.md).
+
+## Principe
+
+Construire les **contrats de briques** d’abord ; le Workflow YAML riche (F-full, loops) vient quand les runners existent.
+
+Preuve à chaque slice = comportement observable (CLI, test, ticket Spark de dogfood), pas « doc only ».
+
+---
+
+## Carte des docs de réflexion
+
+| Doc | Question |
+|---|---|
+| [dev-factory-terminology.md](./dev-factory-terminology.md) | Comment on nomme ? (**ratified**) |
+| [dev-factory.md](./dev-factory.md) | Comment ça s’assemble ? (**design**) |
+| [dev-factory-work-contract.md](./dev-factory-work-contract.md) | Qu’est-ce qu’un Work en data/états ? |
+| [dev-factory-runners.md](./dev-factory-runners.md) | Comment un step s’exécute ? |
+| [dev-factory-spark-ingress.md](./dev-factory-spark-ingress.md) | Comment Spark entre/sort ? |
+| **ce doc** | Dans quel ordre on build ? |
+
+---
+
+## Slices proposées
+
+### Slice 0 — Squelette Work + Engine
+
+| Livrable | Preuve |
+|---|---|
+| Work Registry (store minimal + get_or_create) | CLI ou test : create/resume unicité ticket |
+| Workflow Engine (sequence + terminal + loop counter) | YAML jouet 2–3 steps avance un Work en mémoire/disk |
+| Loader YAML + validation types basiques | reject type inconnu |
+
+**Hors slice** : Spark, git, sandbox, agent.
+
+### Slice 1 — Ingress mince + readiness LLM
+
+| Livrable | Preuve |
+|---|---|
+| Poll Spark `status=todo` (allowlist client) | ticket dogfood → Work créé |
+| Event normalisé + dedupe | double poll ≠ double Work |
+| Runner `llm` readiness | outputs structured en store |
+| Runner `spark.comment` | comment visible si blocked |
+
+**Hors slice** : branch, sandbox, agent.
+
+### Slice 2 — Provision Git
+
+| Livrable | Preuve |
+|---|---|
+| `github.ensure_issue` | issue GH liée au ticket |
+| `git.ensure_branch` | branch `feat/…` poussée depuis staging |
+| Update Work `gh_issue`, `branch`, `head_sha` | registry cohérent |
+
+### Slice 3 — Sandbox lifecycle
+
+| Livrable | Preuve |
+|---|---|
+| Sandbox Manager ensure / hibernate / destroy | cwd stable, idle sweeper unitaire ou manuel |
+| Bind Work ↔ sandbox_id | destroy ne casse pas Work/branch |
+
+### Slice 4 — Agent step
+
+| Livrable | Preuve |
+|---|---|
+| Runner `agent` (backend omp ou clipool) | 1 step (frame **ou** implement S) |
+| Commit artefacts via GitOps | fichiers sur la branch |
+| Job meta `{ work_id, step_id, attempt }` | observable job-model |
+
+### Slice 5 — PR / CI / loops
+
+| Livrable | Preuve |
+|---|---|
+| `gh.pr_create` + `gh.wait_checks` | PR + conclusion |
+| Loop YAML bornée (ci red → fix/implement) | `max_iters` → fail propre |
+| Outbound `staging` post-merge | statut Spark correct (¬done) |
+
+### Slice 6 — HITL + polish
+
+| Livrable | Preuve |
+|---|---|
+| Gate `waiting_hitl` + signal reprise | approve reprend engine |
+| Hibernate sandbox pendant wait | idle respecté |
+| (opt) webhook Spark | latence ↓ |
+| (opt) Mermaid depuis YAML | doc/dashboard |
+
+---
+
+## Dépendances
+
+```
+S0 ──▶ S1 ──▶ S2 ──▶ S3 ──▶ S4 ──▶ S5
+                      │              │
+                      └──────────────┴──▶ S6 (HITL peut glisser dès S4)
+```
+
+S1 peut dogfood métier sans git.  
+S4 est le premier « vrai dev ».  
+S5 ferme la boucle livrable Silex.
+
+---
+
+## Taille / risque (rough)
+
+| Slice | Risque principal |
+|---|---|
+| S0 | Sur-designer l’engine avant un YAML réel |
+| S1 | Qualité readiness LLM ; flakiness API Spark |
+| S2 | Auth GH multi-repo ; conventions branch |
+| S3 | Chemins host, perms, fuite disk |
+| S4 | Coût tokens, non-déterminisme agent, omp ops |
+| S5 | Flaky CI ; boucles mal bornées |
+| S6 | UX HITL ambiguë |
+
+---
+
+## Hors backlog réflexion (plus tard)
+
+- Généralisation hors Gosilex  
+- Runtime Nika  
+- Dashboard Dev Factory dédié  
+- Multi-sandbox containers durs  
+- Board Spark « Tâches »  
+
+---
+
+## Graduation
+
+Quand on lance le chantier :
+
+1. Epic GH (ou Spark) pointant ces slices  
+2. Issues par slice avec AC = colonne « Preuve »  
+3. Ce doc → archive ou `status: superseded` par l’epic living  

--- a/docs/architecture/dev-factory-runners.md
+++ b/docs/architecture/dev-factory-runners.md
@@ -1,0 +1,184 @@
+---
+id: dev-factory-runners
+title: Dev Factory — catalogue runners & StepResult
+status: reflection
+kind: base-de-reflexion
+authority: non-normative
+date: 2026-08-11
+scope: >
+  Esquisse du contrat Step Runner / StepResult et d’un catalogue de `type`
+  pour le Workflow Engine. ¬implémentation · ¬schéma wire figé · ¬ratifié.
+parent: dev-factory.md
+related:
+  - dev-factory.md
+  - dev-factory-terminology.md
+  - dev-factory-work-contract.md
+  - job-model.md
+---
+
+# Dev Factory — runners & StepResult
+
+> **Base de réflexion** — catalogue et contrats d’exécution de steps.
+> Pas de code, pas de subjects NATS figés. Amendable librement.
+> Parent : [dev-factory.md](./dev-factory.md).
+
+## Intent
+
+L’**Workflow Engine** ne connaît que des `type` de steps.  
+Chaque `type` est implémenté par un **Step Runner** enregistré dans le **Runner Catalog**.
+
+Règle d’or (terminology) : **1 exécution de step = 1 Job** (retry = nouveau Job, `attempt+1`).
+
+---
+
+## Contrat générique
+
+### WorkContext (entrée runner)
+
+Données lues par le runner — **lecture** principalement ; mutations Work via engine après `StepResult`.
+
+| Champ (indicatif) | Contenu |
+|---|---|
+| `work` | snapshot Work (ids, branch, tier, readiness, …) |
+| `step_id` | nom du step YAML |
+| `step_cfg` | bloc config du step (prompt, paths, skill, …) |
+| `attempt` | n° de tentative Job |
+| `cwd` | chemin sandbox si ensure déjà fait (sinon null) |
+| `secrets` | handles / refs, pas de secrets en clair dans logs |
+
+### StepResult (sortie)
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `status` | `ok` \| `fail` \| `wait` | pilotage engine |
+| `outputs` | object | données pour transitions / steps suivants |
+| `message` | string? | résumé humain / Outbound |
+| `artifacts` | path[]? | chemins relatifs à commit (si agent/git) |
+| `wait_reason` | `hitl` \| `blocked` \| `external`? | si `wait` |
+| `error` | string? | si `fail` |
+| `touch_sandbox` | bool? | refresh `last_activity_at` |
+
+#### Sémantique `status`
+
+| `status` | Engine |
+|---|---|
+| `ok` | suit `on.ok` / transition succès du step |
+| `fail` | retry policy step **ou** `on.fail` **ou** Work `failed` |
+| `wait` | Work → `waiting_hitl` / `waiting_blocked` ; **pas** de step suivant tant que signal de reprise |
+
+Le runner **ne choisit pas** le prochain `step_id` (sauf outputs que le YAML conditionne). L’engine applique le graphe.
+
+---
+
+## Interface runner (pseudo)
+
+```
+protocol StepRunner:
+  type: str                    # clé catalog
+  needs_sandbox: bool          # hint static ou dérivé de step_cfg
+  async run(ctx: WorkContext) -> StepResult
+```
+
+Enregistrement :
+
+```
+RunnerCatalog.register(runner)
+RunnerCatalog.get("llm") -> StepRunner
+```
+
+Type YAML inconnu → fail validation workflow **avant** exécution (load-time).
+
+---
+
+## Catalogue v0 proposé (types)
+
+### Contrôle de flux (engine-native ou runners triviaux)
+
+| `type` | Rôle | Sandbox |
+|---|---|---|
+| `sequence` | sous-liste ordonnée (macro-step) | — |
+| `switch` | branchement sur expression (`tier`, `ready`, …) | non |
+| `terminal` | fin de Work (`completed` / mapping status) | non |
+
+> Alternative : `sequence` / `switch` / `terminal` **hors** catalog, syntaxe engine pure. À trancher (R1).
+
+### Métier & IO
+
+| `type` | Rôle | Sandbox | Outputs typiques |
+|---|---|---|---|
+| `llm` | call structuré (readiness, classify) | non | object schema-validé |
+| `spark.comment` | Outbound commentaire ticket | non | `comment_id`? |
+| `spark.patch` | patch status / champs | non | `status` |
+| `github.ensure_issue` | create/link issue via Spark ou gh | non | `gh_issue` |
+| `git.ensure_branch` | crée/checkout branch | non\* | `branch`, `head_sha` |
+| `sandbox.ensure` | alloue / warm sandbox | — | `sandbox_id`, `cwd` |
+| `sandbox.hibernate` | force hibernate | — | — |
+| `agent` | tour Agent Runtime + tools | souvent oui | `summary`, `artifacts[]` |
+| `gh.pr_create` | ouvre PR | non | `pr_url`, `pr_number` |
+| `gh.wait_checks` | attend CI | non | `conclusion` green/red |
+
+\* `git.ensure_branch` peut s’exécuter hors sandbox (clone éphémère) ou dans sandbox vide — **à trancher** (R2).
+
+### Runner `agent` — détails
+
+| step_cfg (indicatif) | Rôle |
+|---|---|
+| `skill` | pack contrat (`frame`, `spec`, `implement`, …) |
+| `backend` | `omp-rpc` \| `clipool` \| inherit Work/defaults |
+| `commit.paths` | globs à commit post-run si OK |
+| `gate` | `hitl` → Result `wait` après commit artefacts ? ou step séparé |
+
+Deux shapes possibles pour HITL :
+
+- **A** : runner `agent` finit `ok` + step suivant `type: gate` / `hitl`  
+- **B** : `agent` avec `gate: hitl` renvoie `wait` après artefacts  
+
+Préférence réflexion : **A** (séparation claire) — non figé.
+
+---
+
+## Mapping Job factory
+
+| | |
+|---|---|
+| Mint | engine crée Job avant `runner.run` |
+| Meta | `{ work_id, step_id, attempt, workflow_id, runner_type }` |
+| Progress | optionnel pour `agent` long (`factory.job.<id>.progress`) |
+| Result | `StepResult` sérialisé dans JobResult / side-channel engine |
+
+Steps purement locaux ultra-courts (`switch`) peuvent **ne pas** mint de Job — exception documentée (R3). Sinon uniformité : tout step = Job.
+
+---
+
+## Erreurs & retries
+
+| Cas | Comportement proposé |
+|---|---|
+| Erreur transport / 5xx Spark | retry Job (`attempt+1`) borné |
+| Validation LLM schema fail | retry ou `fail` selon step_cfg |
+| `max_iters` loop workflow | `fail` Work + Outbound (pas retry infini) |
+| Agent timeout | `fail` Job ; policy step |
+
+---
+
+## Questions ouvertes
+
+| # | Question |
+|---|---|
+| R1 | `switch`/`sequence`/`terminal` = engine AST ou runners ? |
+| R2 | git hors sandbox ou toujours après `sandbox.ensure` ? |
+| R3 | Jobs pour steps triviaux ? |
+| R4 | Où vivent les packs `skill` (prompts) : factory repo vs package ? |
+| R5 | L’agent a-t-il le droit d’appeler Spark directement, ou seulement via runners Outbound ? (biais : **non**, whitelist tools) |
+| R6 | Subjects `factory.jobs.dev.*` vs réutiliser queues existantes |
+
+---
+
+## Graduation
+
+Ratification → :
+
+- interfaces Python dans `src/factory/…`
+- table `type` stable (semver breaking si rename)
+- tests contrat par runner
+- page living ou section de `dev-factory.md` / workers-tooling

--- a/docs/architecture/dev-factory-runners.md
+++ b/docs/architecture/dev-factory-runners.md
@@ -35,7 +35,7 @@ Règle d’or (terminology) : **1 exécution de step = 1 Job** (retry = nouveau 
 
 ### WorkContext (entrée runner)
 
-Données lues par le runner — **lecture** principalement ; mutations Work via engine après `StepResult`.
+Données lues par le runner — **lecture** principalement ; mutations Work via engine après `StepResult`. <!-- drift-ignore -->
 
 | Champ (indicatif) | Contenu |
 |---|---|
@@ -144,7 +144,7 @@ Préférence réflexion : **A** (séparation claire) — non figé.
 | Mint | engine crée Job avant `runner.run` |
 | Meta | `{ work_id, step_id, attempt, workflow_id, runner_type }` |
 | Progress | optionnel pour `agent` long (`factory.job.<id>.progress`) |
-| Result | `StepResult` sérialisé dans JobResult / side-channel engine |
+| Result | `StepResult` sérialisé dans JobResult / side-channel engine | <!-- drift-ignore -->
 
 Steps purement locaux ultra-courts (`switch`) peuvent **ne pas** mint de Job — exception documentée (R3). Sinon uniformité : tout step = Job.
 
@@ -178,7 +178,7 @@ Steps purement locaux ultra-courts (`switch`) peuvent **ne pas** mint de Job —
 
 Ratification → :
 
-- interfaces Python dans `src/factory/…`
+- interfaces Python dans `src/factory/…` <!-- drift-ignore -->
 - table `type` stable (semver breaking si rename)
 - tests contrat par runner
 - page living ou section de `dev-factory.md` / workers-tooling

--- a/docs/architecture/dev-factory-spark-ingress.md
+++ b/docs/architecture/dev-factory-spark-ingress.md
@@ -1,0 +1,215 @@
+---
+id: dev-factory-spark-ingress
+title: Dev Factory — Ingress Spark & Outbound
+status: reflection
+kind: base-de-reflexion
+authority: non-normative
+date: 2026-08-11
+scope: >
+  Esquisse connector Ingress Spark (events, dedupe, poll vs webhook) et
+  canal Outbound (comments, status). Cas v0 Gosilex. ¬wire figé · ¬ratifié.
+parent: dev-factory.md
+related:
+  - dev-factory.md
+  - dev-factory-terminology.md
+  - dev-factory-work-contract.md
+  - observability.md
+---
+
+# Dev Factory — Ingress Spark & Outbound
+
+> **Base de réflexion** — comment Spark parle à factory et inversement.
+> S’appuie sur le pattern connector (ADR-096 / `src/factory/ingress/`) sans le spécifier ligne à ligne.
+> Parent : [dev-factory.md](./dev-factory.md).
+
+## Intent
+
+| Direction | Brique | Rôle |
+|---|---|---|
+| Spark → factory | **Ingress** | signaux métier → events normalisés → Work Registry |
+| factory → Spark | **Outbound** | comments, patch status ; canal contrôlé |
+
+Spark reste la **vérité métier** pour l’humain (board Pilotage).  
+Factory reste la **vérité d’orchestration** dev (Work, steps, jobs).
+
+---
+
+## Périmètre v0 (Gosilex)
+
+| In scope | Out of scope v0 |
+|---|---|
+| Tickets **Pilotage** (pas board Tâches) | Webhooks multi-tenant génériques |
+| Trigger principal : `status → todo` | Sync bidirectionnelle complète de tous les champs |
+| Tâches **enfant** (épic = contexte) | Auto-dev sur l’épic entier |
+| Links `parent`, `blocked_by`, `blocks` pour readiness | Toutes relations Spark |
+| Comment + patch `staging` (pas `done` prématuré) | Notifs client publiques automatiques |
+
+Rappel métier Silex : après merge **staging** → status Spark `staging` ; **`done`** seulement après promote main/prod (éviter faux « Livré »).
+
+---
+
+## Ingress — formes d’entrée
+
+### Option A — Poll (biais v0)
+
+```
+cron / factory timer
+  → GET tickets search?status=todo&client=…
+  → pour chaque ticket : emit event interne
+  → Work Registry get_or_create / resume
+```
+
+| Pour | Contre |
+|---|---|
+| Simple, pas de dep webhook Spark | Latence (minute) |
+| Facile à dédupliquer | Charge API si large |
+
+### Option B — Webhook
+
+```
+Spark status_changed → HTTP ingress factory
+  → Connector.spark.verify
+  → normalize → LyraEvent / DevFactoryEvent
+  → same path que poll
+```
+
+| Pour | Contre |
+|---|---|
+| Temps réel | Exige endpoint + secret + support Spark |
+| Moins de poll | Ops (TLS, ACL, replay) |
+
+**Biais réflexion** : poll v0 → webhook quand le signal est stable.
+
+Les deux doivent produire le **même event normalisé**.
+
+---
+
+## Event normalisé (proposition)
+
+```yaml
+# conceptuel — pas un schema JSON figé
+source: spark
+event_type: ticket.status_changed   # ou ticket.todo_observed
+occurred_at: iso8601
+dedupe_key: "spark:{client}:{ticket_cuid}:todo:{status_version_or_updated_at}"
+
+spark:
+  client: metalyde
+  ticket_cuid: "clx…"
+  ticket_ref: 42
+  status: todo
+  title: "…"
+  body: "…"          # optionnel à l’ingress (fetch lazy OK)
+  project_id: "…"
+  project_name: "…"
+  github_repo: "org/repo"   # si connu
+  links:                    # optionnel à l’ingress ; readiness peut re-fetch
+    parent: […]
+    blocked_by: […]
+    blocks: […]
+```
+
+### Dedupe
+
+| Règle | |
+|---|---|
+| Même `dedupe_key` déjà traité récemment | drop |
+| Ticket avec Work non-terminal | **resume** (ne pas créer) |
+| Ticket terminal `completed` + nouveau `todo` | politique ouverte (W2 work-contract) |
+
+---
+
+## Mapping Ingress → Work
+
+```
+event
+  → WorkRegistry.get_open(client, cuid)
+       ├─ exists → touch, maybe re-queue engine if waiting_* and signal = todo/approve
+       └─ none   → create Work { workflow_id: gosilex-dev, step: readiness, status: queued }
+  → Engine.advance(work)  # ou enqueue
+```
+
+L’Ingress **ne lance pas** readiness lui-même : il assure seulement l’event + Work.
+
+---
+
+## Outbound — opérations
+
+| Op | Usage | Notes |
+|---|---|---|
+| `comment` | blocked, progress, PR link, HITL prompt | défaut **internal** staff |
+| `patch_status` | `staging` post-merge ; éventuellement autres | **pas** `done` auto staging |
+| (plus tard) `patch` champs custom | — | — |
+
+### Qui appelle Outbound ?
+
+| Acteur | Autorisé ? |
+|---|---|
+| Runner `spark.*` | **oui** — chemin nominal |
+| Agent Runtime tools | biais **non** (ou allowlist stricte) |
+| Engine direct | non — passe par runner |
+
+---
+
+## Auth & secrets
+
+| Secret | Usage |
+|---|---|
+| Spark PAT / M2M (`spu_…` ou équivalent factory) | API tickets |
+| Webhook signing secret | si Option B |
+| GitHub token | GitOps (brique séparée ; repo depuis projet Spark) |
+
+Même discipline secrets que le reste factory (pas de PAT dans logs, podman secrets / env scoped).
+
+---
+
+## Connector factory (esquisse placement)
+
+Aligné ADR-096 / `ingress.ports.Connector` :
+
+| Méthode | Spark |
+|---|---|
+| `name` | `spark` |
+| `verify` | signature webhook ou no-op poll interne |
+| `parse_external_id` | `ticket_cuid` ou `client:ref` |
+| `normalize` | → event ci-dessus |
+| `apply_lifecycle` | install/enable tenant (si multi-client plus tard) |
+
+Poll peut **contourner** HTTP et publier en interne le même `normalize` output — important pour un seul chemin engine.
+
+---
+
+## Fetch readiness (lazy)
+
+L’event ingress peut être **mince**. Le step `llm` readiness (ou un pre-runner) fait :
+
+```
+tickets get + links + comments (+ parent epic get)
+→ prompt structured
+→ outputs ready/blocked/tier
+→ si blocked : Outbound comment
+```
+
+Évite de surcharger l’ingress et garde un seul endroit « vérité ticket ».
+
+---
+
+## Questions ouvertes
+
+| # | Question |
+|---|---|
+| S1 | Poll interval & multi-client allowlist config |
+| S2 | Spark expose-t-il déjà un webhook status ? (à vérifier côté produit) |
+| S3 | Signal HITL : comment magic `/approve` vs label vs bouton UI |
+| S4 | Idempotence `patch_status` si déjà `staging` |
+| S5 | Faut-il un event `ticket.updated` pour re-readiness auto ? |
+| S6 | Tenant factory = `spark_client` ou org Gosilex unique v0 |
+
+---
+
+## Graduation
+
+- Connector + tests verify/normalize  
+- Runbook `runbooks/ingress-spark.md` (miroir `ingress-webhooks.md`)  
+- `status: living` section dans domain page ou merge partiel dans `dev-factory.md`  
+- ACL NATS / identity si worker poll dédié  

--- a/docs/architecture/dev-factory-terminology.md
+++ b/docs/architecture/dev-factory-terminology.md
@@ -1,0 +1,135 @@
+---
+id: dev-factory-terminology
+title: Dev Factory — terminologie figée
+status: ratified
+kind: glossary
+authority: normative-for-naming
+date: 2026-08-10
+updated: 2026-08-11
+scope: >
+  Usine de développement (cas v0 Gosilex / Spark), runtime roxabi-factory.
+  Vocabulaire stable des briques — indépendant du contenu YAML des workflows.
+  Normatif pour les *noms* uniquement ; l’archi cible reste design/reflection.
+related:
+  - dev-factory.md
+  - dev-factory-work-contract.md
+  - dev-factory-runners.md
+  - dev-factory-spark-ingress.md
+  - dev-factory-implementation-slices.md
+  - job-model.md
+---
+
+# Dev Factory — terminologie
+
+Source de vérité des **noms de briques** et de leurs définitions
+(`authority: normative-for-naming`).
+
+Architecture & flow cible : [dev-factory.md](./dev-factory.md) (`status: design`).  
+Bases de réflexion (non-normatives) : work-contract · runners · spark-ingress · implementation-slices.
+
+Le YAML des workflows est **souple** ; cette terminologie est **stable**.
+
+**Règle d’or** : 1 exécution de step = **1 Job**. Pas de concept séparé « Step run ».
+
+---
+
+## Objets de vie
+
+| Terme | Définition |
+|---|---|
+| **Work** | Unité durable de développement, liée à un ticket Spark (puis issue GH + branch). Survit aux redémarrages, sandboxes et steps. Identifié par `work_id`. |
+| **Step** | Nœud nommé du workflow (ex. `readiness`, `frame`, `implement`). Décrit *quoi* faire à un moment donné du Work. Définition, pas exécution. |
+| **Job** | Exécution technique d’un Step pour un Work (aligné job-model factory : open → progress/steer → result). Métadonnées : `{ work_id, step_id, attempt, workflow_id }`. Retry = nouveau Job, même `step_id`, `attempt+1`. |
+| **Workflow** | Graphe déclaratif (YAML) : steps, transitions, conditions, boucles, gates. Versionnable, modifiable sans changer les briques. |
+| **Tier** | Classe de taille du Work (`S` \| `F-lite` \| `F-full`), issue du readiness ; oriente le sous-chemin du Workflow. |
+
+---
+
+## Briques système
+
+| Brique | Définition |
+|---|---|
+| **Ingress** | Entrée d’événements. Reçoit les signaux externes (ex. Spark ticket → `todo`), authentifie, normalise, déduplique. Ne décide pas du métier au-delà du signal. |
+| **Work Registry** | Stocke et retrouve les Works (état, step courant, branch, liens Spark/GH, sandbox, compteurs de boucle). Garantit create vs resume et unicité *ticket → Work actif*. |
+| **Workflow Engine** | Charge un Workflow, avance un Work step par step, applique transitions / switch / loops / gates. Dispatch vers les runners ; pas de logique Spark/Git en dur. |
+| **Step Runner** | Implémentation d’un `type` de step (`llm`, `agent`, `spark.comment`, `git.ensure_branch`, …). Contrat : `run(context) → StepResult`. |
+| **Runner Catalog** | Registre des `type` connus et de leur runner. Étendre le système = ajouter un type ici. |
+| **Sandbox** | Environnement d’exécution isolé (worktree v0, container plus tard) pour **un** Work. Éphémère ; n’est pas la source de vérité du Work. |
+| **Sandbox Manager** | Cycle de vie sandbox : `ensure`, `run`, `hibernate`, `destroy` + idle policy. Borne le parallélisme (`max_active`). |
+| **GitOps** | Opérations Git/GitHub : branche, commit, push, PR, checks CI. Isolation **1 Work ↔ 1 branch**. |
+| **Outbound** | Sortie métier vers Spark (commentaires, statut). Canal contrôlé. |
+| **Agent Runtime** | Moteur de tour LLM + tools (omp / clipool). Utilisé par le runner `agent` ; interchangeable. |
+| **Artifact** | Fichier produit par un step (frame, spec, plan, code…), **commité sur la branch du Work**. |
+| **Gate (HITL)** | Porte d’approbation : Work → `waiting_hitl` ; sandbox peut hiberner ; reprise sur signal humain. |
+| **Readiness** | Step (souvent `llm` seul) qui décide si le ticket est prêt, bloqué, et quel Tier — **avant** provision branch/sandbox. |
+
+---
+
+## Relations
+
+```
+Ingress  →  Work Registry  →  Workflow Engine
+                                  │
+                                  ▼
+                           Step Runner(s)
+                           ├── llm / spark / github  (souvent sans Sandbox)
+                           └── agent  →  Agent Runtime + Sandbox
+                                          │
+                                          ▼
+                                       GitOps (branch, Artifacts)
+                                          │
+                                          ▼
+                                       Outbound (Spark)
+```
+
+```
+Work  ──step courant──▶  Step (définition YAML)
+                            │
+                            ▼
+                          Job  (cette exécution)
+```
+
+### Règles d’or
+
+| Règle | |
+|---|---|
+| 1 ticket Spark en dev | ≤ **1 Work** actif |
+| 1 Work | ≤ **1 branch** · ≤ **1 Sandbox** active |
+| 1 Step en cours d’exécution | **1 Job** (retry = Job suivant, `attempt+1`) |
+| Reprise | **Work + branch (+ `head_sha`)** ; la Sandbox se recrée |
+| Workflow YAML | câblage souple ; ne redéfinit pas ces termes |
+
+---
+
+## Termes à éviter / préciser
+
+| Ambigu | Préférer |
+|---|---|
+| « Session » seule | **Work** (durable) ou **session Agent Runtime** (éphémère) |
+| « Pipeline » seule | **Workflow** (définition) ou **Job** (exécution) |
+| « Issue » seule | **Spark ticket** vs **GitHub issue** |
+| « Step run » | **Job** (fusionné — ne pas réintroduire) |
+| « Factory » = le workflow | Factory = **plateforme** ; workflow = fichier + engine |
+
+---
+
+## Liste minimale
+
+1. Ingress  
+2. Work / Work Registry  
+3. Workflow / Workflow Engine  
+4. Step / Job / Step Runner / Runner Catalog  
+5. Sandbox / Sandbox Manager  
+6. GitOps  
+7. Outbound  
+8. Agent Runtime  
+9. Artifact · Gate · Readiness · Tier  
+
+---
+
+## Hors scope de ce doc
+
+- Contenu exact des YAML de workflow (changeable)
+- Choix host M1 vs worker sandbox
+- Implémentation détaillée des runners
+- Généralisation hors Gosilex

--- a/docs/architecture/dev-factory-work-contract.md
+++ b/docs/architecture/dev-factory-work-contract.md
@@ -1,0 +1,174 @@
+---
+id: dev-factory-work-contract
+title: Dev Factory — contrat Work (champs & états)
+status: reflection
+kind: base-de-reflexion
+authority: non-normative
+date: 2026-08-11
+scope: >
+  Esquisse du modèle de données et de la machine d’états du Work.
+  Cas de réflexion v0 Gosilex/Spark. ¬SSoT runtime · ¬ratifié · ¬gate CI.
+parent: dev-factory.md
+related:
+  - dev-factory.md
+  - dev-factory-terminology.md
+  - job-model.md
+---
+
+# Dev Factory — contrat Work
+
+> **Base de réflexion** — pas une vérité runtime, pas un contrat wire figé.
+> Sert à discuter champs / états avant implémentation.
+> Vocabulaire : [dev-factory-terminology.md](./dev-factory-terminology.md).
+> Cadre : [dev-factory.md](./dev-factory.md).
+
+## Intent
+
+Le **Work** est l’unité durable multi-jours. Ce doc propose :
+
+1. un **schéma de champs** (registre)
+2. une **machine d’états** indicative
+3. les **invariants** à préserver à l’implémentation
+
+Tout est amendable tant que `status: reflection`.
+
+---
+
+## Identité
+
+| Champ | Type indicatif | Rôle |
+|---|---|---|
+| `work_id` | uuid | PK interne |
+| `workflow_id` | string | ex. `gosilex-dev` |
+| `workflow_version` | int \| semver | pin du YAML au moment du create (reprise stable) |
+
+### Liens métier (Spark)
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `spark_client` | string | slug client |
+| `spark_ticket_cuid` | string | id stable API |
+| `spark_ticket_ref` | string \| int | ref affichable (`42`) |
+
+**Unicité proposée (v0)** : au plus un Work *non-terminal* par `(spark_client, spark_ticket_cuid)`.
+
+### Liens code (GitHub)
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `gh_repo` | `owner/name` | repo du projet Spark |
+| `gh_issue` | int \| null | issue liée (après provision) |
+| `branch` | string \| null | ex. `feat/42-slug` |
+| `base_branch` | string | défaut `staging` |
+| `head_sha` | sha \| null | dernier commit connu du Work |
+
+### Exécution
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `step_id` | string \| null | step YAML courant |
+| `status` | enum | voir machine d’états |
+| `tier` | `S` \| `F-lite` \| `F-full` \| null | post-readiness |
+| `sandbox_id` | string \| null | handle Sandbox Manager |
+| `loop_counts` | map step→int | compteurs de boucles (`review_fix`, …) |
+| `last_job_id` | string \| null | dernier Job step |
+| `last_error` | string \| null | dernier échec lisible |
+| `readiness` | object \| null | snapshot structured (ready, blockers, missing, rationale) |
+
+### Horodatage / activité
+
+| Champ | Rôle |
+|---|---|
+| `created_at` | création Work |
+| `updated_at` | toute mutation registre |
+| `last_activity_at` | dernière activité step/sandbox (idle policy) |
+| `terminal_at` | si status terminal |
+
+---
+
+## Machine d’états (indicative)
+
+```
+                    ┌─────────┐
+           create → │ queued  │  (pool sandbox plein, ou attente engine)
+                    └────┬────┘
+                         │ schedule
+                         ▼
+                    ┌─────────┐
+          ┌────────▶│ running │◀────────┐
+          │         └────┬────┘         │
+          │              │              │
+          │    ┌─────────┼─────────┐    │
+          │    ▼         ▼         ▼    │
+          │ waiting_  waiting_  (step    │
+          │  hitl     blocked   ok →     │
+          │    │         │     next)     │
+          │    │         │              │
+          └────┴─────────┴──────────────┘
+                         │
+           fail / cancel / success
+                         ▼
+              completed | failed | cancelled
+```
+
+| Status | Signification | Sandbox typique |
+|---|---|---|
+| `queued` | accepté, pas encore de Job actif (ou pool saturé) | absente ou hibernated |
+| `running` | un Job de step est en cours (ou engine enchaîne) | active si step l’exige |
+| `waiting_hitl` | Gate humaine ; pas d’auto-advance | hibernate OK |
+| `waiting_blocked` | Readiness KO ou dépendance Spark | pas de sandbox dev |
+| `completed` | terminal OK | destroy policy |
+| `failed` | terminal erreur (loops max, crash non retriable) | destroy policy |
+| `cancelled` | terminal opérateur / abandon ticket | destroy |
+
+### Transitions à figer plus tard
+
+- `todo` Spark répété sur Work `waiting_*` → **resume** (`running`), pas nouveau Work  
+- `todo` sur Work `completed` → politique ouverte (noop vs nouveau cycle) — **à trancher**  
+- timeout HITL → `failed` vs reste `waiting_hitl` — **à trancher**
+
+---
+
+## Invariants proposés
+
+1. **¬deux Works non-terminaux** pour le même ticket Spark.  
+2. Si `branch` set → `gh_repo` set.  
+3. Si `status ∈ {running}` et step `needs_sandbox` → `sandbox_id` non null *ou* Job d’ensure en cours.  
+4. `head_sha` mis à jour seulement après commit GitOps réussi.  
+5. `tier` immuable après premier readiness OK (ou versionné explicitement si re-readiness).  
+6. Compteurs `loop_counts` monotones ; dépassement `max_iters` → `failed` + Outbound.
+
+---
+
+## Relation au Job
+
+```
+Work.step_id = "frame"
+  → mint Job { work_id, step_id: "frame", attempt: N }
+  → JobResult
+  → engine met à jour Work (step suivant | waiting_* | failed)
+```
+
+Le Work **n’est pas** un job longue durée unique (voir job-model).
+
+---
+
+## Questions ouvertes
+
+| # | Question |
+|---|---|
+| W1 | Store : SQLite local factory vs KV NATS vs les deux ? |
+| W2 | Re-readiness autorisée après `waiting_blocked` sans reset branch ? |
+| W3 | Champ `attempt` global vs seulement par step dans `loop_counts` / jobs ? |
+| W4 | Exposition dashboard / CLI (`factory work list`) — MVP champs minimaux ? |
+| W5 | Homonyme code : type `DevWork` vs `Work` pour éviter collision WorkEnvelope ? |
+
+---
+
+## Graduation
+
+Quand ratifié → merger le schéma dans une page living (ou ADR + store) et :
+
+- `status: living` (ou retirer ce fichier au profit du domain page)
+- `authority: normative`
+- lier les gates / tests d’invariants

--- a/docs/architecture/dev-factory-work-contract.md
+++ b/docs/architecture/dev-factory-work-contract.md
@@ -161,7 +161,7 @@ Le Work **n’est pas** un job longue durée unique (voir job-model).
 | W2 | Re-readiness autorisée après `waiting_blocked` sans reset branch ? |
 | W3 | Champ `attempt` global vs seulement par step dans `loop_counts` / jobs ? |
 | W4 | Exposition dashboard / CLI (`factory work list`) — MVP champs minimaux ? |
-| W5 | Homonyme code : type `DevWork` vs `Work` pour éviter collision WorkEnvelope ? |
+| W5 | Homonyme code : type `DevWork` vs `Work` pour éviter collision WorkEnvelope ? | <!-- drift-ignore -->
 
 ---
 

--- a/docs/architecture/dev-factory.md
+++ b/docs/architecture/dev-factory.md
@@ -1,0 +1,404 @@
+---
+id: dev-factory
+title: Dev Factory — architecture & flow
+status: design
+kind: architecture-target
+authority: non-normative
+date: 2026-08-10
+updated: 2026-08-11
+scope: >
+  Usine de développement sur roxabi-factory. Cas v0 = Gosilex / Spark
+  (tickets Pilotage → readiness → branch GitHub → pipeline dev).
+  Vocabulaire : dev-factory-terminology.md (ratified).
+  ¬SSoT runtime actuel — cible de design.
+related:
+  - dev-factory-terminology.md
+  - dev-factory-work-contract.md
+  - dev-factory-runners.md
+  - dev-factory-spark-ingress.md
+  - dev-factory-implementation-slices.md
+  - job-model.md
+  - messaging.md
+---
+
+# Dev Factory — architecture & flow
+
+> Status: **DESIGN** — cible à implémenter. Pas l’état runtime actuel (`authority: non-normative`).
+> Terminologie figée : [dev-factory-terminology.md](./dev-factory-terminology.md).
+> Job technique : [job-model.md](./job-model.md).
+>
+> **Bases de réflexion** (détail amendable, `status: reflection`) :
+> [work-contract](./dev-factory-work-contract.md) ·
+> [runners](./dev-factory-runners.md) ·
+> [spark-ingress](./dev-factory-spark-ingress.md) ·
+> [implementation-slices](./dev-factory-implementation-slices.md).
+
+## Thèse
+
+Factory devient le **runtime d’une usine de développement** en plus du hub chat multi-bot.
+
+- **Spark** = source métier (tickets, liens, statuts) et canal de feedback humain.
+- **GitHub** = isolation code (**1 Work ↔ 1 branch**) + artefacts reviewables.
+- **Workflow YAML** = câblage déclaratif (souple).
+- **Briques ci-dessous** = stable ; on étend le catalogue de runners, pas le moteur.
+
+Cas v0 : **Gosilex uniquement**. Généralisation multi-produit plus tard.
+
+---
+
+## Objectifs
+
+| Objectif | Comment |
+|---|---|
+| Déclencher le dev depuis le métier | Ingress Spark (`status → todo` sur ticket Pilotage) |
+| Ne pas coder un ticket pourri | **Readiness** (LLM, sans sandbox) avant provision |
+| Isoler et paralléliser | 1 Work = 1 branch = ≤1 Sandbox active |
+| Multi-étapes + loops | Workflow Engine + transitions / `max_iters` |
+| Artefacts durables | commits sur la branch (frames, specs, code) |
+| Coût compute borné | Sandbox hibernate / destroy sur idle |
+| Lisible / modifiable | Workflow en YAML (esprit Nika) ; graphe Mermaid = phase 2 |
+
+Non-objectifs v0 : board Spark « Tâches » (≠ Pilotage), multi-clients hors allowlist Gosilex, runtime Nika AGPL, dashboard dédié parfait.
+
+---
+
+## Architecture logique
+
+```
+                         ┌──────────────────────────────────────┐
+   Spark webhook/poll ──▶│              INGRESS                 │
+                         │  verify · normalize · dedupe         │
+                         └──────────────────┬───────────────────┘
+                                            │ event
+                         ┌──────────────────▼───────────────────┐
+                         │           WORK REGISTRY              │
+                         │  get_or_create · resume · state      │
+                         └──────────────────┬───────────────────┘
+                                            │ Work
+                         ┌──────────────────▼───────────────────┐
+                         │         WORKFLOW ENGINE              │
+                         │  load YAML · advance · gates · loops │
+                         └──────────────────┬───────────────────┘
+                                            │ dispatch Step → Job
+              ┌─────────────────────────────┼─────────────────────────────┐
+              ▼                             ▼                             ▼
+     ┌────────────────┐           ┌────────────────┐           ┌────────────────┐
+     │ Step Runners   │           │ Sandbox Mgr    │           │ GitOps         │
+     │ (catalog)      │──────────▶│ ensure/hibernate│◀─────────│ branch/PR/CI   │
+     │ llm agent …    │           │ destroy/idle   │           │                │
+     └───────┬────────┘           └────────────────┘           └───────┬────────┘
+             │ agent                                                    │
+             ▼                                                          │
+     ┌────────────────┐                                                 │
+     │ Agent Runtime  │  omp-rpc / clipool                              │
+     └────────────────┘                                                 │
+             │                                                          │
+             └──────────────────────┬───────────────────────────────────┘
+                                    ▼
+                         ┌────────────────┐
+                         │   OUTBOUND     │  Spark comment / status
+                         └────────────────┘
+```
+
+### Placement dans factory (hexagone)
+
+| Couche | Contenu Dev Factory |
+|---|---|
+| **Ingress / adapters** | Connector Spark ; GitOps (gh/git) ; Outbound Spark ; Sandbox (FS/process) |
+| **Application** | Work Registry · Workflow Engine · Runner Catalog |
+| **Jobs / workers** | Chaque exécution de Step = **Job** (job-model) ; runner `agent` → omp / clipool |
+| **Config** | Fichiers Workflow YAML versionnés dans le repo (ou config déployée) |
+
+Principe : pas de logique Spark dans le core engine — seulement des **ports** + runners typés.
+
+---
+
+## Briques et responsabilités
+
+| Brique | Responsabilité | Ne fait pas |
+|---|---|---|
+| **Ingress** | Signal → event normalisé | Décider readiness / tier |
+| **Work Registry** | Cycle de vie multi-jours du Work ; unicité ticket→Work | Exécuter des steps |
+| **Workflow Engine** | Interpréter le YAML ; avancer ; boucles ; gates | Appeler Spark/Git en dur |
+| **Step Runner** | `run(ctx) → StepResult` pour un `type` | Connaître le graphe global |
+| **Runner Catalog** | Map `type` → runner | Contenir le métier |
+| **Sandbox Manager** | Isoler le FS/process d’un Work | Être SSoT de reprise |
+| **GitOps** | Branch, commit, push, PR, checks | Orchestrer le workflow |
+| **Outbound** | Feedback Spark contrôlé | Remplacer le Work store |
+| **Agent Runtime** | Tour LLM + tools | Porter l’état workflow |
+
+Détail des définitions : [dev-factory-terminology.md](./dev-factory-terminology.md).
+
+### Work vs Job
+
+| | **Work** | **Job** |
+|---|---|---|
+| Durée | jours | secondes → heures d’un step |
+| Portée | tout le développement d’un ticket | une exécution d’un Step |
+| SSoT reprise | Work + branch + `head_sha` | JobResult terminal |
+| Cardinalité | 1 par ticket actif | N par Work (un par step / retry) |
+
+```
+Work meta job : { work_id, step_id, attempt, workflow_id }
+```
+
+Retry d’un step = **nouveau Job**, même `step_id`, `attempt+1`.
+
+---
+
+## Identités et isolation
+
+| Identité | Rôle |
+|---|---|
+| `work_id` | Clé primaire pipeline |
+| Spark `client` + `ticket_cuid` / ref | Lien métier ; clé d’unicité ingress |
+| GitHub issue number | Créée/liée via Spark `github-create` |
+| `branch` | `feat/{spark_ref}-{slug}` (convention v0) |
+| `sandbox_id` | Handle éphémère (nullable) |
+| `head_sha` | Dernier commit connu du Work |
+| `job_id` | Run d’un step (job-model) |
+
+### Règles d’or (parallélisme)
+
+1. **≤ 1 Work actif** par ticket Spark en dev  
+2. **1 Work ↔ 1 branch ↔ ≤ 1 Sandbox active**  
+3. **1 Step en cours d’exécution ↔ 1 Job**  
+4. Re-trigger `todo` sur le même ticket → **resume** Work, pas second Work  
+5. N tickets en parallèle = N Works indépendants  
+
+---
+
+## Flow cible (Gosilex)
+
+### Vue d’ensemble
+
+```
+[Spark] ticket enfant status → todo
+        │
+        ▼
+[Ingress] normalize + dedupe
+        │
+        ▼
+[Work Registry] get_or_create(Work)
+        │
+        ▼
+[Engine] step = readiness          ←── pas de sandbox, pas de branch
+        │
+        ├─ blocked / immature ──▶ Outbound comment Spark
+        │                         Work = waiting_blocked / terminal soft
+        │
+        └─ ready + tier ────────▶ provision
+                                      │
+                        github.ensure_issue
+                        git.ensure_branch
+                        sandbox.ensure
+                                      │
+                                      ▼
+                        pipeline dev (selon Tier)
+                        S      : implement → pr → ci → review ⇄ fix
+                        F-lite : frame → spec → plan → implement → …
+                        F-full : frame → analyze → spec → plan → …
+                                      │
+                        artefacts commités sur la branch
+                        gates HITL → Work waiting_hitl
+                                      │
+                                      ▼
+                        merge staging → Outbound status=staging
+                        sandbox hibernate/destroy
+                        Work = completed
+```
+
+### Phase 1 — Readiness (avant dev)
+
+| | |
+|---|---|
+| Trigger | Ticket Pilotage (tâche enfant) passe `todo` |
+| Inputs | ticket body, comments, **links** (`parent`, `blocked_by`, `blocks`) |
+| Runner | `llm` (structured) |
+| Sandbox / branch | **non** |
+| Sorties | `ready`, `blocked`, `blockers[]`, `tier`, `missing[]`, `rationale` |
+| Si KO | Outbound comment sur Spark ; Work en attente (re-trigger possible) |
+| Si OK | continuer → provision |
+
+L’**épic parent** informe le contexte ; ce n’est pas le Work de code (sauf décision contraire ultérieure).
+
+### Phase 2 — Provision
+
+| Step type (indicatif) | Effet |
+|---|---|
+| `github.ensure_issue` | Spark `github-create` ou reuse link existant |
+| `git.ensure_branch` | Branch depuis `staging` (convention Silex) |
+| `sandbox.ensure` | Worktree (v0) checkout branch |
+
+À partir d’ici : isolation Git active → parallélisable.
+
+### Phase 3 — Développement
+
+- Chemin choisi par **Tier** (switch workflow).
+- Steps `agent` s’appuient sur des **packs de contrats** alignés dev-core (frame / spec / plan / implement / review / fix) — pas sur le plugin Claude interactif `/dev`.
+- Chaque step réussi qui produit des fichiers → **Artifact** commité via GitOps.
+- **Gate HITL** (typiquement F-lite / F-full sur frame/spec/plan) :
+  - Work → `waiting_hitl`
+  - Sandbox → hibernate possible
+  - Reprise sur signal (comment Spark, label, event dédié)
+
+### Phase 4 — PR, CI, loops
+
+```
+implement ──▶ pr ──▶ ci
+               │       │
+               │       ├─ red  ──▶ (fix_ci | implement)  [max_iters]
+               │       └─ green ──▶ review
+               │                      │
+               │                      ├─ changes_requested ──▶ fix ──▶ review  [max_iters]
+               │                      └─ approved ──▶ done_staging
+```
+
+Boucles **bornées** dans le Workflow (`max_iters`) ; dépassement → fail explicite + Outbound.
+
+### Phase 5 — Clôture
+
+| Action | Détail |
+|---|---|
+| Outbound status | `staging` après merge sur staging — **pas** `done` trop tôt (règle Silex : `done` = main/prod) |
+| Comment | lien PR / résumé |
+| Sandbox | hibernate puis destroy selon policy |
+| Work | `completed` (ou `failed` / `cancelled`) |
+
+---
+
+## Lifecycle Sandbox
+
+```
+                 ensure (premier step qui en a besoin)
+                        │
+                        ▼
+                     ACTIVE ── touch à chaque Job sandbox
+                        │
+            idle > T1 (ex. 15–30 min)
+                        ▼
+                   HIBERNATED   (process off ; Work + branch restent)
+                        │
+            prochain step / approve HITL
+                        ▼
+                     ensure (warm) → ACTIVE
+                        │
+     Work terminal  OR  idle > T2 (ex. 7j)  OR  cancel
+                        ▼
+                    DESTROYED
+```
+
+| Règle | |
+|---|---|
+| SSoT de reprise | Work Registry + GitHub branch + `head_sha` |
+| Session Agent Runtime | nice-to-have ; **non** requise pour resume |
+| Pool | `max_active` sandboxes ; excès → Work `queued` |
+
+---
+
+## Workflow déclaratif (rôle, pas le fichier figé)
+
+Le **Workflow** est un YAML versionné :
+
+- steps nommés + `type` (catalog)
+- transitions `on:`
+- `switch` (tier, ready, ci…)
+- loops + `max_iters`
+- gates `hitl`
+- policy sandbox idle (defaults)
+
+**Modifiable sans redéployer l’architecture.**  
+Le premier fichier n’a pas besoin d’être final : un graphe minimal suffit pour valider les briques.
+
+Phase 2 possible : générer un graphe Mermaid depuis le YAML (doc / dashboard).
+
+Inspiration modèle : Nika (Intent-as-Code) — **pas** adoption du runtime Nika en v0.
+
+---
+
+## Mapping job-model factory
+
+| Concept Dev Factory | Job-model / platform |
+|---|---|
+| Job (exécution step) | `job_id` = run ; subjects `factory.job.<id>.*` |
+| Dispatch runner long | `factory.jobs.<name>` (ex. `dev.agent`, `dev.git`) |
+| Work (multi-jours) | **Nouveau** store (SQLite/KV) — distinct du registry jobs TTL court |
+| Steer mid-step | existant Shape-D si step agent long |
+| Agent backend | `omp-rpc` et/ou clipool via Agent Runtime pluggable |
+| Ingress | pattern connector (ADR-096) — nouveau connector `spark` |
+
+Le Work **n’est pas** un job longue durée unique : c’est une **machine à états** qui enchaîne des jobs courts/moyens.
+
+---
+
+## États Work (indicatif)
+
+```
+queued → running ⇄ waiting_hitl
+                 ⇄ waiting_blocked
+                 ⇄ queued (pool sandbox plein)
+        → completed | failed | cancelled
+```
+
+Transitions exactes = responsabilité du Workflow + Engine ; la liste ci-dessus est le vocabulaire d’observabilité.
+
+---
+
+## Sécurité & secrets (cadre)
+
+| Sujet | V0 |
+|---|---|
+| Spark API | PAT staff / secret connector (même famille que secrets factory) |
+| GitHub | token repo cible (projet Spark `githubEnabled`) |
+| Sandbox | pas de secrets host globaux montés en vrac ; injection scoped |
+| Multi-tenant | allowlist clients Gosilex ; un Work ne voit que son repo/branch |
+
+Détail ACL NATS : [security-routing.md](./security-routing.md) + matrix existante (à étendre pour identities `dev-*` si workers dédiés).
+
+---
+
+## Découpage d’implémentation (ordre des briques)
+
+L’ordre construit les **contrats**, pas le YAML final.
+
+| # | Livrable | Preuve |
+|---|---|---|
+| 1 | Work Registry + CLI/show | create/resume, unicité ticket |
+| 2 | Workflow Engine minimal (sequence, switch, terminal, loop counter) | YAML jouet avance un Work |
+| 3 | Ingress Spark (poll v0 OK) | event `todo` → Work |
+| 4 | Runners `llm` + `spark.comment` | readiness E2E sans git |
+| 5 | GitOps ensure_branch + `github.ensure_issue` | branch isolée |
+| 6 | Sandbox Manager ensure/hibernate | cwd stable pour agent |
+| 7 | Runner `agent` (omp) | frame ou implement S + commit Artifact |
+| 8 | PR + wait CI + loops | cycle review/fix borné |
+| 9 | Outbound status `staging` | boucle métier fermée |
+
+---
+
+## Décisions ouvertes (ne bloquent pas le doc)
+
+| # | Sujet | Biais actuel |
+|---|---|---|
+| D1 | Webhook Spark vs poll | poll v0, webhook ensuite |
+| D2 | Host sandboxes (M1 vs runner dédié) | orchestrateur factory ; compute sandbox peut être ailleurs |
+| D3 | HITL exact (comment `/approve`, label, UI) | comment Spark d’abord |
+| D4 | Packs prompts : in-repo factory vs package partagé | in-repo v0 |
+| D5 | Nom stream/subjects `factory.jobs.dev.*` | à figer à l’implémentation |
+
+---
+
+## Documents liés
+
+| Doc | Rôle | Authority |
+|---|---|---|
+| [dev-factory-terminology.md](./dev-factory-terminology.md) | Noms & définitions | **ratified** |
+| [dev-factory-work-contract.md](./dev-factory-work-contract.md) | Champs & états Work | reflection |
+| [dev-factory-runners.md](./dev-factory-runners.md) | Runners + StepResult | reflection |
+| [dev-factory-spark-ingress.md](./dev-factory-spark-ingress.md) | Ingress / Outbound Spark | reflection |
+| [dev-factory-implementation-slices.md](./dev-factory-implementation-slices.md) | Ordre de build | reflection |
+| [job-model.md](./job-model.md) | Jobs techniques factory | living |
+| [messaging.md](./messaging.md) | NATS / dispatch | living |
+| ADR-096 | Ingress connector / tenant | ADR |
+| ADR-084 | WorkEnvelope / job_id (≠ **Work** Dev Factory) | ADR |
+
+> **Homonyme** : dans le job-model historique, « work » apparaît via WorkEnvelope. Ici **Work** = unité durable Dev Factory. En cas de doute dans le code, préférer `DevWork` / `work_id` documenté dans ce domaine.

--- a/docs/architecture/dev-factory.md
+++ b/docs/architecture/dev-factory.md
@@ -401,4 +401,4 @@ L’ordre construit les **contrats**, pas le YAML final.
 | ADR-096 | Ingress connector / tenant | ADR |
 | ADR-084 | WorkEnvelope / job_id (≠ **Work** Dev Factory) | ADR |
 
-> **Homonyme** : dans le job-model historique, « work » apparaît via WorkEnvelope. Ici **Work** = unité durable Dev Factory. En cas de doute dans le code, préférer `DevWork` / `work_id` documenté dans ce domaine.
+> **Homonyme** : dans le job-model historique, « work » apparaît via WorkEnvelope. Ici **Work** = unité durable Dev Factory. En cas de doute dans le code, préférer `DevWork` / `work_id` documenté dans ce domaine. <!-- drift-ignore -->


### PR DESCRIPTION
## Summary
- Capture local WIP docs for the dev-factory architecture (runners, spark ingress, terminology, work contract, implementation slices).
- Link from ARCHITECTURE.md.

## Test Plan
- [x] Docs-only change — no runtime impact